### PR TITLE
Fix script lint false positives and check scripts in make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run check setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security release
+.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security release
 
 ARGS ?= --help
 BENCH_FILE ?=
@@ -197,8 +197,10 @@ check-release-security:
 
 release:
 	./scripts/release.sh $(VERSION)
-
+check-scripts:
+	cargo run -q -p shuck -- check --no-cache scripts
 check:
 	cargo fmt -- --check
 	cargo clippy --all-targets -- -D warnings
 	$(NIX_DEVELOP) env RUSTC_BOOTSTRAP=1 cargo udeps --all-targets
+	$(MAKE) --no-print-directory check-scripts

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1291,6 +1291,24 @@ printf '%s\\n' \"${!args_var}\"
     }
 
     #[test]
+    fn parameter_default_operand_usage_is_not_flagged() {
+        let source = "\
+#!/bin/sh
+repo_root=$(pwd)
+cache_dir=${1:-\"$repo_root/.cache\"}
+printf '%s\\n' \"$cache_dir\"
+";
+        let diagnostics = lint_named_source_with_parse_dialect(
+            Path::new("/tmp/parameter-default.sh"),
+            source,
+            ParseDialect::Posix,
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn local_at_script_scope_is_flagged() {
         let diagnostics = lint(
             "#!/bin/bash\nlocal foo=bar\nprintf '%s\\n' \"$foo\"\n",
@@ -1665,6 +1683,31 @@ download() {
   echo \"$core_arch\"
 }
 ",
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn case_without_matching_arm_keeps_initializer_live() {
+        let source = "\
+#!/bin/sh
+value=''
+case \"$kind\" in
+  one)
+    value=1
+    ;;
+  two)
+    value=2
+    ;;
+esac
+printf '%s\\n' \"$value\"
+";
+        let diagnostics = lint_named_source_with_parse_dialect(
+            Path::new("/tmp/case-no-match.sh"),
+            source,
+            ParseDialect::Posix,
             &LinterSettings::for_rule(Rule::UnusedAssignment),
         );
 

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1267,6 +1267,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             WordPart::ParameterExpansion {
                 reference,
                 operator,
+                operand,
                 ..
             } => {
                 let reference_id = self.visit_var_ref_reference(
@@ -1288,24 +1289,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 if matches!(operator, ParameterOp::AssignDefault) {
                     self.add_parameter_default_binding(reference);
                 }
-                match operator {
-                    ParameterOp::RemovePrefixShort { pattern }
-                    | ParameterOp::RemovePrefixLong { pattern }
-                    | ParameterOp::RemoveSuffixShort { pattern }
-                    | ParameterOp::RemoveSuffixLong { pattern }
-                    | ParameterOp::ReplaceFirst { pattern, .. }
-                    | ParameterOp::ReplaceAll { pattern, .. } => {
-                        self.visit_pattern_into(pattern, kind, flow, nested_regions);
-                    }
-                    ParameterOp::UseDefault
-                    | ParameterOp::AssignDefault
-                    | ParameterOp::UseReplacement
-                    | ParameterOp::Error
-                    | ParameterOp::UpperFirst
-                    | ParameterOp::UpperAll
-                    | ParameterOp::LowerFirst
-                    | ParameterOp::LowerAll => {}
-                }
+                self.visit_parameter_operator_operand(
+                    operator,
+                    operand.as_ref(),
+                    kind,
+                    flow,
+                    nested_regions,
+                );
             }
             WordPart::Length(reference) | WordPart::ArrayLength(reference) => {
                 self.visit_var_ref_reference(
@@ -1476,7 +1466,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         span,
                     );
                 }
-                BourneParameterExpansion::Indirect { reference, .. } => {
+                BourneParameterExpansion::Indirect {
+                    reference,
+                    operator,
+                    operand,
+                    ..
+                } => {
                     let id = self.visit_var_ref_reference(
                         reference,
                         if matches!(kind, WordVisitKind::Conditional) {
@@ -1489,6 +1484,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         span,
                     );
                     self.indirect_expansion_refs.insert(id);
+                    if let Some(operator) = operator {
+                        self.visit_parameter_operator_operand(
+                            operator,
+                            operand.as_ref(),
+                            kind,
+                            flow,
+                            nested_regions,
+                        );
+                    }
                 }
                 BourneParameterExpansion::PrefixMatch { prefix, .. } => {
                     self.add_reference(
@@ -1532,6 +1536,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 BourneParameterExpansion::Operation {
                     reference,
                     operator,
+                    operand,
                     ..
                 } => {
                     let reference_id = self.visit_var_ref_reference(
@@ -1553,24 +1558,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     if matches!(operator, ParameterOp::AssignDefault) {
                         self.add_parameter_default_binding(reference);
                     }
-                    match operator {
-                        ParameterOp::RemovePrefixShort { pattern }
-                        | ParameterOp::RemovePrefixLong { pattern }
-                        | ParameterOp::RemoveSuffixShort { pattern }
-                        | ParameterOp::RemoveSuffixLong { pattern }
-                        | ParameterOp::ReplaceFirst { pattern, .. }
-                        | ParameterOp::ReplaceAll { pattern, .. } => {
-                            self.visit_pattern_into(pattern, kind, flow, nested_regions);
-                        }
-                        ParameterOp::UseDefault
-                        | ParameterOp::AssignDefault
-                        | ParameterOp::UseReplacement
-                        | ParameterOp::Error
-                        | ParameterOp::UpperFirst
-                        | ParameterOp::UpperAll
-                        | ParameterOp::LowerFirst
-                        | ParameterOp::LowerAll => {}
-                    }
+                    self.visit_parameter_operator_operand(
+                        operator,
+                        operand.as_ref(),
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
                 }
                 BourneParameterExpansion::Transformation { reference, .. } => {
                     self.visit_var_ref_reference(
@@ -1660,6 +1654,47 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     ) {
         let word = Parser::parse_word_fragment(self.source, text.slice(self.source), text.span());
         self.visit_word_into(&word, kind, flow, nested_regions);
+    }
+
+    fn visit_parameter_operator_operand(
+        &mut self,
+        operator: &ParameterOp,
+        operand: Option<&shuck_ast::SourceText>,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match operator {
+            ParameterOp::RemovePrefixShort { pattern }
+            | ParameterOp::RemovePrefixLong { pattern }
+            | ParameterOp::RemoveSuffixShort { pattern }
+            | ParameterOp::RemoveSuffixLong { pattern } => {
+                self.visit_pattern_into(pattern, kind, flow, nested_regions);
+            }
+            ParameterOp::ReplaceFirst {
+                pattern,
+                replacement,
+            }
+            | ParameterOp::ReplaceAll {
+                pattern,
+                replacement,
+            } => {
+                self.visit_pattern_into(pattern, kind, flow, nested_regions);
+                self.visit_source_text_as_word(replacement, kind, flow, nested_regions);
+            }
+            ParameterOp::UseDefault
+            | ParameterOp::AssignDefault
+            | ParameterOp::UseReplacement
+            | ParameterOp::Error => {
+                if let Some(operand) = operand {
+                    self.visit_source_text_as_word(operand, kind, flow, nested_regions);
+                }
+            }
+            ParameterOp::UpperFirst
+            | ParameterOp::UpperAll
+            | ParameterOp::LowerFirst
+            | ParameterOp::LowerAll => {}
+        }
     }
 
     fn visit_pattern_part(

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -644,9 +644,7 @@ impl<'a> GraphBuilder<'a> {
             }
         }
 
-        if arms.is_empty() {
-            self.add_edge(head, exit_block, EdgeKind::Sequential);
-        }
+        self.add_edge(head, exit_block, EdgeKind::Sequential);
 
         SequenceResult {
             entry: Some(head),

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2114,6 +2114,30 @@ download() {
     }
 
     #[test]
+    fn case_without_matching_arm_keeps_initializer_live() {
+        let source = "\
+value=''
+case \"$kind\" in
+  one)
+    value=1
+    ;;
+  two)
+    value=2
+    ;;
+esac
+printf '%s\\n' \"$value\"
+";
+        let model = model_with_dialect(source, ShellDialect::Posix);
+        let unused = reportable_unused_names(&model);
+
+        assert!(
+            !unused.contains(&Name::from("value")),
+            "unused bindings: {:?}",
+            unused
+        );
+    }
+
+    #[test]
     fn function_global_assignments_read_later_by_caller_are_live() {
         let source = "\
 pass_args() {
@@ -2741,6 +2765,33 @@ printf '%s\\n' \"$config_path\" \"$still_missing\"
             })
             .unwrap();
         assert_eq!(binding.span.slice(source), "config_path");
+    }
+
+    #[test]
+    fn default_parameter_operand_reads_are_tracked() {
+        let source = "\
+repo_root=$(pwd)
+cache_dir=${1:-\"$repo_root/.cache\"}
+printf '%s\\n' \"$cache_dir\"
+";
+        let model = model_with_dialect(source, ShellDialect::Posix);
+        let unused = reportable_unused_names(&model);
+
+        assert!(
+            !unused.contains(&Name::from("repo_root")),
+            "unused bindings: {:?}",
+            unused
+        );
+
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| {
+                reference.kind == ReferenceKind::Expansion && reference.name == "repo_root"
+            })
+            .unwrap();
+        let binding = model.resolved_binding(reference.id).unwrap();
+        assert_eq!(binding.name, "repo_root");
     }
 
     #[test]

--- a/scripts/sync-claude-md.sh
+++ b/scripts/sync-claude-md.sh
@@ -17,5 +17,9 @@ find "$repo_root" -name AGENTS.md -not -path '*/.git/*' | while read -r agents_f
     fi
 
     ln -s AGENTS.md "$claude_file"
-    echo "Created symlink: ${claude_file#"$repo_root"/}"
+    relative_path="$claude_file"
+    if [[ $claude_file == "$repo_root/"* ]]; then
+        relative_path=${claude_file:$(( ${#repo_root} + 1 ))}
+    fi
+    echo "Created symlink: $relative_path"
 done


### PR DESCRIPTION
## What changed

This PR fixes a pair of script-linting false positives and makes the repo's script linting part of `make check`.

- teach semantic analysis to treat Bourne parameter-expansion operands like `${1:-"$repo_root/.cache"}` as real reads
- model the `case` no-match path so pre-case initializers stay live after `esac`
- rewrite `scripts/sync-claude-md.sh` to avoid dynamic pattern trimming in its status output
- add `check-scripts` and run `shuck --check --no-cache scripts` from `make check`

## Why

`shuck` was incorrectly reporting unused assignments in `scripts/benchmarks/summarize_formatter.sh` even though the values were consumed later. The root causes were:

1. Bourne parameter-expansion operands were not walked for reads.
2. `case` control flow did not preserve the path where no arm matched.

Those gaps also left one remaining script warning in `scripts/sync-claude-md.sh`, so the PR cleans that script up and then ensures the whole `scripts/` tree stays covered by `make check`.

## Impact

- `scripts/benchmarks/summarize_formatter.sh` now passes under the fixed analyzer
- `scripts/` is clean under `shuck --check --no-cache`
- `make check` now fails if a new script warning is introduced

## Validation

- `cargo fmt -- --check`
- `make check-scripts`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
