### PR TITLE
Add validation review coverage for parse and security rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 license = "MIT"
 authors = ["Eric Hauser"]

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -229,17 +229,63 @@ fn if_bracket_glued_span(source: &str, parse_diagnostics: &[ParseDiagnostic]) ->
 
 fn if_bracket_glued_span_on_line(source: &str, line_number: usize) -> Option<Span> {
     let line = line_text_at(source, line_number)?;
-    let text = line.split_once('#').map_or(line, |(before, _)| before);
-    let bytes = text.as_bytes();
+    let bytes = line.as_bytes();
     if bytes.len() < 3 {
         return None;
     }
 
-    for index in 0..=bytes.len() - 3 {
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut double_quote_escape = false;
+    let mut index = 0usize;
+
+    while index + 2 < bytes.len() {
+        let byte = bytes[index];
+
+        if in_single_quotes {
+            if byte == b'\'' {
+                in_single_quotes = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if in_double_quotes {
+            if double_quote_escape {
+                double_quote_escape = false;
+            } else if byte == b'\\' {
+                double_quote_escape = true;
+            } else if byte == b'"' {
+                in_double_quotes = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if byte == b'#' {
+            break;
+        }
+        if byte == b'\\' {
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+        if byte == b'\'' {
+            in_single_quotes = true;
+            index += 1;
+            continue;
+        }
+        if byte == b'"' {
+            in_double_quotes = true;
+            index += 1;
+            continue;
+        }
+
         if bytes[index] != b'i' || bytes[index + 1] != b'f' || bytes[index + 2] != b'[' {
+            index += 1;
             continue;
         }
         if index > 0 && (bytes[index - 1].is_ascii_alphanumeric() || bytes[index - 1] == b'_') {
+            index += 1;
             continue;
         }
 
@@ -353,10 +399,26 @@ fn missing_done_belongs_to_for_loop(file: &File, source: &str) -> bool {
 
 fn missing_done_loop_kind_from_source(source: &str) -> Option<bool> {
     let mut loop_stack = Vec::new();
+    let mut continued_line = String::new();
 
     for line in source.lines() {
         let text = line.split_once('#').map_or(line, |(before, _)| before);
-        let words = shell_like_words(text);
+        let trimmed_end = text.trim_end();
+        if !continued_line.is_empty() {
+            continued_line.push(' ');
+            continued_line.push_str(trimmed_end.trim_start());
+        } else {
+            continued_line.push_str(trimmed_end);
+        }
+
+        if continued_line.ends_with('\\') {
+            continued_line.pop();
+            continue;
+        }
+
+        let logical_line = continued_line.trim().to_owned();
+        let words = shell_like_words(&logical_line);
+        continued_line.clear();
         if words.is_empty() {
             continue;
         }
@@ -374,6 +436,27 @@ fn missing_done_loop_kind_from_source(source: &str) -> Option<bool> {
         for _ in 0..done_count {
             if loop_stack.pop().is_none() {
                 break;
+            }
+        }
+    }
+
+    if !continued_line.is_empty() {
+        let words = shell_like_words(continued_line.trim());
+        if !words.is_empty() {
+            let has_do = words.contains(&"do");
+            if has_do {
+                if words.contains(&"for") {
+                    loop_stack.push(true);
+                } else if words.iter().any(|word| matches!(*word, "while" | "until")) {
+                    loop_stack.push(false);
+                }
+            }
+
+            let done_count = words.iter().filter(|word| **word == "done").count();
+            for _ in 0..done_count {
+                if loop_stack.pop().is_none() {
+                    break;
+                }
             }
         }
     }
@@ -612,7 +695,7 @@ fn line_start_offset(source: &str, target_line: usize) -> Option<usize> {
 mod tests {
     use shuck_parser::parser::Parser;
 
-    use super::collect_parse_rule_diagnostics;
+    use super::{collect_parse_rule_diagnostics, if_bracket_glued_span_on_line};
     use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
@@ -783,6 +866,39 @@ mod tests {
     }
 
     #[test]
+    fn maps_for_loop_missing_done_with_line_continuation_and_heredoc_to_c142() {
+        let source = "#!/bin/sh\nfor name in \\\n  alpha beta; do\n  cat <<EOF\n$name\nEOF\n";
+        let recovered = Parser::new(source).parse_recovered();
+        let settings = LinterSettings::for_rule(Rule::MissingDoneInForLoop);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            &recovered.diagnostics,
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::MissingDoneInForLoop);
+    }
+
+    #[test]
+    fn ignores_for_loop_with_heredoc_and_trailing_done_for_c142() {
+        let source = "#!/bin/sh\nfor name in \\\n  alpha beta; do\n  cat <<EOF\n$name\nEOF\ndone\n";
+        let recovered = Parser::new(source).parse_recovered();
+        let settings = LinterSettings::for_rule(Rule::MissingDoneInForLoop);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            &recovered.diagnostics,
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_while_loop_missing_done_for_c142() {
         let source = "#!/bin/sh\nwhile true; do\n  :\n";
         let recovered = Parser::new(source).parse_recovered();
@@ -813,6 +929,39 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::DanglingElse);
+    }
+
+    #[test]
+    fn maps_nested_empty_else_parse_error_to_c143() {
+        let source = "#!/bin/sh\nif true; then\n  if false; then\n    :\n  else\n  fi\nfi\n";
+        let recovered = Parser::new(source).parse_recovered();
+        let settings = LinterSettings::for_rule(Rule::DanglingElse);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            &recovered.diagnostics,
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::DanglingElse);
+    }
+
+    #[test]
+    fn ignores_non_empty_nested_else_with_other_parse_recovery_noise_for_c143() {
+        let source = "#!/bin/sh\nif true; then\n  :\nelse\n  if false; then\n    :\n  fi\nfi\nfi\n";
+        let recovered = Parser::new(source).parse_recovered();
+        let settings = LinterSettings::for_rule(Rule::DanglingElse);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            &recovered.diagnostics,
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert!(diagnostics.is_empty());
     }
 
     #[test]
@@ -849,8 +998,41 @@ mod tests {
     }
 
     #[test]
+    fn maps_multiline_until_header_missing_do_parse_error_to_c146() {
+        let source = "#!/bin/sh\nuntil\n  false\ndone\n";
+        let recovered = Parser::new(source).parse_recovered();
+        let settings = LinterSettings::for_rule(Rule::UntilMissingDo);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            &recovered.diagnostics,
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UntilMissingDo);
+    }
+
+    #[test]
     fn ignores_non_until_expected_command_parse_errors_for_c146() {
         let source = "#!/bin/sh\nwhile :\ndone\n";
+        let recovered = Parser::new(source).parse_recovered();
+        let settings = LinterSettings::for_rule(Rule::UntilMissingDo);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            &recovered.diagnostics,
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_until_with_do_after_comments_and_blank_lines_for_c146() {
+        let source = "#!/bin/sh\nuntil false\n  # keep checking\n\ndo\n  :\ndone\n";
         let recovered = Parser::new(source).parse_recovered();
         let settings = LinterSettings::for_rule(Rule::UntilMissingDo);
         let diagnostics = collect_parse_rule_diagnostics(
@@ -896,6 +1078,28 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::IfBracketGlued);
         assert_eq!(diagnostics[0].span.slice(source), "if[");
+    }
+
+    #[test]
+    fn ignores_valid_if_bracket_spacing_variants_on_line() {
+        for line in [
+            "if [ \"$x\" = ok ]; then",
+            "if  [ \"$x\" = ok ]; then",
+            "if\t[ \"$x\" = ok ]; then",
+        ] {
+            let source = format!("#!/bin/sh\n{line}\n");
+            assert!(
+                if_bracket_glued_span_on_line(&source, 2).is_none(),
+                "unexpected glued match for `{line}`"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_quoted_if_bracket_prefix_text_on_line() {
+        let source = "#!/bin/sh\necho \"if[ literal\"\n";
+
+        assert!(if_bracket_glued_span_on_line(source, 2).is_none());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
+++ b/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
@@ -22,3 +22,46 @@ pub fn find_execdir_with_shell(checker: &mut Checker) {
 
     checker.report_all_dedup(spans, || FindExecDirWithShell);
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_sh_c_execdir_shell_interpolation() {
+        let source = "#!/bin/sh\nfind . -execdir sh -c 'printf \"%s\\n\" {}' \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindExecDirWithShell),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::FindExecDirWithShell);
+        assert_eq!(diagnostics[0].span.slice(source), "'printf \"%s\\n\" {}'");
+    }
+
+    #[test]
+    fn reports_bash_c_execdir_shell_interpolation() {
+        let source = "#!/bin/sh\nfind . -execdir bash -c 'printf \"%s\\n\" {}' \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindExecDirWithShell),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::FindExecDirWithShell);
+        assert_eq!(diagnostics[0].span.slice(source), "'printf \"%s\\n\" {}'");
+    }
+
+    #[test]
+    fn ignores_execdir_forms_without_shell_interpolation() {
+        let source = "#!/bin/sh\nfind . -execdir mv -- {} renamed-file \\;\nfind . -execdir sh ./rename-helper {} \\;\nfind . -execdir sh -c 'printf safe\\n' \\;\nfind . -execdir bash -c 'echo safe' \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindExecDirWithShell),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -23,3 +23,46 @@ pub fn rm_glob_on_variable_path(checker: &mut Checker) {
 
     checker.report_all_dedup(spans, || RmGlobOnVariablePath);
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_globbed_trimmed_parameter_expansion_paths() {
+        let source = "#!/bin/sh\ndir=/tmp/\nrm -rf \"${dir%/}\"/*\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::RmGlobOnVariablePath);
+        assert_eq!(diagnostics[0].span.slice(source), "\"${dir%/}\"/*");
+    }
+
+    #[test]
+    fn ignores_safe_rm_forms_without_globbed_variable_target() {
+        let source = "#!/bin/bash\ndir=/tmp\nfallback=\nrm -rf -- \"$dir\"\nrm -rf /var/tmp/*\nrm -rf \"$dir\"/cache\nrm -rf \"${fallback:-/tmp}\"/*\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_indirect_expansion_rm_targets() {
+        let source = "#!/bin/bash\nroot_ref=HOME\nrm -rf \"${!root_ref}\"/*\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::RmGlobOnVariablePath);
+        assert_eq!(diagnostics[0].span.slice(source), "\"${!root_ref}\"/*");
+    }
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -48,21 +48,12 @@ The reviewed implemented rules below were checked against three gates:
 | Rule | Facts-only / no walks | Duplication | Coverage status | Outcome |
 |---|---|---|---|---|
 | C141 `loop-without-end` | ✅ | ✅ | ✅ positive plus balanced/nested non-trigger tests | vetted |
-| C142 `missing-done-in-for-loop` | ✅ | ✅ | ❌ only single positive fixture today | keep unvetted |
-| C143 `dangling-else` | ✅ | ✅ | ❌ only single positive fixture today | keep unvetted |
-| C146 `until-missing-do` | ✅ | ✅ | ❌ only single positive fixture today | keep unvetted |
-| C157 `if-bracket-glued` | ✅ | ✅ | ❌ only single positive fixture today | keep unvetted |
-| K001 `rm-glob-on-variable-path` | ✅ | ✅ | ❌ lacks non-trigger and precision edge fixtures | keep unvetted |
-| K004 `find-execdir-with-shell` | ✅ | ✅ | ❌ lacks non-trigger and shell-variant fixtures | keep unvetted |
-
-## Validation TODOs
-
-- **C142 `missing-done-in-for-loop`**: add edge-case fixtures for `for` loops with heredocs/line continuations near EOF and a negative case with a valid trailing `done`.
-- **C143 `dangling-else`**: add cases that distinguish parse-recovery noise from true empty `else` branches, including nested `if` blocks.
-- **C146 `until-missing-do`**: add coverage for multiline `until` headers and ensure no finding when `do` appears after comments/blank lines.
-- **C157 `if-bracket-glued`**: add negative tests for valid `if [` formatting variants and quoted strings starting with `if[` to avoid accidental token-text matching.
-- **K001 `rm-glob-on-variable-path`**: add safety-oriented negatives (`rm -rf -- "$dir"`, literal paths, no glob) and cases with indirect/parameter-expanded targets to verify rule precision.
-- **K004 `find-execdir-with-shell`**: add variants for `sh -c`, `bash -c`, and safe `-execdir` forms without shell interpolation to prove matcher breadth is correct.
+| C142 `missing-done-in-for-loop` | ✅ | ✅ | ✅ positive plus heredoc/line-continuation EOF and valid `done` negative tests | vetted |
+| C143 `dangling-else` | ✅ | ✅ | ✅ positive plus nested empty/non-empty parse-recovery tests | vetted |
+| C146 `until-missing-do` | ✅ | ✅ | ✅ positive plus multiline-header and comment/blank-line `do` tests | vetted |
+| C157 `if-bracket-glued` | ✅ | ✅ | ✅ positive plus spacing-variant and quoted-text negative tests | vetted |
+| K001 `rm-glob-on-variable-path` | ✅ | ✅ | ✅ positive plus safe-`rm`, literal-path, and expansion-precision tests | vetted |
+| K004 `find-execdir-with-shell` | ✅ | ✅ | ✅ positive plus `sh -c`, `bash -c`, and safe `-execdir` tests | vetted |
 
 ## Remaining Rules
 


### PR DESCRIPTION
## Summary
- add the missing validation-review coverage for C142, C143, C146, C157, K001, and K004
- keep the existing fixture snapshots as the representative positive coverage and add focused unit tests for negative and precision cases
- update the validation review table and remove the completed TODO section from `docs/rules.md`

## Why
The validation review documented several implemented rules as still unvetted because they only had a single positive fixture or were missing precision-oriented negatives. Those gaps meant the review doc was ahead of the test suite.

## Impact
The added tests cover heredoc and line-continuation EOF handling, nested parse-recovery cases, `until` headers with comments and blank lines, `if [` spacing variants, and the intended breadth of the `rm` and `find -execdir` security matchers.

## Root Cause
The review identified missing coverage, and while filling it the new tests exposed two small edge-case bugs in parse-diagnostic handling:
- `if[` detection could match inside quoted text on a line
- the missing-`done` fallback classifier did not account for backslash-continued loop headers

This PR fixes both behaviors alongside the test additions.

## Validation
- `cargo test -p shuck-linter`