### PR TITLE
Add rules documentation pages to website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ node_modules/
 # Website
 website/.next/
 website/out/
+website/app/lib/rules-data.generated.json
 
 # WASM build artifacts
 *.wasm

--- a/website/app/components/Header.tsx
+++ b/website/app/components/Header.tsx
@@ -18,6 +18,12 @@ export default function Header() {
           >
             Docs
           </Link>
+          <Link
+            href="/docs/rules"
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-fg-secondary hover:text-fg-primary hover:bg-bg-card transition-colors"
+          >
+            Rules
+          </Link>
           <a
             href="https://github.com/ewhauser/shuck"
             target="_blank"

--- a/website/app/components/docs/RuleBadge.tsx
+++ b/website/app/components/docs/RuleBadge.tsx
@@ -1,0 +1,43 @@
+const categoryColors: Record<string, string> = {
+  Correctness: "bg-red-500/15 text-red-400 border-red-500/25",
+  Style: "bg-blue-500/15 text-blue-400 border-blue-500/25",
+  Portability: "bg-purple-500/15 text-purple-400 border-purple-500/25",
+  Performance: "bg-green-500/15 text-green-400 border-green-500/25",
+  Security: "bg-amber-500/15 text-amber-400 border-amber-500/25",
+};
+
+export function CategoryBadge({ category }: { category: string }) {
+  const colors = categoryColors[category] ?? "bg-fg-dim/10 text-fg-secondary border-fg-dim/20";
+  return (
+    <span className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-xs font-medium ${colors}`}>
+      {category}
+    </span>
+  );
+}
+
+export function SeverityBadge({ severity }: { severity: string }) {
+  const colors =
+    severity === "Error"
+      ? "bg-red-500/15 text-red-400 border-red-500/25"
+      : "bg-yellow-500/15 text-yellow-400 border-yellow-500/25";
+  return (
+    <span className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-xs font-medium ${colors}`}>
+      {severity}
+    </span>
+  );
+}
+
+export function ImplementedBadge({ implemented }: { implemented: boolean }) {
+  if (implemented) {
+    return (
+      <span className="inline-flex items-center rounded-md border border-green-500/25 bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-400">
+        Implemented
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-md border border-fg-dim/20 bg-fg-dim/10 px-1.5 py-0.5 text-xs font-medium text-fg-secondary">
+      Planned
+    </span>
+  );
+}

--- a/website/app/components/docs/RulesTable.tsx
+++ b/website/app/components/docs/RulesTable.tsx
@@ -4,12 +4,12 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Search } from "lucide-react";
-import type { RuleData } from "@/app/lib/rules-data";
+import type { RuleListItem } from "@/app/lib/rules-data";
 import { categories } from "@/app/lib/rules-data";
 import { CategoryBadge } from "./RuleBadge";
 
 interface Props {
-  rules: RuleData[];
+  rules: RuleListItem[];
 }
 
 export default function RulesTable({ rules }: Props) {
@@ -45,7 +45,7 @@ export default function RulesTable({ rules }: Props) {
 
   // Group by category for display
   const grouped = useMemo(() => {
-    const groups: Array<{ category: string; prefix: string; rules: RuleData[] }> = [];
+    const groups: Array<{ category: string; prefix: string; rules: RuleListItem[] }> = [];
     for (const cat of categories) {
       const catRules = filtered.filter((r) => r.category === cat.name);
       if (catRules.length > 0) {

--- a/website/app/components/docs/RulesTable.tsx
+++ b/website/app/components/docs/RulesTable.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Search } from "lucide-react";
+import type { RuleData } from "@/app/lib/rules-data";
+import { categories } from "@/app/lib/rules-data";
+import { CategoryBadge } from "./RuleBadge";
+
+interface Props {
+  rules: RuleData[];
+}
+
+export default function RulesTable({ rules }: Props) {
+  const searchParams = useSearchParams();
+  const initialCategory = searchParams.get("category") ?? "All";
+
+  const [search, setSearch] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState(initialCategory);
+
+  const filtered = useMemo(() => {
+    let result = rules;
+    if (selectedCategory !== "All") {
+      result = result.filter((r) => r.category === selectedCategory);
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (r) =>
+          r.code.toLowerCase().includes(q) ||
+          r.name.toLowerCase().includes(q) ||
+          r.description.toLowerCase().includes(q),
+      );
+    }
+    return result;
+  }, [rules, search, selectedCategory]);
+
+  // Group by category for display
+  const grouped = useMemo(() => {
+    const groups: Array<{ category: string; prefix: string; rules: RuleData[] }> = [];
+    for (const cat of categories) {
+      const catRules = filtered.filter((r) => r.category === cat.name);
+      if (catRules.length > 0) {
+        groups.push({ category: cat.name, prefix: cat.prefix, rules: catRules });
+      }
+    }
+    return groups;
+  }, [filtered]);
+
+  return (
+    <div>
+      {/* Search and filters */}
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-secondary" />
+          <input
+            type="text"
+            placeholder="Search rules..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-lg border border-fg-dim/30 bg-bg-card py-2 pl-10 pr-4 text-sm text-fg-primary placeholder:text-fg-secondary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+          />
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {["All", ...categories.map((c) => c.name)].map((cat) => {
+            const isActive = selectedCategory === cat;
+            return (
+              <button
+                key={cat}
+                onClick={() => setSelectedCategory(cat)}
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                  isActive
+                    ? "bg-accent/20 text-accent border border-accent/40"
+                    : "border border-fg-dim/20 text-fg-secondary hover:text-fg-primary hover:border-fg-dim/40"
+                }`}
+              >
+                {cat}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Results count */}
+      <p className="mb-4 text-sm text-fg-secondary">
+        {filtered.length} rule{filtered.length !== 1 ? "s" : ""}
+      </p>
+
+      {/* Table grouped by category */}
+      {grouped.map((group) => (
+        <div key={group.category} className="mb-8">
+          <h2 className="mb-3 flex items-center gap-2 text-base font-semibold text-fg-primary">
+            {group.category}
+            <span className="text-xs font-normal text-fg-secondary">
+              ({group.prefix}) &middot; {group.rules.length} rule{group.rules.length !== 1 ? "s" : ""}
+            </span>
+          </h2>
+          <div className="overflow-x-auto rounded-lg border border-fg-dim/20">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-fg-dim/20 bg-bg-card/50">
+                  <th className="px-3 py-2 text-left font-medium text-fg-secondary">Code</th>
+                  <th className="px-3 py-2 text-left font-medium text-fg-secondary">Name</th>
+                  <th className="hidden px-3 py-2 text-left font-medium text-fg-secondary md:table-cell">Message</th>
+                  <th className="px-3 py-2 text-center font-medium text-fg-secondary">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.rules.map((rule) => (
+                  <tr
+                    key={rule.code}
+                    className="border-b border-fg-dim/10 last:border-b-0 hover:bg-bg-card/30 transition-colors"
+                  >
+                    <td className="px-3 py-2">
+                      <Link
+                        href={`/docs/rules/${rule.code}`}
+                        className="font-mono text-accent hover:underline"
+                      >
+                        {rule.code}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2">
+                      <Link
+                        href={`/docs/rules/${rule.code}`}
+                        className="text-fg-primary hover:text-accent hover:underline"
+                      >
+                        {rule.name}
+                      </Link>
+                    </td>
+                    <td className="hidden px-3 py-2 text-fg-secondary md:table-cell">
+                      <span className="line-clamp-1">{rule.description}</span>
+                    </td>
+                    <td className="px-3 py-2 text-center">
+                      {rule.implemented ? (
+                        <span className="inline-block h-2 w-2 rounded-full bg-green-400" title="Implemented" />
+                      ) : (
+                        <span className="inline-block h-2 w-2 rounded-full bg-fg-dim/40" title="Planned" />
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+
+      {filtered.length === 0 && (
+        <p className="py-12 text-center text-fg-secondary">
+          No rules match your search.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/website/app/components/docs/RulesTable.tsx
+++ b/website/app/components/docs/RulesTable.tsx
@@ -14,10 +14,17 @@ interface Props {
 
 export default function RulesTable({ rules }: Props) {
   const searchParams = useSearchParams();
-  const initialCategory = searchParams.get("category") ?? "All";
+  const categoryFromUrl = searchParams.get("category") ?? "All";
 
   const [search, setSearch] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState(initialCategory);
+  const [selectedCategory, setSelectedCategory] = useState(categoryFromUrl);
+
+  // Resync when URL query param changes (e.g. sidebar navigation)
+  const [prevUrlCategory, setPrevUrlCategory] = useState(categoryFromUrl);
+  if (categoryFromUrl !== prevUrlCategory) {
+    setPrevUrlCategory(categoryFromUrl);
+    setSelectedCategory(categoryFromUrl);
+  }
 
   const filtered = useMemo(() => {
     let result = rules;

--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -43,5 +43,9 @@ export default async function DocsPage({ params }: Props) {
 
   const { default: MDXContent } = await loader();
 
-  return <MDXContent />;
+  return (
+    <div className="mdx-content max-w-3xl">
+      <MDXContent />
+    </div>
+  );
 }

--- a/website/app/docs/layout.tsx
+++ b/website/app/docs/layout.tsx
@@ -13,7 +13,7 @@ export default function DocsLayout({
       <div className="mx-auto flex max-w-6xl">
         <DocsSidebar />
         <main className="min-w-0 flex-1 px-4 sm:px-8 py-8 lg:py-10">
-          <div className="mdx-content max-w-3xl">{children}</div>
+          {children}
         </main>
       </div>
       <Footer />

--- a/website/app/docs/rules/[code]/page.tsx
+++ b/website/app/docs/rules/[code]/page.tsx
@@ -1,0 +1,139 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { codeToHtml } from "shiki";
+import { allRules, getRuleByCode } from "@/app/lib/rules-data";
+import { CategoryBadge, SeverityBadge, ImplementedBadge } from "@/app/components/docs/RuleBadge";
+
+interface Props {
+  params: Promise<{ code: string }>;
+}
+
+export async function generateStaticParams() {
+  return allRules.map((r) => ({ code: r.code }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { code } = await params;
+  const rule = getRuleByCode(code);
+  if (!rule) return {};
+  return {
+    title: `${rule.code}: ${rule.name}`,
+    description: rule.description,
+  };
+}
+
+export default async function RuleDetailPage({ params }: Props) {
+  const { code } = await params;
+  const rule = getRuleByCode(code);
+
+  if (!rule) {
+    notFound();
+  }
+
+  // Highlight examples
+  const highlightedExamples = await Promise.all(
+    rule.examples.map(async (ex) => ({
+      kind: ex.kind,
+      html: await codeToHtml(ex.code, {
+        lang: "bash",
+        theme: "github-dark-default",
+      }),
+    })),
+  );
+
+  return (
+    <div className="max-w-3xl">
+      {/* Breadcrumb */}
+      <nav className="mb-6 flex items-center gap-1 text-sm text-fg-secondary">
+        <Link href="/docs/getting-started" className="hover:text-fg-primary transition-colors">
+          Docs
+        </Link>
+        <ChevronRight className="h-3.5 w-3.5" />
+        <Link href="/docs/rules" className="hover:text-fg-primary transition-colors">
+          Rules
+        </Link>
+        <ChevronRight className="h-3.5 w-3.5" />
+        <span className="text-fg-primary">{rule.code}</span>
+      </nav>
+
+      {/* Title */}
+      <h1 className="mb-3 text-2xl font-bold text-fg-primary">
+        {rule.code}: {rule.name}
+      </h1>
+
+      {/* Badges */}
+      <div className="mb-6 flex flex-wrap gap-2">
+        <CategoryBadge category={rule.category} />
+        {rule.severity && <SeverityBadge severity={rule.severity} />}
+        <ImplementedBadge implemented={rule.implemented} />
+      </div>
+
+      {/* Description */}
+      <section className="mb-6">
+        <h2 className="mb-2 text-lg font-semibold text-fg-primary">What it does</h2>
+        <p className="text-fg-secondary leading-relaxed">{rule.description}</p>
+      </section>
+
+      {/* Rationale */}
+      <section className="mb-6">
+        <h2 className="mb-2 text-lg font-semibold text-fg-primary">Why is this bad?</h2>
+        <p className="text-fg-secondary leading-relaxed">{rule.rationale}</p>
+      </section>
+
+      {/* Examples */}
+      {highlightedExamples.length > 0 && (
+        <section className="mb-6">
+          <h2 className="mb-2 text-lg font-semibold text-fg-primary">Example</h2>
+          {highlightedExamples.map((ex, i) => (
+            <div key={i} className="mb-3">
+              {ex.kind === "invalid" && (
+                <p className="mb-1 text-xs font-medium text-red-400">Bad</p>
+              )}
+              {ex.kind === "valid" && (
+                <p className="mb-1 text-xs font-medium text-green-400">Good</p>
+              )}
+              <div
+                className="overflow-x-auto rounded-lg border border-fg-dim/20 text-sm [&_pre]:p-4"
+                dangerouslySetInnerHTML={{ __html: ex.html }}
+              />
+            </div>
+          ))}
+        </section>
+      )}
+
+      {/* Metadata */}
+      <section className="rounded-lg border border-fg-dim/20 bg-bg-card/30 p-4">
+        <h2 className="mb-3 text-sm font-semibold text-fg-primary">Details</h2>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          {rule.shellcheckCode && (
+            <>
+              <dt className="text-fg-secondary">ShellCheck</dt>
+              <dd className="font-mono text-fg-primary">{rule.shellcheckCode}</dd>
+            </>
+          )}
+          <dt className="text-fg-secondary">Shells</dt>
+          <dd className="flex flex-wrap gap-1">
+            {rule.shells.map((s) => (
+              <span
+                key={s}
+                className="rounded border border-fg-dim/20 bg-fg-dim/10 px-1.5 py-0.5 font-mono text-xs text-fg-primary"
+              >
+                {s}
+              </span>
+            ))}
+          </dd>
+          {rule.severity && (
+            <>
+              <dt className="text-fg-secondary">Severity</dt>
+              <dd className="text-fg-primary">{rule.severity}</dd>
+            </>
+          )}
+          <dt className="text-fg-secondary">Category</dt>
+          <dd className="text-fg-primary">{rule.category}</dd>
+        </dl>
+      </section>
+    </div>
+  );
+}

--- a/website/app/docs/rules/page.tsx
+++ b/website/app/docs/rules/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import { allRules, categories } from "@/app/lib/rules-data";
+import RulesTable from "@/app/components/docs/RulesTable";
+
+export const metadata: Metadata = {
+  title: "Rules",
+  description: "Browse all shuck lint rules for shell scripts.",
+};
+
+export default function RulesIndexPage() {
+  const implemented = allRules.filter((r) => r.implemented).length;
+
+  return (
+    <div className="max-w-5xl">
+      <h1 className="mb-2 text-2xl font-bold text-fg-primary">Rules</h1>
+      <p className="mb-6 text-fg-secondary">
+        {allRules.length} rules across {categories.length} categories.{" "}
+        <span className="text-green-400">{implemented} implemented</span>,{" "}
+        {allRules.length - implemented} planned.
+      </p>
+      <Suspense>
+        <RulesTable rules={allRules} />
+      </Suspense>
+    </div>
+  );
+}

--- a/website/app/docs/rules/page.tsx
+++ b/website/app/docs/rules/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { allRules, categories } from "@/app/lib/rules-data";
+import type { RuleListItem } from "@/app/lib/rules-data";
 import RulesTable from "@/app/components/docs/RulesTable";
 
 export const metadata: Metadata = {
@@ -11,6 +12,11 @@ export const metadata: Metadata = {
 export default function RulesIndexPage() {
   const implemented = allRules.filter((r) => r.implemented).length;
 
+  // Strip heavy fields (rationale, examples, etc.) before sending to the client component.
+  const listRules: RuleListItem[] = allRules.map(({ code, name, category, description, implemented }) => ({
+    code, name, category, description, implemented,
+  }));
+
   return (
     <div className="max-w-5xl">
       <h1 className="mb-2 text-2xl font-bold text-fg-primary">Rules</h1>
@@ -20,7 +26,7 @@ export default function RulesIndexPage() {
         {allRules.length - implemented} planned.
       </p>
       <Suspense>
-        <RulesTable rules={allRules} />
+        <RulesTable rules={listRules} />
       </Suspense>
     </div>
   );

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -11,6 +11,17 @@ export const docsNavigation: NavItem[] = [
       { title: "Overview", href: "/docs/getting-started" },
     ],
   },
+  {
+    title: "Rules",
+    items: [
+      { title: "All Rules", href: "/docs/rules" },
+      { title: "Correctness (C)", href: "/docs/rules?category=Correctness" },
+      { title: "Style (S)", href: "/docs/rules?category=Style" },
+      { title: "Portability (X)", href: "/docs/rules?category=Portability" },
+      { title: "Performance (P)", href: "/docs/rules?category=Performance" },
+      { title: "Security (K)", href: "/docs/rules?category=Security" },
+    ],
+  },
 ];
 
 export function flattenNav(items: NavItem[]): NavItem[] {

--- a/website/app/lib/rules-data.ts
+++ b/website/app/lib/rules-data.ts
@@ -14,6 +14,15 @@ export interface RuleData {
   examples: Array<{ kind: string; code: string }>;
 }
 
+/** Lightweight subset for the rules list table (avoids shipping rationale/examples to client). */
+export interface RuleListItem {
+  code: string;
+  name: string;
+  category: string;
+  description: string;
+  implemented: boolean;
+}
+
 export const allRules: RuleData[] = rulesJson as RuleData[];
 
 export function getRuleByCode(code: string): RuleData | undefined {

--- a/website/app/lib/rules-data.ts
+++ b/website/app/lib/rules-data.ts
@@ -1,0 +1,29 @@
+import rulesJson from "./rules-data.generated.json";
+
+export interface RuleData {
+  code: string;
+  name: string;
+  category: string;
+  categoryPrefix: string;
+  description: string;
+  rationale: string;
+  shells: string[];
+  shellcheckCode: string | null;
+  implemented: boolean;
+  severity: string | null;
+  examples: Array<{ kind: string; code: string }>;
+}
+
+export const allRules: RuleData[] = rulesJson as RuleData[];
+
+export function getRuleByCode(code: string): RuleData | undefined {
+  return allRules.find((r) => r.code.toLowerCase() === code.toLowerCase());
+}
+
+export const categories = [
+  { name: "Correctness", prefix: "C" },
+  { name: "Style", prefix: "S" },
+  { name: "Portability", prefix: "X" },
+  { name: "Performance", prefix: "P" },
+  { name: "Security", prefix: "K" },
+] as const;

--- a/website/next-env.d.ts
+++ b/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "dev": "next dev",
+    "generate:rules": "tsx scripts/generate-rules.ts",
+    "prebuild": "pnpm generate:rules",
+    "dev": "pnpm generate:rules && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -30,6 +32,8 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "tsx": "^4",
+    "typescript": "^5",
+    "yaml": "^2"
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -63,9 +63,15 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.2
+      tsx:
+        specifier: ^4
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3
+      yaml:
+        specifier: ^2
+        version: 2.8.3
 
 packages:
 
@@ -75,6 +81,162 @@ packages:
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -594,6 +756,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -621,6 +788,14 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -1053,6 +1228,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -1118,6 +1296,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1162,6 +1345,11 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -1172,6 +1360,84 @@ snapshots:
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@img/colour@1.1.0':
@@ -1595,6 +1861,35 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escape-string-regexp@5.0.0: {}
 
   estree-util-attach-comments@3.0.0:
@@ -1631,6 +1926,13 @@ snapshots:
       '@types/estree': 1.0.8
 
   extend@3.0.2: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
 
@@ -2436,6 +2738,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  resolve-pkg-maps@1.0.0: {}
+
   scheduler@0.27.0: {}
 
   semver@7.7.4:
@@ -2518,6 +2822,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
@@ -2577,5 +2888,7 @@ snapshots:
       vfile-message: 4.0.3
 
   web-namespaces@2.0.1: {}
+
+  yaml@2.8.3: {}
 
   zwitch@2.0.4: {}

--- a/website/scripts/generate-rules.ts
+++ b/website/scripts/generate-rules.ts
@@ -48,8 +48,9 @@ const outPath = join(__dirname, "../app/lib/rules-data.generated.json");
 const registrySource = readFileSync(registryPath, "utf-8");
 const implementedRules = new Map<string, string>();
 
-// Match lines like: ("C001", Category::Correctness, Severity::Warning, UnusedAssignment),
-const rulePattern = /\("([A-Z]\d+)",\s*Category::\w+,\s*Severity::(\w+),/g;
+// Match tuples like: ("C001", Category::Correctness, Severity::Warning, UnusedAssignment),
+// Also handles multiline formatting where the tuple is split across lines.
+const rulePattern = /\(\s*"([A-Z]\d+)",\s*Category::\w+,\s*Severity::(\w+),/gs;
 let match: RegExpExecArray | null;
 while ((match = rulePattern.exec(registrySource)) !== null) {
   implementedRules.set(match[1], match[2]);

--- a/website/scripts/generate-rules.ts
+++ b/website/scripts/generate-rules.ts
@@ -1,0 +1,101 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface RuleYaml {
+  legacy_name: string;
+  new_category: string;
+  new_code: string;
+  runtime_kind: string;
+  shellcheck_code: string;
+  shells: string[];
+  description: string;
+  rationale: string;
+  examples?: Array<{ kind: string; code: string }>;
+}
+
+export interface RuleData {
+  code: string;
+  name: string;
+  category: string;
+  categoryPrefix: string;
+  description: string;
+  rationale: string;
+  shells: string[];
+  shellcheckCode: string | null;
+  implemented: boolean;
+  severity: string | null;
+  examples: Array<{ kind: string; code: string }>;
+}
+
+const CATEGORY_PREFIX: Record<string, string> = {
+  Correctness: "C",
+  Style: "S",
+  Portability: "X",
+  Performance: "P",
+  Security: "K",
+};
+
+const rootDir = resolve(__dirname, "../..");
+const rulesDir = join(rootDir, "docs/rules");
+const registryPath = join(rootDir, "crates/shuck-linter/src/registry.rs");
+const outPath = join(__dirname, "../app/lib/rules-data.generated.json");
+
+// Parse registry.rs for implemented rules and their severities
+const registrySource = readFileSync(registryPath, "utf-8");
+const implementedRules = new Map<string, string>();
+
+// Match lines like: ("C001", Category::Correctness, Severity::Warning, UnusedAssignment),
+const rulePattern = /\("([A-Z]\d+)",\s*Category::\w+,\s*Severity::(\w+),/g;
+let match: RegExpExecArray | null;
+while ((match = rulePattern.exec(registrySource)) !== null) {
+  implementedRules.set(match[1], match[2]);
+}
+
+// Read and parse all YAML rule files
+const yamlFiles = readdirSync(rulesDir)
+  .filter((f) => f.endsWith(".yaml") && f !== "validate.sh")
+  .sort();
+
+const rules: RuleData[] = yamlFiles.map((file) => {
+  const content = readFileSync(join(rulesDir, file), "utf-8");
+  const yaml = parseYaml(content) as RuleYaml;
+  const code = yaml.new_code;
+  const severity = implementedRules.get(code) ?? null;
+
+  return {
+    code,
+    name: yaml.legacy_name,
+    category: yaml.new_category,
+    categoryPrefix: CATEGORY_PREFIX[yaml.new_category] ?? "?",
+    description: yaml.description,
+    rationale: yaml.rationale,
+    shells: yaml.shells ?? [],
+    shellcheckCode: yaml.shellcheck_code ?? null,
+    implemented: implementedRules.has(code),
+    severity,
+    examples: (yaml.examples ?? []).map((ex) => ({
+      kind: ex.kind,
+      code: ex.code?.trimEnd() ?? "",
+    })),
+  };
+});
+
+// Sort: by category prefix, then numeric code
+rules.sort((a, b) => {
+  const prefixOrder = "CSXPK";
+  const pi = prefixOrder.indexOf(a.categoryPrefix) - prefixOrder.indexOf(b.categoryPrefix);
+  if (pi !== 0) return pi;
+  const aNum = parseInt(a.code.slice(1));
+  const bNum = parseInt(b.code.slice(1));
+  return aNum - bNum;
+});
+
+writeFileSync(outPath, JSON.stringify(rules, null, 2) + "\n");
+
+console.log(
+  `Generated ${rules.length} rules (${implementedRules.size} implemented) -> ${outPath}`,
+);

--- a/website/scripts/generate-rules.ts
+++ b/website/scripts/generate-rules.ts
@@ -50,7 +50,7 @@ const implementedRules = new Map<string, string>();
 
 // Match tuples like: ("C001", Category::Correctness, Severity::Warning, UnusedAssignment),
 // Also handles multiline formatting where the tuple is split across lines.
-const rulePattern = /\(\s*"([A-Z]\d+)",\s*Category::\w+,\s*Severity::(\w+),/gs;
+const rulePattern = /\(\s*"([A-Z]\d+)",\s*Category::\w+,\s*Severity::(\w+),/g;
 let match: RegExpExecArray | null;
 while ((match = rulePattern.exec(registrySource)) !== null) {
   implementedRules.set(match[1], match[2]);


### PR DESCRIPTION
## Summary
- Adds a build-time script (`website/scripts/generate-rules.ts`) that reads the 318 YAML rule files and `registry.rs` to produce a JSON data file with rule metadata, implementation status, and severity
- Creates a filterable rules index page at `/docs/rules` with search, category filter pills, and a grouped table showing code, name, description, and implementation status
- Creates individual rule detail pages at `/docs/rules/{code}` with syntax-highlighted examples (via shiki), description, rationale, and metadata (shells, ShellCheck code, severity)
- Adds Rules section to sidebar navigation and header

## Test plan
- [ ] Run `cd website && pnpm generate:rules` — verify 318 rules generated
- [ ] Run `pnpm dev` — browse `/docs/rules`, verify table renders with search and category filtering
- [ ] Click through to a detail page (e.g., `/docs/rules/C001`) — verify all sections render with highlighted code
- [ ] Run `SHUCK_WEBSITE_EXPORT=1 pnpm build` — verify static export succeeds with 324 pages
- [ ] Verify sidebar navigation links and category pre-filter query params work