### PR TITLE
Move formatter dialect selection to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ Create a `.shuck.toml` or `shuck.toml` at your project root:
 
 ```toml
 [format]
-dialect = "bash"           # auto | bash | posix | mksh | zsh
 indent-style = "space"     # tab | space
 indent-width = 4           # 1-255, used when indent-style = "space"
 binary-next-line = false   # place binary operators on the next line
@@ -168,6 +167,8 @@ keep-padding = false       # preserve original source padding
 function-next-line = false # opening brace on its own line
 never-split = false        # compact single-line layouts
 ```
+
+Formatter dialect is auto-discovered from the filename or shebang. Use `shuck format --dialect <shell>` when you need an explicit override, especially for stdin input.
 
 ## File discovery
 

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -114,7 +114,7 @@ pub struct FormatCommand {
     /// Omit files or directories matching the provided glob patterns.
     #[arg(long, value_delimiter = ',', value_name = "GLOB")]
     pub exclude: Vec<String>,
-    /// Select the shell dialect used for parsing and formatting.
+    /// Override the auto-discovered shell dialect used for parsing and formatting.
     #[arg(long, value_enum)]
     pub dialect: Option<FormatDialectArg>,
     /// Choose the indentation style.

--- a/crates/shuck/src/config.rs
+++ b/crates/shuck/src/config.rs
@@ -2,15 +2,14 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use serde::Deserialize;
 
 use crate::discover::normalize_path;
-use crate::format_settings::{
-    FormatSettingsPatch, parse_config_dialect, parse_config_indent_style,
-};
+use crate::format_settings::{FormatSettingsPatch, parse_config_indent_style};
 
 const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
+pub(crate) const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
@@ -21,7 +20,7 @@ pub(crate) struct ShuckConfig {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub(crate) struct FormatConfig {
-    pub dialect: Option<String>,
+    pub dialect: Option<toml::Value>,
     pub indent_style: Option<String>,
     pub indent_width: Option<u8>,
     pub binary_next_line: Option<bool>,
@@ -60,12 +59,12 @@ pub(crate) fn load_project_config(project_root: &Path) -> Result<ShuckConfig> {
 
 impl FormatConfig {
     pub(crate) fn to_patch(&self) -> Result<FormatSettingsPatch> {
+        if self.dialect.is_some() {
+            return Err(anyhow!(CONFIG_DIALECT_UNSUPPORTED_ERROR));
+        }
+
         Ok(FormatSettingsPatch {
-            dialect: self
-                .dialect
-                .as_deref()
-                .map(parse_config_dialect)
-                .transpose()?,
+            dialect: None,
             indent_style: self
                 .indent_style
                 .as_deref()

--- a/crates/shuck/src/format_settings.rs
+++ b/crates/shuck/src/format_settings.rs
@@ -109,19 +109,6 @@ pub(crate) fn resolve_project_format_settings(
     Ok(settings)
 }
 
-pub(crate) fn parse_config_dialect(value: &str) -> Result<ShellDialect> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "auto" => Ok(ShellDialect::Auto),
-        "bash" => Ok(ShellDialect::Bash),
-        "posix" => Ok(ShellDialect::Posix),
-        "mksh" => Ok(ShellDialect::Mksh),
-        "zsh" => Ok(ShellDialect::Zsh),
-        _ => Err(anyhow!(
-            "unsupported `[format].dialect` value `{value}`; expected one of: auto, bash, posix, mksh, zsh"
-        )),
-    }
-}
-
 pub(crate) fn parse_config_indent_style(value: &str) -> Result<IndentStyle> {
     match value.trim().to_ascii_lowercase().as_str() {
         "tab" => Ok(IndentStyle::Tab),
@@ -158,7 +145,7 @@ mod tests {
 
     use super::*;
     use crate::args::FormatCommand;
-    use crate::config::FormatConfig;
+    use crate::config::{CONFIG_DIALECT_UNSUPPORTED_ERROR, FormatConfig};
 
     fn format_args() -> FormatCommand {
         FormatCommand {
@@ -204,7 +191,6 @@ mod tests {
     #[test]
     fn config_patch_overrides_defaults() {
         let config = FormatConfig {
-            dialect: Some("mksh".to_owned()),
             indent_style: Some("space".to_owned()),
             indent_width: Some(2),
             binary_next_line: Some(true),
@@ -213,6 +199,7 @@ mod tests {
             keep_padding: Some(true),
             function_next_line: Some(true),
             never_split: Some(true),
+            ..FormatConfig::default()
         };
 
         let mut settings = ResolvedFormatSettings::default();
@@ -221,7 +208,7 @@ mod tests {
             .unwrap();
         let options = settings.to_shell_format_options();
 
-        assert_eq!(options.dialect(), ShellDialect::Mksh);
+        assert_eq!(options.dialect(), ShellDialect::Auto);
         assert_eq!(options.indent_style(), IndentStyle::Space);
         assert_eq!(options.indent_width(), 2);
         assert!(options.binary_next_line());
@@ -251,6 +238,17 @@ mod tests {
 
         assert!(options.function_next_line());
         assert_eq!(options.indent_width(), 4);
+    }
+
+    #[test]
+    fn configured_dialect_errors_with_migration_hint() {
+        let config = FormatConfig {
+            dialect: Some(toml::Value::String("zsh".to_owned())),
+            ..FormatConfig::default()
+        };
+
+        let err = config.to_patch().unwrap_err();
+        assert_eq!(err.to_string(), CONFIG_DIALECT_UNSUPPORTED_ERROR);
     }
 
     #[test]

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -382,7 +382,7 @@ fn format_stdin_filename_infers_zsh_dialect() {
 }
 
 #[test]
-fn format_stdin_uses_configured_zsh_dialect() {
+fn format_stdin_rejects_configured_dialect() {
     let tempdir = tempdir().unwrap();
     fs::write(
         tempdir.path().join("shuck.toml"),
@@ -393,6 +393,17 @@ fn format_stdin_uses_configured_zsh_dialect() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.current_dir(tempdir.path())
         .args(["format", "-"])
+        .write_stdin("print ${(m)foo}\n");
+    cmd.assert()
+        .code(2)
+        .stderr(predicate::str::contains("[format].dialect"))
+        .stderr(predicate::str::contains("--dialect"));
+}
+
+#[test]
+fn format_stdin_uses_cli_zsh_dialect_override() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.args(["format", "--dialect", "zsh", "-"])
         .write_stdin("print ${(m)foo}\n");
     cmd.assert().success().stdout("print ${(m)foo}\n");
 }

--- a/specs/009-formatter.md
+++ b/specs/009-formatter.md
@@ -8,7 +8,7 @@ Partially Implemented
 
 A shell script formatter built on a generic document/printer abstraction, following ruff's formatter architecture. The system is split across three crates: `shuck-format` (language-agnostic document IR and printer), `shuck-formatter` (shell-specific formatting rules, comment handling, and an optional simplify pass), and `shuck` (CLI integration, config, and caching). The formatter parses shell source into an AST, converts AST nodes into a document IR of text, line breaks, indentation, and groups, then prints the IR back to source text respecting user-chosen options like indent style, dialect, and layout preferences.
 
-The formatter supports Bash, POSIX, and mksh dialects with auto-inference from shebangs and file extensions. It exposes 11 formatting options through CLI flags and `[format]` config sections. An optional simplify pass applies safe AST rewrites before formatting, and a minify mode produces compact output without comments.
+The formatter supports Bash, POSIX, and mksh dialects with auto-inference from shebangs and file extensions. It exposes formatting layout options through CLI flags and `[format]` config sections, while `--dialect` remains a CLI-only override. An optional simplify pass applies safe AST rewrites before formatting, and a minify mode produces compact output without comments.
 
 ## Motivation
 
@@ -281,6 +281,8 @@ shuck format-stdin [OPTIONS] [--stdin-filename <NAME>]
 1. CLI flags (`--indent-style space`)
 2. `[format]` section in the nearest `.shuck.toml` / `shuck.toml`
 3. Built-in defaults
+
+Dialect stays on auto-inference unless the user passes `--dialect` on the CLI.
 
 **Caching:** Formatted results are cached via `shuck-cache` (SHA-256 keyed by file content, mtime, permissions, and formatting options). The `--no-cache` flag bypasses caching. Formatting options are part of the cache key, so changing options invalidates cached results.
 

--- a/specs/010-zsh.md
+++ b/specs/010-zsh.md
@@ -90,7 +90,7 @@ The workspace then resolves and threads the dialect consistently:
 
 - `shuck check` must parse with the inferred shell dialect instead of always calling `Parser::new(...)`.
 - `shuck-formatter::ShellDialect` gains `Zsh`.
-- `[format].dialect = "zsh"` and `--dialect zsh` become valid formatter inputs.
+- `--dialect zsh` becomes the explicit formatter override, while config continues to rely on autodiscovery.
 - Any parser-adjacent helpers that currently collapse `zsh` into Bash defaults must be updated to preserve `Zsh`.
 
 This is intentionally end-to-end even though the parser work is the core of the feature. A parser dialect that cannot be selected from the CLI or formatter is not operationally useful.


### PR DESCRIPTION
## Summary
- reject `[format].dialect` in project config and point users to `--dialect`
- keep formatter dialect autodiscovery as the default path and clarify the CLI help and docs
- replace config-based stdin zsh coverage with tests for the config rejection path and the CLI override path

## Why
The formatter already auto-discovers dialect from the filename or shebang, so keeping a config-level dialect knob makes the configuration more confusing than helpful. Explicit dialect selection still makes sense for one-off CLI runs, especially for stdin.

## Validation
- cargo fmt
- cargo test -p shuck format_settings::tests
- cargo test -p shuck format_stdin_
