### PR TITLE
Grant security-events:write to zizmor CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- The zizmor CI job has been failing on main because the `advanced-security: true` setting triggers a SARIF upload via `codeql-action/upload-sarif`, which requires `security-events: write` permission
- The job only had `contents: read`, causing the upload to fail with "Resource not accessible by integration"
- Adds `security-events: write` to the zizmor job's permissions block

## Test plan
- [ ] Verify the zizmor job passes on this PR's CI run