### PR TITLE
Fix grouped command formatter parity regressions

### DIFF
--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -181,6 +181,8 @@ mod tests {
     use super::{Parser, parse_fixture_with_benchmark_counters};
     use super::{TEST_FILES, benchmark_cases, parse_fixture, resources_dir};
     use serde::Deserialize;
+    #[cfg(feature = "parser-benchmarking")]
+    use shuck_parser::parser::Parser;
     use shuck_formatter::{FormattedSource, ShellFormatOptions, format_file_ast, format_source};
     use shuck_indexer::Indexer;
     use shuck_linter::{

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -187,8 +187,6 @@ mod tests {
         LinterSettings, ShellCheckCodeMap, SuppressionIndex, first_statement_line, lint_file,
         parse_directives,
     };
-    #[cfg(feature = "parser-benchmarking")]
-    use shuck_parser::parser::Parser;
 
     #[derive(Debug, Deserialize)]
     struct Manifest {

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -181,14 +181,14 @@ mod tests {
     use super::{Parser, parse_fixture_with_benchmark_counters};
     use super::{TEST_FILES, benchmark_cases, parse_fixture, resources_dir};
     use serde::Deserialize;
-    #[cfg(feature = "parser-benchmarking")]
-    use shuck_parser::parser::Parser;
     use shuck_formatter::{FormattedSource, ShellFormatOptions, format_file_ast, format_source};
     use shuck_indexer::Indexer;
     use shuck_linter::{
         LinterSettings, ShellCheckCodeMap, SuppressionIndex, first_statement_line, lint_file,
         parse_directives,
     };
+    #[cfg(feature = "parser-benchmarking")]
+    use shuck_parser::parser::Parser;
 
     #[derive(Debug, Deserialize)]
     struct Manifest {

--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -2146,17 +2146,48 @@ pub(crate) fn group_attachment_span(
 fn find_group_close_offset(source: &str, sequence_end: usize, close: char) -> Option<usize> {
     let close_len = close.len_utf8();
     let capped_end = sequence_end.min(source.len());
-    if capped_end >= close_len
-        && source
-            .get(capped_end - close_len..capped_end)
-            .is_some_and(|slice| slice.starts_with(close))
-    {
-        return Some(capped_end - close_len);
+    if let Some(offset) = find_group_close_offset_after_sequence(source, capped_end, close) {
+        return Some(offset);
     }
 
-    source[capped_end..]
-        .find(close)
-        .map(|offset| capped_end + offset)
+    let trimmed_end = source[..capped_end]
+        .trim_end_matches(char::is_whitespace)
+        .len();
+    if trimmed_end >= close_len
+        && source
+            .get(trimmed_end - close_len..trimmed_end)
+            .is_some_and(|slice| slice.starts_with(close))
+    {
+        return Some(trimmed_end - close_len);
+    }
+
+    None
+}
+
+fn find_group_close_offset_after_sequence(
+    source: &str,
+    sequence_end: usize,
+    close: char,
+) -> Option<usize> {
+    let mut offset = sequence_end.min(source.len());
+    while offset < source.len() {
+        let tail = &source[offset..];
+        let ch = tail.chars().next()?;
+        if ch.is_whitespace() {
+            offset += ch.len_utf8();
+            continue;
+        }
+        if ch == '#' {
+            offset = tail
+                .find('\n')
+                .map(|newline| offset + newline + 1)
+                .unwrap_or(source.len());
+            continue;
+        }
+        return (ch == close).then_some(offset);
+    }
+
+    None
 }
 
 pub(crate) fn group_was_inline_in_source(

--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -2129,13 +2129,12 @@ pub(crate) fn group_attachment_span(
     let open_offset = source[..stmt_span(first).start.offset].rfind(open)?;
     let sequence_end = commands
         .last()
-        .map(|_| {
+        .and_then(|_| {
             commands
                 .iter()
                 .map(stmt_span)
                 .reduce(|left, right| left.merge(right))
         })
-        .flatten()
         .map(|span| span.end.offset)
         .unwrap_or(0);
     let end = find_group_close_offset(source, sequence_end, close)
@@ -2150,7 +2149,7 @@ fn find_group_close_offset(source: &str, sequence_end: usize, close: char) -> Op
     if capped_end >= close_len
         && source
             .get(capped_end - close_len..capped_end)
-            .is_some_and(|slice| slice.chars().next() == Some(close))
+            .is_some_and(|slice| slice.starts_with(close))
     {
         return Some(capped_end - close_len);
     }

--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -2064,15 +2064,11 @@ fn group_verbatim_span(commands: &[Stmt], source: &str, open: char, close: char)
     if !source[wrapper_prefix_start..inner.start.offset].contains('#') {
         return inner;
     }
-    let Some(close_offset) = source[inner.end.offset..].find(close) else {
+    let Some(close_offset) = find_group_close_offset(source, inner.end.offset, close) else {
         return inner;
     };
 
-    span_for_offsets(
-        source,
-        open_offset,
-        inner.end.offset + close_offset + close.len_utf8(),
-    )
+    span_for_offsets(source, open_offset, close_offset + close.len_utf8())
 }
 
 fn format_group_with_upper_bound(
@@ -2117,7 +2113,8 @@ pub(crate) fn group_open_suffix<'a>(
     let suffix_start = open_offset + open.len_utf8();
     let suffix = source.get(suffix_start..line_end)?;
     suffix
-        .contains('#')
+        .trim_start_matches(char::is_whitespace)
+        .starts_with('#')
         .then(|| (source_map.span_for_offsets(suffix_start, line_end), suffix))
 }
 
@@ -2129,14 +2126,38 @@ pub(crate) fn group_attachment_span(
 ) -> Option<Span> {
     let source = source_map.source();
     let first = commands.first()?;
-    let last = commands.last()?;
     let open_offset = source[..stmt_span(first).start.offset].rfind(open)?;
-    let last_end = stmt_span(last).end.offset;
-    let end = source[last_end..]
-        .find(close)
-        .map(|offset| last_end + offset + close.len_utf8())
-        .unwrap_or(last_end);
+    let sequence_end = commands
+        .last()
+        .map(|_| {
+            commands
+                .iter()
+                .map(stmt_span)
+                .reduce(|left, right| left.merge(right))
+        })
+        .flatten()
+        .map(|span| span.end.offset)
+        .unwrap_or(0);
+    let end = find_group_close_offset(source, sequence_end, close)
+        .map(|offset| offset + close.len_utf8())
+        .unwrap_or(sequence_end);
     Some(source_map.span_for_offsets(open_offset, end))
+}
+
+fn find_group_close_offset(source: &str, sequence_end: usize, close: char) -> Option<usize> {
+    let close_len = close.len_utf8();
+    let capped_end = sequence_end.min(source.len());
+    if capped_end >= close_len
+        && source
+            .get(capped_end - close_len..capped_end)
+            .is_some_and(|slice| slice.chars().next() == Some(close))
+    {
+        return Some(capped_end - close_len);
+    }
+
+    source[capped_end..]
+        .find(close)
+        .map(|offset| capped_end + offset)
 }
 
 pub(crate) fn group_was_inline_in_source(

--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -2132,7 +2132,7 @@ pub(crate) fn group_attachment_span(
         .and_then(|_| {
             commands
                 .iter()
-                .map(stmt_span)
+                .map(|command| stmt_verbatim_span(command, source))
                 .reduce(|left, right| left.merge(right))
         })
         .map(|span| span.end.offset)
@@ -2174,6 +2174,10 @@ fn find_group_close_offset_after_sequence(
         let tail = &source[offset..];
         let ch = tail.chars().next()?;
         if ch.is_whitespace() {
+            offset += ch.len_utf8();
+            continue;
+        }
+        if ch == ';' {
             offset += ch.len_utf8();
             continue;
         }
@@ -2875,6 +2879,10 @@ mod tests {
     use crate::ShellFormatOptions;
     use shuck_parser::parser::{Parser, ShellDialect};
 
+    fn parse(source: &str) -> shuck_ast::File {
+        Parser::new(source).parse().unwrap().file
+    }
+
     #[test]
     fn parsed_standalone_assignment_renders_without_trailing_space() {
         let source = "x=1\n";
@@ -2896,5 +2904,33 @@ mod tests {
         assert!(stmt.redirects.is_empty());
         assert!(!command.name.parts.is_empty());
         assert!(command.name.render_syntax(source).is_empty());
+    }
+
+    #[test]
+    fn group_verbatim_span_keeps_wrapper_comments_with_semicolon_terminated_body() {
+        let source = "{ # note\n  echo ok; # inside\n}\n";
+        let file = parse(source);
+        let brace_group = match &file.body[0].command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group"),
+        };
+
+        let span = group_verbatim_span(brace_group.as_slice(), source, '{', '}');
+
+        assert_eq!(span.slice(source), "{ # note\n  echo ok; # inside\n}");
+    }
+
+    #[test]
+    fn group_verbatim_span_keeps_wrapper_comments_around_heredoc_bodies() {
+        let source = "{ # note\n  cat <<EOF\npayload\nEOF\n}\n";
+        let file = parse(source);
+        let brace_group = match &file.body[0].command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group"),
+        };
+
+        let span = group_verbatim_span(brace_group.as_slice(), source, '{', '}');
+
+        assert_eq!(span.slice(source), "{ # note\n  cat <<EOF\npayload\nEOF\n}");
     }
 }

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -1194,4 +1194,42 @@ mod tests {
         assert!(facts.stmt(&file.body[0]).preserve_verbatim());
         assert!(facts.stmt(&file.body[1]).preserve_verbatim());
     }
+
+    #[test]
+    fn grouped_condition_sequences_do_not_capture_later_file_comments() {
+        let source = "download() {\n  local url\n  url=https://github.com/junegunn/fzf/releases/download/v$version/${1}\n  set -o pipefail\n  if ! (try_curl $url || try_wget $url); then\n    set +o pipefail\n    binary_error=\"Failed to download with curl and wget\"\n    return\n  fi\n  set +o pipefail\n}\n\n# Try to download binary executable\narchi=$(uname -smo 2> /dev/null || uname -sm)\n";
+        let file = parse(source);
+        let options = ShellFormatOptions::default();
+        let resolved = options.resolve(source, Some(Path::new("test.sh")));
+        let facts = FormatterFacts::build(source, &file, &resolved);
+
+        let function = match &file.body[0].command {
+            Command::Function(function) => function,
+            _ => panic!("expected function"),
+        };
+        let function_body = match &function.body.command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group function body"),
+        };
+        let if_command = match &function_body[3].command {
+            Command::Compound(CompoundCommand::If(command)) => command,
+            _ => panic!("expected if command"),
+        };
+        let condition_stmt = &if_command.condition[0];
+        let subshell = match &condition_stmt.command {
+            Command::Compound(CompoundCommand::Subshell(commands)) => commands,
+            _ => panic!("expected subshell condition"),
+        };
+
+        let sequence = facts.sequence(subshell, Some(stmt_span(condition_stmt).end.offset));
+        let attachment_span =
+            group_attachment_span(subshell.as_slice(), facts.source_map(), '(', ')')
+                .expect("expected subshell attachment span");
+        assert!(!sequence.has_comments());
+        assert!(facts.group_was_inline_in_source(subshell));
+        assert_eq!(
+            attachment_span.slice(source),
+            "(try_curl $url || try_wget $url)"
+        );
+    }
 }

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -1273,4 +1273,45 @@ mod tests {
             "(\n  echo $(printf '%s' value)\n)"
         );
     }
+
+    #[test]
+    fn brace_group_attachment_span_keeps_semicolon_terminated_trailing_comments() {
+        let source = "{\n  echo ok; # inside\n}\n# outside\nprintf '%s\\n' done\n";
+        let file = parse(source);
+        let options = ShellFormatOptions::default();
+        let resolved = options.resolve(source, Some(Path::new("test.sh")));
+        let facts = FormatterFacts::build(source, &file, &resolved);
+
+        let brace_group = match &file.body[0].command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group"),
+        };
+        let attachment_span =
+            group_attachment_span(brace_group.as_slice(), facts.source_map(), '{', '}')
+                .expect("expected brace group attachment span");
+
+        assert_eq!(attachment_span.slice(source), "{\n  echo ok; # inside\n}");
+    }
+
+    #[test]
+    fn brace_group_attachment_span_reaches_wrapper_close_after_heredoc_body() {
+        let source = "{\n  cat <<EOF\npayload\nEOF\n}\n# outside\nprintf '%s\\n' done\n";
+        let file = parse(source);
+        let options = ShellFormatOptions::default();
+        let resolved = options.resolve(source, Some(Path::new("test.sh")));
+        let facts = FormatterFacts::build(source, &file, &resolved);
+
+        let brace_group = match &file.body[0].command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group"),
+        };
+        let attachment_span =
+            group_attachment_span(brace_group.as_slice(), facts.source_map(), '{', '}')
+                .expect("expected brace group attachment span");
+
+        assert_eq!(
+            attachment_span.slice(source),
+            "{\n  cat <<EOF\npayload\nEOF\n}"
+        );
+    }
 }

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -1232,4 +1232,45 @@ mod tests {
             "(try_curl $url || try_wget $url)"
         );
     }
+
+    #[test]
+    fn brace_group_attachment_span_reaches_wrapper_close_after_parameter_expansion() {
+        let source = "{\n  echo ${value}\n}\n# outside\nprintf '%s\\n' done\n";
+        let file = parse(source);
+        let options = ShellFormatOptions::default();
+        let resolved = options.resolve(source, Some(Path::new("test.sh")));
+        let facts = FormatterFacts::build(source, &file, &resolved);
+
+        let brace_group = match &file.body[0].command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group"),
+        };
+        let attachment_span =
+            group_attachment_span(brace_group.as_slice(), facts.source_map(), '{', '}')
+                .expect("expected brace group attachment span");
+
+        assert_eq!(attachment_span.slice(source), "{\n  echo ${value}\n}");
+    }
+
+    #[test]
+    fn subshell_attachment_span_reaches_wrapper_close_after_command_substitution() {
+        let source = "(\n  echo $(printf '%s' value)\n)\n# outside\nprintf '%s\\n' done\n";
+        let file = parse(source);
+        let options = ShellFormatOptions::default();
+        let resolved = options.resolve(source, Some(Path::new("test.sh")));
+        let facts = FormatterFacts::build(source, &file, &resolved);
+
+        let subshell = match &file.body[0].command {
+            Command::Compound(CompoundCommand::Subshell(commands)) => commands,
+            _ => panic!("expected subshell"),
+        };
+        let attachment_span =
+            group_attachment_span(subshell.as_slice(), facts.source_map(), '(', ')')
+                .expect("expected subshell attachment span");
+
+        assert_eq!(
+            attachment_span.slice(source),
+            "(\n  echo $(printf '%s' value)\n)"
+        );
+    }
 }

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -802,6 +802,20 @@ mod tests {
     }
 
     #[test]
+    fn negated_subshell_conditions_do_not_capture_later_file_comments() {
+        let source = "download() {\n  local url\n  url=https://github.com/junegunn/fzf/releases/download/v$version/${1}\n  set -o pipefail\n  if ! (try_curl $url || try_wget $url); then\n    set +o pipefail\n    binary_error=\"Failed to download with curl and wget\"\n    return\n  fi\n  set +o pipefail\n}\n\n# Try to download binary executable\narchi=$(uname -smo 2> /dev/null || uname -sm)\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "download() {\n\tlocal url\n\turl=https://github.com/junegunn/fzf/releases/download/v$version/${1}\n\tset -o pipefail\n\tif ! (try_curl $url || try_wget $url); then\n\t\tset +o pipefail\n\t\tbinary_error=\"Failed to download with curl and wget\"\n\t\treturn\n\tfi\n\tset +o pipefail\n}\n\n# Try to download binary executable\narchi=$(uname -smo 2>/dev/null || uname -sm)\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
     fn preserves_else_branch_comments_inside_the_branch() {
         let source = "if foo; then\n  bar\nelse\n  # branch comment\n  baz\nfi\n";
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
@@ -873,6 +887,33 @@ mod tests {
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
 
         assert_eq!(formatted, FormattedSource::Unchanged);
+    }
+
+    #[test]
+    fn preserves_single_line_subshells_inside_case_bodies() {
+        let source = "build_package_pyston() {\n  build_package_copy\n  mkdir -p \"${PREFIX_PATH}/bin\" \"${PREFIX_PATH}/lib\"\n  local bin\n  shopt -s nullglob\n  for bin in \"bin/\"*; do\n    if [ -f \"${bin}\" ] && [ -x \"${bin}\" ] && [ ! -L \"${bin}\" ]; then\n      case \"${bin##*/}\" in\n      \"pyston\"* )\n        ( cd \"${PREFIX_PATH}/bin\" && ln -fs \"${bin##*/}\" \"python\" )\n        ;;\n      esac\n    fi\n  done\n  shopt -u nullglob\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "build_package_pyston() {\n\tbuild_package_copy\n\tmkdir -p \"${PREFIX_PATH}/bin\" \"${PREFIX_PATH}/lib\"\n\tlocal bin\n\tshopt -s nullglob\n\tfor bin in \"bin/\"*; do\n\t\tif [ -f \"${bin}\" ] && [ -x \"${bin}\" ] && [ ! -L \"${bin}\" ]; then\n\t\t\tcase \"${bin##*/}\" in\n\t\t\t\"pyston\"*)\n\t\t\t\t(cd \"${PREFIX_PATH}/bin\" && ln -fs \"${bin##*/}\" \"python\")\n\t\t\t\t;;\n\t\t\tesac\n\t\tfi\n\tdone\n\tshopt -u nullglob\n}\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_inline_group_redirect_suffixes() {
+        let source = "build_package_activepython() {\n  local package_name=\"$1\"\n  { bash \"install.sh\" --install-dir \"${PREFIX_PATH}\"\n  } >&4 2>&1\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "build_package_activepython() {\n\tlocal package_name=\"$1\"\n\t{\n\t\tbash \"install.sh\" --install-dir \"${PREFIX_PATH}\"\n\t} >&4 2>&1\n}\n".to_string()
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This updates the shell formatter's grouped-command handling to avoid a couple of structural parity bugs against `shfmt`.

- fix grouped opener detection so parameter expansions like `${var##...}` are not mistaken for opener comments
- fix grouped close-boundary detection so grouped spans that already include `)` or `}` do not scan forward and capture later comments
- add regression coverage for negated subshell conditions, case-body subshells, redirect-suffixed groups, and grouped-condition facts

## Root Cause

Two helper paths in grouped-command span detection were too permissive:

- opener suffix detection treated any `#` on the opener line as a comment, including `##` inside parameter expansion syntax
- close-boundary detection assumed grouped statement spans ended before the closing token, which is not always true

That combination caused malformed grouped output in the benchmark corpus, including duplicated inline subshell bodies and later file comments being attached to grouped conditions.

## Validation

- `cargo test -p shuck-formatter --lib`
- `make test-oracle-shfmt-fixtures`
- `SHUCK_RUN_SHFMT_ORACLE=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck-formatter --test oracle_shfmt benchmark_corpus_matches_shfmt -- --ignored --exact --nocapture`

The targeted formatter tests and fixture oracle are green. The full benchmark oracle is still failing overall, but this change clears the grouped-command bucket for `fzf-install.sh` and reduces the remaining parity gap in `pyenv-python-build.sh`.
