### PR TITLE
Enforce fact-based linter rule architecture

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1293,6 +1293,10 @@ impl<'a> CommandFact<'a> {
         self.normalized.body_name_word()
     }
 
+    pub fn body_word_span(&self) -> Option<Span> {
+        self.normalized.body_word_span()
+    }
+
     pub fn body_args(&self) -> &[&'a Word] {
         self.normalized.body_args()
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -289,6 +289,14 @@ impl<'a> ConditionalUnaryFact<'a> {
         self.expression
     }
 
+    pub fn operator_span(&self) -> Span {
+        let ConditionalExpr::Unary(expression) = self.expression else {
+            unreachable!("conditional unary fact should wrap a unary expression");
+        };
+
+        expression.op_span
+    }
+
     pub fn op(&self) -> ConditionalUnaryOp {
         self.op
     }
@@ -314,6 +322,14 @@ pub struct ConditionalBinaryFact<'a> {
 impl<'a> ConditionalBinaryFact<'a> {
     pub fn expression(&self) -> &'a ConditionalExpr {
         self.expression
+    }
+
+    pub fn operator_span(&self) -> Span {
+        let ConditionalExpr::Binary(expression) = self.expression else {
+            unreachable!("conditional binary fact should wrap a binary expression");
+        };
+
+        expression.op_span
     }
 
     pub fn op(&self) -> ConditionalBinaryOp {
@@ -358,6 +374,10 @@ pub struct ConditionalFact<'a> {
 }
 
 impl<'a> ConditionalFact<'a> {
+    pub fn expression(&self) -> &'a ConditionalExpr {
+        self.root().expression()
+    }
+
     pub fn root(&self) -> &ConditionalNodeFact<'a> {
         &self.nodes[0]
     }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -40,7 +40,14 @@ pub use rules::common::command::{DeclarationKind, WrapperKind};
 pub use rules::common::expansion::{ExpansionContext, WordQuote};
 pub use rules::common::query::CommandSubstitutionKind;
 pub use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
-pub use rules::common::span::assignment_name_span;
+pub use rules::common::span::{
+    assignment_name_span, conditional_array_subscript_span, conditional_extglob_span,
+    double_quoted_scalar_affix_span, word_array_subscript_span, word_extglob_span,
+    word_has_single_literal_part, word_literal_part_spans_excluding_parameter_operator_tails,
+    word_literal_scan_segments_excluding_expansions, word_nested_zsh_substitution_spans,
+    word_standalone_literal_backslash_span, word_unquoted_star_parameter_spans,
+    word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,
+};
 pub use rules::common::word::{TestOperandClass, static_word_text};
 pub use settings::LinterSettings;
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/rules/common/command.rs
+++ b/crates/shuck-linter/src/rules/common/command.rs
@@ -52,6 +52,7 @@ pub struct NormalizedCommand<'a> {
     pub effective_name: Option<String>,
     pub wrappers: Vec<WrapperKind>,
     pub body_span: Span,
+    pub body_word_span: Option<Span>,
     pub body_words: Vec<&'a Word>,
     pub declaration: Option<NormalizedDeclaration<'a>>,
 }
@@ -75,6 +76,10 @@ impl<'a> NormalizedCommand<'a> {
         self.body_words.first().copied()
     }
 
+    pub fn body_word_span(&self) -> Option<Span> {
+        self.body_word_span
+    }
+
     pub fn body_args(&self) -> &[&'a Word] {
         self.body_words.split_first().map_or(&[], |(_, rest)| rest)
     }
@@ -91,6 +96,7 @@ pub(crate) fn normalize_command<'a>(command: &'a Command, source: &str) -> Norma
                 effective_name: Some(name),
                 wrappers: Vec::new(),
                 body_span: builtin_span(command),
+                body_word_span: None,
                 body_words: Vec::new(),
                 declaration: None,
             }
@@ -112,6 +118,7 @@ fn normalize_simple_command<'a>(command: &'a SimpleCommand, source: &str) -> Nor
         effective_name: literal_name.clone(),
         wrappers: Vec::new(),
         body_span: command.name.span,
+        body_word_span: Some(command.name.span),
         body_words: literal_name
             .as_ref()
             .map_or_else(Vec::new, |_| words.clone()),
@@ -133,6 +140,7 @@ fn normalize_simple_command<'a>(command: &'a SimpleCommand, source: &str) -> Nor
             } => {
                 normalized.effective_name = Some(effective_name);
                 normalized.body_span = words[body_index].span;
+                normalized.body_word_span = Some(words[body_index].span);
                 normalized.body_words = words[body_index..].to_vec();
                 break;
             }
@@ -141,11 +149,13 @@ fn normalize_simple_command<'a>(command: &'a SimpleCommand, source: &str) -> Nor
 
                 let Some(target_index) = target_index else {
                     normalized.effective_name = None;
+                    normalized.body_word_span = None;
                     normalized.body_words.clear();
                     break;
                 };
 
                 normalized.body_span = words[target_index].span;
+                normalized.body_word_span = Some(words[target_index].span);
                 normalized.body_words = words[target_index..].to_vec();
                 normalized.effective_name = static_word_text(words[target_index], source);
                 current_index = target_index;
@@ -177,6 +187,7 @@ fn normalize_decl_command<'a>(command: &'a DeclClause, source: &str) -> Normaliz
         effective_name: Some(raw_kind.clone()),
         wrappers: Vec::new(),
         body_span: command.variant_span,
