### PR TITLE
Refactor shared source portability helpers

### DIFF
--- a/crates/shuck-linter/src/rules/portability/mod.rs
+++ b/crates/shuck-linter/src/rules/portability/mod.rs
@@ -31,6 +31,7 @@ pub mod replacement_expansion;
 pub mod select_loop;
 pub mod signal_name_in_trap;
 pub mod source_builtin_in_sh;
+mod source_common;
 pub mod source_inside_function_in_sh;
 pub mod sourced_with_args;
 pub mod standalone_arithmetic;

--- a/crates/shuck-linter/src/rules/portability/source_builtin_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/source_builtin_in_sh.rs
@@ -1,7 +1,6 @@
-use shuck_ast::{Command, Redirect, SimpleCommand, Span};
-use shuck_semantic::ScopeKind;
+use crate::{Checker, Rule, Violation};
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use super::source_common::{SourceScopeFilter, source_command_spans_in_sh};
 
 pub struct SourceBuiltinInSh;
 
@@ -16,72 +15,6 @@ impl Violation for SourceBuiltinInSh {
 }
 
 pub fn source_builtin_in_sh(checker: &mut Checker) {
-    if !matches!(checker.shell(), ShellDialect::Sh | ShellDialect::Dash) {
-        return;
-    }
-
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter(|fact| fact.effective_name_is("source"))
-        .filter(|fact| !inside_function(checker, fact.span()))
-        .map(|fact| {
-            source_anchor_span(
-                fact.command(),
-                fact.redirects(),
-                fact.span(),
-                checker.source(),
-            )
-        })
-        .collect::<Vec<_>>();
-
+    let spans = source_command_spans_in_sh(checker, SourceScopeFilter::OutsideFunction);
     checker.report_all(spans, || SourceBuiltinInSh);
-}
-
-fn inside_function(checker: &Checker<'_>, span: Span) -> bool {
-    let scope = checker.semantic().scope_at(span.start.offset);
-    checker
-        .semantic()
-        .ancestor_scopes(scope)
-        .any(|scope| matches!(checker.semantic().scope_kind(scope), ScopeKind::Function(_)))
-}
-
-fn source_anchor_span(
-    command: &Command,
-    redirects: &[Redirect],
-    fallback: Span,
-    source: &str,
-) -> Span {
-    match command {
-        Command::Simple(command) => {
-            clip_first_line(simple_command_span(command, redirects), source)
-        }
-        _ => clip_first_line(fallback, source),
-    }
-}
-
-fn simple_command_span(command: &SimpleCommand, redirects: &[Redirect]) -> Span {
-    let start = command
-        .assignments
-        .first()
-        .map_or(command.name.span.start, |assignment| assignment.span.start);
-    let mut end = command
-        .args
-        .last()
-        .map_or(command.name.span.end, |word| word.span.end);
-    if let Some(redirect) = redirects.last() {
-        end = redirect.span.end;
-    }
-    Span::from_positions(start, end)
-}
-
-fn clip_first_line(span: Span, source: &str) -> Span {
-    let text = span.slice(source);
-    let Some(line_end) = text.find('\n') else {
-        return span;
-    };
-
-    let first_line = text[..line_end].trim_end_matches('\r');
-    Span::from_positions(span.start, span.start.advanced_by(first_line))
 }

--- a/crates/shuck-linter/src/rules/portability/source_common.rs
+++ b/crates/shuck-linter/src/rules/portability/source_common.rs
@@ -1,0 +1,85 @@
+use shuck_ast::{Command, Redirect, SimpleCommand, Span};
+use shuck_semantic::ScopeKind;
+
+use crate::{Checker, ShellDialect};
+
+#[derive(Clone, Copy)]
+pub(super) enum SourceScopeFilter {
+    InsideFunction,
+    OutsideFunction,
+}
+
+impl SourceScopeFilter {
+    fn matches(self, inside_function: bool) -> bool {
+        match self {
+            Self::InsideFunction => inside_function,
+            Self::OutsideFunction => !inside_function,
+        }
+    }
+}
+
+pub(super) fn source_command_spans_in_sh(
+    checker: &Checker<'_>,
+    filter: SourceScopeFilter,
+) -> Vec<Span> {
+    if !matches!(checker.shell(), ShellDialect::Sh | ShellDialect::Dash) {
+        return Vec::new();
+    }
+
+    let source = checker.source();
+    checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("source"))
+        .filter(|fact| filter.matches(inside_function(checker, fact.span())))
+        .map(|fact| source_anchor_span(fact.command(), fact.redirects(), fact.span(), source))
+        .collect()
+}
+
+fn inside_function(checker: &Checker<'_>, span: Span) -> bool {
+    let scope = checker.semantic().scope_at(span.start.offset);
+    checker
+        .semantic()
+        .ancestor_scopes(scope)
+        .any(|scope| matches!(checker.semantic().scope_kind(scope), ScopeKind::Function(_)))
+}
+
+fn source_anchor_span(
+    command: &Command,
+    redirects: &[Redirect],
+    fallback: Span,
+    source: &str,
+) -> Span {
+    match command {
+        Command::Simple(command) => {
+            clip_first_line(simple_command_span(command, redirects), source)
+        }
+        _ => clip_first_line(fallback, source),
+    }
+}
+
+fn simple_command_span(command: &SimpleCommand, redirects: &[Redirect]) -> Span {
+    let start = command
+        .assignments
+        .first()
+        .map_or(command.name.span.start, |assignment| assignment.span.start);
+    let mut end = command
+        .args
+        .last()
+        .map_or(command.name.span.end, |word| word.span.end);
+    if let Some(redirect) = redirects.last() {
+        end = redirect.span.end;
+    }
+    Span::from_positions(start, end)
+}
+
+fn clip_first_line(span: Span, source: &str) -> Span {
+    let text = span.slice(source);
+    let Some(line_end) = text.find('\n') else {
+        return span;
+    };
+
+    let first_line = text[..line_end].trim_end_matches('\r');
+    Span::from_positions(span.start, span.start.advanced_by(first_line))
+}

