### PR TITLE
Fix case CFG no-match edge for catch-all arms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 license = "MIT"
 authors = ["Eric Hauser"]

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -4,8 +4,8 @@ use shuck_ast::{
     ArithmeticLvalue, ArithmeticUnaryOp, ArrayElem, ArrayExpr, ArrayKind, Assignment,
     AssignmentValue, BinaryCommand, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command,
     CompoundCommand, ConditionalExpr, DeclOperand, File, FunctionDef, Name, ParameterExpansion,
-    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, PatternPartNode, Span, Stmt,
-    StmtSeq, Subscript, VarRef, Word, WordPart, WordPartNode, ZshExpansionOperation,
+    ParameterExpansionSyntax, ParameterOp, Pattern, PatternGroupKind, PatternPart, PatternPartNode,
+    Span, Stmt, StmtSeq, Subscript, VarRef, Word, WordPart, WordPartNode, ZshExpansionOperation,
     ZshExpansionTarget, ZshGlobSegment,
 };
 use shuck_indexer::Indexer;
@@ -714,6 +714,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         }
                         RecordedCaseArm {
                             terminator: case.terminator,
+                            matches_anything: case_arm_matches_anything(&case.patterns),
                             commands,
                         }
                     })
@@ -2910,6 +2911,71 @@ fn single_literal_word(word: &Word) -> Option<&str> {
             _ => None,
         },
         _ => None,
