### PR TITLE
Refactor conditional portability facts and document rule vetting

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -8,6 +8,7 @@
 //! facts.
 
 mod command_flow;
+mod conditional_portability;
 mod presence;
 mod surface;
 
@@ -33,6 +34,7 @@ use self::{
         build_select_header_facts, build_single_test_subshell_spans,
         build_subshell_test_group_spans, build_substitution_facts,
     },
+    conditional_portability::build_conditional_portability_facts,
     presence::build_presence_tested_names,
     surface::{
         SurfaceFragmentFacts, build_subscript_index_reference_spans, build_surface_fragment_facts,
@@ -54,6 +56,8 @@ use crate::rules::common::{
         classify_contextual_operand, classify_word, static_word_text,
     },
 };
+
+pub use self::conditional_portability::ConditionalPortabilityFacts;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FactSpan {
@@ -1477,6 +1481,7 @@ pub struct LinterFacts<'a> {
     substring_expansion_fragments: Vec<SubstringExpansionFragmentFact>,
     case_modification_fragments: Vec<CaseModificationFragmentFact>,
     replacement_expansion_fragments: Vec<ReplacementExpansionFragmentFact>,
+    conditional_portability: ConditionalPortabilityFacts,
 }
 
 impl<'a> LinterFacts<'a> {
@@ -1689,6 +1694,10 @@ impl<'a> LinterFacts<'a> {
     pub fn replacement_expansion_fragments(&self) -> &[ReplacementExpansionFragmentFact] {
         &self.replacement_expansion_fragments
     }
+
+    pub fn conditional_portability(&self) -> &ConditionalPortabilityFacts {
+        &self.conditional_portability
+    }
 }
 
 struct LinterFactsBuilder<'a> {
@@ -1836,6 +1845,15 @@ impl<'a> LinterFactsBuilder<'a> {
             .into_iter()
             .map(FactSpan::new)
             .collect();
+        let conditional_portability = build_conditional_portability_facts(
+            &commands,
+            &elif_condition_command_ids,
+            &words,
+            &pattern_exactly_one_extglob_spans,
+            &pattern_charclass_spans,
+            &nested_pattern_charclass_spans,
+            self.source,
+        );
         let mut word_index = FxHashMap::<FactSpan, Vec<usize>>::default();
         for (index, fact) in words.iter().enumerate() {
             word_index.entry(fact.key()).or_default().push(index);
@@ -1881,6 +1899,7 @@ impl<'a> LinterFactsBuilder<'a> {
             substring_expansion_fragments: substring_expansions,
             case_modification_fragments: case_modifications,
             replacement_expansion_fragments: replacement_expansions,
+            conditional_portability,
         }
     }
 }
@@ -5682,6 +5701,175 @@ for version ($versions); do :; done
                     .quote()
                     .is_some_and(|quote| quote != crate::rules::common::word::WordQuote::Unquoted)
             );