+        body_word_span: None,
         body_words: Vec::new(),
         declaration: Some(NormalizedDeclaration {
             kind: declaration_kind(raw_kind),
@@ -235,6 +246,7 @@ fn empty_normalized_command<'a>(span: Span) -> NormalizedCommand<'a> {
         effective_name: None,
         wrappers: Vec::new(),
         body_span: span,
+        body_word_span: None,
         body_words: Vec::new(),
         declaration: None,
     }

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -1,6 +1,7 @@
 use shuck_ast::{
-    Assignment, BinaryCommand, BourneParameterExpansion, ParameterExpansion,
-    ParameterExpansionSyntax, Redirect, Span, Word, WordPart, WordPartNode,
+    Assignment, BinaryCommand, BourneParameterExpansion, ConditionalExpr, ParameterExpansion,
+    ParameterExpansionSyntax, Pattern, PatternPart, Redirect, Span, VarRef, Word, WordPart,
+    WordPartNode, ZshExpansionTarget,
 };
 
 pub fn assignment_name_span(assignment: &Assignment) -> Span {
@@ -68,6 +69,202 @@ pub fn scalar_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_scalar_expansion_spans(&word.parts, &mut spans);
     spans
+}
+
+pub fn double_quoted_scalar_affix_span(word: &Word) -> Option<Span> {
+    if !word.is_fully_double_quoted() {
+        return None;
+    }
+
+    let mut saw_literal = false;
+    let mut saw_scalar_expansion = false;
+    let mut literal_span = None;
+    if !collect_double_quoted_scalar_affix_state(
+        &word.parts,
+        &mut saw_literal,
+        &mut saw_scalar_expansion,
+        &mut literal_span,
+    ) {
+        return None;
+    }
+
+    (saw_literal && saw_scalar_expansion)
+        .then_some(literal_span)
+        .flatten()
+}
+
+pub fn word_literal_part_spans_excluding_parameter_operator_tails(
+    word: &Word,
+    source: &str,
+) -> Vec<Span> {
+    word.parts
+        .iter()
+        .enumerate()
+        .filter_map(|(index, part)| match &part.kind {
+            WordPart::Literal(_)
+                if !literal_part_is_parameter_operator_tail(&word.parts, index, source) =>
+            {
+                Some(part.span)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+pub fn word_has_single_literal_part(word: &Word) -> bool {
+    matches!(
+        word.parts.as_slice(),
+        [part] if matches!(part.kind, WordPart::Literal(_))
+    )
+}
+
+pub fn word_literal_scan_segments_excluding_expansions(word: &Word, source: &str) -> Vec<Span> {
+    let mut excluded = Vec::new();
+    collect_literal_scan_exclusions(&word.parts, &mut excluded);
+    scan_span_excluding(word.span, &excluded, source)
+}
+
+pub fn word_standalone_literal_backslash_span(word: &Word, source: &str) -> Option<Span> {
+    let [part] = word.parts.as_slice() else {
+        return None;
+    };
+    if !matches!(part.kind, WordPart::Literal(_)) {
+        return None;
+    }
+
+    let text = word.span.slice(source);
+    let bytes = text.as_bytes();
+    if bytes.len() != 2 || bytes[0] != b'\\' {
+        return None;
+    }
+
+    let target = bytes[1];
+    if !target.is_ascii_lowercase() || matches!(target, b'n' | b'r' | b't') {
+        return None;
+    }
+
+    Some(Span::from_positions(word.span.start, word.span.start))
+}
+
+pub fn word_unquoted_star_parameter_spans(word: &Word, unquoted_array_spans: &[Span]) -> Vec<Span> {
+    word.parts_with_spans()
+        .filter_map(|(part, span)| {
+            (unquoted_array_spans.contains(&span)
+                && matches!(part, WordPart::Variable(name) if name.as_str() == "*"))
+            .then_some(span)
+        })
+        .collect()
+}
+
+pub fn word_zsh_flag_modifier_spans(word: &Word) -> Vec<Span> {
+    word.parts
+        .iter()
+        .filter_map(|part| {
+            let WordPart::Parameter(parameter) = &part.kind else {
+                return None;
+            };
+            let ParameterExpansionSyntax::Zsh(syntax) = &parameter.syntax else {
+                return None;
+            };
+            if syntax.modifiers.is_empty() {
+                return None;
+            }
+
+            match syntax.target {
+                ZshExpansionTarget::Reference(_) | ZshExpansionTarget::Word(_) => {}
+                ZshExpansionTarget::Nested(_) | ZshExpansionTarget::Empty => return None,
+            }
+
+            syntax.modifiers.first().map(|modifier| modifier.span)
+        })
+        .collect()
+}
+
+pub fn word_zsh_nested_expansion_spans(word: &Word) -> Vec<Span> {
+    word.parts
+        .iter()
+        .filter_map(|part| {
+            let WordPart::Parameter(parameter) = &part.kind else {
+                return None;
+            };
+            let ParameterExpansionSyntax::Zsh(syntax) = &parameter.syntax else {
+                return None;
+            };
+
+            matches!(syntax.target, ZshExpansionTarget::Nested(_))
+                .then_some(syntax.operation.is_none())
+                .filter(|is_none| *is_none)
+                .map(|_| parameter.span)
+        })
+        .collect()
+}
+
+pub fn word_nested_zsh_substitution_spans(word: &Word) -> Vec<Span> {
+    word.parts
+        .iter()
+        .filter_map(|part| {
+            let WordPart::Parameter(parameter) = &part.kind else {
+                return None;
+            };
+            let ParameterExpansionSyntax::Zsh(syntax) = &parameter.syntax else {
+                return None;
+            };
+
+            matches!(syntax.target, ZshExpansionTarget::Nested(_))
+                .then_some(syntax.operation.as_ref())
+                .flatten()
+                .map(|_| parameter.span)
+        })
+        .collect()
+}
+
+pub fn conditional_extglob_span(expression: &ConditionalExpr, source: &str) -> Option<Span> {
+    match expression {
+        ConditionalExpr::Binary(expr) => conditional_extglob_span(&expr.left, source)
+            .or_else(|| conditional_extglob_span(&expr.right, source)),
+        ConditionalExpr::Unary(expr) => conditional_extglob_span(&expr.expr, source),
+        ConditionalExpr::Parenthesized(expr) => conditional_extglob_span(&expr.expr, source),
+        ConditionalExpr::Pattern(pattern) => pattern_extglob_span(pattern, source),
+        ConditionalExpr::Word(_) | ConditionalExpr::Regex(_) | ConditionalExpr::VarRef(_) => None,
+    }
+}
+
+pub fn conditional_array_subscript_span(
+    expression: &ConditionalExpr,
+    source: &str,
+) -> Option<Span> {
+    match expression {
+        ConditionalExpr::Binary(expr) => conditional_array_subscript_span(&expr.left, source)
+            .or_else(|| conditional_array_subscript_span(&expr.right, source)),
+        ConditionalExpr::Unary(expr) => conditional_array_subscript_span(&expr.expr, source),
+        ConditionalExpr::Parenthesized(expr) => {
+            conditional_array_subscript_span(&expr.expr, source)
+        }
+        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
+            word_array_subscript_span(word, source)
+        }
+        ConditionalExpr::Pattern(pattern) => pattern_array_subscript_span(pattern, source),
+        ConditionalExpr::VarRef(reference) => var_ref_subscript_span(reference),
+    }
+}
+
+pub fn word_array_subscript_span(word: &Word, source: &str) -> Option<Span> {
+    word_array_subscript_span_from_parts(&word.parts, source).or_else(|| {
+        (!word.has_quoted_parts() && text_has_variable_subscript(word.span.slice(source)))
+            .then_some(word.span)
+    })
+}
+
+pub fn word_extglob_span(word: &Word, source: &str) -> Option<Span> {
+    word_extglob_span_from_parts(&word.parts, source).or_else(|| {
+        (!word.has_quoted_parts()
+            && word
+                .parts
+                .iter()
+                .all(|part| matches!(part.kind, WordPart::Literal(_)))
+            && text_looks_like_extglob(word.span.slice(source)))
+        .then_some(word.span)
+    })
 }
 
 fn collect_command_substitution_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
@@ -192,6 +389,447 @@ fn collect_scalar_expansion_spans(parts: &[WordPartNode], spans: &mut Vec<Span>)
             WordPart::ArrayIndices(_) | WordPart::ArraySlice { .. } => {}
         }
     }
+}
+
+fn collect_double_quoted_scalar_affix_state(
+    parts: &[WordPartNode],
+    saw_literal: &mut bool,
+    saw_scalar_expansion: &mut bool,
+    literal_span: &mut Option<Span>,
+) -> bool {
+    for part in parts {
+        match &part.kind {
+            WordPart::Literal(_) | WordPart::SingleQuoted { .. } => {
+                *saw_literal = true;
+                if literal_span.is_none() {
+                    *literal_span = Some(part.span);
+                }
+            }
+            WordPart::DoubleQuoted { parts, .. } => {
+                if !collect_double_quoted_scalar_affix_state(
+                    parts,
+                    saw_literal,
+                    saw_scalar_expansion,
+                    literal_span,
+                ) {
+                    return false;
+                }
+            }
+            WordPart::Variable(_)
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::Substring { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::Transformation { .. } => {
+                *saw_scalar_expansion = true;
+            }
+            WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::ArraySlice { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::ZshQualifiedGlob(_) => {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+fn literal_part_is_parameter_operator_tail(
+    parts: &[WordPartNode],
+    index: usize,
+    source: &str,
+) -> bool {
+    let Some(previous) = index.checked_sub(1).and_then(|index| parts.get(index)) else {
+        return false;
+    };
+    if !matches!(
+        previous.kind,
+        WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::IndirectExpansion { .. }
+    ) {
+        return false;
+    }
+
+    let text = parts[index].span.slice(source);
+    text.ends_with('}') && (text.starts_with('/') || text.starts_with('%') || text.starts_with('#'))
+}
+
+fn collect_literal_scan_exclusions(parts: &[WordPartNode], excluded: &mut Vec<Span>) {
+    for part in parts {
+        match &part.kind {
+            WordPart::Literal(_) => {}
+            WordPart::DoubleQuoted { parts, .. } => {
+                collect_literal_scan_exclusions(parts, excluded);
+            }
+            WordPart::CommandSubstitution { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::Transformation { .. }
+            | WordPart::ZshQualifiedGlob(_) => excluded.push(part.span),
+        }
+    }
+}
+
+fn scan_span_excluding(span: Span, excluded: &[Span], source: &str) -> Vec<Span> {
+    if excluded.is_empty() {
+        return vec![span];
+    }
+
+    let mut spans = Vec::new();
+    let mut cursor = span.start.offset;
+    for excluded_span in excluded.iter().copied().filter(|excluded_span| {
+        excluded_span.end.offset > span.start.offset && excluded_span.start.offset < span.end.offset
+    }) {
+        let segment_end = excluded_span.start.offset.min(span.end.offset);
+        if cursor < segment_end {
+            spans.push(scan_span_segment(span, cursor, segment_end, source));
+        }
+        cursor = cursor.max(excluded_span.end.offset).min(span.end.offset);
+    }
+
+    if cursor < span.end.offset {
+        spans.push(scan_span_segment(span, cursor, span.end.offset, source));
+    }
+
+    spans
+}
+
+fn scan_span_segment(span: Span, start: usize, end: usize, source: &str) -> Span {
+    let segment_start = span.start.advanced_by(&source[span.start.offset..start]);
+    let segment_end = span.start.advanced_by(&source[span.start.offset..end]);
+    Span::from_positions(segment_start, segment_end)
+}
+
+fn pattern_extglob_span(pattern: &Pattern, source: &str) -> Option<Span> {
+    for part in &pattern.parts {
+        match &part.kind {
+            PatternPart::Group { patterns, .. } => {
+                return Some(part.span).or_else(|| {
+                    patterns
+                        .iter()
+                        .find_map(|pattern| pattern_extglob_span(pattern, source))
+                });
+            }
+            PatternPart::Word(word) => {
+                if let Some(span) = word_extglob_span(word, source) {
+                    return Some(span);
+                }
+            }
+            PatternPart::Literal(_)
+            | PatternPart::AnyString
+            | PatternPart::AnyChar
+            | PatternPart::CharClass(_) => {}
+        }
+    }
+
+    None
+}
+
+fn pattern_array_subscript_span(pattern: &Pattern, source: &str) -> Option<Span> {
+    for part in &pattern.parts {
+        match &part.kind {
+            PatternPart::Group { patterns, .. } => {
+                if let Some(span) = patterns
+                    .iter()
+                    .find_map(|pattern| pattern_array_subscript_span(pattern, source))
+                {
+                    return Some(span);
+                }
+            }
+            PatternPart::Word(word) => {
+                if let Some(span) = word_array_subscript_span(word, source) {
+                    return Some(span);
+                }
+            }
+            PatternPart::Literal(_)
+            | PatternPart::AnyString
+            | PatternPart::AnyChar
+            | PatternPart::CharClass(_) => {}
+        }
+    }
+
+    None
+}
+
+fn word_array_subscript_span_from_parts(parts: &[WordPartNode], source: &str) -> Option<Span> {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => {
+                if let Some(span) = word_array_subscript_span_from_parts(parts, source) {
+                    return Some(span);
+                }
+            }
+            WordPart::Literal(_) => {
+                if text_has_variable_subscript(part.span.slice(source)) {
+                    return Some(part.span);
+                }
+            }
+            WordPart::Parameter(parameter) => {
+                if let Some(span) = parameter_array_subscript_span(parameter) {
+                    return Some(span);
+                }
+            }
+            WordPart::ParameterExpansion { reference, .. }
+            | WordPart::Length(reference)
+            | WordPart::ArrayAccess(reference)
+            | WordPart::ArrayLength(reference)
+            | WordPart::ArrayIndices(reference)
+            | WordPart::Substring { reference, .. }
+            | WordPart::ArraySlice { reference, .. }
+            | WordPart::IndirectExpansion { reference, .. }
+            | WordPart::Transformation { reference, .. } => {
+                if let Some(span) = var_ref_subscript_span(reference) {
+                    return Some(span);
+                }
+            }
+            WordPart::ZshQualifiedGlob(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. } => {}
+        }
+    }
+
+    None
+}
+
+fn parameter_array_subscript_span(parameter: &ParameterExpansion) -> Option<Span> {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+            BourneParameterExpansion::Access { reference }
+            | BourneParameterExpansion::Length { reference }
+            | BourneParameterExpansion::Indices { reference }
+            | BourneParameterExpansion::Indirect { reference, .. }
+            | BourneParameterExpansion::Slice { reference, .. }
+            | BourneParameterExpansion::Operation { reference, .. }
+            | BourneParameterExpansion::Transformation { reference, .. } => {
+                var_ref_subscript_span(reference)
+            }
+            BourneParameterExpansion::PrefixMatch { .. } => None,
+        },
+        ParameterExpansionSyntax::Zsh(syntax) => match &syntax.target {
+            ZshExpansionTarget::Reference(reference) => var_ref_subscript_span(reference),
+            ZshExpansionTarget::Nested(parameter) => parameter_array_subscript_span(parameter),
+            ZshExpansionTarget::Word(_) | ZshExpansionTarget::Empty => None,
+        },
+    }
+}
+
+fn var_ref_subscript_span(reference: &VarRef) -> Option<Span> {
+    reference
+        .subscript
+        .as_ref()
+        .filter(|subscript| subscript.selector().is_none())
+        .map(|_| reference.span)
+}
+
+fn word_extglob_span_from_parts(parts: &[WordPartNode], source: &str) -> Option<Span> {
+    for part in parts {
+        match &part.kind {
+            WordPart::Literal(_) => {
+                if text_looks_like_extglob(part.span.slice(source)) {
+                    return Some(part.span);
+                }
+            }
+            WordPart::DoubleQuoted { .. } | WordPart::SingleQuoted { .. } => {}
+            WordPart::ZshQualifiedGlob(_)
+            | WordPart::Variable(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. } => {}
+        }
+    }
+
+    None
+}
+
+fn text_has_variable_subscript(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b'$' || byte_is_backslash_escaped(bytes, index) {
+            index += 1;
+            continue;
+        }
+
+        let next = index + 1;
+        if next >= bytes.len() {
+            break;
+        }
+
+        if bytes[next] == b'{' {
+            let mut cursor = next + 1;
+            while cursor < bytes.len() && bytes[cursor] != b'}' {
+                if bytes[cursor] == b'['
+                    && bytes[cursor + 1..].contains(&b']')
+                    && bytes[cursor + 1..].contains(&b'}')
+                {
+                    return true;
+                }
+                cursor += 1;
+            }
+            index = cursor.saturating_add(1);
+            continue;
+        }
+
+        if !is_name_start(bytes[next]) {
+            index += 1;
+            continue;
+        }
+
+        let mut cursor = next + 1;
+        while cursor < bytes.len() && is_name_continue(bytes[cursor]) {
+            cursor += 1;
+        }
+
+        if cursor < bytes.len() && bytes[cursor] == b'[' && bytes[cursor + 1..].contains(&b']') {
+            return true;
+        }
+
+        index = cursor;
+    }
+
+    false
+}
+
+fn text_looks_like_extglob(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    if text_has_parenthesized_alternation(bytes) {
+        return true;
+    }
+
+    let mut index = 0usize;
+
+    while index + 1 < bytes.len() {
+        if !is_extglob_operator(bytes[index])
+            || bytes[index + 1] != b'('
+            || byte_is_backslash_escaped(bytes, index)
+        {
+            index += 1;
+            continue;
+        }
+
+        return matching_group_end(bytes, index + 1).is_some();
+    }
+
+    false
+}
+
+fn text_has_parenthesized_alternation(bytes: &[u8]) -> bool {
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b'(' || byte_is_backslash_escaped(bytes, index) {
+            index += 1;
+            continue;
+        }
+
+        let Some(close) = matching_group_end(bytes, index) else {
+            index += 1;
+            continue;
+        };
+
+        if bytes[index + 1..close]
+            .iter()
+            .enumerate()
+            .any(|(offset, byte)| {
+                *byte == b'|' && !byte_is_backslash_escaped(bytes, index + 1 + offset)
+            })
+        {
+            return true;
+        }
+
+        index = close + 1;
+    }
+
+    false
+}
+
+fn matching_group_end(bytes: &[u8], open_index: usize) -> Option<usize> {
+    let mut depth = 1usize;
+    let mut cursor = open_index + 1;
+
+    while cursor < bytes.len() {
+        if byte_is_backslash_escaped(bytes, cursor) {
+            cursor += 1;
+            continue;
+        }
+
+        match bytes[cursor] {
+            b'(' => {
+                depth += 1;
+            }
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(cursor);
+                }
+            }
+            _ => {}
+        }
+
+        cursor += 1;
+    }
+
+    None
+}
+
+fn byte_is_backslash_escaped(bytes: &[u8], index: usize) -> bool {
+    let mut cursor = index;
+    let mut backslashes = 0usize;
+
+    while cursor > 0 && bytes[cursor - 1] == b'\\' {
+        backslashes += 1;
+        cursor -= 1;
+    }
+
+    backslashes % 2 == 1
+}
+
+fn is_extglob_operator(byte: u8) -> bool {
+    matches!(byte, b'@' | b'?' | b'+' | b'*' | b'!')
+}
+
+fn is_name_start(byte: u8) -> bool {
+    byte == b'_' || byte.is_ascii_alphabetic()
+}
+
+fn is_name_continue(byte: u8) -> bool {
+    is_name_start(byte) || byte.is_ascii_digit()
 }
 
 fn parameter_is_array_like(parameter: &ParameterExpansion) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
@@ -1,8 +1,8 @@
-use shuck_ast::{Span, Word, WordPart, WordPartNode};
+use shuck_ast::Span;
 
 use crate::{
     Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, SimpleTestOperatorFamily,
-    SimpleTestShape, Violation,
+    SimpleTestShape, Violation, double_quoted_scalar_affix_span,
 };
 
 pub struct ConstantComparisonTest;
@@ -60,79 +60,7 @@ fn simple_test_is_constant(fact: &crate::SimpleTestFact<'_>) -> bool {
 fn simple_test_unary_affix_span(fact: &crate::SimpleTestFact<'_>) -> Option<Span> {
     let operand = fact.operands().get(1)?;
 
-    word_scalar_affix_span(operand)
-}
-
-fn word_scalar_affix_span(word: &Word) -> Option<Span> {
-    if !word.is_fully_double_quoted() {
-        return None;
-    }
-
-    let mut saw_literal = false;
-    let mut saw_scalar_expansion = false;
-    let mut literal_span = None;
-    if !word_scalar_affix_span_parts(
-        &word.parts,
-        &mut saw_literal,
-        &mut saw_scalar_expansion,
-        &mut literal_span,
-    ) {
-        return None;
-    }
-
-    (saw_literal && saw_scalar_expansion)
-        .then_some(literal_span)
-        .flatten()
-}
-
-fn word_scalar_affix_span_parts(
-    parts: &[WordPartNode],
-    saw_literal: &mut bool,
-    saw_scalar_expansion: &mut bool,
-    literal_span: &mut Option<Span>,
-) -> bool {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(_) | WordPart::SingleQuoted { .. } => {
-                *saw_literal = true;
-                if literal_span.is_none() {
-                    *literal_span = Some(part.span);
-                }
-            }
-            WordPart::DoubleQuoted { parts, .. } => {
-                if !word_scalar_affix_span_parts(
-                    parts,
-                    saw_literal,
-                    saw_scalar_expansion,
-                    literal_span,
-                ) {
-                    return false;
-                }
-            }
-            WordPart::Variable(_)
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::Substring { .. }
-            | WordPart::IndirectExpansion { .. }
-            | WordPart::Transformation { .. } => {
-                *saw_scalar_expansion = true;
-            }
-            WordPart::ArrayAccess(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::ArrayIndices(_)
-            | WordPart::ArraySlice { .. }
-            | WordPart::PrefixMatch { .. }
-            | WordPart::CommandSubstitution { .. }
-            | WordPart::ArithmeticExpansion { .. }
-            | WordPart::ProcessSubstitution { .. }
-            | WordPart::ZshQualifiedGlob(_) => {
-                return false;
-            }
-        }
-    }
-
-    true
+    double_quoted_scalar_affix_span(operand)
 }
 
 fn simple_test_report_span(fact: &crate::SimpleTestFact<'_>, fallback: Span) -> Span {

--- a/crates/shuck-linter/src/rules/mod.rs
+++ b/crates/shuck-linter/src/rules/mod.rs
@@ -3,3 +3,69 @@ pub mod correctness;
 pub mod performance;
 pub mod portability;
 pub mod style;
+
+#[cfg(test)]
+mod architecture_tests {
+    use std::fs;
+    use std::path::Path;
+
+    const RULE_DIRS: &[&str] = &["correctness", "performance", "portability", "style"];
+    const FORBIDDEN_TOKENS: &[&str] = &[
+        "WordPart",
+        "WordPartNode",
+        "ConditionalExpr",
+        "PatternPart",
+        "ParameterExpansionSyntax",
+        "ZshExpansionTarget",
+        "ConditionalCommand",
+        "BourneParameterExpansion",
+        "iter_commands",
+        "query::",
+    ];
+
+    #[test]
+    fn rule_modules_avoid_direct_ast_traversal_tokens() {
+        let rules_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
+        let mut violations = Vec::new();
+
+        for dir in RULE_DIRS {
+            let category_dir = rules_root.join(dir);
+            let entries = fs::read_dir(&category_dir).unwrap_or_else(|error| {
+                panic!("failed to read {}: {error}", category_dir.display())
+            });
+
+            for entry in entries {
+                let entry = entry.unwrap_or_else(|error| {
+                    panic!(
+                        "failed to read entry in {}: {error}",
+                        category_dir.display()
+                    )
+                });
+                let path = entry.path();
+                if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                    continue;
+                }
+                if matches!(
+                    path.file_name().and_then(|name| name.to_str()),
+                    Some("mod.rs" | "syntax.rs")
+                ) {
+                    continue;
+                }
+
+                let source = fs::read_to_string(&path)
+                    .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+                for token in FORBIDDEN_TOKENS {
+                    if source.contains(token) {
+                        violations.push(format!("{} contains `{token}`", path.display()));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "rule files should rely on fact/shared helper APIs instead of direct AST traversal:\n{}",
+            violations.join("\n"),
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/portability/conditional_portability.rs
+++ b/crates/shuck-linter/src/rules/portability/conditional_portability.rs
@@ -1,11 +1,9 @@
-use shuck_ast::{
-    BourneParameterExpansion, Command, CompoundCommand, ConditionalBinaryOp, ConditionalCommand,
-    ConditionalExpr, ConditionalUnaryOp, ParameterExpansion, ParameterExpansionSyntax, Pattern,
-    PatternPart, Span, VarRef, Word, WordPart, WordPartNode, ZshExpansionTarget,
-};
+use shuck_ast::{ConditionalBinaryOp, ConditionalUnaryOp, Span};
 
 use crate::{
-    Checker, Rule, ShellDialect, SimpleTestFact, SimpleTestSyntax, Violation, static_word_text,
+    Checker, ConditionalNodeFact, Rule, ShellDialect, SimpleTestFact, SimpleTestSyntax, Violation,
+    conditional_array_subscript_span, conditional_extglob_span, static_word_text,
+    word_array_subscript_span, word_extglob_span,
 };
 
 pub struct DoubleBracketInSh;
@@ -172,7 +170,7 @@ pub fn double_bracket_in_sh(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter(|fact| conditional_command(fact).is_some())
+        .filter(|fact| fact.conditional().is_some())
         .map(crate::CommandFact::span)
         .collect::<Vec<_>>();
 
@@ -213,12 +211,9 @@ pub fn test_equality_operator(checker: &mut Checker) {
             .facts()
             .commands()
             .iter()
-            .filter_map(conditional_command)
-            .flat_map(|command| {
-                conditional_binary_operator_spans(
-                    &command.expression,
-                    ConditionalBinaryOp::PatternEq,
-                )
+            .filter_map(|fact| fact.conditional())
+            .flat_map(|conditional| {
+                conditional_binary_operator_spans(conditional, ConditionalBinaryOp::PatternEq)
             }),
     );
 
@@ -235,7 +230,7 @@ pub fn if_elif_bash_test(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| checker.facts().is_elif_condition_command(fact.id()))
-        .filter(|fact| conditional_command(fact).is_some())
+        .filter(|fact| fact.conditional().is_some())
         .map(crate::CommandFact::span)
         .collect::<Vec<_>>();
 
@@ -252,8 +247,8 @@ pub fn extended_glob_in_test(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(conditional_command)
-        .filter_map(|command| conditional_extglob_span(&command.expression, source))
+        .filter_map(|fact| fact.conditional())
+        .filter_map(|conditional| conditional_extglob_span(conditional.expression(), source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ExtendedGlobInTest);
@@ -291,8 +286,10 @@ pub fn array_subscript_condition(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(conditional_command)
-        .filter_map(|command| conditional_array_subscript_span(&command.expression, source))
+        .filter_map(|fact| fact.conditional())
+        .filter_map(|conditional| {
+            conditional_array_subscript_span(conditional.expression(), source)
+        })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ArraySubscriptCondition);
@@ -329,12 +326,9 @@ pub fn greater_than_in_double_bracket(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(conditional_command)
-        .flat_map(|command| {
-            conditional_binary_operator_spans(
-                &command.expression,
-                ConditionalBinaryOp::LexicalAfter,
-            )
+        .filter_map(|fact| fact.conditional())
+        .flat_map(|conditional| {
+            conditional_binary_operator_spans(conditional, ConditionalBinaryOp::LexicalAfter)
         })
         .collect::<Vec<_>>();
 
@@ -350,9 +344,9 @@ pub fn regex_match_in_sh(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(conditional_command)
-        .flat_map(|command| {
-            conditional_binary_operator_spans(&command.expression, ConditionalBinaryOp::RegexMatch)
+        .filter_map(|fact| fact.conditional())
+        .flat_map(|conditional| {
+            conditional_binary_operator_spans(conditional, ConditionalBinaryOp::RegexMatch)
         })
         .collect::<Vec<_>>();
 
@@ -368,9 +362,9 @@ pub fn v_test_in_sh(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(conditional_command)
-        .flat_map(|command| {
-            conditional_unary_operator_spans(&command.expression, |operator, _| {
+        .filter_map(|fact| fact.conditional())
+        .flat_map(|conditional| {
+            conditional_unary_operator_spans(conditional, |operator, _| {
                 operator == ConditionalUnaryOp::VariableSet
             })
         })
@@ -389,9 +383,9 @@ pub fn a_test_in_sh(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(conditional_command)
-        .flat_map(|command| {
-            conditional_unary_operator_spans(&command.expression, |operator, op_span| {
+        .filter_map(|fact| fact.conditional())
+        .flat_map(|conditional| {
+            conditional_unary_operator_spans(conditional, |operator, op_span| {
                 operator == ConditionalUnaryOp::Exists && op_span.slice(source) == "-a"
             })
         })
@@ -409,9 +403,9 @@ pub fn option_test_in_sh(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(conditional_command)
-        .flat_map(|command| {
-            conditional_unary_operator_spans(&command.expression, |operator, _| {
+        .filter_map(|fact| fact.conditional())
+        .flat_map(|conditional| {
+            conditional_unary_operator_spans(conditional, |operator, _| {
                 operator == ConditionalUnaryOp::OptionSet
             })
         })
@@ -466,14 +460,6 @@ pub fn ownership_test_in_sh(checker: &mut Checker) {
 
 fn is_posix_sh_shell(shell: ShellDialect) -> bool {
     matches!(shell, ShellDialect::Sh | ShellDialect::Dash)
-}
-
-fn conditional_command<'a>(fact: &'a crate::CommandFact<'a>) -> Option<&'a ConditionalCommand> {
-    let Command::Compound(CompoundCommand::Conditional(command)) = fact.command() else {
-        return None;
-    };
-
-    Some(command)
 }
 
 fn simple_test_binary_operator_token_spans(
@@ -633,441 +619,42 @@ fn simple_test_command_span(
     Some(Span::from_positions(name.span.start, end))
 }
 
-fn conditional_extglob_span(expression: &ConditionalExpr, source: &str) -> Option<Span> {
-    match expression {
-        ConditionalExpr::Binary(expr) => conditional_extglob_span(&expr.left, source)
-            .or_else(|| conditional_extglob_span(&expr.right, source)),
-        ConditionalExpr::Unary(expr) => conditional_extglob_span(&expr.expr, source),
-        ConditionalExpr::Parenthesized(expr) => conditional_extglob_span(&expr.expr, source),
-        ConditionalExpr::Pattern(pattern) => pattern_extglob_span(pattern, source),
-        ConditionalExpr::Word(_) | ConditionalExpr::Regex(_) | ConditionalExpr::VarRef(_) => None,
-    }
-}
-
-fn pattern_extglob_span(pattern: &Pattern, source: &str) -> Option<Span> {
-    for part in &pattern.parts {
-        match &part.kind {
-            PatternPart::Group { patterns, .. } => {
-                return Some(part.span).or_else(|| {
-                    patterns
-                        .iter()
-                        .find_map(|pattern| pattern_extglob_span(pattern, source))
-                });
-            }
-            PatternPart::Word(word) => {
-                if let Some(span) = word_extglob_span(word, source) {
-                    return Some(span);
-                }
-            }
-            PatternPart::Literal(_)
-            | PatternPart::AnyString
-            | PatternPart::AnyChar
-            | PatternPart::CharClass(_) => {}
-        }
-    }
-
-    None
-}
-
-fn conditional_array_subscript_span(expression: &ConditionalExpr, source: &str) -> Option<Span> {
-    match expression {
-        ConditionalExpr::Binary(expr) => conditional_array_subscript_span(&expr.left, source)
-            .or_else(|| conditional_array_subscript_span(&expr.right, source)),
-        ConditionalExpr::Unary(expr) => conditional_array_subscript_span(&expr.expr, source),
-        ConditionalExpr::Parenthesized(expr) => {
-            conditional_array_subscript_span(&expr.expr, source)
-        }
-        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-            word_array_subscript_span(word, source)
-        }
-        ConditionalExpr::Pattern(pattern) => pattern_array_subscript_span(pattern, source),
-        ConditionalExpr::VarRef(reference) => var_ref_subscript_span(reference),
-    }
-}
-
-fn pattern_array_subscript_span(pattern: &Pattern, source: &str) -> Option<Span> {
-    for part in &pattern.parts {
-        match &part.kind {
-            PatternPart::Group { patterns, .. } => {
-                if let Some(span) = patterns
-                    .iter()
-                    .find_map(|pattern| pattern_array_subscript_span(pattern, source))
-                {
-                    return Some(span);
-                }
-            }
-            PatternPart::Word(word) => {
-                if let Some(span) = word_array_subscript_span(word, source) {
-                    return Some(span);
-                }
-            }
-            PatternPart::Literal(_)
-            | PatternPart::AnyString
-            | PatternPart::AnyChar
-            | PatternPart::CharClass(_) => {}
-        }
-    }
-
-    None
-}
-
-fn word_array_subscript_span(word: &Word, source: &str) -> Option<Span> {
-    word_array_subscript_span_from_parts(&word.parts, source).or_else(|| {
-        (!word.has_quoted_parts() && text_has_variable_subscript(word.span.slice(source)))
-            .then_some(word.span)
-    })
-}
-
-fn word_array_subscript_span_from_parts(parts: &[WordPartNode], source: &str) -> Option<Span> {
-    for part in parts {
-        match &part.kind {
-            WordPart::DoubleQuoted { parts, .. } => {
-                if let Some(span) = word_array_subscript_span_from_parts(parts, source) {
-                    return Some(span);
-                }
-            }
-            WordPart::Literal(_) => {
-                if text_has_variable_subscript(part.span.slice(source)) {
-                    return Some(part.span);
-                }
-            }
-            WordPart::Parameter(parameter) => {
-                if let Some(span) = parameter_array_subscript_span(parameter) {
-                    return Some(span);
-                }
-            }
-            WordPart::ParameterExpansion { reference, .. }
-            | WordPart::Length(reference)
-            | WordPart::ArrayAccess(reference)
-            | WordPart::ArrayLength(reference)
-            | WordPart::ArrayIndices(reference)
-            | WordPart::Substring { reference, .. }
-            | WordPart::ArraySlice { reference, .. }
-            | WordPart::IndirectExpansion { reference, .. }
-            | WordPart::Transformation { reference, .. } => {
-                if let Some(span) = var_ref_subscript_span(reference) {
-                    return Some(span);
-                }
-            }
-            WordPart::ZshQualifiedGlob(_)
-            | WordPart::SingleQuoted { .. }
-            | WordPart::Variable(_)
-            | WordPart::CommandSubstitution { .. }
-            | WordPart::ArithmeticExpansion { .. }
-            | WordPart::PrefixMatch { .. }
-            | WordPart::ProcessSubstitution { .. } => {}
-        }
-    }
-
-    None
-}
-
-fn parameter_array_subscript_span(parameter: &ParameterExpansion) -> Option<Span> {
-    match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
-            BourneParameterExpansion::Access { reference }
-            | BourneParameterExpansion::Length { reference }
-            | BourneParameterExpansion::Indices { reference }
-            | BourneParameterExpansion::Indirect { reference, .. }
-            | BourneParameterExpansion::Slice { reference, .. }
-            | BourneParameterExpansion::Operation { reference, .. }
-            | BourneParameterExpansion::Transformation { reference, .. } => {
-                var_ref_subscript_span(reference)
-            }
-            BourneParameterExpansion::PrefixMatch { .. } => None,
-        },
-        ParameterExpansionSyntax::Zsh(syntax) => match &syntax.target {
-            ZshExpansionTarget::Reference(reference) => var_ref_subscript_span(reference),
-            ZshExpansionTarget::Nested(parameter) => parameter_array_subscript_span(parameter),
-            ZshExpansionTarget::Word(_) | ZshExpansionTarget::Empty => None,
-        },
-    }
-}
-
-fn var_ref_subscript_span(reference: &VarRef) -> Option<Span> {
-    reference
-        .subscript
-        .as_ref()
-        .filter(|subscript| subscript.selector().is_none())
-        .map(|_| reference.span)
-}
-
-fn word_extglob_span(word: &Word, source: &str) -> Option<Span> {
-    word_extglob_span_from_parts(&word.parts, source).or_else(|| {
-        (!word.has_quoted_parts()
-            && word_has_only_literal_parts(&word.parts)
-            && text_looks_like_extglob(word.span.slice(source)))
-        .then_some(word.span)
-    })
-}
-
-fn word_extglob_span_from_parts(parts: &[WordPartNode], source: &str) -> Option<Span> {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(_) => {
-                if text_looks_like_extglob(part.span.slice(source)) {
-                    return Some(part.span);
-                }
-            }
-            WordPart::DoubleQuoted { .. } | WordPart::SingleQuoted { .. } => {}
-            WordPart::ZshQualifiedGlob(_)
-            | WordPart::Variable(_)
-            | WordPart::CommandSubstitution { .. }
-            | WordPart::ArithmeticExpansion { .. }
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::ArrayAccess(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::ArrayIndices(_)
-            | WordPart::Substring { .. }
-            | WordPart::ArraySlice { .. }
-            | WordPart::IndirectExpansion { .. }
-            | WordPart::PrefixMatch { .. }
-            | WordPart::ProcessSubstitution { .. }
-            | WordPart::Transformation { .. } => {}
-        }
-    }
-
-    None
-}
-
-fn word_has_only_literal_parts(parts: &[WordPartNode]) -> bool {
-    parts
-        .iter()
-        .all(|part| matches!(part.kind, WordPart::Literal(_)))
-}
-
-fn text_has_variable_subscript(text: &str) -> bool {
-    let bytes = text.as_bytes();
-    let mut index = 0usize;
-
-    while index < bytes.len() {
-        if bytes[index] != b'$' || byte_is_backslash_escaped(bytes, index) {
-            index += 1;
-            continue;
-        }
-
-        let next = index + 1;
-        if next >= bytes.len() {
-            break;
-        }
-
-        if bytes[next] == b'{' {
-            let mut cursor = next + 1;
-            while cursor < bytes.len() && bytes[cursor] != b'}' {
-                if bytes[cursor] == b'['
-                    && bytes[cursor + 1..].contains(&b']')
-                    && bytes[cursor + 1..].contains(&b'}')
-                {
-                    return true;
-                }
-                cursor += 1;
-            }
-            index = cursor.saturating_add(1);
-            continue;
-        }
-
-        if !is_name_start(bytes[next]) {
-            index += 1;
-            continue;
-        }
-
-        let mut cursor = next + 1;
-        while cursor < bytes.len() && is_name_continue(bytes[cursor]) {
-            cursor += 1;
-        }
-
-        if cursor < bytes.len() && bytes[cursor] == b'[' && bytes[cursor + 1..].contains(&b']') {
-            return true;
-        }
-
-        index = cursor;
-    }
-
-    false
-}
-
-fn text_looks_like_extglob(text: &str) -> bool {
-    let bytes = text.as_bytes();
-    if text_has_parenthesized_alternation(bytes) {
-        return true;
-    }
-
-    let mut index = 0usize;
-
-    while index + 1 < bytes.len() {
-        if !is_extglob_operator(bytes[index])
-            || bytes[index + 1] != b'('
-            || byte_is_backslash_escaped(bytes, index)
-        {
-            index += 1;
-            continue;
-        }
-
-        return matching_group_end(bytes, index + 1).is_some();
-    }
-
-    false
-}
-
-fn text_has_parenthesized_alternation(bytes: &[u8]) -> bool {
-    let mut index = 0usize;
-
-    while index < bytes.len() {
-        if bytes[index] != b'(' || byte_is_backslash_escaped(bytes, index) {
-            index += 1;
-            continue;
-        }
-
-        let Some(close) = matching_group_end(bytes, index) else {
-            index += 1;
-            continue;
-        };
-
-        if bytes[index + 1..close]
-            .iter()
-            .enumerate()
-            .any(|(offset, byte)| {
-                *byte == b'|' && !byte_is_backslash_escaped(bytes, index + 1 + offset)
-            })
-        {
-            return true;
-        }
-
-        index = close + 1;
-    }
-
-    false
-}
-
-fn matching_group_end(bytes: &[u8], open_index: usize) -> Option<usize> {
-    let mut depth = 1usize;
-    let mut cursor = open_index + 1;
-
-    while cursor < bytes.len() {
-        if byte_is_backslash_escaped(bytes, cursor) {
-            cursor += 1;
-            continue;
-        }
-
-        match bytes[cursor] {
-            b'(' => {
-                depth += 1;
-            }
-            b')' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(cursor);
-                }
-            }
-            _ => {}
-        }
-
-        cursor += 1;
-    }
-
-    None
-}
-
-fn byte_is_backslash_escaped(bytes: &[u8], index: usize) -> bool {
-    let mut cursor = index;
-    let mut backslashes = 0usize;
-
-    while cursor > 0 && bytes[cursor - 1] == b'\\' {
-        backslashes += 1;
-        cursor -= 1;
-    }
-
-    backslashes % 2 == 1
-}
-
-fn is_extglob_operator(byte: u8) -> bool {
-    matches!(byte, b'@' | b'?' | b'+' | b'*' | b'!')
-}
-
 fn conditional_binary_operator_spans(
-    expression: &ConditionalExpr,
+    conditional: &crate::ConditionalFact<'_>,
     operator: ConditionalBinaryOp,
 ) -> Vec<Span> {
-    let mut spans = Vec::new();
-    collect_conditional_binary_operator_spans(expression, operator, &mut spans);
-    spans
-}
-
-fn collect_conditional_binary_operator_spans(
-    expression: &ConditionalExpr,
-    operator: ConditionalBinaryOp,
-    spans: &mut Vec<Span>,
-) {
-    match expression {
-        ConditionalExpr::Binary(expr) => {
-            if expr.op == operator {
-                spans.push(expr.op_span);
+    conditional
+        .nodes()
+        .iter()
+        .filter_map(|node| match node {
+            ConditionalNodeFact::Binary(binary) if binary.op() == operator => {
+                Some(binary.operator_span())
             }
-            collect_conditional_binary_operator_spans(&expr.left, operator, spans);
-            collect_conditional_binary_operator_spans(&expr.right, operator, spans);
-        }
-        ConditionalExpr::Unary(expr) => {
-            collect_conditional_binary_operator_spans(&expr.expr, operator, spans);
-        }
-        ConditionalExpr::Parenthesized(expr) => {
-            collect_conditional_binary_operator_spans(&expr.expr, operator, spans);
-        }
-        ConditionalExpr::Word(_)
-        | ConditionalExpr::Regex(_)
-        | ConditionalExpr::Pattern(_)
-        | ConditionalExpr::VarRef(_) => {}
-    }
+            _ => None,
+        })
+        .collect()
 }
 
 fn conditional_unary_operator_spans(
-    expression: &ConditionalExpr,
+    conditional: &crate::ConditionalFact<'_>,
     predicate: impl Fn(ConditionalUnaryOp, Span) -> bool + Copy,
 ) -> Vec<Span> {
-    let mut spans = Vec::new();
-    collect_conditional_unary_operator_spans(expression, predicate, &mut spans);
-    spans
-}
-
-fn collect_conditional_unary_operator_spans(
-    expression: &ConditionalExpr,
-    predicate: impl Fn(ConditionalUnaryOp, Span) -> bool + Copy,
-    spans: &mut Vec<Span>,
-) {
-    match expression {
-        ConditionalExpr::Binary(expr) => {
-            collect_conditional_unary_operator_spans(&expr.left, predicate, spans);
-            collect_conditional_unary_operator_spans(&expr.right, predicate, spans);
-        }
-        ConditionalExpr::Unary(expr) => {
-            if predicate(expr.op, expr.op_span) {
-                spans.push(expr.op_span);
+    conditional
+        .nodes()
+        .iter()
+        .filter_map(|node| match node {
+            ConditionalNodeFact::Unary(unary) if predicate(unary.op(), unary.operator_span()) => {
+                Some(unary.operator_span())
             }
-            collect_conditional_unary_operator_spans(&expr.expr, predicate, spans);
-        }
-        ConditionalExpr::Parenthesized(expr) => {
-            collect_conditional_unary_operator_spans(&expr.expr, predicate, spans);
-        }
-        ConditionalExpr::Word(_)
-        | ConditionalExpr::Regex(_)
-        | ConditionalExpr::Pattern(_)
-        | ConditionalExpr::VarRef(_) => {}
-    }
+            _ => None,
+        })
+        .collect()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SimpleTestOperatorKind {
     Unary,
     Binary,
-}
-
-fn is_name_start(byte: u8) -> bool {
-    byte == b'_' || byte.is_ascii_alphabetic()
-}
-
-fn is_name_continue(byte: u8) -> bool {
-    is_name_start(byte) || byte.is_ascii_digit()
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/portability/nested_zsh_substitution.rs
+++ b/crates/shuck-linter/src/rules/portability/nested_zsh_substitution.rs
@@ -1,7 +1,5 @@
-use shuck_ast::{ParameterExpansionSyntax, WordPart, ZshExpansionTarget};
-
 use super::targets_non_zsh_shell;
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, Violation, word_nested_zsh_substitution_spans};
 
 pub struct NestedZshSubstitution;
 
@@ -24,24 +22,7 @@ pub fn nested_zsh_substitution(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| {
-            fact.word()
-                .parts
-                .iter()
-                .filter_map(|part| {
-                    let WordPart::Parameter(parameter) = &part.kind else {
-                        return None;
-                    };
-                    let ParameterExpansionSyntax::Zsh(syntax) = &parameter.syntax else {
-                        return None;
-                    };
-                    matches!(syntax.target, ZshExpansionTarget::Nested(_))
-                        .then_some(syntax.operation.as_ref())
-                        .flatten()
-                        .map(|_| parameter.span)
-                })
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|fact| word_nested_zsh_substitution_spans(fact.word()))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || NestedZshSubstitution);

--- a/crates/shuck-linter/src/rules/portability/zsh_flag_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_flag_expansion.rs
@@ -1,7 +1,5 @@
-use shuck_ast::{ParameterExpansionSyntax, WordPart, ZshExpansionTarget};
-
 use super::targets_non_zsh_shell;
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, Violation, word_zsh_flag_modifier_spans};
 
 pub struct ZshFlagExpansion;
 
@@ -24,32 +22,7 @@ pub fn zsh_flag_expansion(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| {
-            fact.word()
-                .parts
-                .iter()
-                .filter_map(|part| {
-                    let WordPart::Parameter(parameter) = &part.kind else {
-                        return None;
-                    };
-                    let ParameterExpansionSyntax::Zsh(syntax) = &parameter.syntax else {
-                        return None;
-                    };
-                    if syntax.modifiers.is_empty() {
-                        return None;
-                    }
-
-                    match syntax.target {
-                        ZshExpansionTarget::Reference(_) | ZshExpansionTarget::Word(_) => {}
-                        ZshExpansionTarget::Nested(_) | ZshExpansionTarget::Empty => {
-                            return None;
-                        }
-                    }
-
-                    syntax.modifiers.first().map(|modifier| modifier.span)
-                })
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|fact| word_zsh_flag_modifier_spans(fact.word()))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ZshFlagExpansion);

--- a/crates/shuck-linter/src/rules/portability/zsh_nested_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_nested_expansion.rs
@@ -1,7 +1,5 @@
-use shuck_ast::{ParameterExpansionSyntax, WordPart, ZshExpansionTarget};
-
 use super::targets_non_zsh_shell;
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, Violation, word_zsh_nested_expansion_spans};
 
 pub struct ZshNestedExpansion;
 
@@ -24,24 +22,7 @@ pub fn zsh_nested_expansion(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| {
-            fact.word()
-                .parts
-                .iter()
-                .filter_map(|part| {
-                    let WordPart::Parameter(parameter) = &part.kind else {
-                        return None;
-                    };
-                    let ParameterExpansionSyntax::Zsh(syntax) = &parameter.syntax else {
-                        return None;
-                    };
-                    matches!(syntax.target, ZshExpansionTarget::Nested(_))
-                        .then_some(syntax.operation.is_none())
-                        .filter(|is_none| *is_none)
-                        .map(|_| parameter.span)
-                })
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|fact| word_zsh_nested_expansion_spans(fact.word()))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ZshNestedExpansion);

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -43,8 +43,7 @@ pub fn escaped_underscore(checker: &mut Checker) {
         .flat_map(|fact| {
             word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
                 .into_iter()
-                .map(|span| needless_backslash_spans(span, source))
-                .flatten()
+                .flat_map(|span| needless_backslash_spans(span, source))
                 .collect::<Vec<_>>()
         })
         .chain(

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -1,7 +1,11 @@
-use shuck_ast::{Command, Span, WordPart, WordPartNode};
+use shuck_ast::Span;
 
 use crate::context::FileContextTag;
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{
+    Checker, ExpansionContext, Rule, Violation,
+    word_literal_part_spans_excluding_parameter_operator_tails,
+    word_literal_scan_segments_excluding_expansions,
+};
 
 pub struct EscapedUnderscore;
 
@@ -37,23 +41,9 @@ pub fn escaped_underscore(checker: &mut Checker) {
             )
         })
         .flat_map(|fact| {
-            fact.word()
-                .parts
-                .iter()
-                .enumerate()
-                .filter_map(|(index, part)| match &part.kind {
-                    WordPart::Literal(_)
-                        if !literal_part_is_parameter_operator_tail(
-                            &fact.word().parts,
-                            index,
-                            source,
-                        ) =>
-                    {
-                        Some(needless_backslash_spans(part.span, source))
-                    }
-                    WordPart::Literal(_) => None,
-                    _ => None,
-                })
+            word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
+                .into_iter()
+                .map(|span| needless_backslash_spans(span, source))
                 .flatten()
                 .collect::<Vec<_>>()
         })
@@ -84,11 +74,11 @@ pub fn escaped_underscore(checker: &mut Checker) {
             facts
                 .commands()
                 .iter()
-                .filter_map(|command| match command.command() {
-                    Command::Simple(simple) if simple.name.span.slice(source).contains('/') => {
-                        Some(needless_backslash_spans(simple.name.span, source))
-                    }
-                    _ => None,
+                .filter_map(|command| {
+                    command
+                        .body_name_word()
+                        .filter(|word| word.span.slice(source).contains('/'))
+                        .map(|word| needless_backslash_spans(word.span, source))
                 })
                 .flatten(),
         )
@@ -141,67 +131,10 @@ fn redirect_target_needless_backslash_spans(
     fact: &crate::facts::WordFact<'_>,
     source: &str,
 ) -> Vec<Span> {
-    let mut excluded = Vec::new();
-    collect_redirect_target_excluded_spans(fact.word().parts.as_slice(), &mut excluded);
-    scan_span_excluding(fact.span(), &excluded, source)
-}
-
-fn collect_redirect_target_excluded_spans(parts: &[WordPartNode], excluded: &mut Vec<Span>) {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(_) => {}
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_redirect_target_excluded_spans(parts, excluded);
-            }
-            WordPart::CommandSubstitution { .. }
-            | WordPart::ProcessSubstitution { .. }
-            | WordPart::SingleQuoted { .. }
-            | WordPart::Variable(_)
-            | WordPart::ArithmeticExpansion { .. }
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::ArrayAccess(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::ArrayIndices(_)
-            | WordPart::Substring { .. }
-            | WordPart::ArraySlice { .. }
-            | WordPart::IndirectExpansion { .. }
-            | WordPart::PrefixMatch { .. }
-            | WordPart::Transformation { .. }
-            | WordPart::ZshQualifiedGlob(_) => excluded.push(part.span),
-        }
-    }
-}
-
-fn scan_span_excluding(span: Span, excluded: &[Span], source: &str) -> Vec<Span> {
-    if excluded.is_empty() {
-        return needless_backslash_spans(span, source);
-    }
-
-    let mut spans = Vec::new();
-    let mut cursor = span.start.offset;
-    for excluded_span in excluded.iter().copied().filter(|excluded_span| {
-        excluded_span.end.offset > span.start.offset && excluded_span.start.offset < span.end.offset
-    }) {
-        let segment_end = excluded_span.start.offset.min(span.end.offset);
-        if cursor < segment_end {
-            spans.extend(scan_span_segment(span, cursor, segment_end, source));
-        }
-        cursor = cursor.max(excluded_span.end.offset).min(span.end.offset);
-    }
-
-    if cursor < span.end.offset {
-        spans.extend(scan_span_segment(span, cursor, span.end.offset, source));
-    }
-
-    spans
-}
-
-fn scan_span_segment(span: Span, start: usize, end: usize, source: &str) -> Vec<Span> {
-    let segment_start = span.start.advanced_by(&source[span.start.offset..start]);
-    let segment_end = span.start.advanced_by(&source[span.start.offset..end]);
-    needless_backslash_spans(Span::from_positions(segment_start, segment_end), source)
+    word_literal_scan_segments_excluding_expansions(fact.word(), source)
+        .into_iter()
+        .flat_map(|span| needless_backslash_spans(span, source))
+        .collect()
 }
 
 fn is_grep_style_argument<'a>(
@@ -223,27 +156,6 @@ fn is_grep_style_argument<'a>(
     command
         .effective_or_literal_name()
         .is_some_and(|name| name.contains("grep"))
-}
-
-fn literal_part_is_parameter_operator_tail(
-    parts: &[WordPartNode],
-    index: usize,
-    source: &str,
-) -> bool {
-    let Some(previous) = index.checked_sub(1).and_then(|index| parts.get(index)) else {
-        return false;
-    };
-    if !matches!(
-        previous.kind,
-        WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::IndirectExpansion { .. }
-    ) {
-        return false;
-    }
-
-    let text = parts[index].span.slice(source);
-    text.ends_with('}') && (text.starts_with('/') || text.starts_with('%') || text.starts_with('#'))
 }
 
 fn needless_backslash_spans(word_span: Span, source: &str) -> Vec<Span> {

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -75,9 +75,9 @@ pub fn escaped_underscore(checker: &mut Checker) {
                 .iter()
                 .filter_map(|command| {
                     command
-                        .body_name_word()
-                        .filter(|word| word.span.slice(source).contains('/'))
-                        .map(|word| needless_backslash_spans(word.span, source))
+                        .body_word_span()
+                        .filter(|span| span.slice(source).contains('/'))
+                        .map(|span| needless_backslash_spans(span, source))
                 })
                 .flatten(),
         )
@@ -329,5 +329,16 @@ done < <(sed -e \"s/^$/\\xFF/g\" \"${BOOTSTRAP_TMPDIR}/packages.${architecture}\
         let diagnostics = test_posix_snippet_at_path(Path::new("/tmp/nested-redirects"), source);
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_dynamic_path_like_command_names() {
+        let source = "\
+#!/bin/bash
+${bindir}/foo\\_bar
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
+
+        assert_eq!(diagnostics.len(), 1);
     }
 }

--- a/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
@@ -43,8 +43,7 @@ pub fn escaped_underscore_literal(checker: &mut Checker) {
         .flat_map(|fact| {
             word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
                 .into_iter()
-                .map(|span| needless_backslash_spans(span, source))
-                .flatten()
+                .flat_map(|span| needless_backslash_spans(span, source))
                 .collect::<Vec<_>>()
         })
         .chain(

--- a/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
@@ -75,9 +75,9 @@ pub fn escaped_underscore_literal(checker: &mut Checker) {
                 .iter()
                 .filter_map(|command| {
                     command
-                        .body_name_word()
-                        .filter(|word| word.span.slice(source).contains('/'))
-                        .map(|word| needless_backslash_spans(word.span, source))
+                        .body_word_span()
+                        .filter(|span| span.slice(source).contains('/'))
+                        .map(|span| needless_backslash_spans(span, source))
                 })
                 .flatten(),
         )
@@ -283,5 +283,19 @@ base64 -d ${vkb64} > ${rootfs}/var/db/xbps/keys/60\\:ae\\:0c\\:d6\\:f0\\:95\\:17
         let diagnostics = test_posix_snippet_at_path(Path::new("/tmp/lxc-void"), source);
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_dynamic_path_like_command_names() {
+        let source = "\
+#!/bin/bash
+${bindir}/foo\\_bar
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::EscapedUnderscoreLiteral),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
     }
 }

--- a/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
@@ -1,7 +1,11 @@
-use shuck_ast::{Command, Span, WordPart, WordPartNode};
+use shuck_ast::Span;
 
 use crate::context::FileContextTag;
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{
+    Checker, ExpansionContext, Rule, Violation,
+    word_literal_part_spans_excluding_parameter_operator_tails,
+    word_literal_scan_segments_excluding_expansions,
+};
 
 pub struct EscapedUnderscoreLiteral;
 
@@ -37,23 +41,9 @@ pub fn escaped_underscore_literal(checker: &mut Checker) {
             )
         })
         .flat_map(|fact| {
-            fact.word()
-                .parts
-                .iter()
-                .enumerate()
-                .filter_map(|(index, part)| match &part.kind {
-                    WordPart::Literal(_)
-                        if !literal_part_is_parameter_operator_tail(
-                            &fact.word().parts,
-                            index,
-                            source,
-                        ) =>
-                    {
-                        Some(needless_backslash_spans(part.span, source))
-                    }
-                    WordPart::Literal(_) => None,
-                    _ => None,
-                })
+            word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
+                .into_iter()
+                .map(|span| needless_backslash_spans(span, source))
                 .flatten()
                 .collect::<Vec<_>>()
         })
@@ -84,11 +74,11 @@ pub fn escaped_underscore_literal(checker: &mut Checker) {
             facts
                 .commands()
                 .iter()
-                .filter_map(|command| match command.command() {
-                    Command::Simple(simple) if simple.name.span.slice(source).contains('/') => {
-                        Some(needless_backslash_spans(simple.name.span, source))
-                    }
-                    _ => None,
+                .filter_map(|command| {
+                    command
+                        .body_name_word()
+                        .filter(|word| word.span.slice(source).contains('/'))
+                        .map(|word| needless_backslash_spans(word.span, source))
                 })
                 .flatten(),
         )
@@ -141,67 +131,10 @@ fn redirect_target_needless_backslash_spans(
     fact: &crate::facts::WordFact<'_>,
     source: &str,
 ) -> Vec<Span> {
-    let mut excluded = Vec::new();
-    collect_redirect_target_excluded_spans(fact.word().parts.as_slice(), &mut excluded);
-    scan_span_excluding(fact.span(), &excluded, source)
-}
-
-fn collect_redirect_target_excluded_spans(parts: &[WordPartNode], excluded: &mut Vec<Span>) {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(_) => {}
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_redirect_target_excluded_spans(parts, excluded);
-            }
-            WordPart::CommandSubstitution { .. }
-            | WordPart::ProcessSubstitution { .. }
-            | WordPart::SingleQuoted { .. }
-            | WordPart::Variable(_)
-            | WordPart::ArithmeticExpansion { .. }
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::ArrayAccess(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::ArrayIndices(_)
-            | WordPart::Substring { .. }
-            | WordPart::ArraySlice { .. }
-            | WordPart::IndirectExpansion { .. }
-            | WordPart::PrefixMatch { .. }
-            | WordPart::Transformation { .. }
-            | WordPart::ZshQualifiedGlob(_) => excluded.push(part.span),
-        }
-    }
-}
-
-fn scan_span_excluding(span: Span, excluded: &[Span], source: &str) -> Vec<Span> {
-    if excluded.is_empty() {
-        return needless_backslash_spans(span, source);
-    }
-
-    let mut spans = Vec::new();
-    let mut cursor = span.start.offset;
-    for excluded_span in excluded.iter().copied().filter(|excluded_span| {
-        excluded_span.end.offset > span.start.offset && excluded_span.start.offset < span.end.offset
-    }) {
-        let segment_end = excluded_span.start.offset.min(span.end.offset);
-        if cursor < segment_end {
-            spans.extend(scan_span_segment(span, cursor, segment_end, source));
-        }
-        cursor = cursor.max(excluded_span.end.offset).min(span.end.offset);
-    }
-
-    if cursor < span.end.offset {
-        spans.extend(scan_span_segment(span, cursor, span.end.offset, source));
-    }
-
-    spans
-}
-
-fn scan_span_segment(span: Span, start: usize, end: usize, source: &str) -> Vec<Span> {
-    let segment_start = span.start.advanced_by(&source[span.start.offset..start]);
-    let segment_end = span.start.advanced_by(&source[span.start.offset..end]);
-    needless_backslash_spans(Span::from_positions(segment_start, segment_end), source)
+    word_literal_scan_segments_excluding_expansions(fact.word(), source)
+        .into_iter()
+        .flat_map(|span| needless_backslash_spans(span, source))
+        .collect()
 }
 
 fn is_grep_style_argument<'a>(
@@ -223,27 +156,6 @@ fn is_grep_style_argument<'a>(
     command
         .effective_or_literal_name()
         .is_some_and(|name| name.contains("grep"))
-}
-
-fn literal_part_is_parameter_operator_tail(
-    parts: &[WordPartNode],
-    index: usize,
-    source: &str,
-) -> bool {
-    let Some(previous) = index.checked_sub(1).and_then(|index| parts.get(index)) else {
-        return false;
-    };
-    if !matches!(
-        previous.kind,
-        WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::IndirectExpansion { .. }
-    ) {
-        return false;
-    }
-
-    let text = parts[index].span.slice(source);
-    text.ends_with('}') && (text.starts_with('/') || text.starts_with('%') || text.starts_with('#'))
 }
 
 fn needless_backslash_spans(word_span: Span, source: &str) -> Vec<Span> {

--- a/crates/shuck-linter/src/rules/style/literal_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash.rs
@@ -1,6 +1,4 @@
-use shuck_ast::{Span, Word, WordPart};
-
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{Checker, ExpansionContext, Rule, Violation, word_standalone_literal_backslash_span};
 
 pub struct LiteralBackslash;
 
@@ -25,7 +23,7 @@ pub fn literal_backslash(checker: &mut Checker) {
         .filter(|fact| !fact.is_nested_word_command())
         .filter(|fact| !is_command_name_word(facts, fact))
         .filter(|fact| !is_unalias_argument(facts, fact))
-        .filter_map(|fact| standalone_literal_backslash_span(fact.word(), source))
+        .filter_map(|fact| word_standalone_literal_backslash_span(fact.word(), source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || LiteralBackslash);
@@ -40,28 +38,6 @@ fn is_relevant_word_context(context: Option<ExpansionContext>) -> bool {
                 | ExpansionContext::SelectList
         )
     )
-}
-
-fn standalone_literal_backslash_span(word: &Word, source: &str) -> Option<Span> {
-    let [part] = word.parts.as_slice() else {
-        return None;
-    };
-    if !matches!(part.kind, WordPart::Literal(_)) {
-        return None;
-    }
-
-    let text = word.span.slice(source);
-    let bytes = text.as_bytes();
-    if bytes.len() != 2 || bytes[0] != b'\\' {
-        return None;
-    }
-
-    let target = bytes[1];
-    if !target.is_ascii_lowercase() || matches!(target, b'n' | b'r' | b't') {
-        return None;
-    }
-
-    Some(Span::from_positions(word.span.start, word.span.start))
 }
 
 fn is_command_name_word<'a>(

--- a/crates/shuck-linter/src/rules/style/needless_backslash_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/needless_backslash_underscore.rs
@@ -104,9 +104,9 @@ pub fn needless_backslash_underscore(checker: &mut Checker) {
                 .iter()
                 .filter_map(|command| {
                     command
-                        .body_name_word()
-                        .filter(|word| word.span.slice(source).contains('/'))
-                        .map(|word| needless_backslash_spans(word.span, source))
+                        .body_word_span()
+                        .filter(|span| span.slice(source).contains('/'))
+                        .map(|span| needless_backslash_spans(span, source))
                 })
                 .flatten(),
         )
@@ -309,5 +309,19 @@ fi
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_dynamic_path_like_command_names() {
+        let source = "\
+#!/bin/bash
+${bindir}/foo\\nbar
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::NeedlessBackslashUnderscore),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
     }
 }

--- a/crates/shuck-linter/src/rules/style/needless_backslash_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/needless_backslash_underscore.rs
@@ -1,7 +1,11 @@
-use shuck_ast::{Command, Span, WordPart, WordPartNode};
+use shuck_ast::Span;
 
 use crate::context::FileContextTag;
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{
+    Checker, ExpansionContext, Rule, Violation, word_has_single_literal_part,
+    word_literal_part_spans_excluding_parameter_operator_tails,
+    word_literal_scan_segments_excluding_expansions,
+};
 
 pub struct NeedlessBackslashUnderscore;
 
@@ -38,23 +42,9 @@ pub fn needless_backslash_underscore(checker: &mut Checker) {
             )
         })
         .flat_map(|fact| {
-            fact.word()
-                .parts
-                .iter()
-                .enumerate()
-                .filter_map(|(index, part)| match &part.kind {
-                    WordPart::Literal(_)
-                        if !literal_part_is_parameter_operator_tail(
-                            &fact.word().parts,
-                            index,
-                            source,
-                        ) =>
-                    {
-                        Some(needless_backslash_spans(part.span, source))
-                    }
-                    WordPart::Literal(_) => None,
-                    _ => None,
-                })
+            word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
+                .into_iter()
+                .map(|span| needless_backslash_spans(span, source))
                 .flatten()
                 .collect::<Vec<_>>()
         })
@@ -72,12 +62,7 @@ pub fn needless_backslash_underscore(checker: &mut Checker) {
                         )
                     )
                 })
-                .filter(|fact| {
-                    matches!(
-                        fact.word().parts.as_slice(),
-                        [part] if matches!(part.kind, WordPart::Literal(_))
-                    )
-                })
+                .filter(|fact| word_has_single_literal_part(fact.word()))
                 .filter(|fact| {
                     !word_contains_single_quoted_fragment(fact.span(), single_quoted_fragments)
                 })
@@ -118,11 +103,11 @@ pub fn needless_backslash_underscore(checker: &mut Checker) {
             facts
                 .commands()
                 .iter()
-                .filter_map(|command| match command.command() {
-                    Command::Simple(simple) if simple.name.span.slice(source).contains('/') => {
-                        Some(needless_backslash_spans(simple.name.span, source))
-                    }
-                    _ => None,
+                .filter_map(|command| {
+                    command
+                        .body_name_word()
+                        .filter(|word| word.span.slice(source).contains('/'))
+                        .map(|word| needless_backslash_spans(word.span, source))
                 })
                 .flatten(),
         )
@@ -187,67 +172,10 @@ fn redirect_target_needless_backslash_spans(
     fact: &crate::facts::WordFact<'_>,
     source: &str,
 ) -> Vec<Span> {
-    let mut excluded = Vec::new();
-    collect_redirect_target_excluded_spans(fact.word().parts.as_slice(), &mut excluded);
-    scan_span_excluding(fact.span(), &excluded, source)
-}
-
-fn collect_redirect_target_excluded_spans(parts: &[WordPartNode], excluded: &mut Vec<Span>) {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(_) => {}
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_redirect_target_excluded_spans(parts, excluded);
-            }
-            WordPart::CommandSubstitution { .. }
-            | WordPart::ProcessSubstitution { .. }
-            | WordPart::SingleQuoted { .. }
-            | WordPart::Variable(_)
-            | WordPart::ArithmeticExpansion { .. }
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::ArrayAccess(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::ArrayIndices(_)
-            | WordPart::Substring { .. }
-            | WordPart::ArraySlice { .. }
-            | WordPart::IndirectExpansion { .. }
-            | WordPart::PrefixMatch { .. }
-            | WordPart::Transformation { .. }
-            | WordPart::ZshQualifiedGlob(_) => excluded.push(part.span),
-        }
-    }
-}
-
-fn scan_span_excluding(span: Span, excluded: &[Span], source: &str) -> Vec<Span> {
-    if excluded.is_empty() {
-        return needless_backslash_spans(span, source);
-    }
-
-    let mut spans = Vec::new();
-    let mut cursor = span.start.offset;
-    for excluded_span in excluded.iter().copied().filter(|excluded_span| {
-        excluded_span.end.offset > span.start.offset && excluded_span.start.offset < span.end.offset
-    }) {
-        let segment_end = excluded_span.start.offset.min(span.end.offset);
-        if cursor < segment_end {
-            spans.extend(scan_span_segment(span, cursor, segment_end, source));
-        }
-        cursor = cursor.max(excluded_span.end.offset).min(span.end.offset);
-    }
-
-    if cursor < span.end.offset {
-        spans.extend(scan_span_segment(span, cursor, span.end.offset, source));
-    }
-
-    spans
-}
-
-fn scan_span_segment(span: Span, start: usize, end: usize, source: &str) -> Vec<Span> {
-    let segment_start = span.start.advanced_by(&source[span.start.offset..start]);
-    let segment_end = span.start.advanced_by(&source[span.start.offset..end]);
-    needless_backslash_spans(Span::from_positions(segment_start, segment_end), source)
+    word_literal_scan_segments_excluding_expansions(fact.word(), source)
+        .into_iter()
+        .flat_map(|span| needless_backslash_spans(span, source))
+        .collect()
 }
 
 fn is_grep_style_argument<'a>(
@@ -269,27 +197,6 @@ fn is_grep_style_argument<'a>(
     command
         .effective_or_literal_name()
         .is_some_and(|name| name.contains("grep"))
-}
-
-fn literal_part_is_parameter_operator_tail(
-    parts: &[WordPartNode],
-    index: usize,
-    source: &str,
-) -> bool {
-    let Some(previous) = index.checked_sub(1).and_then(|index| parts.get(index)) else {
-        return false;
-    };
-    if !matches!(
-        previous.kind,
-        WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::IndirectExpansion { .. }
-    ) {
-        return false;
-    }
-
-    let text = parts[index].span.slice(source);
-    text.ends_with('}') && (text.starts_with('/') || text.starts_with('%') || text.starts_with('#'))
 }
 
 fn needless_backslash_spans(word_span: Span, source: &str) -> Vec<Span> {

--- a/crates/shuck-linter/src/rules/style/needless_backslash_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/needless_backslash_underscore.rs
@@ -44,8 +44,7 @@ pub fn needless_backslash_underscore(checker: &mut Checker) {
         .flat_map(|fact| {
             word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
                 .into_iter()
-                .map(|span| needless_backslash_spans(span, source))
-                .flatten()
+                .flat_map(|span| needless_backslash_spans(span, source))
                 .collect::<Vec<_>>()
         })
         .chain(

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1,8 +1,6 @@
-use shuck_ast::WordPart;
-
 use crate::{
     Checker, ExpansionContext, Rule, SafeValueIndex, SafeValueQuery, ShellDialect, Violation,
-    WordFact,
+    WordFact, word_unquoted_star_parameter_spans,
 };
 
 pub struct UnquotedExpansion;
@@ -63,7 +61,8 @@ fn report_word_expansions(
 ) {
     let scalar_spans = fact.scalar_expansion_spans();
     let array_spans = fact.unquoted_array_expansion_spans();
-    if scalar_spans.is_empty() && !contains_unquoted_star_parameter(fact) {
+    let star_spans = word_unquoted_star_parameter_spans(fact.word(), array_spans);
+    if scalar_spans.is_empty() && star_spans.is_empty() {
         return;
     }
     if context == ExpansionContext::CommandName && !fact.has_literal_affixes() {
@@ -73,8 +72,7 @@ fn report_word_expansions(
         .expect("checked expansion context should map to a safe-value query");
 
     for (part, part_span) in fact.word().parts_with_spans() {
-        let report_unquoted_star = array_spans.contains(&part_span)
-            && matches!(part, WordPart::Variable(name) if name.as_str() == "*");
+        let report_unquoted_star = star_spans.contains(&part_span);
         if !scalar_spans.contains(&part_span) && !report_unquoted_star {
             continue;
         }
@@ -84,13 +82,6 @@ fn report_word_expansions(
 
         spans.push(part_span);
     }
-}
-
-fn contains_unquoted_star_parameter(fact: &WordFact<'_>) -> bool {
-    fact.word().parts_with_spans().any(|(part, span)| {
-        fact.unquoted_array_expansion_spans().contains(&span)
-            && matches!(part, WordPart::Variable(name) if name.as_str() == "*")
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- move the AST-heavy word and conditional span discovery into shared linter helpers and small fact accessors
- refactor the affected rule modules to consume facts and shared helpers instead of traversing AST trees directly
- add an architecture regression test that rejects direct traversal tokens in rule modules

## Why
Recent rule additions had started to mix direct AST walking back into individual rule files. This restores the intended split where shared structural discovery lives in the fact/helper layer and rule files stay focused on policy.

## Impact
This keeps rule implementations more uniform, reduces duplicated traversal logic, and gives us a guardrail so future rules stay on the same fact-driven path.

## Validation
- cargo fmt --all
- cargo test -p shuck-linter