### PR TITLE
Implement variable and assignment lint rules

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C095.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C095.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# shellcheck disable=2034
+qt=qt-unicode-3.2

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C101.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C101.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# shellcheck disable=2154
+while IFS='\n' read -r comp; do
+  echo "$comp"
+done < /dev/null

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C116.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C116.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# shellcheck disable=2288
+test "$2" || 2="."

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C117.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C117.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# shellcheck disable=2034
++YYYY="$( date +%Y )"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C130.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C130.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# shellcheck disable=2154,3024,2086,2034,2090
+myfunc() {
+	CFLAGS+=" -DDIR=\"$PREFIX/share/\""
+	$CC $CFLAGS -c test.c -o test.o
+}
+myfunc

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C136.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C136.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# shellcheck disable=3043,2034,2155
+myfunc() {
+  local iface="${1}" ifvar="$(echo "${iface}" | tr - _)"
+  echo "$iface $ifvar"
+}
+myfunc eth0

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C139.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C139.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+export foo =bar

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C140.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C140.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+9var=ok

--- a/crates/shuck-linter/resources/test/fixtures/style/S042.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S042.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+while IFS== read -r key val; do
+  echo "$key=$val"
+done < /dev/null

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -545,6 +545,11 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::UnicodeQuoteInString) {
             rules::correctness::unicode_quote_in_string::unicode_quote_in_string(self);
         }
