### PR TITLE
Publish large corpus report to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,7 +137,20 @@ jobs:
       - name: "Run large corpus tests"
         id: large-corpus
         continue-on-error: true
-        run: nix develop --command make NIX_DEVELOP= test-large-corpus
+        run: |
+          mkdir -p target/large-corpus-report
+          nix develop --command make NIX_DEVELOP= test-large-corpus 2>&1 | tee target/large-corpus-report/latest.log
+      - name: "Generate HTML report"
+        id: report
+        if: always() && steps.large-corpus.outcome != 'cancelled'
+        run: |
+          mkdir -p target/pages/reports/corpus
+          python3 scripts/large_corpus_report.py --log target/large-corpus-report/latest.log --output target/pages/reports/corpus/index.html
+      - name: "Upload report artifact"
+        if: always() && steps.report.outcome == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/pages
       - name: "Summarize large corpus result"
         if: always()
         run: |
@@ -146,3 +159,23 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "This job is non-blocking for now, so corpus mismatches do not fail CI." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  deploy-report:
+    name: "deploy corpus report"
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: large-corpus
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: "Deploy to GitHub Pages"
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ That said, shuck is not a port of ShellCheck. It is a clean-room reimplementatio
 - Shuck's parser and analysis logic were written from scratch. Edge cases may be handled differently, and some diagnostics may fire in slightly different locations or contexts.
 - In cases where ShellCheck's behavior appears incorrect or inconsistent with shell semantics, shuck intentionally chooses correctness over compatibility.
 
+Compatibility is continuously validated against a large corpus of shell scripts from popular open-source projects including [acme.sh](https://github.com/acmesh-official/acme.sh), [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh), [nvm](https://github.com/nvm-sh/nvm), [pyenv](https://github.com/pyenv/pyenv), [pi-hole](https://github.com/pi-hole/pi-hole), [bats-core](https://github.com/bats-core/bats-core), [powerlevel10k](https://github.com/romkatv/powerlevel10k), [dokku](https://github.com/dokku/dokku), [gentoo](https://github.com/gentoo/gentoo), and [many others](scripts/corpus-download.sh). The latest conformance report is published at [ewhauser.github.io/shuck/reports/corpus](https://ewhauser.github.io/shuck/reports/corpus/).
+
 ## Suppression
 
 Suppress diagnostics with inline comments. Both native and ShellCheck-style directives are supported.


### PR DESCRIPTION
## Summary

- Extend the `large-corpus` CI job to capture test output to a log file, generate an HTML conformance report via `large_corpus_report.py`, and upload it as a GitHub Pages artifact on main pushes.
- Add a `deploy-report` job that deploys the report to GitHub Pages at `/reports/corpus/`.
- Add a paragraph to the README under "ShellCheck compatibility" listing representative corpus repos and linking to the published report.

**Note:** Requires a one-time setup in repo Settings > Pages to set the source to "GitHub Actions".

## Test plan

- [ ] Verify the CI workflow runs successfully on a push to main
- [ ] Confirm the HTML report is accessible at `ewhauser.github.io/shuck/reports/corpus/`
- [ ] Verify the report is not generated/deployed on PR builds