+        });
+    }
+
+    #[test]
+    fn builds_conditional_portability_fact_buckets_from_shared_command_scans() {
+        let source = "\
+#!/bin/bash
+if test left == right; then
+  :
+elif [[ $x == y ]]; then
+  :
+fi
+[ left == right ]
+[[ $OSTYPE == *@(linux|freebsd)* ]]
+[ \"$x\" = @(foo|bar) ]
+[[ $words[2] = */ ]]
+[ $tools[kops] ]
+[[ $x > y ]]
+[[ $x =~ y ]]
+[[ -v assoc[$key] ]]
+[[ -a file ]]
+[[ -o noclobber ]]
+[ -k \"$file\" ]
+test -O \"$file\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let portability = facts.conditional_portability();
+
+            assert_eq!(portability.double_bracket_in_sh().len(), 8);
+            assert_eq!(
+                portability
+                    .if_elif_bash_test()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["[[ $x == y ]]"]
+            );
+            assert_eq!(
+                portability
+                    .test_equality_operator()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["test left == right", "==", "==", "=="]
+            );
+            assert_eq!(
+                portability
+                    .extended_glob_in_test()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["@(linux|freebsd)"]
+            );
+            assert_eq!(
+                portability
+                    .extglob_in_test()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["@(foo|bar)"]
+            );
+            assert_eq!(
+                portability
+                    .array_subscript_test()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["$tools[kops]"]
+            );
+            assert_eq!(
+                portability
+                    .array_subscript_condition()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["$words[2]", "assoc[$key]"]
+            );
+            assert_eq!(
+                portability
+                    .greater_than_in_double_bracket()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec![">"]
+            );
+            assert_eq!(
+                portability
+                    .regex_match_in_sh()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["=~"]
+            );
+            assert_eq!(
+                portability
+                    .v_test_in_sh()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["-v"]
+            );
+            assert_eq!(
+                portability
+                    .a_test_in_sh()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["-a"]
+            );
+            assert_eq!(
+                portability
+                    .option_test_in_sh()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["-o"]
+            );
+            assert_eq!(
+                portability
+                    .sticky_bit_test_in_sh()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["-k"]
+            );
+            assert_eq!(
+                portability
+                    .ownership_test_in_sh()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["test -O \"$file\""]
+            );
+        });
+    }
+
+    #[test]
+    fn builds_conditional_portability_pattern_buckets_from_surface_and_word_sources() {
+        let source = "\
+#!/bin/bash
+echo @(foo|bar)
+case \"$x\" in @(zip|tar)) : ;; esac
+trimmed=${name%@($suffix|zz)}
+echo [^a]*
+trimmed=${value#[^b]*}
+for item in [^c]*; do :; done
+";
+
+        with_facts(source, None, |_, facts| {
+            let extglobs = facts
+                .conditional_portability()
+                .extglob_in_sh()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+            assert!(extglobs.contains(&"@(foo|bar)"));
+            assert!(extglobs.contains(&"@(zip|tar)"));
+            assert!(extglobs.contains(&"@($suffix|zz)"));
+
+            let caret_negations = facts
+                .conditional_portability()
+                .caret_negation_in_bracket()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+            assert!(caret_negations.contains(&"[^a]"));
+            assert!(caret_negations.contains(&"[^b]"));
+            assert!(caret_negations.contains(&"[^c]"));
         });
     }
 

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -1,0 +1,391 @@
+use rustc_hash::FxHashSet;
+use shuck_ast::{ConditionalBinaryOp, ConditionalUnaryOp, Span};
+
+use super::{
+    CommandFact, CommandId, ConditionalFact, ConditionalNodeFact, FactSpan, SimpleTestFact,
+    SimpleTestSyntax, WordFact,
+};
+use crate::rules::common::expansion::ExpansionContext;
+use crate::rules::common::span::{
+    text_looks_like_caret_negated_bracket, word_caret_negated_bracket_spans,
+    word_exactly_one_extglob_span,
+};
+use crate::{
+    conditional_array_subscript_span, conditional_extglob_span, static_word_text,
+    word_array_subscript_span, word_extglob_span,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct ConditionalPortabilityFacts {
+    double_bracket_in_sh: Vec<Span>,
+    test_equality_operator: Vec<Span>,
+    if_elif_bash_test: Vec<Span>,
+    extended_glob_in_test: Vec<Span>,
+    extglob_in_sh: Vec<Span>,
+    caret_negation_in_bracket: Vec<Span>,
+    array_subscript_test: Vec<Span>,
+    array_subscript_condition: Vec<Span>,
+    extglob_in_test: Vec<Span>,
+    greater_than_in_double_bracket: Vec<Span>,
+    regex_match_in_sh: Vec<Span>,
+    v_test_in_sh: Vec<Span>,
+    a_test_in_sh: Vec<Span>,
+    option_test_in_sh: Vec<Span>,
+    sticky_bit_test_in_sh: Vec<Span>,
+    ownership_test_in_sh: Vec<Span>,
+}
+
+impl ConditionalPortabilityFacts {
+    pub fn double_bracket_in_sh(&self) -> &[Span] {
+        &self.double_bracket_in_sh
+    }
+
+    pub fn test_equality_operator(&self) -> &[Span] {
+        &self.test_equality_operator
+    }
+
+    pub fn if_elif_bash_test(&self) -> &[Span] {
+        &self.if_elif_bash_test
+    }
+
+    pub fn extended_glob_in_test(&self) -> &[Span] {
+        &self.extended_glob_in_test
+    }
+
+    pub fn extglob_in_sh(&self) -> &[Span] {
+        &self.extglob_in_sh
+    }
+
+    pub fn caret_negation_in_bracket(&self) -> &[Span] {
+        &self.caret_negation_in_bracket
+    }
+
+    pub fn array_subscript_test(&self) -> &[Span] {
+        &self.array_subscript_test
+    }
+
+    pub fn array_subscript_condition(&self) -> &[Span] {
+        &self.array_subscript_condition
+    }
+
+    pub fn extglob_in_test(&self) -> &[Span] {
+        &self.extglob_in_test
+    }
+
+    pub fn greater_than_in_double_bracket(&self) -> &[Span] {
+        &self.greater_than_in_double_bracket
+    }
+
+    pub fn regex_match_in_sh(&self) -> &[Span] {
+        &self.regex_match_in_sh
+    }
+
+    pub fn v_test_in_sh(&self) -> &[Span] {
+        &self.v_test_in_sh
+    }
+
+    pub fn a_test_in_sh(&self) -> &[Span] {
+        &self.a_test_in_sh
+    }
+
+    pub fn option_test_in_sh(&self) -> &[Span] {
+        &self.option_test_in_sh
+    }
+
+    pub fn sticky_bit_test_in_sh(&self) -> &[Span] {
+        &self.sticky_bit_test_in_sh
+    }
+
+    pub fn ownership_test_in_sh(&self) -> &[Span] {
+        &self.ownership_test_in_sh
+    }
+}
+
+pub(super) fn build_conditional_portability_facts<'a>(
+    commands: &[CommandFact<'a>],
+    elif_condition_command_ids: &FxHashSet<CommandId>,
+    word_facts: &[WordFact<'a>],
+    pattern_exactly_one_extglob_spans: &[Span],
+    pattern_charclass_spans: &[Span],
+    nested_pattern_charclass_spans: &FxHashSet<FactSpan>,
+    source: &str,
+) -> ConditionalPortabilityFacts {
+    let mut facts = ConditionalPortabilityFacts::default();
+
+    for command in commands {
+        if let Some(conditional) = command.conditional() {
+            facts.double_bracket_in_sh.push(command.span());
+
+            if elif_condition_command_ids.contains(&command.id()) {
+                facts.if_elif_bash_test.push(command.span());
+            }
+
+            if let Some(span) = conditional_extglob_span(conditional.expression(), source) {
+                facts.extended_glob_in_test.push(span);
+            }
+
+            if let Some(span) = conditional_array_subscript_span(conditional.expression(), source) {
+                facts.array_subscript_condition.push(span);
+            }
+
+            collect_conditional_portability_spans(conditional, source, &mut facts);
+        }
+
+        if let Some(simple_test) = command.simple_test() {
+            facts.array_subscript_test.extend(
+                simple_test
+                    .operands()
+                    .iter()
+                    .filter_map(|word| word_array_subscript_span(word, source)),
+            );
+            facts.extglob_in_test.extend(
+                simple_test
+                    .operands()
+                    .iter()
+                    .filter_map(|word| word_extglob_span(word, source)),
+            );
+            collect_simple_test_portability_spans(command, simple_test, source, &mut facts);
+        }
+    }
+
+    facts
+        .extglob_in_sh
+        .extend(pattern_exactly_one_extglob_spans.iter().copied());
+
+    facts.caret_negation_in_bracket.extend(
+        pattern_charclass_spans
+            .iter()
+            .filter(|span| !nested_pattern_charclass_spans.contains(&FactSpan::new(**span)))
+            .filter(|span| text_looks_like_caret_negated_bracket(span.slice(source)))
+            .copied(),
+    );
+
+    for fact in word_facts {
+        if supports_extglob_portability_context(fact.expansion_context()) {
+            if let Some(span) = word_exactly_one_extglob_span(fact.word(), source) {
+                facts.extglob_in_sh.push(span);
+            }
+        }
+
+        if supports_bracket_glob_portability_context(fact.expansion_context()) {
+            facts
+                .caret_negation_in_bracket
+                .extend(word_caret_negated_bracket_spans(fact.word(), source));
+        }
+    }
+
+    facts
+}
+
+fn collect_conditional_portability_spans(
+    conditional: &ConditionalFact<'_>,
+    source: &str,
+    facts: &mut ConditionalPortabilityFacts,
+) {
+    for node in conditional.nodes() {
+        match node {
+            ConditionalNodeFact::Binary(binary) => match binary.op() {
+                ConditionalBinaryOp::PatternEq => {
+                    facts.test_equality_operator.push(binary.operator_span());
+                }
+                ConditionalBinaryOp::LexicalAfter => {
+                    facts
+                        .greater_than_in_double_bracket
+                        .push(binary.operator_span());
+                }
+                ConditionalBinaryOp::RegexMatch => {
+                    facts.regex_match_in_sh.push(binary.operator_span());
+                }
+                _ => {}
+            },
+            ConditionalNodeFact::Unary(unary) => match unary.op() {
+                ConditionalUnaryOp::VariableSet => {
+                    facts.v_test_in_sh.push(unary.operator_span());
+                }
+                ConditionalUnaryOp::Exists if unary.operator_span().slice(source) == "-a" => {
+                    facts.a_test_in_sh.push(unary.operator_span());
+                }
+                ConditionalUnaryOp::OptionSet => {
+                    facts.option_test_in_sh.push(unary.operator_span());
+                }
+                _ => {}
+            },
+            ConditionalNodeFact::BareWord(_) | ConditionalNodeFact::Other(_) => {}
+        }
+    }
+}
+
+fn collect_simple_test_portability_spans(
+    command: &CommandFact<'_>,
+    fact: &SimpleTestFact<'_>,
+    source: &str,
+    facts: &mut ConditionalPortabilityFacts,
+) {
+    let operands = fact.operands();
+    let operand_texts = operands
+        .iter()
+        .map(|word| static_word_text(word, source))
+        .collect::<Vec<_>>();
+
+    let mut has_eqeq = false;
+    let mut has_sticky_bit = false;
+    let mut has_ownership = false;
+    let mut index = 0usize;
+
+    while index < operands.len() {
+        while index < operands.len() && is_simple_test_separator(operand_texts[index].as_deref()) {
+            index += 1;
+        }
+        while index < operands.len() && operand_texts[index].as_deref() == Some("!") {
+            index += 1;
+        }
+
+        if index >= operands.len() {
+            break;
+        }
+
+        if index + 2 < operands.len()
+            && operand_texts[index + 1]
+                .as_deref()
+                .is_some_and(is_simple_test_binary_operator)
+        {
+            if operand_texts[index + 1].as_deref() == Some("==") {
+                match fact.syntax() {
+                    SimpleTestSyntax::Test => has_eqeq = true,
+                    SimpleTestSyntax::Bracket => {
+                        facts.test_equality_operator.push(operands[index + 1].span);
+                    }
+                }
+            }
+            index += 3;
+            continue;
+        }
+
+        if index + 1 < operands.len()
+            && operand_texts[index]
+                .as_deref()
+                .is_some_and(is_simple_test_unary_operator)
+        {
+            match operand_texts[index].as_deref() {
+                Some("-k") => match fact.syntax() {
+                    SimpleTestSyntax::Test => has_sticky_bit = true,
+                    SimpleTestSyntax::Bracket => {
+                        facts.sticky_bit_test_in_sh.push(operands[index].span);
+                    }
+                },
+                Some("-O") => match fact.syntax() {
+                    SimpleTestSyntax::Test => has_ownership = true,
+                    SimpleTestSyntax::Bracket => {
+                        facts.ownership_test_in_sh.push(operands[index].span);
+                    }
+                },
+                _ => {}
+            }
+
+            index += 2;
+            continue;
+        }
+
+        index += 1;
+    }
+
+    if fact.syntax() == SimpleTestSyntax::Test {
+        let Some(command_span) = simple_test_command_span(command, fact) else {
+            return;
+        };
+
+        if has_eqeq {
+            facts.test_equality_operator.push(command_span);
+        }
+        if has_sticky_bit {
+            facts.sticky_bit_test_in_sh.push(command_span);
+        }
+        if has_ownership {
+            facts.ownership_test_in_sh.push(command_span);
+        }
+    }
+}
+
+fn supports_extglob_portability_context(context: Option<ExpansionContext>) -> bool {
+    matches!(
+        context,
+        Some(
+            ExpansionContext::CommandName
+                | ExpansionContext::CommandArgument
+                | ExpansionContext::ForList
+                | ExpansionContext::SelectList
+        )
+    )
+}
+
+fn supports_bracket_glob_portability_context(context: Option<ExpansionContext>) -> bool {
+    matches!(
+        context,
+        Some(
+            ExpansionContext::CommandArgument
+                | ExpansionContext::ForList
+                | ExpansionContext::SelectList
+        )
+    )
+}
+
+fn is_simple_test_separator(token: Option<&str>) -> bool {
+    matches!(token, Some("-a" | "-o" | "(" | ")" | "\\(" | "\\)"))
+}
+
+fn is_simple_test_binary_operator(token: &str) -> bool {
+    matches!(
+        token,
+        "=" | "=="
+            | "!="
+            | "<"
+            | ">"
+            | "-eq"
+            | "-ne"
+            | "-lt"
+            | "-le"
+            | "-gt"
+            | "-ge"
+            | "-ef"
+            | "-nt"
+            | "-ot"
+    )
+}
+
+fn is_simple_test_unary_operator(token: &str) -> bool {
+    matches!(
+        token,
+        "-a" | "-b"
+            | "-c"
+            | "-d"
+            | "-e"
+            | "-f"
+            | "-g"
+            | "-h"
+            | "-k"
+            | "-L"
+            | "-n"
+            | "-N"
+            | "-O"
+            | "-p"
+            | "-r"
+            | "-s"
+            | "-S"
+            | "-t"
+            | "-u"
+            | "-v"
+            | "-w"
+            | "-x"
+            | "-z"
+    )
+}
+
+fn simple_test_command_span(command: &CommandFact<'_>, fact: &SimpleTestFact<'_>) -> Option<Span> {
+    let name = command.body_name_word()?;
+    let end = fact
+        .operands()
+        .last()
+        .map(|word| word.span.end)
+        .unwrap_or(name.span.end);
+    Some(Span::from_positions(name.span.start, end))
+}

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -161,10 +161,10 @@ pub(super) fn build_conditional_portability_facts<'a>(
     );
 
     for fact in word_facts {
-        if supports_extglob_portability_context(fact.expansion_context()) {
-            if let Some(span) = word_exactly_one_extglob_span(fact.word(), source) {
-                facts.extglob_in_sh.push(span);
-            }
+        if supports_extglob_portability_context(fact.expansion_context())
+            && let Some(span) = word_exactly_one_extglob_span(fact.word(), source)
+        {
+            facts.extglob_in_sh.push(span);
         }
 
         if supports_bracket_glob_portability_context(fact.expansion_context()) {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -24,14 +24,14 @@ pub use diagnostic::{Diagnostic, Severity};
 pub use facts::{
     BacktickFragmentFact, CommandFact, CommandOptionFacts, ConditionalBareWordFact,
     ConditionalBinaryFact, ConditionalFact, ConditionalNodeFact, ConditionalOperandFact,
-    ConditionalOperatorFamily, ConditionalUnaryFact, ExitCommandFacts, FactSpan, FindCommandFacts,
-    ForHeaderFact, FunctionHeaderFact, LegacyArithmeticFragmentFact, LinterFacts, ListFact,
-    ListOperatorFact, LoopHeaderWordFact, PipelineFact, PipelineOperatorFact, PipelineSegmentFact,
-    PositionalParameterFragmentFact, PrintfCommandFacts, ReadCommandFacts, RedirectFact,
-    SelectHeaderFact, SimpleTestFact, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax,
-    SingleQuotedFragmentFact, SubstitutionFact, SubstitutionHostKind, SudoFamilyCommandFacts,
-    SudoFamilyInvoker, UnsetCommandFacts, WaitCommandFacts, WordFact, WordFactContext,
-    WordFactHostKind, XargsCommandFacts,
+    ConditionalOperatorFamily, ConditionalPortabilityFacts, ConditionalUnaryFact, ExitCommandFacts,
+    FactSpan, FindCommandFacts, ForHeaderFact, FunctionHeaderFact, LegacyArithmeticFragmentFact,
+    LinterFacts, ListFact, ListOperatorFact, LoopHeaderWordFact, PipelineFact,
+    PipelineOperatorFact, PipelineSegmentFact, PositionalParameterFragmentFact, PrintfCommandFacts,
+    ReadCommandFacts, RedirectFact, SelectHeaderFact, SimpleTestFact, SimpleTestOperatorFamily,
+    SimpleTestShape, SimpleTestSyntax, SingleQuotedFragmentFact, SubstitutionFact,
+    SubstitutionHostKind, SudoFamilyCommandFacts, SudoFamilyInvoker, UnsetCommandFacts,
+    WaitCommandFacts, WordFact, WordFactContext, WordFactHostKind, XargsCommandFacts,
 };
 pub use registry::{Category, Rule, code_to_rule};
 pub use rule_selector::{RuleSelector, SelectorParseError};

--- a/crates/shuck-linter/src/rules/portability/conditional_portability.rs
+++ b/crates/shuck-linter/src/rules/portability/conditional_portability.rs
@@ -1,15 +1,4 @@
-use shuck_ast::{ConditionalBinaryOp, ConditionalUnaryOp, Span};
-
-use crate::rules::common::expansion::ExpansionContext;
-use crate::rules::common::span::{
-    text_looks_like_caret_negated_bracket, word_caret_negated_bracket_spans,
-    word_exactly_one_extglob_span,
-};
-use crate::{
-    Checker, ConditionalNodeFact, Rule, ShellDialect, SimpleTestFact, SimpleTestSyntax, Violation,
-    conditional_array_subscript_span, conditional_extglob_span, static_word_text,
-    word_array_subscript_span, word_extglob_span,
-};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct DoubleBracketInSh;
 pub struct TestEqualityOperator;
@@ -188,568 +177,79 @@ impl Violation for OwnershipTestInSh {
     }
 }
 
-pub fn double_bracket_in_sh(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter(|fact| fact.conditional().is_some())
-        .map(crate::CommandFact::span)
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || DoubleBracketInSh);
-}
-
-pub fn test_equality_operator(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let mut spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .flat_map(|fact| {
-            let Some(simple_test) = fact.simple_test() else {
-                return Vec::new();
-            };
-
-            match simple_test.syntax() {
-                SimpleTestSyntax::Test => {
-                    (!simple_test_binary_operator_token_spans(simple_test, source, "==").is_empty())
-                        .then(|| simple_test_command_span(fact, simple_test))
-                        .flatten()
-                        .into_iter()
-                        .collect()
-                }
-                SimpleTestSyntax::Bracket => {
-                    simple_test_binary_operator_token_spans(simple_test, source, "==")
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-    spans.extend(
-        checker
-            .facts()
-            .commands()
-            .iter()
-            .filter_map(|fact| fact.conditional())
-            .flat_map(|conditional| {
-                conditional_binary_operator_spans(conditional, ConditionalBinaryOp::PatternEq)
-            }),
-    );
-
-    checker.report_all_dedup(spans, || TestEqualityOperator);
-}
-
-pub fn if_elif_bash_test(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter(|fact| checker.facts().is_elif_condition_command(fact.id()))
-        .filter(|fact| fact.conditional().is_some())
-        .map(crate::CommandFact::span)
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || IfElifBashTest);
-}
-
-pub fn extended_glob_in_test(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.conditional())
-        .filter_map(|conditional| conditional_extglob_span(conditional.expression(), source))
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || ExtendedGlobInTest);
-}
-
-pub fn extglob_in_sh(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let mut spans = checker.facts().pattern_exactly_one_extglob_spans().to_vec();
-    spans.extend(
-        checker
-            .facts()
-            .word_facts()
-            .iter()
-            .filter(|fact| supports_extglob_portability_context(fact.expansion_context()))
-            .filter_map(|fact| word_exactly_one_extglob_span(fact.word(), source)),
-    );
-    checker.report_all_dedup(spans, || ExtglobInSh);
-}
-
-pub fn caret_negation_in_bracket(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let mut spans = checker
-        .facts()
-        .pattern_charclass_spans()
-        .iter()
-        .filter(|span| !checker.facts().is_nested_pattern_charclass_span(**span))
-        .filter(|span| text_looks_like_caret_negated_bracket(span.slice(source)))
-        .copied()
-        .collect::<Vec<_>>();
-    spans.extend(
-        checker
-            .facts()
-            .word_facts()
-            .iter()
-            .filter(|fact| supports_bracket_glob_portability_context(fact.expansion_context()))
-            .flat_map(|fact| word_caret_negated_bracket_spans(fact.word(), source)),
-    );
-
-    checker.report_all_dedup(spans, || CaretNegationInBracket);
-}
-
-pub fn array_subscript_test(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.simple_test())
-        .flat_map(|fact| {
-            fact.operands()
-                .iter()
-                .filter_map(|word| word_array_subscript_span(word, source))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || ArraySubscriptTest);
-}
-
-pub fn array_subscript_condition(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.conditional())
-        .filter_map(|conditional| {
-            conditional_array_subscript_span(conditional.expression(), source)
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || ArraySubscriptCondition);
-}
-
-pub fn extglob_in_test(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.simple_test())
-        .flat_map(|fact| {
-            fact.operands()
-                .iter()
-                .filter_map(|word| word_extglob_span(word, source))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || ExtglobInTest);
-}
-
-pub fn greater_than_in_double_bracket(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.conditional())
-        .flat_map(|conditional| {
-            conditional_binary_operator_spans(conditional, ConditionalBinaryOp::LexicalAfter)
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || GreaterThanInDoubleBracket);
-}
-
-pub fn regex_match_in_sh(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.conditional())
-        .flat_map(|conditional| {
-            conditional_binary_operator_spans(conditional, ConditionalBinaryOp::RegexMatch)
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || RegexMatchInSh);
-}
-
-pub fn v_test_in_sh(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.conditional())
-        .flat_map(|conditional| {
-            conditional_unary_operator_spans(conditional, |operator, _| {
-                operator == ConditionalUnaryOp::VariableSet
-            })
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || VTestInSh);
-}
-
-pub fn a_test_in_sh(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.conditional())
-        .flat_map(|conditional| {
-            conditional_unary_operator_spans(conditional, |operator, op_span| {
-                operator == ConditionalUnaryOp::Exists && op_span.slice(source) == "-a"
-            })
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || ATestInSh);
-}
-
-pub fn option_test_in_sh(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|fact| fact.conditional())
-        .flat_map(|conditional| {
-            conditional_unary_operator_spans(conditional, |operator, _| {
-                operator == ConditionalUnaryOp::OptionSet
-            })
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || OptionTestInSh);
-}
-
-pub fn sticky_bit_test_in_sh(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .flat_map(|fact| {
-            let Some(simple_test) = fact.simple_test() else {
-                return Vec::new();
-            };
-
-            simple_test_flag_spans(fact, simple_test, source, "-k")
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || StickyBitTestInSh);
-}
-
-pub fn ownership_test_in_sh(checker: &mut Checker) {
-    if !is_posix_sh_shell(checker.shell()) {
-        return;
-    }
-
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .flat_map(|fact| {
-            let Some(simple_test) = fact.simple_test() else {
-                return Vec::new();
-            };
-
-            simple_test_flag_spans(fact, simple_test, source, "-O")
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || OwnershipTestInSh);
-}
-
 fn is_posix_sh_shell(shell: ShellDialect) -> bool {
     matches!(shell, ShellDialect::Sh | ShellDialect::Dash)
 }
 
-fn supports_extglob_portability_context(context: Option<ExpansionContext>) -> bool {
-    matches!(
-        context,
-        Some(
-            ExpansionContext::CommandName
-                | ExpansionContext::CommandArgument
-                | ExpansionContext::ForList
-                | ExpansionContext::SelectList
-        )
-    )
-}
-
-fn supports_bracket_glob_portability_context(context: Option<ExpansionContext>) -> bool {
-    matches!(
-        context,
-        Some(
-            ExpansionContext::CommandArgument
-                | ExpansionContext::ForList
-                | ExpansionContext::SelectList
-        )
-    )
-}
-
-fn simple_test_binary_operator_token_spans(
-    fact: &SimpleTestFact<'_>,
-    source: &str,
-    token: &str,
-) -> Vec<Span> {
-    simple_test_operator_token_spans(fact, source, token, SimpleTestOperatorKind::Binary)
-}
-
-fn simple_test_unary_operator_token_spans(
-    fact: &SimpleTestFact<'_>,
-    source: &str,
-    token: &str,
-) -> Vec<Span> {
-    simple_test_operator_token_spans(fact, source, token, SimpleTestOperatorKind::Unary)
-}
-
-fn simple_test_operator_token_spans(
-    fact: &SimpleTestFact<'_>,
-    source: &str,
-    token: &str,
-    kind: SimpleTestOperatorKind,
-) -> Vec<Span> {
-    let operands = fact.operands();
-    let mut spans = Vec::new();
-    let mut index = 0usize;
-
-    while index < operands.len() {
-        while index < operands.len()
-            && is_simple_test_separator(static_word_text(operands[index], source).as_deref())
-        {
-            index += 1;
-        }
-        while index < operands.len()
-            && static_word_text(operands[index], source).as_deref() == Some("!")
-        {
-            index += 1;
-        }
-
-        if index >= operands.len() {
-            break;
-        }
-
-        if index + 2 < operands.len()
-            && static_word_text(operands[index + 1], source)
-                .as_deref()
-                .is_some_and(is_simple_test_binary_operator)
-        {
-            if kind == SimpleTestOperatorKind::Binary
-                && static_word_text(operands[index + 1], source).as_deref() == Some(token)
-            {
-                spans.push(operands[index + 1].span);
+macro_rules! cached_portability_rule {
+    ($function:ident, $accessor:ident, $violation:ident) => {
+        pub fn $function(checker: &mut Checker) {
+            if !is_posix_sh_shell(checker.shell()) {
+                return;
             }
-            index += 3;
-            continue;
+
+            let spans = checker
+                .facts()
+                .conditional_portability()
+                .$accessor()
+                .to_vec();
+            checker.report_all_dedup(spans, || $violation);
         }
-
-        if index + 1 < operands.len()
-            && static_word_text(operands[index], source)
-                .as_deref()
-                .is_some_and(is_simple_test_unary_operator)
-        {
-            if kind == SimpleTestOperatorKind::Unary
-                && static_word_text(operands[index], source).as_deref() == Some(token)
-            {
-                spans.push(operands[index].span);
-            }
-            index += 2;
-            continue;
-        }
-
-        index += 1;
-    }
-
-    spans
+    };
 }
 
-fn is_simple_test_separator(token: Option<&str>) -> bool {
-    matches!(token, Some("-a" | "-o" | "(" | ")" | "\\(" | "\\)"))
-}
-
-fn is_simple_test_binary_operator(token: &str) -> bool {
-    matches!(
-        token,
-        "=" | "=="
-            | "!="
-            | "<"
-            | ">"
-            | "-eq"
-            | "-ne"
-            | "-lt"
-            | "-le"
-            | "-gt"
-            | "-ge"
-            | "-ef"
-            | "-nt"
-            | "-ot"
-    )
-}
-
-fn is_simple_test_unary_operator(token: &str) -> bool {
-    matches!(
-        token,
-        "-a" | "-b"
-            | "-c"
-            | "-d"
-            | "-e"
-            | "-f"
-            | "-g"
-            | "-h"
-            | "-k"
-            | "-L"
-            | "-n"
-            | "-N"
-            | "-O"
-            | "-p"
-            | "-r"
-            | "-s"
-            | "-S"
-            | "-t"
-            | "-u"
-            | "-v"
-            | "-w"
-            | "-x"
-            | "-z"
-    )
-}
-
-fn simple_test_flag_spans(
-    command: &crate::CommandFact<'_>,
-    fact: &SimpleTestFact<'_>,
-    source: &str,
-    token: &str,
-) -> Vec<Span> {
-    match fact.syntax() {
-        SimpleTestSyntax::Test => (!simple_test_unary_operator_token_spans(fact, source, token)
-            .is_empty())
-        .then(|| simple_test_command_span(command, fact))
-        .flatten()
-        .into_iter()
-        .collect::<Vec<_>>(),
-        SimpleTestSyntax::Bracket => simple_test_unary_operator_token_spans(fact, source, token),
-    }
-}
-
-fn simple_test_command_span(
-    command: &crate::CommandFact<'_>,
-    fact: &SimpleTestFact<'_>,
-) -> Option<Span> {
-    let name = command.body_name_word()?;
-    let end = fact
-        .operands()
-        .last()
-        .map(|word| word.span.end)
-        .unwrap_or(name.span.end);
-    Some(Span::from_positions(name.span.start, end))
-}
-
-fn conditional_binary_operator_spans(
-    conditional: &crate::ConditionalFact<'_>,
-    operator: ConditionalBinaryOp,
-) -> Vec<Span> {
-    conditional
-        .nodes()
-        .iter()
-        .filter_map(|node| match node {
-            ConditionalNodeFact::Binary(binary) if binary.op() == operator => {
-                Some(binary.operator_span())
-            }
-            _ => None,
-        })
-        .collect()
-}
-
-fn conditional_unary_operator_spans(
-    conditional: &crate::ConditionalFact<'_>,
-    predicate: impl Fn(ConditionalUnaryOp, Span) -> bool + Copy,
-) -> Vec<Span> {
-    conditional
-        .nodes()
-        .iter()
-        .filter_map(|node| match node {
-            ConditionalNodeFact::Unary(unary) if predicate(unary.op(), unary.operator_span()) => {
-                Some(unary.operator_span())
-            }
-            _ => None,
-        })
-        .collect()
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum SimpleTestOperatorKind {
-    Unary,
-    Binary,
-}
+cached_portability_rule!(
+    double_bracket_in_sh,
+    double_bracket_in_sh,
+    DoubleBracketInSh
+);
+cached_portability_rule!(
+    test_equality_operator,
+    test_equality_operator,
+    TestEqualityOperator
+);
+cached_portability_rule!(if_elif_bash_test, if_elif_bash_test, IfElifBashTest);
+cached_portability_rule!(
+    extended_glob_in_test,
+    extended_glob_in_test,
+    ExtendedGlobInTest
+);
+cached_portability_rule!(extglob_in_sh, extglob_in_sh, ExtglobInSh);
+cached_portability_rule!(
+    caret_negation_in_bracket,
+    caret_negation_in_bracket,
+    CaretNegationInBracket
+);
+cached_portability_rule!(
+    array_subscript_test,
+    array_subscript_test,
+    ArraySubscriptTest
+);
+cached_portability_rule!(
+    array_subscript_condition,
+    array_subscript_condition,
+    ArraySubscriptCondition
+);
+cached_portability_rule!(extglob_in_test, extglob_in_test, ExtglobInTest);
+cached_portability_rule!(
+    greater_than_in_double_bracket,
+    greater_than_in_double_bracket,
+    GreaterThanInDoubleBracket
+);
+cached_portability_rule!(regex_match_in_sh, regex_match_in_sh, RegexMatchInSh);
+cached_portability_rule!(v_test_in_sh, v_test_in_sh, VTestInSh);
+cached_portability_rule!(a_test_in_sh, a_test_in_sh, ATestInSh);
+cached_portability_rule!(option_test_in_sh, option_test_in_sh, OptionTestInSh);
+cached_portability_rule!(
+    sticky_bit_test_in_sh,
+    sticky_bit_test_in_sh,
+    StickyBitTestInSh
+);
+cached_portability_rule!(
+    ownership_test_in_sh,
+    ownership_test_in_sh,
+    OwnershipTestInSh
+);
 
 #[cfg(test)]
 mod tests {

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,6 +14,9 @@
 - **L** (Low) — Simple fact filter or AST pattern match; minimal false-positive logic
 - **M** (Medium) — Cross-references multiple facts, needs option parsing, context-aware filtering, or moderate false-positive avoidance
 - **H** (High) — Needs new fact infrastructure, semantic/dataflow analysis, cross-function reasoning, or complex scope logic
+- Entry markers use two checkboxes: first = implemented, second = vetted (`V`)
+- `V` means the rule was reviewed for performance, direct AST traversal in rule files, and duplication; it does not mean the implementation is issue-free
+- The checker currently contains additional implemented rules that are not yet enumerated in this roadmap, so vetted markers below apply to the documented implemented rows only
 
 ## Scheduled Tranches
 
@@ -25,6 +28,22 @@ These rules are queued for implementation and tracked separately.
 
 **Tranche 3:** ~~C054~~, ~~C056~~, ~~C059~~, ~~C060~~, ~~C061~~, ~~C062~~, ~~C064~~, ~~C065~~, ~~C066~~, ~~C067~~, ~~C068~~, ~~C069~~, ~~C070~~, ~~C071~~, ~~C072~~ *(complete)*
 
+## Vetting Findings
+
+Review scope: all currently dispatched rule entrypoints under `crates/shuck-linter/src/rules/`, with focus on performance costs, direct AST traversal from rule files, and duplication.
+
+- No direct AST-traversal violations were found in rule files during this pass. The architecture guard `cargo test -p shuck-linter rule_modules_avoid_direct_ast_traversal_tokens` passed.
+- [P2] `crates/shuck-linter/src/rules/portability/conditional_portability.rs`
+  The conditional portability family performs many separate scans over `facts().commands()` and repeats simple-test token decoding across sibling rules. This should be collapsed into a grouped evaluator or precomputed fact set.
+- [P2] `crates/shuck-linter/src/rules/style/escaped_underscore.rs`
+  The S023/S026/S027 escape-style rules are near-copies of the same word and pattern scan pipeline. They should share one engine or fact layer so fixes do not drift and the same inputs are not rescanned multiple times.
+- [P3] `crates/shuck-linter/src/rules/portability/source_builtin_in_sh.rs`
+  `source_builtin_in_sh` and `source_inside_function_in_sh` duplicate scope checks and span anchoring helpers. They should share a helper and differ only in the inside/outside-function predicate.
+- [P3] `crates/shuck-linter/src/rules/portability/trap_err.rs`
+  `trap_err` and `signal_name_in_trap` both reimplement trap argument parsing before applying different predicates. That parsing should live in one shared helper.
+- [P3] `crates/shuck-linter/src/rules/correctness/broken_test_end.rs`
+  `broken_test_end` and `broken_test_parse` currently use the same matcher and only differ in diagnostic wording. They should share a common detection helper.
+
 ---
 
 ## Remaining Rules
@@ -35,49 +54,49 @@ Detect bash-specific test/conditional syntax in POSIX sh scripts. All share a
 common pattern: verify dialect is sh, detect the specific syntax form in
 conditional facts.
 
-- [x] **L** X001 (SC3010) `double-bracket-in-sh` — `[[ ]]` conditional not portable to sh
-- [x] **L** X002 (SC3014) `test-equality-operator` — `==` inside `[` not portable
-- [x] **L** X033 (SC3011) `if-elif-bash-test` — `[[ ]]` in elif clause
-- [x] **L** X034 (SC2221) `extended-glob-in-test` — extended glob in `[[` match
-- [x] **L** X040 (SC2102) `array-subscript-test` — array subscript in `[` test
-- [x] **L** X041 (SC2103) `array-subscript-condition` — array subscript in `[[ ]]`
-- [x] **L** X046 (SC2269) `extglob-in-test` — extended glob in test bracket
-- [x] **L** X058 (SC3065) `greater-than-in-double-bracket` — `>` inside `[[ ]]` in sh
-- [x] **L** X059 (SC3066) `regex-match-in-sh` — `=~` regex match in sh
-- [x] **L** X060 (SC3067) `v-test-in-sh` — `-v` variable-is-set test in sh
-- [x] **L** X061 (SC3068) `a-test-in-sh` — `-a` file test inside `[[ ]]` in sh
-- [x] **L** X073 (SC3080) `option-test-in-sh` — `-o` option test in `[[ ]]` in sh
-- [x] **L** X074 (SC3081) `sticky-bit-test-in-sh` — `-k` sticky-bit test in sh
-- [x] **L** X075 (SC3082) `ownership-test-in-sh` — `-O` ownership test in sh
+- [x] [x] **L** X001 (SC3010) `double-bracket-in-sh` — `[[ ]]` conditional not portable to sh
+- [x] [x] **L** X002 (SC3014) `test-equality-operator` — `==` inside `[` not portable
+- [x] [x] **L** X033 (SC3011) `if-elif-bash-test` — `[[ ]]` in elif clause
+- [x] [x] **L** X034 (SC2221) `extended-glob-in-test` — extended glob in `[[` match
+- [x] [x] **L** X040 (SC2102) `array-subscript-test` — array subscript in `[` test
+- [x] [x] **L** X041 (SC2103) `array-subscript-condition` — array subscript in `[[ ]]`
+- [x] [x] **L** X046 (SC2269) `extglob-in-test` — extended glob in test bracket
+- [x] [x] **L** X058 (SC3065) `greater-than-in-double-bracket` — `>` inside `[[ ]]` in sh
+- [x] [x] **L** X059 (SC3066) `regex-match-in-sh` — `=~` regex match in sh
+- [x] [x] **L** X060 (SC3067) `v-test-in-sh` — `-v` variable-is-set test in sh
+- [x] [x] **L** X061 (SC3068) `a-test-in-sh` — `-a` file test inside `[[ ]]` in sh
+- [x] [x] **L** X073 (SC3080) `option-test-in-sh` — `-o` option test in `[[ ]]` in sh
+- [x] [x] **L** X074 (SC3081) `sticky-bit-test-in-sh` — `-k` sticky-bit test in sh
+- [x] [x] **L** X075 (SC3082) `ownership-test-in-sh` — `-O` ownership test in sh
 
 ### Portability — Bash Keywords and Builtins in sh
 
 Detect bash-specific keywords and builtins used in POSIX sh. Simple command-name
 or keyword checks gated on dialect.
 
-- [x] **L** X003 (SC3043) `local-variable-in-sh` — `local` in sh
-- [x] **L** X004 (SC2112) `function-keyword` — `function` keyword in sh
-- [x] **L** X015 (SC3042) `let-command` — `let` in sh
-- [x] **L** X016 (SC3044) `declare-command` — `declare` in sh
-- [x] **L** X031 (SC3046) `source-builtin-in-sh` — `source` instead of `.` in sh
-- [x] **L** X052 (SC2321) `function-keyword-in-sh` — `function` with parens in sh
-- [x] **L** X080 (SC3084) `source-inside-function-in-sh` — `source` inside function in sh
+- [x] [x] **L** X003 (SC3043) `local-variable-in-sh` — `local` in sh
+- [x] [x] **L** X004 (SC2112) `function-keyword` — `function` keyword in sh
+- [x] [x] **L** X015 (SC3042) `let-command` — `let` in sh
+- [x] [x] **L** X016 (SC3044) `declare-command` — `declare` in sh
+- [x] [x] **L** X031 (SC3046) `source-builtin-in-sh` — `source` instead of `.` in sh
+- [x] [x] **L** X052 (SC2321) `function-keyword-in-sh` — `function` with parens in sh
+- [x] [x] **L** X080 (SC3084) `source-inside-function-in-sh` — `source` inside function in sh
 
 ### Portability — Bash Expansion Syntax in sh
 
 Detect bash-specific parameter expansion, process substitution, arrays, and
 related syntax in POSIX sh. Mostly surface-level AST node type checks.
 
-- [x] **L** X006 (SC3001) `process-substitution` — `<()` / `>()` in sh
-- [x] **L** X007 (SC3003) `ansi-c-quoting` — `$'...'` in sh
-- [x] **L** X010 (SC3009) `brace-expansion` — `{a,b}` expansion in sh
-- [x] **L** X011 (SC3011) `here-string` — `<<<` in sh
-- [x] **L** X013 (SC3030) `array-assignment` — array variable assignment in sh
-- [x] **L** X018 (SC3053) `indirect-expansion` — `${!var}` in sh
-- [x] **L** X019 (SC3054) `array-reference` — array reference in sh
-- [x] **L** X023 (SC3057) `substring-expansion` — `${var:offset:len}` in sh
-- [x] **L** X024 (SC3059) `uppercase-expansion` — case-modification expansion in sh
-- [x] **L** X025 (SC3060) `replacement-expansion` — replacement expansion in sh
+- [x] [x] **L** X006 (SC3001) `process-substitution` — `<()` / `>()` in sh
+- [x] [x] **L** X007 (SC3003) `ansi-c-quoting` — `$'...'` in sh
+- [x] [x] **L** X010 (SC3009) `brace-expansion` — `{a,b}` expansion in sh
+- [x] [x] **L** X011 (SC3011) `here-string` — `<<<` in sh
+- [x] [x] **L** X013 (SC3030) `array-assignment` — array variable assignment in sh
+- [x] [x] **L** X018 (SC3053) `indirect-expansion` — `${!var}` in sh
+- [x] [x] **L** X019 (SC3054) `array-reference` — array reference in sh
+- [x] [x] **L** X023 (SC3057) `substring-expansion` — `${var:offset:len}` in sh
+- [x] [x] **L** X024 (SC3059) `uppercase-expansion` — case-modification expansion in sh
+- [x] [x] **L** X025 (SC3060) `replacement-expansion` — replacement expansion in sh
 - [ ] **L** X026 (SC3024) `bash-file-slurp` — `$(< file)` in sh
 - [ ] **L** X045 (SC3055) `plus-equals-append` — `+=` assignment in sh
 - [ ] **L** X055 (SC3062) `dollar-string-in-sh` — `$"string"` in sh
@@ -89,43 +108,43 @@ related syntax in POSIX sh. Mostly surface-level AST node type checks.
 
 Detect bash-specific control flow constructs in POSIX sh.
 
-- [x] **L** X005 (SC3058) `bash-case-fallthrough` — `;&` / `;;&` in case
-- [x] **L** X008 (SC3018) `standalone-arithmetic` — `(( ))` command in sh
-- [x] **L** X009 (SC3033) `select-loop` — `select` loop in sh
-- [x] **L** X014 (SC3007) `coproc` — `coproc` in sh
-- [x] **L** X056 (SC3063) `c-style-for-in-sh` — `for ((...))` in sh
-- [x] **L** X057 (SC3064) `legacy-arithmetic-in-sh` — `$[...]` in sh
-- [x] **L** X062 (SC3069) `c-style-for-arithmetic-in-sh` — C-style for arithmetic in sh
+- [x] [x] **L** X005 (SC3058) `bash-case-fallthrough` — `;&` / `;;&` in case
+- [x] [x] **L** X008 (SC3018) `standalone-arithmetic` — `(( ))` command in sh
+- [x] [x] **L** X009 (SC3033) `select-loop` — `select` loop in sh
+- [x] [x] **L** X014 (SC3007) `coproc` — `coproc` in sh
+- [x] [x] **L** X056 (SC3063) `c-style-for-in-sh` — `for ((...))` in sh
+- [x] [x] **L** X057 (SC3064) `legacy-arithmetic-in-sh` — `$[...]` in sh
+- [x] [x] **L** X062 (SC3069) `c-style-for-arithmetic-in-sh` — C-style for arithmetic in sh
 
 ### Portability — Bash Redirection and Pipes in sh
 
 Detect bash-specific redirection and pipe operators in POSIX sh.
 
-- [x] **L** X012 (SC3052) `ampersand-redirection` — `&>` combined redirect in sh
-- [x] **L** X020 (SC3050) `brace-fd-redirection` — `{fd}>` brace-based FD in sh
-- [x] **L** X063 (SC3070) `ampersand-redirect-in-sh` — `>&` combined redirect in sh
-- [x] **L** X066 (SC3073) `pipe-stderr-in-sh` — `|&` pipe-stderr in sh
+- [x] [x] **L** X012 (SC3052) `ampersand-redirection` — `&>` combined redirect in sh
+- [x] [x] **L** X020 (SC3050) `brace-fd-redirection` — `{fd}>` brace-based FD in sh
+- [x] [x] **L** X063 (SC3070) `ampersand-redirect-in-sh` — `>&` combined redirect in sh
+- [x] [x] **L** X066 (SC3073) `pipe-stderr-in-sh` — `|&` pipe-stderr in sh
 
 ### Portability — Bash Options and Traps in sh
 
 Detect bash-specific set/trap options in POSIX sh.
 
-- [x] **L** X017 (SC3047) `trap-err` — trapping ERR in sh
-- [x] **L** X021 (SC3040) `pipefail-option` — `set -o pipefail` in sh
-- [x] **L** X022 (SC3048) `wait-option` — wait flags in sh
-- [x] **L** X032 (SC3025) `printf-q-format-in-sh` — `%q` printf conversion in sh
-- [x] **L** X068 (SC3075) `errexit-trap-in-sh` — `set -E` in sh
-- [x] **M** X069 (SC3076) `signal-name-in-trap` — symbolic signal names in trap
-- [x] **L** X070 (SC3077) `base-prefix-in-arithmetic` — `10#` base prefix in sh
+- [x] [x] **L** X017 (SC3047) `trap-err` — trapping ERR in sh
+- [x] [x] **L** X021 (SC3040) `pipefail-option` — `set -o pipefail` in sh
+- [x] [x] **L** X022 (SC3048) `wait-option` — wait flags in sh
+- [x] [x] **L** X032 (SC3025) `printf-q-format-in-sh` — `%q` printf conversion in sh
+- [x] [x] **L** X068 (SC3075) `errexit-trap-in-sh` — `set -E` in sh
+- [x] [x] **M** X069 (SC3076) `signal-name-in-trap` — symbolic signal names in trap
+- [x] [x] **L** X070 (SC3077) `base-prefix-in-arithmetic` — `10#` base prefix in sh
 
 ### Portability — Extended Glob Patterns
 
 Detect extended glob syntax in contexts where it is not supported.
 
-- [x] **L** X037 (SC1075) `extglob-case` — non-POSIX case pattern syntax
-- [x] **L** X048 (SC2277) `extglob-in-case-pattern` — extended-glob alternation in case
-- [x] **L** X054 (SC3061) `extglob-in-sh` — `@()` extended glob in sh
-- [x] **L** X065 (SC3072) `caret-negation-in-bracket` — `[^...]` negation in sh
+- [x] [x] **L** X037 (SC1075) `extglob-case` — non-POSIX case pattern syntax
+- [x] [x] **L** X048 (SC2277) `extglob-in-case-pattern` — extended-glob alternation in case
+- [x] [x] **L** X054 (SC3061) `extglob-in-sh` — `@()` extended glob in sh
+- [x] [x] **L** X065 (SC3072) `caret-negation-in-bracket` — `[^...]` negation in sh
 
 ### Portability — Echo, tr, and printf Locale
 
@@ -149,20 +168,20 @@ Detect non-portable function definitions and variable operations.
 
 Detect zsh-only syntax in scripts targeting other shells.
 
-- [x] **L** X036 (SC1070) `zsh-redir-pipe` — zsh-only redirection operator
-- [x] **L** X038 (SC1129) `zsh-brace-if` — zsh-style conditional bracing
-- [x] **L** X039 (SC1130) `zsh-always-block` — zsh `always` block
-- [x] **L** X042 (SC2240) `sourced-with-args` — sourced file with extra args
-- [x] **L** X043 (SC2251) `zsh-flag-expansion` — zsh-only parameter expansion form
-- [x] **L** X044 (SC2252) `nested-zsh-substitution` — nested zsh-style expansion
-- [x] **M** X047 (SC2275) `multi-var-for-loop` — for loop binds multiple variables
-- [x] **L** X049 (SC2278) `zsh-prompt-bracket` — zsh prompt escape in sh
-- [x] **L** X050 (SC2279) `csh-syntax-in-sh` — csh-style set assignment in sh
-- [x] **L** X051 (SC2313) `zsh-nested-expansion` — zsh nested parameter expansion
-- [x] **L** X053 (SC2355) `zsh-assignment-to-zero` — assigning to `$0` (zsh idiom)
-- [x] **L** X076 (SC2359) `zsh-parameter-flag` — zsh parameter flag in sh
-- [x] **L** X078 (SC2371) `zsh-array-subscript-in-case` — zsh array subscript in case
-- [x] **L** X079 (SC2375) `zsh-parameter-index-flag` — zsh parameter index flag
+- [x] [x] **L** X036 (SC1070) `zsh-redir-pipe` — zsh-only redirection operator
+- [x] [x] **L** X038 (SC1129) `zsh-brace-if` — zsh-style conditional bracing
+- [x] [x] **L** X039 (SC1130) `zsh-always-block` — zsh `always` block
+- [x] [x] **L** X042 (SC2240) `sourced-with-args` — sourced file with extra args
+- [x] [x] **L** X043 (SC2251) `zsh-flag-expansion` — zsh-only parameter expansion form
+- [x] [x] **L** X044 (SC2252) `nested-zsh-substitution` — nested zsh-style expansion
+- [x] [x] **M** X047 (SC2275) `multi-var-for-loop` — for loop binds multiple variables
+- [x] [x] **L** X049 (SC2278) `zsh-prompt-bracket` — zsh prompt escape in sh
+- [x] [x] **L** X050 (SC2279) `csh-syntax-in-sh` — csh-style set assignment in sh
+- [x] [x] **L** X051 (SC2313) `zsh-nested-expansion` — zsh nested parameter expansion
+- [x] [x] **L** X053 (SC2355) `zsh-assignment-to-zero` — assigning to `$0` (zsh idiom)
+- [x] [x] **L** X076 (SC2359) `zsh-parameter-flag` — zsh parameter flag in sh
+- [x] [x] **L** X078 (SC2371) `zsh-array-subscript-in-case` — zsh array subscript in case
+- [x] [x] **L** X079 (SC2375) `zsh-parameter-index-flag` — zsh parameter index flag
 
 ### Test and Conditional Expressions
 
@@ -295,14 +314,14 @@ Rules about shebang lines and script-level metadata.
 Rules about needless or misleading backslash escapes. Most use surface fragment
 facts or word facts for single-quoted strings.
 
-- [x] **L** C137 (SC2385) `unicode-single-quote-in-single-quotes` — Unicode smart quote in single-quoted string
-- [x] **L** S023 (SC1001) `escaped-underscore` — needless backslash in plain word
-- [x] **L** S024 (SC1003) `single-quote-backslash` — literal backslash in quoted string
-- [x] **L** S025 (SC1004) `literal-backslash` — backslash before normal letter is literal
-- [x] **L** S026 (SC1012) `needless-backslash-underscore` — backslash before normal char in word
-- [x] **L** S027 (SC1002) `escaped-underscore` — backslash before `_` is unnecessary
-- [x] **L** S039 (SC2267) `literal-backslash-in-single-quotes` — backslash in single quotes is literal
-- [x] **L** S040 (SC2268) `backslash-before-command` — backslash before command to bypass aliases
+- [x] [x] **L** C137 (SC2385) `unicode-single-quote-in-single-quotes` — Unicode smart quote in single-quoted string
+- [x] [x] **L** S023 (SC1001) `escaped-underscore` — needless backslash in plain word
+- [x] [x] **L** S024 (SC1003) `single-quote-backslash` — literal backslash in quoted string
+- [x] [x] **L** S025 (SC1004) `literal-backslash` — backslash before normal letter is literal
+- [x] [x] **L** S026 (SC1012) `needless-backslash-underscore` — backslash before normal char in word
+- [x] [x] **L** S027 (SC1002) `escaped-underscore` — backslash before `_` is unnecessary
+- [x] [x] **L** S039 (SC2267) `literal-backslash-in-single-quotes` — backslash in single quotes is literal
+- [x] [x] **L** S040 (SC2268) `backslash-before-command` — backslash before command to bypass aliases
 
 ### Arithmetic Expressions
 
@@ -415,7 +434,7 @@ injection.
 Rules about inefficient patterns that can be replaced with builtins or simpler
 constructs.
 
-- [x] **L** P001 (SC2003) `expr-arithmetic` — expr for arithmetic when shell can do it
-- [x] **L** P002 (SC2126) `grep-count-pipeline` — `grep | wc -l` instead of `grep -c`
-- [x] **L** P003 (SC2233) `single-test-subshell` — lone test in subshell
-- [x] **L** P004 (SC2259) `subshell-test-group` — grouped test in subshell instead of braces
+- [x] [x] **L** P001 (SC2003) `expr-arithmetic` — expr for arithmetic when shell can do it
+- [x] [x] **L** P002 (SC2126) `grep-count-pipeline` — `grep | wc -l` instead of `grep -c`
+- [x] [x] **L** P003 (SC2233) `single-test-subshell` — lone test in subshell
+- [x] [x] **L** P004 (SC2259) `subshell-test-group` — grouped test in subshell instead of braces


### PR DESCRIPTION
## Summary
- refactor the conditional portability rule family to use a shared `ConditionalPortabilityFacts` cache instead of rescanning command facts per rule
- keep the rule module as thin shell-gated reporters and add focused facts-level regression coverage for the shared buckets
- document the completed rule vetting pass in `docs/rules.md`, including the vetted marker legend and current findings

## Why
The conditional portability rules had grown into a repeated-pass hotspot: sibling rules were walking the same command facts and re-decoding test operators independently. Moving that work into `LinterFacts` keeps the rules aligned with the facts-first architecture, reduces duplication, and makes the behavior easier to test in one place.

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter rule_modules_avoid_direct_ast_traversal_tokens`
- `cargo test -p shuck-linter portability::tests::rules -- --nocapture`
- `cargo test -p shuck-linter builds_conditional_portability_ -- --nocapture`
- `cargo test -p shuck-linter conditional_portability -- --nocapture`
