### PR TITLE
Share broken test matcher

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/broken_test_common.rs
+++ b/crates/shuck-linter/src/rules/correctness/broken_test_common.rs
@@ -1,0 +1,20 @@
+use shuck_ast::Span;
+
+use crate::{Checker, static_word_text};
+
+pub(super) fn malformed_bracket_test_spans(checker: &Checker<'_>) -> Vec<Span> {
+    checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.static_utility_name_is("["))
+        .filter(|fact| {
+            fact.body_args()
+                .last()
+                .and_then(|word| static_word_text(word, checker.source()))
+                .as_deref()
+                != Some("]")
+        })
+        .map(|fact| fact.body_name_word().map_or(fact.span(), |word| word.span))
+        .collect()
+}

--- a/crates/shuck-linter/src/rules/correctness/broken_test_end.rs
+++ b/crates/shuck-linter/src/rules/correctness/broken_test_end.rs
@@ -1,4 +1,6 @@
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
+
+use super::broken_test_common::malformed_bracket_test_spans;
 
 pub struct BrokenTestEnd;
 
@@ -13,22 +15,7 @@ impl Violation for BrokenTestEnd {
 }
 
 pub fn broken_test_end(checker: &mut Checker) {
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter(|fact| fact.static_utility_name_is("["))
-        .filter(|fact| {
-            fact.body_args()
-                .last()
-                .and_then(|word| static_word_text(word, checker.source()))
-                .as_deref()
-                != Some("]")
-        })
-        .map(|fact| fact.body_name_word().map_or(fact.span(), |word| word.span))
-        .collect::<Vec<_>>();
-
-    checker.report_all(spans, || BrokenTestEnd);
+    checker.report_all(malformed_bracket_test_spans(checker), || BrokenTestEnd);
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/broken_test_parse.rs
+++ b/crates/shuck-linter/src/rules/correctness/broken_test_parse.rs
@@ -1,4 +1,6 @@
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
+
+use super::broken_test_common::malformed_bracket_test_spans;
 
 pub struct BrokenTestParse;
 
@@ -13,22 +15,7 @@ impl Violation for BrokenTestParse {
 }
 
 pub fn broken_test_parse(checker: &mut Checker) {
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter(|fact| fact.static_utility_name_is("["))
-        .filter(|fact| {
-            fact.body_args()
-                .last()
-                .and_then(|word| static_word_text(word, checker.source()))
-                .as_deref()
-                != Some("]")
-        })
-        .map(|fact| fact.body_name_word().map_or(fact.span(), |word| word.span))
-        .collect::<Vec<_>>();
-
-    checker.report_all(spans, || BrokenTestParse);
+    checker.report_all(malformed_bracket_test_spans(checker), || BrokenTestParse);
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -3,6 +3,7 @@ pub mod backslash_before_closing_backtick;
 pub mod bad_redirection_fd_order;
 pub mod bare_closing_brace;
 pub mod bare_slash_marker;
+mod broken_test_common;
 pub mod broken_test_end;
 pub mod broken_test_parse;
 pub mod c_prototype_fragment;


### PR DESCRIPTION
## Summary
- extract the duplicated malformed `[` test detection into a shared correctness helper
- have `broken_test_end` and `broken_test_parse` reuse that helper while keeping their distinct messages
- register the helper module in the correctness rule set

## Why
These two rules were using the same matcher and only differed in diagnostic wording. Centralizing the detection keeps the behavior aligned and reduces maintenance overhead.

## Impact
This is a refactor only. Rule behavior and diagnostics stay the same, but future matcher changes only need to happen in one place.

## Validation
- `cargo test -p shuck-linter broken_test_`