### PR TITLE
Fix SC2321 suppression alias and wrapped arithmetic fallback

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4938,7 +4938,7 @@ fn is_unescaped_dollar(bytes: &[u8], index: usize) -> bool {
         cursor -= 1;
     }
 
-    backslash_count % 2 == 0
+    backslash_count.is_multiple_of(2)
 }
 
 fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4907,7 +4907,10 @@ fn collect_wrapped_arithmetic_command_substitution_spans(
     let mut index = 0usize;
 
     while index + 1 < bytes.len() {
-        if bytes[index] != b'$' || bytes[index + 1] != b'(' || bytes.get(index + 2) == Some(&b'(') {
+        if !is_unescaped_dollar(bytes, index)
+            || bytes[index + 1] != b'('
+            || bytes.get(index + 2) == Some(&b'(')
+        {
             index += 1;
             continue;
         }
@@ -4923,6 +4926,21 @@ fn collect_wrapped_arithmetic_command_substitution_spans(
     }
 }
 
+fn is_unescaped_dollar(bytes: &[u8], index: usize) -> bool {
+    if bytes.get(index) != Some(&b'$') {
+        return false;
+    }
+
+    let mut backslash_count = 0usize;
+    let mut cursor = index;
+    while cursor > 0 && bytes[cursor - 1] == b'\\' {
+        backslash_count += 1;
+        cursor -= 1;
+    }
+
+    backslash_count % 2 == 0
+}
+
 fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
     let mut paren_depth = 0usize;
     let mut cursor = start + 2;
@@ -4934,7 +4952,7 @@ fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
         }
 
         if cursor + 2 < bytes.len()
-            && bytes[cursor] == b'$'
+            && is_unescaped_dollar(bytes, cursor)
             && bytes[cursor + 1] == b'('
             && bytes[cursor + 2] == b'('
         {
@@ -4942,7 +4960,10 @@ fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
             continue;
         }
 
-        if cursor + 1 < bytes.len() && bytes[cursor] == b'$' && bytes[cursor + 1] == b'(' {
+        if cursor + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, cursor)
+            && bytes[cursor + 1] == b'('
+        {
             cursor = find_command_substitution_end(bytes, cursor)?;
             continue;
         }
@@ -4978,7 +4999,7 @@ fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<usize> {
         }
 
         if cursor + 2 < bytes.len()
-            && bytes[cursor] == b'$'
+            && is_unescaped_dollar(bytes, cursor)
             && bytes[cursor + 1] == b'('
             && bytes[cursor + 2] == b'('
         {
@@ -4986,7 +5007,10 @@ fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<usize> {
             continue;
         }
 
-        if cursor + 1 < bytes.len() && bytes[cursor] == b'$' && bytes[cursor + 1] == b'(' {
+        if cursor + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, cursor)
+            && bytes[cursor + 1] == b'('
+        {
             cursor = find_command_substitution_end(bytes, cursor)?;
             continue;
         }
@@ -5034,7 +5058,7 @@ fn skip_double_quoted(bytes: &[u8], start: usize) -> Option<usize> {
         }
 
         if cursor + 2 < bytes.len()
-            && bytes[cursor] == b'$'
+            && is_unescaped_dollar(bytes, cursor)
             && bytes[cursor + 1] == b'('
             && bytes[cursor + 2] == b'('
         {
@@ -5042,7 +5066,10 @@ fn skip_double_quoted(bytes: &[u8], start: usize) -> Option<usize> {
             continue;
         }
 
-        if cursor + 1 < bytes.len() && bytes[cursor] == b'$' && bytes[cursor + 1] == b'(' {
+        if cursor + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, cursor)
+            && bytes[cursor + 1] == b'('
+        {
             cursor = find_command_substitution_end(bytes, cursor)?;
             continue;
         }
@@ -8497,6 +8524,21 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
                 .collect::<Vec<_>>();
 
             assert_eq!(spans, vec!["$(printf 1)"]);
+        });
+    }
+
+    #[test]
+    fn ignores_escaped_command_substitution_tokens_in_wrapped_substring_offset_arithmetic() {
+        let source = "#!/bin/bash\ns=abcdef\ni=1\nprintf '%s\\n' \"${s:$(($i+\\$(printf 1)))}\"\n";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .arithmetic_command_substitution_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+
+            assert!(spans.is_empty(), "unexpected spans: {spans:?}");
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4671,10 +4671,11 @@ impl<'a> WordFactCollector<'a> {
         if host_kind == WordFactHostKind::Direct
             && word_needs_wrapped_arithmetic_fallback(word, self.source)
         {
-            collect_wrapped_arithmetic_dollar_spans_in_word(
+            collect_wrapped_arithmetic_spans_in_word(
                 word,
                 self.source,
                 &mut self.arithmetic.dollar_in_arithmetic_spans,
+                &mut self.arithmetic.arithmetic_command_substitution_spans,
             );
         }
     }
@@ -4823,10 +4824,11 @@ fn collect_dollar_prefixed_arithmetic_variable_spans(
     }
 }
 
-fn collect_wrapped_arithmetic_dollar_spans_in_word(
+fn collect_wrapped_arithmetic_spans_in_word(
     word: &Word,
     source: &str,
-    spans: &mut Vec<Span>,
+    dollar_spans: &mut Vec<Span>,
+    command_substitution_spans: &mut Vec<Span>,
 ) {
     let text = word.span.slice(source);
     let bytes = text.as_bytes();
@@ -4864,10 +4866,16 @@ fn collect_wrapped_arithmetic_dollar_spans_in_word(
                         let expr_end = cursor;
                         let start = word.span.start.advanced_by(&text[..expr_start]);
                         let end = start.advanced_by(&text[expr_start..expr_end]);
+                        let expression_span = Span::from_positions(start, end);
                         collect_dollar_prefixed_arithmetic_variable_spans(
-                            Span::from_positions(start, end),
+                            expression_span,
                             source,
-                            spans,
+                            dollar_spans,
+                        );
+                        collect_wrapped_arithmetic_command_substitution_spans(
+                            expression_span,
+                            source,
+                            command_substitution_spans,
                         );
                         index = cursor + 2;
                         matched = true;
@@ -4887,6 +4895,181 @@ fn collect_wrapped_arithmetic_dollar_spans_in_word(
             break;
         }
     }
+}
+
+fn collect_wrapped_arithmetic_command_substitution_spans(
+    span: Span,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let text = span.slice(source);
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+
+    while index + 1 < bytes.len() {
+        if bytes[index] != b'$' || bytes[index + 1] != b'(' || bytes.get(index + 2) == Some(&b'(') {
+            index += 1;
+            continue;
+        }
+
+        let Some(end) = find_command_substitution_end(bytes, index) else {
+            break;
+        };
+
+        let start = span.start.advanced_by(&text[..index]);
+        let end_pos = start.advanced_by(&text[index..end]);
+        spans.push(Span::from_positions(start, end_pos));
+        index = end;
+    }
+}
+
+fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut cursor = start + 2;
+
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            cursor = (cursor + 2).min(bytes.len());
+            continue;
+        }
+
+        if cursor + 2 < bytes.len()
+            && bytes[cursor] == b'$'
+            && bytes[cursor + 1] == b'('
+            && bytes[cursor + 2] == b'('
+        {
+            cursor = find_wrapped_arithmetic_end(bytes, cursor)?;
+            continue;
+        }
+
+        if cursor + 1 < bytes.len() && bytes[cursor] == b'$' && bytes[cursor + 1] == b'(' {
+            cursor = find_command_substitution_end(bytes, cursor)?;
+            continue;
+        }
+
+        match bytes[cursor] {
+            b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
+            b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
+            b'`' => cursor = skip_backticks(bytes, cursor + 1)?,
+            b'(' => {
+                paren_depth += 1;
+                cursor += 1;
+            }
+            b')' if paren_depth == 0 => return Some(cursor + 1),
+            b')' => {
+                paren_depth -= 1;
+                cursor += 1;
+            }
+            _ => cursor += 1,
+        }
+    }
+
+    None
+}
+
+fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut cursor = start + 3;
+
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            cursor = (cursor + 2).min(bytes.len());
+            continue;
+        }
+
+        if cursor + 2 < bytes.len()
+            && bytes[cursor] == b'$'
+            && bytes[cursor + 1] == b'('
+            && bytes[cursor + 2] == b'('
+        {
+            cursor = find_wrapped_arithmetic_end(bytes, cursor)?;
+            continue;
+        }
+
+        if cursor + 1 < bytes.len() && bytes[cursor] == b'$' && bytes[cursor + 1] == b'(' {
+            cursor = find_command_substitution_end(bytes, cursor)?;
+            continue;
+        }
+
+        match bytes[cursor] {
+            b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
+            b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
+            b'`' => cursor = skip_backticks(bytes, cursor + 1)?,
+            b'(' => {
+                paren_depth += 1;
+                cursor += 1;
+            }
+            b')' if paren_depth == 0 && cursor + 1 < bytes.len() && bytes[cursor + 1] == b')' => {
+                return Some(cursor + 2);
+            }
+            b')' if paren_depth > 0 => {
+                paren_depth -= 1;
+                cursor += 1;
+            }
+            _ => cursor += 1,
+        }
+    }
+
+    None
+}
+
+fn skip_single_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\'' {
+            return Some(cursor + 1);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn skip_double_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut cursor = start;
+
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            cursor = (cursor + 2).min(bytes.len());
+            continue;
+        }
+
+        if cursor + 2 < bytes.len()
+            && bytes[cursor] == b'$'
+            && bytes[cursor + 1] == b'('
+            && bytes[cursor + 2] == b'('
+        {
+            cursor = find_wrapped_arithmetic_end(bytes, cursor)?;
+            continue;
+        }
+
+        if cursor + 1 < bytes.len() && bytes[cursor] == b'$' && bytes[cursor + 1] == b'(' {
+            cursor = find_command_substitution_end(bytes, cursor)?;
+            continue;
+        }
+
+        match bytes[cursor] {
+            b'"' => return Some(cursor + 1),
+            b'`' => cursor = skip_backticks(bytes, cursor + 1)?,
+            _ => cursor += 1,
+        }
+    }
+
+    None
+}
+
+fn skip_backticks(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            cursor = (cursor + 2).min(bytes.len());
+            continue;
+        }
+        if bytes[cursor] == b'`' {
+            return Some(cursor + 1);
+        }
+        cursor += 1;
+    }
+    None
 }
 
 fn word_needs_wrapped_arithmetic_fallback(word: &Word, source: &str) -> bool {
@@ -8298,6 +8481,22 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
                 .collect::<Vec<_>>();
 
             assert_eq!(spans, vec!["$len"], "command words: {words:?}");
+        });
+    }
+
+    #[test]
+    fn collects_command_substitution_spans_for_wrapped_substring_offset_arithmetic() {
+        let source =
+            "#!/bin/bash\nrest=abcdef\nprintf '%s\\n' \"${rest:$((${#rest}-$(printf 1)))}\"\n";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .arithmetic_command_substitution_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+
+            assert_eq!(spans, vec!["$(printf 1)"]);
         });
     }
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -2986,6 +2986,35 @@ function f() { :; }
     }
 
     #[test]
