### PR TITLE
Use PAT for tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
+          token: ${{ secrets.RELEASE_PAT }}
       - name: Create and push tag
         run: |
           TAG="${BRANCH#release/}"


### PR DESCRIPTION
## Summary
- Use `RELEASE_PAT` secret in the tag-release checkout so the pushed tag triggers the release workflow
- Tags pushed by the default `GITHUB_TOKEN` are ignored by other workflows by design

## Test plan
- [ ] After merging, delete and re-push `v0.0.4` to verify the release workflow triggers