+    }
+}
+
+fn case_arm_matches_anything(patterns: &[Pattern]) -> bool {
+    patterns.iter().any(pattern_matches_anything)
+}
+
+fn pattern_matches_anything(pattern: &Pattern) -> bool {
+    !pattern.parts.is_empty()
+        && pattern
+            .parts
+            .iter()
+            .all(|part| pattern_part_can_match_empty(&part.kind))
+        && pattern
+            .parts
+            .iter()
+            .any(|part| pattern_part_matches_anything(&part.kind))
+}
+
+fn pattern_can_match_empty(pattern: &Pattern) -> bool {
+    pattern
+        .parts
+        .iter()
+        .all(|part| pattern_part_can_match_empty(&part.kind))
+}
+
+fn pattern_part_matches_anything(part: &PatternPart) -> bool {
+    match part {
+        PatternPart::AnyString => true,
+        PatternPart::Group { kind, patterns } => pattern_group_matches_anything(*kind, patterns),
+        PatternPart::Literal(_)
+        | PatternPart::AnyChar
+        | PatternPart::CharClass(_)
+        | PatternPart::Word(_) => false,
+    }
+}
+
+fn pattern_part_can_match_empty(part: &PatternPart) -> bool {
+    match part {
+        PatternPart::AnyString => true,
+        PatternPart::Group { kind, patterns } => pattern_group_can_match_empty(*kind, patterns),
+        PatternPart::Literal(_)
+        | PatternPart::AnyChar
+        | PatternPart::CharClass(_)
+        | PatternPart::Word(_) => false,
+    }
+}
+
+fn pattern_group_matches_anything(kind: PatternGroupKind, patterns: &[Pattern]) -> bool {
+    match kind {
+        PatternGroupKind::ZeroOrOne
+        | PatternGroupKind::ZeroOrMore
+        | PatternGroupKind::OneOrMore
+        | PatternGroupKind::ExactlyOne => patterns.iter().any(pattern_matches_anything),
+        PatternGroupKind::NoneOf => false,
+    }
+}
+
+fn pattern_group_can_match_empty(kind: PatternGroupKind, patterns: &[Pattern]) -> bool {
+    match kind {
+        PatternGroupKind::ZeroOrOne | PatternGroupKind::ZeroOrMore => true,
+        PatternGroupKind::OneOrMore | PatternGroupKind::ExactlyOne => {
+            patterns.iter().any(pattern_can_match_empty)
+        }
+        PatternGroupKind::NoneOf => false,
     }
 }
 

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -607,12 +607,18 @@ impl<'a> GraphBuilder<'a> {
         let mut fallthrough_from = Vec::new();
 
         for arm in arms {
-            let arm_seq = self.build_sequence(&arm.commands, loops);
-            if let Some(arm_entry) = arm_seq.entry {
-                self.add_edge(head, arm_entry, EdgeKind::CaseArm);
-                for block in &fallthrough_from {
-                    self.add_edge(*block, arm_entry, EdgeKind::CaseFallthrough);
-                }
+            let mut arm_seq = self.build_sequence(&arm.commands, loops);
+            if arm_seq.entry.is_none() {
+                let empty_arm = self.empty_block();
+                arm_seq.entry = Some(empty_arm);
+                arm_seq.exits.push(empty_arm);
+            }
+            let arm_entry = arm_seq
+                .entry
+                .expect("empty case arms get a synthetic CFG block");
+            self.add_edge(head, arm_entry, EdgeKind::CaseArm);
+            for block in &fallthrough_from {
+                self.add_edge(*block, arm_entry, EdgeKind::CaseFallthrough);
             }
 
             match arm.terminator {

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -603,9 +603,13 @@ impl<'a> GraphBuilder<'a> {
         let head = self.command_block(command.span);
         self.attach_nested_regions(head, &command.nested_regions, loops);
         let exit_block = self.empty_block();
-        let no_match_possible = arms.is_empty() || !arms.iter().any(|arm| arm.matches_anything);
-        let mut fallthrough_from = Vec::new();
-
+        let dispatch_count = arms.len().max(1);
+        let mut dispatch_blocks = Vec::with_capacity(dispatch_count);
+        dispatch_blocks.push(head);
+        for _ in 1..dispatch_count {
+            dispatch_blocks.push(self.empty_block());
+        }
+        let mut arm_sequences = Vec::with_capacity(arms.len());
         for arm in arms {
             let mut arm_seq = self.build_sequence(&arm.commands, loops);
             if arm_seq.entry.is_none() {
@@ -613,10 +617,33 @@ impl<'a> GraphBuilder<'a> {
                 arm_seq.entry = Some(empty_arm);
                 arm_seq.exits.push(empty_arm);
             }
+            arm_sequences.push(arm_seq);
+        }
+
+        for (dispatch_index, dispatch) in dispatch_blocks.iter().copied().enumerate() {
+            let mut matched_all = false;
+            for (arm_index, arm) in arms.iter().enumerate().skip(dispatch_index) {
+                let arm_entry = arm_sequences[arm_index]
+                    .entry
+                    .expect("empty case arms get a synthetic CFG block");
+                self.add_edge(dispatch, arm_entry, EdgeKind::CaseArm);
+                if arm.matches_anything {
+                    matched_all = true;
+                    break;
+                }
+            }
+            if !matched_all {
+                self.add_edge(dispatch, exit_block, EdgeKind::Sequential);
+            }
+        }
+
+        let mut fallthrough_from = Vec::new();
+
+        for (arm_index, arm) in arms.iter().enumerate() {
+            let arm_seq = &arm_sequences[arm_index];
             let arm_entry = arm_seq
                 .entry
                 .expect("empty case arms get a synthetic CFG block");
-            self.add_edge(head, arm_entry, EdgeKind::CaseArm);
             for block in &fallthrough_from {
                 self.add_edge(*block, arm_entry, EdgeKind::CaseFallthrough);
             }
@@ -632,28 +659,26 @@ impl<'a> GraphBuilder<'a> {
                     fallthrough_from = arm_seq.exits.clone();
                 }
                 CaseTerminator::Continue => {
-                    fallthrough_from = arm_seq.exits.clone();
-                    for block in &fallthrough_from {
-                        self.successors
-                            .entry(*block)
-                            .or_default()
-                            .push((head, EdgeKind::CaseContinue));
+                    let continue_target = dispatch_blocks
+                        .get(arm_index + 1)
+                        .copied()
+                        .unwrap_or(exit_block);
+                    for block in &arm_seq.exits {
+                        self.add_edge(*block, continue_target, EdgeKind::CaseContinue);
                     }
+                    fallthrough_from.clear();
                 }
                 CaseTerminator::ContinueMatching => {
-                    fallthrough_from = arm_seq.exits.clone();
-                    for block in &fallthrough_from {
-                        self.successors
-                            .entry(*block)
-                            .or_default()
-                            .push((head, EdgeKind::CaseContinue));
+                    let continue_target = dispatch_blocks
+                        .get(arm_index + 1)
+                        .copied()
+                        .unwrap_or(exit_block);
+                    for block in &arm_seq.exits {
+                        self.add_edge(*block, continue_target, EdgeKind::CaseContinue);
                     }
+                    fallthrough_from.clear();
                 }
             }
-        }
-
-        if no_match_possible {
-            self.add_edge(head, exit_block, EdgeKind::Sequential);
         }
 
         SequenceResult {

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -174,6 +174,7 @@ pub(crate) enum RecordedCommandKind {
 #[derive(Debug, Clone)]
 pub(crate) struct RecordedCaseArm {
     pub(crate) terminator: CaseTerminator,
+    pub(crate) matches_anything: bool,
     pub(crate) commands: Vec<RecordedCommand>,
 }
 
@@ -602,6 +603,7 @@ impl<'a> GraphBuilder<'a> {
         let head = self.command_block(command.span);
         self.attach_nested_regions(head, &command.nested_regions, loops);
         let exit_block = self.empty_block();
+        let no_match_possible = arms.is_empty() || !arms.iter().any(|arm| arm.matches_anything);
         let mut fallthrough_from = Vec::new();
 
         for arm in arms {
@@ -644,7 +646,9 @@ impl<'a> GraphBuilder<'a> {
             }
         }
 
-        self.add_edge(head, exit_block, EdgeKind::Sequential);
+        if no_match_possible {
+            self.add_edge(head, exit_block, EdgeKind::Sequential);
+        }
 
         SequenceResult {
             entry: Some(head),

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2138,6 +2138,30 @@ printf '%s\\n' \"$value\"
     }
 
     #[test]
+    fn case_with_catch_all_arm_overwrites_initializer() {
+        let source = "\
+value=''
+case \"$kind\" in
+  one)
+    value=1
+    ;;
+  *)
+    value=2
+    ;;
+esac
+printf '%s\\n' \"$value\"
+";
+        let model = model_with_dialect(source, ShellDialect::Posix);
+        let unused = reportable_unused_names(&model);
+        let count = unused
+            .iter()
+            .filter(|name| **name == Name::from("value"))
+            .count();
+
+        assert_eq!(count, 1, "unused bindings: {:?}", unused);
+    }
+
+    #[test]
     fn function_global_assignments_read_later_by_caller_are_live() {
         let source = "\
 pass_args() {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2153,12 +2153,27 @@ printf '%s\\n' \"$value\"
 ";
         let model = model_with_dialect(source, ShellDialect::Posix);
         let unused = reportable_unused_names(&model);
-        let count = unused
-            .iter()
-            .filter(|name| **name == Name::from("value"))
-            .count();
+        let count = unused.iter().filter(|name| name.as_str() == "value").count();
 
         assert_eq!(count, 1, "unused bindings: {:?}", unused);
+    }
+
+    #[test]
+    fn empty_case_catch_all_arm_keeps_following_code_reachable() {
+        let source = "\
+case \"$kind\" in
+  *)
+    ;;
+esac
+printf '%s\\n' ok
+";
+        let model = model_with_dialect(source, ShellDialect::Posix);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2153,7 +2153,10 @@ printf '%s\\n' \"$value\"
 ";
         let model = model_with_dialect(source, ShellDialect::Posix);
         let unused = reportable_unused_names(&model);
-        let count = unused.iter().filter(|name| name.as_str() == "value").count();
+        let count = unused
+            .iter()
+            .filter(|name| name.as_str() == "value")
+            .count();
 
         assert_eq!(count, 1, "unused bindings: {:?}", unused);
     }
@@ -2168,6 +2171,25 @@ esac
 printf '%s\\n' ok
 ";
         let model = model_with_dialect(source, ShellDialect::Posix);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
+    fn catch_all_continue_case_arm_keeps_following_code_reachable() {
+        let source = "\
+case \"$kind\" in
+  *)
+    :
+    ;;&
+esac
+printf '%s\\n' ok
+";
+        let model = model(source);
 
         assert!(
             model.analysis().dead_code().is_empty(),


### PR DESCRIPTION
## Summary
- record when a case arm can match any subject
- only add the synthetic no-match CFG edge when no catch-all arm exists
- add regression coverage for catch-all and no-match case liveness

## Why
The CFG always added a head-to-exit edge for case commands, even when a catch-all arm made that path impossible.

## Impact
Dataflow no longer keeps pre-case assignments artificially live or treats post-case code as reachable when every real execution must enter an arm.

## Validation
- cargo test -p shuck-semantic