### PR TITLE
Improve zsh parameter parsing for nested and quoted expansions

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1346,6 +1346,7 @@ pub enum BourneParameterExpansion {
 pub struct ZshParameterExpansion {
     pub target: ZshExpansionTarget,
     pub modifiers: Vec<ZshModifier>,
+    pub length_prefix: Option<Span>,
     pub operation: Option<ZshExpansionOperation>,
 }
 

--- a/crates/shuck-parser/src/parser/arithmetic.rs
+++ b/crates/shuck-parser/src/parser/arithmetic.rs
@@ -720,7 +720,12 @@ impl<'a> ArithmeticParser<'a> {
     fn lex_shell_word(&mut self, start: usize) -> Result<Token> {
         let end = self.scan_shell_word_end(start)?;
         let raw = &self.input[start..end];
-        let mut word = Parser::parse_word_string_with_limits(raw, self.max_depth, self.max_fuel);
+        let mut word = Parser::parse_word_string_with_limits_and_dialect(
+            raw,
+            self.max_depth,
+            self.max_fuel,
+            self.dialect,
+        );
         Parser::rebase_word(&mut word, self.position_at(start));
         self.index = end;
         Ok(Token {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -665,7 +665,23 @@ impl<'a> Parser<'a> {
     /// Parse a word string with caller-configured limits.
     /// Prevents bypass of parser limits in parameter expansion contexts.
     pub fn parse_word_string_with_limits(input: &str, max_depth: usize, max_fuel: usize) -> Word {
+        Self::parse_word_string_with_limits_and_dialect(
+            input,
+            max_depth,
+            max_fuel,
+            ShellDialect::Bash,
+        )
+    }
+
+    /// Parse a word string with caller-configured limits and shell dialect.
+    pub fn parse_word_string_with_limits_and_dialect(
+        input: &str,
+        max_depth: usize,
+        max_fuel: usize,
+        dialect: ShellDialect,
+    ) -> Word {
         let mut parser = Parser::with_limits(input, max_depth, max_fuel);
+        parser.dialect = dialect;
         let start = Position::new();
         parser.parse_word_with_context(
             input,
@@ -2650,6 +2666,9 @@ impl<'a> Parser<'a> {
                         argument.rebased(base);
                     }
                 }
+                if let Some(length_prefix) = &mut syntax.length_prefix {
+                    *length_prefix = length_prefix.rebased(base);
+                }
                 if let Some(operation) = &mut syntax.operation {
                     match operation {
                         ZshExpansionOperation::PatternOperation { operand, .. }
@@ -3146,6 +3165,7 @@ impl<'a> Parser<'a> {
         let text = raw_body.slice(self.input);
         let mut index = 0;
         let mut modifiers = Vec::new();
+        let mut length_prefix = None;
         let source_backed = raw_body.is_source_backed();
 
         while text[index..].starts_with('(')
@@ -3154,6 +3174,13 @@ impl<'a> Parser<'a> {
         {
             modifiers.extend(group_modifiers);
             index = next_index;
+        }
+
+        if text[index..].starts_with('#') {
+            let prefix_start = base.advanced_by(&text[..index]);
+            let prefix_end = prefix_start.advanced_by("#");
+            length_prefix = Some(Span::from_positions(prefix_start, prefix_end));
+            index += '#'.len_utf8();
         }
 
         let (target, operation_index) = if text[index..].starts_with("${") {
@@ -3198,6 +3225,7 @@ impl<'a> Parser<'a> {
         ZshParameterExpansion {
             target,
             modifiers,
+            length_prefix,
             operation,
         }
     }
@@ -3250,18 +3278,28 @@ impl<'a> Parser<'a> {
         }
 
         let raw_body = SourceText::from(text[2..text.len() - 1].to_string());
-        let syntax = if raw_body.slice(self.input).starts_with('(')
-            || raw_body.slice(self.input).starts_with(':')
-            || raw_body.slice(self.input).starts_with('^')
-            || raw_body.slice(self.input).starts_with('~')
-            || raw_body.slice(self.input).starts_with('.')
+        let raw_body_text = raw_body.slice(self.input);
+        let syntax = if raw_body_text.starts_with('(')
+            || raw_body_text.starts_with(':')
+            || raw_body_text.starts_with('^')
+            || raw_body_text.starts_with('~')
+            || raw_body_text.starts_with('.')
+            || raw_body_text.starts_with('#')
+            || raw_body_text.starts_with('"')
+            || raw_body_text.starts_with('\'')
+            || raw_body_text.starts_with('$')
+            || raw_body_text
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_digit())
+            || self.find_zsh_operation_start(raw_body_text).is_some()
         {
             ParameterExpansionSyntax::Zsh(
                 self.parse_zsh_parameter_syntax(&raw_body, Position::new()),
             )
         } else {
             ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access {
-                reference: self.parse_loose_var_ref(raw_body.slice(self.input)),
+                reference: self.parse_loose_var_ref(raw_body_text),
             })
         };
 
@@ -3425,15 +3463,38 @@ impl<'a> Parser<'a> {
         None
     }
 
+    fn zsh_modifier_suffix_candidate(rest: &str) -> bool {
+        if rest.is_empty() {
+            return false;
+        }
+
+        let Some(first) = rest.chars().next() else {
+            return false;
+        };
+        if first.is_ascii_digit()
+            || first.is_ascii_whitespace()
+            || matches!(first, '$' | '\'' | '"' | '(' | '{')
+        {
+            return false;
+        }
+
+        rest.split(':').all(|segment| {
+            !segment.is_empty()
+                && segment.len() <= 2
+                && segment.chars().all(|ch| ch.is_ascii_alphabetic())
+        })
+    }
+
     fn zsh_slice_candidate(rest: &str) -> bool {
         let Some(first) = rest.chars().next() else {
             return false;
         };
 
-        first.is_ascii_alphanumeric()
-            || first == '_'
-            || first.is_ascii_whitespace()
-            || matches!(first, '$' | '\'' | '"' | '(' | '{')
+        !Self::zsh_modifier_suffix_candidate(rest)
+            && (first.is_ascii_alphanumeric()
+                || first == '_'
+                || first.is_ascii_whitespace()
+                || matches!(first, '$' | '\'' | '"' | '(' | '{'))
     }
 
     fn parse_zsh_parameter_operation(&self, text: &str, base: Position) -> ZshExpansionOperation {
@@ -3521,17 +3582,25 @@ impl<'a> Parser<'a> {
             };
         }
 
-        if let Some(rest) = text.strip_prefix(':')
-            && Self::zsh_slice_candidate(rest)
-        {
-            let separator = self.find_zsh_top_level_delimiter(rest, ':');
-            let offset_end = separator.unwrap_or(rest.len());
-            return ZshExpansionOperation::Slice {
-                offset: self.zsh_operation_source_text(text, base, 1, 1 + offset_end),
-                length: separator.map(|separator| {
-                    self.zsh_operation_source_text(text, base, 1 + separator + 1, text.len())
-                }),
-            };
+        if let Some(rest) = text.strip_prefix(':') {
+            if Self::zsh_modifier_suffix_candidate(rest) {
+                return ZshExpansionOperation::Unknown(self.source_text(
+                    text.to_string(),
+                    base,
+                    base.advanced_by(text),
+                ));
+            }
+
+            if Self::zsh_slice_candidate(rest) {
+                let separator = self.find_zsh_top_level_delimiter(rest, ':');
+                let offset_end = separator.unwrap_or(rest.len());
+                return ZshExpansionOperation::Slice {
+                    offset: self.zsh_operation_source_text(text, base, 1, 1 + offset_end),
+                    length: separator.map(|separator| {
+                        self.zsh_operation_source_text(text, base, 1 + separator + 1, text.len())
+                    }),
+                };
+            }
         }
 
         ZshExpansionOperation::Unknown(self.source_text(

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -3288,10 +3288,6 @@ impl<'a> Parser<'a> {
             || raw_body_text.starts_with('"')
             || raw_body_text.starts_with('\'')
             || raw_body_text.starts_with('$')
-            || raw_body_text
-                .chars()
-                .next()
-                .is_some_and(|ch| ch.is_ascii_digit())
             || self.find_zsh_operation_start(raw_body_text).is_some()
         {
             ParameterExpansionSyntax::Zsh(

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -3463,6 +3463,19 @@ impl<'a> Parser<'a> {
         None
     }
 
+    fn zsh_simple_modifier_suffix_segment(segment: &str) -> bool {
+        let mut chars = segment.chars();
+        let Some(first) = chars.next() else {
+            return false;
+        };
+
+        match first {
+            'a' | 'A' | 'c' | 'e' | 'l' | 'P' | 'q' | 'Q' | 'r' | 'u' => chars.next().is_none(),
+            'h' | 't' => chars.all(|ch| ch.is_ascii_digit()),
+            _ => false,
+        }
+    }
+
     fn zsh_modifier_suffix_candidate(rest: &str) -> bool {
         if rest.is_empty() {
             return false;
@@ -3478,11 +3491,8 @@ impl<'a> Parser<'a> {
             return false;
         }
 
-        rest.split(':').all(|segment| {
-            !segment.is_empty()
-                && segment.len() <= 2
-                && segment.chars().all(|ch| ch.is_ascii_alphabetic())
-        })
+        rest.split(':')
+            .all(Self::zsh_simple_modifier_suffix_segment)
     }
 
     fn zsh_slice_candidate(rest: &str) -> bool {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -3262,14 +3262,7 @@ impl<'a> Parser<'a> {
 
     fn maybe_parse_loose_var_ref_target(&self, text: &str) -> Option<VarRef> {
         let trimmed = text.trim();
-        let name = if let Some(open) = trimmed.find('[') {
-            trimmed.strip_suffix(']')?;
-            &trimmed[..open]
-        } else {
-            trimmed
-        };
-
-        Self::is_valid_identifier(name).then(|| self.parse_loose_var_ref(trimmed))
+        Self::looks_like_plain_parameter_access(trimmed).then(|| self.parse_loose_var_ref(trimmed))
     }
 
     fn is_plain_special_parameter_name(name: &str) -> bool {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -3272,6 +3272,30 @@ impl<'a> Parser<'a> {
         Self::is_valid_identifier(name).then(|| self.parse_loose_var_ref(trimmed))
     }
 
+    fn is_plain_special_parameter_name(name: &str) -> bool {
+        matches!(name, "#" | "$" | "!" | "*" | "@" | "?" | "-") || name == "0"
+    }
+
+    fn looks_like_plain_parameter_access(text: &str) -> bool {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+
+        let name = if let Some(open) = trimmed.find('[') {
+            if !trimmed.ends_with(']') {
+                return false;
+            }
+            &trimmed[..open]
+        } else {
+            trimmed
+        };
+
+        Self::is_valid_identifier(name)
+            || name.bytes().all(|byte| byte.is_ascii_digit())
+            || Self::is_plain_special_parameter_name(name)
+    }
+
     fn parse_nested_parameter_target(&mut self, text: &str) -> ZshExpansionTarget {
         if !(text.starts_with("${") && text.ends_with('}')) {
             return self.parse_zsh_target_from_text(text, Position::new(), false);
@@ -3279,7 +3303,12 @@ impl<'a> Parser<'a> {
 
         let raw_body = SourceText::from(text[2..text.len() - 1].to_string());
         let raw_body_text = raw_body.slice(self.input);
-        let syntax = if raw_body_text.starts_with('(')
+        let has_operation = self.find_zsh_operation_start(raw_body_text).is_some();
+        let syntax = if Self::looks_like_plain_parameter_access(raw_body_text) && !has_operation {
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access {
+                reference: self.parse_loose_var_ref(raw_body_text),
+            })
+        } else if raw_body_text.starts_with('(')
             || raw_body_text.starts_with(':')
             || raw_body_text.starts_with('^')
             || raw_body_text.starts_with('~')
@@ -3288,7 +3317,7 @@ impl<'a> Parser<'a> {
             || raw_body_text.starts_with('"')
             || raw_body_text.starts_with('\'')
             || raw_body_text.starts_with('$')
-            || self.find_zsh_operation_start(raw_body_text).is_some()
+            || has_operation
         {
             ParameterExpansionSyntax::Zsh(
                 self.parse_zsh_parameter_syntax(&raw_body, Position::new()),

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3846,6 +3846,41 @@ fn test_zsh_parameter_colon_modifiers_preserve_targets_without_bourne_slice_offs
 }
 
 #[test]
+fn test_zsh_parameter_colon_modifiers_with_digits_preserve_targets() {
+    let source = "print ${path:A:h3} ${path:t2}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let first = expect_parameter(&command.args[0]);
+    let ParameterExpansionSyntax::Zsh(first) = &first.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &first.target else {
+        panic!("expected reference target");
+    };
+    assert_eq!(reference.name.as_str(), "path");
+    assert!(matches!(
+        first.operation,
+        Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":A:h3"
+    ));
+
+    let second = expect_parameter(&command.args[1]);
+    let ParameterExpansionSyntax::Zsh(second) = &second.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &second.target else {
+        panic!("expected reference target");
+    };
+    assert_eq!(reference.name.as_str(), "path");
+    assert!(matches!(
+        second.operation,
+        Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":t2"
+    ));
+}
+
+#[test]
 fn test_parse_zsh_array_assignment_with_word_target_and_glob_qualifier() {
     let source = "dirs=( /proc/${^$(pidof zsh):#$$}/cwd(N:A) )\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)
@@ -3975,6 +4010,81 @@ fn test_parse_zsh_arithmetic_shell_word_preserves_nested_length_target() {
             ref pattern,
             replacement: Some(ref replacement),
         }) if pattern.slice(source) == "${~q}" && replacement.slice(source).is_empty()
+    ));
+}
+
+#[test]
+fn test_zsh_parameter_identifier_slices_preserve_legacy_slice_parts() {
+    let source = "print ${foo:i} ${foo:i:j}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let (first_reference, first_offset_ast, first_length_ast) =
+        expect_substring_part(&command.args[0].parts[0].kind);
+    assert_eq!(first_reference.name.as_str(), "foo");
+    assert_eq!(
+        first_offset_ast
+            .as_ref()
+            .expect("expected first offset AST")
+            .span
+            .slice(source),
+        "i"
+    );
+    assert!(first_length_ast.is_none());
+
+    let (second_reference, second_offset_ast, second_length_ast) =
+        expect_substring_part(&command.args[1].parts[0].kind);
+    assert_eq!(second_reference.name.as_str(), "foo");
+    assert_eq!(
+        second_offset_ast
+            .as_ref()
+            .expect("expected second offset AST")
+            .span
+            .slice(source),
+        "i"
+    );
+    assert_eq!(
+        second_length_ast
+            .as_ref()
+            .expect("expected second length AST")
+            .span
+            .slice(source),
+        "j"
+    );
+}
+
+#[test]
+fn test_zsh_parameter_identifier_slices_stay_typed_in_zsh_parameter_nodes() {
+    let source = "print ${(m)foo:i:j}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let parameter = expect_parameter(&command.args[0]);
+    let ParameterExpansionSyntax::Zsh(parameter) = &parameter.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        parameter
+            .modifiers
+            .iter()
+            .map(|modifier| modifier.name)
+            .collect::<Vec<_>>(),
+        vec!['m']
+    );
+    let ZshExpansionTarget::Reference(reference) = &parameter.target else {
+        panic!("expected reference target");
+    };
+    assert_eq!(reference.name.as_str(), "foo");
+    assert!(matches!(
+        parameter.operation,
+        Some(ZshExpansionOperation::Slice {
+            ref offset,
+            length: Some(ref length),
+        }) if offset.slice(source) == "i" && length.slice(source) == "j"
     ));
 }
 

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -4174,6 +4174,67 @@ fn test_zsh_nested_parameter_modifier_records_nested_target_and_pattern_operatio
 }
 
 #[test]
+fn test_zsh_nested_positional_targets_preserve_bourne_refs_without_modifier_regression() {
+    let source = "print ${${10}} ${#${10}} ${${1:t}}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let nested = expect_parameter(&command.args[0]);
+    let ParameterExpansionSyntax::Zsh(nested) = &nested.syntax else {
+        panic!("expected outer zsh syntax");
+    };
+    let ZshExpansionTarget::Nested(inner) = &nested.target else {
+        panic!("expected nested target");
+    };
+    assert!(matches!(
+        &inner.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+            if reference.name.as_str() == "10"
+    ));
+
+    let length = expect_parameter(&command.args[1]);
+    let ParameterExpansionSyntax::Zsh(length) = &length.syntax else {
+        panic!("expected outer zsh syntax");
+    };
+    assert_eq!(
+        length
+            .length_prefix
+            .expect("expected zsh length prefix")
+            .slice(source),
+        "#"
+    );
+    let ZshExpansionTarget::Nested(inner) = &length.target else {
+        panic!("expected nested length target");
+    };
+    assert!(matches!(
+        &inner.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+            if reference.name.as_str() == "10"
+    ));
+
+    let modifier = expect_parameter(&command.args[2]);
+    let ParameterExpansionSyntax::Zsh(modifier) = &modifier.syntax else {
+        panic!("expected outer zsh syntax");
+    };
+    let ZshExpansionTarget::Nested(inner) = &modifier.target else {
+        panic!("expected nested modifier target");
+    };
+    let ParameterExpansionSyntax::Zsh(inner) = &inner.syntax else {
+        panic!("expected inner zsh syntax");
+    };
+    let ZshExpansionTarget::Word(word) = &inner.target else {
+        panic!("expected positional word target");
+    };
+    assert_eq!(word.render(source), "1");
+    assert!(matches!(
+        inner.operation,
+        Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":t"
+    ));
+}
+
+#[test]
 fn test_zsh_parameter_supported_operations_are_typed_and_preserve_source_spans() {
     let source = "print ${(m)foo#${needle}} ${(S)foo//\"pre\"$suffix/$replacement} ${(m)foo:$offset:${length}} ${(m)foo:^other}\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -4174,8 +4174,8 @@ fn test_zsh_nested_parameter_modifier_records_nested_target_and_pattern_operatio
 }
 
 #[test]
-fn test_zsh_nested_positional_targets_preserve_bourne_refs_without_modifier_regression() {
-    let source = "print ${${10}} ${#${10}} ${${1:t}}\n";
+fn test_zsh_nested_plain_access_targets_preserve_bourne_refs_without_modifier_regression() {
+    let source = "print ${${10}} ${#${10}} ${${#}} ${${$}} ${${1:t}}\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)
         .parse()
         .unwrap();
@@ -4214,7 +4214,33 @@ fn test_zsh_nested_positional_targets_preserve_bourne_refs_without_modifier_regr
             if reference.name.as_str() == "10"
     ));
 
-    let modifier = expect_parameter(&command.args[2]);
+    let count = expect_parameter(&command.args[2]);
+    let ParameterExpansionSyntax::Zsh(count) = &count.syntax else {
+        panic!("expected outer zsh syntax");
+    };
+    let ZshExpansionTarget::Nested(inner) = &count.target else {
+        panic!("expected nested count target");
+    };
+    assert!(matches!(
+        &inner.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+            if reference.name.as_str() == "#"
+    ));
+
+    let pid = expect_parameter(&command.args[3]);
+    let ParameterExpansionSyntax::Zsh(pid) = &pid.syntax else {
+        panic!("expected outer zsh syntax");
+    };
+    let ZshExpansionTarget::Nested(inner) = &pid.target else {
+        panic!("expected nested pid target");
+    };
+    assert!(matches!(
+        &inner.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+            if reference.name.as_str() == "$"
+    ));
+
+    let modifier = expect_parameter(&command.args[4]);
     let ParameterExpansionSyntax::Zsh(modifier) = &modifier.syntax else {
         panic!("expected outer zsh syntax");
     };

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3881,6 +3881,43 @@ fn test_zsh_parameter_colon_modifiers_with_digits_preserve_targets() {
 }
 
 #[test]
+fn test_zsh_plain_positional_parameters_preserve_bourne_references() {
+    let source = "print ${1} ${10} ${#1} ${#10}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let first = expect_parameter(&command.args[0]);
+    assert!(matches!(
+        &first.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+            if reference.name.as_str() == "1"
+    ));
+
+    let second = expect_parameter(&command.args[1]);
+    assert!(matches!(
+        &second.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+            if reference.name.as_str() == "10"
+    ));
+
+    let third = expect_parameter(&command.args[2]);
+    assert!(matches!(
+        &third.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { reference })
+            if reference.name.as_str() == "1"
+    ));
+
+    let fourth = expect_parameter(&command.args[3]);
+    assert!(matches!(
+        &fourth.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { reference })
+            if reference.name.as_str() == "10"
+    ));
+}
+
+#[test]
 fn test_parse_zsh_array_assignment_with_word_target_and_glob_qualifier() {
     let source = "dirs=( /proc/${^$(pidof zsh):#$$}/cwd(N:A) )\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3732,6 +3732,120 @@ fn test_zsh_parameter_word_target_preserves_non_reference_target_text() {
 }
 
 #[test]
+fn test_zsh_parameter_word_target_accepts_quoted_command_substitution_text() {
+    let source = "print ${\"$(xcode-select -p)\"%%/Contents/Developer*}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+    let parameter = expect_parameter(&command.args[0]);
+
+    let ParameterExpansionSyntax::Zsh(parameter) = &parameter.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert!(parameter.length_prefix.is_none());
+    let ZshExpansionTarget::Word(word) = &parameter.target else {
+        panic!("expected quoted word target");
+    };
+    assert_eq!(word.span.slice(source), "\"$(xcode-select -p)\"");
+    assert!(matches!(
+        parameter.operation,
+        Some(ZshExpansionOperation::TrimOperation {
+            kind: ZshTrimOp::RemoveSuffixLong,
+            ref operand,
+        }) if operand.slice(source) == "/Contents/Developer*"
+    ));
+}
+
+#[test]
+fn test_zsh_parameter_length_prefix_preserves_nested_replacement_target() {
+    let source = "print ${#${cd//${~q}/}}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+    let parameter = expect_parameter(&command.args[0]);
+
+    let ParameterExpansionSyntax::Zsh(parameter) = &parameter.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        parameter
+            .length_prefix
+            .expect("expected zsh length prefix")
+            .slice(source),
+        "#"
+    );
+    let ZshExpansionTarget::Nested(inner) = &parameter.target else {
+        panic!("expected nested zsh target");
+    };
+    assert_eq!(inner.raw_body.slice(source), "cd//${~q}/");
+    let ParameterExpansionSyntax::Zsh(inner) = &inner.syntax else {
+        panic!("expected nested zsh syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &inner.target else {
+        panic!("expected nested replacement target reference");
+    };
+    assert_eq!(reference.name.as_str(), "cd");
+    assert!(matches!(
+        inner.operation,
+        Some(ZshExpansionOperation::ReplacementOperation {
+            kind: ZshReplacementOp::ReplaceAll,
+            ref pattern,
+            replacement: Some(ref replacement),
+        }) if pattern.slice(source) == "${~q}" && replacement.slice(source).is_empty()
+    ));
+}
+
+#[test]
+fn test_zsh_parameter_colon_modifiers_preserve_targets_without_bourne_slice_offsets() {
+    let source = "print ${REPLY:l} ${1:t} ${0:h}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let reply = expect_parameter(&command.args[0]);
+    let ParameterExpansionSyntax::Zsh(reply) = &reply.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &reply.target else {
+        panic!("expected reference target");
+    };
+    assert_eq!(reference.name.as_str(), "REPLY");
+    assert!(matches!(
+        reply.operation,
+        Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":l"
+    ));
+
+    let first = expect_parameter(&command.args[1]);
+    let ParameterExpansionSyntax::Zsh(first) = &first.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Word(word) = &first.target else {
+        panic!("expected positional word target");
+    };
+    assert_eq!(word.render(source), "1");
+    assert!(matches!(
+        first.operation,
+        Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":t"
+    ));
+
+    let zero = expect_parameter(&command.args[2]);
+    let ParameterExpansionSyntax::Zsh(zero) = &zero.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Word(word) = &zero.target else {
+        panic!("expected script-name word target");
+    };
+    assert_eq!(word.render(source), "0");
+    assert!(matches!(
+        zero.operation,
+        Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":h"
+    ));
+}
+
+#[test]
 fn test_parse_zsh_array_assignment_with_word_target_and_glob_qualifier() {
     let source = "dirs=( /proc/${^$(pidof zsh):#$$}/cwd(N:A) )\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)
@@ -3813,6 +3927,55 @@ fn test_parse_zsh_arithmetic_shell_word_lookup_with_nested_modifier() {
     Parser::with_dialect(source, ShellDialect::Zsh)
         .parse()
         .unwrap();
+}
+
+#[test]
+fn test_parse_zsh_arithmetic_shell_word_preserves_nested_length_target() {
+    let source = "(( q_chars = ${#${cd//${~q}/}} ))\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let (compound, _) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::Arithmetic(command) = compound else {
+        panic!("expected arithmetic command");
+    };
+    let expr = command.expr_ast.as_ref().expect("expected arithmetic AST");
+    let ArithmeticExpr::Assignment { value, .. } = &expr.kind else {
+        panic!("expected arithmetic assignment");
+    };
+    let ArithmeticExpr::ShellWord(word) = &value.kind else {
+        panic!("expected arithmetic shell word");
+    };
+    let parameter = expect_parameter(word);
+
+    let ParameterExpansionSyntax::Zsh(parameter) = &parameter.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        parameter
+            .length_prefix
+            .expect("expected zsh length prefix")
+            .slice(source),
+        "#"
+    );
+    let ZshExpansionTarget::Nested(inner) = &parameter.target else {
+        panic!("expected nested zsh target");
+    };
+    let ParameterExpansionSyntax::Zsh(inner) = &inner.syntax else {
+        panic!("expected nested zsh syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &inner.target else {
+        panic!("expected nested reference target");
+    };
+    assert_eq!(reference.name.as_str(), "cd");
+    assert!(matches!(
+        inner.operation,
+        Some(ZshExpansionOperation::ReplacementOperation {
+            kind: ZshReplacementOp::ReplaceAll,
+            ref pattern,
+            replacement: Some(ref replacement),
+        }) if pattern.slice(source) == "${~q}" && replacement.slice(source).is_empty()
+    ));
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3822,10 +3822,10 @@ fn test_zsh_parameter_colon_modifiers_preserve_targets_without_bourne_slice_offs
     let ParameterExpansionSyntax::Zsh(first) = &first.syntax else {
         panic!("expected zsh parameter syntax");
     };
-    let ZshExpansionTarget::Word(word) = &first.target else {
-        panic!("expected positional word target");
+    let ZshExpansionTarget::Reference(reference) = &first.target else {
+        panic!("expected positional reference target");
     };
-    assert_eq!(word.render(source), "1");
+    assert_eq!(reference.name.as_str(), "1");
     assert!(matches!(
         first.operation,
         Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":t"
@@ -3835,10 +3835,10 @@ fn test_zsh_parameter_colon_modifiers_preserve_targets_without_bourne_slice_offs
     let ParameterExpansionSyntax::Zsh(zero) = &zero.syntax else {
         panic!("expected zsh parameter syntax");
     };
-    let ZshExpansionTarget::Word(word) = &zero.target else {
-        panic!("expected script-name word target");
+    let ZshExpansionTarget::Reference(reference) = &zero.target else {
+        panic!("expected script-name reference target");
     };
-    assert_eq!(word.render(source), "0");
+    assert_eq!(reference.name.as_str(), "0");
     assert!(matches!(
         zero.operation,
         Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":h"
@@ -4250,10 +4250,10 @@ fn test_zsh_nested_plain_access_targets_preserve_bourne_refs_without_modifier_re
     let ParameterExpansionSyntax::Zsh(inner) = &inner.syntax else {
         panic!("expected inner zsh syntax");
     };
-    let ZshExpansionTarget::Word(word) = &inner.target else {
-        panic!("expected positional word target");
+    let ZshExpansionTarget::Reference(reference) = &inner.target else {
+        panic!("expected positional reference target");
     };
-    assert_eq!(word.render(source), "1");
+    assert_eq!(reference.name.as_str(), "1");
     assert!(matches!(
         inner.operation,
         Some(ZshExpansionOperation::Unknown(ref operand)) if operand.slice(source) == ":t"

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2022,15 +2022,49 @@ impl<'a> Parser<'a> {
         &self,
         chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
     ) -> bool {
-        self.dialect.features().zsh_parameter_modifiers
-            && chars.peek().copied() == Some(':')
-            && Self::zsh_modifier_suffix_candidate(
-                chars
-                    .clone()
-                    .skip(1)
-                    .collect::<String>()
-                    .trim_end_matches('}'),
-            )
+        if !self.dialect.features().zsh_parameter_modifiers || chars.peek().copied() != Some(':') {
+            return false;
+        }
+
+        let mut lookahead = chars.clone();
+        lookahead.next();
+        Self::zsh_modifier_suffix_candidate_chars(&mut lookahead)
+    }
+
+    fn zsh_modifier_suffix_candidate_chars(
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    ) -> bool {
+        let mut saw_segment = false;
+
+        loop {
+            let Some(first) = chars.next() else {
+                return saw_segment;
+            };
+
+            if first == '}' {
+                return saw_segment;
+            }
+
+            match first {
+                'a' | 'A' | 'c' | 'e' | 'l' | 'P' | 'q' | 'Q' | 'r' | 'u' => {}
+                'h' | 't' => {
+                    while matches!(chars.peek(), Some(ch) if ch.is_ascii_digit()) {
+                        chars.next();
+                    }
+                }
+                _ => return false,
+            }
+
+            saw_segment = true;
+
+            match chars.peek().copied() {
+                Some(':') => {
+                    chars.next();
+                }
+                Some('}') | None => return true,
+                _ => return false,
+            }
+        }
     }
 
     fn prefixed_parameter_raw_body(

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1998,6 +1998,60 @@ impl<'a> Parser<'a> {
         )))
     }
 
+    fn zsh_parameter_requires_fallback(
+        &self,
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    ) -> bool {
+        if !self.dialect.features().zsh_parameter_modifiers {
+            return false;
+        }
+
+        match chars.peek().copied() {
+            Some('"') | Some('\'') => true,
+            Some(ch) if ch.is_ascii_digit() => true,
+            Some('$') => {
+                let mut lookahead = chars.clone();
+                lookahead.next();
+                matches!(lookahead.peek().copied(), Some('(' | '{' | '"' | '\''))
+            }
+            _ => false,
+        }
+    }
+
+    fn zsh_parameter_suffix_looks_like_modifier(
+        &self,
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    ) -> bool {
+        self.dialect.features().zsh_parameter_modifiers
+            && chars.peek().copied() == Some(':')
+            && Self::zsh_modifier_suffix_candidate(
+                chars
+                    .clone()
+                    .skip(1)
+                    .collect::<String>()
+                    .trim_end_matches('}'),
+            )
+    }
+
+    fn prefixed_parameter_raw_body(
+        &self,
+        prefix: &str,
+        prefix_start: Position,
+        tail: SourceText,
+        source_backed: bool,
+    ) -> SourceText {
+        if source_backed && tail.is_source_backed() {
+            SourceText::source(Span::from_positions(prefix_start, tail.span().end))
+        } else {
+            let prefix_end = prefix_start.advanced_by(prefix);
+            self.source_text(
+                format!("{prefix}{}", tail.slice(self.input)),
+                prefix_start,
+                prefix_end.advanced_by(tail.slice(self.input)),
+            )
+        }
+    }
+
     pub(super) fn parse_var_ref_from_word(
         &self,
         word: &Word,
@@ -2857,6 +2911,14 @@ impl<'a> Parser<'a> {
                     continue;
                 }
 
+                if self.zsh_parameter_requires_fallback(&mut chars) {
+                    let raw_body = self.read_brace_operand(&mut chars, &mut cursor, source_backed);
+                    let parameter = self.zsh_parameter_word_part(raw_body, part_start, cursor);
+                    Self::push_word_part(parts, parameter, part_start, cursor);
+                    current_start = cursor;
+                    continue;
+                }
+
                 if Self::consume_word_char_if(&mut chars, &mut cursor, '#') {
                     if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
                         let part = self.parameter_word_part_from_legacy(
@@ -2866,6 +2928,20 @@ impl<'a> Parser<'a> {
                             source_backed,
                         );
                         Self::push_word_part(parts, part, part_start, cursor);
+                        current_start = cursor;
+                        continue;
+                    }
+
+                    if self.zsh_parameter_requires_fallback(&mut chars) {
+                        let tail = self.read_brace_operand(&mut chars, &mut cursor, source_backed);
+                        let raw_body = self.prefixed_parameter_raw_body(
+                            "#",
+                            brace_body_start,
+                            tail,
+                            source_backed,
+                        );
+                        let parameter = self.zsh_parameter_word_part(raw_body, part_start, cursor);
+                        Self::push_word_part(parts, parameter, part_start, cursor);
                         current_start = cursor;
                         continue;
                     }
@@ -3249,6 +3325,20 @@ impl<'a> Parser<'a> {
                                     operand: Some(operand),
                                     colon_variant: true,
                                 }
+                            } else if self.zsh_parameter_suffix_looks_like_modifier(&mut chars) {
+                                let tail =
+                                    self.read_brace_operand(&mut chars, &mut cursor, source_backed);
+                                let raw_body = self.prefixed_parameter_raw_body(
+                                    &format!("{}[{}]", var_name, subscript.syntax_text(self.input)),
+                                    brace_body_start,
+                                    tail,
+                                    source_backed,
+                                );
+                                let parameter =
+                                    self.zsh_parameter_word_part(raw_body, part_start, cursor);
+                                Self::push_word_part(parts, parameter, part_start, cursor);
+                                current_start = cursor;
+                                continue;
                             } else {
                                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
                                 let offset = self.read_source_text_while(
@@ -3370,6 +3460,22 @@ impl<'a> Parser<'a> {
                 let part = if let Some(c) = chars.peek().copied() {
                     match c {
                         ':' => {
+                            if self.zsh_parameter_suffix_looks_like_modifier(&mut chars) {
+                                let tail =
+                                    self.read_brace_operand(&mut chars, &mut cursor, source_backed);
+                                let raw_body = self.prefixed_parameter_raw_body(
+                                    &var_name,
+                                    brace_body_start,
+                                    tail,
+                                    source_backed,
+                                );
+                                let parameter =
+                                    self.zsh_parameter_word_part(raw_body, part_start, cursor);
+                                Self::push_word_part(parts, parameter, part_start, cursor);
+                                current_start = cursor;
+                                continue;
+                            }
+
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             match chars.peek() {
                                 Some(&'-') | Some(&'=') | Some(&'+') | Some(&'?') => {

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2008,7 +2008,7 @@ impl<'a> Parser<'a> {
 
         match chars.peek().copied() {
             Some('"') | Some('\'') => true,
-            Some(ch) if ch.is_ascii_digit() => true,
+            Some(ch) if ch.is_ascii_digit() => self.zsh_numeric_parameter_requires_fallback(chars),
             Some('$') => {
                 let mut lookahead = chars.clone();
                 lookahead.next();
@@ -2016,6 +2016,23 @@ impl<'a> Parser<'a> {
             }
             _ => false,
         }
+    }
+
+    fn zsh_numeric_parameter_requires_fallback(
+        &self,
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    ) -> bool {
+        let mut lookahead = chars.clone();
+        while matches!(lookahead.peek(), Some(ch) if ch.is_ascii_digit()) {
+            lookahead.next();
+        }
+
+        if lookahead.peek().copied() != Some(':') {
+            return false;
+        }
+
+        lookahead.next();
+        Self::zsh_modifier_suffix_candidate_chars(&mut lookahead)
     }
 
     fn zsh_parameter_suffix_looks_like_modifier(

--- a/crates/shuck-parser/tests/testdata/oils/zsh-large-corpus-regressions.test.sh
+++ b/crates/shuck-parser/tests/testdata/oils/zsh-large-corpus-regressions.test.sh
@@ -3130,3 +3130,21 @@ else
     }
   }
 fi
+
+#### minimization__zsh_parameter_quoted_word_target_trim
+
+# regression surface: quoted command-substitution targets in zsh parameter trims
+
+print ${"$(xcode-select -p)"%%/Contents/Developer*}
+
+#### minimization__zsh_parameter_nested_length_target
+
+# regression surface: nested zsh replacement expressions under ${#...} length prefixes
+
+print ${#${cd//${~q}/}}
+
+#### minimization__zsh_parameter_colon_modifier_targets
+
+# regression surface: zsh :h/:t/:l-style suffixes on identifier and positional targets
+
+print ${REPLY:l} ${1:t} ${0:h}

--- a/crates/shuck-parser/tests/testdata/oils_expectations.json
+++ b/crates/shuck-parser/tests/testdata/oils_expectations.json
@@ -631,6 +631,18 @@
     "expectation": "parse_ok",
     "reason": "while loops with arithmetic conditionals and zsh contextual subscripts now parse in this fixture"
   },
+  "oils/zsh-large-corpus-regressions.test.sh::minimization__zsh_parameter_quoted_word_target_trim": {
+    "expectation": "parse_ok",
+    "reason": "regression minimization for zsh quoted parameter word targets in trim operations"
+  },
+  "oils/zsh-large-corpus-regressions.test.sh::minimization__zsh_parameter_nested_length_target": {
+    "expectation": "parse_ok",
+    "reason": "regression minimization for zsh nested length prefixes over replacement expressions"
+  },
+  "oils/zsh-large-corpus-regressions.test.sh::minimization__zsh_parameter_colon_modifier_targets": {
+    "expectation": "parse_ok",
+    "reason": "regression minimization for zsh colon modifier suffixes on identifier and positional targets"
+  },
   "oils/zsh-large-corpus-regressions.test.sh": {
     "expectation": "skip",
     "reason": "zsh-only regression snippets are covered by the zsh-mode parser corpus test"


### PR DESCRIPTION
## Summary
- preserve zsh parameter structure for quoted targets and length-prefixed nested expansions
- treat common zsh colon modifiers as zsh modifiers instead of Bourne slice offsets
- parse arithmetic shell words with the active shell dialect and add parser/Oils regressions

## Why
Valid zsh constructs were being decoded into malformed parameter shapes, which could leak bogus variable references into downstream analysis.

## Validation
- cargo fmt
- cargo test -p shuck-parser -- --nocapture
- cargo build -p shuck
- direct uncached `shuck check` probes against minimized zsh snippets and local zsh files

## Follow-up
One remaining C006 false positive still shows up around `(( ${fpath[(ie)${0:A:h}]} <= ${#fpath} ))` in `~/.oh-my-zsh/plugins/z/z.plugin.zsh`, and it now looks linter-side rather than parser-side.
