### PR TITLE
Improve parser performance in lookahead and statement building

### DIFF
--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__zsh_redir_pipe__tests__X036_X036.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__zsh_redir_pipe__tests__X036_X036.sh.snap
@@ -1,8 +1,15 @@
 ---
 source: crates/shuck-linter/src/rules/portability/zsh_redir_pipe.rs
+assertion_line: 54
 ---
 X036 `&|` is zsh-only syntax and is not portable to this shell
  --> <source>:4:14
   |
 4 | echo "first" &|
+  |
+
+X036 `&|` is zsh-only syntax and is not portable to this shell
+ --> <source>:5:3
+  |
+5 | : &|
   |

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -473,15 +473,15 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
 
-        let checkpoint = self.clone();
+        let checkpoint = self.checkpoint();
         let mut redirects = self.parse_trailing_redirects();
         if redirects.is_empty() || !self.current_starts_prefix_redirect_compound() {
-            *self = checkpoint;
+            self.restore(checkpoint);
             return Ok(None);
         }
 
         let Some(mut command) = self.parse_command()? else {
-            *self = checkpoint;
+            self.restore(checkpoint);
             return Ok(None);
         };
 
@@ -492,7 +492,7 @@ impl<'a> Parser<'a> {
                 Ok(Some(command))
             }
             _ => {
-                *self = checkpoint;
+                self.restore(checkpoint);
                 Ok(None)
             }
         }
