### PR TITLE
Enable Renovate for security-only dependency updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "security:only-security-updates",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "description": "Keep GitHub Action updates together so digest refreshes stay readable.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.renovaterc.json5` with `security:only-security-updates` mode
- Pins GitHub Action digests via `helpers:pinGitHubActionDigests`
- Groups GitHub Action updates into a single PR

## Test plan
- [ ] Verify Renovate bot picks up the config and activates on the repo