--- a/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
@@ -1,7 +1,6 @@
-use shuck_ast::{Command, Redirect, SimpleCommand, Span};
-use shuck_semantic::ScopeKind;
+use crate::{Checker, Rule, Violation};
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use super::source_common::{SourceScopeFilter, source_command_spans_in_sh};
 
 pub struct SourceInsideFunctionInSh;
 
@@ -16,72 +15,6 @@ impl Violation for SourceInsideFunctionInSh {
 }
 
 pub fn source_inside_function_in_sh(checker: &mut Checker) {
-    if !matches!(checker.shell(), ShellDialect::Sh | ShellDialect::Dash) {
-        return;
-    }
-
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter(|fact| fact.effective_name_is("source"))
-        .filter(|fact| inside_function(checker, fact.span()))
-        .map(|fact| {
-            source_anchor_span(
-                fact.command(),
-                fact.redirects(),
-                fact.span(),
-                checker.source(),
-            )
-        })
-        .collect::<Vec<_>>();
-
+    let spans = source_command_spans_in_sh(checker, SourceScopeFilter::InsideFunction);
     checker.report_all(spans, || SourceInsideFunctionInSh);
-}
-
-fn inside_function(checker: &Checker<'_>, span: Span) -> bool {
-    let scope = checker.semantic().scope_at(span.start.offset);
-    checker
-        .semantic()
-        .ancestor_scopes(scope)
-        .any(|scope| matches!(checker.semantic().scope_kind(scope), ScopeKind::Function(_)))
-}
-
-fn source_anchor_span(
-    command: &Command,
-    redirects: &[Redirect],
-    fallback: Span,
-    source: &str,
-) -> Span {
-    match command {
-        Command::Simple(command) => {
-            clip_first_line(simple_command_span(command, redirects), source)
-        }
-        _ => clip_first_line(fallback, source),
-    }
-}
-
-fn simple_command_span(command: &SimpleCommand, redirects: &[Redirect]) -> Span {
-    let start = command
-        .assignments
-        .first()
-        .map_or(command.name.span.start, |assignment| assignment.span.start);
-    let mut end = command
-        .args
-        .last()
-        .map_or(command.name.span.end, |word| word.span.end);
-    if let Some(redirect) = redirects.last() {
-        end = redirect.span.end;
-    }
-    Span::from_positions(start, end)
-}
-
-fn clip_first_line(span: Span, source: &str) -> Span {
-    let text = span.slice(source);
-    let Some(line_end) = text.find('\n') else {
-        return span;
-    };
-
-    let first_line = text[..line_end].trim_end_matches('\r');
-    Span::from_positions(span.start, span.start.advanced_by(first_line))
 }


### PR DESCRIPTION
## Summary
- extract the shared `source`-in-`sh` command filtering, function-scope check, and span anchoring into a new portability-local helper module
- update X031 and X080 to differ only by the inside/outside-function scope predicate they request
- keep rule messages, suppression behavior, and diagnostic anchoring unchanged

## Why
These two portability rules had drift-prone duplicated logic for the same semantic scope lookup and command span handling. Pulling that logic into one helper keeps the behavior aligned while making future changes safer.

## Impact
This is a refactor only. User-visible diagnostics should stay the same, but the implementation is smaller and easier to maintain.

## Validation
- `cargo fmt --all`
- `cargo test -p shuck-linter source_builtin_in_`
- `cargo test -p shuck-linter source_inside_function`
- `cargo test -p shuck-linter sourcebuiltininsh_path_new_x031_sh_expects`
- `cargo test -p shuck-linter sourceinsidefunctioninsh_path_new_x080_sh_expects`