### PR TITLE
Skip cargo-dist CI file freshness check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,5 @@ install-path = "CARGO_HOME"
 install-updater = false
 # Don't run release checks on pull requests
 pr-run-mode = "skip"
+# We pin actions to commit SHAs, so skip the CI file freshness check
+allow-dirty = ["ci"]


### PR DESCRIPTION
## Summary
- Add `allow-dirty = ["ci"]` to `[workspace.metadata.dist]` so cargo-dist doesn't fail when `release.yml` diverges from its template
- We pin actions to commit SHAs and add an `environment: release` gate, which causes the freshness check to fail

## Test plan
- [ ] Verify the release workflow passes after deleting and re-pushing `v0.0.5`