+        if self.is_rule_enabled(Rule::AssignmentLooksLikeComparison) {
+            rules::correctness::assignment_looks_like_comparison::assignment_looks_like_comparison(
+                self,
+            );
+        }
         if self.is_rule_enabled(Rule::CommentedContinuationLine) {
             rules::correctness::commented_continuation_line::commented_continuation_line(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -563,6 +563,9 @@ impl<'a> Checker<'a> {
                 self,
             );
         }
+        if self.is_rule_enabled(Rule::AppendWithEscapedQuotes) {
+            rules::correctness::append_with_escaped_quotes::append_with_escaped_quotes(self);
+        }
         if self.is_rule_enabled(Rule::CommentedContinuationLine) {
             rules::correctness::commented_continuation_line::commented_continuation_line(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -569,6 +569,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::LocalCrossReference) {
             rules::correctness::local_cross_reference::local_cross_reference(self);
         }
+        if self.is_rule_enabled(Rule::SpacedAssignment) {
+            rules::correctness::spaced_assignment::spaced_assignment(self);
+        }
         if self.is_rule_enabled(Rule::CommentedContinuationLine) {
             rules::correctness::commented_continuation_line::commented_continuation_line(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -550,6 +550,11 @@ impl<'a> Checker<'a> {
                 self,
             );
         }
+        if self.is_rule_enabled(Rule::AssignmentToNumericVariable) {
+            rules::correctness::assignment_to_numeric_variable::assignment_to_numeric_variable(
+                self,
+            );
+        }
         if self.is_rule_enabled(Rule::IfsSetToLiteralBackslashN) {
             rules::correctness::ifs_set_to_literal_backslash_n::ifs_set_to_literal_backslash_n(
                 self,

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -550,6 +550,11 @@ impl<'a> Checker<'a> {
                 self,
             );
         }
+        if self.is_rule_enabled(Rule::IfsSetToLiteralBackslashN) {
+            rules::correctness::ifs_set_to_literal_backslash_n::ifs_set_to_literal_backslash_n(
+                self,
+            );
+        }
         if self.is_rule_enabled(Rule::CommentedContinuationLine) {
             rules::correctness::commented_continuation_line::commented_continuation_line(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -513,6 +513,9 @@ impl<'a> Checker<'a> {
                 self,
             );
         }
+        if self.is_rule_enabled(Rule::IfsEqualsAmbiguity) {
+            rules::style::ifs_equals_ambiguity::ifs_equals_ambiguity(self);
+        }
         if self.is_rule_enabled(Rule::SingleQuotedLiteral) {
             rules::correctness::single_quoted_literal::single_quoted_literal(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -555,6 +555,9 @@ impl<'a> Checker<'a> {
                 self,
             );
         }
+        if self.is_rule_enabled(Rule::PlusPrefixInAssignment) {
+            rules::correctness::plus_prefix_in_assignment::plus_prefix_in_assignment(self);
+        }
         if self.is_rule_enabled(Rule::IfsSetToLiteralBackslashN) {
             rules::correctness::ifs_set_to_literal_backslash_n::ifs_set_to_literal_backslash_n(
                 self,

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -572,6 +572,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::SpacedAssignment) {
             rules::correctness::spaced_assignment::spaced_assignment(self);
         }
+        if self.is_rule_enabled(Rule::BadVarName) {
+            rules::correctness::bad_var_name::bad_var_name(self);
+        }
         if self.is_rule_enabled(Rule::CommentedContinuationLine) {
             rules::correctness::commented_continuation_line::commented_continuation_line(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -566,6 +566,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::AppendWithEscapedQuotes) {
             rules::correctness::append_with_escaped_quotes::append_with_escaped_quotes(self);
         }
+        if self.is_rule_enabled(Rule::LocalCrossReference) {
+            rules::correctness::local_cross_reference::local_cross_reference(self);
+        }
         if self.is_rule_enabled(Rule::CommentedContinuationLine) {
             rules::correctness::commented_continuation_line::commented_continuation_line(self);
         }

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -320,6 +320,7 @@ declare_rules! {
         LiteralBackslashInSingleQuotes
     ),
     ("S040", Category::Style, Severity::Warning, BackslashBeforeCommand),
+    ("S042", Category::Style, Severity::Warning, IfsEqualsAmbiguity),
     ("S072", Category::Style, Severity::Warning, LinebreakBeforeAnd),
     ("S074", Category::Style, Severity::Warning, AmpersandSemicolon),
 }
@@ -372,6 +373,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-087" => Some(Rule::SingleQuoteBackslash),
         "SH-172" => Some(Rule::LiteralBackslashInSingleQuotes),
         "SH-173" => Some(Rule::BackslashBeforeCommand),
+        "SH-185" => Some(Rule::IfsEqualsAmbiguity),
         "SH-088" => Some(Rule::LiteralBackslash),
         "SH-092" => Some(Rule::NeedlessBackslashUnderscore),
         "SH-258" => Some(Rule::AssignmentToNumericVariable),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -188,6 +188,7 @@ declare_rules! {
         LocalCrossReference
     ),
     ("C139", Category::Correctness, Severity::Warning, SpacedAssignment),
+    ("C140", Category::Correctness, Severity::Warning, BadVarName),
     (
         "C137",
         Category::Correctness,
@@ -493,6 +494,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-314" => Some(Rule::LocalCrossReference),
         "SH-315" => Some(Rule::UnicodeSingleQuoteInSingleQuotes),
         "SH-319" => Some(Rule::SpacedAssignment),
+        "SH-320" => Some(Rule::BadVarName),
         "SH-321" => Some(Rule::LoopWithoutEnd),
         "SH-322" => Some(Rule::MissingDoneInForLoop),
         "SH-327" => Some(Rule::DanglingElse),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -187,6 +187,7 @@ declare_rules! {
         Severity::Warning,
         LocalCrossReference
     ),
+    ("C139", Category::Correctness, Severity::Warning, SpacedAssignment),
     (
         "C137",
         Category::Correctness,
@@ -489,7 +490,9 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-281" => Some(Rule::StickyBitTestInSh),
         "SH-282" => Some(Rule::OwnershipTestInSh),
         "SH-283" => Some(Rule::FindExecDirWithShell),
+        "SH-314" => Some(Rule::LocalCrossReference),
         "SH-315" => Some(Rule::UnicodeSingleQuoteInSingleQuotes),
+        "SH-319" => Some(Rule::SpacedAssignment),
         "SH-321" => Some(Rule::LoopWithoutEnd),
         "SH-322" => Some(Rule::MissingDoneInForLoop),
         "SH-327" => Some(Rule::DanglingElse),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -168,6 +168,12 @@ declare_rules! {
         Severity::Warning,
         AssignmentToNumericVariable
     ),
+    (
+        "C117",
+        Category::Correctness,
+        Severity::Warning,
+        PlusPrefixInAssignment
+    ),
     ("C124", Category::Correctness, Severity::Warning, UnreachableAfterExit),
     (
         "C137",
@@ -355,6 +361,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-088" => Some(Rule::LiteralBackslash),
         "SH-092" => Some(Rule::NeedlessBackslashUnderscore),
         "SH-258" => Some(Rule::AssignmentToNumericVariable),
+        "SH-259" => Some(Rule::PlusPrefixInAssignment),
         "SH-025" => Some(Rule::DynamicSourcePath),
         "SH-026" => Some(Rule::UntrackedSourceFile),
         "SH-027" => Some(Rule::UncheckedDirectoryChange),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -182,6 +182,12 @@ declare_rules! {
         AppendWithEscapedQuotes
     ),
     (
+        "C136",
+        Category::Correctness,
+        Severity::Warning,
+        LocalCrossReference
+    ),
+    (
         "C137",
         Category::Correctness,
         Severity::Warning,

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -176,6 +176,12 @@ declare_rules! {
     ),
     ("C124", Category::Correctness, Severity::Warning, UnreachableAfterExit),
     (
+        "C130",
+        Category::Correctness,
+        Severity::Warning,
+        AppendWithEscapedQuotes
+    ),
+    (
         "C137",
         Category::Correctness,
         Severity::Warning,
@@ -362,6 +368,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-092" => Some(Rule::NeedlessBackslashUnderscore),
         "SH-258" => Some(Rule::AssignmentToNumericVariable),
         "SH-259" => Some(Rule::PlusPrefixInAssignment),
+        "SH-307" => Some(Rule::AppendWithEscapedQuotes),
         "SH-025" => Some(Rule::DynamicSourcePath),
         "SH-026" => Some(Rule::UntrackedSourceFile),
         "SH-027" => Some(Rule::UncheckedDirectoryChange),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -155,6 +155,12 @@ declare_rules! {
         Severity::Warning,
         AssignmentLooksLikeComparison
     ),
+    (
+        "C101",
+        Category::Correctness,
+        Severity::Warning,
+        IfsSetToLiteralBackslashN
+    ),
     ("C104", Category::Correctness, Severity::Warning, NonShellSyntaxInScript),
     ("C124", Category::Correctness, Severity::Warning, UnreachableAfterExit),
     (
@@ -324,6 +330,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-080" => Some(Rule::SourceBuiltinInSh),
         "SH-081" => Some(Rule::PrintfQFormatInSh),
         "SH-226" => Some(Rule::FunctionKeywordInSh),
+        "SH-234" => Some(Rule::IfsSetToLiteralBackslashN),
         "SH-304" => Some(Rule::SourceInsideFunctionInSh),
         "SH-275" => Some(Rule::ErrexitTrapInSh),
         "SH-276" => Some(Rule::SignalNameInTrap),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -149,6 +149,12 @@ declare_rules! {
         CommentedContinuationLine
     ),
     ("C077", Category::Correctness, Severity::Warning, SubshellInArithmetic),
+    (
+        "C095",
+        Category::Correctness,
+        Severity::Warning,
+        AssignmentLooksLikeComparison
+    ),
     ("C104", Category::Correctness, Severity::Warning, NonShellSyntaxInScript),
     ("C124", Category::Correctness, Severity::Warning, UnreachableAfterExit),
     (
@@ -408,6 +414,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-187" => Some(Rule::PositionalParamAsOperator),
         "SH-188" => Some(Rule::DoubleParenGrouping),
         "SH-189" => Some(Rule::UnicodeQuoteInString),
+        "SH-224" => Some(Rule::AssignmentLooksLikeComparison),
         "SH-194" => Some(Rule::CommentedContinuationLine),
         "SH-195" => Some(Rule::SubshellInArithmetic),
         "SH-238" => Some(Rule::NonShellSyntaxInScript),
@@ -626,6 +633,10 @@ mod tests {
         assert_eq!(code_to_rule("SH-188"), Some(Rule::DoubleParenGrouping));
         assert_eq!(code_to_rule("SH-189"), Some(Rule::UnicodeQuoteInString));
         assert_eq!(code_to_rule("SH-079"), Some(Rule::AvoidLetBuiltin));
+        assert_eq!(
+            code_to_rule("SH-224"),
+            Some(Rule::AssignmentLooksLikeComparison)
+        );
         assert_eq!(code_to_rule("SH-195"), Some(Rule::SubshellInArithmetic));
         assert_eq!(code_to_rule("C006"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("SH-039"), Some(Rule::UndefinedVariable));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -162,6 +162,12 @@ declare_rules! {
         IfsSetToLiteralBackslashN
     ),
     ("C104", Category::Correctness, Severity::Warning, NonShellSyntaxInScript),
+    (
+        "C116",
+        Category::Correctness,
+        Severity::Warning,
+        AssignmentToNumericVariable
+    ),
     ("C124", Category::Correctness, Severity::Warning, UnreachableAfterExit),
     (
         "C137",
@@ -348,6 +354,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-173" => Some(Rule::BackslashBeforeCommand),
         "SH-088" => Some(Rule::LiteralBackslash),
         "SH-092" => Some(Rule::NeedlessBackslashUnderscore),
+        "SH-258" => Some(Rule::AssignmentToNumericVariable),
         "SH-025" => Some(Rule::DynamicSourcePath),
         "SH-026" => Some(Rule::UntrackedSourceFile),
         "SH-027" => Some(Rule::UncheckedDirectoryChange),

--- a/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
@@ -1,0 +1,230 @@
+use shuck_ast::{
+    Assignment, AssignmentValue, BourneParameterExpansion, BuiltinCommand, Command, DeclOperand,
+    ParameterExpansion, Span, WordPart, ZshExpansionTarget,
+};
+
+use crate::facts::WordFact;
+use crate::rules::common::word::{ExpansionContext, WordQuote};
+use crate::{Checker, Rule, Violation};
+
+pub struct AppendWithEscapedQuotes;
+
+impl Violation for AppendWithEscapedQuotes {
+    fn rule() -> Rule {
+        Rule::AppendWithEscapedQuotes
+    }
+
+    fn message(&self) -> String {
+        "escaped quotes in `+=` text will stay literal".to_owned()
+    }
+}
+
+pub fn append_with_escaped_quotes(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| command_assignment_spans(checker, fact.command(), source))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || AppendWithEscapedQuotes);
+}
+
+fn command_assignment_spans(checker: &Checker<'_>, command: &Command, source: &str) -> Vec<Span> {
+    match command {
+        Command::Simple(command) => command
+            .assignments
+            .iter()
+            .filter_map(|assignment| escaped_quote_append_span(checker, assignment, source))
+            .collect(),
+        Command::Builtin(command) => builtin_assignments(command)
+            .iter()
+            .filter_map(|assignment| escaped_quote_append_span(checker, assignment, source))
+            .collect(),
+        Command::Decl(command) => command
+            .assignments
+            .iter()
+            .chain(command.operands.iter().filter_map(|operand| match operand {
+                DeclOperand::Assignment(assignment) => Some(assignment),
+                DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Dynamic(_) => None,
+            }))
+            .filter_map(|assignment| escaped_quote_append_span(checker, assignment, source))
+            .collect(),
+        Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => Vec::new(),
+    }
+}
+
+fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
+    match command {
+        BuiltinCommand::Break(command) => &command.assignments,
+        BuiltinCommand::Continue(command) => &command.assignments,
+        BuiltinCommand::Return(command) => &command.assignments,
+        BuiltinCommand::Exit(command) => &command.assignments,
+    }
+}
+
+fn escaped_quote_append_span(
+    checker: &Checker<'_>,
+    assignment: &Assignment,
+    source: &str,
+) -> Option<Span> {
+    if !assignment.append || assignment.target.subscript.is_some() {
+        return None;
+    }
+
+    let AssignmentValue::Scalar(word) = &assignment.value else {
+        return None;
+    };
+
+    let text = word.span.slice(source);
+    let first = text.find("\\\"")?;
+    if !word_has_parameter_like_part(&word.parts) || word_has_command_substitution(&word.parts) {
+        return None;
+    }
+    if !has_later_unquoted_command_argument_use(checker, assignment) {
+        return None;
+    }
+
+    let end = word.span.start.advanced_by(&text[..first + 2]);
+    Some(Span::from_positions(word.span.start, end))
+}
+
+fn word_has_parameter_like_part(parts: &[shuck_ast::WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Variable(_)
+        | WordPart::Parameter(_)
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::Transformation { .. } => true,
+        WordPart::DoubleQuoted { parts, .. } => word_has_parameter_like_part(parts),
+        _ => false,
+    })
+}
+
+fn word_has_command_substitution(parts: &[shuck_ast::WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::CommandSubstitution { .. } => true,
+        WordPart::DoubleQuoted { parts, .. } => word_has_command_substitution(parts),
+        _ => false,
+    })
+}
+
+fn has_later_unquoted_command_argument_use(checker: &Checker<'_>, assignment: &Assignment) -> bool {
+    checker
+        .facts()
+        .expansion_word_facts(ExpansionContext::CommandArgument)
+        .filter(|fact| fact.classification().quote == WordQuote::Unquoted)
+        .filter(|fact| fact.span().start.offset > assignment.target.name_span.start.offset)
+        .any(|fact| word_references_name(fact, assignment.target.name.as_str()))
+}
+
+fn word_references_name(fact: &WordFact<'_>, target_name: &str) -> bool {
+    word_parts_reference_name(&fact.word().parts, target_name)
+}
+
+fn word_parts_reference_name(parts: &[shuck_ast::WordPartNode], target_name: &str) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Variable(name) => name.as_str() == target_name,
+        WordPart::Parameter(expansion) => parameter_expansion_references_name(expansion, target_name),
+        WordPart::ParameterExpansion { reference, .. }
+        | WordPart::Length(reference)
+        | WordPart::ArrayAccess(reference)
+        | WordPart::ArrayLength(reference)
+        | WordPart::ArrayIndices(reference)
+        | WordPart::Substring { reference, .. }
+        | WordPart::ArraySlice { reference, .. }
+        | WordPart::IndirectExpansion { reference, .. }
+        | WordPart::Transformation { reference, .. } => reference.name.as_str() == target_name,
+        WordPart::DoubleQuoted { parts, .. } => word_parts_reference_name(parts, target_name),
+        _ => false,
+    })
+}
+
+fn parameter_expansion_references_name(expansion: &ParameterExpansion, target_name: &str) -> bool {
+    match expansion.bourne() {
+        Some(BourneParameterExpansion::Access { reference })
+        | Some(BourneParameterExpansion::Length { reference })
+        | Some(BourneParameterExpansion::Indices { reference })
+        | Some(BourneParameterExpansion::Indirect { reference, .. })
+        | Some(BourneParameterExpansion::Slice { reference, .. })
+        | Some(BourneParameterExpansion::Operation { reference, .. })
+        | Some(BourneParameterExpansion::Transformation { reference, .. }) => {
+            reference.name.as_str() == target_name
+        }
+        Some(BourneParameterExpansion::PrefixMatch { prefix, .. }) => prefix.as_str() == target_name,
+        None => expansion.zsh().is_some_and(|zsh| match &zsh.target {
+            ZshExpansionTarget::Reference(reference) => reference.name.as_str() == target_name,
+            ZshExpansionTarget::Nested(expansion) => {
+                parameter_expansion_references_name(expansion, target_name)
+            }
+            ZshExpansionTarget::Word(word) => word_parts_reference_name(&word.parts, target_name),
+            ZshExpansionTarget::Empty => false,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_escaped_quote_segments_in_append_assignments() {
+        let source = "\
+#!/bin/sh
+CFLAGS+=\" -DDIR=\\\"$PREFIX/share/\\\"\"\n\
+$CC $CFLAGS -c test.c -o test.o\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "\" -DDIR=\\\"");
+    }
+
+    #[test]
+    fn ignores_non_append_and_non_escaped_quote_assignments() {
+        let source = "\
+#!/bin/sh
+CFLAGS=\" -DDIR=\\\"$PREFIX/share/\\\"\"\nCFLAGS+=\" -DDIR=$PREFIX/share/\"\nCFLAGS+=\" -DDIR=\\\"arm\\\"\"\nshell+=$(printf '%s' \"\\\"$PREFIX\\\"\")\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_append_strings_only_reused_as_quoted_arguments() {
+        let source = "\
+#!/bin/bash
+GO_LDFLAGS=\"\"
+GO_LDFLAGS+=\" -X \\\"main.GitVersion=$VERSION\\\"\"\n\
+go build -ldflags \"$GO_LDFLAGS\"\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_subscripted_appends() {
+        let source = "\
+#!/bin/bash
+DEPENDENTS[0]+=\" --slave \\\"$prefix/bin/tool\\\" \\\"tool\\\" \\\"$prefix/bin/tool-real\\\"\"\n\
+printf '%s\\n' \"${DEPENDENTS[0]}\"\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
@@ -136,7 +136,9 @@ fn word_references_name(fact: &WordFact<'_>, target_name: &str) -> bool {
 fn word_parts_reference_name(parts: &[shuck_ast::WordPartNode], target_name: &str) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::Variable(name) => name.as_str() == target_name,
-        WordPart::Parameter(expansion) => parameter_expansion_references_name(expansion, target_name),
+        WordPart::Parameter(expansion) => {
+            parameter_expansion_references_name(expansion, target_name)
+        }
         WordPart::ParameterExpansion { reference, .. }
         | WordPart::Length(reference)
         | WordPart::ArrayAccess(reference)
@@ -162,7 +164,9 @@ fn parameter_expansion_references_name(expansion: &ParameterExpansion, target_na
         | Some(BourneParameterExpansion::Transformation { reference, .. }) => {
             reference.name.as_str() == target_name
         }
-        Some(BourneParameterExpansion::PrefixMatch { prefix, .. }) => prefix.as_str() == target_name,
+        Some(BourneParameterExpansion::PrefixMatch { prefix, .. }) => {
+            prefix.as_str() == target_name
+        }
         None => expansion.zsh().is_some_and(|zsh| match &zsh.target {
             ZshExpansionTarget::Reference(reference) => reference.name.as_str() == target_name,
             ZshExpansionTarget::Nested(expansion) => {
@@ -185,8 +189,10 @@ mod tests {
 #!/bin/sh
 CFLAGS+=\" -DDIR=\\\"$PREFIX/share/\\\"\"\n\
 $CC $CFLAGS -c test.c -o test.o\n";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
+        );
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "\" -DDIR=\\\"");
@@ -197,8 +203,10 @@ $CC $CFLAGS -c test.c -o test.o\n";
         let source = "\
 #!/bin/sh
 CFLAGS=\" -DDIR=\\\"$PREFIX/share/\\\"\"\nCFLAGS+=\" -DDIR=$PREFIX/share/\"\nCFLAGS+=\" -DDIR=\\\"arm\\\"\"\nshell+=$(printf '%s' \"\\\"$PREFIX\\\"\")\n";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
+        );
 
         assert!(diagnostics.is_empty());
     }
@@ -210,8 +218,10 @@ CFLAGS=\" -DDIR=\\\"$PREFIX/share/\\\"\"\nCFLAGS+=\" -DDIR=$PREFIX/share/\"\nCFL
 GO_LDFLAGS=\"\"
 GO_LDFLAGS+=\" -X \\\"main.GitVersion=$VERSION\\\"\"\n\
 go build -ldflags \"$GO_LDFLAGS\"\n";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
+        );
 
         assert!(diagnostics.is_empty());
     }
@@ -222,8 +232,10 @@ go build -ldflags \"$GO_LDFLAGS\"\n";
 #!/bin/bash
 DEPENDENTS[0]+=\" --slave \\\"$prefix/bin/tool\\\" \\\"tool\\\" \\\"$prefix/bin/tool-real\\\"\"\n\
 printf '%s\\n' \"${DEPENDENTS[0]}\"\n";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
+        );
 
         assert!(diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
@@ -136,9 +136,7 @@ fn word_references_name(fact: &WordFact<'_>, target_name: &str) -> bool {
 fn word_parts_reference_name(parts: &[shuck_ast::WordPartNode], target_name: &str) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::Variable(name) => name.as_str() == target_name,
-        WordPart::Parameter(expansion) => {
-            parameter_expansion_references_name(expansion, target_name)
-        }
+        WordPart::Parameter(expansion) => parameter_expansion_references_name(expansion, target_name),
         WordPart::ParameterExpansion { reference, .. }
         | WordPart::Length(reference)
         | WordPart::ArrayAccess(reference)
@@ -164,9 +162,7 @@ fn parameter_expansion_references_name(expansion: &ParameterExpansion, target_na
         | Some(BourneParameterExpansion::Transformation { reference, .. }) => {
             reference.name.as_str() == target_name
         }
-        Some(BourneParameterExpansion::PrefixMatch { prefix, .. }) => {
-            prefix.as_str() == target_name
-        }
+        Some(BourneParameterExpansion::PrefixMatch { prefix, .. }) => prefix.as_str() == target_name,
         None => expansion.zsh().is_some_and(|zsh| match &zsh.target {
             ZshExpansionTarget::Reference(reference) => reference.name.as_str() == target_name,
             ZshExpansionTarget::Nested(expansion) => {
@@ -189,10 +185,8 @@ mod tests {
 #!/bin/sh
 CFLAGS+=\" -DDIR=\\\"$PREFIX/share/\\\"\"\n\
 $CC $CFLAGS -c test.c -o test.o\n";
-        let diagnostics = test_snippet(
-            source,
-            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
-        );
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "\" -DDIR=\\\"");
@@ -203,10 +197,8 @@ $CC $CFLAGS -c test.c -o test.o\n";
         let source = "\
 #!/bin/sh
 CFLAGS=\" -DDIR=\\\"$PREFIX/share/\\\"\"\nCFLAGS+=\" -DDIR=$PREFIX/share/\"\nCFLAGS+=\" -DDIR=\\\"arm\\\"\"\nshell+=$(printf '%s' \"\\\"$PREFIX\\\"\")\n";
-        let diagnostics = test_snippet(
-            source,
-            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
-        );
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
 
         assert!(diagnostics.is_empty());
     }
@@ -218,10 +210,8 @@ CFLAGS=\" -DDIR=\\\"$PREFIX/share/\\\"\"\nCFLAGS+=\" -DDIR=$PREFIX/share/\"\nCFL
 GO_LDFLAGS=\"\"
 GO_LDFLAGS+=\" -X \\\"main.GitVersion=$VERSION\\\"\"\n\
 go build -ldflags \"$GO_LDFLAGS\"\n";
-        let diagnostics = test_snippet(
-            source,
-            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
-        );
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
 
         assert!(diagnostics.is_empty());
     }
@@ -232,10 +222,8 @@ go build -ldflags \"$GO_LDFLAGS\"\n";
 #!/bin/bash
 DEPENDENTS[0]+=\" --slave \\\"$prefix/bin/tool\\\" \\\"tool\\\" \\\"$prefix/bin/tool-real\\\"\"\n\
 printf '%s\\n' \"${DEPENDENTS[0]}\"\n";
-        let diagnostics = test_snippet(
-            source,
-            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
-        );
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes));
 
         assert!(diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
@@ -1,11 +1,7 @@
-use shuck_ast::{
-    Assignment, AssignmentValue, BourneParameterExpansion, BuiltinCommand, Command, DeclOperand,
-    ParameterExpansion, Span, WordPart, ZshExpansionTarget,
-};
+use shuck_ast::{Assignment, AssignmentValue, BuiltinCommand, Command, DeclOperand, Span};
+use shuck_semantic::ReferenceKind;
 
-use crate::facts::WordFact;
-use crate::rules::common::word::{ExpansionContext, WordQuote};
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote};
 
 pub struct AppendWithEscapedQuotes;
 
@@ -36,11 +32,25 @@ fn command_assignment_spans(checker: &Checker<'_>, command: &Command, source: &s
         Command::Simple(command) => command
             .assignments
             .iter()
-            .filter_map(|assignment| escaped_quote_append_span(checker, assignment, source))
+            .filter_map(|assignment| {
+                escaped_quote_append_span(
+                    checker,
+                    assignment,
+                    source,
+                    WordFactContext::Expansion(ExpansionContext::AssignmentValue),
+                )
+            })
             .collect(),
         Command::Builtin(command) => builtin_assignments(command)
             .iter()
-            .filter_map(|assignment| escaped_quote_append_span(checker, assignment, source))
+            .filter_map(|assignment| {
+                escaped_quote_append_span(
+                    checker,
+                    assignment,
+                    source,
+                    WordFactContext::Expansion(ExpansionContext::AssignmentValue),
+                )
+            })
             .collect(),
         Command::Decl(command) => command
             .assignments
@@ -49,7 +59,14 @@ fn command_assignment_spans(checker: &Checker<'_>, command: &Command, source: &s
                 DeclOperand::Assignment(assignment) => Some(assignment),
                 DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Dynamic(_) => None,
             }))
-            .filter_map(|assignment| escaped_quote_append_span(checker, assignment, source))
+            .filter_map(|assignment| {
+                escaped_quote_append_span(
+                    checker,
+                    assignment,
+                    source,
+                    WordFactContext::Expansion(ExpansionContext::DeclarationAssignmentValue),
+                )
+            })
             .collect(),
         Command::Binary(_)
         | Command::Compound(_)
@@ -71,6 +88,7 @@ fn escaped_quote_append_span(
     checker: &Checker<'_>,
     assignment: &Assignment,
     source: &str,
+    context: WordFactContext,
 ) -> Option<Span> {
     if !assignment.append || assignment.target.subscript.is_some() {
         return None;
@@ -80,9 +98,11 @@ fn escaped_quote_append_span(
         return None;
     };
 
+    let fact = checker.facts().word_fact(word.span, context)?;
+    let classification = fact.classification();
     let text = word.span.slice(source);
     let first = text.find("\\\"")?;
-    if !word_has_parameter_like_part(&word.parts) || word_has_command_substitution(&word.parts) {
+    if !classification.has_scalar_expansion() || classification.has_command_substitution() {
         return None;
     }
     if !has_later_unquoted_command_argument_use(checker, assignment) {
@@ -93,89 +113,23 @@ fn escaped_quote_append_span(
     Some(Span::from_positions(word.span.start, end))
 }
 
-fn word_has_parameter_like_part(parts: &[shuck_ast::WordPartNode]) -> bool {
-    parts.iter().any(|part| match &part.kind {
-        WordPart::Variable(_)
-        | WordPart::Parameter(_)
-        | WordPart::ParameterExpansion { .. }
-        | WordPart::Length(_)
-        | WordPart::ArrayAccess(_)
-        | WordPart::ArrayLength(_)
-        | WordPart::ArrayIndices(_)
-        | WordPart::Substring { .. }
-        | WordPart::ArraySlice { .. }
-        | WordPart::IndirectExpansion { .. }
-        | WordPart::PrefixMatch { .. }
-        | WordPart::Transformation { .. } => true,
-        WordPart::DoubleQuoted { parts, .. } => word_has_parameter_like_part(parts),
-        _ => false,
-    })
-}
-
-fn word_has_command_substitution(parts: &[shuck_ast::WordPartNode]) -> bool {
-    parts.iter().any(|part| match &part.kind {
-        WordPart::CommandSubstitution { .. } => true,
-        WordPart::DoubleQuoted { parts, .. } => word_has_command_substitution(parts),
-        _ => false,
-    })
-}
-
 fn has_later_unquoted_command_argument_use(checker: &Checker<'_>, assignment: &Assignment) -> bool {
     checker
         .facts()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| fact.classification().quote == WordQuote::Unquoted)
         .filter(|fact| fact.span().start.offset > assignment.target.name_span.start.offset)
-        .any(|fact| word_references_name(fact, assignment.target.name.as_str()))
+        .any(|fact| {
+            checker.semantic().references().iter().any(|reference| {
+                reference.kind != ReferenceKind::DeclarationName
+                    && reference.name.as_str() == assignment.target.name.as_str()
+                    && contains_span(fact.span(), reference.span)
+            })
+        })
 }
 
-fn word_references_name(fact: &WordFact<'_>, target_name: &str) -> bool {
-    word_parts_reference_name(&fact.word().parts, target_name)
-}
-
-fn word_parts_reference_name(parts: &[shuck_ast::WordPartNode], target_name: &str) -> bool {
-    parts.iter().any(|part| match &part.kind {
-        WordPart::Variable(name) => name.as_str() == target_name,
-        WordPart::Parameter(expansion) => {
-            parameter_expansion_references_name(expansion, target_name)
-        }
-        WordPart::ParameterExpansion { reference, .. }
-        | WordPart::Length(reference)
-        | WordPart::ArrayAccess(reference)
-        | WordPart::ArrayLength(reference)
-        | WordPart::ArrayIndices(reference)
-        | WordPart::Substring { reference, .. }
-        | WordPart::ArraySlice { reference, .. }
-        | WordPart::IndirectExpansion { reference, .. }
-        | WordPart::Transformation { reference, .. } => reference.name.as_str() == target_name,
-        WordPart::DoubleQuoted { parts, .. } => word_parts_reference_name(parts, target_name),
-        _ => false,
-    })
-}
-
-fn parameter_expansion_references_name(expansion: &ParameterExpansion, target_name: &str) -> bool {
-    match expansion.bourne() {
-        Some(BourneParameterExpansion::Access { reference })
-        | Some(BourneParameterExpansion::Length { reference })
-        | Some(BourneParameterExpansion::Indices { reference })
-        | Some(BourneParameterExpansion::Indirect { reference, .. })
-        | Some(BourneParameterExpansion::Slice { reference, .. })
-        | Some(BourneParameterExpansion::Operation { reference, .. })
-        | Some(BourneParameterExpansion::Transformation { reference, .. }) => {
-            reference.name.as_str() == target_name
-        }
-        Some(BourneParameterExpansion::PrefixMatch { prefix, .. }) => {
-            prefix.as_str() == target_name
-        }
-        None => expansion.zsh().is_some_and(|zsh| match &zsh.target {
-            ZshExpansionTarget::Reference(reference) => reference.name.as_str() == target_name,
-            ZshExpansionTarget::Nested(expansion) => {
-                parameter_expansion_references_name(expansion, target_name)
-            }
-            ZshExpansionTarget::Word(word) => word_parts_reference_name(&word.parts, target_name),
-            ZshExpansionTarget::Empty => false,
-        }),
-    }
+fn contains_span(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
@@ -1,0 +1,158 @@
+use shuck_ast::{Assignment, AssignmentValue, BuiltinCommand, Command, DeclOperand, Span};
+
+use crate::{
+    Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote, static_word_text,
+};
+
+pub struct AssignmentLooksLikeComparison;
+
+impl Violation for AssignmentLooksLikeComparison {
+    fn rule() -> Rule {
+        Rule::AssignmentLooksLikeComparison
+    }
+
+    fn message(&self) -> String {
+        "assignment value looks like arithmetic subtraction".to_owned()
+    }
+}
+
+pub fn assignment_looks_like_comparison(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| command_assignment_spans(checker, fact.command(), source))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || AssignmentLooksLikeComparison);
+}
+
+fn command_assignment_spans(checker: &Checker<'_>, command: &Command, source: &str) -> Vec<Span> {
+    match command {
+        Command::Simple(command) => command
+            .assignments
+            .iter()
+            .filter_map(|assignment| {
+                assignment_value_looks_like_comparison(
+                    checker,
+                    assignment,
+                    source,
+                    WordFactContext::Expansion(ExpansionContext::AssignmentValue),
+                )
+            })
+            .collect(),
+        Command::Builtin(command) => builtin_assignments(command)
+            .iter()
+            .filter_map(|assignment| {
+                assignment_value_looks_like_comparison(
+                    checker,
+                    assignment,
+                    source,
+                    WordFactContext::Expansion(ExpansionContext::AssignmentValue),
+                )
+            })
+            .collect(),
+        Command::Decl(command) => command
+            .assignments
+            .iter()
+            .chain(command.operands.iter().filter_map(|operand| match operand {
+                DeclOperand::Assignment(assignment) => Some(assignment),
+                DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Dynamic(_) => None,
+            }))
+            .filter_map(|assignment| {
+                assignment_value_looks_like_comparison(
+                    checker,
+                    assignment,
+                    source,
+                    WordFactContext::Expansion(ExpansionContext::DeclarationAssignmentValue),
+                )
+            })
+            .collect(),
+        Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => Vec::new(),
+    }
+}
+
+fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
+    match command {
+        BuiltinCommand::Break(command) => &command.assignments,
+        BuiltinCommand::Continue(command) => &command.assignments,
+        BuiltinCommand::Return(command) => &command.assignments,
+        BuiltinCommand::Exit(command) => &command.assignments,
+    }
+}
+
+fn assignment_value_looks_like_comparison(
+    checker: &Checker<'_>,
+    assignment: &Assignment,
+    source: &str,
+    context: WordFactContext,
+) -> Option<Span> {
+    let AssignmentValue::Scalar(word) = &assignment.value else {
+        return None;
+    };
+
+    let fact = checker.facts().word_fact(word.span, context)?;
+    if fact.classification().quote != WordQuote::Unquoted {
+        return None;
+    }
+
+    let target = assignment.target.name.as_str();
+    let value = static_word_text(word, source)?;
+    let Some(remainder) = value.strip_prefix(target) else {
+        return None;
+    };
+    if !remainder.starts_with('-') || remainder == "-" {
+        return None;
+    }
+
+    Some(word.span)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn anchors_on_assignment_values() {
+        let source = "\
+#!/bin/bash
+foo=foo-bar
+foo+=foo-1
+bar=bar_baz
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentLooksLikeComparison),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["foo-bar", "foo-1"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_matching_or_non_static_assignments() {
+        let source = "\
+#!/bin/bash
+foo=bar-baz
+foo=\"$foo-bar\"
+foo=${foo}-bar
+foo=(foo-bar)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentLooksLikeComparison),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
@@ -102,9 +102,7 @@ fn assignment_value_looks_like_comparison(
 
     let target = assignment.target.name.as_str();
     let value = static_word_text(word, source)?;
-    let Some(remainder) = value.strip_prefix(target) else {
-        return None;
-    };
+    let remainder = value.strip_prefix(target)?;
     if !remainder.starts_with('-') || remainder == "-" {
         return None;
     }

--- a/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
@@ -1,0 +1,119 @@
+use shuck_ast::{DeclOperand, Position, Span};
+
+use crate::{Checker, Rule, Violation};
+
+pub struct AssignmentToNumericVariable;
+
+impl Violation for AssignmentToNumericVariable {
+    fn rule() -> Rule {
+        Rule::AssignmentToNumericVariable
+    }
+
+    fn message(&self) -> String {
+        "assignment target is numeric".to_owned()
+    }
+}
+
+pub fn assignment_to_numeric_variable(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| command_assignment_spans(fact, source))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || AssignmentToNumericVariable);
+}
+
+fn command_assignment_spans(fact: &crate::facts::CommandFact<'_>, source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+
+    if let Some(span) = command_numeric_assignment_span(fact, source) {
+        spans.push(span);
+    }
+
+    if let Some(declaration) = fact.declaration() {
+        spans.extend(
+            declaration
+                .operands
+                .iter()
+                .filter_map(|operand| match operand {
+                    DeclOperand::Dynamic(word) => {
+                        numeric_assignment_target_span(word.span.slice(source), word.span.start)
+                    }
+                    DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Assignment(_) => {
+                        None
+                    }
+                }),
+        );
+    }
+
+    spans
+}
+
+fn command_numeric_assignment_span(
+    fact: &crate::facts::CommandFact<'_>,
+    source: &str,
+) -> Option<Span> {
+    let text = fact.span().slice(source);
+    let first_word = text.split_whitespace().next()?;
+    numeric_assignment_target_span(first_word, fact.span().start)
+}
+
+fn numeric_assignment_target_span(text: &str, start: Position) -> Option<Span> {
+    let target_end = text.find("+=").or_else(|| text.find('='))?;
+    let target = &text[..target_end];
+    if !target.is_empty() && target.chars().all(|character| character.is_ascii_digit()) {
+        Some(Span::from_positions(start, start.advanced_by(target)))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn anchors_on_numeric_assignment_targets() {
+        let source = "\
+#!/bin/sh
+# shellcheck disable=2288
+test \"$2\" || 2=\".\"
+export 3=foo
+local 4=bar
+declare 5=baz
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentToNumericVariable),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["2", "3", "4", "5"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_numeric_assignment_targets() {
+        let source = "\
+#!/bin/sh
+foo=1
+_2=1
+a2=1
+2foo=1
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentToNumericVariable),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/bad_var_name.rs
+++ b/crates/shuck-linter/src/rules/correctness/bad_var_name.rs
@@ -1,0 +1,92 @@
+use shuck_ast::{Command, Span, Word};
+
+use crate::{Checker, Rule, Violation};
+
+pub struct BadVarName;
+
+impl Violation for BadVarName {
+    fn rule() -> Rule {
+        Rule::BadVarName
+    }
+
+    fn message(&self) -> String {
+        "assignment target starts with an invalid character".to_owned()
+    }
+}
+
+pub fn bad_var_name(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter_map(|fact| match fact.command() {
+            Command::Simple(command) => bad_var_name_span(&command.name, source),
+            Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Binary(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || BadVarName);
+}
+
+fn bad_var_name_span(word: &Word, source: &str) -> Option<Span> {
+    let text = word.span.slice(source);
+    let target_end = text.find('=')?;
+    if target_end > 0 && text.as_bytes()[target_end - 1] == b'+' {
+        return None;
+    }
+
+    let target = &text[..target_end];
+    let first = target.chars().next()?;
+    if !first.is_ascii_digit() || target.chars().all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(word.span)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn anchors_on_assignment_like_words_with_digit_prefixed_names() {
+        let source = "\
+#!/bin/sh
+9var=ok
+1_name=value
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BadVarName));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["9var=ok", "1_name=value"]
+        );
+    }
+
+    #[test]
+    fn ignores_numeric_targets_append_forms_and_declaration_builtins() {
+        let source = "\
+#!/bin/sh
+9=ok
+10=ok
+9var+=ok
+export 9var=ok
+readonly 9var=ok
+command 9var=ok
+foo=ok
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BadVarName));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/ifs_set_to_literal_backslash_n.rs
+++ b/crates/shuck-linter/src/rules/correctness/ifs_set_to_literal_backslash_n.rs
@@ -1,0 +1,134 @@
+use shuck_ast::{Assignment, AssignmentValue, BuiltinCommand, Command, DeclOperand, Span};
+
+use crate::{Checker, Rule, Violation, static_word_text};
+
+pub struct IfsSetToLiteralBackslashN;
+
+impl Violation for IfsSetToLiteralBackslashN {
+    fn rule() -> Rule {
+        Rule::IfsSetToLiteralBackslashN
+    }
+
+    fn message(&self) -> String {
+        "IFS contains a literal \\n sequence".to_owned()
+    }
+}
+
+pub fn ifs_set_to_literal_backslash_n(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| command_assignment_spans(fact.command(), source))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || IfsSetToLiteralBackslashN);
+}
+
+fn command_assignment_spans(command: &Command, source: &str) -> Vec<Span> {
+    match command {
+        Command::Simple(command) => command
+            .assignments
+            .iter()
+            .filter_map(|assignment| {
+                assignment_value_contains_literal_backslash_n(assignment, source)
+            })
+            .collect(),
+        Command::Builtin(command) => builtin_assignments(command)
+            .iter()
+            .filter_map(|assignment| {
+                assignment_value_contains_literal_backslash_n(assignment, source)
+            })
+            .collect(),
+        Command::Decl(command) => command
+            .assignments
+            .iter()
+            .chain(command.operands.iter().filter_map(|operand| match operand {
+                DeclOperand::Assignment(assignment) => Some(assignment),
+                DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Dynamic(_) => None,
+            }))
+            .filter_map(|assignment| {
+                assignment_value_contains_literal_backslash_n(assignment, source)
+            })
+            .collect(),
+        Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => Vec::new(),
+    }
+}
+
+fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
+    match command {
+        BuiltinCommand::Break(command) => &command.assignments,
+        BuiltinCommand::Continue(command) => &command.assignments,
+        BuiltinCommand::Return(command) => &command.assignments,
+        BuiltinCommand::Exit(command) => &command.assignments,
+    }
+}
+
+fn assignment_value_contains_literal_backslash_n(
+    assignment: &Assignment,
+    source: &str,
+) -> Option<Span> {
+    if assignment.target.name.as_str() != "IFS" {
+        return None;
+    }
+
+    let AssignmentValue::Scalar(word) = &assignment.value else {
+        return None;
+    };
+
+    static_word_text(word, source)
+        .is_some_and(|text| text.contains("\\n"))
+        .then_some(word.span)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn anchors_on_ifs_assignment_values() {
+        let source = "\
+#!/bin/sh
+IFS='\\n'
+export IFS=\"x\\n\"
+foo() {
+  local IFS='\\n\\t'
+}
+declare IFS='prefix\\nsuffix'
+bar='\\n'
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::IfsSetToLiteralBackslashN),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["'\\n'", "\"x\\n\"", "'\\n\\t'", "'prefix\\nsuffix'"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_literal_or_non_ifs_assignments() {
+        let source = "\
+#!/bin/sh
+IFS=$'\\n'
+foo='\\n'
+bar=bar-n
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::IfsSetToLiteralBackslashN),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
+++ b/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
@@ -1,0 +1,126 @@
+use rustc_hash::FxHashMap;
+use shuck_ast::{ArrayElem, Assignment, AssignmentValue, Span};
+use shuck_semantic::ReferenceKind;
+
+use crate::{Checker, Rule, Violation};
+
+pub struct LocalCrossReference;
+
+impl Violation for LocalCrossReference {
+    fn rule() -> Rule {
+        Rule::LocalCrossReference
+    }
+
+    fn message(&self) -> String {
+        "assignment is reused later in the same declaration".to_owned()
+    }
+}
+
+pub fn local_cross_reference(checker: &mut Checker) {
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| declaration_cross_reference_spans(checker, fact))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || LocalCrossReference);
+}
+
+fn declaration_cross_reference_spans(
+    checker: &Checker<'_>,
+    fact: &crate::CommandFact<'_>,
+) -> Vec<Span> {
+    let Some(declaration) = fact.declaration() else {
+        return Vec::new();
+    };
+
+    let mut seen_targets = FxHashMap::default();
+    let mut spans = Vec::new();
+
+    for assignment in declaration.assignment_operands.iter().copied() {
+        for value_span in assignment_value_spans(assignment) {
+            for reference in checker.semantic().references().iter().filter(|reference| {
+                reference.kind != ReferenceKind::DeclarationName
+                    && contains_span(value_span, reference.span)
+            }) {
+                if let Some(previous_span) = seen_targets.get(reference.name.as_str()) {
+                    spans.push(*previous_span);
+                }
+            }
+        }
+
+        seen_targets.insert(
+            assignment.target.name.as_str().to_owned(),
+            assignment.target.name_span,
+        );
+    }
+
+    spans
+}
+
+fn assignment_value_spans(assignment: &Assignment) -> Vec<Span> {
+    match &assignment.value {
+        AssignmentValue::Scalar(word) => vec![word.span],
+        AssignmentValue::Compound(array) => array
+            .elements
+            .iter()
+            .flat_map(array_element_spans)
+            .collect(),
+    }
+}
+
+fn array_element_spans(element: &ArrayElem) -> Vec<Span> {
+    match element {
+        ArrayElem::Sequential(word) => vec![word.span],
+        ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
+            vec![key.span(), value.span]
+        }
+    }
+}
+
+fn contains_span(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn anchors_on_prior_assignment_names_in_declarations() {
+        let source = "\
+#!/bin/sh
+local a=1 b=$a c=$b
+declare x=1 y=$(printf '%s' \"$x\")
+readonly p=1 q=(\"$p\")
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::LocalCrossReference));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "x", "p"]
+        );
+    }
+
+    #[test]
+    fn prefers_the_most_recent_prior_assignment_for_reused_names() {
+        let source = "\
+#!/bin/sh
+local a=1 a=2 c=$a
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::LocalCrossReference));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.start.offset,
+            source.find("a=2").unwrap()
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -33,6 +33,7 @@ pub mod leading_glob_argument;
 pub mod line_oriented_input;
 pub mod linebreak_in_test;
 pub mod literal_unary_string_test;
+pub mod local_cross_reference;
 pub mod loop_control_outside_loop;
 pub mod loop_without_end;
 pub mod missing_done_in_for_loop;
@@ -142,6 +143,7 @@ mod tests {
     #[test_case(Rule::NonShellSyntaxInScript, Path::new("C104.sh"))]
     #[test_case(Rule::UnreachableAfterExit, Path::new("C124.sh"))]
     #[test_case(Rule::AppendWithEscapedQuotes, Path::new("C130.sh"))]
+    #[test_case(Rule::LocalCrossReference, Path::new("C136.sh"))]
     #[test_case(Rule::UnicodeSingleQuoteInSingleQuotes, Path::new("C137.sh"))]
     #[test_case(Rule::LoopWithoutEnd, Path::new("C141.sh"))]
     #[test_case(Rule::MissingDoneInForLoop, Path::new("C142.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -1,9 +1,10 @@
-pub mod arithmetic_redirection_target;
 pub mod append_with_escaped_quotes;
+pub mod arithmetic_redirection_target;
 pub mod assignment_looks_like_comparison;
 pub mod assignment_to_numeric_variable;
 pub mod backslash_before_closing_backtick;
 pub mod bad_redirection_fd_order;
+pub mod bad_var_name;
 pub mod bare_closing_brace;
 pub mod bare_slash_marker;
 mod broken_test_common;
@@ -52,8 +53,8 @@ pub mod positional_ten_braces;
 pub mod quoted_bash_regex;
 pub mod redirect_to_command_name;
 pub mod script_scope_local;
-pub mod spaced_assignment;
 pub mod single_quoted_literal;
+pub mod spaced_assignment;
 pub mod status_capture_after_branch_test;
 pub mod subshell_in_arithmetic;
 pub mod subst_with_redirect;
@@ -146,6 +147,7 @@ mod tests {
     #[test_case(Rule::AppendWithEscapedQuotes, Path::new("C130.sh"))]
     #[test_case(Rule::LocalCrossReference, Path::new("C136.sh"))]
     #[test_case(Rule::SpacedAssignment, Path::new("C139.sh"))]
+    #[test_case(Rule::BadVarName, Path::new("C140.sh"))]
     #[test_case(Rule::UnicodeSingleQuoteInSingleQuotes, Path::new("C137.sh"))]
     #[test_case(Rule::LoopWithoutEnd, Path::new("C141.sh"))]
     #[test_case(Rule::MissingDoneInForLoop, Path::new("C142.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -25,6 +25,7 @@ pub mod find_output_loop;
 pub mod find_output_to_xargs;
 pub mod if_bracket_glued;
 pub mod if_missing_then;
+pub mod ifs_set_to_literal_backslash_n;
 pub mod invalid_exit_status;
 pub mod leading_glob_argument;
 pub mod line_oriented_input;
@@ -132,6 +133,7 @@ mod tests {
     #[test_case(Rule::CommentedContinuationLine, Path::new("C076.sh"))]
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
+    #[test_case(Rule::IfsSetToLiteralBackslashN, Path::new("C101.sh"))]
     #[test_case(Rule::NonShellSyntaxInScript, Path::new("C104.sh"))]
     #[test_case(Rule::UnreachableAfterExit, Path::new("C124.sh"))]
     #[test_case(Rule::UnicodeSingleQuoteInSingleQuotes, Path::new("C137.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -44,6 +44,7 @@ pub mod open_double_quote;
 pub mod overwritten_function;
 pub mod pattern_with_variable;
 pub mod pipe_to_kill;
+pub mod plus_prefix_in_assignment;
 pub mod positional_param_as_operator;
 pub mod positional_ten_braces;
 pub mod quoted_bash_regex;
@@ -135,6 +136,7 @@ mod tests {
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
     #[test_case(Rule::AssignmentToNumericVariable, Path::new("C116.sh"))]
+    #[test_case(Rule::PlusPrefixInAssignment, Path::new("C117.sh"))]
     #[test_case(Rule::IfsSetToLiteralBackslashN, Path::new("C101.sh"))]
     #[test_case(Rule::NonShellSyntaxInScript, Path::new("C104.sh"))]
     #[test_case(Rule::UnreachableAfterExit, Path::new("C124.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -52,6 +52,7 @@ pub mod positional_ten_braces;
 pub mod quoted_bash_regex;
 pub mod redirect_to_command_name;
 pub mod script_scope_local;
+pub mod spaced_assignment;
 pub mod single_quoted_literal;
 pub mod status_capture_after_branch_test;
 pub mod subshell_in_arithmetic;
@@ -144,6 +145,7 @@ mod tests {
     #[test_case(Rule::UnreachableAfterExit, Path::new("C124.sh"))]
     #[test_case(Rule::AppendWithEscapedQuotes, Path::new("C130.sh"))]
     #[test_case(Rule::LocalCrossReference, Path::new("C136.sh"))]
+    #[test_case(Rule::SpacedAssignment, Path::new("C139.sh"))]
     #[test_case(Rule::UnicodeSingleQuoteInSingleQuotes, Path::new("C137.sh"))]
     #[test_case(Rule::LoopWithoutEnd, Path::new("C141.sh"))]
     #[test_case(Rule::MissingDoneInForLoop, Path::new("C142.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -1,4 +1,5 @@
 pub mod arithmetic_redirection_target;
+pub mod assignment_looks_like_comparison;
 pub mod backslash_before_closing_backtick;
 pub mod bad_redirection_fd_order;
 pub mod bare_closing_brace;
@@ -130,6 +131,7 @@ mod tests {
     #[test_case(Rule::UnicodeQuoteInString, Path::new("C072.sh"))]
     #[test_case(Rule::CommentedContinuationLine, Path::new("C076.sh"))]
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
+    #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
     #[test_case(Rule::NonShellSyntaxInScript, Path::new("C104.sh"))]
     #[test_case(Rule::UnreachableAfterExit, Path::new("C124.sh"))]
     #[test_case(Rule::UnicodeSingleQuoteInSingleQuotes, Path::new("C137.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -1,4 +1,5 @@
 pub mod arithmetic_redirection_target;
+pub mod append_with_escaped_quotes;
 pub mod assignment_looks_like_comparison;
 pub mod assignment_to_numeric_variable;
 pub mod backslash_before_closing_backtick;
@@ -140,6 +141,7 @@ mod tests {
     #[test_case(Rule::IfsSetToLiteralBackslashN, Path::new("C101.sh"))]
     #[test_case(Rule::NonShellSyntaxInScript, Path::new("C104.sh"))]
     #[test_case(Rule::UnreachableAfterExit, Path::new("C124.sh"))]
+    #[test_case(Rule::AppendWithEscapedQuotes, Path::new("C130.sh"))]
     #[test_case(Rule::UnicodeSingleQuoteInSingleQuotes, Path::new("C137.sh"))]
     #[test_case(Rule::LoopWithoutEnd, Path::new("C141.sh"))]
     #[test_case(Rule::MissingDoneInForLoop, Path::new("C142.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -1,5 +1,6 @@
 pub mod arithmetic_redirection_target;
 pub mod assignment_looks_like_comparison;
+pub mod assignment_to_numeric_variable;
 pub mod backslash_before_closing_backtick;
 pub mod bad_redirection_fd_order;
 pub mod bare_closing_brace;
@@ -133,6 +134,7 @@ mod tests {
     #[test_case(Rule::CommentedContinuationLine, Path::new("C076.sh"))]
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
+    #[test_case(Rule::AssignmentToNumericVariable, Path::new("C116.sh"))]
     #[test_case(Rule::IfsSetToLiteralBackslashN, Path::new("C101.sh"))]
     #[test_case(Rule::NonShellSyntaxInScript, Path::new("C104.sh"))]
     #[test_case(Rule::UnreachableAfterExit, Path::new("C124.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -1,0 +1,100 @@
+use shuck_ast::{Command, DeclOperand, Span, Word};
+
+use crate::{Checker, Rule, Violation};
+
+pub struct PlusPrefixInAssignment;
+
+impl Violation for PlusPrefixInAssignment {
+    fn rule() -> Rule {
+        Rule::PlusPrefixInAssignment
+    }
+
+    fn message(&self) -> String {
+        "leading `+` makes this look like a command instead of an assignment".to_owned()
+    }
+}
+
+pub fn plus_prefix_in_assignment(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| match fact.command() {
+            Command::Simple(command) => assignment_like_plus_span(&command.name, source)
+                .into_iter()
+                .collect::<Vec<_>>(),
+            Command::Decl(command) => command
+                .operands
+                .iter()
+                .filter_map(|operand| match operand {
+                    DeclOperand::Dynamic(word) => assignment_like_plus_span(word, source),
+                    DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Assignment(_) => {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>(),
+            Command::Builtin(_)
+            | Command::Binary(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => Vec::new(),
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || PlusPrefixInAssignment);
+}
+
+fn assignment_like_plus_span(word: &Word, source: &str) -> Option<Span> {
+    let text = word.span.slice(source);
+    let remainder = text.strip_prefix('+')?;
+    let target_end = remainder.find("+=").or_else(|| remainder.find('='))?;
+    let target = &remainder[..target_end];
+
+    is_valid_identifier(target).then_some(word.span)
+}
+
+fn is_valid_identifier(text: &str) -> bool {
+    let mut chars = text.chars();
+    matches!(chars.next(), Some('A'..='Z' | 'a'..='z' | '_'))
+        && chars.all(|character| matches!(character, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn anchors_on_assignment_like_words_with_a_leading_plus() {
+        let source = "\
+#!/bin/bash
++YYYY=\"$( date +%Y )\"
+export +MONTH=12
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::PlusPrefixInAssignment));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["+YYYY=\"$( date +%Y )\"", "+MONTH=12"]
+        );
+    }
+
+    #[test]
+    fn ignores_regular_commands_and_non_identifier_targets() {
+        let source = "\
+#!/bin/sh
+echo +YEAR=2024
++1=bad
+name+=still_ok
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::PlusPrefixInAssignment));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -72,8 +72,10 @@ mod tests {
 +YYYY=\"$( date +%Y )\"
 export +MONTH=12
 ";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::PlusPrefixInAssignment));
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PlusPrefixInAssignment),
+        );
 
         assert_eq!(
             diagnostics
@@ -92,8 +94,10 @@ echo +YEAR=2024
 +1=bad
 name+=still_ok
 ";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::PlusPrefixInAssignment));
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PlusPrefixInAssignment),
+        );
 
         assert!(diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C095_C095.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C095_C095.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C095 assignment value looks like arithmetic subtraction
+ --> <source>:3:4
+  |
+3 | qt=qt-unicode-3.2
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C101_C101.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C101_C101.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C101 IFS contains a literal \n sequence
+ --> <source>:3:11
+  |
+3 | while IFS='\n' read -r comp; do
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C116_C116.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C116_C116.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C116 assignment target is numeric
+ --> <source>:3:14
+  |
+3 | test "$2" || 2="."
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C117_C117.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C117_C117.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C117 leading `+` makes this look like a command instead of an assignment
+ --> <source>:3:1
+  |
+3 | +YYYY="$( date +%Y )"
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C130_C130.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C130_C130.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C130 escaped quotes in `+=` text will stay literal
+ --> <source>:4:10
+  |
+4 | 	CFLAGS+=" -DDIR=\"$PREFIX/share/\""
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C136_C136.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C136_C136.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 142
+---
+C136 assignment is reused later in the same declaration
+ --> <source>:4:9
+  |
+4 |   local iface="${1}" ifvar="$(echo "${iface}" | tr - _)"
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C139_C139.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C139_C139.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 144
+---
+C139 remove spaces around `=` in this assignment
+ --> <source>:2:12
+  |
+2 | export foo =bar
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C140_C140.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C140_C140.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 146
+---
+C140 assignment target starts with an invalid character
+ --> <source>:2:1
+  |
+2 | 9var=ok
+  |

--- a/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
@@ -1,0 +1,79 @@
+use shuck_ast::DeclOperand;
+
+use crate::{Checker, Rule, Violation, static_word_text};
+
+pub struct SpacedAssignment;
+
+impl Violation for SpacedAssignment {
+    fn rule() -> Rule {
+        Rule::SpacedAssignment
+    }
+
+    fn message(&self) -> String {
+        "remove spaces around `=` in this assignment".to_owned()
+    }
+}
+
+pub fn spaced_assignment(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .structural_commands()
+        .filter_map(|fact| fact.declaration())
+        .flat_map(|declaration| {
+            declaration
+                .operands
+                .windows(2)
+                .filter_map(|pair| spaced_assignment_span(pair, source))
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || SpacedAssignment);
+}
+
+fn spaced_assignment_span(pair: &[DeclOperand], source: &str) -> Option<shuck_ast::Span> {
+    let [DeclOperand::Name(_), DeclOperand::Dynamic(word)] = pair else {
+        return None;
+    };
+
+    static_word_text(word, source)?
+        .starts_with('=')
+        .then_some(word.span)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn anchors_on_the_stray_equals_word() {
+        let source = "\
+#!/bin/sh
+export foo =bar
+readonly bar = baz
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpacedAssignment));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["=bar", "="]
+        );
+    }
+
+    #[test]
+    fn ignores_tight_assignments_and_plain_commands() {
+        let source = "\
+#!/bin/sh
+export foo=bar
+foo =bar
+foo= bar
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpacedAssignment));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/style/ifs_equals_ambiguity.rs
+++ b/crates/shuck-linter/src/rules/style/ifs_equals_ambiguity.rs
@@ -1,0 +1,104 @@
+use shuck_ast::{Assignment, BuiltinCommand, Command, Span};
+
+use crate::{Checker, Rule, Violation};
+
+pub struct IfsEqualsAmbiguity;
+
+impl Violation for IfsEqualsAmbiguity {
+    fn rule() -> Rule {
+        Rule::IfsEqualsAmbiguity
+    }
+
+    fn message(&self) -> String {
+        "quote `=` when assigning IFS to avoid looking like `==`".to_owned()
+    }
+}
+
+pub fn ifs_equals_ambiguity(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| command_assignment_spans(fact.command(), source))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || IfsEqualsAmbiguity);
+}
+
+fn command_assignment_spans(command: &Command, source: &str) -> Vec<Span> {
+    match command {
+        Command::Simple(command) => command
+            .assignments
+            .iter()
+            .filter_map(|assignment| ifs_equals_ambiguity_span(assignment, source))
+            .collect(),
+        Command::Builtin(command) => builtin_assignments(command)
+            .iter()
+            .filter_map(|assignment| ifs_equals_ambiguity_span(assignment, source))
+            .collect(),
+        Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => Vec::new(),
+    }
+}
+
+fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
+    match command {
+        BuiltinCommand::Break(command) => &command.assignments,
+        BuiltinCommand::Continue(command) => &command.assignments,
+        BuiltinCommand::Return(command) => &command.assignments,
+        BuiltinCommand::Exit(command) => &command.assignments,
+    }
+}
+
+fn ifs_equals_ambiguity_span(assignment: &Assignment, source: &str) -> Option<Span> {
+    if assignment.append || assignment.target.name.as_str() != "IFS" {
+        return None;
+    }
+
+    (assignment.span.slice(source) == "IFS==").then(|| Span::at(assignment.span.start.advanced_by("IFS=")))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn anchors_on_the_second_equals_sign() {
+        let source = "\
+#!/bin/bash
+IFS== read x
+while IFS== read -r key val; do
+  :
+done < /dev/null
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::IfsEqualsAmbiguity));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .collect::<Vec<_>>(),
+            vec![(2, 5), (3, 11)]
+        );
+        assert!(diagnostics.iter().all(|diagnostic| diagnostic.span.start == diagnostic.span.end));
+    }
+
+    #[test]
+    fn ignores_quoted_equals_and_other_assignments() {
+        let source = "\
+#!/bin/bash
+IFS='=' read x
+IFS=\"=\" read y
+IFS=\\= read z
+foo==bar env
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::IfsEqualsAmbiguity));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/style/ifs_equals_ambiguity.rs
+++ b/crates/shuck-linter/src/rules/style/ifs_equals_ambiguity.rs
@@ -59,7 +59,8 @@ fn ifs_equals_ambiguity_span(assignment: &Assignment, source: &str) -> Option<Sp
         return None;
     }
 
-    (assignment.span.slice(source) == "IFS==").then(|| Span::at(assignment.span.start.advanced_by("IFS=")))
+    (assignment.span.slice(source) == "IFS==")
+        .then(|| Span::at(assignment.span.start.advanced_by("IFS=")))
 }
 
 #[cfg(test)]
@@ -85,7 +86,11 @@ done < /dev/null
                 .collect::<Vec<_>>(),
             vec![(2, 5), (3, 11)]
         );
-        assert!(diagnostics.iter().all(|diagnostic| diagnostic.span.start == diagnostic.span.end));
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.span.start == diagnostic.span.end)
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -9,6 +9,7 @@ pub mod echoed_command_substitution;
 pub mod escaped_underscore;
 pub mod escaped_underscore_literal;
 pub mod export_command_substitution;
+pub mod ifs_equals_ambiguity;
 pub mod legacy_arithmetic_expansion;
 pub mod legacy_backticks;
 pub mod linebreak_before_and;
@@ -58,6 +59,7 @@ mod tests {
     #[test_case(Rule::LiteralBackslashInSingleQuotes, Path::new("S039.sh"))]
     #[test_case(Rule::NeedlessBackslashUnderscore, Path::new("S026.sh"))]
     #[test_case(Rule::BackslashBeforeCommand, Path::new("S040.sh"))]
+    #[test_case(Rule::IfsEqualsAmbiguity, Path::new("S042.sh"))]
     #[test_case(Rule::SuspectClosingQuote, Path::new("S028.sh"))]
     #[test_case(Rule::LiteralBraces, Path::new("S029.sh"))]
     #[test_case(Rule::TrailingDirective, Path::new("S031.sh"))]

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S042_S042.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S042_S042.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+assertion_line: 54
+---
+S042 quote `=` when assigning IFS to avoid looking like `==`
+ --> <source>:2:11
+  |
+2 | while IFS== read -r key val; do
+  |

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -236,11 +236,12 @@ impl Default for ShellCheckCodeMap {
             (2272, Rule::MissingSemicolonBeforeBrace),
             (2273, Rule::EmptyFunctionBody),
             (2274, Rule::BareClosingBrace),
-            (2277, Rule::ExtglobInCasePattern),
-            (2100, Rule::AssignmentLooksLikeComparison),
-            (2319, Rule::StatusCaptureAfterBranchTest),
-            (2365, Rule::UnreachableAfterExit),
-            (3010, Rule::DoubleBracketInSh),
+                (2277, Rule::ExtglobInCasePattern),
+                (2100, Rule::AssignmentLooksLikeComparison),
+                (2319, Rule::StatusCaptureAfterBranchTest),
+                (2141, Rule::IfsSetToLiteralBackslashN),
+                (2365, Rule::UnreachableAfterExit),
+                (3010, Rule::DoubleBracketInSh),
             (3012, Rule::GreaterThanInDoubleBracket),
             (3014, Rule::TestEqualityOperator),
             (3015, Rule::RegexMatchInSh),
@@ -417,6 +418,7 @@ impl Default for ShellCheckCodeMap {
                 (2277, Rule::ExtglobInCasePattern),
                 (2100, Rule::AssignmentLooksLikeComparison),
                 (2319, Rule::StatusCaptureAfterBranchTest),
+                (2141, Rule::IfsSetToLiteralBackslashN),
                 (2365, Rule::UnreachableAfterExit),
                 (3010, Rule::DoubleBracketInSh),
                 (3012, Rule::GreaterThanInDoubleBracket),
@@ -433,6 +435,7 @@ impl Default for ShellCheckCodeMap {
                 (3061, Rule::ExtglobInSh),
                 (3072, Rule::CaretNegationInBracket),
                 (2319, Rule::AssignmentLooksLikeComparison),
+                (2329, Rule::IfsSetToLiteralBackslashN),
             ],
             comparison,
         }
@@ -676,6 +679,8 @@ mod tests {
         assert_eq!(map.resolve("SC2397"), Some(Rule::AmpersandSemicolon));
         assert_eq!(map.resolve("SC2266"), Some(Rule::OverwrittenFunction));
         assert_eq!(map.resolve("SC2365"), Some(Rule::UnreachableAfterExit));
+        assert_eq!(map.resolve("SC2141"), Some(Rule::IfsSetToLiteralBackslashN));
+        assert_eq!(map.resolve("SC2329"), Some(Rule::IfsSetToLiteralBackslashN));
         assert_eq!(map.resolve("SC7777"), None);
     }
 
@@ -790,7 +795,8 @@ mod tests {
             (2294, Rule::EvalOnArray),
             (2313, Rule::ZshNestedExpansion),
             (2319, Rule::StatusCaptureAfterBranchTest),
-            (2323, Rule::ArithmeticScoreLine),
+            (2141, Rule::IfsSetToLiteralBackslashN),
+            (2329, Rule::IfsSetToLiteralBackslashN),
             (2321, Rule::FunctionKeywordInSh),
             (2323, Rule::ArithmeticScoreLine),
             (2333, Rule::NonShellSyntaxInScript),
@@ -938,6 +944,7 @@ mod tests {
         assert!(comparison.contains(&(2321, Rule::ArrayIndexArithmetic)));
         assert!(comparison.contains(&(2323, Rule::ArithmeticScoreLine)));
         assert!(!comparison.contains(&(2004, Rule::DollarInArithmeticContext)));
+        assert!(comparison.contains(&(2141, Rule::IfsSetToLiteralBackslashN)));
         assert!(!comparison.contains(&(1075, Rule::ExtglobCase)));
         assert!(!comparison.contains(&(2321, Rule::FunctionKeywordInSh)));
         assert!(!comparison.contains(&(3061, Rule::ExtglobInSh)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -237,6 +237,7 @@ impl Default for ShellCheckCodeMap {
             (2273, Rule::EmptyFunctionBody),
             (2274, Rule::BareClosingBrace),
             (2277, Rule::ExtglobInCasePattern),
+            (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::StatusCaptureAfterBranchTest),
             (2365, Rule::UnreachableAfterExit),
             (3010, Rule::DoubleBracketInSh),
@@ -414,6 +415,7 @@ impl Default for ShellCheckCodeMap {
                 (2273, Rule::EmptyFunctionBody),
                 (2274, Rule::BareClosingBrace),
                 (2277, Rule::ExtglobInCasePattern),
+                (2100, Rule::AssignmentLooksLikeComparison),
                 (2319, Rule::StatusCaptureAfterBranchTest),
                 (2365, Rule::UnreachableAfterExit),
                 (3010, Rule::DoubleBracketInSh),
@@ -430,6 +432,7 @@ impl Default for ShellCheckCodeMap {
                 (1075, Rule::ExtglobCase),
                 (3061, Rule::ExtglobInSh),
                 (3072, Rule::CaretNegationInBracket),
+                (2319, Rule::AssignmentLooksLikeComparison),
             ],
             comparison,
         }
@@ -615,8 +618,19 @@ mod tests {
             Some(Rule::StatusCaptureAfterBranchTest)
         );
         assert_eq!(
+            map.resolve("SC2100"),
+            Some(Rule::AssignmentLooksLikeComparison)
+        );
+        assert_eq!(
             map.resolve("SC2319"),
             Some(Rule::StatusCaptureAfterBranchTest)
+        );
+        assert_eq!(
+            map.resolve_all("SC2319"),
+            vec![
+                Rule::StatusCaptureAfterBranchTest,
+                Rule::AssignmentLooksLikeComparison,
+            ]
         );
         assert_eq!(
             map.resolve("SC2257"),
@@ -845,6 +859,8 @@ mod tests {
             (3076, Rule::SignalNameInTrap),
             (3077, Rule::BasePrefixInArithmetic),
             (3084, Rule::SourceInsideFunctionInSh),
+            (2100, Rule::AssignmentLooksLikeComparison),
+            (2319, Rule::AssignmentLooksLikeComparison),
             (2277, Rule::ExtglobInCasePattern),
         ]
         .into_iter()

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -228,6 +228,7 @@ impl Default for ShellCheckCodeMap {
             (2250, Rule::PatternWithVariable),
             (2255, Rule::SubstWithRedirect),
             (2256, Rule::SubstWithRedirectErr),
+            (2276, Rule::PlusPrefixInAssignment),
             (2238, Rule::RedirectToCommandName),
             (2259, Rule::SubshellTestGroup),
             (2266, Rule::OverwrittenFunction),
@@ -408,6 +409,7 @@ impl Default for ShellCheckCodeMap {
                 (2250, Rule::PatternWithVariable),
                 (2255, Rule::SubstWithRedirect),
                 (2256, Rule::SubstWithRedirectErr),
+                (2276, Rule::PlusPrefixInAssignment),
                 (2238, Rule::RedirectToCommandName),
                 (2266, Rule::OverwrittenFunction),
                 (2270, Rule::AssignmentToNumericVariable),
@@ -437,6 +439,7 @@ impl Default for ShellCheckCodeMap {
                 (2319, Rule::AssignmentLooksLikeComparison),
                 (2329, Rule::IfsSetToLiteralBackslashN),
                 (2353, Rule::AssignmentToNumericVariable),
+                (2354, Rule::PlusPrefixInAssignment),
                 (2270, Rule::IfMissingThen),
             ],
             comparison,
@@ -653,6 +656,7 @@ mod tests {
         assert_eq!(map.resolve("SC2261"), Some(Rule::NonAbsoluteShebang));
         assert_eq!(map.resolve("SC2262"), Some(Rule::TemplateBraceInCommand));
         assert_eq!(map.resolve("SC2264"), Some(Rule::NestedParameterExpansion));
+        assert_eq!(map.resolve("SC2276"), Some(Rule::PlusPrefixInAssignment));
         assert_eq!(
             map.resolve("SC2270"),
             Some(Rule::AssignmentToNumericVariable)
@@ -688,6 +692,7 @@ mod tests {
             map.resolve("SC2353"),
             Some(Rule::AssignmentToNumericVariable)
         );
+        assert_eq!(map.resolve("SC2354"), Some(Rule::PlusPrefixInAssignment));
         assert_eq!(
             map.resolve_all("SC2270"),
             vec![Rule::AssignmentToNumericVariable, Rule::IfMissingThen]
@@ -787,6 +792,7 @@ mod tests {
             (2252, Rule::NestedZshSubstitution),
             (2255, Rule::SubstWithRedirect),
             (2256, Rule::SubstWithRedirectErr),
+            (2276, Rule::PlusPrefixInAssignment),
             (2257, Rule::ArithmeticRedirectionTarget),
             (2290, Rule::SubshellInArithmetic),
             (2292, Rule::DollarInArithmetic),
@@ -811,6 +817,7 @@ mod tests {
             (2319, Rule::StatusCaptureAfterBranchTest),
             (2141, Rule::IfsSetToLiteralBackslashN),
             (2353, Rule::AssignmentToNumericVariable),
+            (2354, Rule::PlusPrefixInAssignment),
             (2329, Rule::IfsSetToLiteralBackslashN),
             (2321, Rule::FunctionKeywordInSh),
             (2323, Rule::ArithmeticScoreLine),
@@ -961,7 +968,9 @@ mod tests {
         assert!(!comparison.contains(&(2004, Rule::DollarInArithmeticContext)));
         assert!(comparison.contains(&(2141, Rule::IfsSetToLiteralBackslashN)));
         assert!(comparison.contains(&(2270, Rule::AssignmentToNumericVariable)));
+        assert!(comparison.contains(&(2276, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
+        assert!(!comparison.contains(&(2354, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(1075, Rule::ExtglobCase)));
         assert!(!comparison.contains(&(2321, Rule::FunctionKeywordInSh)));
         assert!(!comparison.contains(&(3061, Rule::ExtglobInSh)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -57,7 +57,7 @@ impl ShellCheckCodeMap {
             return vec![Rule::BackslashBeforeClosingBacktick];
         }
         if number == 2282 {
-            return vec![Rule::PositionalParamAsOperator];
+            return vec![Rule::BadVarName, Rule::PositionalParamAsOperator];
         }
         if number == 2283 {
             return vec![Rule::DoubleParenGrouping];
@@ -236,6 +236,9 @@ impl Default for ShellCheckCodeMap {
             // Keep SC2387 as a suppression alias, but prefer the current code for comparisons.
             (2290, Rule::SpacedAssignment),
             (2276, Rule::PlusPrefixInAssignment),
+            // ShellCheck 0.11.0 reports digit-prefixed assignment names as SC2282.
+            // Keep SC2388 as a suppression alias, but prefer the current code for comparisons.
+            (2282, Rule::BadVarName),
             (2238, Rule::RedirectToCommandName),
             (2259, Rule::SubshellTestGroup),
             (2266, Rule::OverwrittenFunction),
@@ -312,6 +315,7 @@ impl Default for ShellCheckCodeMap {
                 (2275, Rule::MultiVarForLoop),
                 (2278, Rule::ZshPromptBracket),
                 (2279, Rule::CshSyntaxInSh),
+                (2282, Rule::BadVarName),
                 (2355, Rule::ZshAssignmentToZero),
                 (2359, Rule::ZshParameterFlag),
                 (2371, Rule::ZshArraySubscriptInCase),
@@ -451,6 +455,7 @@ impl Default for ShellCheckCodeMap {
                 (2353, Rule::AssignmentToNumericVariable),
                 (2354, Rule::PlusPrefixInAssignment),
                 (2387, Rule::SpacedAssignment),
+                (2388, Rule::BadVarName),
                 (2384, Rule::LocalCrossReference),
                 (2377, Rule::AppendWithEscapedQuotes),
                 (2270, Rule::IfMissingThen),
@@ -689,7 +694,11 @@ mod tests {
             map.resolve("SC2281"),
             Some(Rule::BackslashBeforeClosingBacktick)
         );
-        assert_eq!(map.resolve("SC2282"), Some(Rule::PositionalParamAsOperator));
+        assert_eq!(map.resolve("SC2282"), Some(Rule::BadVarName));
+        assert_eq!(
+            map.resolve_all("SC2282"),
+            vec![Rule::BadVarName, Rule::PositionalParamAsOperator]
+        );
         assert_eq!(map.resolve("SC2283"), Some(Rule::DoubleParenGrouping));
         assert_eq!(map.resolve("SC2284"), Some(Rule::UnicodeQuoteInString));
         assert_eq!(map.resolve("SC2288"), Some(Rule::TemplateBraceInCommand));
@@ -710,6 +719,7 @@ mod tests {
         );
         assert_eq!(map.resolve("SC2354"), Some(Rule::PlusPrefixInAssignment));
         assert_eq!(map.resolve("SC2387"), Some(Rule::SpacedAssignment));
+        assert_eq!(map.resolve("SC2388"), Some(Rule::BadVarName));
         assert_eq!(map.resolve("SC2384"), Some(Rule::LocalCrossReference));
         assert_eq!(map.resolve("SC2377"), Some(Rule::AppendWithEscapedQuotes));
         assert_eq!(
@@ -835,6 +845,7 @@ mod tests {
             (2275, Rule::MultiVarForLoop),
             (2278, Rule::ZshPromptBracket),
             (2279, Rule::CshSyntaxInSh),
+            (2282, Rule::BadVarName),
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (2294, Rule::EvalOnArray),
@@ -860,6 +871,7 @@ mod tests {
             (2371, Rule::ZshArraySubscriptInCase),
             (2375, Rule::ZshParameterIndexFlag),
             (2385, Rule::UnicodeSingleQuoteInSingleQuotes),
+            (2388, Rule::BadVarName),
             (3001, Rule::ProcessSubstitution),
             (3002, Rule::ExtglobInSh),
             (3003, Rule::AnsiCQuoting),
@@ -996,11 +1008,13 @@ mod tests {
         assert!(comparison.contains(&(2089, Rule::AppendWithEscapedQuotes)));
         assert!(comparison.contains(&(2318, Rule::LocalCrossReference)));
         assert!(comparison.contains(&(2290, Rule::SpacedAssignment)));
+        assert!(comparison.contains(&(2282, Rule::BadVarName)));
         assert!(comparison.contains(&(2270, Rule::AssignmentToNumericVariable)));
         assert!(comparison.contains(&(2276, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
         assert!(!comparison.contains(&(2354, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2387, Rule::SpacedAssignment)));
+        assert!(!comparison.contains(&(2388, Rule::BadVarName)));
         assert!(!comparison.contains(&(2384, Rule::LocalCrossReference)));
         assert!(!comparison.contains(&(2377, Rule::AppendWithEscapedQuotes)));
         assert!(!comparison.contains(&(1075, Rule::ExtglobCase)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -231,17 +231,17 @@ impl Default for ShellCheckCodeMap {
             (2238, Rule::RedirectToCommandName),
             (2259, Rule::SubshellTestGroup),
             (2266, Rule::OverwrittenFunction),
-            (2270, Rule::IfMissingThen),
+            (2270, Rule::AssignmentToNumericVariable),
             (2271, Rule::ElseWithoutThen),
             (2272, Rule::MissingSemicolonBeforeBrace),
             (2273, Rule::EmptyFunctionBody),
             (2274, Rule::BareClosingBrace),
-                (2277, Rule::ExtglobInCasePattern),
-                (2100, Rule::AssignmentLooksLikeComparison),
-                (2319, Rule::StatusCaptureAfterBranchTest),
-                (2141, Rule::IfsSetToLiteralBackslashN),
-                (2365, Rule::UnreachableAfterExit),
-                (3010, Rule::DoubleBracketInSh),
+            (2277, Rule::ExtglobInCasePattern),
+            (2100, Rule::AssignmentLooksLikeComparison),
+            (2319, Rule::StatusCaptureAfterBranchTest),
+            (2141, Rule::IfsSetToLiteralBackslashN),
+            (2365, Rule::UnreachableAfterExit),
+            (3010, Rule::DoubleBracketInSh),
             (3012, Rule::GreaterThanInDoubleBracket),
             (3014, Rule::TestEqualityOperator),
             (3015, Rule::RegexMatchInSh),
@@ -410,7 +410,7 @@ impl Default for ShellCheckCodeMap {
                 (2256, Rule::SubstWithRedirectErr),
                 (2238, Rule::RedirectToCommandName),
                 (2266, Rule::OverwrittenFunction),
-                (2270, Rule::IfMissingThen),
+                (2270, Rule::AssignmentToNumericVariable),
                 (2271, Rule::ElseWithoutThen),
                 (2272, Rule::MissingSemicolonBeforeBrace),
                 (2273, Rule::EmptyFunctionBody),
@@ -436,6 +436,8 @@ impl Default for ShellCheckCodeMap {
                 (3072, Rule::CaretNegationInBracket),
                 (2319, Rule::AssignmentLooksLikeComparison),
                 (2329, Rule::IfsSetToLiteralBackslashN),
+                (2353, Rule::AssignmentToNumericVariable),
+                (2270, Rule::IfMissingThen),
             ],
             comparison,
         }
@@ -651,7 +653,10 @@ mod tests {
         assert_eq!(map.resolve("SC2261"), Some(Rule::NonAbsoluteShebang));
         assert_eq!(map.resolve("SC2262"), Some(Rule::TemplateBraceInCommand));
         assert_eq!(map.resolve("SC2264"), Some(Rule::NestedParameterExpansion));
-        assert_eq!(map.resolve("SC2270"), Some(Rule::IfMissingThen));
+        assert_eq!(
+            map.resolve("SC2270"),
+            Some(Rule::AssignmentToNumericVariable)
+        );
         assert_eq!(map.resolve("SC2271"), Some(Rule::ElseWithoutThen));
         assert_eq!(
             map.resolve("SC2272"),
@@ -679,6 +684,14 @@ mod tests {
         assert_eq!(map.resolve("SC2397"), Some(Rule::AmpersandSemicolon));
         assert_eq!(map.resolve("SC2266"), Some(Rule::OverwrittenFunction));
         assert_eq!(map.resolve("SC2365"), Some(Rule::UnreachableAfterExit));
+        assert_eq!(
+            map.resolve("SC2353"),
+            Some(Rule::AssignmentToNumericVariable)
+        );
+        assert_eq!(
+            map.resolve_all("SC2270"),
+            vec![Rule::AssignmentToNumericVariable, Rule::IfMissingThen]
+        );
         assert_eq!(map.resolve("SC2141"), Some(Rule::IfsSetToLiteralBackslashN));
         assert_eq!(map.resolve("SC2329"), Some(Rule::IfsSetToLiteralBackslashN));
         assert_eq!(map.resolve("SC7777"), None);
@@ -782,6 +795,7 @@ mod tests {
             (2264, Rule::NestedParameterExpansion),
             (2266, Rule::OverwrittenFunction),
             (2267, Rule::LiteralBackslashInSingleQuotes),
+            (2270, Rule::AssignmentToNumericVariable),
             (2270, Rule::IfMissingThen),
             (2271, Rule::ElseWithoutThen),
             (2272, Rule::MissingSemicolonBeforeBrace),
@@ -796,6 +810,7 @@ mod tests {
             (2313, Rule::ZshNestedExpansion),
             (2319, Rule::StatusCaptureAfterBranchTest),
             (2141, Rule::IfsSetToLiteralBackslashN),
+            (2353, Rule::AssignmentToNumericVariable),
             (2329, Rule::IfsSetToLiteralBackslashN),
             (2321, Rule::FunctionKeywordInSh),
             (2323, Rule::ArithmeticScoreLine),
@@ -945,6 +960,8 @@ mod tests {
         assert!(comparison.contains(&(2323, Rule::ArithmeticScoreLine)));
         assert!(!comparison.contains(&(2004, Rule::DollarInArithmeticContext)));
         assert!(comparison.contains(&(2141, Rule::IfsSetToLiteralBackslashN)));
+        assert!(comparison.contains(&(2270, Rule::AssignmentToNumericVariable)));
+        assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
         assert!(!comparison.contains(&(1075, Rule::ExtglobCase)));
         assert!(!comparison.contains(&(2321, Rule::FunctionKeywordInSh)));
         assert!(!comparison.contains(&(3061, Rule::ExtglobInSh)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -229,6 +229,9 @@ impl Default for ShellCheckCodeMap {
             (2255, Rule::SubstWithRedirect),
             (2256, Rule::SubstWithRedirectErr),
             (2089, Rule::AppendWithEscapedQuotes),
+            // ShellCheck 0.11.0 reports declaration cross-reference warnings as SC2318.
+            // Keep SC2384 as a suppression alias, but prefer the current code for comparisons.
+            (2318, Rule::LocalCrossReference),
             (2276, Rule::PlusPrefixInAssignment),
             (2238, Rule::RedirectToCommandName),
             (2259, Rule::SubshellTestGroup),
@@ -415,6 +418,7 @@ impl Default for ShellCheckCodeMap {
                 (2238, Rule::RedirectToCommandName),
                 (2266, Rule::OverwrittenFunction),
                 (2270, Rule::AssignmentToNumericVariable),
+                (2318, Rule::LocalCrossReference),
                 (2271, Rule::ElseWithoutThen),
                 (2272, Rule::MissingSemicolonBeforeBrace),
                 (2273, Rule::EmptyFunctionBody),
@@ -442,6 +446,7 @@ impl Default for ShellCheckCodeMap {
                 (2329, Rule::IfsSetToLiteralBackslashN),
                 (2353, Rule::AssignmentToNumericVariable),
                 (2354, Rule::PlusPrefixInAssignment),
+                (2384, Rule::LocalCrossReference),
                 (2377, Rule::AppendWithEscapedQuotes),
                 (2270, Rule::IfMissingThen),
             ],
@@ -660,6 +665,7 @@ mod tests {
         assert_eq!(map.resolve("SC2262"), Some(Rule::TemplateBraceInCommand));
         assert_eq!(map.resolve("SC2264"), Some(Rule::NestedParameterExpansion));
         assert_eq!(map.resolve("SC2089"), Some(Rule::AppendWithEscapedQuotes));
+        assert_eq!(map.resolve("SC2318"), Some(Rule::LocalCrossReference));
         assert_eq!(map.resolve("SC2276"), Some(Rule::PlusPrefixInAssignment));
         assert_eq!(
             map.resolve("SC2270"),
@@ -697,11 +703,13 @@ mod tests {
             Some(Rule::AssignmentToNumericVariable)
         );
         assert_eq!(map.resolve("SC2354"), Some(Rule::PlusPrefixInAssignment));
+        assert_eq!(map.resolve("SC2384"), Some(Rule::LocalCrossReference));
         assert_eq!(map.resolve("SC2377"), Some(Rule::AppendWithEscapedQuotes));
         assert_eq!(
             map.resolve_all("SC2270"),
             vec![Rule::AssignmentToNumericVariable, Rule::IfMissingThen]
         );
+        assert_eq!(map.resolve_all("SC2384"), vec![Rule::LocalCrossReference]);
         assert_eq!(map.resolve("SC2141"), Some(Rule::IfsSetToLiteralBackslashN));
         assert_eq!(map.resolve("SC2329"), Some(Rule::IfsSetToLiteralBackslashN));
         assert_eq!(map.resolve("SC7777"), None);
@@ -809,6 +817,8 @@ mod tests {
             (2267, Rule::LiteralBackslashInSingleQuotes),
             (2270, Rule::AssignmentToNumericVariable),
             (2270, Rule::IfMissingThen),
+            (2318, Rule::LocalCrossReference),
+            (2384, Rule::LocalCrossReference),
             (2271, Rule::ElseWithoutThen),
             (2272, Rule::MissingSemicolonBeforeBrace),
             (2273, Rule::EmptyFunctionBody),
@@ -975,10 +985,12 @@ mod tests {
         assert!(!comparison.contains(&(2004, Rule::DollarInArithmeticContext)));
         assert!(comparison.contains(&(2141, Rule::IfsSetToLiteralBackslashN)));
         assert!(comparison.contains(&(2089, Rule::AppendWithEscapedQuotes)));
+        assert!(comparison.contains(&(2318, Rule::LocalCrossReference)));
         assert!(comparison.contains(&(2270, Rule::AssignmentToNumericVariable)));
         assert!(comparison.contains(&(2276, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
         assert!(!comparison.contains(&(2354, Rule::PlusPrefixInAssignment)));
+        assert!(!comparison.contains(&(2384, Rule::LocalCrossReference)));
         assert!(!comparison.contains(&(2377, Rule::AppendWithEscapedQuotes)));
         assert!(!comparison.contains(&(1075, Rule::ExtglobCase)));
         assert!(!comparison.contains(&(2321, Rule::FunctionKeywordInSh)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -228,6 +228,7 @@ impl Default for ShellCheckCodeMap {
             (2250, Rule::PatternWithVariable),
             (2255, Rule::SubstWithRedirect),
             (2256, Rule::SubstWithRedirectErr),
+            (2089, Rule::AppendWithEscapedQuotes),
             (2276, Rule::PlusPrefixInAssignment),
             (2238, Rule::RedirectToCommandName),
             (2259, Rule::SubshellTestGroup),
@@ -409,6 +410,7 @@ impl Default for ShellCheckCodeMap {
                 (2250, Rule::PatternWithVariable),
                 (2255, Rule::SubstWithRedirect),
                 (2256, Rule::SubstWithRedirectErr),
+                (2089, Rule::AppendWithEscapedQuotes),
                 (2276, Rule::PlusPrefixInAssignment),
                 (2238, Rule::RedirectToCommandName),
                 (2266, Rule::OverwrittenFunction),
@@ -440,6 +442,7 @@ impl Default for ShellCheckCodeMap {
                 (2329, Rule::IfsSetToLiteralBackslashN),
                 (2353, Rule::AssignmentToNumericVariable),
                 (2354, Rule::PlusPrefixInAssignment),
+                (2377, Rule::AppendWithEscapedQuotes),
                 (2270, Rule::IfMissingThen),
             ],
             comparison,
@@ -656,6 +659,7 @@ mod tests {
         assert_eq!(map.resolve("SC2261"), Some(Rule::NonAbsoluteShebang));
         assert_eq!(map.resolve("SC2262"), Some(Rule::TemplateBraceInCommand));
         assert_eq!(map.resolve("SC2264"), Some(Rule::NestedParameterExpansion));
+        assert_eq!(map.resolve("SC2089"), Some(Rule::AppendWithEscapedQuotes));
         assert_eq!(map.resolve("SC2276"), Some(Rule::PlusPrefixInAssignment));
         assert_eq!(
             map.resolve("SC2270"),
@@ -693,6 +697,7 @@ mod tests {
             Some(Rule::AssignmentToNumericVariable)
         );
         assert_eq!(map.resolve("SC2354"), Some(Rule::PlusPrefixInAssignment));
+        assert_eq!(map.resolve("SC2377"), Some(Rule::AppendWithEscapedQuotes));
         assert_eq!(
             map.resolve_all("SC2270"),
             vec![Rule::AssignmentToNumericVariable, Rule::IfMissingThen]
@@ -760,6 +765,7 @@ mod tests {
             (2068, Rule::UnquotedArrayExpansion),
             (2076, Rule::QuotedBashRegex),
             (2078, Rule::TruthyLiteralTest),
+            (2089, Rule::AppendWithEscapedQuotes),
             (2086, Rule::UnquotedExpansion),
             (2104, Rule::LoopControlOutsideLoop),
             (2112, Rule::FunctionKeyword),
@@ -818,6 +824,7 @@ mod tests {
             (2141, Rule::IfsSetToLiteralBackslashN),
             (2353, Rule::AssignmentToNumericVariable),
             (2354, Rule::PlusPrefixInAssignment),
+            (2377, Rule::AppendWithEscapedQuotes),
             (2329, Rule::IfsSetToLiteralBackslashN),
             (2321, Rule::FunctionKeywordInSh),
             (2323, Rule::ArithmeticScoreLine),
@@ -967,10 +974,12 @@ mod tests {
         assert!(comparison.contains(&(2323, Rule::ArithmeticScoreLine)));
         assert!(!comparison.contains(&(2004, Rule::DollarInArithmeticContext)));
         assert!(comparison.contains(&(2141, Rule::IfsSetToLiteralBackslashN)));
+        assert!(comparison.contains(&(2089, Rule::AppendWithEscapedQuotes)));
         assert!(comparison.contains(&(2270, Rule::AssignmentToNumericVariable)));
         assert!(comparison.contains(&(2276, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
         assert!(!comparison.contains(&(2354, Rule::PlusPrefixInAssignment)));
+        assert!(!comparison.contains(&(2377, Rule::AppendWithEscapedQuotes)));
         assert!(!comparison.contains(&(1075, Rule::ExtglobCase)));
         assert!(!comparison.contains(&(2321, Rule::FunctionKeywordInSh)));
         assert!(!comparison.contains(&(3061, Rule::ExtglobInSh)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -232,6 +232,9 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports declaration cross-reference warnings as SC2318.
             // Keep SC2384 as a suppression alias, but prefer the current code for comparisons.
             (2318, Rule::LocalCrossReference),
+            // ShellCheck 0.11.0 reports declaration spacing warnings as SC2290.
+            // Keep SC2387 as a suppression alias, but prefer the current code for comparisons.
+            (2290, Rule::SpacedAssignment),
             (2276, Rule::PlusPrefixInAssignment),
             (2238, Rule::RedirectToCommandName),
             (2259, Rule::SubshellTestGroup),
@@ -419,6 +422,7 @@ impl Default for ShellCheckCodeMap {
                 (2266, Rule::OverwrittenFunction),
                 (2270, Rule::AssignmentToNumericVariable),
                 (2318, Rule::LocalCrossReference),
+                (2290, Rule::SpacedAssignment),
                 (2271, Rule::ElseWithoutThen),
                 (2272, Rule::MissingSemicolonBeforeBrace),
                 (2273, Rule::EmptyFunctionBody),
@@ -446,6 +450,7 @@ impl Default for ShellCheckCodeMap {
                 (2329, Rule::IfsSetToLiteralBackslashN),
                 (2353, Rule::AssignmentToNumericVariable),
                 (2354, Rule::PlusPrefixInAssignment),
+                (2387, Rule::SpacedAssignment),
                 (2384, Rule::LocalCrossReference),
                 (2377, Rule::AppendWithEscapedQuotes),
                 (2270, Rule::IfMissingThen),
@@ -666,6 +671,7 @@ mod tests {
         assert_eq!(map.resolve("SC2264"), Some(Rule::NestedParameterExpansion));
         assert_eq!(map.resolve("SC2089"), Some(Rule::AppendWithEscapedQuotes));
         assert_eq!(map.resolve("SC2318"), Some(Rule::LocalCrossReference));
+        assert_eq!(map.resolve("SC2290"), Some(Rule::SpacedAssignment));
         assert_eq!(map.resolve("SC2276"), Some(Rule::PlusPrefixInAssignment));
         assert_eq!(
             map.resolve("SC2270"),
@@ -703,6 +709,7 @@ mod tests {
             Some(Rule::AssignmentToNumericVariable)
         );
         assert_eq!(map.resolve("SC2354"), Some(Rule::PlusPrefixInAssignment));
+        assert_eq!(map.resolve("SC2387"), Some(Rule::SpacedAssignment));
         assert_eq!(map.resolve("SC2384"), Some(Rule::LocalCrossReference));
         assert_eq!(map.resolve("SC2377"), Some(Rule::AppendWithEscapedQuotes));
         assert_eq!(
@@ -818,7 +825,9 @@ mod tests {
             (2270, Rule::AssignmentToNumericVariable),
             (2270, Rule::IfMissingThen),
             (2318, Rule::LocalCrossReference),
+            (2290, Rule::SpacedAssignment),
             (2384, Rule::LocalCrossReference),
+            (2387, Rule::SpacedAssignment),
             (2271, Rule::ElseWithoutThen),
             (2272, Rule::MissingSemicolonBeforeBrace),
             (2273, Rule::EmptyFunctionBody),
@@ -986,10 +995,12 @@ mod tests {
         assert!(comparison.contains(&(2141, Rule::IfsSetToLiteralBackslashN)));
         assert!(comparison.contains(&(2089, Rule::AppendWithEscapedQuotes)));
         assert!(comparison.contains(&(2318, Rule::LocalCrossReference)));
+        assert!(comparison.contains(&(2290, Rule::SpacedAssignment)));
         assert!(comparison.contains(&(2270, Rule::AssignmentToNumericVariable)));
         assert!(comparison.contains(&(2276, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
         assert!(!comparison.contains(&(2354, Rule::PlusPrefixInAssignment)));
+        assert!(!comparison.contains(&(2387, Rule::SpacedAssignment)));
         assert!(!comparison.contains(&(2384, Rule::LocalCrossReference)));
         assert!(!comparison.contains(&(2377, Rule::AppendWithEscapedQuotes)));
         assert!(!comparison.contains(&(1075, Rule::ExtglobCase)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -109,6 +109,7 @@ impl Default for ShellCheckCodeMap {
             (1083, Rule::LiteralBraces),
             (1090, Rule::DynamicSourcePath),
             (1091, Rule::UntrackedSourceFile),
+            (1097, Rule::IfsEqualsAmbiguity),
             (1101, Rule::BackslashBeforeClosingBacktick),
             (1102, Rule::PositionalParamAsOperator),
             (1110, Rule::UnicodeQuoteInString),
@@ -294,6 +295,7 @@ impl Default for ShellCheckCodeMap {
                 (1083, Rule::LiteralBraces),
                 (1090, Rule::DynamicSourcePath),
                 (1091, Rule::UntrackedSourceFile),
+                (1097, Rule::IfsEqualsAmbiguity),
                 (1101, Rule::BackslashBeforeClosingBacktick),
                 (1102, Rule::PositionalParamAsOperator),
                 (1110, Rule::UnicodeQuoteInString),
@@ -458,6 +460,7 @@ impl Default for ShellCheckCodeMap {
                 (2388, Rule::BadVarName),
                 (2384, Rule::LocalCrossReference),
                 (2377, Rule::AppendWithEscapedQuotes),
+                (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
             ],
             comparison,
@@ -527,6 +530,7 @@ mod tests {
         assert_eq!(map.resolve("SC1080"), Some(Rule::LinebreakInTest));
         assert_eq!(map.resolve("SC1090"), Some(Rule::DynamicSourcePath));
         assert_eq!(map.resolve("SC1091"), Some(Rule::UntrackedSourceFile));
+        assert_eq!(map.resolve("SC1097"), Some(Rule::IfsEqualsAmbiguity));
         assert_eq!(
             map.resolve("SC1101"),
             Some(Rule::BackslashBeforeClosingBacktick)
@@ -711,6 +715,7 @@ mod tests {
         assert_eq!(map.resolve("SC2392"), Some(Rule::LinebreakBeforeAnd));
         assert_eq!(map.resolve("SC2396"), Some(Rule::UntilMissingDo));
         assert_eq!(map.resolve("SC2397"), Some(Rule::AmpersandSemicolon));
+        assert_eq!(map.resolve("SC2280"), Some(Rule::IfsEqualsAmbiguity));
         assert_eq!(map.resolve("SC2266"), Some(Rule::OverwrittenFunction));
         assert_eq!(map.resolve("SC2365"), Some(Rule::UnreachableAfterExit));
         assert_eq!(
@@ -759,6 +764,7 @@ mod tests {
             (1083, Rule::LiteralBraces),
             (1090, Rule::DynamicSourcePath),
             (1091, Rule::UntrackedSourceFile),
+            (1097, Rule::IfsEqualsAmbiguity),
             (1101, Rule::BackslashBeforeClosingBacktick),
             (1102, Rule::PositionalParamAsOperator),
             (1110, Rule::UnicodeQuoteInString),
@@ -845,6 +851,7 @@ mod tests {
             (2275, Rule::MultiVarForLoop),
             (2278, Rule::ZshPromptBracket),
             (2279, Rule::CshSyntaxInSh),
+            (2280, Rule::IfsEqualsAmbiguity),
             (2282, Rule::BadVarName),
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
@@ -1005,6 +1012,7 @@ mod tests {
         assert!(comparison.contains(&(2323, Rule::ArithmeticScoreLine)));
         assert!(!comparison.contains(&(2004, Rule::DollarInArithmeticContext)));
         assert!(comparison.contains(&(2141, Rule::IfsSetToLiteralBackslashN)));
+        assert!(comparison.contains(&(1097, Rule::IfsEqualsAmbiguity)));
         assert!(comparison.contains(&(2089, Rule::AppendWithEscapedQuotes)));
         assert!(comparison.contains(&(2318, Rule::LocalCrossReference)));
         assert!(comparison.contains(&(2290, Rule::SpacedAssignment)));
@@ -1014,6 +1022,7 @@ mod tests {
         assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
         assert!(!comparison.contains(&(2354, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2387, Rule::SpacedAssignment)));
+        assert!(!comparison.contains(&(2280, Rule::IfsEqualsAmbiguity)));
         assert!(!comparison.contains(&(2388, Rule::BadVarName)));
         assert!(!comparison.contains(&(2384, Rule::LocalCrossReference)));
         assert!(!comparison.contains(&(2377, Rule::AppendWithEscapedQuotes)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -207,7 +207,6 @@ impl Default for ShellCheckCodeMap {
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (1133, Rule::LinebreakBeforeAnd),
-            (2290, Rule::SubshellInArithmetic),
             (2292, Rule::DollarInArithmetic),
             (2294, Rule::EvalOnArray),
             (2297, Rule::DollarInArithmeticContext),
@@ -428,7 +427,6 @@ impl Default for ShellCheckCodeMap {
                 (2266, Rule::OverwrittenFunction),
                 (2270, Rule::AssignmentToNumericVariable),
                 (2318, Rule::LocalCrossReference),
-                (2290, Rule::SpacedAssignment),
                 (2271, Rule::ElseWithoutThen),
                 (2272, Rule::MissingSemicolonBeforeBrace),
                 (2273, Rule::EmptyFunctionBody),
@@ -460,6 +458,7 @@ impl Default for ShellCheckCodeMap {
                 (2388, Rule::BadVarName),
                 (2384, Rule::LocalCrossReference),
                 (2377, Rule::AppendWithEscapedQuotes),
+                (2290, Rule::SpacedAssignment),
                 (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
             ],
@@ -540,6 +539,10 @@ mod tests {
         assert_eq!(map.resolve("SC1113"), Some(Rule::TrailingDirective));
         assert_eq!(map.resolve("SC1126"), Some(Rule::TrailingDirective));
         assert_eq!(map.resolve("SC2290"), Some(Rule::SubshellInArithmetic));
+        assert_eq!(
+            map.resolve_all("SC2290"),
+            vec![Rule::SubshellInArithmetic, Rule::SpacedAssignment]
+        );
         assert_eq!(
             map.resolve("SC2385"),
             Some(Rule::UnicodeSingleQuoteInSingleQuotes)
@@ -680,7 +683,6 @@ mod tests {
         assert_eq!(map.resolve("SC2264"), Some(Rule::NestedParameterExpansion));
         assert_eq!(map.resolve("SC2089"), Some(Rule::AppendWithEscapedQuotes));
         assert_eq!(map.resolve("SC2318"), Some(Rule::LocalCrossReference));
-        assert_eq!(map.resolve("SC2290"), Some(Rule::SpacedAssignment));
         assert_eq!(map.resolve("SC2276"), Some(Rule::PlusPrefixInAssignment));
         assert_eq!(
             map.resolve("SC2270"),

--- a/crates/shuck/tests/testdata/corpus-metadata/c130.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c130.yaml
@@ -1,0 +1,45 @@
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "acmesh-official__acme.sh__dnsapi__dns_oci.sh"
+    line: 272
+    end_line: 272
+    column: 19
+    end_column: 54
+    labels:
+      - directive-handling
+    reason: "This site is a plain `=` assignment that embeds escaped quotes in a JSON payload string. C130 is intentionally limited to `+=` appends, so this broader SC2089 warning is outside the rule's comparison scope."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__libunibilium__build.sh"
+    reason: "This append assignment matches C130, but the oracle anchors the diagnostic one column later inside the same quoted fragment. The difference is location only."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__libunibilium__build.sh"
+    reason: "This append assignment matches C130, but Shuck anchors on the opening quote while the oracle starts one column later in the same fragment. The difference is location only."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__suitesparse__build.sh"
+    line: 14
+    end_line: 18
+    column: 34
+    end_column: 67
+    reason: "This warning comes from a plain `=` assignment that builds a multiline CMake argument string. C130 only compares `+=` append cases, so this broader SC2089 report is out of scope."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__swift__build.sh"
+    line: 23
+    end_line: 23
+    column: 24
+    end_column: 73
+    reason: "This warning comes from a plain `=` assignment that assembles toolchain flags. C130 is scoped to `+=` appends rather than every quoted string assignment SC2089 reports."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__tracepath__build.sh"
+    reason: "This append assignment matches C130, but the oracle anchors the diagnostic one column later inside the same quoted fragment. The difference is location only."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__tracepath__build.sh"
+    reason: "This append assignment matches C130, but Shuck anchors on the opening quote while the oracle starts one column later in the same fragment. The difference is location only."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__interception-tools__files__udevmon__run"
+    line: 8
+    end_line: 8
+    column: 16
+    end_column: 21
+    labels:
+      - project-closure
+    reason: "This site is a plain `=` assignment that embeds quoting in an option string. C130 intentionally stays focused on `+=` appends, so this broader SC2089 report is outside the rule's comparison target."

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -254,7 +254,7 @@ Rules about assignment syntax, variable naming, and value issues.
 - [x] **L** C117 (SC2354) `plus-prefix-in-assignment` — `+` before variable assignment
 - [x] **M** C130 (SC2377) `append-with-escaped-quotes` — `+=` with escaped quotes
 - [x] **M** C136 (SC2384) `local-cross-reference` — local assigns from same-line variable
-- [ ] **L** C139 (SC2387) `spaced-assignment` — assignment-like word with stray spaces
+- [x] **L** C139 (SC2387) `spaced-assignment` — assignment-like word with stray spaces
 - [ ] **L** C140 (SC2388) `bad-var-name` — variable name starts with invalid character
 - [ ] **L** S042 (SC2280) `ifs-equals-ambiguity` — `IFS==` looks like comparison
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -253,7 +253,7 @@ Rules about assignment syntax, variable naming, and value issues.
 - [x] **L** C116 (SC2353) `assignment-to-numeric-variable` — numeric string as variable name
 - [x] **L** C117 (SC2354) `plus-prefix-in-assignment` — `+` before variable assignment
 - [x] **M** C130 (SC2377) `append-with-escaped-quotes` — `+=` with escaped quotes
-- [ ] **M** C136 (SC2384) `local-cross-reference` — local assigns from same-line variable
+- [x] **M** C136 (SC2384) `local-cross-reference` — local assigns from same-line variable
 - [ ] **L** C139 (SC2387) `spaced-assignment` — assignment-like word with stray spaces
 - [ ] **L** C140 (SC2388) `bad-var-name` — variable name starts with invalid character
 - [ ] **L** S042 (SC2280) `ifs-equals-ambiguity` — `IFS==` looks like comparison

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -251,7 +251,7 @@ Rules about assignment syntax, variable naming, and value issues.
 - [x] **M** C095 (SC2319) `assignment-looks-like-comparison` — assignment value with dash may be typo
 - [x] **M** C101 (SC2329) `ifs-set-to-literal-backslash-n` — IFS set to literal `\n` not newline
 - [x] **L** C116 (SC2353) `assignment-to-numeric-variable` — numeric string as variable name
-- [ ] **L** C117 (SC2354) `plus-prefix-in-assignment` — `+` before variable assignment
+- [x] **L** C117 (SC2354) `plus-prefix-in-assignment` — `+` before variable assignment
 - [ ] **M** C130 (SC2377) `append-with-escaped-quotes` — `+=` with escaped quotes
 - [ ] **M** C136 (SC2384) `local-cross-reference` — local assigns from same-line variable
 - [ ] **L** C139 (SC2387) `spaced-assignment` — assignment-like word with stray spaces

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -255,7 +255,7 @@ Rules about assignment syntax, variable naming, and value issues.
 - [x] **M** C130 (SC2377) `append-with-escaped-quotes` — `+=` with escaped quotes
 - [x] **M** C136 (SC2384) `local-cross-reference` — local assigns from same-line variable
 - [x] **L** C139 (SC2387) `spaced-assignment` — assignment-like word with stray spaces
-- [ ] **L** C140 (SC2388) `bad-var-name` — variable name starts with invalid character
+- [x] **L** C140 (SC2388) `bad-var-name` — variable name starts with invalid character
 - [ ] **L** S042 (SC2280) `ifs-equals-ambiguity` — `IFS==` looks like comparison
 
 ### Command-Specific Checks

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -252,7 +252,7 @@ Rules about assignment syntax, variable naming, and value issues.
 - [x] **M** C101 (SC2329) `ifs-set-to-literal-backslash-n` — IFS set to literal `\n` not newline
 - [x] **L** C116 (SC2353) `assignment-to-numeric-variable` — numeric string as variable name
 - [x] **L** C117 (SC2354) `plus-prefix-in-assignment` — `+` before variable assignment
-- [ ] **M** C130 (SC2377) `append-with-escaped-quotes` — `+=` with escaped quotes
+- [x] **M** C130 (SC2377) `append-with-escaped-quotes` — `+=` with escaped quotes
 - [ ] **M** C136 (SC2384) `local-cross-reference` — local assigns from same-line variable
 - [ ] **L** C139 (SC2387) `spaced-assignment` — assignment-like word with stray spaces
 - [ ] **L** C140 (SC2388) `bad-var-name` — variable name starts with invalid character

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -248,7 +248,7 @@ Rules about array assignment, conversion, and element access patterns.
 
 Rules about assignment syntax, variable naming, and value issues.
 
-- [ ] **M** C095 (SC2319) `assignment-looks-like-comparison` — assignment value with dash may be typo
+- [x] **M** C095 (SC2319) `assignment-looks-like-comparison` — assignment value with dash may be typo
 - [ ] **M** C101 (SC2329) `ifs-set-to-literal-backslash-n` — IFS set to literal `\n` not newline
 - [ ] **L** C116 (SC2353) `assignment-to-numeric-variable` — numeric string as variable name
 - [ ] **L** C117 (SC2354) `plus-prefix-in-assignment` — `+` before variable assignment

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -249,7 +249,7 @@ Rules about array assignment, conversion, and element access patterns.
 Rules about assignment syntax, variable naming, and value issues.
 
 - [x] **M** C095 (SC2319) `assignment-looks-like-comparison` — assignment value with dash may be typo
-- [ ] **M** C101 (SC2329) `ifs-set-to-literal-backslash-n` — IFS set to literal `\n` not newline
+- [x] **M** C101 (SC2329) `ifs-set-to-literal-backslash-n` — IFS set to literal `\n` not newline
 - [ ] **L** C116 (SC2353) `assignment-to-numeric-variable` — numeric string as variable name
 - [ ] **L** C117 (SC2354) `plus-prefix-in-assignment` — `+` before variable assignment
 - [ ] **M** C130 (SC2377) `append-with-escaped-quotes` — `+=` with escaped quotes

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -256,7 +256,7 @@ Rules about assignment syntax, variable naming, and value issues.
 - [x] **M** C136 (SC2384) `local-cross-reference` — local assigns from same-line variable
 - [x] **L** C139 (SC2387) `spaced-assignment` — assignment-like word with stray spaces
 - [x] **L** C140 (SC2388) `bad-var-name` — variable name starts with invalid character
-- [ ] **L** S042 (SC2280) `ifs-equals-ambiguity` — `IFS==` looks like comparison
+- [x] **L** S042 (SC2280) `ifs-equals-ambiguity` — `IFS==` looks like comparison
 
 ### Command-Specific Checks
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -250,7 +250,7 @@ Rules about assignment syntax, variable naming, and value issues.
 
 - [x] **M** C095 (SC2319) `assignment-looks-like-comparison` — assignment value with dash may be typo
 - [x] **M** C101 (SC2329) `ifs-set-to-literal-backslash-n` — IFS set to literal `\n` not newline
-- [ ] **L** C116 (SC2353) `assignment-to-numeric-variable` — numeric string as variable name
+- [x] **L** C116 (SC2353) `assignment-to-numeric-variable` — numeric string as variable name
 - [ ] **L** C117 (SC2354) `plus-prefix-in-assignment` — `+` before variable assignment
 - [ ] **M** C130 (SC2377) `append-with-escaped-quotes` — `+=` with escaped quotes
 - [ ] **M** C136 (SC2384) `local-cross-reference` — local assigns from same-line variable


### PR DESCRIPTION
## What changed

This PR implements the remaining variable and assignment rules in this batch:

- `C095` assignment-looks-like-comparison
- `C101` ifs-set-to-literal-backslash-n
- `C116` assignment-to-numeric-variable
- `C117` plus-prefix-in-assignment
- `C130` append-with-escaped-quotes
- `C136` local-cross-reference
- `C139` spaced-assignment
- `C140` bad-var-name
- `S042` ifs-equals-ambiguity

It also updates `docs/rules.md` to mark these rules complete and adds the corresponding fixtures, snapshots, registry wiring, checker dispatch, and ShellCheck suppression/comparison mappings.

## Why

These rules complete the requested variable/assignment rule set and bring the linter closer to the intended ShellCheck-compatible behavior for common assignment mistakes and ambiguous syntax.

## Impact

Users now get diagnostics for these assignment-related patterns, including current ShellCheck code drift where needed:

- `C130` compares against current `SC2089` with `SC2377` retained as an alias
- `C136` compares against current `SC2318` with `SC2384` retained as an alias
- `C139` compares against current `SC2290` with `SC2387` retained as an alias
- `C140` compares against current `SC2282` with `SC2388` retained as an alias
- `S042` compares against current `SC1097` with `SC2280` retained as an alias

## Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