@@ -625,70 +625,80 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn looks_like_command_style_double_paren(&self) -> bool {
-        let mut probe = self.clone();
-        if probe.current_token_kind != Some(TokenKind::DoubleLeftParen) {
+    fn looks_like_command_style_double_paren(&mut self) -> bool {
+        if self.current_token_kind != Some(TokenKind::DoubleLeftParen) {
             return false;
         }
 
-        probe.advance();
+        let checkpoint = self.checkpoint();
+        self.advance();
         let mut paren_depth = 0_i32;
         let mut previous_top_level_operand = false;
 
         loop {
-            match probe.current_token_kind {
+            match self.current_token_kind {
                 Some(TokenKind::DoubleLeftParen) => {
                     paren_depth += 2;
                     previous_top_level_operand = false;
-                    probe.advance();
+                    self.advance();
                 }
                 Some(TokenKind::LeftParen) => {
                     paren_depth += 1;
                     previous_top_level_operand = false;
-                    probe.advance();
+                    self.advance();
                 }
                 Some(TokenKind::DoubleRightParen) => {
                     if paren_depth == 0 {
+                        self.restore(checkpoint);
                         return false;
                     }
                     if paren_depth == 1 {
+                        self.restore(checkpoint);
                         return false;
                     }
                     paren_depth -= 2;
                     previous_top_level_operand = false;
-                    probe.advance();
+                    self.advance();
                 }
                 Some(TokenKind::RightParen) => {
                     if paren_depth == 0 {
+                        self.restore(checkpoint);
                         return true;
                     }
                     paren_depth -= 1;
                     previous_top_level_operand = false;
-                    probe.advance();
+                    self.advance();
                 }
                 Some(TokenKind::Newline) | Some(TokenKind::Semicolon) if paren_depth == 0 => {
                     previous_top_level_operand = false;
-                    probe.advance();
+                    self.advance();
                 }
-                Some(TokenKind::Comment) if probe.dialect == ShellDialect::Zsh => return false,
+                Some(TokenKind::Comment) if self.dialect == ShellDialect::Zsh => {
+                    self.restore(checkpoint);
+                    return false;
+                }
                 Some(_)
                     if paren_depth == 0
-                        && probe
+                        && self
                             .current_token
                             .as_ref()
                             .is_some_and(Self::is_operand_like_double_paren_token) =>
                 {
                     if previous_top_level_operand {
+                        self.restore(checkpoint);
                         return true;
                     }
                     previous_top_level_operand = true;
-                    probe.advance();
+                    self.advance();
                 }
                 Some(_) => {
                     previous_top_level_operand = false;
-                    probe.advance();
+                    self.advance();
                 }
-                None => return false,
+                None => {
+                    self.restore(checkpoint);
+                    return false;
+                }
             }
         }
     }
@@ -767,10 +777,12 @@ impl<'a> Parser<'a> {
             && let Some(word) = self.current_source_like_word_text()
             && self.peek_next_is(TokenKind::LeftParen)
         {
-            let mut probe = self.clone();
-            probe.advance();
-            probe.advance();
-            if probe.at(TokenKind::RightParen) {
+            let checkpoint = self.checkpoint();
+            self.advance();
+            self.advance();
+            let is_right_paren = self.at(TokenKind::RightParen);
+            self.restore(checkpoint);
+            if is_right_paren {
                 // Check for POSIX-style function: name() { body }
                 // Exclude obvious assignment-like heads such as `a[(1+2)*3]=9`.
                 if !word.contains('=') && !word.contains('[') {
@@ -793,21 +805,23 @@ impl<'a> Parser<'a> {
                 return self.parse_compound_with_redirects(|s| s.parse_subshell());
             }
 
-            let mut arithmetic_probe = self.clone();
-            if let Ok(compound) = arithmetic_probe.parse_arithmetic_command() {
-                let redirects = arithmetic_probe.parse_trailing_redirects();
-                *self = arithmetic_probe;
+            let checkpoint = self.checkpoint();
+            if let Ok(compound) = self.parse_arithmetic_command() {
+                let redirects = self.parse_trailing_redirects();
                 return Ok(Some(Command::Compound(Box::new(compound), redirects)));
             }
+            self.restore(checkpoint);
 
             self.split_current_double_left_paren();
             return self.parse_compound_with_redirects(|s| s.parse_subshell());
         }
 
         if self.dialect == ShellDialect::Zsh && self.at(TokenKind::LeftParen) {
-            let mut probe = self.clone();
-            probe.advance();
-            if probe.at(TokenKind::RightParen) {
+            let checkpoint = self.checkpoint();
+            self.advance();
+            let is_right_paren = self.at(TokenKind::RightParen);
+            self.restore(checkpoint);
+            if is_right_paren {
                 return self.parse_anonymous_paren_function().map(Some);
             }
         }
@@ -1051,9 +1065,8 @@ impl<'a> Parser<'a> {
                 match self.current_token_kind {
                     Some(kind) if kind.is_word_like() => {
                         let word = self
-                            .current_word()
+                            .take_current_word_and_advance()
                             .ok_or_else(|| self.error("expected for word"))?;
-                        self.advance_past_word(&word);
                         words.push(word);
                     }
                     Some(_) | None => {
@@ -1307,9 +1320,8 @@ impl<'a> Parser<'a> {
                     }
 
                     let word = self
-                        .current_word()
+                        .take_current_word_and_advance()
                         .ok_or_else(|| self.error("expected for word"))?;
-                    self.advance_past_word(&word);
                     words.push(word);
                 }
                 Some(TokenKind::Semicolon) => {
@@ -1486,9 +1498,8 @@ impl<'a> Parser<'a> {
                 match self.current_token_kind {
                     Some(kind) if kind.is_word_like() => {
                         let word = self
-                            .current_word()
+                            .take_current_word_and_advance()
                             .ok_or_else(|| self.error("expected foreach word"))?;
-                        self.advance_past_word(&word);
                         words.push(word);
                     }
                     Some(_) | None => {
@@ -1534,9 +1545,8 @@ impl<'a> Parser<'a> {
                     _ if self.current_keyword() == Some(Keyword::Do) => break false,
                     Some(kind) if kind.is_word_like() => {
                         let word = self
-                            .current_word()
+                            .take_current_word_and_advance()
                             .ok_or_else(|| self.error("expected foreach word"))?;
-                        self.advance_past_word(&word);
                         words.push(word);
                     }
                     Some(TokenKind::Semicolon) => {
@@ -1636,8 +1646,7 @@ impl<'a> Parser<'a> {
             match self.current_token_kind {
                 _ if self.current_keyword() == Some(Keyword::Do) => break,
                 Some(kind) if kind.is_word_like() => {
-                    if let Some(word) = self.current_word() {
-                        self.advance_past_word(&word);
+                    if let Some(word) = self.take_current_word_and_advance() {
                         words.push(word);
                     }
                 }
@@ -2001,8 +2010,7 @@ impl<'a> Parser<'a> {
 
         let mut patterns = Vec::new();
         while self.at_word_like() {
-            if let Some(word) = self.current_word() {
-                self.advance_past_word(&word);
+            if let Some(word) = self.take_current_word_and_advance() {
                 patterns.push(self.pattern_from_word(&word));
             }
 
@@ -2615,15 +2623,18 @@ impl<'a> Parser<'a> {
             self.skip_newlines()?;
 
             if self.at(TokenKind::Semicolon) {
-                let mut probe = self.clone();
-                probe.advance();
-                probe.skip_newlines()?;
-                if probe.is_keyword(Keyword::Then)
-                    || (allow_brace_body && !commands.is_empty() && probe.at(TokenKind::LeftBrace))
+                let checkpoint = self.checkpoint();
+                self.advance();
+                if let Err(error) = self.skip_newlines() {
+                    self.restore(checkpoint);
+                    return Err(error);
+                }
+                if self.is_keyword(Keyword::Then)
+                    || (allow_brace_body && !commands.is_empty() && self.at(TokenKind::LeftBrace))
                 {
-                    *self = probe;
                     break;
                 }
+                self.restore(checkpoint);
             }
 
             if self.is_keyword(Keyword::Then)
@@ -2737,14 +2748,17 @@ impl<'a> Parser<'a> {
             && self.next_token_after_tight_semicolon_is(TokenKind::RightBrace)
     }
 
-    fn next_token_after_tight_semicolon_is(&self, expected: TokenKind) -> bool {
-        let mut probe = self.clone();
-        probe.advance();
-        if !probe.at(TokenKind::Semicolon) {
+    fn next_token_after_tight_semicolon_is(&mut self, expected: TokenKind) -> bool {
+        let checkpoint = self.checkpoint();
+        self.advance();
+        if !self.at(TokenKind::Semicolon) {
+            self.restore(checkpoint);
             return false;
         }
-        probe.advance();
-        probe.at(expected)
+        self.advance();
+        let result = self.at(expected);
+        self.restore(checkpoint);
+        result
     }
 
     /// Parse arithmetic command ((expression))
@@ -2947,10 +2961,11 @@ impl<'a> Parser<'a> {
             return Ok(word);
         }
 
-        let Some(word) = self
-            .current_word()
-            .or_else(|| self.current_conditional_literal_word())
-        else {
+        if let Some(word) = self.take_current_word_and_advance() {
+            return Ok(word);
+        }
+
+        let Some(word) = self.current_conditional_literal_word() else {
             return Err(self.error("expected conditional operand"));
         };
         self.advance_past_word(&word);
@@ -3222,6 +3237,9 @@ impl<'a> Parser<'a> {
             {
                 let gap_span = Span::from_positions(prev_end, self.current_span.start);
                 let gap_text = gap_span.slice(self.input);
+                if let Some(word) = first_word.take() {
+                    parts.extend(word.parts);
+                }
                 if Self::source_text_needs_quote_preserving_decode(gap_text) {
                     let gap_word = self.decode_word_text_preserving_quotes_if_needed(
                         gap_text,
@@ -3242,18 +3260,22 @@ impl<'a> Parser<'a> {
             match self.current_token_kind {
                 Some(TokenKind::Word | TokenKind::LiteralWord | TokenKind::QuotedWord) => {
                     let word = self
-                        .current_word()
+                        .take_current_word()
                         .ok_or_else(|| self.error("expected conditional operand"))?;
                     if start.is_none() {
                         start = Some(word.span.start);
                     } else {
+                        if let Some(first) = first_word.take() {
+                            parts.extend(first.parts);
+                        }
                         composite = true;
                     }
                     end = Some(word.span.end);
                     if first_word.is_none() && !composite {
-                        first_word = Some(word.clone());
+                        first_word = Some(word);
+                    } else {
+                        parts.extend(word.parts);
                     }
-                    parts.extend(word.parts.clone());
                     previous_end = Some(self.current_span.end);
                     self.advance();
                 }
@@ -3262,6 +3284,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(LiteralText::owned("(")),
                         self.current_span,
@@ -3276,6 +3301,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(LiteralText::owned("((")),
                         self.current_span,
@@ -3293,6 +3321,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(LiteralText::owned(")")),
                         self.current_span,
@@ -3307,6 +3338,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(LiteralText::owned("))")),
                         self.current_span,
@@ -3321,6 +3355,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(LiteralText::owned("|")),
                         self.current_span,
@@ -3337,6 +3374,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(LiteralText::owned("&&")),
                         self.current_span,
@@ -3353,6 +3393,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(LiteralText::owned("||")),
                         self.current_span,
@@ -3371,6 +3414,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(self.literal_text(
                             literal,
@@ -3394,6 +3440,9 @@ impl<'a> Parser<'a> {
                         start = Some(self.current_span.start);
                     }
                     end = Some(self.current_span.end);
+                    if let Some(word) = first_word.take() {
+                        parts.extend(word.parts);
+                    }
                     parts.push(WordPartNode::new(
                         WordPart::Literal(self.literal_text(
                             literal,
@@ -3535,11 +3584,11 @@ impl<'a> Parser<'a> {
                         self.split_current_double_left_paren();
                         self.parse_subshell()?
                     } else {
-                        let mut arithmetic_probe = self.clone();
-                        if let Ok(compound) = arithmetic_probe.parse_arithmetic_command() {
-                            *self = arithmetic_probe;
+                        let checkpoint = self.checkpoint();
+                        if let Ok(compound) = self.parse_arithmetic_command() {
                             compound
                         } else {
+                            self.restore(checkpoint);
                             self.split_current_double_left_paren();
                             self.parse_subshell()?
                         }
@@ -3558,11 +3607,9 @@ impl<'a> Parser<'a> {
 
     fn parse_function_header_entry(&mut self) -> Result<FunctionHeaderEntry> {
         let word = self
-            .current_word()
+            .take_current_word_and_advance()
             .ok_or_else(|| self.error("expected function name"))?;
-        let entry = self.function_header_entry_from_word(word.clone());
-        self.advance_past_word(&word);
-        Ok(entry)
+        Ok(self.function_header_entry_from_word(word))
     }
 
     fn function_header_entry_from_word(&self, word: Word) -> FunctionHeaderEntry {
@@ -3695,9 +3742,8 @@ impl<'a> Parser<'a> {
         let mut args = Vec::new();
         while self.current_token_kind.is_some_and(TokenKind::is_word_like) {
             let word = self
-                .current_word()
+                .take_current_word_and_advance()
                 .ok_or_else(|| self.error("expected anonymous function argument"))?;
-            self.advance_past_word(&word);
             args.push(word);
         }
         Ok(args)
@@ -3829,12 +3875,17 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
 
-        let mut probe = self.clone();
-        probe.advance();
-        probe.skip_newlines()?;
-        if !probe.at(TokenKind::LeftBrace) {
+        let checkpoint = self.checkpoint();
+        self.advance();
+        if let Err(error) = self.skip_newlines() {
+            self.restore(checkpoint);
+            return Err(error);
+        }
+        if !self.at(TokenKind::LeftBrace) {
+            self.restore(checkpoint);
             return Ok(None);
         }
+        self.restore(checkpoint);
 
         let start_span = self.current_span;
         let header_span =
@@ -3984,7 +4035,7 @@ impl<'a> Parser<'a> {
                     // Handle compound array assignment in arg position:
                     // declare -a arr=(x y z) → arr=(x y z) as single arg
                     if word_text.ends_with('=') && !words.is_empty() {
-                        let original_word = self.current_word();
+                        let original_word = self.current_word_ref().cloned();
                         let saved_span = self.current_span;
                         self.advance();
                         if let Some(word) =
@@ -4000,16 +4051,14 @@ impl<'a> Parser<'a> {
                         continue;
                     }
 
-                    if let Some(word) = self.current_word() {
-                        self.advance_past_word(&word);
+                    if let Some(word) = self.take_current_word_and_advance() {
                         words.push(word);
                     }
                 }
                 Some(TokenKind::LeftParen) if !words.is_empty() => {
-                    let Some(word) = self.current_word() else {
+                    let Some(word) = self.take_current_word_and_advance() else {
                         break;
                     };
-                    self.advance_past_word(&word);
                     words.push(word);
                 }
                 Some(TokenKind::Newline) => {

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -39,15 +39,15 @@ impl ZshCaseScanState {
 }
 
 impl<'a> Parser<'a> {
-    fn apply_simple_command_effects(&mut self, command: &SimpleCommand) {
-        let Some(name) = self.literal_word_text(&command.name) else {
+    fn apply_word_command_effects(&mut self, name: &Word, args: &[Word]) {
+        let Some(name) = self.literal_word_text(name) else {
             return;
         };
 
         match name.as_str() {
             "shopt" => {
                 let mut toggle = None;
-                for arg in &command.args {
+                for arg in args {
                     let Some(arg) = self.literal_word_text(arg) else {
                         continue;
                     };
@@ -64,7 +64,7 @@ impl<'a> Parser<'a> {
                 }
             }
             "alias" => {
-                for arg in &command.args {
+                for arg in args {
                     let Some(arg) = self.literal_word_text(arg) else {
                         continue;
                     };
@@ -79,7 +79,7 @@ impl<'a> Parser<'a> {
                 }
             }
             "unalias" => {
-                for arg in &command.args {
+                for arg in args {
                     let Some(arg) = self.literal_word_text(arg) else {
                         continue;
                     };
@@ -96,20 +96,26 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn apply_command_effects(&mut self, command: &Command) {
-        match command {
-            Command::Simple(simple) => self.apply_simple_command_effects(simple),
-            Command::List(list) => {
-                self.apply_command_effects(&list.first);
-                for item in &list.rest {
-                    self.apply_command_effects(&item.command);
-                }
+    fn apply_stmt_effects(&mut self, stmt: &Stmt) {
+        match &stmt.command {
+            AstCommand::Simple(simple) => {
+                self.apply_word_command_effects(&simple.name, &simple.args)
+            }
+            AstCommand::Binary(binary) if matches!(binary.op, BinaryOp::And | BinaryOp::Or) => {
+                self.apply_stmt_effects(&binary.left);
+                self.apply_stmt_effects(&binary.right);
             }
             _ => {}
         }
     }
 
-    fn parse_command_list_required(&mut self) -> Result<Command> {
+    fn apply_stmt_list_effects(&mut self, stmts: &[Stmt]) {
+        for stmt in stmts {
+            self.apply_stmt_effects(stmt);
+        }
+    }
+
+    fn parse_command_list_required(&mut self) -> Result<Vec<Stmt>> {
         self.parse_command_list()?
             .ok_or_else(|| self.error("expected command"))
     }
@@ -186,7 +192,7 @@ impl<'a> Parser<'a> {
 
         let file_span =
             Span::from_positions(Position::new(), Position::new().advanced_by(self.input));
-        let mut commands = Vec::new();
+        let mut stmts = Vec::new();
 
         while self.current_token.is_some() {
             self.tick()?;
@@ -195,13 +201,13 @@ impl<'a> Parser<'a> {
             if self.current_token.is_none() {
                 break;
             }
-            let command = self.parse_command_list_required()?;
-            self.apply_command_effects(&command);
-            commands.push(command);
+            let command_stmts = self.parse_command_list_required()?;
+            self.apply_stmt_list_effects(&command_stmts);
+            stmts.extend(command_stmts);
         }
 
         let mut file = File {
-            body: Self::lower_commands_to_stmt_seq(commands, file_span),
+            body: Self::stmt_seq_with_span(file_span, stmts),
             span: file_span,
         };
         self.attach_comments_to_file(&mut file);
@@ -216,7 +222,7 @@ impl<'a> Parser<'a> {
     fn parse_recovered_impl(&mut self) -> RecoveredParse {
         let file_span =
             Span::from_positions(Position::new(), Position::new().advanced_by(self.input));
-        let mut commands = Vec::new();
+        let mut stmts = Vec::new();
         let mut diagnostics = Vec::new();
 
         while self.current_token.is_some() {
@@ -243,9 +249,9 @@ impl<'a> Parser<'a> {
 
             let command_start = self.current_span.start.offset;
             match self.parse_command_list_required() {
-                Ok(command) => {
-                    self.apply_command_effects(&command);
-                    commands.push(command);
+                Ok(command_stmts) => {
+                    self.apply_stmt_list_effects(&command_stmts);
+                    stmts.extend(command_stmts);
                 }
                 Err(error) => {
                     diagnostics.push(self.parse_diagnostic_from_error(error));
@@ -257,7 +263,7 @@ impl<'a> Parser<'a> {
         }
 
         let mut file = File {
-            body: Self::lower_commands_to_stmt_seq(commands, file_span),
+            body: Self::stmt_seq_with_span(file_span, stmts),
             span: file_span,
         };
         self.attach_comments_to_file(&mut file);
@@ -287,29 +293,35 @@ impl<'a> Parser<'a> {
         (output, parser.finish_benchmark_counters())
     }
 
-    fn parse_command_list(&mut self) -> Result<Option<Command>> {
+    fn parse_command_list(&mut self) -> Result<Option<Vec<Stmt>>> {
         self.tick()?;
-        let first = match self.parse_pipeline()? {
-            Some(cmd) => cmd,
+        let mut current = match self.parse_pipeline()? {
+            Some(stmt) => stmt,
             None => return Ok(None),
         };
 
-        let mut rest = Vec::with_capacity(1);
+        let mut stmts = Vec::with_capacity(2);
 
         loop {
-            let (op, allow_empty_tail) = match self.current_token_kind {
-                Some(TokenKind::And) => (ListOperator::And, false),
-                Some(TokenKind::Or) => (ListOperator::Or, false),
-                Some(TokenKind::Semicolon) => (ListOperator::Semicolon, true),
-                Some(TokenKind::Background) => {
-                    (ListOperator::Background(BackgroundOperator::Plain), true)
-                }
-                Some(TokenKind::BackgroundPipe) => {
-                    (ListOperator::Background(BackgroundOperator::Pipe), true)
-                }
-                Some(TokenKind::BackgroundBang) => {
-                    (ListOperator::Background(BackgroundOperator::Bang), true)
-                }
+            let (op, terminator, allow_empty_tail) = match self.current_token_kind {
+                Some(TokenKind::And) => (Some(BinaryOp::And), None, false),
+                Some(TokenKind::Or) => (Some(BinaryOp::Or), None, false),
+                Some(TokenKind::Semicolon) => (None, Some(StmtTerminator::Semicolon), true),
+                Some(TokenKind::Background) => (
+                    None,
+                    Some(StmtTerminator::Background(BackgroundOperator::Plain)),
+                    true,
+                ),
+                Some(TokenKind::BackgroundPipe) => (
+                    None,
+                    Some(StmtTerminator::Background(BackgroundOperator::Pipe)),
+                    true,
+                ),
+                Some(TokenKind::BackgroundBang) => (
+                    None,
+                    Some(StmtTerminator::Background(BackgroundOperator::Bang)),
+                    true,
+                ),
                 _ => break,
             };
             let operator_span = self.current_span;
@@ -317,26 +329,27 @@ impl<'a> Parser<'a> {
 
             self.skip_newlines()?;
             if allow_empty_tail && self.current_token.is_none() {
-                rest.push(CommandListItem {
-                    operator: op,
-                    operator_span,
-                    command: Command::Simple(SimpleCommand {
-                        name: Word::literal(""),
-                        args: vec![],
-                        redirects: vec![],
-                        assignments: vec![],
-                        span: self.current_span,
-                    }),
-                });
-                break;
+                current.terminator = terminator;
+                current.terminator_span = Some(operator_span);
+                stmts.push(current);
+                return Ok(Some(stmts));
             }
 
-            if let Some(cmd) = self.parse_pipeline()? {
-                rest.push(CommandListItem {
-                    operator: op,
-                    operator_span,
-                    command: cmd,
-                });
+            if let Some(binary_op) = op {
+                if let Some(right) = self.parse_pipeline()? {
+                    current = Self::binary_stmt(current, binary_op, operator_span, right);
+                } else {
+                    break;
+                }
+                continue;
+            }
+
+            let terminator = terminator.expect("list terminator should be present");
+            if let Some(next) = self.parse_pipeline()? {
+                current.terminator = Some(terminator);
+                current.terminator_span = Some(operator_span);
+                stmts.push(current);
+                current = next;
             } else if allow_empty_tail {
                 if self
                     .current_keyword()
@@ -350,37 +363,23 @@ impl<'a> Parser<'a> {
                 ) {
                     self.advance();
                 }
-                rest.push(CommandListItem {
-                    operator: op,
-                    operator_span,
-                    command: Command::Simple(SimpleCommand {
-                        name: Word::literal(""),
-                        args: vec![],
-                        redirects: vec![],
-                        assignments: vec![],
-                        span: self.current_span,
-                    }),
-                });
-                break;
+                current.terminator = Some(terminator);
+                current.terminator_span = Some(operator_span);
+                stmts.push(current);
+                return Ok(Some(stmts));
             } else {
                 break;
             }
         }
 
-        if rest.is_empty() {
-            Ok(Some(first))
-        } else {
-            Ok(Some(Command::List(CommandList {
-                first: Box::new(first),
-                rest,
-            })))
-        }
+        stmts.push(current);
+        Ok(Some(stmts))
     }
 
     /// Parse a pipeline (commands connected by |)
     ///
     /// Handles `!` pipeline negation: `! cmd | cmd2` negates the exit code.
-    fn parse_pipeline(&mut self) -> Result<Option<Command>> {
+    fn parse_pipeline(&mut self) -> Result<Option<Stmt>> {
         let start_span = self.current_span;
 
         // Check for pipeline negation: `! command`
@@ -389,8 +388,8 @@ impl<'a> Parser<'a> {
             self.advance();
         }
 
-        let first = match self.parse_command()? {
-            Some(cmd) => cmd,
+        let mut stmt = match self.parse_command()? {
+            Some(cmd) => Self::lower_non_sequence_command_to_stmt(cmd),
             None => {
                 if negated {
                     return Err(self.error("expected command after !"));
@@ -399,11 +398,9 @@ impl<'a> Parser<'a> {
             }
         };
 
-        let mut commands = Vec::with_capacity(2);
-        commands.push(first);
-        let mut operators = Vec::with_capacity(1);
-
+        let mut saw_pipe = false;
         while self.at_in_set(PIPE_OPERATOR_TOKENS) {
+            saw_pipe = true;
             let op = if self.at(TokenKind::PipeBoth) {
                 BinaryOp::PipeAll
             } else {
@@ -414,23 +411,18 @@ impl<'a> Parser<'a> {
             self.skip_newlines()?;
 
             if let Some(cmd) = self.parse_command()? {
-                operators.push((op, operator_span));
-                commands.push(cmd);
+                let right = Self::lower_non_sequence_command_to_stmt(cmd);
+                stmt = Self::binary_stmt(stmt, op, operator_span, right);
             } else {
                 return Err(self.error("expected command after |"));
             }
         }
 
-        if commands.len() == 1 && !negated {
-            Ok(Some(commands.remove(0)))
-        } else {
-            Ok(Some(Command::Pipeline(Pipeline {
-                negated,
-                commands,
-                operators,
-                span: start_span.merge(self.current_span),
-            })))
+        if negated || saw_pipe {
+            stmt.negated = negated;
+            stmt.span = start_span.merge(self.current_span);
         }
+        Ok(Some(stmt))
     }
 
     fn parse_compound_with_redirects(
@@ -857,7 +849,7 @@ impl<'a> Parser<'a> {
         let allow_brace_syntax = self.dialect.features().zsh_brace_if;
         let condition = self.parse_if_condition_until_body_start(allow_brace_syntax)?;
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
-        let condition = Self::lower_commands_to_stmt_seq(condition, condition_span);
+        let condition = Self::stmt_seq_with_span(condition_span, condition);
 
         let (mut syntax, then_branch, brace_style) =
             if allow_brace_syntax && self.at(TokenKind::LeftBrace) {
@@ -891,7 +883,7 @@ impl<'a> Parser<'a> {
                         return Err(self.error("syntax error: empty then clause"));
                     }
                 } else {
-                    Self::lower_commands_to_stmt_seq(then_branch, then_branch_span)
+                    Self::stmt_seq_with_span(then_branch_span, then_branch)
                 };
 
                 (
@@ -914,8 +906,7 @@ impl<'a> Parser<'a> {
             let elif_condition = self.parse_if_condition_until_body_start(brace_style)?;
             let elif_condition_span =
                 Span::from_positions(elif_condition_start, self.current_span.start);
-            let elif_condition =
-                Self::lower_commands_to_stmt_seq(elif_condition, elif_condition_span);
+            let elif_condition = Self::stmt_seq_with_span(elif_condition_span, elif_condition);
 
             let elif_body = if brace_style {
                 if !self.at(TokenKind::LeftBrace) {
@@ -952,7 +943,7 @@ impl<'a> Parser<'a> {
                         return Err(self.error("syntax error: empty elif clause"));
                     }
                 } else {
-                    Self::lower_commands_to_stmt_seq(elif_body, elif_body_span)
+                    Self::stmt_seq_with_span(elif_body_span, elif_body)
                 }
             };
 
@@ -997,7 +988,7 @@ impl<'a> Parser<'a> {
                         return Err(self.error("syntax error: empty else clause"));
                     }
                 } else {
-                    Some(Self::lower_commands_to_stmt_seq(branch, else_span))
+                    Some(Self::stmt_seq_with_span(else_span, branch))
                 }
             }
         } else {
@@ -1178,7 +1169,7 @@ impl<'a> Parser<'a> {
                 let body = if body.is_empty() {
                     Self::stmt_seq_with_span(body_span, Vec::new())
                 } else {
-                    Self::lower_commands_to_stmt_seq(body, body_span)
+                    Self::stmt_seq_with_span(body_span, body)
                 };
                 (
                     body,
@@ -1219,7 +1210,7 @@ impl<'a> Parser<'a> {
                 let body = if body.is_empty() {
                     Self::stmt_seq_with_span(body_span, Vec::new())
                 } else {
-                    Self::lower_commands_to_stmt_seq(body, body_span)
+                    Self::stmt_seq_with_span(body_span, body)
                 };
                 (
                     body,
@@ -1374,7 +1365,7 @@ impl<'a> Parser<'a> {
                 self.advance();
                 (
                     RepeatSyntax::DoDone { do_span, done_span },
-                    Self::lower_commands_to_stmt_seq(body, body_span),
+                    Self::stmt_seq_with_span(body_span, body),
                     done_span,
                 )
             }
@@ -1419,7 +1410,7 @@ impl<'a> Parser<'a> {
                 self.advance();
                 (
                     RepeatSyntax::DoDone { do_span, done_span },
-                    Self::lower_commands_to_stmt_seq(body, body_span),
+                    Self::stmt_seq_with_span(body_span, body),
                     done_span,
                 )
             }
@@ -1448,13 +1439,12 @@ impl<'a> Parser<'a> {
                 self.advance();
                 (
                     RepeatSyntax::DoDone { do_span, done_span },
-                    Self::lower_commands_to_stmt_seq(body, body_span),
+                    Self::stmt_seq_with_span(body_span, body),
                     done_span,
                 )
             }
             _ => {
-                let command = self.parse_single_stmt_command()?;
-                let stmt = Self::lower_non_sequence_command_to_stmt(command);
+                let stmt = self.parse_single_stmt_command()?;
                 let span = stmt.span;
                 (
                     RepeatSyntax::Direct,
@@ -1591,7 +1581,7 @@ impl<'a> Parser<'a> {
             self.advance();
             (
                 words,
-                Self::lower_commands_to_stmt_seq(body, body_span),
+                Self::stmt_seq_with_span(body_span, body),
                 ForeachSyntax::InDoDone {
                     in_span,
                     do_span,
@@ -1674,7 +1664,7 @@ impl<'a> Parser<'a> {
             self.pop_depth();
             return Err(self.error("syntax error: empty select loop body"));
         }
-        let body = Self::lower_commands_to_stmt_seq(body, body_span);
+        let body = Self::stmt_seq_with_span(body_span, body);
 
         // Expect 'done'
         self.expect_keyword(Keyword::Done)?;
@@ -1802,9 +1792,12 @@ impl<'a> Parser<'a> {
             let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
-                Self::lower_commands_to_stmt_seq(
-                    vec![Command::Compound(Box::new(body), Vec::new())],
+                Self::stmt_seq_with_span(
                     span,
+                    vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
+                        Box::new(body),
+                        Vec::new(),
+                    ))],
                 ),
                 self.current_span,
             )
@@ -1829,7 +1822,7 @@ impl<'a> Parser<'a> {
             }
             let done_span = self.current_span;
             self.advance();
-            (Self::lower_commands_to_stmt_seq(body, body_span), done_span)
+            (Self::stmt_seq_with_span(body_span, body), done_span)
         };
 
         Ok(CompoundCommand::ArithmeticFor(Box::new(
@@ -1861,7 +1854,7 @@ impl<'a> Parser<'a> {
         let condition_start = self.current_span.start;
         let condition = self.parse_compound_list(Keyword::Do)?;
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
-        let condition = Self::lower_commands_to_stmt_seq(condition, condition_span);
+        let condition = Self::stmt_seq_with_span(condition_span, condition);
 
         // Expect 'do'
         self.expect_keyword(Keyword::Do)?;
@@ -1877,7 +1870,7 @@ impl<'a> Parser<'a> {
             self.pop_depth();
             return Err(self.error("syntax error: empty while loop body"));
         }
-        let body = Self::lower_commands_to_stmt_seq(body, body_span);
+        let body = Self::stmt_seq_with_span(body_span, body);
 
         // Expect 'done'
         self.expect_keyword(Keyword::Done)?;
@@ -1901,7 +1894,7 @@ impl<'a> Parser<'a> {
         let condition_start = self.current_span.start;
         let condition = self.parse_compound_list(Keyword::Do)?;
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
-        let condition = Self::lower_commands_to_stmt_seq(condition, condition_span);
+        let condition = Self::stmt_seq_with_span(condition_span, condition);
 
         // Expect 'do'
         self.expect_keyword(Keyword::Do)?;
@@ -1917,7 +1910,7 @@ impl<'a> Parser<'a> {
             self.pop_depth();
             return Err(self.error("syntax error: empty until loop body"));
         }
-        let body = Self::lower_commands_to_stmt_seq(body, body_span);
+        let body = Self::stmt_seq_with_span(body_span, body);
 
         // Expect 'done'
         self.expect_keyword(Keyword::Done)?;
@@ -1969,7 +1962,7 @@ impl<'a> Parser<'a> {
                 && !self.is_keyword(Keyword::Esac)
                 && self.current_token.is_some()
             {
-                commands.push(self.parse_command_list_required()?);
+                commands.extend(self.parse_command_list_required()?);
                 self.skip_newlines()?;
             }
 
@@ -1977,7 +1970,7 @@ impl<'a> Parser<'a> {
             let body_span = Span::from_positions(body_start, self.current_span.start);
             cases.push(CaseItem {
                 patterns,
-                body: Self::lower_commands_to_stmt_seq(commands, body_span),
+                body: Self::stmt_seq_with_span(body_span, commands),
                 terminator,
                 terminator_span,
             });
@@ -2395,9 +2388,7 @@ impl<'a> Parser<'a> {
 
         // Parse the command to time (if any)
         // time with no command is valid in bash (just outputs timing header)
-        let command = self
-            .parse_pipeline()?
-            .map(|command| Box::new(Self::lower_non_sequence_command_to_stmt(command)));
+        let command = self.parse_pipeline()?.map(Box::new);
 
         Ok(CompoundCommand::Time(TimeCommand {
             posix_format,
@@ -2445,7 +2436,6 @@ impl<'a> Parser<'a> {
         // Parse the command body (could be simple, compound, or pipeline)
         let body = self.parse_pipeline()?;
         let body = body.ok_or_else(|| self.error("coproc: missing command"))?;
-        let body = Self::lower_non_sequence_command_to_stmt(body);
 
         Ok(CompoundCommand::Coproc(CoprocCommand {
             name,
@@ -2511,7 +2501,7 @@ impl<'a> Parser<'a> {
             ) {
                 break;
             }
-            commands.push(self.parse_command_list_required()?);
+            commands.extend(self.parse_command_list_required()?);
         }
 
         if self.at(TokenKind::DoubleRightParen) {
@@ -2525,9 +2515,9 @@ impl<'a> Parser<'a> {
         }
 
         self.pop_depth();
-        Ok(CompoundCommand::Subshell(Self::lower_commands_to_stmt_seq(
-            commands,
+        Ok(CompoundCommand::Subshell(Self::stmt_seq_with_span(
             Span::from_positions(body_start, self.current_span.start),
+            commands,
         )))
     }
 
@@ -2580,7 +2570,7 @@ impl<'a> Parser<'a> {
             if self.at(TokenKind::RightBrace) {
                 break;
             }
-            commands.push(self.parse_command_list_required()?);
+            commands.extend(self.parse_command_list_required()?);
         }
 
         if !self.at(TokenKind::RightBrace) {
@@ -2604,20 +2594,17 @@ impl<'a> Parser<'a> {
         self.brace_body_stack.pop();
         self.brace_group_depth -= 1;
         Ok((
-            Self::lower_commands_to_stmt_seq(
-                commands,
+            Self::stmt_seq_with_span(
                 Span::from_positions(body_start, right_brace_span.start),
+                commands,
             ),
             left_brace_span,
             right_brace_span,
         ))
     }
 
-    fn parse_if_condition_until_body_start(
-        &mut self,
-        allow_brace_body: bool,
-    ) -> Result<Vec<Command>> {
-        let mut commands = Vec::with_capacity(2);
+    fn parse_if_condition_until_body_start(&mut self, allow_brace_body: bool) -> Result<Vec<Stmt>> {
+        let mut stmts = Vec::with_capacity(2);
 
         loop {
             self.skip_newlines()?;
@@ -2630,7 +2617,7 @@ impl<'a> Parser<'a> {
                     return Err(error);
                 }
                 if self.is_keyword(Keyword::Then)
-                    || (allow_brace_body && !commands.is_empty() && self.at(TokenKind::LeftBrace))
+                    || (allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace))
                 {
                     break;
                 }
@@ -2638,7 +2625,7 @@ impl<'a> Parser<'a> {
             }
 
             if self.is_keyword(Keyword::Then)
-                || (allow_brace_body && !commands.is_empty() && self.at(TokenKind::LeftBrace))
+                || (allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace))
             {
                 break;
             }
@@ -2647,12 +2634,12 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            let command = self.parse_command_list_required()?;
-            self.apply_command_effects(&command);
-            commands.push(command);
+            let command_stmts = self.parse_command_list_required()?;
+            self.apply_stmt_list_effects(&command_stmts);
+            stmts.extend(command_stmts);
         }
 
-        Ok(commands)
+        Ok(stmts)
     }
 
     fn has_recorded_comment_between(&self, start_offset: usize, end_offset: usize) -> bool {
@@ -3550,10 +3537,13 @@ impl<'a> Parser<'a> {
         None
     }
 
-    fn parse_function_body_command(&mut self, allow_bare_compound: bool) -> Result<Command> {
+    fn parse_function_body_command(&mut self, allow_bare_compound: bool) -> Result<Stmt> {
         if let Some(compound) = self.try_parse_compact_function_brace_body()? {
             let redirects = self.parse_trailing_redirects();
-            return Ok(Command::Compound(Box::new(compound), redirects));
+            return Ok(Self::lower_non_sequence_command_to_stmt(Command::Compound(
+                Box::new(compound),
+                redirects,
+            )));
         }
 
         let compound = match self.current_keyword() {
@@ -3602,7 +3592,10 @@ impl<'a> Parser<'a> {
             },
         };
         let redirects = self.parse_trailing_redirects();
-        Ok(Command::Compound(Box::new(compound), redirects))
+        Ok(Self::lower_non_sequence_command_to_stmt(Command::Compound(
+            Box::new(compound),
+            redirects,
+        )))
     }
 
     fn parse_function_header_entry(&mut self) -> Result<FunctionHeaderEntry> {
@@ -3654,88 +3647,64 @@ impl<'a> Parser<'a> {
             )));
         }
 
-        let command = self.parse_single_stmt_command()?;
-        Ok(Self::lower_non_sequence_command_to_stmt(command))
+        self.parse_single_stmt_command()
     }
 
-    fn parse_single_stmt_command(&mut self) -> Result<Command> {
-        let first = self
+    fn parse_single_stmt_command(&mut self) -> Result<Stmt> {
+        let mut stmt = self
             .parse_pipeline()?
             .ok_or_else(|| self.error("expected command"))?;
 
-        let mut rest = Vec::with_capacity(1);
+        let Some(kind) = self.current_token_kind else {
+            return Ok(stmt);
+        };
+        let operator = match kind {
+            TokenKind::And => Some((Some(BinaryOp::And), None, false)),
+            TokenKind::Or => Some((Some(BinaryOp::Or), None, false)),
+            TokenKind::Semicolon => Some((None, Some(StmtTerminator::Semicolon), true)),
+            TokenKind::Background => Some((
+                None,
+                Some(StmtTerminator::Background(BackgroundOperator::Plain)),
+                true,
+            )),
+            TokenKind::BackgroundPipe => Some((
+                None,
+                Some(StmtTerminator::Background(BackgroundOperator::Pipe)),
+                true,
+            )),
+            TokenKind::BackgroundBang => Some((
+                None,
+                Some(StmtTerminator::Background(BackgroundOperator::Bang)),
+                true,
+            )),
+            _ => None,
+        };
+        let Some((binary_op, terminator, allow_empty_tail)) = operator else {
+            return Ok(stmt);
+        };
+        let operator_span = self.current_span;
+        self.advance();
 
-        'tail: {
-            let Some(kind) = self.current_token_kind else {
-                break 'tail;
-            };
-            let operator = match kind {
-                TokenKind::And => Some((ListOperator::And, false)),
-                TokenKind::Or => Some((ListOperator::Or, false)),
-                TokenKind::Semicolon => Some((ListOperator::Semicolon, true)),
-                TokenKind::Background => {
-                    Some((ListOperator::Background(BackgroundOperator::Plain), true))
-                }
-                TokenKind::BackgroundPipe => {
-                    Some((ListOperator::Background(BackgroundOperator::Pipe), true))
-                }
-                TokenKind::BackgroundBang => {
-                    Some((ListOperator::Background(BackgroundOperator::Bang), true))
-                }
-                _ => None,
-            };
-            let Some((operator, allow_empty_tail)) = operator else {
-                break 'tail;
-            };
-            let operator_span = self.current_span;
+        if let Some(binary_op) = binary_op {
+            self.skip_newlines()?;
+            if let Some(right) = self.parse_pipeline()? {
+                stmt = Self::binary_stmt(stmt, binary_op, operator_span, right);
+            }
+            return Ok(stmt);
+        }
+
+        if allow_empty_tail
+            && matches!(
+                self.current_token_kind,
+                Some(TokenKind::Semicolon | TokenKind::Newline)
+            )
+        {
             self.advance();
-
-            if matches!(operator, ListOperator::And | ListOperator::Or) {
-                self.skip_newlines()?;
-                if let Some(command) = self.parse_pipeline()? {
-                    rest.push(CommandListItem {
-                        operator,
-                        operator_span,
-                        command,
-                    });
-                }
-                break 'tail;
-            }
-
-            if allow_empty_tail
-                && matches!(
-                    self.current_token_kind,
-                    Some(TokenKind::Semicolon | TokenKind::Newline)
-                )
-            {
-                self.advance();
-            }
-
-            rest.push(CommandListItem {
-                operator,
-                operator_span,
-                command: if allow_empty_tail {
-                    Command::Simple(SimpleCommand {
-                        name: Word::literal(""),
-                        args: vec![],
-                        redirects: vec![],
-                        assignments: vec![],
-                        span: self.current_span,
-                    })
-                } else {
-                    unreachable!()
-                },
-            });
         }
 
-        if rest.is_empty() {
-            Ok(first)
-        } else {
-            Ok(Command::List(CommandList {
-                first: Box::new(first),
-                rest,
-            }))
-        }
+        stmt.terminator = terminator;
+        stmt.terminator_span = Some(operator_span);
+        Ok(stmt)
     }
 
     fn parse_anonymous_function_args(&mut self) -> Result<Vec<Word>> {
@@ -3812,7 +3781,6 @@ impl<'a> Parser<'a> {
         };
 
         let body = self.parse_function_body_command(allow_bare_compound)?;
-        let body = Self::lower_non_sequence_command_to_stmt(body);
         let span = start_span.merge(self.current_span);
 
         Ok(Command::Function(FunctionDef {
@@ -3845,8 +3813,7 @@ impl<'a> Parser<'a> {
             self.parse_zsh_function_body_stmt()?
         } else {
             self.skip_newlines()?;
-            let body = self.parse_function_body_command(true)?;
-            Self::lower_non_sequence_command_to_stmt(body)
+            self.parse_function_body_command(true)?
         };
 
         Ok(Command::Function(FunctionDef {
@@ -3919,13 +3886,13 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse commands until a terminating keyword
-    fn parse_compound_list(&mut self, terminator: Keyword) -> Result<Vec<Command>> {
+    fn parse_compound_list(&mut self, terminator: Keyword) -> Result<Vec<Stmt>> {
         self.parse_compound_list_until(KeywordSet::single(terminator))
     }
 
     /// Parse commands until one of the terminating keywords
-    fn parse_compound_list_until(&mut self, terminators: KeywordSet) -> Result<Vec<Command>> {
-        let mut commands = Vec::with_capacity(4);
+    fn parse_compound_list_until(&mut self, terminators: KeywordSet) -> Result<Vec<Stmt>> {
+        let mut stmts = Vec::with_capacity(4);
 
         loop {
             self.skip_command_separators()?;
@@ -3942,12 +3909,12 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            let command = self.parse_command_list_required()?;
-            self.apply_command_effects(&command);
-            commands.push(command);
+            let command_stmts = self.parse_command_list_required()?;
+            self.apply_stmt_list_effects(&command_stmts);
+            stmts.extend(command_stmts);
         }
 
-        Ok(commands)
+        Ok(stmts)
     }
 
     /// Reserved words that cannot start a simple command.

--- a/crates/shuck-parser/src/parser/heredocs.rs
+++ b/crates/shuck-parser/src/parser/heredocs.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl<'a> Parser<'a> {
     pub(super) fn current_static_heredoc_delimiter(&mut self) -> Option<(Word, String, bool)> {
-        let word = self.current_word()?;
+        let word = self.current_word_ref()?.clone();
         let raw_text = word.span.slice(self.input);
         let quoted_parts = word.has_quoted_parts();
 

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -331,6 +331,26 @@ pub struct Parser<'a> {
     benchmark_counters: Option<ParserBenchmarkCounters>,
 }
 
+#[derive(Clone)]
+struct ParserCheckpoint<'a> {
+    lexer: Lexer<'a>,
+    synthetic_tokens: VecDeque<SyntheticToken>,
+    alias_replays: Vec<AliasReplay>,
+    current_token: Option<LexedToken<'a>>,
+    current_word_cache: Option<Word>,
+    current_token_kind: Option<TokenKind>,
+    current_keyword: Option<Keyword>,
+    current_span: Span,
+    peeked_token: Option<LexedToken<'a>>,
+    current_depth: usize,
+    fuel: usize,
+    expand_next_word: bool,
+    brace_group_depth: usize,
+    brace_body_stack: Vec<BraceBodyContext>,
+    #[cfg(feature = "benchmarking")]
+    benchmark_counters: Option<ParserBenchmarkCounters>,
+}
+
 /// A parser diagnostic emitted while recovering from invalid input.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseDiagnostic {
@@ -1643,6 +1663,14 @@ impl<'a> Parser<'a> {
         Some(self.word_with_parts(parts, span))
     }
 
+    fn current_word_ref(&mut self) -> Option<&Word> {
+        if self.current_word_cache.is_none() {
+            self.current_word_cache = self.current_word();
+        }
+
+        self.current_word_cache.as_ref()
+    }
+
     fn current_word(&mut self) -> Option<Word> {
         if let Some(word) = self.current_word_cache.as_ref() {
             return Some(word.clone());
@@ -1667,6 +1695,34 @@ impl<'a> Parser<'a> {
             self.current_word_cache = Some(word.clone());
         }
         word
+    }
+
+    fn take_current_word(&mut self) -> Option<Word> {
+        if let Some(word) = self.current_word_cache.take() {
+            return Some(word);
+        }
+
+        if let Some(word) = self.current_zsh_glob_word_from_source() {
+            return Some(word);
+        }
+
+        let span = self.current_span;
+        if let Some(token) = self.current_token.clone()
+            && let Some(word) = self.simple_word_from_token(&token, span)
+        {
+            return Some(word);
+        }
+
+        let token = self.current_token.take()?;
+        let word = self.decode_word_from_token(&token, span);
+        self.current_token = Some(token);
+        word
+    }
+
+    fn take_current_word_and_advance(&mut self) -> Option<Word> {
+        let word = self.take_current_word()?;
+        self.advance_past_word(&word);
+        Some(word)
     }
 
     fn current_zsh_glob_word_from_source(&mut self) -> Option<Word> {
@@ -3565,6 +3621,48 @@ impl<'a> Parser<'a> {
             && span.slice(self.input) == text
     }
 
+    fn checkpoint(&self) -> ParserCheckpoint<'a> {
+        ParserCheckpoint {
+            lexer: self.lexer.clone(),
+            synthetic_tokens: self.synthetic_tokens.clone(),
+            alias_replays: self.alias_replays.clone(),
+            current_token: self.current_token.clone(),
+            current_word_cache: self.current_word_cache.clone(),
+            current_token_kind: self.current_token_kind,
+            current_keyword: self.current_keyword,
+            current_span: self.current_span,
+            peeked_token: self.peeked_token.clone(),
+            current_depth: self.current_depth,
+            fuel: self.fuel,
+            expand_next_word: self.expand_next_word,
+            brace_group_depth: self.brace_group_depth,
+            brace_body_stack: self.brace_body_stack.clone(),
+            #[cfg(feature = "benchmarking")]
+            benchmark_counters: self.benchmark_counters,
+        }
+    }
+
+    fn restore(&mut self, checkpoint: ParserCheckpoint<'a>) {
+        self.lexer = checkpoint.lexer;
+        self.synthetic_tokens = checkpoint.synthetic_tokens;
+        self.alias_replays = checkpoint.alias_replays;
+        self.current_token = checkpoint.current_token;
+        self.current_word_cache = checkpoint.current_word_cache;
+        self.current_token_kind = checkpoint.current_token_kind;
+        self.current_keyword = checkpoint.current_keyword;
+        self.current_span = checkpoint.current_span;
+        self.peeked_token = checkpoint.peeked_token;
+        self.current_depth = checkpoint.current_depth;
+        self.fuel = checkpoint.fuel;
+        self.expand_next_word = checkpoint.expand_next_word;
+        self.brace_group_depth = checkpoint.brace_group_depth;
+        self.brace_body_stack = checkpoint.brace_body_stack;
+        #[cfg(feature = "benchmarking")]
+        {
+            self.benchmark_counters = checkpoint.benchmark_counters;
+        }
+    }
+
     fn set_current_spanned(&mut self, token: LexedToken<'a>) {
         #[cfg(feature = "benchmarking")]
         self.maybe_record_set_current_spanned_call();
@@ -4700,91 +4798,100 @@ impl<'a> Parser<'a> {
         self.current_keyword
     }
 
-    fn looks_like_disabled_repeat_loop(&self) -> Result<bool> {
+    fn looks_like_disabled_repeat_loop(&mut self) -> Result<bool> {
         if self.current_keyword() != Some(Keyword::Repeat) {
             return Ok(false);
         }
 
-        let mut probe = self.clone();
-        probe.advance();
-        if !probe.at_word_like() {
+        let checkpoint = self.checkpoint();
+        self.advance();
+        if !self.at_word_like() {
+            self.restore(checkpoint);
             return Ok(false);
         }
-        probe.advance();
+        self.advance();
 
-        match probe.current_token_kind {
+        let result = match self.current_token_kind {
             Some(TokenKind::LeftBrace) => Ok(true),
             Some(TokenKind::Semicolon) => {
-                probe.advance();
-                probe.skip_newlines()?;
-                Ok(probe.current_keyword() == Some(Keyword::Do))
+                self.advance();
+                self.skip_newlines()?;
+                Ok(self.current_keyword() == Some(Keyword::Do))
             }
             Some(TokenKind::Newline) => {
-                probe.skip_newlines()?;
-                Ok(probe.current_keyword() == Some(Keyword::Do))
+                self.skip_newlines()?;
+                Ok(self.current_keyword() == Some(Keyword::Do))
             }
             _ => Ok(false),
-        }
+        };
+        self.restore(checkpoint);
+        result
     }
 
-    fn looks_like_disabled_foreach_loop(&self) -> Result<bool> {
+    fn looks_like_disabled_foreach_loop(&mut self) -> Result<bool> {
         if self.current_keyword() != Some(Keyword::Foreach) {
             return Ok(false);
         }
 
-        let mut probe = self.clone();
-        probe.advance();
-        if probe.current_name_token().is_none() {
+        let checkpoint = self.checkpoint();
+        self.advance();
+        if self.current_name_token().is_none() {
+            self.restore(checkpoint);
             return Ok(false);
         }
-        probe.advance();
+        self.advance();
 
-        if probe.at(TokenKind::LeftParen) {
-            probe.advance();
+        let result = if self.at(TokenKind::LeftParen) {
+            self.advance();
             let mut saw_word = false;
-            while !probe.at(TokenKind::RightParen) {
-                if !probe.at_word_like() {
+            while !self.at(TokenKind::RightParen) {
+                if !self.at_word_like() {
+                    self.restore(checkpoint);
                     return Ok(false);
                 }
                 saw_word = true;
-                probe.advance();
+                self.advance();
             }
             if !saw_word {
+                self.restore(checkpoint);
                 return Ok(false);
             }
-            probe.advance();
-            return Ok(probe.at(TokenKind::LeftBrace));
-        }
-
-        if probe.current_keyword() != Some(Keyword::In) {
-            return Ok(false);
-        }
-        probe.advance();
-
-        let mut saw_word = false;
-        let saw_separator = loop {
-            if probe.current_keyword() == Some(Keyword::Do) {
-                break false;
+            self.advance();
+            Ok(self.at(TokenKind::LeftBrace))
+        } else {
+            if self.current_keyword() != Some(Keyword::In) {
+                self.restore(checkpoint);
+                return Ok(false);
             }
+            self.advance();
 
-            match probe.current_token_kind {
-                Some(kind) if kind.is_word_like() => {
-                    saw_word = true;
-                    probe.advance();
+            let mut saw_word = false;
+            let saw_separator = loop {
+                if self.current_keyword() == Some(Keyword::Do) {
+                    break false;
                 }
-                Some(TokenKind::Semicolon) => {
-                    probe.advance();
-                    break true;
+
+                match self.current_token_kind {
+                    Some(kind) if kind.is_word_like() => {
+                        saw_word = true;
+                        self.advance();
+                    }
+                    Some(TokenKind::Semicolon) => {
+                        self.advance();
+                        break true;
+                    }
+                    Some(TokenKind::Newline) => {
+                        self.skip_newlines()?;
+                        break true;
+                    }
+                    _ => break false,
                 }
-                Some(TokenKind::Newline) => {
-                    probe.skip_newlines()?;
-                    break true;
-                }
-                _ => break false,
-            }
+            };
+
+            Ok(saw_word && saw_separator && self.current_keyword() == Some(Keyword::Do))
         };
-
-        Ok(saw_word && saw_separator && probe.current_keyword() == Some(Keyword::Do))
+        self.restore(checkpoint);
+        result
     }
 
     fn skip_newlines_with_flag(&mut self) -> Result<bool> {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -147,41 +147,10 @@ struct DeclClause {
 }
 
 #[derive(Debug, Clone)]
-struct Pipeline {
-    negated: bool,
-    commands: Vec<Command>,
-    operators: Vec<(BinaryOp, Span)>,
-    span: Span,
-}
-
-#[derive(Debug, Clone)]
-struct CommandList {
-    first: Box<Command>,
-    rest: Vec<CommandListItem>,
-}
-
-#[derive(Debug, Clone)]
-struct CommandListItem {
-    operator: ListOperator,
-    operator_span: Span,
-    command: Command,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ListOperator {
-    And,
-    Or,
-    Semicolon,
-    Background(BackgroundOperator),
-}
-
-#[derive(Debug, Clone)]
 enum Command {
     Simple(SimpleCommand),
     Builtin(BuiltinCommand),
     Decl(DeclClause),
-    Pipeline(Pipeline),
-    List(CommandList),
     Compound(Box<CompoundCommand>, Vec<Redirect>),
     Function(FunctionDef),
     AnonymousFunction(AnonymousFunctionCommand, Vec<Redirect>),
@@ -3994,22 +3963,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn is_empty_stmt_placeholder(command: &Command) -> bool {
-        matches!(
-            command,
-            Command::Simple(SimpleCommand {
-                name,
-                args,
-                redirects,
-                assignments,
-                ..
-            }) if name.render("").is_empty()
-                && args.is_empty()
-                && redirects.is_empty()
-                && assignments.is_empty()
-        )
-    }
-
     fn compound_span(compound: &CompoundCommand) -> Span {
         match compound {
             CompoundCommand::If(command) => command.span,
@@ -4039,82 +3992,24 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn lower_commands_to_stmt_seq(commands: Vec<Command>, span: Span) -> StmtSeq {
-        let mut stmts = Vec::new();
-        for command in commands {
-            Self::lower_command_into_stmts(command, &mut stmts);
-        }
-        Self::stmt_seq_with_span(span, stmts)
-    }
-
-    fn lower_command_into_stmts(command: Command, stmts: &mut Vec<Stmt>) {
-        match command {
-            Command::List(list) => Self::lower_list_into_stmts(list, stmts),
-            other => stmts.push(Self::lower_non_sequence_command_to_stmt(other)),
-        }
-    }
-
-    fn lower_list_into_stmts(list: CommandList, stmts: &mut Vec<Stmt>) {
-        let CommandList { first, rest, .. } = list;
-        let mut current = *first;
-        let mut pending = Vec::new();
-
-        for item in rest {
-            match item.operator {
-                ListOperator::And | ListOperator::Or => pending.push(item),
-                ListOperator::Semicolon | ListOperator::Background(_) => {
-                    let terminator = match item.operator {
-                        ListOperator::Semicolon => StmtTerminator::Semicolon,
-                        ListOperator::Background(operator) => StmtTerminator::Background(operator),
-                        ListOperator::And | ListOperator::Or => unreachable!(),
-                    };
-                    let mut stmt =
-                        Self::lower_and_or_segment(current, std::mem::take(&mut pending));
-                    stmt.terminator = Some(terminator);
-                    stmt.terminator_span = Some(item.operator_span);
-                    stmts.push(stmt);
-
-                    if Self::is_empty_stmt_placeholder(&item.command) {
-                        return;
-                    }
-                    current = item.command;
-                }
-            }
-        }
-
-        stmts.push(Self::lower_and_or_segment(current, pending));
-    }
-
-    fn lower_and_or_segment(first: Command, rest: Vec<CommandListItem>) -> Stmt {
-        let mut stmt = Self::lower_non_sequence_command_to_stmt(first);
-
-        for item in rest {
-            let op = match item.operator {
-                ListOperator::And => BinaryOp::And,
-                ListOperator::Or => BinaryOp::Or,
-                ListOperator::Semicolon | ListOperator::Background(_) => unreachable!(),
-            };
-            let right = Self::lower_non_sequence_command_to_stmt(item.command);
-            let span = stmt.span.merge(right.span);
-            stmt = Stmt {
-                leading_comments: Vec::new(),
-                command: AstCommand::Binary(BinaryCommand {
-                    left: Box::new(stmt),
-                    op,
-                    op_span: item.operator_span,
-                    right: Box::new(right),
-                    span,
-                }),
-                negated: false,
-                redirects: Vec::new(),
-                terminator: None,
-                terminator_span: None,
-                inline_comment: None,
+    fn binary_stmt(left: Stmt, op: BinaryOp, op_span: Span, right: Stmt) -> Stmt {
+        let span = left.span.merge(right.span);
+        Stmt {
+            leading_comments: Vec::new(),
+            command: AstCommand::Binary(BinaryCommand {
+                left: Box::new(left),
+                op,
+                op_span,
+                right: Box::new(right),
                 span,
-            };
+            }),
+            negated: false,
+            redirects: Vec::new(),
+            terminator: None,
+            terminator_span: None,
+            inline_comment: None,
+            span,
         }
-
-        stmt
     }
 
     fn lower_builtin_command(builtin: BuiltinCommand) -> (AstBuiltinCommand, Vec<Redirect>, Span) {
@@ -4224,43 +4119,6 @@ impl<'a> Parser<'a> {
                 inline_comment: None,
                 span: command.span,
             },
-            Command::Pipeline(pipeline) => {
-                let Pipeline {
-                    negated,
-                    commands,
-                    operators,
-                    span,
-                } = pipeline;
-                let mut commands = commands.into_iter();
-                let mut stmt = Self::lower_non_sequence_command_to_stmt(
-                    commands
-                        .next()
-                        .expect("pipeline should contain at least one command"),
-                );
-                for ((op, op_span), command) in operators.into_iter().zip(commands) {
-                    let right = Self::lower_non_sequence_command_to_stmt(command);
-                    let binary_span = stmt.span.merge(right.span);
-                    stmt = Stmt {
-                        leading_comments: Vec::new(),
-                        command: AstCommand::Binary(BinaryCommand {
-                            left: Box::new(stmt),
-                            op,
-                            op_span,
-                            right: Box::new(right),
-                            span: binary_span,
-                        }),
-                        negated: false,
-                        redirects: Vec::new(),
-                        terminator: None,
-                        terminator_span: None,
-                        inline_comment: None,
-                        span: binary_span,
-                    };
-                }
-                stmt.negated = negated;
-                stmt.span = span;
-                stmt
-            }
             Command::Compound(compound, redirects) => {
                 let span = Self::compound_span(&compound);
                 Stmt {
@@ -4294,14 +4152,6 @@ impl<'a> Parser<'a> {
                 terminator_span: None,
                 inline_comment: None,
             },
-            Command::List(list) => {
-                let mut stmts = Vec::new();
-                Self::lower_list_into_stmts(list, &mut stmts);
-                stmts
-                    .into_iter()
-                    .next()
-                    .expect("command list should lower to at least one statement")
-            }
         }
     }
 

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -4668,11 +4668,17 @@ impl<'a> Parser<'a> {
             Some(TokenKind::LeftBrace) => Ok(true),
             Some(TokenKind::Semicolon) => {
                 self.advance();
-                self.skip_newlines()?;
+                if let Err(error) = self.skip_newlines() {
+                    self.restore(checkpoint);
+                    return Err(error);
+                }
                 Ok(self.current_keyword() == Some(Keyword::Do))
             }
             Some(TokenKind::Newline) => {
-                self.skip_newlines()?;
+                if let Err(error) = self.skip_newlines() {
+                    self.restore(checkpoint);
+                    return Err(error);
+                }
                 Ok(self.current_keyword() == Some(Keyword::Do))
             }
             _ => Ok(false),
@@ -4734,7 +4740,10 @@ impl<'a> Parser<'a> {
                         break true;
                     }
                     Some(TokenKind::Newline) => {
-                        self.skip_newlines()?;
+                        if let Err(error) = self.skip_newlines() {
+                            self.restore(checkpoint);
+                            return Err(error);
+                        }
                         break true;
                     }
                     _ => break false,

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -313,6 +313,7 @@ struct ParserCheckpoint<'a> {
     peeked_token: Option<LexedToken<'a>>,
     current_depth: usize,
     fuel: usize,
+    comments: Vec<Comment>,
     expand_next_word: bool,
     brace_group_depth: usize,
     brace_body_stack: Vec<BraceBodyContext>,
@@ -3603,6 +3604,7 @@ impl<'a> Parser<'a> {
             peeked_token: self.peeked_token.clone(),
             current_depth: self.current_depth,
             fuel: self.fuel,
+            comments: self.comments.clone(),
             expand_next_word: self.expand_next_word,
             brace_group_depth: self.brace_group_depth,
             brace_body_stack: self.brace_body_stack.clone(),
@@ -3623,6 +3625,7 @@ impl<'a> Parser<'a> {
         self.peeked_token = checkpoint.peeked_token;
         self.current_depth = checkpoint.current_depth;
         self.fuel = checkpoint.fuel;
+        self.comments = checkpoint.comments;
         self.expand_next_word = checkpoint.expand_next_word;
         self.brace_group_depth = checkpoint.brace_group_depth;
         self.brace_body_stack = checkpoint.brace_body_stack;

--- a/crates/shuck-parser/src/parser/redirects.rs
+++ b/crates/shuck-parser/src/parser/redirects.rs
@@ -52,7 +52,7 @@ impl<'a> Parser<'a> {
             return Some(fd_var);
         }
 
-        let word = self.current_word()?;
+        let word = self.current_word_ref()?.clone();
         let text = self.literal_word_text(&word)?;
         Self::fd_var_from_text(&text, word.span)
     }

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -109,6 +109,42 @@ fn test_parse_recovered_skips_invalid_command_and_continues() {
     assert_eq!(second.args[0].render(input), "two");
 }
 
+#[test]
+fn test_disabled_repeat_probe_restores_checkpoint_when_newline_skip_errors() {
+    let input = "repeat 3\ndo echo hi; done\n";
+    let mut parser = Parser::with_fuel(input, 0);
+    let original_span = parser.current_span();
+
+    assert_eq!(parser.current_keyword(), Some(Keyword::Repeat));
+
+    let error = parser.looks_like_disabled_repeat_loop().unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::Parse { ref message, .. } if message.contains("parser fuel exhausted")
+    ));
+    assert_eq!(parser.current_keyword(), Some(Keyword::Repeat));
+    assert_eq!(parser.current_span(), original_span);
+}
+
+#[test]
+fn test_disabled_foreach_probe_restores_checkpoint_when_newline_skip_errors() {
+    let input = "foreach item in a\ndo echo hi; done\n";
+    let mut parser = Parser::with_fuel(input, 0);
+    let original_span = parser.current_span();
+
+    assert_eq!(parser.current_keyword(), Some(Keyword::Foreach));
+
+    let error = parser.looks_like_disabled_foreach_loop().unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::Parse { ref message, .. } if message.contains("parser fuel exhausted")
+    ));
+    assert_eq!(parser.current_keyword(), Some(Keyword::Foreach));
+    assert_eq!(parser.current_span(), original_span);
+}
+
 #[cfg(feature = "benchmarking")]
 #[test]
 fn test_parse_with_benchmark_counters_is_repeatable() {

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2490,6 +2490,34 @@ fn test_comment_ranges_with_unicode() {
 }
 
 #[test]
+fn test_if_condition_semicolon_probe_does_not_duplicate_comments() {
+    let source = "\
+if foo; # keep this once
+bar; then
+  baz
+fi
+";
+    let output = Parser::new(source).parse().unwrap();
+    let comments = collect_file_comments(&output.file);
+    let texts: Vec<&str> = comments
+        .iter()
+        .map(|comment| {
+            let start = usize::from(comment.range.start());
+            let end = usize::from(comment.range.end());
+            &source[start..end]
+        })
+        .collect();
+
+    assert_eq!(texts, vec!["# keep this once"]);
+
+    let (compound, _) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::If(command) = compound else {
+        panic!("expected if command");
+    };
+    assert_eq!(command.condition.len(), 2);
+}
+
+#[test]
 fn test_zsh_dialect_accepts_c_style_for_loops() {
     Parser::with_dialect(
         "for ((i=0; i<2; i++)); do echo hi; done\n",

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2120,26 +2120,25 @@ impl<'a> Parser<'a> {
         // Empty value — check for arr=(...) syntax with separate tokens
         if value_str.is_empty() {
             let assignment_span = self.current_span;
-            let (target, is_append, value_start) = self.current_word().and_then(|word| {
-                let ParsedWordTarget {
-                    name,
-                    name_span,
-                    subscript,
-                    boundary,
-                } = self.parse_word_target(&word, SubscriptInterpretation::Contextual, true)?;
-                let WordTargetBoundary::Assignment {
-                    append,
-                    value_start,
-                } = boundary
-                else {
-                    return None;
-                };
-                Some((
-                    self.var_ref(name, name_span, subscript, assignment_span),
-                    append,
-                    value_start,
-                ))
-            })?;
+            let word = self.current_word_ref()?.clone();
+            let ParsedWordTarget {
+                name,
+                name_span,
+                subscript,
+                boundary,
+            } = self.parse_word_target(&word, SubscriptInterpretation::Contextual, true)?;
+            let WordTargetBoundary::Assignment {
+                append,
+                value_start,
+            } = boundary
+            else {
+                return None;
+            };
+            let (target, is_append, value_start) = (
+                self.var_ref(name, name_span, subscript, assignment_span),
+                append,
+                value_start,
+            );
             self.advance();
             if self.at(TokenKind::LeftParen) {
                 let open_paren_span = self.current_span;
@@ -2298,9 +2297,8 @@ impl<'a> Parser<'a> {
             }
             _ => {
                 let word = self
-                    .current_word()
+                    .take_current_word_and_advance()
                     .ok_or_else(|| self.error("expected word"))?;
-                self.advance_past_word(&word);
                 Ok(word)
             }
         }


### PR DESCRIPTION
## Summary
- replace speculative parser `clone()` lookahead with lightweight checkpoints and restore points
- reduce unnecessary `Word` ownership churn on hot read-and-advance paths
- build `Stmt` trees directly while parsing lists and pipelines instead of building parser-private list/pipeline IR and lowering it later

## Why
Parser time was dominating the benchmark suite, and the biggest costs were speculative parser cloning plus the extra parse-then-lower pass for command lists and pipelines. This keeps the public AST stable while removing work from the hot path.

## Performance
Measured with `cargo bench -p shuck-benchmark --bench parser -- --noplot` against the local pre-change baseline captured before this work:
- `parser/all`: `33.643 ms` -> `13.160 ms` (`60.9%` faster)
- `parser/nvm`: `11.777 ms` -> `6.662 ms` (`43.4%` faster)
- `parser/homebrew-install`: `2.390 ms` -> `0.986 ms` (`58.8%` faster)
- `parser/ruby-build`: `4.525 ms` -> `1.806 ms` (`60.1%` faster)
- `parser_counts` stayed at `160685 / 35725 / 35730`

## Validation
- `cargo test -p shuck-parser`
- `cargo test -p shuck-benchmark benchmark_corpus_parses_in_best_effort_mode -- --nocapture`
- `cargo test -p shuck-benchmark -- --nocapture`
- `cargo bench -p shuck-benchmark --bench parser -- --noplot`
