### PR TITLE
Factor shared escape scanning for S023, S026, and S027

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -36,7 +36,7 @@ use self::{
         build_subshell_test_group_spans, build_substitution_facts,
     },
     conditional_portability::build_conditional_portability_facts,
-    escape_scan::{EscapeScanMatch, build_escape_scan_matches},
+    escape_scan::{EscapeScanContext, EscapeScanMatch, build_escape_scan_matches},
     presence::build_presence_tested_names,
     surface::{
         SurfaceFragmentFacts, build_subscript_index_reference_spans, build_surface_fragment_facts,
@@ -1856,8 +1856,10 @@ impl<'a> LinterFactsBuilder<'a> {
             &pattern_charclass_spans,
             &single_quoted,
             &backticks,
-            self.source,
-            self._file_context,
+            EscapeScanContext {
+                source: self.source,
+                file_context: self._file_context,
+            },
         );
         let nested_pattern_charclass_spans = nested_pattern_charclass_spans
             .into_iter()

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -9,6 +9,7 @@
 
 mod command_flow;
 mod conditional_portability;
+mod escape_scan;
 mod presence;
 mod surface;
 
@@ -35,6 +36,7 @@ use self::{
         build_subshell_test_group_spans, build_substitution_facts,
     },
     conditional_portability::build_conditional_portability_facts,
+    escape_scan::{EscapeScanMatch, build_escape_scan_matches},
     presence::build_presence_tested_names,
     surface::{
         SurfaceFragmentFacts, build_subscript_index_reference_spans, build_surface_fragment_facts,
@@ -58,6 +60,7 @@ use crate::rules::common::{
 };
 
 pub use self::conditional_portability::ConditionalPortabilityFacts;
+pub(crate) use self::escape_scan::EscapeScanSourceKind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FactSpan {
@@ -1470,6 +1473,7 @@ pub struct LinterFacts<'a> {
     double_paren_grouping_spans: Vec<Span>,
     arithmetic_for_update_operator_spans: Vec<Span>,
     base_prefix_arithmetic_spans: Vec<Span>,
+    escape_scan_matches: Vec<EscapeScanMatch>,
     unicode_smart_quote_spans: Vec<Span>,
     pattern_exactly_one_extglob_spans: Vec<Span>,
     pattern_literal_spans: Vec<Span>,
@@ -1648,6 +1652,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn base_prefix_arithmetic_spans(&self) -> &[Span] {
         &self.base_prefix_arithmetic_spans
+    }
+
+    pub(crate) fn escape_scan_matches(&self) -> &[EscapeScanMatch] {
+        &self.escape_scan_matches
     }
 
     pub fn unicode_smart_quote_spans(&self) -> &[Span] {
@@ -1841,6 +1849,16 @@ impl<'a> LinterFactsBuilder<'a> {
             build_subscript_index_reference_spans(self._semantic, &subscript_spans);
         pattern_exactly_one_extglob_spans.extend(surface_pattern_exactly_one_extglob_spans);
         pattern_charclass_spans.extend(surface_pattern_charclass_spans);
+        let escape_scan_matches = build_escape_scan_matches(
+            &commands,
+            &words,
+            &pattern_literal_spans,
+            &pattern_charclass_spans,
+            &single_quoted,
+            &backticks,
+            self.source,
+            self._file_context,
+        );
         let nested_pattern_charclass_spans = nested_pattern_charclass_spans
             .into_iter()
             .map(FactSpan::new)
@@ -1888,6 +1906,7 @@ impl<'a> LinterFactsBuilder<'a> {
             double_paren_grouping_spans,
             arithmetic_for_update_operator_spans,
             base_prefix_arithmetic_spans,
+            escape_scan_matches,
             unicode_smart_quote_spans,
             pattern_exactly_one_extglob_spans,
             pattern_literal_spans,

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -1,0 +1,429 @@
+use shuck_ast::Span;
+
+use super::{BacktickFragmentFact, CommandFact, SingleQuotedFragmentFact, WordFact};
+use crate::FileContext;
+use crate::context::FileContextTag;
+use crate::rules::common::expansion::ExpansionContext;
+use crate::rules::common::span::{
+    word_has_single_literal_part, word_literal_part_spans_excluding_parameter_operator_tails,
+    word_literal_scan_segments_excluding_expansions,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EscapeScanSourceKind {
+    WordLiteralPart,
+    RedirectLiteralSegment,
+    DynamicPathCommandName,
+    PatternLiteral,
+    PatternCharClass,
+    SingleLiteralAssignmentWord,
+    BacktickFragment,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EscapeScanMatch {
+    span: Span,
+    escaped_byte: u8,
+    source_kind: EscapeScanSourceKind,
+    nested_word_command: bool,
+    host_contains_single_quoted_fragment: bool,
+    inside_single_quoted_fragment: bool,
+}
+
+impl EscapeScanMatch {
+    pub(crate) fn span(self) -> Span {
+        self.span
+    }
+
+    pub(crate) fn escaped_byte(self) -> u8 {
+        self.escaped_byte
+    }
+
+    pub(crate) fn source_kind(self) -> EscapeScanSourceKind {
+        self.source_kind
+    }
+
+    pub(crate) fn is_nested_word_command(self) -> bool {
+        self.nested_word_command
+    }
+
+    pub(crate) fn host_contains_single_quoted_fragment(self) -> bool {
+        self.host_contains_single_quoted_fragment
+    }
+
+    pub(crate) fn inside_single_quoted_fragment(self) -> bool {
+        self.inside_single_quoted_fragment
+    }
+}
+
+pub(super) fn build_escape_scan_matches(
+    commands: &[CommandFact<'_>],
+    words: &[WordFact<'_>],
+    pattern_literal_spans: &[Span],
+    pattern_charclass_spans: &[Span],
+    single_quoted_fragments: &[SingleQuotedFragmentFact],
+    backtick_fragments: &[BacktickFragmentFact],
+    source: &str,
+    file_context: &FileContext,
+) -> Vec<EscapeScanMatch> {
+    if file_context.has_tag(FileContextTag::PatchFile) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for fact in words
+        .iter()
+        .filter(|fact| is_relevant_word_context(fact.expansion_context()))
+    {
+        if is_grep_style_argument(commands, fact) || is_regex_like_context(fact.expansion_context())
+        {
+            continue;
+        }
+
+        let host_contains_single_quoted_fragment =
+            span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments);
+
+        for span in word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
+        {
+            append_escape_scan_matches(
+                &mut matches,
+                span,
+                source,
+                EscapeScanSourceKind::WordLiteralPart,
+                fact.is_nested_word_command(),
+                host_contains_single_quoted_fragment,
+                single_quoted_fragments,
+            );
+        }
+    }
+
+    for fact in words
+        .iter()
+        .filter(|fact| is_assignment_value_context(fact.expansion_context()))
+    {
+        if !word_has_single_literal_part(fact.word()) || is_grep_style_argument(commands, fact) {
+            continue;
+        }
+
+        append_escape_scan_matches(
+            &mut matches,
+            fact.span(),
+            source,
+            EscapeScanSourceKind::SingleLiteralAssignmentWord,
+            fact.is_nested_word_command(),
+            span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments),
+            single_quoted_fragments,
+        );
+    }
+
+    for fact in words.iter().filter(|fact| {
+        matches!(
+            fact.expansion_context(),
+            Some(ExpansionContext::RedirectTarget(_))
+        )
+    }) {
+        if is_grep_style_argument(commands, fact) || is_regex_like_context(fact.expansion_context())
+        {
+            continue;
+        }
+
+        let host_contains_single_quoted_fragment =
+            span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments);
+
+        for span in word_literal_scan_segments_excluding_expansions(fact.word(), source) {
+            append_escape_scan_matches(
+                &mut matches,
+                span,
+                source,
+                EscapeScanSourceKind::RedirectLiteralSegment,
+                fact.is_nested_word_command(),
+                host_contains_single_quoted_fragment,
+                single_quoted_fragments,
+            );
+        }
+    }
+
+    for command in commands {
+        let Some(span) = command
+            .body_word_span()
+            .filter(|span| span.slice(source).contains('/'))
+        else {
+            continue;
+        };
+
+        append_escape_scan_matches(
+            &mut matches,
+            span,
+            source,
+            EscapeScanSourceKind::DynamicPathCommandName,
+            command.is_nested_word_command(),
+            span_contains_single_quoted_fragment(span, single_quoted_fragments),
+            single_quoted_fragments,
+        );
+    }
+
+    for span in pattern_literal_spans {
+        append_escape_scan_matches(
+            &mut matches,
+            *span,
+            source,
+            EscapeScanSourceKind::PatternLiteral,
+            false,
+            span_contains_single_quoted_fragment(*span, single_quoted_fragments),
+            single_quoted_fragments,
+        );
+    }
+
+    for span in pattern_charclass_spans {
+        append_escape_scan_matches(
+            &mut matches,
+            *span,
+            source,
+            EscapeScanSourceKind::PatternCharClass,
+            false,
+            span_contains_single_quoted_fragment(*span, single_quoted_fragments),
+            single_quoted_fragments,
+        );
+    }
+
+    for fragment in backtick_fragments {
+        append_escape_scan_matches(
+            &mut matches,
+            fragment.span(),
+            source,
+            EscapeScanSourceKind::BacktickFragment,
+            false,
+            span_contains_single_quoted_fragment(fragment.span(), single_quoted_fragments),
+            single_quoted_fragments,
+        );
+    }
+
+    matches
+}
+
+fn append_escape_scan_matches(
+    matches: &mut Vec<EscapeScanMatch>,
+    scan_span: Span,
+    source: &str,
+    source_kind: EscapeScanSourceKind,
+    nested_word_command: bool,
+    host_contains_single_quoted_fragment: bool,
+    single_quoted_fragments: &[SingleQuotedFragmentFact],
+) {
+    let text = scan_span.slice(source);
+    let bytes = text.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] != b'\\' {
+            index += 1;
+            continue;
+        }
+
+        let run_start = index;
+        while index < bytes.len() && bytes[index] == b'\\' {
+            index += 1;
+        }
+
+        let Some(&escaped_byte) = bytes.get(index) else {
+            continue;
+        };
+
+        if (index - run_start) % 2 == 0 {
+            continue;
+        }
+
+        let start = scan_span.start.advanced_by(&text[..index - 1]);
+        let report_span = Span::from_positions(start, start);
+        matches.push(EscapeScanMatch {
+            span: report_span,
+            escaped_byte,
+            source_kind,
+            nested_word_command,
+            host_contains_single_quoted_fragment,
+            inside_single_quoted_fragment: span_within_single_quoted_fragment(
+                report_span,
+                single_quoted_fragments,
+            ),
+        });
+    }
+}
+
+fn is_relevant_word_context(context: Option<ExpansionContext>) -> bool {
+    matches!(
+        context,
+        Some(
+            ExpansionContext::CommandArgument
+                | ExpansionContext::AssignmentValue
+                | ExpansionContext::DeclarationAssignmentValue
+                | ExpansionContext::RedirectTarget(_)
+                | ExpansionContext::ForList
+                | ExpansionContext::SelectList
+                | ExpansionContext::CasePattern
+        )
+    )
+}
+
+fn is_assignment_value_context(context: Option<ExpansionContext>) -> bool {
+    matches!(
+        context,
+        Some(ExpansionContext::AssignmentValue | ExpansionContext::DeclarationAssignmentValue)
+    )
+}
+
+fn is_regex_like_context(context: Option<ExpansionContext>) -> bool {
+    matches!(
+        context,
+        Some(ExpansionContext::RegexOperand | ExpansionContext::StringTestOperand)
+    )
+}
+
+fn span_contains_single_quoted_fragment(
+    span: Span,
+    fragments: &[SingleQuotedFragmentFact],
+) -> bool {
+    fragments.iter().any(|fragment| {
+        let fragment_span = fragment.span();
+        fragment_span.start.offset >= span.start.offset
+            && fragment_span.end.offset <= span.end.offset
+    })
+}
+
+fn span_within_single_quoted_fragment(span: Span, fragments: &[SingleQuotedFragmentFact]) -> bool {
+    fragments.iter().any(|fragment| {
+        let fragment_span = fragment.span();
+        span.start.offset >= fragment_span.start.offset
+            && span.end.offset <= fragment_span.end.offset
+    })
+}
+
+fn is_grep_style_argument(commands: &[CommandFact<'_>], fact: &WordFact<'_>) -> bool {
+    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
+        return false;
+    }
+
+    let command = &commands[fact.command_id().index()];
+    if command
+        .body_name_word()
+        .is_some_and(|word| word.span == fact.span())
+    {
+        return false;
+    }
+
+    command
+        .effective_or_literal_name()
+        .is_some_and(|name| name.contains("grep"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use shuck_indexer::Indexer;
+    use shuck_parser::parser::{Parser, ShellDialect as ParseShellDialect};
+    use shuck_semantic::SemanticModel;
+
+    use super::EscapeScanSourceKind;
+    use crate::{LinterFacts, ShellDialect, classify_file_context};
+
+    fn with_matches(
+        source: &str,
+        path: Option<&Path>,
+        parse_dialect: ParseShellDialect,
+        shell: ShellDialect,
+        visit: impl FnOnce(&[super::EscapeScanMatch]),
+    ) {
+        let output = Parser::with_dialect(source, parse_dialect).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, path, shell);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        visit(facts.escape_scan_matches());
+    }
+
+    #[test]
+    fn records_only_odd_escape_runs_and_char_class_matches() {
+        let source = r#"#!/bin/sh
+echo foo\_bar
+echo foo\\_bar
+case x in [a\-z]) : ;; esac
+"#;
+
+        with_matches(
+            source,
+            None,
+            ParseShellDialect::Posix,
+            ShellDialect::Sh,
+            |matches| {
+                let underscore_word_matches = matches
+                    .iter()
+                    .filter(|escape| {
+                        escape.escaped_byte() == b'_'
+                            && escape.source_kind() == EscapeScanSourceKind::WordLiteralPart
+                    })
+                    .count();
+
+                assert_eq!(underscore_word_matches, 1);
+                assert!(matches.iter().any(|escape| {
+                    escape.escaped_byte() == b'-'
+                        && escape.source_kind() == EscapeScanSourceKind::PatternCharClass
+                }));
+            },
+        );
+    }
+
+    #[test]
+    fn records_backtick_fragment_matches() {
+        let source = r#"#!/bin/sh
+`echo \n`
+"#;
+
+        with_matches(
+            source,
+            None,
+            ParseShellDialect::Posix,
+            ShellDialect::Sh,
+            |matches| {
+                let backtick_match = matches
+                    .iter()
+                    .copied()
+                    .find(|escape| {
+                        escape.escaped_byte() == b'n'
+                            && escape.source_kind() == EscapeScanSourceKind::BacktickFragment
+                    })
+                    .expect("expected backtick fragment match");
+
+                assert!(!backtick_match.inside_single_quoted_fragment());
+            },
+        );
+    }
+
+    #[test]
+    fn records_nested_word_command_single_quote_metadata() {
+        let source = r#"#!/bin/bash
+echo "$(printf prefix'quoted'\n)"
+"#;
+
+        with_matches(
+            source,
+            None,
+            ParseShellDialect::Bash,
+            ShellDialect::Bash,
+            |matches| {
+                let nested_match = matches
+                    .iter()
+                    .copied()
+                    .find(|escape| {
+                        escape.escaped_byte() == b'n'
+                            && escape.source_kind() == EscapeScanSourceKind::WordLiteralPart
+                            && escape.is_nested_word_command()
+                            && escape.host_contains_single_quoted_fragment()
+                    })
+                    .expect("expected nested command word match");
+
+                assert!(nested_match.inside_single_quoted_fragment());
+            },
+        );
+    }
+}

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -9,6 +9,11 @@ use crate::rules::common::span::{
     word_literal_scan_segments_excluding_expansions,
 };
 
+pub(super) struct EscapeScanContext<'a> {
+    pub(super) source: &'a str,
+    pub(super) file_context: &'a FileContext,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EscapeScanSourceKind {
     WordLiteralPart,
@@ -63,10 +68,9 @@ pub(super) fn build_escape_scan_matches(
     pattern_charclass_spans: &[Span],
     single_quoted_fragments: &[SingleQuotedFragmentFact],
     backtick_fragments: &[BacktickFragmentFact],
-    source: &str,
-    file_context: &FileContext,
+    context: EscapeScanContext<'_>,
 ) -> Vec<EscapeScanMatch> {
-    if file_context.has_tag(FileContextTag::PatchFile) {
+    if context.file_context.has_tag(FileContextTag::PatchFile) {
         return Vec::new();
     }
 
@@ -84,12 +88,13 @@ pub(super) fn build_escape_scan_matches(
         let host_contains_single_quoted_fragment =
             span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments);
 
-        for span in word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
+        for span in
+            word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), context.source)
         {
             append_escape_scan_matches(
                 &mut matches,
                 span,
-                source,
+                context.source,
                 EscapeScanSourceKind::WordLiteralPart,
                 fact.is_nested_word_command(),
                 host_contains_single_quoted_fragment,
@@ -109,7 +114,7 @@ pub(super) fn build_escape_scan_matches(
         append_escape_scan_matches(
             &mut matches,
             fact.span(),
-            source,
+            context.source,
             EscapeScanSourceKind::SingleLiteralAssignmentWord,
             fact.is_nested_word_command(),
             span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments),
@@ -131,11 +136,11 @@ pub(super) fn build_escape_scan_matches(
         let host_contains_single_quoted_fragment =
             span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments);
 
-        for span in word_literal_scan_segments_excluding_expansions(fact.word(), source) {
+        for span in word_literal_scan_segments_excluding_expansions(fact.word(), context.source) {
             append_escape_scan_matches(
                 &mut matches,
                 span,
-                source,
+                context.source,
                 EscapeScanSourceKind::RedirectLiteralSegment,
                 fact.is_nested_word_command(),
                 host_contains_single_quoted_fragment,
@@ -147,7 +152,7 @@ pub(super) fn build_escape_scan_matches(
     for command in commands {
         let Some(span) = command
             .body_word_span()
-            .filter(|span| span.slice(source).contains('/'))
+            .filter(|span| span.slice(context.source).contains('/'))
         else {
             continue;
         };
@@ -155,7 +160,7 @@ pub(super) fn build_escape_scan_matches(
         append_escape_scan_matches(
             &mut matches,
             span,
-            source,
+            context.source,
             EscapeScanSourceKind::DynamicPathCommandName,
             command.is_nested_word_command(),
             span_contains_single_quoted_fragment(span, single_quoted_fragments),
@@ -167,7 +172,7 @@ pub(super) fn build_escape_scan_matches(
         append_escape_scan_matches(
             &mut matches,
             *span,
-            source,
+            context.source,
             EscapeScanSourceKind::PatternLiteral,
             false,
             span_contains_single_quoted_fragment(*span, single_quoted_fragments),
@@ -179,7 +184,7 @@ pub(super) fn build_escape_scan_matches(
         append_escape_scan_matches(
             &mut matches,
             *span,
-            source,
+            context.source,
             EscapeScanSourceKind::PatternCharClass,
             false,
             span_contains_single_quoted_fragment(*span, single_quoted_fragments),
@@ -191,7 +196,7 @@ pub(super) fn build_escape_scan_matches(
         append_escape_scan_matches(
             &mut matches,
             fragment.span(),
-            source,
+            context.source,
             EscapeScanSourceKind::BacktickFragment,
             false,
             span_contains_single_quoted_fragment(fragment.span(), single_quoted_fragments),

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -1,11 +1,5 @@
-use shuck_ast::Span;
-
-use crate::context::FileContextTag;
-use crate::{
-    Checker, ExpansionContext, Rule, Violation,
-    word_literal_part_spans_excluding_parameter_operator_tails,
-    word_literal_scan_segments_excluding_expansions,
-};
+use crate::facts::EscapeScanSourceKind;
+use crate::{Checker, Rule, Violation};
 
 pub struct EscapedUnderscore;
 
@@ -20,200 +14,30 @@ impl Violation for EscapedUnderscore {
 }
 
 pub fn escaped_underscore(checker: &mut Checker) {
-    if checker.file_context().has_tag(FileContextTag::PatchFile) {
-        return;
-    }
-
-    let source = checker.source();
-    let facts = checker.facts();
-    let single_quoted_fragments = facts.single_quoted_fragments();
     let spans = checker
         .facts()
-        .word_facts()
+        .escape_scan_matches()
         .iter()
-        .filter(|fact| is_relevant_word_context(fact.expansion_context()))
-        .filter(|fact| !word_contains_single_quoted_fragment(fact.span(), single_quoted_fragments))
-        .filter(|fact| !is_grep_style_argument(facts, fact))
-        .filter(|fact| {
-            !matches!(
-                fact.expansion_context(),
-                Some(ExpansionContext::RegexOperand | ExpansionContext::StringTestOperand)
-            )
+        .copied()
+        .filter(|escape| match escape.source_kind() {
+            EscapeScanSourceKind::WordLiteralPart
+            | EscapeScanSourceKind::RedirectLiteralSegment => {
+                !escape.host_contains_single_quoted_fragment()
+            }
+            EscapeScanSourceKind::DynamicPathCommandName
+            | EscapeScanSourceKind::PatternLiteral
+            | EscapeScanSourceKind::PatternCharClass => true,
+            EscapeScanSourceKind::SingleLiteralAssignmentWord
+            | EscapeScanSourceKind::BacktickFragment => false,
         })
-        .flat_map(|fact| {
-            word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
-                .into_iter()
-                .flat_map(|span| needless_backslash_spans(span, source))
-                .collect::<Vec<_>>()
+        .filter(|escape| match escape.source_kind() {
+            EscapeScanSourceKind::PatternCharClass => escape.escaped_byte() == b'-',
+            _ => is_regular_plain_word_escape_target(escape.escaped_byte()),
         })
-        .chain(
-            checker
-                .facts()
-                .word_facts()
-                .iter()
-                .filter(|fact| {
-                    matches!(
-                        fact.expansion_context(),
-                        Some(ExpansionContext::RedirectTarget(_))
-                    )
-                })
-                .filter(|fact| {
-                    !word_contains_single_quoted_fragment(fact.span(), single_quoted_fragments)
-                })
-                .filter(|fact| !is_grep_style_argument(facts, fact))
-                .filter(|fact| {
-                    !matches!(
-                        fact.expansion_context(),
-                        Some(ExpansionContext::RegexOperand | ExpansionContext::StringTestOperand)
-                    )
-                })
-                .flat_map(|fact| redirect_target_needless_backslash_spans(fact, source)),
-        )
-        .chain(
-            facts
-                .commands()
-                .iter()
-                .filter_map(|command| {
-                    command
-                        .body_word_span()
-                        .filter(|span| span.slice(source).contains('/'))
-                        .map(|span| needless_backslash_spans(span, source))
-                })
-                .flatten(),
-        )
-        .chain(
-            facts
-                .pattern_literal_spans()
-                .iter()
-                .copied()
-                .flat_map(|span| needless_backslash_spans(span, source)),
-        )
-        .chain(
-            facts
-                .pattern_charclass_spans()
-                .iter()
-                .copied()
-                .flat_map(|span| needless_backslash_spans_in_char_class(span, source)),
-        )
+        .map(|escape| escape.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || EscapedUnderscore);
-}
-
-fn is_relevant_word_context(context: Option<ExpansionContext>) -> bool {
-    matches!(
-        context,
-        Some(
-            ExpansionContext::CommandArgument
-                | ExpansionContext::AssignmentValue
-                | ExpansionContext::DeclarationAssignmentValue
-                | ExpansionContext::RedirectTarget(_)
-                | ExpansionContext::ForList
-                | ExpansionContext::SelectList
-                | ExpansionContext::CasePattern
-        )
-    )
-}
-
-fn word_contains_single_quoted_fragment(
-    word_span: Span,
-    fragments: &[crate::facts::SingleQuotedFragmentFact],
-) -> bool {
-    fragments.iter().any(|fragment| {
-        let fragment_span = fragment.span();
-        fragment_span.start.offset >= word_span.start.offset
-            && fragment_span.end.offset <= word_span.end.offset
-    })
-}
-
-fn redirect_target_needless_backslash_spans(
-    fact: &crate::facts::WordFact<'_>,
-    source: &str,
-) -> Vec<Span> {
-    word_literal_scan_segments_excluding_expansions(fact.word(), source)
-        .into_iter()
-        .flat_map(|span| needless_backslash_spans(span, source))
-        .collect()
-}
-
-fn is_grep_style_argument<'a>(
-    facts: &'a crate::facts::LinterFacts<'a>,
-    fact: &crate::facts::WordFact<'a>,
-) -> bool {
-    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
-        return false;
-    }
-
-    let command = facts.command(fact.command_id());
-    if command
-        .body_name_word()
-        .is_some_and(|word| word.span == fact.span())
-    {
-        return false;
-    }
-
-    command
-        .effective_or_literal_name()
-        .is_some_and(|name| name.contains("grep"))
-}
-
-fn needless_backslash_spans(word_span: Span, source: &str) -> Vec<Span> {
-    let text = word_span.slice(source);
-    let bytes = text.as_bytes();
-    let mut spans = Vec::new();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] != b'\\' {
-            index += 1;
-            continue;
-        }
-
-        let run_start = index;
-        while index < bytes.len() && bytes[index] == b'\\' {
-            index += 1;
-        }
-
-        if text
-            .as_bytes()
-            .get(index)
-            .is_some_and(|byte| is_regular_plain_word_escape_target(*byte))
-            && (index - run_start) % 2 == 1
-        {
-            let start = word_span.start.advanced_by(&text[..index - 1]);
-            spans.push(Span::from_positions(start, start));
-        }
-    }
-
-    spans
-}
-
-fn needless_backslash_spans_in_char_class(span: Span, source: &str) -> Vec<Span> {
-    let text = span.slice(source);
-    let bytes = text.as_bytes();
-    let mut spans = Vec::new();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] != b'\\' {
-            index += 1;
-            continue;
-        }
-
-        let run_start = index;
-        while index < bytes.len() && bytes[index] == b'\\' {
-            index += 1;
-        }
-
-        if text.as_bytes().get(index).is_some_and(|byte| *byte == b'-')
-            && (index - run_start) % 2 == 1
-        {
-            let start = span.start.advanced_by(&text[..index - 1]);
-            spans.push(Span::from_positions(start, start));
-        }
-    }
-
-    spans
 }
 
 fn is_regular_plain_word_escape_target(byte: u8) -> bool {

--- a/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
@@ -1,11 +1,5 @@
-use shuck_ast::Span;
-
-use crate::context::FileContextTag;
-use crate::{
-    Checker, ExpansionContext, Rule, Violation,
-    word_literal_part_spans_excluding_parameter_operator_tails,
-    word_literal_scan_segments_excluding_expansions,
-};
+use crate::facts::EscapeScanSourceKind;
+use crate::{Checker, Rule, Violation};
 
 pub struct EscapedUnderscoreLiteral;
 
@@ -20,204 +14,30 @@ impl Violation for EscapedUnderscoreLiteral {
 }
 
 pub fn escaped_underscore_literal(checker: &mut Checker) {
-    if checker.file_context().has_tag(FileContextTag::PatchFile) {
-        return;
-    }
-
-    let source = checker.source();
-    let facts = checker.facts();
-    let single_quoted_fragments = facts.single_quoted_fragments();
     let spans = checker
         .facts()
-        .word_facts()
+        .escape_scan_matches()
         .iter()
-        .filter(|fact| is_relevant_word_context(fact.expansion_context()))
-        .filter(|fact| !word_contains_single_quoted_fragment(fact.span(), single_quoted_fragments))
-        .filter(|fact| !is_grep_style_argument(facts, fact))
-        .filter(|fact| {
-            !matches!(
-                fact.expansion_context(),
-                Some(ExpansionContext::RegexOperand | ExpansionContext::StringTestOperand)
-            )
+        .copied()
+        .filter(|escape| match escape.source_kind() {
+            EscapeScanSourceKind::WordLiteralPart
+            | EscapeScanSourceKind::RedirectLiteralSegment => {
+                !escape.host_contains_single_quoted_fragment()
+            }
+            EscapeScanSourceKind::DynamicPathCommandName
+            | EscapeScanSourceKind::PatternLiteral
+            | EscapeScanSourceKind::PatternCharClass => true,
+            EscapeScanSourceKind::SingleLiteralAssignmentWord
+            | EscapeScanSourceKind::BacktickFragment => false,
         })
-        .flat_map(|fact| {
-            word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
-                .into_iter()
-                .flat_map(|span| needless_backslash_spans(span, source))
-                .collect::<Vec<_>>()
+        .filter(|escape| match escape.source_kind() {
+            EscapeScanSourceKind::PatternCharClass => escape.escaped_byte() == b'-',
+            _ => escape.escaped_byte() == b'_',
         })
-        .chain(
-            checker
-                .facts()
-                .word_facts()
-                .iter()
-                .filter(|fact| {
-                    matches!(
-                        fact.expansion_context(),
-                        Some(ExpansionContext::RedirectTarget(_))
-                    )
-                })
-                .filter(|fact| {
-                    !word_contains_single_quoted_fragment(fact.span(), single_quoted_fragments)
-                })
-                .filter(|fact| !is_grep_style_argument(facts, fact))
-                .filter(|fact| {
-                    !matches!(
-                        fact.expansion_context(),
-                        Some(ExpansionContext::RegexOperand | ExpansionContext::StringTestOperand)
-                    )
-                })
-                .flat_map(|fact| redirect_target_needless_backslash_spans(fact, source)),
-        )
-        .chain(
-            facts
-                .commands()
-                .iter()
-                .filter_map(|command| {
-                    command
-                        .body_word_span()
-                        .filter(|span| span.slice(source).contains('/'))
-                        .map(|span| needless_backslash_spans(span, source))
-                })
-                .flatten(),
-        )
-        .chain(
-            facts
-                .pattern_literal_spans()
-                .iter()
-                .copied()
-                .flat_map(|span| needless_backslash_spans(span, source)),
-        )
-        .chain(
-            facts
-                .pattern_charclass_spans()
-                .iter()
-                .copied()
-                .flat_map(|span| needless_backslash_spans_in_char_class(span, source)),
-        )
+        .map(|escape| escape.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || EscapedUnderscoreLiteral);
-}
-
-fn is_relevant_word_context(context: Option<ExpansionContext>) -> bool {
-    matches!(
-        context,
-        Some(
-            ExpansionContext::CommandArgument
-                | ExpansionContext::AssignmentValue
-                | ExpansionContext::DeclarationAssignmentValue
-                | ExpansionContext::RedirectTarget(_)
-                | ExpansionContext::ForList
-                | ExpansionContext::SelectList
-                | ExpansionContext::CasePattern
-        )
-    )
-}
-
-fn word_contains_single_quoted_fragment(
-    word_span: Span,
-    fragments: &[crate::facts::SingleQuotedFragmentFact],
-) -> bool {
-    fragments.iter().any(|fragment| {
-        let fragment_span = fragment.span();
-        fragment_span.start.offset >= word_span.start.offset
-            && fragment_span.end.offset <= word_span.end.offset
-    })
-}
-
-fn redirect_target_needless_backslash_spans(
-    fact: &crate::facts::WordFact<'_>,
-    source: &str,
-) -> Vec<Span> {
-    word_literal_scan_segments_excluding_expansions(fact.word(), source)
-        .into_iter()
-        .flat_map(|span| needless_backslash_spans(span, source))
-        .collect()
-}
-
-fn is_grep_style_argument<'a>(
-    facts: &'a crate::facts::LinterFacts<'a>,
-    fact: &crate::facts::WordFact<'a>,
-) -> bool {
-    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
-        return false;
-    }
-
-    let command = facts.command(fact.command_id());
-    if command
-        .body_name_word()
-        .is_some_and(|word| word.span == fact.span())
-    {
-        return false;
-    }
-
-    command
-        .effective_or_literal_name()
-        .is_some_and(|name| name.contains("grep"))
-}
-
-fn needless_backslash_spans(word_span: Span, source: &str) -> Vec<Span> {
-    let text = word_span.slice(source);
-    let bytes = text.as_bytes();
-    let mut spans = Vec::new();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] != b'\\' {
-            index += 1;
-            continue;
-        }
-
-        let run_start = index;
-        while index < bytes.len() && bytes[index] == b'\\' {
-            index += 1;
-        }
-
-        if text
-            .as_bytes()
-            .get(index)
-            .is_some_and(|byte| is_needless_backslash_target(*byte))
-            && (index - run_start) % 2 == 1
-        {
-            let start = word_span.start.advanced_by(&text[..index - 1]);
-            spans.push(Span::from_positions(start, start));
-        }
-    }
-
-    spans
-}
-
-fn needless_backslash_spans_in_char_class(span: Span, source: &str) -> Vec<Span> {
-    let text = span.slice(source);
-    let bytes = text.as_bytes();
-    let mut spans = Vec::new();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] != b'\\' {
-            index += 1;
-            continue;
-        }
-
-        let run_start = index;
-        while index < bytes.len() && bytes[index] == b'\\' {
-            index += 1;
-        }
-
-        if text.as_bytes().get(index).is_some_and(|byte| *byte == b'-')
-            && (index - run_start) % 2 == 1
-        {
-            let start = span.start.advanced_by(&text[..index - 1]);
-            spans.push(Span::from_positions(start, start));
-        }
-    }
-
-    spans
-}
-
-fn is_needless_backslash_target(byte: u8) -> bool {
-    byte == b'_'
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/needless_backslash_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/needless_backslash_underscore.rs
@@ -1,11 +1,5 @@
-use shuck_ast::Span;
-
-use crate::context::FileContextTag;
-use crate::{
-    Checker, ExpansionContext, Rule, Violation, word_has_single_literal_part,
-    word_literal_part_spans_excluding_parameter_operator_tails,
-    word_literal_scan_segments_excluding_expansions,
-};
+use crate::facts::EscapeScanSourceKind;
+use crate::{Checker, Rule, Violation};
 
 pub struct NeedlessBackslashUnderscore;
 
@@ -20,248 +14,30 @@ impl Violation for NeedlessBackslashUnderscore {
 }
 
 pub fn needless_backslash_underscore(checker: &mut Checker) {
-    if checker.file_context().has_tag(FileContextTag::PatchFile) {
-        return;
-    }
-
-    let source = checker.source();
-    let facts = checker.facts();
-    let single_quoted_fragments = facts.single_quoted_fragments();
     let spans = checker
         .facts()
-        .word_facts()
+        .escape_scan_matches()
         .iter()
-        .filter(|fact| is_relevant_word_context(fact.expansion_context()))
-        .filter(|fact| !fact.is_nested_word_command())
-        .filter(|fact| !word_contains_single_quoted_fragment(fact.span(), single_quoted_fragments))
-        .filter(|fact| !is_grep_style_argument(facts, fact))
-        .filter(|fact| {
-            !matches!(
-                fact.expansion_context(),
-                Some(ExpansionContext::RegexOperand | ExpansionContext::StringTestOperand)
-            )
+        .copied()
+        .filter(|escape| match escape.source_kind() {
+            EscapeScanSourceKind::WordLiteralPart => {
+                !escape.is_nested_word_command() && !escape.host_contains_single_quoted_fragment()
+            }
+            EscapeScanSourceKind::RedirectLiteralSegment
+            | EscapeScanSourceKind::SingleLiteralAssignmentWord => {
+                !escape.host_contains_single_quoted_fragment()
+            }
+            EscapeScanSourceKind::DynamicPathCommandName
+            | EscapeScanSourceKind::PatternLiteral
+            | EscapeScanSourceKind::PatternCharClass
+            | EscapeScanSourceKind::BacktickFragment => true,
         })
-        .flat_map(|fact| {
-            word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), source)
-                .into_iter()
-                .flat_map(|span| needless_backslash_spans(span, source))
-                .collect::<Vec<_>>()
-        })
-        .chain(
-            checker
-                .facts()
-                .word_facts()
-                .iter()
-                .filter(|fact| {
-                    matches!(
-                        fact.expansion_context(),
-                        Some(
-                            ExpansionContext::AssignmentValue
-                                | ExpansionContext::DeclarationAssignmentValue
-                        )
-                    )
-                })
-                .filter(|fact| word_has_single_literal_part(fact.word()))
-                .filter(|fact| {
-                    !word_contains_single_quoted_fragment(fact.span(), single_quoted_fragments)
-                })
-                .filter(|fact| !is_grep_style_argument(facts, fact))
-                .flat_map(|fact| needless_backslash_spans(fact.span(), source)),
-        )
-        .chain(
-            facts
-                .backtick_fragments()
-                .iter()
-                .copied()
-                .flat_map(|fragment| needless_backslash_spans(fragment.span(), source)),
-        )
-        .chain(
-            checker
-                .facts()
-                .word_facts()
-                .iter()
-                .filter(|fact| {
-                    matches!(
-                        fact.expansion_context(),
-                        Some(ExpansionContext::RedirectTarget(_))
-                    )
-                })
-                .filter(|fact| {
-                    !word_contains_single_quoted_fragment(fact.span(), single_quoted_fragments)
-                })
-                .filter(|fact| !is_grep_style_argument(facts, fact))
-                .filter(|fact| {
-                    !matches!(
-                        fact.expansion_context(),
-                        Some(ExpansionContext::RegexOperand | ExpansionContext::StringTestOperand)
-                    )
-                })
-                .flat_map(|fact| redirect_target_needless_backslash_spans(fact, source)),
-        )
-        .chain(
-            facts
-                .commands()
-                .iter()
-                .filter_map(|command| {
-                    command
-                        .body_word_span()
-                        .filter(|span| span.slice(source).contains('/'))
-                        .map(|span| needless_backslash_spans(span, source))
-                })
-                .flatten(),
-        )
-        .chain(
-            facts
-                .pattern_literal_spans()
-                .iter()
-                .copied()
-                .flat_map(|span| needless_backslash_spans(span, source)),
-        )
-        .chain(
-            facts
-                .pattern_charclass_spans()
-                .iter()
-                .copied()
-                .flat_map(|span| needless_backslash_spans_in_char_class(span, source)),
-        )
-        .filter(|span| !span_within_single_quoted_fragment(*span, single_quoted_fragments))
+        .filter(|escape| !escape.inside_single_quoted_fragment())
+        .filter(|escape| matches!(escape.escaped_byte(), b'n' | b'r' | b't'))
+        .map(|escape| escape.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || NeedlessBackslashUnderscore);
-}
-
-fn is_relevant_word_context(context: Option<ExpansionContext>) -> bool {
-    matches!(
-        context,
-        Some(
-            ExpansionContext::CommandArgument
-                | ExpansionContext::AssignmentValue
-                | ExpansionContext::DeclarationAssignmentValue
-                | ExpansionContext::RedirectTarget(_)
-                | ExpansionContext::ForList
-                | ExpansionContext::SelectList
-                | ExpansionContext::CasePattern
-        )
-    )
-}
-
-fn word_contains_single_quoted_fragment(
-    word_span: Span,
-    fragments: &[crate::facts::SingleQuotedFragmentFact],
-) -> bool {
-    fragments.iter().any(|fragment| {
-        let fragment_span = fragment.span();
-        fragment_span.start.offset >= word_span.start.offset
-            && fragment_span.end.offset <= word_span.end.offset
-    })
-}
-
-fn span_within_single_quoted_fragment(
-    span: Span,
-    fragments: &[crate::facts::SingleQuotedFragmentFact],
-) -> bool {
-    fragments.iter().any(|fragment| {
-        let fragment_span = fragment.span();
-        span.start.offset >= fragment_span.start.offset
-            && span.end.offset <= fragment_span.end.offset
-    })
-}
-
-fn redirect_target_needless_backslash_spans(
-    fact: &crate::facts::WordFact<'_>,
-    source: &str,
-) -> Vec<Span> {
-    word_literal_scan_segments_excluding_expansions(fact.word(), source)
-        .into_iter()
-        .flat_map(|span| needless_backslash_spans(span, source))
-        .collect()
-}
-
-fn is_grep_style_argument<'a>(
-    facts: &'a crate::facts::LinterFacts<'a>,
-    fact: &crate::facts::WordFact<'a>,
-) -> bool {
-    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
-        return false;
-    }
-
-    let command = facts.command(fact.command_id());
-    if command
-        .body_name_word()
-        .is_some_and(|word| word.span == fact.span())
-    {
-        return false;
-    }
-
-    command
-        .effective_or_literal_name()
-        .is_some_and(|name| name.contains("grep"))
-}
-
-fn needless_backslash_spans(word_span: Span, source: &str) -> Vec<Span> {
-    let text = word_span.slice(source);
-    let bytes = text.as_bytes();
-    let mut spans = Vec::new();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] != b'\\' {
-            index += 1;
-            continue;
-        }
-
-        let run_start = index;
-        while index < bytes.len() && bytes[index] == b'\\' {
-            index += 1;
-        }
-
-        if text
-            .as_bytes()
-            .get(index)
-            .is_some_and(|byte| is_needless_backslash_target(*byte))
-            && (index - run_start) % 2 == 1
-        {
-            let start = word_span.start.advanced_by(&text[..index - 1]);
-            spans.push(Span::from_positions(start, start));
-        }
-    }
-
-    spans
-}
-
-fn needless_backslash_spans_in_char_class(span: Span, source: &str) -> Vec<Span> {
-    let text = span.slice(source);
-    let bytes = text.as_bytes();
-    let mut spans = Vec::new();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] != b'\\' {
-            index += 1;
-            continue;
-        }
-
-        let run_start = index;
-        while index < bytes.len() && bytes[index] == b'\\' {
-            index += 1;
-        }
-
-        if text
-            .as_bytes()
-            .get(index)
-            .is_some_and(|byte| is_needless_backslash_target(*byte))
-            && (index - run_start) % 2 == 1
-        {
-            let start = span.start.advanced_by(&text[..index - 1]);
-            spans.push(Span::from_positions(start, start));
-        }
-    }
-
-    spans
-}
-
-fn is_needless_backslash_target(byte: u8) -> bool {
-    matches!(byte, b'n' | b'r' | b't')
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a shared `escape_scan` fact that scans escape candidates once per file and records the metadata needed by the style rules
- rewrite `S023`, `S026`, and `S027` as thin filters over the shared escape-scan inventory instead of repeating nearly identical scan pipelines
- add focused engine tests for odd/even backslash runs, char class matches, backtick fragments, and nested word command metadata

## Why
These three rules were all re-walking the same word and pattern facts with slightly diverging copies of the same scanning logic. Moving the scan into `LinterFacts` removes repeated work and keeps the edge-case behavior aligned in one place.

## Impact
This keeps the user-facing diagnostics, spans, and exclusions for `S023`, `S026`, and `S027` the same while reducing duplicated maintenance surface in the linter.

## Validation
- `cargo test -p shuck-linter escape_scan -- --nocapture`
- `cargo test -p shuck-linter escaped_underscore -- --nocapture`
- `cargo test -p shuck-linter needless_backslash_underscore -- --nocapture`
- `cargo test -p shuck-linter rule_escapedunderscore_path_new_s023_sh_expects -- --nocapture`
- `cargo test -p shuck-linter rule_needlessbackslashunderscore_path_new_s026_sh_expects -- --nocapture`
- `cargo test -p shuck-linter rule_escapedunderscoreliteral_path_new_s027_sh_expects -- --nocapture`
- `cargo test -p shuck-linter`
