### PR TITLE
Implement array operation correctness rules

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C106.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C106.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Invalid: this appends text to an existing array element.
+items=(one)
+items+=" two"
+
+# Invalid: declaration-created arrays still need +=(...) for new elements.
+declare -a flags=(--first)
+flags+=" ${extra}"
+
+# Valid: this appends a new element.
+items+=("three")
+
+# Valid: scalar append is intentional.
+name=base
+name+=" suffix"
+
+# Valid: appending to a specific element is outside this rule.
+items[0]+=" tail"
+
+# Valid: array defined later should not classify this as an array append.
+late+=" value"
+late=(value)
+
+# Valid: local scalar shadowing should not inherit outer array type.
+arr=(one)
+f() {
+  local arr=base
+  arr+=" two"
+}

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C108.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C108.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Invalid: quoted keys in associative-array unset operands.
+declare -A parts
+parts[one]=1
+parts[two]=2
+unset parts["one"]
+unset parts['two']
+key=two
+unset parts["$key"]
+
+# Valid: unquoted key operand for associative arrays.
+unset parts[$key]
+
+# Valid: quote the entire operand to keep it literal.
+unset 'parts[key]'
+unset "parts[key]"
+
+# Valid: indexed arrays are outside this rule.
+declare -a nums
+nums[1]=one
+unset nums["1"]

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C133.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C133.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Invalid: array flattened into same-name scalar, then reused as scalar text.
+exts=("txt" "pdf" "doc")
+exts="${exts[*]}"
+exts+=" ${exts^^}"
+echo "$exts"
+
+# Valid: flattening into a different scalar variable.
+joined="${exts[*]}"
+echo "$joined"
+
+# Valid: non all-elements subscript does not trigger this rule.
+head="${exts[0]}"
+echo "$head"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C148.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C148.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Invalid: associative-array key is missing its closing bracket.
+declare -A table=([left]=1 [right=2)
+
+# Valid: properly closed associative-array keys.
+declare -A table_ok=([left]=1 [right]=2)
+
+# Valid: indexed arrays are outside this rule.
+declare -a nums=([0]=1 [1=2)
+
+# Valid: non-key words in associative compound assignments.
+declare -A pairs=(left one right two)

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C151.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C151.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Invalid: commas inside unquoted array values become part of one element.
+parts=(alpha,beta)
+parts=(alpha, beta)
+parts+=(gamma,delta)
+declare -a flags=(--one,--two)
+declare -A assoc=([left]=1, [right]=2)
+values=(head,$tail)
+mixed=(head,{left,right},tail)
+
+# Valid: whitespace-separated array elements.
+parts_ok=(alpha beta)
+parts_ok+=(gamma delta)
+declare -A assoc_ok=([left]=1 [right]=2)
+
+# Valid: commas in quoted words are literal data.
+quoted1=("alpha,beta")
+quoted2=('gamma,delta')
+
+# Valid: brace expansion comma lists are not array separators.
+brace=({one,two})
+brace_paths=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -159,6 +159,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::BrokenAssocKey) {
             rules::correctness::broken_assoc_key::broken_assoc_key(self);
         }
+        if self.is_rule_enabled(Rule::CommaArrayElements) {
+            rules::correctness::comma_array_elements::comma_array_elements(self);
+        }
     }
 
     fn check_references(&mut self) {

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -153,6 +153,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::AppendToArrayAsString) {
             rules::correctness::append_to_array_as_string::append_to_array_as_string(self);
         }
+        if self.is_rule_enabled(Rule::ArrayToStringConversion) {
+            rules::correctness::array_to_string_conversion::array_to_string_conversion(self);
+        }
     }
 
     fn check_references(&mut self) {

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -150,6 +150,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::UnusedAssignment) {
             rules::correctness::unused_assignment::unused_assignment(self);
         }
+        if self.is_rule_enabled(Rule::AppendToArrayAsString) {
+            rules::correctness::append_to_array_as_string::append_to_array_as_string(self);
+        }
     }
 
     fn check_references(&mut self) {

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -306,6 +306,11 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::FindOrWithoutGrouping) {
             rules::correctness::find_or_without_grouping::find_or_without_grouping(self);
         }