+    fn array_index_arithmetic_suppressed_by_shellcheck_directive() {
+        let source = "\
+#!/bin/bash
+# shellcheck disable=SC2321
+arr[$((1+1))]=x
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let directives = parse_directives(
+            source,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        let suppressions = SuppressionIndex::new(
+            &directives,
+            &output.file,
+            first_statement_line(&output.file).unwrap_or(u32::MAX),
+        );
+        let diagnostics = lint_file(
+            &output.file,
+            source,
+            &indexer,
+            &LinterSettings::for_rule(Rule::ArrayIndexArithmetic),
+            Some(&suppressions),
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn source_inside_function_suppressed_by_shellcheck_directive() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/subshell_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_in_arithmetic.rs
@@ -63,4 +63,15 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "$(printf 1)");
     }
+
+    #[test]
+    fn ignores_escaped_command_substitution_tokens_in_wrapped_substring_offset_arithmetic() {
+        let source = "#!/bin/bash\ns=abcdef\ni=1\nprintf '%s\\n' \"${s:$(($i+\\$(printf 1)))}\"\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellInArithmetic),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/subshell_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_in_arithmetic.rs
@@ -50,4 +50,17 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "$(printf 1)");
     }
+
+    #[test]
+    fn reports_command_substitutions_in_wrapped_substring_offset_arithmetic() {
+        let source =
+            "#!/bin/bash\nrest=abcdef\nprintf '%s\\n' \"${rest:$((${#rest}-$(printf 1)))}\"\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellInArithmetic),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "$(printf 1)");
+    }
 }

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -385,7 +385,6 @@ impl Default for ShellCheckCodeMap {
                 (3069, Rule::CStyleForArithmeticInSh),
                 (3075, Rule::ErrexitTrapInSh),
                 (3076, Rule::SignalNameInTrap),
-                (2321, Rule::FunctionKeywordInSh),
                 (2323, Rule::ArithmeticScoreLine),
                 (3051, Rule::SourceInsideFunctionInSh),
                 (3084, Rule::SourceInsideFunctionInSh),
@@ -448,6 +447,7 @@ impl Default for ShellCheckCodeMap {
             ]),
             aliases: vec![
                 (1075, Rule::ExtglobCase),
+                (2321, Rule::FunctionKeywordInSh),
                 (3061, Rule::ExtglobInSh),
                 (3072, Rule::CaretNegationInBracket),
                 (2319, Rule::AssignmentLooksLikeComparison),
@@ -624,7 +624,11 @@ mod tests {
         assert_eq!(map.resolve("SC3077"), Some(Rule::BasePrefixInArithmetic));
         assert_eq!(map.resolve("SC3075"), Some(Rule::ErrexitTrapInSh));
         assert_eq!(map.resolve("SC3076"), Some(Rule::SignalNameInTrap));
-        assert_eq!(map.resolve("SC2321"), Some(Rule::FunctionKeywordInSh));
+        assert_eq!(map.resolve("SC2321"), Some(Rule::ArrayIndexArithmetic));
+        assert_eq!(
+            map.resolve_all("SC2321"),
+            vec![Rule::ArrayIndexArithmetic, Rule::FunctionKeywordInSh]
+        );
         assert_eq!(map.resolve("SC2323"), Some(Rule::ArithmeticScoreLine));
         assert_eq!(map.resolve("SC2333"), Some(Rule::NonShellSyntaxInScript));
         assert_eq!(map.resolve("SC2389"), Some(Rule::LoopWithoutEnd));
@@ -865,6 +869,8 @@ mod tests {
             (2354, Rule::PlusPrefixInAssignment),
             (2377, Rule::AppendWithEscapedQuotes),
             (2329, Rule::IfsSetToLiteralBackslashN),
+            (2321, Rule::ArrayIndexArithmetic),
+            (2323, Rule::ArithmeticScoreLine),
             (2321, Rule::FunctionKeywordInSh),
             (2323, Rule::ArithmeticScoreLine),
             (2333, Rule::NonShellSyntaxInScript),


### PR DESCRIPTION
## Summary
- preserve `SC2321` as the primary ShellCheck mapping for `ArrayIndexArithmetic` while keeping `FunctionKeywordInSh` as an alias
- collect wrapped-arithmetic command substitutions in substring offset fallbacks so C077 sees nested `$(...)`
- add regression coverage for the `SC2321` suppression path and wrapped substring arithmetic command substitutions

## Why
- the duplicate `SC2321` map entry meant suppressions always resolved to `FunctionKeywordInSh`
- the wrapped `$(())` fallback only recorded dollar-prefixed variables, so nested command substitutions could be missed entirely

## Impact
- `# shellcheck disable=SC2321` now suppresses array-index arithmetic findings as intended
- wrapped substring offset arithmetic now reports command substitutions consistently with the AST-backed path

## Validation
- `cargo test -p shuck-linter`
