### PR TITLE
Auto-tag releases on PR merge

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,29 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: true
+      - name: Create and push tag
+        run: |
+          TAG="${BRANCH#release/}"
+          echo "Tagging ${TAG} at ${SHA}"
+          git tag "${TAG}" "${SHA}"
+          git push origin "${TAG}"
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,8 +123,7 @@ PR_URL=$(gh pr create \
 
 echo
 echo "Pull request created: $PR_URL"
-echo "After merging, tag the release with:"
-echo "  git pull && git tag v$NEW_VERSION && git push --tags"
+echo "Merging the PR will automatically tag v$NEW_VERSION and trigger the release workflow."
 
 # Return to main
 git -C "$REPO_ROOT" checkout main


### PR DESCRIPTION
## Summary
- Add `tag-release.yml` workflow that triggers when a `release/v*` PR is merged into main, automatically creating and pushing the version tag
- Update `release.sh` to reflect the new automated flow instead of printing manual tag instructions

## Test plan
- [ ] Run `make release --dry-run` to verify updated messaging
- [ ] Merge a test release PR and confirm the tag is created and the release workflow triggers