+        if self.is_rule_enabled(Rule::UnsetAssociativeArrayElement) {
+            rules::correctness::unset_associative_array_element::unset_associative_array_element(
+                self,
+            );
+        }
         if self.is_rule_enabled(Rule::MisspelledOptionName) {
             rules::correctness::misspelled_option_name::misspelled_option_name(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -156,6 +156,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::ArrayToStringConversion) {
             rules::correctness::array_to_string_conversion::array_to_string_conversion(self);
         }
+        if self.is_rule_enabled(Rule::BrokenAssocKey) {
+            rules::correctness::broken_assoc_key::broken_assoc_key(self);
+        }
     }
 
     fn check_references(&mut self) {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -8041,16 +8041,21 @@ fn collect_broken_assoc_key_spans_in_assignment(
         let ArrayElem::Sequential(word) = element else {
             continue;
         };
-        if has_unclosed_assoc_key_prefix(word.span.slice(source)) {
+        if has_unclosed_assoc_key_prefix(word, source) {
             spans.push(word.span);
         }
     }
 }
 
-fn has_unclosed_assoc_key_prefix(text: &str) -> bool {
+fn has_unclosed_assoc_key_prefix(word: &Word, source: &str) -> bool {
+    let text = word.span.slice(source);
     if !text.starts_with('[') {
         return false;
     }
+
+    let mut excluded = expansion_part_spans(word);
+    excluded.sort_by_key(|span| span.start.offset);
+    let mut excluded = excluded.into_iter().peekable();
 
     let mut bracket_depth = 0_i32;
     let mut in_single = false;
@@ -8058,7 +8063,21 @@ fn has_unclosed_assoc_key_prefix(text: &str) -> bool {
     let mut escaped = false;
     let mut saw_equals = false;
 
-    for ch in text.chars() {
+    for (offset, ch) in text.char_indices() {
+        let absolute_offset = word.span.start.offset + offset;
+        while matches!(
+            excluded.peek(),
+            Some(span) if absolute_offset >= span.end.offset
+        ) {
+            excluded.next();
+        }
+        if matches!(
+            excluded.peek(),
+            Some(span) if absolute_offset >= span.start.offset && absolute_offset < span.end.offset
+        ) {
+            continue;
+        }
+
         if escaped {
             escaped = false;
             continue;
@@ -8570,7 +8589,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn collects_broken_assoc_key_spans_from_compound_array_assignments() {
-        let source = "#!/bin/bash\ndeclare -A table=([left]=1 [right=2)\nother=([ok]=1 [broken=2)\ndeclare -a nums=([0]=1 [1=2)\n";
+        let source = "#!/bin/bash\ndeclare -A table=([left]=1 [right=2)\nother=([ok]=1 [broken=2)\ndeclare -A third=([$(echo ])=3)\ndeclare -A valid=([$(printf key)]=4)\ndeclare -a nums=([0]=1 [1=2)\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -8583,7 +8602,7 @@ complex[$((i+=1))]+=x
                 .iter()
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["[right=2", "[broken=2"]
+            vec!["[right=2", "[broken=2", "[$(echo ])=3"]
         );
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -16,9 +16,9 @@ mod surface;
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,
-    ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem, Assignment, AssignmentValue, BinaryCommand,
-    BinaryOp, BourneParameterExpansion, BraceQuoteContext, BraceSyntaxKind, BuiltinCommand,
-    CaseItem, CaseTerminator, Command, CommandSubstitutionSyntax, CompoundCommand,
+    ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem, ArrayKind, Assignment, AssignmentValue,
+    BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext, BraceSyntaxKind,
+    BuiltinCommand, CaseItem, CaseTerminator, Command, CommandSubstitutionSyntax, CompoundCommand,
     ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclClause, DeclOperand, File,
     ForCommand, FunctionDef, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp,
     Pattern, PatternPart, Position, Redirect, RedirectKind, SelectCommand, SimpleCommand,
@@ -1670,6 +1670,7 @@ pub struct LinterFacts<'a> {
     command_ids_by_span: CommandLookupIndex,
     elif_condition_command_ids: FxHashSet<CommandId>,
     scalar_bindings: FxHashMap<FactSpan, &'a Word>,
+    broken_assoc_key_spans: Vec<Span>,
     presence_tested_names: FxHashSet<Name>,
     subscript_index_reference_spans: FxHashSet<FactSpan>,
     words: Vec<WordFact<'a>>,
@@ -1780,6 +1781,10 @@ impl<'a> LinterFacts<'a> {
 
     pub(crate) fn scalar_binding_values(&self) -> &FxHashMap<FactSpan, &'a Word> {
         &self.scalar_bindings
+    }
+
+    pub fn broken_assoc_key_spans(&self) -> &[Span] {
+        &self.broken_assoc_key_spans
     }
 
     pub fn is_elif_condition_command(&self, id: CommandId) -> bool {
@@ -2091,6 +2096,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut structural_command_ids = Vec::new();
         let mut command_ids_by_span = CommandLookupIndex::default();
         let mut scalar_bindings = FxHashMap::default();
+        let mut broken_assoc_key_spans = Vec::new();
         let mut words = Vec::new();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut pattern_literal_spans = Vec::new();
@@ -2115,6 +2121,7 @@ impl<'a> LinterFactsBuilder<'a> {
             });
 
             collect_scalar_bindings(visit.command, &mut scalar_bindings);
+            collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
             let normalized = command::normalize_command(visit.command, self.source);
             let nested_word_command = !structural_commands.contains(&key);
             if !nested_word_command {
@@ -2267,6 +2274,7 @@ impl<'a> LinterFactsBuilder<'a> {
             command_ids_by_span,
             elif_condition_command_ids,
             scalar_bindings,
+            broken_assoc_key_spans,
             presence_tested_names,
             subscript_index_reference_spans,
             words,
@@ -7992,6 +8000,94 @@ fn collect_scalar_bindings<'a>(
     }
 }
 
+fn collect_broken_assoc_key_spans(command: &Command, source: &str, spans: &mut Vec<Span>) {
+    for assignment in query::command_assignments(command) {
+        collect_broken_assoc_key_spans_in_assignment(assignment, source, spans);
+    }
+
+    for operand in query::declaration_operands(command) {
+        let DeclOperand::Assignment(assignment) = operand else {
+            continue;
+        };
+        collect_broken_assoc_key_spans_in_assignment(assignment, source, spans);
+    }
+}
+
+fn collect_broken_assoc_key_spans_in_assignment(
+    assignment: &Assignment,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        return;
+    };
+    if array.kind == ArrayKind::Indexed {
+        return;
+    }
+
+    for element in &array.elements {
+        let ArrayElem::Sequential(word) = element else {
+            continue;
+        };
+        if has_unclosed_assoc_key_prefix(word.span.slice(source)) {
+            spans.push(word.span);
+        }
+    }
+}
+
+fn has_unclosed_assoc_key_prefix(text: &str) -> bool {
+    if !text.starts_with('[') {
+        return false;
+    }
+
+    let mut bracket_depth = 0_i32;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    let mut saw_equals = false;
+
+    for ch in text.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if !in_single => {
+                escaped = true;
+                continue;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+                continue;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                continue;
+            }
+            _ => {}
+        }
+
+        if in_single || in_double {
+            continue;
+        }
+
+        match ch {
+            '[' => bracket_depth += 1,
+            ']' if bracket_depth > 0 => {
+                bracket_depth -= 1;
+                if bracket_depth == 0 {
+                    return false;
+                }
+            }
+            '=' if bracket_depth > 0 => saw_equals = true,
+            _ => {}
+        }
+    }
+
+    saw_equals
+}
+
 fn command_span(command: &Command) -> Span {
     match command {
         Command::Simple(command) => command.span,
@@ -8311,6 +8407,25 @@ complex[$((i+=1))]+=x
                 vec!["x", "arr", "r", "index[1+2]", "complex[$((i+=1))]"]
             );
         });
+    }
+
+    #[test]
+    fn collects_broken_assoc_key_spans_from_compound_array_assignments() {
+        let source = "#!/bin/bash\ndeclare -A table=([left]=1 [right=2)\nother=([ok]=1 [broken=2)\ndeclare -a nums=([0]=1 [1=2)\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert_eq!(
+            facts
+                .broken_assoc_key_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["[right=2", "[broken=2"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1671,6 +1671,7 @@ pub struct LinterFacts<'a> {
     elif_condition_command_ids: FxHashSet<CommandId>,
     scalar_bindings: FxHashMap<FactSpan, &'a Word>,
     broken_assoc_key_spans: Vec<Span>,
+    comma_array_assignment_spans: Vec<Span>,
     presence_tested_names: FxHashSet<Name>,
     subscript_index_reference_spans: FxHashSet<FactSpan>,
     words: Vec<WordFact<'a>>,
@@ -1785,6 +1786,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn broken_assoc_key_spans(&self) -> &[Span] {
         &self.broken_assoc_key_spans
+    }
+
+    pub fn comma_array_assignment_spans(&self) -> &[Span] {
+        &self.comma_array_assignment_spans
     }
 
     pub fn is_elif_condition_command(&self, id: CommandId) -> bool {
@@ -2097,6 +2102,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut command_ids_by_span = CommandLookupIndex::default();
         let mut scalar_bindings = FxHashMap::default();
         let mut broken_assoc_key_spans = Vec::new();
+        let mut comma_array_assignment_spans = Vec::new();
         let mut words = Vec::new();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut pattern_literal_spans = Vec::new();
@@ -2122,6 +2128,11 @@ impl<'a> LinterFactsBuilder<'a> {
 
             collect_scalar_bindings(visit.command, &mut scalar_bindings);
             collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
+            collect_comma_array_assignment_spans(
+                visit.command,
+                self.source,
+                &mut comma_array_assignment_spans,
+            );
             let normalized = command::normalize_command(visit.command, self.source);
             let nested_word_command = !structural_commands.contains(&key);
             if !nested_word_command {
@@ -2275,6 +2286,7 @@ impl<'a> LinterFactsBuilder<'a> {
             elif_condition_command_ids,
             scalar_bindings,
             broken_assoc_key_spans,
+            comma_array_assignment_spans,
             presence_tested_names,
             subscript_index_reference_spans,
             words,
@@ -8088,6 +8100,153 @@ fn has_unclosed_assoc_key_prefix(text: &str) -> bool {
     saw_equals
 }
 
+fn collect_comma_array_assignment_spans(command: &Command, source: &str, spans: &mut Vec<Span>) {
+    for assignment in query::command_assignments(command) {
+        if let Some(span) = comma_array_assignment_span(assignment, source) {
+            spans.push(span);
+        }
+    }
+
+    for operand in query::declaration_operands(command) {
+        let DeclOperand::Assignment(assignment) = operand else {
+            continue;
+        };
+        if let Some(span) = comma_array_assignment_span(assignment, source) {
+            spans.push(span);
+        }
+    }
+}
+
+fn comma_array_assignment_span(assignment: &Assignment, source: &str) -> Option<Span> {
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        return None;
+    };
+    if !array_value_has_unquoted_comma(array, source) {
+        return None;
+    }
+
+    compound_assignment_paren_span(assignment, source)
+}
+
+fn array_value_has_unquoted_comma(array: &shuck_ast::ArrayExpr, source: &str) -> bool {
+    array.elements.iter().any(|element| match element {
+        ArrayElem::Sequential(word) => word_has_unquoted_array_comma(word, source),
+        ArrayElem::Keyed { value, .. } | ArrayElem::KeyedAppend { value, .. } => {
+            word_has_unquoted_array_comma(value, source)
+        }
+    })
+}
+
+fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
+    word.parts.iter().any(|part| {
+        let WordPart::Literal(text) = &part.kind else {
+            return false;
+        };
+        let text = text.as_str(source, part.span);
+
+        text.char_indices().any(|(index, ch)| {
+            if ch != ',' {
+                return false;
+            }
+
+            let prefix = &text[..index];
+            let comma = part.span.start.advanced_by(prefix);
+            let escaped = trailing_backslashes(prefix) % 2 == 1;
+            !comma_is_brace_separator(word, source, comma.offset, escaped)
+        })
+    })
+}
+
+fn comma_is_brace_separator(word: &Word, source: &str, offset: usize, escaped: bool) -> bool {
+    if escaped {
+        return false;
+    }
+
+    inside_active_brace_expansion(word, offset) || inside_unquoted_brace_group(word, source, offset)
+}
+
+fn inside_active_brace_expansion(word: &Word, offset: usize) -> bool {
+    word.brace_syntax()
+        .iter()
+        .copied()
+        .filter(|brace| brace.expands())
+        .any(|brace| brace.span.start.offset <= offset && offset < brace.span.end.offset)
+}
+
+fn inside_unquoted_brace_group(word: &Word, source: &str, target_offset: usize) -> bool {
+    let text = word.span.slice(source);
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    let mut brace_depth = 0usize;
+
+    for (index, ch) in text.char_indices() {
+        let absolute = word.span.start.offset + index;
+
+        if absolute == target_offset {
+            return brace_depth > 0;
+        }
+
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if !in_single => {
+                escaped = true;
+                continue;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+                continue;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                continue;
+            }
+            _ => {}
+        }
+
+        if in_single || in_double {
+            continue;
+        }
+
+        match ch {
+            '{' if !text[..index].ends_with('$') => brace_depth += 1,
+            '}' if brace_depth > 0 => brace_depth -= 1,
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn trailing_backslashes(text: &str) -> usize {
+    text.chars().rev().take_while(|ch| *ch == '\\').count()
+}
+
+fn compound_assignment_paren_span(assignment: &Assignment, source: &str) -> Option<Span> {
+    let AssignmentValue::Compound(_) = &assignment.value else {
+        return None;
+    };
+
+    let text = assignment.span.slice(source);
+    let equals = text.find('=')?;
+    let open = text[equals + 1..].find('(')? + equals + 1;
+    let close = text.rfind(')')?;
+    if close < open {
+        return None;
+    }
+
+    let start = assignment.span.start.advanced_by(&text[..open]);
+    let end = assignment
+        .span
+        .start
+        .advanced_by(&text[..close + ')'.len_utf8()]);
+    Some(Span::from_positions(start, end))
+}
+
 fn command_span(command: &Command) -> Span {
     match command {
         Command::Simple(command) => command.span,
@@ -8425,6 +8584,31 @@ complex[$((i+=1))]+=x
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["[right=2", "[broken=2"]
+        );
+    }
+
+    #[test]
+    fn collects_comma_array_assignment_spans_from_compound_values() {
+        let source = "#!/bin/bash\na=(alpha,beta)\nb=(\"alpha,beta\")\nc=({x,y})\nd=([k]=v, [q]=w)\ne=(x,$y)\nf=(x\\, y)\ng=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)\nh=(foo,{x,y},bar)\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert_eq!(
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "(alpha,beta)",
+                "([k]=v, [q]=w)",
+                "(x,$y)",
+                "(x\\, y)",
+                "(foo,{x,y},bar)"
+            ]
         );
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7734,7 +7734,7 @@ fn configure_option_misspelling(option_name: &str) -> Option<&'static str> {
     }
 }
 
-fn leading_literal_word_prefix(word: &Word, source: &str) -> String {
+pub(crate) fn leading_literal_word_prefix(word: &Word, source: &str) -> String {
     let mut prefix = String::new();
     collect_leading_literal_word_parts(&word.parts, source, &mut prefix);
     prefix

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7246,7 +7246,7 @@ fn parse_unset_command<'a>(args: &[&'a Word], source: &str) -> UnsetCommandFacts
         let Some(text) = static_word_text(word, source) else {
             if parsing_options {
                 options_parseable = false;
-                break;
+                parsing_options = false;
             }
 
             operands.push(*word);
@@ -8546,6 +8546,37 @@ complex[$((i+=1))]+=x
             .and_then(|fact| fact.options().sudo_family())
             .expect("expected sudo-family facts");
         assert_eq!(doas.invoker, SudoFamilyInvoker::Doas);
+    }
+
+    #[test]
+    fn preserves_dynamic_unset_operands_after_option_parsing_stops() {
+        let source = "\
+#!/bin/bash
+declare -A parts
+key=one
+unset parts[\"$key\"] extra
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let unset = facts
+            .commands()
+            .iter()
+            .find(|fact| fact.effective_name_is("unset"))
+            .and_then(|fact| fact.options().unset())
+            .expect("expected unset facts");
+
+        assert_eq!(
+            unset
+                .operand_words()
+                .iter()
+                .map(|word| word.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["parts[\"$key\"]", "extra"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -180,12 +180,23 @@ declare_rules! {
         FindOrWithoutGrouping
     ),
     (
+        "C104",
+        Category::Correctness,
+        Severity::Warning,
+        NonShellSyntaxInScript
+    ),
+    (
+        "C106",
+        Category::Correctness,
+        Severity::Warning,
+        AppendToArrayAsString
+    ),
+    (
         "C109",
         Category::Correctness,
         Severity::Warning,
         MapfileProcessSubstitution
     ),
-    ("C104", Category::Correctness, Severity::Warning, NonShellSyntaxInScript),
     (
         "C116",
         Category::Correctness,
@@ -577,6 +588,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-235" => Some(Rule::FunctionInAlias),
         "SH-237" => Some(Rule::FindOrWithoutGrouping),
         "SH-238" => Some(Rule::NonShellSyntaxInScript),
+        "SH-241" => Some(Rule::AppendToArrayAsString),
         "SH-244" => Some(Rule::MapfileProcessSubstitution),
         "SH-253" => Some(Rule::FindOutputLoop),
         "SH-293" => Some(Rule::UnreachableAfterExit),
@@ -867,14 +879,16 @@ mod tests {
         assert_eq!(code_to_rule("SH-235"), Some(Rule::FunctionInAlias));
         assert_eq!(code_to_rule("C103"), Some(Rule::FindOrWithoutGrouping));
         assert_eq!(code_to_rule("SH-237"), Some(Rule::FindOrWithoutGrouping));
+        assert_eq!(code_to_rule("C104"), Some(Rule::NonShellSyntaxInScript));
+        assert_eq!(code_to_rule("SH-238"), Some(Rule::NonShellSyntaxInScript));
+        assert_eq!(code_to_rule("C106"), Some(Rule::AppendToArrayAsString));
+        assert_eq!(code_to_rule("SH-241"), Some(Rule::AppendToArrayAsString));
         assert_eq!(code_to_rule("C109"), Some(Rule::MapfileProcessSubstitution));
         assert_eq!(
             code_to_rule("SH-244"),
             Some(Rule::MapfileProcessSubstitution)
         );
         assert_eq!(code_to_rule("SH-253"), Some(Rule::FindOutputLoop));
-        assert_eq!(code_to_rule("C104"), Some(Rule::NonShellSyntaxInScript));
-        assert_eq!(code_to_rule("SH-238"), Some(Rule::NonShellSyntaxInScript));
         assert_eq!(code_to_rule("C124"), Some(Rule::UnreachableAfterExit));
         assert_eq!(code_to_rule("SH-293"), Some(Rule::UnreachableAfterExit));
         assert_eq!(code_to_rule("C127"), Some(Rule::UnusedHeredoc));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -292,6 +292,7 @@ declare_rules! {
     ("C146", Category::Correctness, Severity::Error, UntilMissingDo),
     ("C147", Category::Correctness, Severity::Warning, KeywordFunctionName),
     ("C148", Category::Correctness, Severity::Warning, BrokenAssocKey),
+    ("C151", Category::Correctness, Severity::Warning, CommaArrayElements),
     ("C157", Category::Correctness, Severity::Error, IfBracketGlued),
     ("P001", Category::Performance, Severity::Warning, ExprArithmetic),
     ("P002", Category::Performance, Severity::Warning, GrepCountPipeline),
@@ -512,6 +513,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-311" => Some(Rule::ArrayToStringConversion),
         "SH-336" => Some(Rule::KeywordFunctionName),
         "SH-337" => Some(Rule::BrokenAssocKey),
+        "SH-340" => Some(Rule::CommaArrayElements),
         "SH-036" => Some(Rule::SingleQuotedLiteral),
         "SH-037" => Some(Rule::PrintfFormatVariable),
         "SH-038" => Some(Rule::UnquotedArrayExpansion),
@@ -945,6 +947,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-336"), Some(Rule::KeywordFunctionName));
         assert_eq!(code_to_rule("C148"), Some(Rule::BrokenAssocKey));
         assert_eq!(code_to_rule("SH-337"), Some(Rule::BrokenAssocKey));
+        assert_eq!(code_to_rule("C151"), Some(Rule::CommaArrayElements));
+        assert_eq!(code_to_rule("SH-340"), Some(Rule::CommaArrayElements));
         assert_eq!(code_to_rule("SH-283"), Some(Rule::FindExecDirWithShell));
         assert_eq!(
             code_to_rule("C137"),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -291,6 +291,7 @@ declare_rules! {
     ("C145", Category::Correctness, Severity::Warning, MisquotedHeredocClose),
     ("C146", Category::Correctness, Severity::Error, UntilMissingDo),
     ("C147", Category::Correctness, Severity::Warning, KeywordFunctionName),
+    ("C148", Category::Correctness, Severity::Warning, BrokenAssocKey),
     ("C157", Category::Correctness, Severity::Error, IfBracketGlued),
     ("P001", Category::Performance, Severity::Warning, ExprArithmetic),
     ("P002", Category::Performance, Severity::Warning, GrepCountPipeline),
@@ -510,6 +511,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-308" => Some(Rule::VariableAsCommandName),
         "SH-311" => Some(Rule::ArrayToStringConversion),
         "SH-336" => Some(Rule::KeywordFunctionName),
+        "SH-337" => Some(Rule::BrokenAssocKey),
         "SH-036" => Some(Rule::SingleQuotedLiteral),
         "SH-037" => Some(Rule::PrintfFormatVariable),
         "SH-038" => Some(Rule::UnquotedArrayExpansion),
@@ -941,6 +943,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-311"), Some(Rule::ArrayToStringConversion));
         assert_eq!(code_to_rule("C147"), Some(Rule::KeywordFunctionName));
         assert_eq!(code_to_rule("SH-336"), Some(Rule::KeywordFunctionName));
+        assert_eq!(code_to_rule("C148"), Some(Rule::BrokenAssocKey));
+        assert_eq!(code_to_rule("SH-337"), Some(Rule::BrokenAssocKey));
         assert_eq!(code_to_rule("SH-283"), Some(Rule::FindExecDirWithShell));
         assert_eq!(
             code_to_rule("C137"),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -192,6 +192,12 @@ declare_rules! {
         AppendToArrayAsString
     ),
     (
+        "C108",
+        Category::Correctness,
+        Severity::Warning,
+        UnsetAssociativeArrayElement
+    ),
+    (
         "C109",
         Category::Correctness,
         Severity::Warning,
@@ -589,6 +595,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-237" => Some(Rule::FindOrWithoutGrouping),
         "SH-238" => Some(Rule::NonShellSyntaxInScript),
         "SH-241" => Some(Rule::AppendToArrayAsString),
+        "SH-243" => Some(Rule::UnsetAssociativeArrayElement),
         "SH-244" => Some(Rule::MapfileProcessSubstitution),
         "SH-253" => Some(Rule::FindOutputLoop),
         "SH-293" => Some(Rule::UnreachableAfterExit),
@@ -883,6 +890,14 @@ mod tests {
         assert_eq!(code_to_rule("SH-238"), Some(Rule::NonShellSyntaxInScript));
         assert_eq!(code_to_rule("C106"), Some(Rule::AppendToArrayAsString));
         assert_eq!(code_to_rule("SH-241"), Some(Rule::AppendToArrayAsString));
+        assert_eq!(
+            code_to_rule("C108"),
+            Some(Rule::UnsetAssociativeArrayElement)
+        );
+        assert_eq!(
+            code_to_rule("SH-243"),
+            Some(Rule::UnsetAssociativeArrayElement)
+        );
         assert_eq!(code_to_rule("C109"), Some(Rule::MapfileProcessSubstitution));
         assert_eq!(
             code_to_rule("SH-244"),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -254,6 +254,12 @@ declare_rules! {
         MisspelledOptionName
     ),
     (
+        "C133",
+        Category::Correctness,
+        Severity::Warning,
+        ArrayToStringConversion
+    ),
+    (
         "C136",
         Category::Correctness,
         Severity::Warning,
@@ -502,6 +508,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-295" => Some(Rule::UncheckedDirectoryChangeInFunction),
         "SH-296" => Some(Rule::ContinueOutsideLoopInFunction),
         "SH-308" => Some(Rule::VariableAsCommandName),
+        "SH-311" => Some(Rule::ArrayToStringConversion),
         "SH-336" => Some(Rule::KeywordFunctionName),
         "SH-036" => Some(Rule::SingleQuotedLiteral),
         "SH-037" => Some(Rule::PrintfFormatVariable),
@@ -930,6 +937,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-308"), Some(Rule::VariableAsCommandName));
         assert_eq!(code_to_rule("C132"), Some(Rule::MisspelledOptionName));
         assert_eq!(code_to_rule("SH-310"), Some(Rule::MisspelledOptionName));
+        assert_eq!(code_to_rule("C133"), Some(Rule::ArrayToStringConversion));
+        assert_eq!(code_to_rule("SH-311"), Some(Rule::ArrayToStringConversion));
         assert_eq!(code_to_rule("C147"), Some(Rule::KeywordFunctionName));
         assert_eq!(code_to_rule("SH-336"), Some(Rule::KeywordFunctionName));
         assert_eq!(code_to_rule("SH-283"), Some(Rule::FindExecDirWithShell));

--- a/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
@@ -1,0 +1,148 @@
+use shuck_semantic::{Binding, BindingAttributes, BindingKind};
+
+use crate::facts::leading_literal_word_prefix;
+use crate::{Checker, Rule, Violation};
+
+pub struct AppendToArrayAsString;
+
+impl Violation for AppendToArrayAsString {
+    fn rule() -> Rule {
+        Rule::AppendToArrayAsString
+    }
+
+    fn message(&self) -> String {
+        "appending a string to an array with `+=` merges into an element; use `+=(...)`".to_owned()
+    }
+}
+
+pub fn append_to_array_as_string(checker: &mut Checker) {
+    let source = checker.source();
+    let semantic = checker.semantic();
+
+    let spans = semantic
+        .bindings()
+        .iter()
+        .filter_map(|binding| {
+            if binding.kind != BindingKind::AppendAssignment {
+                return None;
+            }
+            if binding
+                .attributes
+                .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+            {
+                return None;
+            }
+
+            let prior_binding = previous_visible_binding(semantic, binding)?;
+            if !binding_is_array_like(prior_binding) {
+                return None;
+            }
+
+            let value = checker.facts().scalar_binding_value(binding.span)?;
+            leading_literal_word_prefix(value, source)
+                .starts_with(' ')
+                .then_some(binding.span)
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || AppendToArrayAsString);
+}
+
+fn previous_visible_binding<'a>(
+    semantic: &'a shuck_semantic::SemanticModel,
+    binding: &Binding,
+) -> Option<&'a Binding> {
+    for scope_id in semantic.ancestor_scopes(binding.scope) {
+        let Some(scope) = semantic.scopes().iter().find(|scope| scope.id == scope_id) else {
+            continue;
+        };
+        let Some(candidates) = scope.bindings.get(&binding.name) else {
+            continue;
+        };
+
+        for candidate_id in candidates.iter().rev() {
+            let candidate = semantic.binding(*candidate_id);
+
+            if candidate.id == binding.id {
+                continue;
+            }
+            if candidate.span.start.offset <= binding.span.start.offset {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+fn binding_is_array_like(binding: &Binding) -> bool {
+    binding
+        .attributes
+        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+        || binding.kind == BindingKind::ArrayAssignment
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_string_appends_on_array_bindings() {
+        let source = "\
+#!/bin/bash
+items=(one)
+items+=\" two\"
+declare -a flags=(--first)
+flags+=\" ${extra}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendToArrayAsString),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["items", "flags"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_array_and_element_appends() {
+        let source = "\
+#!/bin/bash
+name=base
+name+=\" suffix\"
+items=(one)
+items+=(\" two\")
+items[0]+=\" tail\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendToArrayAsString),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_shadowed_local_scalars_when_outer_binding_is_array() {
+        let source = "\
+#!/bin/bash
+arr=(one)
+f() {
+  local arr=base
+  arr+=\" two\"
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendToArrayAsString),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -1,0 +1,152 @@
+use shuck_ast::Span;
+use shuck_semantic::{Binding, BindingAttributes, BindingKind};
+
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext};
+
+pub struct ArrayToStringConversion;
+
+impl Violation for ArrayToStringConversion {
+    fn rule() -> Rule {
+        Rule::ArrayToStringConversion
+    }
+
+    fn message(&self) -> String {
+        "array values are flattened to a scalar string before later scalar use".to_owned()
+    }
+}
+
+pub fn array_to_string_conversion(checker: &mut Checker) {
+    let semantic = checker.semantic();
+
+    let spans = semantic
+        .bindings()
+        .iter()
+        .filter_map(|binding| {
+            let context = binding_assignment_value_context(binding)?;
+            if binding
+                .attributes
+                .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+            {
+                return None;
+            }
+
+            let value = checker.facts().scalar_binding_value(binding.span)?;
+            let value_fact = checker.facts().word_fact(value.span, context)?;
+            if !uses_array_to_scalar_conversion_pattern(checker, binding, value_fact) {
+                return None;
+            }
+
+            Some(binding.span)
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || ArrayToStringConversion);
+}
+
+fn binding_assignment_value_context(binding: &Binding) -> Option<WordFactContext> {
+    match binding.kind {
+        BindingKind::Assignment | BindingKind::ParameterDefaultAssignment => Some(
+            WordFactContext::Expansion(ExpansionContext::AssignmentValue),
+        ),
+        BindingKind::Declaration(_) => Some(WordFactContext::Expansion(
+            ExpansionContext::DeclarationAssignmentValue,
+        )),
+        _ => None,
+    }
+}
+
+fn uses_array_to_scalar_conversion_pattern(
+    checker: &Checker<'_>,
+    binding: &Binding,
+    value_fact: &crate::WordFact<'_>,
+) -> bool {
+    value_fact
+        .array_expansion_spans()
+        .iter()
+        .copied()
+        .any(|span| {
+            checker.semantic().references().iter().any(|reference| {
+                reference.name == binding.name
+                    && contains_span(span, reference.span)
+                    && checker
+                        .semantic()
+                        .resolved_binding(reference.id)
+                        .is_some_and(binding_is_array_like)
+            })
+        })
+}
+
+fn binding_is_array_like(binding: &Binding) -> bool {
+    binding
+        .attributes
+        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+        || binding.kind == BindingKind::ArrayAssignment
+}
+
+fn contains_span(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_true_array_to_scalar_conversions() {
+        let source = "\
+#!/bin/bash
+exts=(txt pdf doc)
+exts=\"${exts[*]}\"
+items=(one two)
+items=\"${items[0]}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["exts"],
+            "{diagnostics:#?}"
+        );
+    }
+
+    #[test]
+    fn ignores_assignments_without_prior_array_like_binding() {
+        let source = "\
+#!/bin/bash
+name=base
+name=\"${name}-suffix\"
+other=\"${unknown:-fallback}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_shadowed_local_scalars_without_array_conversion_in_value() {
+        let source = "\
+#!/bin/bash
+exts=(txt pdf)
+f() {
+  local exts=base
+  exts=\"${exts}-suffix\"
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/broken_assoc_key.rs
+++ b/crates/shuck-linter/src/rules/correctness/broken_assoc_key.rs
@@ -1,0 +1,56 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct BrokenAssocKey;
+
+impl Violation for BrokenAssocKey {
+    fn rule() -> Rule {
+        Rule::BrokenAssocKey
+    }
+
+    fn message(&self) -> String {
+        "associative array keys in compound assignments need a closing `]` before `=`".to_owned()
+    }
+}
+
+pub fn broken_assoc_key(checker: &mut Checker) {
+    checker.report_all_dedup(checker.facts().broken_assoc_key_spans().to_vec(), || {
+        BrokenAssocKey
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_broken_assoc_keys_in_compound_assignments() {
+        let source = "\
+#!/bin/bash
+declare -A table=([left]=1 [right=2)
+other=([ok]=1 [broken=2)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BrokenAssocKey));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["[right=2", "[broken=2"]
+        );
+    }
+
+    #[test]
+    fn ignores_valid_or_non_associative_key_forms() {
+        let source = "\
+#!/bin/bash
+declare -A table=([left]=1 [right]=2)
+declare -a nums=([0]=1 [1=2)
+declare -A pairs=(left one right two)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BrokenAssocKey));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/broken_assoc_key.rs
+++ b/crates/shuck-linter/src/rules/correctness/broken_assoc_key.rs
@@ -29,6 +29,7 @@ mod tests {
 #!/bin/bash
 declare -A table=([left]=1 [right=2)
 other=([ok]=1 [broken=2)
+declare -A third=([$(echo ])=3)
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BrokenAssocKey));
 
@@ -37,7 +38,7 @@ other=([ok]=1 [broken=2)
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["[right=2", "[broken=2"]
+            vec!["[right=2", "[broken=2", "[$(echo ])=3"]
         );
     }
 
@@ -46,6 +47,7 @@ other=([ok]=1 [broken=2)
         let source = "\
 #!/bin/bash
 declare -A table=([left]=1 [right]=2)
+declare -A dynamic=([$(printf key)]=1)
 declare -a nums=([0]=1 [1=2)
 declare -A pairs=(left one right two)
 ";

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -1,0 +1,68 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct CommaArrayElements;
+
+impl Violation for CommaArrayElements {
+    fn rule() -> Rule {
+        Rule::CommaArrayElements
+    }
+
+    fn message(&self) -> String {
+        "separate array literal elements with whitespace, not commas".to_owned()
+    }
+}
+
+pub fn comma_array_elements(checker: &mut Checker) {
+    checker.report_all_dedup(
+        checker.facts().comma_array_assignment_spans().to_vec(),
+        || CommaArrayElements,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_comma_separated_array_literals() {
+        let source = "\
+#!/bin/bash
+a=(alpha,beta)
+b=(alpha, beta)
+c=([k]=v, [q]=w)
+d+=(x,y)
+e=(foo,{x,y},bar)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "(alpha,beta)",
+                "(alpha, beta)",
+                "([k]=v, [q]=w)",
+                "(x,y)",
+                "(foo,{x,y},bar)"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_quoted_and_brace_expansion_commas() {
+        let source = "\
+#!/bin/bash
+a=(\"alpha,beta\")
+b=('alpha,beta')
+c=({x,y})
+d=($(printf 'x,y'))
+e=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -16,6 +16,7 @@ pub mod c_prototype_fragment;
 pub mod c_style_comment;
 pub mod case_pattern_var;
 pub mod chained_test_branches;
+pub mod comma_array_elements;
 pub mod commented_continuation_line;
 pub mod constant_case_subject;
 pub mod constant_comparison_test;
@@ -188,6 +189,7 @@ mod tests {
     #[test_case(Rule::UntilMissingDo, Path::new("C146.sh"))]
     #[test_case(Rule::KeywordFunctionName, Path::new("C147.sh"))]
     #[test_case(Rule::BrokenAssocKey, Path::new("C148.sh"))]
+    #[test_case(Rule::CommaArrayElements, Path::new("C151.sh"))]
     #[test_case(Rule::IfBracketGlued, Path::new("C157.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {
         let snapshot = format!("{}_{}", rule.code(), path.display());

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -1,5 +1,6 @@
 pub mod append_with_escaped_quotes;
 pub mod arithmetic_redirection_target;
+pub mod array_to_string_conversion;
 pub mod assignment_looks_like_comparison;
 pub mod assignment_to_numeric_variable;
 pub mod backslash_before_closing_backtick;
@@ -171,6 +172,7 @@ mod tests {
     #[test_case(Rule::AppendWithEscapedQuotes, Path::new("C130.sh"))]
     #[test_case(Rule::VariableAsCommandName, Path::new("C131.sh"))]
     #[test_case(Rule::MisspelledOptionName, Path::new("C132.sh"))]
+    #[test_case(Rule::ArrayToStringConversion, Path::new("C133.sh"))]
     #[test_case(Rule::LocalCrossReference, Path::new("C136.sh"))]
     #[test_case(Rule::SpacedAssignment, Path::new("C139.sh"))]
     #[test_case(Rule::BadVarName, Path::new("C140.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -1,3 +1,4 @@
+pub mod append_to_array_as_string;
 pub mod append_with_escaped_quotes;
 pub mod arithmetic_redirection_target;
 pub mod array_to_string_conversion;

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -158,6 +158,7 @@ mod tests {
     #[test_case(Rule::IfsSetToLiteralBackslashN, Path::new("C101.sh"))]
     #[test_case(Rule::FindOrWithoutGrouping, Path::new("C103.sh"))]
     #[test_case(Rule::NonShellSyntaxInScript, Path::new("C104.sh"))]
+    #[test_case(Rule::AppendToArrayAsString, Path::new("C106.sh"))]
     #[test_case(Rule::MapfileProcessSubstitution, Path::new("C109.sh"))]
     #[test_case(Rule::AssignmentToNumericVariable, Path::new("C116.sh"))]
     #[test_case(Rule::PlusPrefixInAssignment, Path::new("C117.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -8,6 +8,7 @@ pub mod bad_redirection_fd_order;
 pub mod bad_var_name;
 pub mod bare_closing_brace;
 pub mod bare_slash_marker;
+pub mod broken_assoc_key;
 mod broken_test_common;
 pub mod broken_test_end;
 pub mod broken_test_parse;
@@ -186,6 +187,7 @@ mod tests {
     #[test_case(Rule::MisquotedHeredocClose, Path::new("C145.sh"))]
     #[test_case(Rule::UntilMissingDo, Path::new("C146.sh"))]
     #[test_case(Rule::KeywordFunctionName, Path::new("C147.sh"))]
+    #[test_case(Rule::BrokenAssocKey, Path::new("C148.sh"))]
     #[test_case(Rule::IfBracketGlued, Path::new("C157.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {
         let snapshot = format!("{}_{}", rule.code(), path.display());

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -81,6 +81,7 @@ pub mod undefined_variable;
 pub mod unicode_quote_in_string;
 pub mod unicode_single_quote_in_single_quotes;
 pub mod unreachable_after_exit;
+pub mod unset_associative_array_element;
 pub mod until_missing_do;
 pub mod untracked_source_file;
 pub mod unused_assignment;
@@ -159,6 +160,7 @@ mod tests {
     #[test_case(Rule::FindOrWithoutGrouping, Path::new("C103.sh"))]
     #[test_case(Rule::NonShellSyntaxInScript, Path::new("C104.sh"))]
     #[test_case(Rule::AppendToArrayAsString, Path::new("C106.sh"))]
+    #[test_case(Rule::UnsetAssociativeArrayElement, Path::new("C108.sh"))]
     #[test_case(Rule::MapfileProcessSubstitution, Path::new("C109.sh"))]
     #[test_case(Rule::AssignmentToNumericVariable, Path::new("C116.sh"))]
     #[test_case(Rule::PlusPrefixInAssignment, Path::new("C117.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C106_C106.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C106_C106.sh.snap
@@ -1,0 +1,15 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 181
+---
+C106 appending a string to an array with `+=` merges into an element; use `+=(...)`
+ --> <source>:5:1
+  |
+5 | items+=" two"
+  |
+
+C106 appending a string to an array with `+=` merges into an element; use `+=(...)`
+ --> <source>:9:1
+  |
+9 | flags+=" ${extra}"
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C108_C108.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C108_C108.sh.snap
@@ -1,0 +1,21 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 183
+---
+C108 quote associative-array unset targets as `'name[key]'` to keep keys literal
+ --> <source>:7:7
+  |
+7 | unset parts["one"]
+  |
+
+C108 quote associative-array unset targets as `'name[key]'` to keep keys literal
+ --> <source>:8:7
+  |
+8 | unset parts['two']
+  |
+
+C108 quote associative-array unset targets as `'name[key]'` to keep keys literal
+  --> <source>:10:7
+   |
+10 | unset parts["$key"]
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C133_C133.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C133_C133.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 185
+---
+C133 array values are flattened to a scalar string before later scalar use
+ --> <source>:5:1
+  |
+5 | exts="${exts[*]}"
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C148_C148.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C148_C148.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C148 associative array keys in compound assignments need a closing `]` before `=`
+ --> <source>:4:28
+  |
+4 | declare -A table=([left]=1 [right=2)
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C151_C151.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C151_C151.sh.snap
@@ -1,0 +1,44 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C151 separate array literal elements with whitespace, not commas
+ --> <source>:4:7
+  |
+4 | parts=(alpha,beta)
+  |
+
+C151 separate array literal elements with whitespace, not commas
+ --> <source>:5:7
+  |
+5 | parts=(alpha, beta)
+  |
+
+C151 separate array literal elements with whitespace, not commas
+ --> <source>:6:8
+  |
+6 | parts+=(gamma,delta)
+  |
+
+C151 separate array literal elements with whitespace, not commas
+ --> <source>:7:18
+  |
+7 | declare -a flags=(--one,--two)
+  |
+
+C151 separate array literal elements with whitespace, not commas
+ --> <source>:8:18
+  |
+8 | declare -A assoc=([left]=1, [right]=2)
+  |
+
+C151 separate array literal elements with whitespace, not commas
+ --> <source>:9:8
+  |
+9 | values=(head,$tail)
+  |
+
+C151 separate array literal elements with whitespace, not commas
+  --> <source>:10:7
+   |
+10 | mixed=(head,{left,right},tail)
+   |

--- a/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
+++ b/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
@@ -1,0 +1,136 @@
+use shuck_ast::Name;
+use shuck_semantic::BindingAttributes;
+
+use crate::{Checker, Rule, Violation};
+
+pub struct UnsetAssociativeArrayElement;
+
+impl Violation for UnsetAssociativeArrayElement {
+    fn rule() -> Rule {
+        Rule::UnsetAssociativeArrayElement
+    }
+
+    fn message(&self) -> String {
+        "quote associative-array unset targets as `'name[key]'` to keep keys literal".to_owned()
+    }
+}
+
+pub fn unset_associative_array_element(checker: &mut Checker) {
+    let source = checker.source();
+    let semantic = checker.semantic();
+    let mut spans = Vec::new();
+
+    for fact in checker
+        .facts()
+        .structural_commands()
+        .filter(|fact| fact.effective_name_is("unset"))
+    {
+        let Some(unset) = fact.options().unset() else {
+            continue;
+        };
+
+        for operand in unset.operand_words() {
+            let Some((name, key_text)) = parse_array_operand(operand.span.slice(source)) else {
+                continue;
+            };
+            if !key_has_unescaped_quote(key_text) {
+                continue;
+            }
+
+            let Some(visible) = semantic.visible_binding(&Name::from(name), operand.span) else {
+                continue;
+            };
+            if visible.attributes.contains(BindingAttributes::ASSOC) {
+                spans.push(operand.span);
+            }
+        }
+    }
+
+    checker.report_all_dedup(spans, || UnsetAssociativeArrayElement);
+}
+
+fn parse_array_operand(text: &str) -> Option<(&str, &str)> {
+    let (name, key_with_bracket) = text.split_once('[')?;
+    let key = key_with_bracket.strip_suffix(']')?;
+    is_shell_name(name).then_some((name, key))
+}
+
+fn is_shell_name(text: &str) -> bool {
+    let mut chars = text.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn key_has_unescaped_quote(text: &str) -> bool {
+    let mut backslashes = 0usize;
+    for ch in text.chars() {
+        if ch == '\\' {
+            backslashes += 1;
+            continue;
+        }
+
+        let escaped = backslashes % 2 == 1;
+        backslashes = 0;
+
+        if !escaped && (ch == '\'' || ch == '"') {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_quoted_associative_unset_keys() {
+        let source = "\
+#!/bin/bash
+declare -A parts
+parts[one]=1
+unset parts[\"one\"]
+unset parts['two']
+key=three
+unset parts[\"$key\"]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnsetAssociativeArrayElement),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["parts[\"one\"]", "parts['two']", "parts[\"$key\"]"]
+        );
+    }
+
+    #[test]
+    fn ignores_indexed_or_safely_quoted_unset_operands() {
+        let source = "\
+#!/bin/bash
+declare -a nums
+declare -A parts
+key=one
+unset nums[\"1\"]
+unset parts[$key]
+unset 'parts[key]'
+unset \"parts[key]\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnsetAssociativeArrayElement),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
+++ b/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
@@ -33,7 +33,7 @@ pub fn unset_associative_array_element(checker: &mut Checker) {
             let Some((name, key_text)) = parse_array_operand(operand.span.slice(source)) else {
                 continue;
             };
-            if !key_has_unescaped_quote(key_text) {
+            if !key_contains_quote(key_text) {
                 continue;
             }
 
@@ -65,23 +65,8 @@ fn is_shell_name(text: &str) -> bool {
         && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
-fn key_has_unescaped_quote(text: &str) -> bool {
-    let mut backslashes = 0usize;
-    for ch in text.chars() {
-        if ch == '\\' {
-            backslashes += 1;
-            continue;
-        }
-
-        let escaped = backslashes % 2 == 1;
-        backslashes = 0;
-
-        if !escaped && (ch == '\'' || ch == '"') {
-            return true;
-        }
-    }
-
-    false
+fn key_contains_quote(text: &str) -> bool {
+    text.chars().any(|ch| ch == '\'' || ch == '"')
 }
 
 #[cfg(test)]
@@ -99,6 +84,7 @@ unset parts[\"one\"]
 unset parts['two']
 key=three
 unset parts[\"$key\"]
+unset parts[\\\"four\\\"]
 ";
         let diagnostics = test_snippet(
             source,
@@ -110,7 +96,12 @@ unset parts[\"$key\"]
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["parts[\"one\"]", "parts['two']", "parts[\"$key\"]"]
+            vec![
+                "parts[\"one\"]",
+                "parts['two']",
+                "parts[\"$key\"]",
+                "parts[\\\"four\\\"]"
+            ]
         );
     }
 

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -258,6 +258,7 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports `set` flag-prefix issues as SC2121.
             // Keep SC2324 as a suppression alias for historical compatibility.
             (2121, Rule::SetFlagsWithoutDashes),
+            (2336, Rule::AppendToArrayAsString),
             (2339, Rule::MapfileProcessSubstitution),
             (2115, Rule::RmGlobOnVariablePath),
             (2104, Rule::LoopControlOutsideLoop),
@@ -542,6 +543,7 @@ impl Default for ShellCheckCodeMap {
                     (3075, Rule::ErrexitTrapInSh),
                     (3076, Rule::SignalNameInTrap),
                     (2323, Rule::ArithmeticScoreLine),
+                    (2336, Rule::AppendToArrayAsString),
                     (2339, Rule::MapfileProcessSubstitution),
                     (3051, Rule::SourceInsideFunctionInSh),
                     (3084, Rule::SourceInsideFunctionInSh),
@@ -959,6 +961,7 @@ mod tests {
             Some(Rule::FunctionReferencesUnsetParam)
         );
         assert_eq!(map.resolve("SC2323"), Some(Rule::ArithmeticScoreLine));
+        assert_eq!(map.resolve("SC2336"), Some(Rule::AppendToArrayAsString));
         assert_eq!(
             map.resolve("SC2339"),
             Some(Rule::MapfileProcessSubstitution)
@@ -1195,6 +1198,7 @@ mod tests {
             (2086, Rule::UnquotedExpansion),
             (2146, Rule::FindOrWithoutGrouping),
             (2121, Rule::SetFlagsWithoutDashes),
+            (2336, Rule::AppendToArrayAsString),
             (2339, Rule::MapfileProcessSubstitution),
             (2104, Rule::LoopControlOutsideLoop),
             (2112, Rule::FunctionKeyword),
@@ -1445,6 +1449,7 @@ mod tests {
         assert!(comparison.contains(&(2127, Rule::BashCaseFallthrough)));
         assert!(comparison.contains(&(2146, Rule::FindOrWithoutGrouping)));
         assert!(comparison.contains(&(2121, Rule::SetFlagsWithoutDashes)));
+        assert!(comparison.contains(&(2336, Rule::AppendToArrayAsString)));
         assert!(comparison.contains(&(2339, Rule::MapfileProcessSubstitution)));
         assert!(comparison.contains(&(2380, Rule::MisspelledOptionName)));
         assert!(!comparison.contains(&(2348, Rule::FindOutputLoop)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -261,6 +261,9 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports quoted associative-array unset keys as SC2184.
             // Keep SC2338 as a suppression alias for historical compatibility.
             (2184, Rule::UnsetAssociativeArrayElement),
+            // ShellCheck 0.11.0 reports array-to-scalar rebinding as SC2178.
+            // Keep SC2381 as a suppression alias for authored C133 metadata.
+            (2178, Rule::ArrayToStringConversion),
             (2336, Rule::AppendToArrayAsString),
             (2339, Rule::MapfileProcessSubstitution),
             (2115, Rule::RmGlobOnVariablePath),
@@ -520,6 +523,7 @@ impl Default for ShellCheckCodeMap {
                     (2121, Rule::SetFlagsWithoutDashes),
                     (2324, Rule::SetFlagsWithoutDashes),
                     (2184, Rule::UnsetAssociativeArrayElement),
+                    (2178, Rule::ArrayToStringConversion),
                     (2115, Rule::RmGlobOnVariablePath),
                     (2104, Rule::LoopControlOutsideLoop),
                     (2112, Rule::FunctionKeyword),
@@ -610,6 +614,7 @@ impl Default for ShellCheckCodeMap {
                     (3016, Rule::VTestInSh),
                     (3017, Rule::ATestInSh),
                     (2338, Rule::UnsetAssociativeArrayElement),
+                    (2381, Rule::ArrayToStringConversion),
                     (3062, Rule::OptionTestInSh),
                     (3065, Rule::StickyBitTestInSh),
                     (3067, Rule::OwnershipTestInSh),
@@ -892,6 +897,8 @@ mod tests {
             map.resolve("SC2338"),
             Some(Rule::UnsetAssociativeArrayElement)
         );
+        assert_eq!(map.resolve("SC2178"), Some(Rule::ArrayToStringConversion));
+        assert_eq!(map.resolve("SC2381"), Some(Rule::ArrayToStringConversion));
         assert_eq!(
             map.resolve_all("SC3024"),
             vec![
@@ -1183,6 +1190,7 @@ mod tests {
             (2060, Rule::UnquotedTrRange),
             (2303, Rule::UnquotedTrClass),
             (2184, Rule::UnsetAssociativeArrayElement),
+            (2178, Rule::ArrayToStringConversion),
             (2322, Rule::SuWithoutFlag),
             (2340, Rule::DeprecatedTempfileCommand),
             (2342, Rule::EgrepDeprecated),
@@ -1346,6 +1354,7 @@ mod tests {
             (3032, Rule::Coproc),
             (3033, Rule::SelectLoop),
             (2338, Rule::UnsetAssociativeArrayElement),
+            (2381, Rule::ArrayToStringConversion),
             (3039, Rule::LetCommand),
             (3040, Rule::PipefailOption),
             (3042, Rule::LetCommand),
@@ -1447,6 +1456,7 @@ mod tests {
         assert!(comparison.contains(&(2186, Rule::DeprecatedTempfileCommand)));
         assert!(comparison.contains(&(2196, Rule::EgrepDeprecated)));
         assert!(comparison.contains(&(2184, Rule::UnsetAssociativeArrayElement)));
+        assert!(comparison.contains(&(2178, Rule::ArrayToStringConversion)));
         assert!(comparison.contains(&(2139, Rule::CommandSubstitutionInAlias)));
         assert!(comparison.contains(&(2142, Rule::FunctionInAlias)));
         assert!(!comparison.contains(&(2322, Rule::SuWithoutFlag)));
@@ -1518,6 +1528,7 @@ mod tests {
         assert!(comparison.contains(&(2270, Rule::AssignmentToNumericVariable)));
         assert!(comparison.contains(&(2276, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2338, Rule::UnsetAssociativeArrayElement)));
+        assert!(!comparison.contains(&(2381, Rule::ArrayToStringConversion)));
         assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
         assert!(!comparison.contains(&(2354, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2290, Rule::SpacedAssignment)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -258,6 +258,9 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports `set` flag-prefix issues as SC2121.
             // Keep SC2324 as a suppression alias for historical compatibility.
             (2121, Rule::SetFlagsWithoutDashes),
+            // ShellCheck 0.11.0 reports quoted associative-array unset keys as SC2184.
+            // Keep SC2338 as a suppression alias for historical compatibility.
+            (2184, Rule::UnsetAssociativeArrayElement),
             (2336, Rule::AppendToArrayAsString),
             (2339, Rule::MapfileProcessSubstitution),
             (2115, Rule::RmGlobOnVariablePath),
@@ -516,6 +519,7 @@ impl Default for ShellCheckCodeMap {
                     (2332, Rule::FindOrWithoutGrouping),
                     (2121, Rule::SetFlagsWithoutDashes),
                     (2324, Rule::SetFlagsWithoutDashes),
+                    (2184, Rule::UnsetAssociativeArrayElement),
                     (2115, Rule::RmGlobOnVariablePath),
                     (2104, Rule::LoopControlOutsideLoop),
                     (2112, Rule::FunctionKeyword),
@@ -605,6 +609,7 @@ impl Default for ShellCheckCodeMap {
                     (3015, Rule::RegexMatchInSh),
                     (3016, Rule::VTestInSh),
                     (3017, Rule::ATestInSh),
+                    (2338, Rule::UnsetAssociativeArrayElement),
                     (3062, Rule::OptionTestInSh),
                     (3065, Rule::StickyBitTestInSh),
                     (3067, Rule::OwnershipTestInSh),
@@ -879,6 +884,14 @@ mod tests {
         assert_eq!(map.resolve("SC3024"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3055"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3071"), Some(Rule::PlusEqualsInSh));
+        assert_eq!(
+            map.resolve("SC2184"),
+            Some(Rule::UnsetAssociativeArrayElement)
+        );
+        assert_eq!(
+            map.resolve("SC2338"),
+            Some(Rule::UnsetAssociativeArrayElement)
+        );
         assert_eq!(
             map.resolve_all("SC3024"),
             vec![
@@ -1169,6 +1182,7 @@ mod tests {
             (2060, Rule::UnquotedTrClass),
             (2060, Rule::UnquotedTrRange),
             (2303, Rule::UnquotedTrClass),
+            (2184, Rule::UnsetAssociativeArrayElement),
             (2322, Rule::SuWithoutFlag),
             (2340, Rule::DeprecatedTempfileCommand),
             (2342, Rule::EgrepDeprecated),
@@ -1331,6 +1345,7 @@ mod tests {
             (3030, Rule::ArrayAssignment),
             (3032, Rule::Coproc),
             (3033, Rule::SelectLoop),
+            (2338, Rule::UnsetAssociativeArrayElement),
             (3039, Rule::LetCommand),
             (3040, Rule::PipefailOption),
             (3042, Rule::LetCommand),
@@ -1431,6 +1446,7 @@ mod tests {
         assert!(comparison.contains(&(2117, Rule::SuWithoutFlag)));
         assert!(comparison.contains(&(2186, Rule::DeprecatedTempfileCommand)));
         assert!(comparison.contains(&(2196, Rule::EgrepDeprecated)));
+        assert!(comparison.contains(&(2184, Rule::UnsetAssociativeArrayElement)));
         assert!(comparison.contains(&(2139, Rule::CommandSubstitutionInAlias)));
         assert!(comparison.contains(&(2142, Rule::FunctionInAlias)));
         assert!(!comparison.contains(&(2322, Rule::SuWithoutFlag)));
@@ -1501,6 +1517,7 @@ mod tests {
         assert!(comparison.contains(&(2282, Rule::BadVarName)));
         assert!(comparison.contains(&(2270, Rule::AssignmentToNumericVariable)));
         assert!(comparison.contains(&(2276, Rule::PlusPrefixInAssignment)));
+        assert!(!comparison.contains(&(2338, Rule::UnsetAssociativeArrayElement)));
         assert!(!comparison.contains(&(2353, Rule::AssignmentToNumericVariable)));
         assert!(!comparison.contains(&(2354, Rule::PlusPrefixInAssignment)));
         assert!(!comparison.contains(&(2290, Rule::SpacedAssignment)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -335,6 +335,7 @@ impl Default for ShellCheckCodeMap {
             (2389, Rule::LoopWithoutEnd),
             (2390, Rule::MissingDoneInForLoop),
             (2391, Rule::DanglingElse),
+            (2399, Rule::BrokenAssocKey),
             (2392, Rule::LinebreakBeforeAnd),
             (2396, Rule::UntilMissingDo),
             (2397, Rule::AmpersandSemicolon),
@@ -551,6 +552,7 @@ impl Default for ShellCheckCodeMap {
                     (3075, Rule::ErrexitTrapInSh),
                     (3076, Rule::SignalNameInTrap),
                     (2323, Rule::ArithmeticScoreLine),
+                    (2399, Rule::BrokenAssocKey),
                     (2336, Rule::AppendToArrayAsString),
                     (2339, Rule::MapfileProcessSubstitution),
                     (3051, Rule::SourceInsideFunctionInSh),
@@ -986,6 +988,7 @@ mod tests {
             map.resolve("SC2339"),
             Some(Rule::MapfileProcessSubstitution)
         );
+        assert_eq!(map.resolve("SC2399"), Some(Rule::BrokenAssocKey));
         assert_eq!(map.resolve("SC2333"), Some(Rule::NonShellSyntaxInScript));
         assert_eq!(map.resolve("SC2370"), Some(Rule::UnusedHeredoc));
         assert_eq!(map.resolve("SC2389"), Some(Rule::LoopWithoutEnd));
@@ -1220,6 +1223,7 @@ mod tests {
             (2086, Rule::UnquotedExpansion),
             (2146, Rule::FindOrWithoutGrouping),
             (2121, Rule::SetFlagsWithoutDashes),
+            (2399, Rule::BrokenAssocKey),
             (2336, Rule::AppendToArrayAsString),
             (2339, Rule::MapfileProcessSubstitution),
             (2104, Rule::LoopControlOutsideLoop),
@@ -1302,6 +1306,7 @@ mod tests {
             (2120, Rule::FunctionCalledWithoutArgs),
             (2323, Rule::ArithmeticScoreLine),
             (2332, Rule::FindOrWithoutGrouping),
+            (2399, Rule::BrokenAssocKey),
             (2339, Rule::MapfileProcessSubstitution),
             (2324, Rule::SetFlagsWithoutDashes),
             (2333, Rule::NonShellSyntaxInScript),
@@ -1475,6 +1480,7 @@ mod tests {
         assert!(comparison.contains(&(2127, Rule::BashCaseFallthrough)));
         assert!(comparison.contains(&(2146, Rule::FindOrWithoutGrouping)));
         assert!(comparison.contains(&(2121, Rule::SetFlagsWithoutDashes)));
+        assert!(comparison.contains(&(2399, Rule::BrokenAssocKey)));
         assert!(comparison.contains(&(2336, Rule::AppendToArrayAsString)));
         assert!(comparison.contains(&(2339, Rule::MapfileProcessSubstitution)));
         assert!(comparison.contains(&(2380, Rule::MisspelledOptionName)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -264,6 +264,7 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports array-to-scalar rebinding as SC2178.
             // Keep SC2381 as a suppression alias for authored C133 metadata.
             (2178, Rule::ArrayToStringConversion),
+            (2054, Rule::CommaArrayElements),
             (2336, Rule::AppendToArrayAsString),
             (2339, Rule::MapfileProcessSubstitution),
             (2115, Rule::RmGlobOnVariablePath),
@@ -553,6 +554,7 @@ impl Default for ShellCheckCodeMap {
                     (3076, Rule::SignalNameInTrap),
                     (2323, Rule::ArithmeticScoreLine),
                     (2399, Rule::BrokenAssocKey),
+                    (2054, Rule::CommaArrayElements),
                     (2336, Rule::AppendToArrayAsString),
                     (2339, Rule::MapfileProcessSubstitution),
                     (3051, Rule::SourceInsideFunctionInSh),
@@ -983,6 +985,7 @@ mod tests {
             Some(Rule::FunctionReferencesUnsetParam)
         );
         assert_eq!(map.resolve("SC2323"), Some(Rule::ArithmeticScoreLine));
+        assert_eq!(map.resolve("SC2054"), Some(Rule::CommaArrayElements));
         assert_eq!(map.resolve("SC2336"), Some(Rule::AppendToArrayAsString));
         assert_eq!(
             map.resolve("SC2339"),
@@ -1224,6 +1227,7 @@ mod tests {
             (2146, Rule::FindOrWithoutGrouping),
             (2121, Rule::SetFlagsWithoutDashes),
             (2399, Rule::BrokenAssocKey),
+            (2054, Rule::CommaArrayElements),
             (2336, Rule::AppendToArrayAsString),
             (2339, Rule::MapfileProcessSubstitution),
             (2104, Rule::LoopControlOutsideLoop),
@@ -1307,6 +1311,7 @@ mod tests {
             (2323, Rule::ArithmeticScoreLine),
             (2332, Rule::FindOrWithoutGrouping),
             (2399, Rule::BrokenAssocKey),
+            (2054, Rule::CommaArrayElements),
             (2339, Rule::MapfileProcessSubstitution),
             (2324, Rule::SetFlagsWithoutDashes),
             (2333, Rule::NonShellSyntaxInScript),
@@ -1480,6 +1485,7 @@ mod tests {
         assert!(comparison.contains(&(2127, Rule::BashCaseFallthrough)));
         assert!(comparison.contains(&(2146, Rule::FindOrWithoutGrouping)));
         assert!(comparison.contains(&(2121, Rule::SetFlagsWithoutDashes)));
+        assert!(comparison.contains(&(2054, Rule::CommaArrayElements)));
         assert!(comparison.contains(&(2399, Rule::BrokenAssocKey)));
         assert!(comparison.contains(&(2336, Rule::AppendToArrayAsString)));
         assert!(comparison.contains(&(2339, Rule::MapfileProcessSubstitution)));

--- a/crates/shuck/tests/testdata/corpus-metadata/c108.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c108.yaml
@@ -1,0 +1,21 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2184"
+    reason: "In the current oracle environment, SC2184 covers both quoted associative-key cases and broader `unset` globbing patterns. C108 remains focused on quoted-key associative subscript usage."
+
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__completions__pyenv.bash"
+    line: 9
+    reason: "This is an unquoted indexed-array subscript unset target. C108 intentionally models the narrower quoted-key associative pattern."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__completions__pyenv.bash"
+    line: 10
+    reason: "This is an unquoted indexed-array subscript unset target. C108 intentionally models the narrower quoted-key associative pattern."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__pyenv.d__rehash__conda.bash"
+    line: 55
+    reason: "This unquoted subscript unset uses expansion inside the key. C108 remains scoped to quoted-key associative-element unsets."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__set"
+    line: 182
+    reason: "This is an unquoted indexed-array subscript unset target. C108 intentionally models the narrower quoted-key associative pattern."

--- a/crates/shuck/tests/testdata/corpus-metadata/c133.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c133.yaml
@@ -1,0 +1,7 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2178"
+    reason: "In the current oracle environment, array-to-scalar rebinding for this rule family is reported as SC2178 rather than SC2381."
+
+reviewed_divergences:
+  - side: shellcheck-only
+    reason: "C133 intentionally requires an actual array-expansion conversion pattern in the assignment value. Plain same-name scalar reassignments after historical array bindings are treated as out of scope for this rule."

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -259,7 +259,7 @@ Rules about array assignment, conversion, and element access patterns.
 
 - [x] **M** C106 (SC2336) `append-to-array-as-string` — string appended to array with `+=`
 - [x] **M** C108 (SC2338) `unset-associative-array-element` — associative array element unset with quoted key
-- [ ] **M** C133 (SC2381) `array-to-string-conversion` — array flattened to string
+- [x] **M** C133 (SC2381) `array-to-string-conversion` — array flattened to string
 - [ ] **M** C148 (SC2399) `broken-assoc-key` — associative array key missing closing bracket
 - [ ] **M** C151 (SC2054) `comma-array-elements` — commas in bash array literal
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -260,7 +260,7 @@ Rules about array assignment, conversion, and element access patterns.
 - [x] **M** C106 (SC2336) `append-to-array-as-string` — string appended to array with `+=`
 - [x] **M** C108 (SC2338) `unset-associative-array-element` — associative array element unset with quoted key
 - [x] **M** C133 (SC2381) `array-to-string-conversion` — array flattened to string
-- [ ] **M** C148 (SC2399) `broken-assoc-key` — associative array key missing closing bracket
+- [x] **M** C148 (SC2399) `broken-assoc-key` — associative array key missing closing bracket
 - [ ] **M** C151 (SC2054) `comma-array-elements` — commas in bash array literal
 
 ### Variable and Assignment

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -258,7 +258,7 @@ contexts. Use word facts and expansion word facts.
 Rules about array assignment, conversion, and element access patterns.
 
 - [x] **M** C106 (SC2336) `append-to-array-as-string` — string appended to array with `+=`
-- [ ] **M** C108 (SC2338) `unset-associative-array-element` — associative array element unset with quoted key
+- [x] **M** C108 (SC2338) `unset-associative-array-element` — associative array element unset with quoted key
 - [ ] **M** C133 (SC2381) `array-to-string-conversion` — array flattened to string
 - [ ] **M** C148 (SC2399) `broken-assoc-key` — associative array key missing closing bracket
 - [ ] **M** C151 (SC2054) `comma-array-elements` — commas in bash array literal

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -257,7 +257,7 @@ contexts. Use word facts and expansion word facts.
 
 Rules about array assignment, conversion, and element access patterns.
 
-- [ ] **M** C106 (SC2336) `append-to-array-as-string` — string appended to array with `+=`
+- [x] **M** C106 (SC2336) `append-to-array-as-string` — string appended to array with `+=`
 - [ ] **M** C108 (SC2338) `unset-associative-array-element` — associative array element unset with quoted key
 - [ ] **M** C133 (SC2381) `array-to-string-conversion` — array flattened to string
 - [ ] **M** C148 (SC2399) `broken-assoc-key` — associative array key missing closing bracket

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -261,7 +261,7 @@ Rules about array assignment, conversion, and element access patterns.
 - [x] **M** C108 (SC2338) `unset-associative-array-element` — associative array element unset with quoted key
 - [x] **M** C133 (SC2381) `array-to-string-conversion` — array flattened to string
 - [x] **M** C148 (SC2399) `broken-assoc-key` — associative array key missing closing bracket
-- [ ] **M** C151 (SC2054) `comma-array-elements` — commas in bash array literal
+- [x] **M** C151 (SC2054) `comma-array-elements` — commas in bash array literal
 
 ### Variable and Assignment
 


### PR DESCRIPTION
## What changed

This PR implements the remaining array-operation correctness rules in the linter:

- `C106` `append-to-array-as-string`
- `C108` `unset-associative-array-element`
- `C133` `array-to-string-conversion`
- `C148` `broken-assoc-key`
- `C151` `comma-array-elements`

It also checks those rules off in `docs/rules.md`, adds the needed fixtures/snapshots, and records reviewed corpus metadata for the rules that needed oracle notes.

## Why

These rules were still missing from the array-operation tranche. The implementations lean on shared facts and existing expansion analysis so the new diagnostics reuse common logic instead of duplicating array/expansion parsing in rule modules.

Several edge cases were tightened while validating against the corpus, including shadowed bindings, quoted associative unset operands, malformed associative literals, and brace-expansion commas that should not trigger `C151`.

## Impact

Shuck now catches a broader set of Bash array mistakes while staying aligned with the current large-corpus oracle for this rule family.

## Validation

- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C106,C108,C133,C148,C151`
