### PR TITLE
Extract shared trap argument parsing

### DIFF
--- a/crates/shuck-linter/src/rules/portability/mod.rs
+++ b/crates/shuck-linter/src/rules/portability/mod.rs
@@ -36,6 +36,7 @@ pub mod source_inside_function_in_sh;
 pub mod sourced_with_args;
 pub mod standalone_arithmetic;
 pub mod substring_expansion;
+mod trap_common;
 pub mod trap_err;
 pub mod uppercase_expansion;
 pub mod wait_option;

--- a/crates/shuck-linter/src/rules/portability/signal_name_in_trap.rs
+++ b/crates/shuck-linter/src/rules/portability/signal_name_in_trap.rs
@@ -1,5 +1,6 @@
 use shuck_ast::{Span, Word};
 
+use super::trap_common::parse_trap_args;
 use crate::{Checker, Rule, ShellDialect, Violation, static_word_text};
 
 pub struct SignalNameInTrap;
@@ -31,29 +32,15 @@ pub fn signal_name_in_trap(checker: &mut Checker) {
 }
 
 fn trap_signal_name_spans(args: &[&Word], source: &str) -> Vec<Span> {
-    let signal_words = match args.first().and_then(|word| static_word_text(word, source)) {
-        Some(first) if trap_is_listing_mode(first.as_str()) => return Vec::new(),
-        Some(first) if first == "--" => {
-            if args.len() == 2 {
-                &args[1..]
-            } else if args.len() > 2 {
-                &args[2..]
-            } else {
-                return Vec::new();
-            }
-        }
-        _ => {
-            if args.len() == 1 {
-                args
-            } else if args.len() > 1 {
-                &args[1..]
-            } else {
-                return Vec::new();
-            }
-        }
+    let Some(parsed) = parse_trap_args(args, source) else {
+        return Vec::new();
     };
+    if parsed.listing_mode {
+        return Vec::new();
+    }
 
-    signal_words
+    parsed
+        .signal_words
         .iter()
         .filter_map(|word| {
             let text = static_word_text(word, source)?;
@@ -67,12 +54,6 @@ fn trap_signal_name_spans(args: &[&Word], source: &str) -> Vec<Span> {
             .then_some(word.span)
         })
         .collect()
-}
-
-fn trap_is_listing_mode(text: &str) -> bool {
-    text.strip_prefix('-').is_some_and(|flags| {
-        !flags.is_empty() && flags.chars().all(|flag| matches!(flag, 'l' | 'p'))
-    })
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/portability/trap_common.rs
+++ b/crates/shuck-linter/src/rules/portability/trap_common.rs
@@ -1,0 +1,52 @@
+use shuck_ast::Word;
+
+use crate::static_word_text;
+
+pub(super) struct ParsedTrapArgs<'a> {
+    pub(super) signal_words: &'a [&'a Word],
+    pub(super) listing_mode: bool,
+}
+
+pub(super) fn parse_trap_args<'a>(
+    args: &'a [&'a Word],
+    source: &str,
+) -> Option<ParsedTrapArgs<'a>> {
+    let first = args.first().and_then(|word| static_word_text(word, source));
+
+    match first.as_deref() {
+        Some(first) if trap_is_listing_mode(first) => Some(ParsedTrapArgs {
+            signal_words: &args[1..],
+            listing_mode: true,
+        }),
+        Some("--") => {
+            let signal_words = match args.len() {
+                0 | 1 => return None,
+                2 => &args[1..],
+                _ => &args[2..],
+            };
+
+            Some(ParsedTrapArgs {
+                signal_words,
+                listing_mode: false,
+            })
+        }
+        _ => {
+            let signal_words = match args.len() {
+                0 => return None,
+                1 => args,
+                _ => &args[1..],
+            };
+
+            Some(ParsedTrapArgs {
+                signal_words,
+                listing_mode: false,
+            })
+        }
+    }
+}
+
+fn trap_is_listing_mode(text: &str) -> bool {
+    text.strip_prefix('-').is_some_and(|flags| {
+        !flags.is_empty() && flags.chars().all(|flag| matches!(flag, 'l' | 'p'))
+    })
+}

--- a/crates/shuck-linter/src/rules/portability/trap_err.rs
+++ b/crates/shuck-linter/src/rules/portability/trap_err.rs
@@ -1,3 +1,4 @@
+use super::trap_common::parse_trap_args;
 use crate::{Checker, Rule, ShellDialect, Violation, static_word_text};
 
 pub struct TrapErr;
@@ -29,29 +30,12 @@ pub fn trap_err(checker: &mut Checker) {
 }
 
 fn trap_err_signal_spans(args: &[&shuck_ast::Word], source: &str) -> Vec<shuck_ast::Span> {
-    let signal_words = match args.first().and_then(|word| static_word_text(word, source)) {
-        Some(first) if matches!(first.as_str(), "-p" | "-l") => &args[1..],
-        Some(first) if first == "--" => {
-            if args.len() == 2 {
-                &args[1..]
-            } else if args.len() > 2 {
-                &args[2..]
-            } else {
-                return Vec::new();
-            }
-        }
-        _ => {
-            if args.len() == 1 {
-                args
-            } else if args.len() > 1 {
-                &args[1..]
-            } else {
-                return Vec::new();
-            }
-        }
+    let Some(parsed) = parse_trap_args(args, source) else {
+        return Vec::new();
     };
 
-    signal_words
+    parsed
+        .signal_words
         .iter()
         .filter_map(|word| {
             static_word_text(word, source)
@@ -84,16 +68,17 @@ trap 'echo hi' ERR
 #!/bin/sh
 trap -p ERR
 trap -l ERR
+trap -lp ERR
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrapErr));
 
-        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics.len(), 3);
         assert_eq!(
             diagnostics
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["ERR", "ERR"]
+            vec!["ERR", "ERR", "ERR"]
         );
     }
 


### PR DESCRIPTION
## Summary
- factor shared `trap` operand parsing into a portability helper used by both `trap_err` and `signal_name_in_trap`
- keep each rule's predicate local while removing duplicated parsing branches
- add coverage for combined listing flags so `trap -lp ERR` follows the shared parser behavior

## Why
Both portability rules were independently decoding `trap` arguments before checking different conditions. Pulling that logic into one helper keeps the command-shape handling consistent and makes future changes less error-prone.

## Validation
- `cargo fmt --all`
- `cargo test -p shuck-linter trap_err`
- `cargo test -p shuck-linter signal_name_in_trap`