### PR TITLE
Handle grouped close scans across line continuations

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -2172,6 +2172,10 @@ fn find_group_close_offset_after_sequence(
     let mut offset = sequence_end.min(source.len());
     while offset < source.len() {
         let tail = &source[offset..];
+        if tail.starts_with("\\\n") {
+            offset += "\\\n".len();
+            continue;
+        }
         let ch = tail.chars().next()?;
         if ch.is_whitespace() {
             offset += ch.len_utf8();
@@ -2932,5 +2936,19 @@ mod tests {
         let span = group_verbatim_span(brace_group.as_slice(), source, '{', '}');
 
         assert_eq!(span.slice(source), "{ # note\n  cat <<EOF\npayload\nEOF\n}");
+    }
+
+    #[test]
+    fn group_verbatim_span_keeps_wrapper_comments_across_line_continuations() {
+        let source = "{ # note\n  echo ok; \\\n}\n";
+        let file = parse(source);
+        let brace_group = match &file.body[0].command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group"),
+        };
+
+        let span = group_verbatim_span(brace_group.as_slice(), source, '{', '}');
+
+        assert_eq!(span.slice(source), "{ # note\n  echo ok; \\\n}");
     }
 }

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -1314,4 +1314,24 @@ mod tests {
             "{\n  cat <<EOF\npayload\nEOF\n}"
         );
     }
+
+    #[test]
+    fn brace_group_attachment_span_reaches_wrapper_close_after_line_continuation() {
+        let source = "{ echo ok; \\\n}\n# outside\nprintf '%s\\n' done\n";
+        let file = parse(source);
+        let options = ShellFormatOptions::default();
+        let resolved = options.resolve(source, Some(Path::new("test.sh")));
+        let facts = FormatterFacts::build(source, &file, &resolved);
+
+        let brace_group = match &file.body[0].command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group"),
+        };
+        let attachment_span =
+            group_attachment_span(brace_group.as_slice(), facts.source_map(), '{', '}')
+                .expect("expected brace group attachment span");
+
+        assert!(!facts.group_was_inline_in_source(brace_group));
+        assert_eq!(attachment_span.slice(source), "{ echo ok; \\\n}");
+    }
 }


### PR DESCRIPTION
## Summary
- teach the grouped-close scanner to skip backslash-newline continuations while searching for the wrapper close
- add formatter regressions for verbatim-span and attachment-span handling across line continuations

## Why
The formatter already handled whitespace, semicolons, comments, and heredoc bodies after the last statement in a group. A trailing line continuation still caused the scan to stop early at `\`, which could truncate the group span before the real `}` or `)` and misclassify attached comments or inline groups.

## Impact
Brace groups and subshells now keep their wrapper close and nearby comments attached when the last statement ends with a shell line continuation.

## Validation
- `cargo test -p shuck-formatter`
