### PR TITLE
Implement glob and pattern matching rules

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C078.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C078.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+find . -exec echo *.txt {} +
+find . -exec echo foo[ab]bar {} +
+find . -exec echo $(basename "$dir") {} +
+find . -exec echo $(basename "$dir")* {} +
+find . -execdir echo "$prefix"*.tmp {} \;
+
+find . -exec echo "$file" {} +
+find . -exec echo "*.txt" {} +
+find . -exec echo "$(basename "$dir")" {} +
+find . -name *.txt -print
+printf '*.txt'

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+grep start* out.txt
+grep -e item? out.txt
+grep --regexp item,[0-4] out.txt
+grep -Eq item,[0-4] out.txt
+grep -eo item* out.txt
+grep -F -- item,[0-4] out.txt
+
+grep "start*" out.txt
+grep --regexp='item,[0-4]' out.txt
+grep --regexp=item,[0-4] out.txt
+grep -eitem* out.txt
+grep -f patterns.txt item,[0-4] out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
@@ -5,6 +5,8 @@ grep 'foo*bar' out.txt
 grep foo*bar out.txt
 grep -efoo* out.txt
 grep --regexp start* out.txt
+grep --regexp='start*' out.txt
+grep --regexp=foo*bar out.txt
 grep --exclude '*.txt' foo*bar out.txt
 grep --label stdin foo*bar out.txt
 grep "foo*bar" out.txt
@@ -25,6 +27,4 @@ grep -F "foo*bar" out.txt
 grep --fixed-strings foo*bar out.txt
 grep --fixed-strings "foo*bar" out.txt
 grep -eo foo* out.txt
-grep --regexp='start*' out.txt
-grep --regexp=start* out.txt
 grep -efoo out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
@@ -3,6 +3,7 @@ grep start* out.txt
 grep "start*" out.txt
 grep 'foo*bar' out.txt
 grep foo*bar out.txt
+grep -efoo* out.txt
 grep --regexp start* out.txt
 grep "foo*bar" out.txt
 grep item\* out.txt
@@ -21,6 +22,7 @@ grep -F foo*bar out.txt
 grep -F "foo*bar" out.txt
 grep --fixed-strings foo*bar out.txt
 grep --fixed-strings "foo*bar" out.txt
+grep -eo foo* out.txt
 grep --regexp='start*' out.txt
 grep --regexp=start* out.txt
-grep -estart* out.txt
+grep -efoo out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
@@ -1,13 +1,26 @@
 #!/bin/sh
 grep start* out.txt
-grep -e item? out.txt
-grep --regexp item,[0-4] out.txt
-grep -Eq item,[0-4] out.txt
-grep -eo item* out.txt
-grep -F -- item,[0-4] out.txt
-
 grep "start*" out.txt
-grep --regexp='item,[0-4]' out.txt
-grep --regexp=item,[0-4] out.txt
-grep -eitem* out.txt
-grep -f patterns.txt item,[0-4] out.txt
+grep 'foo*bar' out.txt
+grep foo*bar out.txt
+grep --regexp start* out.txt
+grep "foo*bar" out.txt
+grep item\* out.txt
+grep -E "foo*bar" out.txt
+
+grep "a.*" out.txt
+grep a.* out.txt
+grep "[ab]*" out.txt
+grep [ab]* out.txt
+grep '*start' out.txt
+grep '*start*' out.txt
+grep item\\* out.txt
+grep '^ *#' out.txt
+grep '"name": *"$x"' out.txt
+grep -F foo*bar out.txt
+grep -F "foo*bar" out.txt
+grep --fixed-strings foo*bar out.txt
+grep --fixed-strings "foo*bar" out.txt
+grep --regexp='start*' out.txt
+grep --regexp=start* out.txt
+grep -estart* out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C080.sh
@@ -5,6 +5,8 @@ grep 'foo*bar' out.txt
 grep foo*bar out.txt
 grep -efoo* out.txt
 grep --regexp start* out.txt
+grep --exclude '*.txt' foo*bar out.txt
+grep --label stdin foo*bar out.txt
 grep "foo*bar" out.txt
 grep item\* out.txt
 grep -E "foo*bar" out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C081.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C081.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+if [[ $mirror == $pkgs ]]; then echo same; fi
+if [[ "$a" = $1 ]]; then :; fi
+if [[ "$a" != ${b%%x} ]]; then :; fi
+if [[ "$a" == ${arr[0]} ]]; then :; fi
+printf '%s\n' "$( [[ $mirror == $pkgs ]] && echo same )"
+
+if [[ "$a" == "$b" ]]; then :; fi
+if [[ "$a" == $b* ]]; then :; fi
+if [[ "$a" == $b$c ]]; then :; fi
+if [[ "$a" == ${b}_x ]]; then :; fi
+if [[ "$a" < $b ]]; then :; fi
+if [ "$a" = $b ]; then :; fi

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C083.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C083.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 find ./ -name *.jar
 find ./ -name "$prefix"*.jar
+find ./ -wholename */tmp/*
 for f in $(find ./ -name *.cfg); do :; done
 printf '%s\n' "$(find . -path */tmp/*)"
 
 find ./ -name '*.jar'
 find ./ -name \*.tmp
 find ./ -path \*/tmp/\*
+find ./ -wholename \*/tmp/\*
 find ./ -type f*
 command find ./ -name *.jar
 find ./ -name "$pattern"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C083.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C083.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 find ./ -name *.jar
+find ./ -name "$prefix"*.jar
 for f in $(find ./ -name *.cfg); do :; done
 printf '%s\n' "$(find . -path */tmp/*)"
 

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C083.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C083.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+find ./ -name *.jar
+for f in $(find ./ -name *.cfg); do :; done
+printf '%s\n' "$(find . -path */tmp/*)"
+
+find ./ -name '*.jar'
+find ./ -name \*.tmp
+find ./ -path \*/tmp/\*
+find ./ -type f*
+command find ./ -name *.jar
+find ./ -name "$pattern"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C084.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C084.sh
@@ -5,6 +5,7 @@ grep -eitem* out.txt
 grep -oe item* out.txt
 grep --regexp item,[0-4] out.txt
 grep -Eq item,[0-4] out.txt
+grep --regexp=foo*bar out.txt
 grep --exclude '*.txt' foo*bar out.txt
 grep --label stdin item? out.txt
 grep -F -- item,[0-4] out.txt
@@ -14,7 +15,6 @@ checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
 
 grep "start*" out.txt
 grep --regexp='item,[0-4]' out.txt
-grep --regexp=item,[0-4] out.txt
 grep -eo item* out.txt
 grep -f patterns.txt item,[0-4] out.txt
 grep --exclude '*.txt' "foo*bar" out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C084.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C084.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 grep start* out.txt
 grep -e item? out.txt
+grep -eitem* out.txt
+grep -oe item* out.txt
 grep --regexp item,[0-4] out.txt
 grep -Eq item,[0-4] out.txt
-grep -eo item* out.txt
 grep -F -- item,[0-4] out.txt
 grep -F foo*bar out.txt
 grep [0-9a-f]{40} out.txt
@@ -12,7 +13,7 @@ checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
 grep "start*" out.txt
 grep --regexp='item,[0-4]' out.txt
 grep --regexp=item,[0-4] out.txt
-grep -eitem* out.txt
+grep -eo item* out.txt
 grep -f patterns.txt item,[0-4] out.txt
 grep \[ab\]\* out.txt
 grep -F "foo*bar" out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C084.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C084.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+grep start* out.txt
+grep -e item? out.txt
+grep --regexp item,[0-4] out.txt
+grep -Eq item,[0-4] out.txt
+grep -eo item* out.txt
+grep -F -- item,[0-4] out.txt
+grep -F foo*bar out.txt
+grep [0-9a-f]{40} out.txt
+checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
+
+grep "start*" out.txt
+grep --regexp='item,[0-4]' out.txt
+grep --regexp=item,[0-4] out.txt
+grep -eitem* out.txt
+grep -f patterns.txt item,[0-4] out.txt
+grep \[ab\]\* out.txt
+grep -F "foo*bar" out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C084.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C084.sh
@@ -5,6 +5,8 @@ grep -eitem* out.txt
 grep -oe item* out.txt
 grep --regexp item,[0-4] out.txt
 grep -Eq item,[0-4] out.txt
+grep --exclude '*.txt' foo*bar out.txt
+grep --label stdin item? out.txt
 grep -F -- item,[0-4] out.txt
 grep -F foo*bar out.txt
 grep [0-9a-f]{40} out.txt
@@ -15,5 +17,6 @@ grep --regexp='item,[0-4]' out.txt
 grep --regexp=item,[0-4] out.txt
 grep -eo item* out.txt
 grep -f patterns.txt item,[0-4] out.txt
+grep --exclude '*.txt' "foo*bar" out.txt
 grep \[ab\]\* out.txt
 grep -F "foo*bar" out.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C114.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C114.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+for i in $CWD/file.*pattern*; do :; done
+for i in ${CWD}/file.*pattern*; do :; done
+for i in $(pwd)/file.*pattern*; do :; done
+
+for i in "$CWD"/file.*pattern*; do :; done
+for i in file.*pattern*; do :; done
+for i in "$CWD"/*.txt; do :; done
+for i in $DIR/setjmp-aarch64/{setjmp.S,private-*.h}; do :; done

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C114.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C114.sh
@@ -6,4 +6,5 @@ for i in $(pwd)/file.*pattern*; do :; done
 for i in "$CWD"/file.*pattern*; do :; done
 for i in file.*pattern*; do :; done
 for i in "$CWD"/*.txt; do :; done
+for i in $DIR/{1..3}*.txt; do :; done
 for i in $DIR/setjmp-aarch64/{setjmp.S,private-*.h}; do :; done

--- a/crates/shuck-linter/resources/test/fixtures/style/S055.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S055.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+LOCS=*.oxt
+LOCS="*.oxt"
+LOCS=$dir/*.oxt
+LOCS="$dir"/*.oxt
+LOCS=${dir}/*.oxt
+LOCS=$(pwd)/*.oxt
+LOCS=\*.oxt
+readonly LOCS=foo*bar
+export LOCS=$dir/*.txt
+LOCS=(*.oxt)
+LOCS=("$dir"/*.txt)
+LOCS=${name#*:}

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -473,6 +473,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::GlobInGrepPattern) {
             rules::correctness::glob_in_grep_pattern::glob_in_grep_pattern(self);
         }
+        if self.is_rule_enabled(Rule::UnquotedGrepRegex) {
+            rules::correctness::unquoted_grep_regex::unquoted_grep_regex(self);
+        }
         if self.is_rule_enabled(Rule::ZshFlagExpansion) {
             rules::portability::zsh_flag_expansion::zsh_flag_expansion(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -476,6 +476,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::UnquotedGrepRegex) {
             rules::correctness::unquoted_grep_regex::unquoted_grep_regex(self);
         }
+        if self.is_rule_enabled(Rule::GlobWithExpansionInLoop) {
+            rules::correctness::glob_with_expansion_in_loop::glob_with_expansion_in_loop(self);
+        }
         if self.is_rule_enabled(Rule::ZshFlagExpansion) {
             rules::portability::zsh_flag_expansion::zsh_flag_expansion(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -467,6 +467,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::UnquotedGlobsInFind) {
             rules::correctness::unquoted_globs_in_find::unquoted_globs_in_find(self);
         }
+        if self.is_rule_enabled(Rule::GlobInFindSubstitution) {
+            rules::correctness::glob_in_find_substitution::glob_in_find_substitution(self);
+        }
         if self.is_rule_enabled(Rule::GlobInGrepPattern) {
             rules::correctness::glob_in_grep_pattern::glob_in_grep_pattern(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -746,6 +746,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::GrepOutputInTest) {
             rules::style::grep_output_in_test::grep_output_in_test(self);
         }
+        if self.is_rule_enabled(Rule::GlobInStringComparison) {
+            rules::correctness::glob_in_string_comparison::glob_in_string_comparison(self);
+        }
         if self.is_rule_enabled(Rule::TestEqualityOperator) {
             rules::portability::conditional_portability::test_equality_operator(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -479,6 +479,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::GlobWithExpansionInLoop) {
             rules::correctness::glob_with_expansion_in_loop::glob_with_expansion_in_loop(self);
         }
+        if self.is_rule_enabled(Rule::GlobAssignedToVariable) {
+            rules::style::glob_assigned_to_variable::glob_assigned_to_variable(self);
+        }
         if self.is_rule_enabled(Rule::ZshFlagExpansion) {
             rules::portability::zsh_flag_expansion::zsh_flag_expansion(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -467,6 +467,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::UnquotedGlobsInFind) {
             rules::correctness::unquoted_globs_in_find::unquoted_globs_in_find(self);
         }
+        if self.is_rule_enabled(Rule::GlobInGrepPattern) {
+            rules::correctness::glob_in_grep_pattern::glob_in_grep_pattern(self);
+        }
         if self.is_rule_enabled(Rule::ZshFlagExpansion) {
             rules::portability::zsh_flag_expansion::zsh_flag_expansion(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -464,6 +464,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::PatternWithVariable) {
             rules::correctness::pattern_with_variable::pattern_with_variable(self);
         }
+        if self.is_rule_enabled(Rule::UnquotedGlobsInFind) {
+            rules::correctness::unquoted_globs_in_find::unquoted_globs_in_find(self);
+        }
         if self.is_rule_enabled(Rule::ZshFlagExpansion) {
             rules::portability::zsh_flag_expansion::zsh_flag_expansion(self);
         }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1321,9 +1321,16 @@ impl WaitCommandFacts {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct GrepCommandFacts {
+#[derive(Debug, Clone)]
+pub struct GrepCommandFacts<'a> {
     pub uses_only_matching: bool,
+    pattern_words: Box<[&'a Word]>,
+}
+
+impl<'a> GrepCommandFacts<'a> {
+    pub fn pattern_words(&self) -> &[&'a Word] {
+        &self.pattern_words
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1431,7 +1438,7 @@ pub struct CommandOptionFacts<'a> {
     mapfile: Option<MapfileCommandFacts>,
     xargs: Option<XargsCommandFacts>,
     wait: Option<WaitCommandFacts>,
-    grep: Option<GrepCommandFacts>,
+    grep: Option<GrepCommandFacts<'a>>,
     ps: Option<PsCommandFacts>,
     set: Option<SetCommandFacts>,
     configure: Option<ConfigureCommandFacts>,
@@ -1481,7 +1488,7 @@ impl<'a> CommandOptionFacts<'a> {
         self.wait.as_ref()
     }
 
-    pub fn grep(&self) -> Option<&GrepCommandFacts> {
+    pub fn grep(&self) -> Option<&GrepCommandFacts<'a>> {
         self.grep.as_ref()
     }
 
@@ -6989,9 +6996,12 @@ fn split_brace_alternatives(text: &str) -> Vec<&str> {
     alternatives
 }
 
-fn parse_grep_command(args: &[&Word], source: &str) -> Option<GrepCommandFacts> {
+fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommandFacts<'a>> {
     let mut index = 0usize;
     let mut pending_dynamic_option_arg = false;
+    let mut uses_only_matching = false;
+    let mut explicit_pattern_source = false;
+    let mut pattern_words = Vec::new();
 
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
@@ -7011,6 +7021,7 @@ fn parse_grep_command(args: &[&Word], source: &str) -> Option<GrepCommandFacts> 
         };
 
         if text == "--" {
+            index += 1;
             break;
         }
 
@@ -7025,33 +7036,108 @@ fn parse_grep_command(args: &[&Word], source: &str) -> Option<GrepCommandFacts> 
         }
 
         pending_dynamic_option_arg = false;
+
         if text == "--only-matching" {
-            return Some(GrepCommandFacts {
-                uses_only_matching: true,
-            });
+            uses_only_matching = true;
+            index += 1;
+            continue;
+        }
+
+        if text == "--regexp" {
+            explicit_pattern_source = true;
+            if let Some(pattern_word) = args.get(index + 1) {
+                pattern_words.push(*pattern_word);
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+
+        if text.starts_with("--regexp=") {
+            explicit_pattern_source = true;
+            index += 1;
+            continue;
+        }
+
+        if text == "--file" {
+            explicit_pattern_source = true;
+            index += if args.get(index + 1).is_some() { 2 } else { 1 };
+            continue;
+        }
+
+        if text.starts_with("--file=") {
+            explicit_pattern_source = true;
+            index += 1;
+            continue;
+        }
+
+        if text.starts_with("--") {
+            index += 1;
+            continue;
+        }
+
+        if text == "-e" {
+            explicit_pattern_source = true;
+            if let Some(pattern_word) = args.get(index + 1) {
+                pattern_words.push(*pattern_word);
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+
+        if text == "-f" {
+            explicit_pattern_source = true;
+            index += if args.get(index + 1).is_some() { 2 } else { 1 };
+            continue;
         }
 
         let mut chars = text[1..].chars().peekable();
+        let mut consume_next_argument = false;
         while let Some(flag) = chars.next() {
             if flag == 'o' {
-                return Some(GrepCommandFacts {
-                    uses_only_matching: true,
-                });
+                uses_only_matching = true;
+            }
+
+            if flag == 'e' {
+                if chars.peek().is_none() {
+                    explicit_pattern_source = true;
+                }
+                if chars.peek().is_none()
+                    && let Some(pattern_word) = args.get(index + 1)
+                {
+                    pattern_words.push(*pattern_word);
+                    consume_next_argument = true;
+                }
+                break;
             }
 
             if grep_option_takes_argument(flag) {
+                if flag == 'f' {
+                    explicit_pattern_source = true;
+                }
                 if chars.peek().is_none() {
-                    index += 1;
+                    consume_next_argument = true;
                 }
                 break;
             }
         }
 
         index += 1;
+        if consume_next_argument {
+            index += 1;
+        }
+    }
+
+    if !explicit_pattern_source && let Some(pattern_word) = args.get(index) {
+        pattern_words.push(*pattern_word);
     }
 
     Some(GrepCommandFacts {
-        uses_only_matching: false,
+        uses_only_matching,
+        pattern_words: pattern_words.into_boxed_slice(),
     })
 }
 
@@ -8911,6 +8997,13 @@ complex[$((i+=1))]+=x
             .and_then(|fact| fact.options().grep())
             .expect("expected grep facts");
         assert!(grep.uses_only_matching);
+        assert_eq!(
+            grep.pattern_words()
+                .iter()
+                .map(|word| word.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["content"]
+        );
 
         let exit = facts
             .commands()
@@ -9013,6 +9106,51 @@ unset parts[\"$key\"] extra
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
         assert_eq!(find_or_without_grouping_spans, vec!["-print"]);
+    }
+
+    #[test]
+    fn parses_grep_pattern_words_from_flags_and_operands() {
+        let source = "\
+#!/bin/bash
+grep item,[0-4] data.txt
+grep -e item* data.txt
+grep --regexp='a[b]c' data.txt
+grep --regexp item? data.txt
+grep -eo item* data.txt
+grep -F -- item* data.txt
+grep -f patterns.txt item* data.txt
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let grep_patterns = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("grep"))
+            .filter_map(|fact| fact.options().grep())
+            .map(|grep| {
+                grep.pattern_words()
+                    .iter()
+                    .map(|word| word.span.slice(source))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            grep_patterns,
+            vec![
+                vec!["item,[0-4]"],
+                vec!["item*"],
+                Vec::new(),
+                vec!["item?"],
+                vec!["item*"],
+                vec!["item*"],
+                Vec::new(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -6456,10 +6456,10 @@ fn build_conditional_operand_fact<'a>(
     let expression = strip_parenthesized_conditionals(expression);
     let word = match expression {
         ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => Some(word),
+        ConditionalExpr::Pattern(pattern) => conditional_pattern_single_word(pattern),
         ConditionalExpr::Binary(_)
         | ConditionalExpr::Unary(_)
         | ConditionalExpr::Parenthesized(_)
-        | ConditionalExpr::Pattern(_)
         | ConditionalExpr::VarRef(_) => None,
     };
 
@@ -6468,6 +6468,20 @@ fn build_conditional_operand_fact<'a>(
         class: classify_conditional_operand(expression, source),
         word,
         word_classification: word.map(|word| classify_word(word, source)),
+    }
+}
+
+fn conditional_pattern_single_word(pattern: &Pattern) -> Option<&Word> {
+    match pattern.parts.as_slice() {
+        [part] => match &part.kind {
+            PatternPart::Word(word) => Some(word),
+            PatternPart::Literal(_)
+            | PatternPart::AnyString
+            | PatternPart::AnyChar
+            | PatternPart::CharClass(_)
+            | PatternPart::Group { .. } => None,
+        },
+        _ => None,
     }
 }
 
@@ -8542,7 +8556,7 @@ fn compound_span(command: &CompoundCommand) -> Span {
 mod tests {
     use std::path::Path;
 
-    use shuck_ast::BinaryOp;
+    use shuck_ast::{BinaryOp, ConditionalBinaryOp};
     use shuck_indexer::Indexer;
     use shuck_parser::parser::{Parser, ShellDialect as ParseShellDialect};
     use shuck_semantic::SemanticModel;
@@ -10150,7 +10164,7 @@ for version ($versions); do :; done
         let source = "\
 #!/bin/bash
 [[ ( ( -z foo ) ) ]]
-[[ foo && -n \"$bar\" && left == right && $value =~ ^\"foo\"bar$ && left == *.sh ]]
+[[ foo && -n \"$bar\" && left == right && $value =~ ^\"foo\"bar$ && left == *.sh && left == $rhs ]]
 ";
 
         with_facts(source, None, |_, facts| {
@@ -10183,6 +10197,15 @@ for version ($versions); do :; done
             assert!(logical.nodes().iter().any(|node| matches!(node, ConditionalNodeFact::Unary(unary) if unary.operator_family() == ConditionalOperatorFamily::StringUnary)));
             assert!(logical.nodes().iter().any(|node| matches!(node, ConditionalNodeFact::Binary(binary) if binary.operator_family() == ConditionalOperatorFamily::StringBinary && binary.right().class().is_fixed_literal())));
             assert!(logical.nodes().iter().any(|node| matches!(node, ConditionalNodeFact::Binary(binary) if binary.operator_family() == ConditionalOperatorFamily::StringBinary && !binary.right().class().is_fixed_literal())));
+            assert!(logical.nodes().iter().any(|node| matches!(
+                node,
+                ConditionalNodeFact::Binary(binary)
+                    if matches!(binary.op(), ConditionalBinaryOp::PatternEq)
+                        && binary
+                            .right()
+                            .word()
+                            .is_some_and(|word| word.span.slice(source) == "$rhs")
+            )));
 
             let regex = logical.regex_nodes().next().expect("expected regex node");
             assert_eq!(regex.operator_family(), ConditionalOperatorFamily::Regex);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1275,11 +1275,16 @@ impl SshCommandFacts {
 pub struct FindCommandFacts {
     pub has_print0: bool,
     or_without_grouping_spans: Box<[Span]>,
+    glob_pattern_operand_spans: Box<[Span]>,
 }
 
 impl FindCommandFacts {
     pub fn or_without_grouping_spans(&self) -> &[Span] {
         &self.or_without_grouping_spans
+    }
+
+    pub fn glob_pattern_operand_spans(&self) -> &[Span] {
+        &self.glob_pattern_operand_spans
     }
 }
 
@@ -7500,6 +7505,7 @@ fn parse_find_execdir_shell_command(
 fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
     let mut has_print0 = false;
     let mut or_without_grouping_spans = Vec::new();
+    let mut glob_pattern_operand_spans = Vec::new();
     let mut group_stack = vec![FindGroupState::default()];
     let mut pending_argument: Option<FindPendingArgument> = None;
 
@@ -7512,6 +7518,11 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
         };
 
         if let Some(state) = pending_argument {
+            if state.expects_pattern_operand()
+                && !span::word_unquoted_glob_pattern_spans(word, source).is_empty()
+            {
+                glob_pattern_operand_spans.push(word.span);
+            }
             pending_argument = state.after_consuming(text.as_str());
             continue;
         }
@@ -7568,21 +7579,31 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
     FindCommandFacts {
         has_print0,
         or_without_grouping_spans: or_without_grouping_spans.into_boxed_slice(),
+        glob_pattern_operand_spans: glob_pattern_operand_spans.into_boxed_slice(),
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 enum FindPendingArgument {
-    Words(usize),
+    Words {
+        remaining: usize,
+        pattern_operand: bool,
+    },
     UntilExecTerminator,
 }
 
 impl FindPendingArgument {
     fn after_consuming(self, token: &str) -> Option<Self> {
         match self {
-            Self::Words(remaining) => remaining
-                .checked_sub(1)
-                .and_then(|next| (next > 0).then_some(Self::Words(next))),
+            Self::Words {
+                remaining,
+                pattern_operand: _,
+            } => remaining.checked_sub(1).and_then(|next| {
+                (next > 0).then_some(Self::Words {
+                    remaining: next,
+                    pattern_operand: false,
+                })
+            }),
             Self::UntilExecTerminator => {
                 (!matches!(token, ";" | "\\;" | "+")).then_some(Self::UntilExecTerminator)
             }
@@ -7591,11 +7612,27 @@ impl FindPendingArgument {
 
     fn after_consuming_dynamic(self) -> Option<Self> {
         match self {
-            Self::Words(remaining) => remaining
-                .checked_sub(1)
-                .and_then(|next| (next > 0).then_some(Self::Words(next))),
+            Self::Words {
+                remaining,
+                pattern_operand: _,
+            } => remaining.checked_sub(1).and_then(|next| {
+                (next > 0).then_some(Self::Words {
+                    remaining: next,
+                    pattern_operand: false,
+                })
+            }),
             Self::UntilExecTerminator => Some(Self::UntilExecTerminator),
         }
+    }
+
+    fn expects_pattern_operand(self) -> bool {
+        matches!(
+            self,
+            Self::Words {
+                pattern_operand: true,
+                ..
+            }
+        )
     }
 }
 
@@ -7712,19 +7749,38 @@ fn is_find_reportable_action_token(token: &str) -> bool {
 
 fn find_pending_argument(token: &str) -> Option<FindPendingArgument> {
     match token {
-        "-fls" | "-fprint" | "-fprint0" | "-printf" => Some(FindPendingArgument::Words(1)),
-        "-fprintf" => Some(FindPendingArgument::Words(2)),
+        "-fls" | "-fprint" | "-fprint0" | "-printf" => Some(FindPendingArgument::Words {
+            remaining: 1,
+            pattern_operand: false,
+        }),
+        "-fprintf" => Some(FindPendingArgument::Words {
+            remaining: 2,
+            pattern_operand: false,
+        }),
         "-exec" | "-execdir" | "-ok" | "-okdir" => Some(FindPendingArgument::UntilExecTerminator),
         "-amin" | "-anewer" | "-atime" | "-cmin" | "-cnewer" | "-context" | "-fstype" | "-gid"
         | "-group" | "-ilname" | "-iname" | "-inum" | "-ipath" | "-iregex" | "-links"
         | "-lname" | "-maxdepth" | "-mindepth" | "-mmin" | "-mtime" | "-name" | "-newer"
         | "-path" | "-perm" | "-regex" | "-samefile" | "-size" | "-type" | "-uid" | "-used"
-        | "-user" | "-xtype" | "-files0-from" => Some(FindPendingArgument::Words(1)),
+        | "-user" | "-xtype" | "-files0-from" => Some(FindPendingArgument::Words {
+            remaining: 1,
+            pattern_operand: is_find_pattern_predicate_token(token),
+        }),
         token if token.starts_with("-newer") && token.len() > "-newer".len() => {
-            Some(FindPendingArgument::Words(1))
+            Some(FindPendingArgument::Words {
+                remaining: 1,
+                pattern_operand: false,
+            })
         }
         _ => None,
     }
+}
+
+fn is_find_pattern_predicate_token(token: &str) -> bool {
+    matches!(
+        token,
+        "-name" | "-iname" | "-path" | "-ipath" | "-regex" | "-iregex" | "-lname" | "-ilname"
+    )
 }
 
 fn is_find_predicate_token(token: &str) -> bool {
@@ -8801,7 +8857,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn summarizes_command_options_and_invokers() {
-        let source = "#!/bin/bash\nread -r name\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
+        let source = "#!/bin/bash\nread -r name\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -8898,6 +8954,15 @@ complex[$((i+=1))]+=x
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
         assert_eq!(find_or_without_grouping_spans, vec!["-print"]);
+        let find_glob_pattern_operand_spans = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("find"))
+            .filter_map(|fact| fact.options().find())
+            .flat_map(|find| find.glob_pattern_operand_spans().iter().copied())
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+        assert_eq!(find_glob_pattern_operand_spans, vec!["*.cfg"]);
 
         let find_execdir = facts
             .commands()

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1747,6 +1747,7 @@ pub struct LinterFacts<'a> {
     comma_array_assignment_spans: Vec<Span>,
     presence_tested_names: FxHashSet<Name>,
     subscript_index_reference_spans: FxHashSet<FactSpan>,
+    compound_assignment_value_word_spans: FxHashSet<FactSpan>,
     words: Vec<WordFact<'a>>,
     word_index: FxHashMap<FactSpan, Vec<usize>>,
     function_headers: Vec<FunctionHeaderFact<'a>>,
@@ -1880,6 +1881,11 @@ impl<'a> LinterFacts<'a> {
 
     pub fn word_facts(&self) -> &[WordFact<'a>] {
         &self.words
+    }
+
+    pub fn is_compound_assignment_value_word(&self, fact: &WordFact<'_>) -> bool {
+        self.compound_assignment_value_word_spans
+            .contains(&fact.key())
     }
 
     pub fn expansion_word_facts(
@@ -2177,6 +2183,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
         let mut words = Vec::new();
+        let mut compound_assignment_value_word_spans = FxHashSet::default();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut pattern_literal_spans = Vec::new();
         let mut pattern_charclass_spans = Vec::new();
@@ -2213,6 +2220,8 @@ impl<'a> LinterFactsBuilder<'a> {
             }
             let collected_words =
                 build_word_facts_for_command(visit, self.source, id, nested_word_command);
+            compound_assignment_value_word_spans
+                .extend(collected_words.compound_assignment_value_word_spans);
             words.extend(collected_words.facts);
             pattern_literal_spans.extend(collected_words.pattern_literal_spans);
             pattern_charclass_spans.extend(collected_words.pattern_charclass_spans);
@@ -2362,6 +2371,7 @@ impl<'a> LinterFactsBuilder<'a> {
             comma_array_assignment_spans,
             presence_tested_names,
             subscript_index_reference_spans,
+            compound_assignment_value_word_spans,
             words,
             word_index,
             function_headers,
@@ -4821,6 +4831,7 @@ fn build_word_facts_for_command<'a>(
 
 struct CollectedWordFacts<'a> {
     facts: Vec<WordFact<'a>>,
+    compound_assignment_value_word_spans: FxHashSet<FactSpan>,
     pattern_literal_spans: Vec<Span>,
     pattern_charclass_spans: Vec<Span>,
     arithmetic: ArithmeticFactSummary,
@@ -4832,6 +4843,7 @@ struct WordFactCollector<'a> {
     nested_word_command: bool,
     facts: Vec<WordFact<'a>>,
     seen: FxHashSet<(FactSpan, WordFactContext, WordFactHostKind)>,
+    compound_assignment_value_word_spans: FxHashSet<FactSpan>,
     pattern_literal_spans: Vec<Span>,
     pattern_charclass_spans: Vec<Span>,
     arithmetic: ArithmeticFactSummary,
@@ -4845,6 +4857,7 @@ impl<'a> WordFactCollector<'a> {
             nested_word_command,
             facts: Vec::new(),
             seen: FxHashSet::default(),
+            compound_assignment_value_word_spans: FxHashSet::default(),
             pattern_literal_spans: Vec::new(),
             pattern_charclass_spans: Vec::new(),
             arithmetic: ArithmeticFactSummary::default(),
@@ -4854,6 +4867,7 @@ impl<'a> WordFactCollector<'a> {
     fn finish(self) -> CollectedWordFacts<'a> {
         CollectedWordFacts {
             facts: self.facts,
+            compound_assignment_value_word_spans: self.compound_assignment_value_word_spans,
             pattern_literal_spans: self.pattern_literal_spans,
             pattern_charclass_spans: self.pattern_charclass_spans,
             arithmetic: self.arithmetic,
@@ -5163,6 +5177,8 @@ impl<'a> WordFactCollector<'a> {
                 for element in &array.elements {
                     match element {
                         ArrayElem::Sequential(word) => {
+                            self.compound_assignment_value_word_spans
+                                .insert(FactSpan::new(word.span));
                             self.push_word(word, context, WordFactHostKind::Direct);
                         }
                         ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
@@ -5173,6 +5189,8 @@ impl<'a> WordFactCollector<'a> {
                                     WordFactHostKind::ArrayKeySubscript,
                                 );
                             });
+                            self.compound_assignment_value_word_spans
+                                .insert(FactSpan::new(value.span));
                             self.push_word(value, context, WordFactHostKind::Direct);
                         }
                     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1329,6 +1329,7 @@ impl WaitCommandFacts {
 #[derive(Debug, Clone)]
 pub struct GrepCommandFacts<'a> {
     pub uses_only_matching: bool,
+    pub uses_fixed_strings: bool,
     pattern_words: Box<[&'a Word]>,
 }
 
@@ -7019,6 +7020,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
     let mut index = 0usize;
     let mut pending_dynamic_option_arg = false;
     let mut uses_only_matching = false;
+    let mut uses_fixed_strings = false;
     let mut explicit_pattern_source = false;
     let mut pattern_words = Vec::new();
 
@@ -7058,6 +7060,21 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
         if text == "--only-matching" {
             uses_only_matching = true;
+            index += 1;
+            continue;
+        }
+
+        if text == "--fixed-strings" {
+            uses_fixed_strings = true;
+            index += 1;
+            continue;
+        }
+
+        if matches!(
+            text.as_str(),
+            "--basic-regexp" | "--extended-regexp" | "--perl-regexp"
+        ) {
+            uses_fixed_strings = false;
             index += 1;
             continue;
         }
@@ -7120,6 +7137,14 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                 uses_only_matching = true;
             }
 
+            if flag == 'F' {
+                uses_fixed_strings = true;
+            }
+
+            if matches!(flag, 'E' | 'G' | 'P') {
+                uses_fixed_strings = false;
+            }
+
             if flag == 'e' {
                 if chars.peek().is_none() {
                     explicit_pattern_source = true;
@@ -7156,6 +7181,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
     Some(GrepCommandFacts {
         uses_only_matching,
+        uses_fixed_strings,
         pattern_words: pattern_words.into_boxed_slice(),
     })
 }
@@ -9076,6 +9102,7 @@ complex[$((i+=1))]+=x
             .and_then(|fact| fact.options().grep())
             .expect("expected grep facts");
         assert!(grep.uses_only_matching);
+        assert!(!grep.uses_fixed_strings);
         assert_eq!(
             grep.pattern_words()
                 .iter()
@@ -9198,6 +9225,8 @@ grep --regexp item? data.txt
 grep -eo item* data.txt
 grep -F -- item* data.txt
 grep -f patterns.txt item* data.txt
+grep -F -E foo*bar data.txt
+grep -E -F foo*bar data.txt
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
@@ -9211,23 +9240,28 @@ grep -f patterns.txt item* data.txt
             .filter(|fact| fact.effective_name_is("grep"))
             .filter_map(|fact| fact.options().grep())
             .map(|grep| {
-                grep.pattern_words()
-                    .iter()
-                    .map(|word| word.span.slice(source))
-                    .collect::<Vec<_>>()
+                (
+                    grep.pattern_words()
+                        .iter()
+                        .map(|word| word.span.slice(source))
+                        .collect::<Vec<_>>(),
+                    grep.uses_fixed_strings,
+                )
             })
             .collect::<Vec<_>>();
 
         assert_eq!(
             grep_patterns,
             vec![
-                vec!["item,[0-4]"],
-                vec!["item*"],
-                Vec::new(),
-                vec!["item?"],
-                vec!["item*"],
-                vec!["item*"],
-                Vec::new(),
+                (vec!["item,[0-4]"], false),
+                (vec!["item*"], false),
+                (Vec::new(), false),
+                (vec!["item?"], false),
+                (vec!["item*"], false),
+                (vec!["item*"], true),
+                (Vec::new(), false),
+                (vec!["foo*bar"], false),
+                (vec!["foo*bar"], true),
             ]
         );
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1330,12 +1330,32 @@ impl WaitCommandFacts {
 pub struct GrepCommandFacts<'a> {
     pub uses_only_matching: bool,
     pub uses_fixed_strings: bool,
-    pattern_words: Box<[&'a Word]>,
+    patterns: Box<[GrepPatternFact<'a>]>,
 }
 
 impl<'a> GrepCommandFacts<'a> {
-    pub fn pattern_words(&self) -> &[&'a Word] {
-        &self.pattern_words
+    pub fn patterns(&self) -> &[GrepPatternFact<'a>] {
+        &self.patterns
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GrepPatternFact<'a> {
+    word: &'a Word,
+    static_text: Option<Box<str>>,
+}
+
+impl<'a> GrepPatternFact<'a> {
+    pub fn word(&self) -> &'a Word {
+        self.word
+    }
+
+    pub fn span(&self) -> Span {
+        self.word.span
+    }
+
+    pub fn static_text(&self) -> Option<&str> {
+        self.static_text.as_deref()
     }
 }
 
@@ -7040,7 +7060,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
     let mut uses_only_matching = false;
     let mut uses_fixed_strings = false;
     let mut explicit_pattern_source = false;
-    let mut pattern_words = Vec::new();
+    let mut patterns = Vec::new();
 
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
@@ -7100,7 +7120,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
         if text == "--regexp" {
             explicit_pattern_source = true;
             if let Some(pattern_word) = args.get(index + 1) {
-                pattern_words.push(*pattern_word);
+                patterns.push(grep_pattern_fact(pattern_word, source));
                 index += 2;
             } else {
                 index += 1;
@@ -7110,7 +7130,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
         if text.starts_with("--regexp=") {
             explicit_pattern_source = true;
-            pattern_words.push(*word);
+            patterns.push(grep_prefixed_pattern_fact(word, source, "--regexp=".len()));
             index += 1;
             continue;
         }
@@ -7141,7 +7161,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
         if text == "-e" {
             explicit_pattern_source = true;
             if let Some(pattern_word) = args.get(index + 1) {
-                pattern_words.push(*pattern_word);
+                patterns.push(grep_pattern_fact(pattern_word, source));
                 index += 2;
             } else {
                 index += 1;
@@ -7173,9 +7193,9 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
             if flag == 'e' {
                 explicit_pattern_source = true;
                 if chars.peek().is_some() {
-                    pattern_words.push(*word);
+                    patterns.push(grep_prefixed_pattern_fact(word, source, 2));
                 } else if let Some(pattern_word) = args.get(index + 1) {
-                    pattern_words.push(*pattern_word);
+                    patterns.push(grep_pattern_fact(pattern_word, source));
                     consume_next_argument = true;
                 }
                 break;
@@ -7199,14 +7219,30 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
     }
 
     if !explicit_pattern_source && let Some(pattern_word) = args.get(index) {
-        pattern_words.push(*pattern_word);
+        patterns.push(grep_pattern_fact(pattern_word, source));
     }
 
     Some(GrepCommandFacts {
         uses_only_matching,
         uses_fixed_strings,
-        pattern_words: pattern_words.into_boxed_slice(),
+        patterns: patterns.into_boxed_slice(),
     })
+}
+
+fn grep_pattern_fact<'a>(word: &'a Word, source: &str) -> GrepPatternFact<'a> {
+    grep_prefixed_pattern_fact(word, source, 0)
+}
+
+fn grep_prefixed_pattern_fact<'a>(
+    word: &'a Word,
+    source: &str,
+    prefix_len: usize,
+) -> GrepPatternFact<'a> {
+    let static_text = static_word_text(word, source)
+        .and_then(|text| text.get(prefix_len..).map(str::to_owned))
+        .map(String::into_boxed_str);
+
+    GrepPatternFact { word, static_text }
 }
 
 fn grep_option_takes_argument(flag: char) -> bool {
@@ -7226,6 +7262,7 @@ fn grep_long_option_takes_argument(option: &str) -> bool {
         "after-context"
             | "before-context"
             | "binary-files"
+            | "context"
             | "devices"
             | "directories"
             | "exclude"
@@ -9173,9 +9210,9 @@ complex[$((i+=1))]+=x
         assert!(grep.uses_only_matching);
         assert!(!grep.uses_fixed_strings);
         assert_eq!(
-            grep.pattern_words()
+            grep.patterns()
                 .iter()
-                .map(|word| word.span.slice(source))
+                .map(|pattern| pattern.span().slice(source))
                 .collect::<Vec<_>>(),
             vec!["content"]
         );
@@ -9302,6 +9339,9 @@ grep -E -F foo*bar data.txt
 grep --exclude '*.txt' foo* data.txt
 grep --label stdin foo* data.txt
 grep --color foo* data.txt
+grep --context 3 foo* data.txt
+grep --regexp='*start' data.txt
+grep -e'*start' data.txt
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
@@ -9316,9 +9356,9 @@ grep --color foo* data.txt
             .filter_map(|fact| fact.options().grep())
             .map(|grep| {
                 (
-                    grep.pattern_words()
+                    grep.patterns()
                         .iter()
-                        .map(|word| word.span.slice(source))
+                        .map(|pattern| (pattern.span().slice(source), pattern.static_text()))
                         .collect::<Vec<_>>(),
                     grep.uses_fixed_strings,
                 )
@@ -9328,21 +9368,24 @@ grep --color foo* data.txt
         assert_eq!(
             grep_patterns,
             vec![
-                (vec!["item,[0-4]"], false),
-                (vec!["item*"], false),
-                (vec!["-eitem*"], false),
-                (vec!["item*"], false),
-                (vec!["--regexp='a[b]c'"], false),
-                (vec!["item?"], false),
-                (vec!["--regexp=foo*"], false),
-                (vec!["-eo"], false),
-                (vec!["item*"], true),
+                (vec![("item,[0-4]", Some("item,[0-4]"))], false),
+                (vec![("item*", Some("item*"))], false),
+                (vec![("-eitem*", Some("item*"))], false),
+                (vec![("item*", Some("item*"))], false),
+                (vec![("--regexp='a[b]c'", Some("a[b]c"))], false),
+                (vec![("item?", Some("item?"))], false),
+                (vec![("--regexp=foo*", Some("foo*"))], false),
+                (vec![("-eo", Some("o"))], false),
+                (vec![("item*", Some("item*"))], true),
                 (Vec::new(), false),
-                (vec!["foo*bar"], false),
-                (vec!["foo*bar"], true),
-                (vec!["foo*"], false),
-                (vec!["foo*"], false),
-                (vec!["foo*"], false),
+                (vec![("foo*bar", Some("foo*bar"))], false),
+                (vec![("foo*bar", Some("foo*bar"))], true),
+                (vec![("foo*", Some("foo*"))], false),
+                (vec![("foo*", Some("foo*"))], false),
+                (vec![("foo*", Some("foo*"))], false),
+                (vec![("foo*", Some("foo*"))], false),
+                (vec![("--regexp='*start'", Some("*start"))], false),
+                (vec![("-e'*start'", Some("*start"))], false),
             ]
         );
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7110,6 +7110,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
         if text.starts_with("--regexp=") {
             explicit_pattern_source = true;
+            pattern_words.push(*word);
             index += 1;
             continue;
         }
@@ -7842,10 +7843,12 @@ fn find_pending_argument(token: &str) -> Option<FindPendingArgument> {
         | "-group" | "-ilname" | "-iname" | "-inum" | "-ipath" | "-iregex" | "-links"
         | "-lname" | "-maxdepth" | "-mindepth" | "-mmin" | "-mtime" | "-name" | "-newer"
         | "-path" | "-perm" | "-regex" | "-samefile" | "-size" | "-type" | "-uid" | "-used"
-        | "-user" | "-xtype" | "-files0-from" => Some(FindPendingArgument::Words {
-            remaining: 1,
-            pattern_operand: is_find_pattern_predicate_token(token),
-        }),
+        | "-user" | "-wholename" | "-iwholename" | "-xtype" | "-files0-from" => {
+            Some(FindPendingArgument::Words {
+                remaining: 1,
+                pattern_operand: is_find_pattern_predicate_token(token),
+            })
+        }
         token if token.starts_with("-newer") && token.len() > "-newer".len() => {
             Some(FindPendingArgument::Words {
                 remaining: 1,
@@ -7859,7 +7862,16 @@ fn find_pending_argument(token: &str) -> Option<FindPendingArgument> {
 fn is_find_pattern_predicate_token(token: &str) -> bool {
     matches!(
         token,
-        "-name" | "-iname" | "-path" | "-ipath" | "-regex" | "-iregex" | "-lname" | "-ilname"
+        "-name"
+            | "-iname"
+            | "-path"
+            | "-ipath"
+            | "-regex"
+            | "-iregex"
+            | "-lname"
+            | "-ilname"
+            | "-wholename"
+            | "-iwholename"
     )
 }
 
@@ -8937,7 +8949,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn summarizes_command_options_and_invokers() {
-        let source = "#!/bin/bash\nread -r name\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
+        let source = "#!/bin/bash\nread -r name\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -9044,7 +9056,7 @@ complex[$((i+=1))]+=x
             .collect::<Vec<_>>();
         assert_eq!(
             find_glob_pattern_operand_spans,
-            vec!["*.cfg", "\"$prefix\"*.jar"]
+            vec!["*.cfg", "\"$prefix\"*.jar", "*/tmp/*"]
         );
 
         let find_execdir = facts
@@ -9281,6 +9293,7 @@ grep -eitem* data.txt
 grep -oe item* data.txt
 grep --regexp='a[b]c' data.txt
 grep --regexp item? data.txt
+grep --regexp=foo* data.txt
 grep -eo item* data.txt
 grep -F -- item* data.txt
 grep -f patterns.txt item* data.txt
@@ -9319,8 +9332,9 @@ grep --color foo* data.txt
                 (vec!["item*"], false),
                 (vec!["-eitem*"], false),
                 (vec!["item*"], false),
-                (Vec::new(), false),
+                (vec!["--regexp='a[b]c'"], false),
                 (vec!["item?"], false),
+                (vec!["--regexp=foo*"], false),
                 (vec!["-eo"], false),
                 (vec!["item*"], true),
                 (Vec::new(), false),

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7164,12 +7164,10 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
             }
 
             if flag == 'e' {
-                if chars.peek().is_none() {
-                    explicit_pattern_source = true;
-                }
-                if chars.peek().is_none()
-                    && let Some(pattern_word) = args.get(index + 1)
-                {
+                explicit_pattern_source = true;
+                if chars.peek().is_some() {
+                    pattern_words.push(*word);
+                } else if let Some(pattern_word) = args.get(index + 1) {
                     pattern_words.push(*pattern_word);
                     consume_next_argument = true;
                 }
@@ -9238,6 +9236,8 @@ unset parts[\"$key\"] extra
 #!/bin/bash
 grep item,[0-4] data.txt
 grep -e item* data.txt
+grep -eitem* data.txt
+grep -oe item* data.txt
 grep --regexp='a[b]c' data.txt
 grep --regexp item? data.txt
 grep -eo item* data.txt
@@ -9273,15 +9273,41 @@ grep -E -F foo*bar data.txt
             vec![
                 (vec!["item,[0-4]"], false),
                 (vec!["item*"], false),
+                (vec!["-eitem*"], false),
+                (vec!["item*"], false),
                 (Vec::new(), false),
                 (vec!["item?"], false),
-                (vec!["item*"], false),
+                (vec!["-eo"], false),
                 (vec!["item*"], true),
                 (Vec::new(), false),
                 (vec!["foo*bar"], false),
                 (vec!["foo*bar"], true),
             ]
         );
+    }
+
+    #[test]
+    fn attached_short_e_patterns_do_not_accidentally_toggle_only_matching() {
+        let source = "\
+#!/bin/bash
+grep -oe item* data.txt
+grep -eo item* data.txt
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let grep_modes = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("grep"))
+            .filter_map(|fact| fact.options().grep())
+            .map(|grep| grep.uses_only_matching)
+            .collect::<Vec<_>>();
+
+        assert_eq!(grep_modes, vec![true, false]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7127,7 +7127,13 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
         }
 
         if text.starts_with("--") {
-            index += 1;
+            index += if grep_long_option_takes_argument(text.as_str())
+                && args.get(index + 1).is_some()
+            {
+                2
+            } else {
+                1
+            };
             continue;
         }
 
@@ -7204,6 +7210,33 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
 fn grep_option_takes_argument(flag: char) -> bool {
     matches!(flag, 'A' | 'B' | 'C' | 'D' | 'd' | 'e' | 'f' | 'm')
+}
+
+fn grep_long_option_takes_argument(option: &str) -> bool {
+    let Some(name) = option.strip_prefix("--") else {
+        return false;
+    };
+    if name.contains('=') {
+        return false;
+    }
+
+    matches!(
+        name,
+        "after-context"
+            | "before-context"
+            | "binary-files"
+            | "devices"
+            | "directories"
+            | "exclude"
+            | "exclude-dir"
+            | "exclude-from"
+            | "file"
+            | "group-separator"
+            | "include"
+            | "label"
+            | "max-count"
+            | "regexp"
+    )
 }
 
 fn parse_ps_command(args: &[&Word], source: &str) -> PsCommandFacts {
@@ -7554,6 +7587,11 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
     for word in args {
         let Some(text) = static_word_text(word, source) else {
             if let Some(state) = pending_argument {
+                if state.expects_pattern_operand()
+                    && !span::word_unquoted_glob_pattern_spans(word, source).is_empty()
+                {
+                    glob_pattern_operand_spans.push(word.span);
+                }
                 pending_argument = state.after_consuming_dynamic();
             }
             continue;
@@ -8899,7 +8937,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn summarizes_command_options_and_invokers() {
-        let source = "#!/bin/bash\nread -r name\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
+        let source = "#!/bin/bash\nread -r name\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -9004,7 +9042,10 @@ complex[$((i+=1))]+=x
             .flat_map(|find| find.glob_pattern_operand_spans().iter().copied())
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
-        assert_eq!(find_glob_pattern_operand_spans, vec!["*.cfg"]);
+        assert_eq!(
+            find_glob_pattern_operand_spans,
+            vec!["*.cfg", "\"$prefix\"*.jar"]
+        );
 
         let find_execdir = facts
             .commands()
@@ -9245,6 +9286,9 @@ grep -F -- item* data.txt
 grep -f patterns.txt item* data.txt
 grep -F -E foo*bar data.txt
 grep -E -F foo*bar data.txt
+grep --exclude '*.txt' foo* data.txt
+grep --label stdin foo* data.txt
+grep --color foo* data.txt
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
@@ -9282,6 +9326,9 @@ grep -E -F foo*bar data.txt
                 (Vec::new(), false),
                 (vec!["foo*bar"], false),
                 (vec!["foo*bar"], true),
+                (vec!["foo*"], false),
+                (vec!["foo*"], false),
+                (vec!["foo*"], false),
             ]
         );
     }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -46,8 +46,9 @@ pub use rules::common::span::{
     double_quoted_scalar_affix_span, word_array_subscript_span, word_extglob_span,
     word_has_single_literal_part, word_literal_part_spans_excluding_parameter_operator_tails,
     word_literal_scan_segments_excluding_expansions, word_nested_zsh_substitution_spans,
-    word_standalone_literal_backslash_span, word_unquoted_star_parameter_spans,
-    word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,
+    word_standalone_literal_backslash_span, word_unquoted_glob_pattern_spans,
+    word_unquoted_star_parameter_spans, word_zsh_flag_modifier_spans,
+    word_zsh_nested_expansion_spans,
 };
 pub use rules::common::word::{TestOperandClass, static_word_text};
 pub use settings::LinterSettings;

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -44,13 +44,17 @@ pub use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
 pub use rules::common::span::{
     assignment_name_span, conditional_array_subscript_span, conditional_extglob_span,
     double_quoted_scalar_affix_span, word_array_subscript_span, word_extglob_span,
-    word_has_single_literal_part, word_literal_part_spans_excluding_parameter_operator_tails,
+    word_has_single_literal_part, word_has_unquoted_brace_expansion,
+    word_literal_part_spans_excluding_parameter_operator_tails,
     word_literal_scan_segments_excluding_expansions, word_nested_zsh_substitution_spans,
     word_standalone_literal_backslash_span, word_unquoted_glob_pattern_spans,
     word_unquoted_star_parameter_spans, word_zsh_flag_modifier_spans,
     word_zsh_nested_expansion_spans,
 };
-pub use rules::common::word::{TestOperandClass, static_word_text};
+pub use rules::common::word::{
+    TestOperandClass, conditional_binary_op_is_string_match, static_word_text,
+    word_is_standalone_variable_like,
+};
 pub use settings::LinterSettings;
 pub use shell::ShellDialect;
 pub use suppression::{

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -150,6 +150,7 @@ declare_rules! {
     ),
     ("C077", Category::Correctness, Severity::Warning, SubshellInArithmetic),
     ("C078", Category::Correctness, Severity::Warning, UnquotedGlobsInFind),
+    ("C080", Category::Correctness, Severity::Warning, GlobInGrepPattern),
     (
         "C079",
         Category::Correctness,
@@ -620,6 +621,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-194" => Some(Rule::CommentedContinuationLine),
         "SH-195" => Some(Rule::SubshellInArithmetic),
         "SH-200" => Some(Rule::UnquotedGlobsInFind),
+        "SH-204" => Some(Rule::GlobInGrepPattern),
         "SH-229" => Some(Rule::SetFlagsWithoutDashes),
         "SH-233" => Some(Rule::CommandSubstitutionInAlias),
         "SH-235" => Some(Rule::FunctionInAlias),
@@ -914,6 +916,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-195"), Some(Rule::SubshellInArithmetic));
         assert_eq!(code_to_rule("C078"), Some(Rule::UnquotedGlobsInFind));
         assert_eq!(code_to_rule("SH-200"), Some(Rule::UnquotedGlobsInFind));
+        assert_eq!(code_to_rule("C080"), Some(Rule::GlobInGrepPattern));
+        assert_eq!(code_to_rule("SH-204"), Some(Rule::GlobInGrepPattern));
         assert_eq!(code_to_rule("C006"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("SH-039"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("C076"), Some(Rule::CommentedContinuationLine));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -152,6 +152,7 @@ declare_rules! {
     ("C078", Category::Correctness, Severity::Warning, UnquotedGlobsInFind),
     ("C080", Category::Correctness, Severity::Warning, GlobInGrepPattern),
     ("C081", Category::Correctness, Severity::Warning, GlobInStringComparison),
+    ("C083", Category::Correctness, Severity::Warning, GlobInFindSubstitution),
     (
         "C079",
         Category::Correctness,
@@ -624,6 +625,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-200" => Some(Rule::UnquotedGlobsInFind),
         "SH-204" => Some(Rule::GlobInGrepPattern),
         "SH-206" => Some(Rule::GlobInStringComparison),
+        "SH-209" => Some(Rule::GlobInFindSubstitution),
         "SH-229" => Some(Rule::SetFlagsWithoutDashes),
         "SH-233" => Some(Rule::CommandSubstitutionInAlias),
         "SH-235" => Some(Rule::FunctionInAlias),
@@ -922,6 +924,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-204"), Some(Rule::GlobInGrepPattern));
         assert_eq!(code_to_rule("C081"), Some(Rule::GlobInStringComparison));
         assert_eq!(code_to_rule("SH-206"), Some(Rule::GlobInStringComparison));
+        assert_eq!(code_to_rule("C083"), Some(Rule::GlobInFindSubstitution));
+        assert_eq!(code_to_rule("SH-209"), Some(Rule::GlobInFindSubstitution));
         assert_eq!(code_to_rule("C006"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("SH-039"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("C076"), Some(Rule::CommentedContinuationLine));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -215,6 +215,12 @@ declare_rules! {
         MapfileProcessSubstitution
     ),
     (
+        "C114",
+        Category::Correctness,
+        Severity::Warning,
+        GlobWithExpansionInLoop
+    ),
+    (
         "C115",
         Category::Correctness,
         Severity::Warning,
@@ -636,6 +642,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-241" => Some(Rule::AppendToArrayAsString),
         "SH-243" => Some(Rule::UnsetAssociativeArrayElement),
         "SH-244" => Some(Rule::MapfileProcessSubstitution),
+        "SH-254" => Some(Rule::GlobWithExpansionInLoop),
         "SH-253" => Some(Rule::FindOutputLoop),
         "SH-293" => Some(Rule::UnreachableAfterExit),
         "SH-298" => Some(Rule::UnusedHeredoc),
@@ -963,6 +970,8 @@ mod tests {
             code_to_rule("SH-244"),
             Some(Rule::MapfileProcessSubstitution)
         );
+        assert_eq!(code_to_rule("C114"), Some(Rule::GlobWithExpansionInLoop));
+        assert_eq!(code_to_rule("SH-254"), Some(Rule::GlobWithExpansionInLoop));
         assert_eq!(code_to_rule("SH-253"), Some(Rule::FindOutputLoop));
         assert_eq!(code_to_rule("C124"), Some(Rule::UnreachableAfterExit));
         assert_eq!(code_to_rule("SH-293"), Some(Rule::UnreachableAfterExit));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -417,6 +417,12 @@ declare_rules! {
     ("S044", Category::Style, Severity::Warning, UnquotedVariableInSed),
     ("S051", Category::Style, Severity::Warning, UnquotedTrClass),
     ("S054", Category::Style, Severity::Warning, SuWithoutFlag),
+    (
+        "S055",
+        Category::Style,
+        Severity::Warning,
+        GlobAssignedToVariable
+    ),
     ("S056", Category::Style, Severity::Warning, CommandSubstitutionInAlias),
     ("S057", Category::Style, Severity::Warning, FunctionInAlias),
     ("S059", Category::Style, Severity::Warning, DeprecatedTempfileCommand),
@@ -627,6 +633,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-189" => Some(Rule::UnicodeQuoteInString),
         "SH-224" => Some(Rule::AssignmentLooksLikeComparison),
         "SH-227" => Some(Rule::SuWithoutFlag),
+        "SH-231" => Some(Rule::GlobAssignedToVariable),
         "SH-194" => Some(Rule::CommentedContinuationLine),
         "SH-195" => Some(Rule::SubshellInArithmetic),
         "SH-200" => Some(Rule::UnquotedGlobsInFind),
@@ -779,6 +786,8 @@ mod tests {
             code_to_rule("SH-202"),
             Some(Rule::DollarInArithmeticContext)
         );
+        assert_eq!(code_to_rule("S055"), Some(Rule::GlobAssignedToVariable));
+        assert_eq!(code_to_rule("SH-231"), Some(Rule::GlobAssignedToVariable));
         assert_eq!(code_to_rule("SH-203"), Some(Rule::UnquotedTrRange));
         assert_eq!(code_to_rule("S024"), Some(Rule::SingleQuoteBackslash));
         assert_eq!(code_to_rule("SH-087"), Some(Rule::SingleQuoteBackslash));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -149,6 +149,7 @@ declare_rules! {
         CommentedContinuationLine
     ),
     ("C077", Category::Correctness, Severity::Warning, SubshellInArithmetic),
+    ("C078", Category::Correctness, Severity::Warning, UnquotedGlobsInFind),
     (
         "C079",
         Category::Correctness,
@@ -618,6 +619,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-227" => Some(Rule::SuWithoutFlag),
         "SH-194" => Some(Rule::CommentedContinuationLine),
         "SH-195" => Some(Rule::SubshellInArithmetic),
+        "SH-200" => Some(Rule::UnquotedGlobsInFind),
         "SH-229" => Some(Rule::SetFlagsWithoutDashes),
         "SH-233" => Some(Rule::CommandSubstitutionInAlias),
         "SH-235" => Some(Rule::FunctionInAlias),
@@ -910,6 +912,8 @@ mod tests {
         );
         assert_eq!(code_to_rule("SH-227"), Some(Rule::SuWithoutFlag));
         assert_eq!(code_to_rule("SH-195"), Some(Rule::SubshellInArithmetic));
+        assert_eq!(code_to_rule("C078"), Some(Rule::UnquotedGlobsInFind));
+        assert_eq!(code_to_rule("SH-200"), Some(Rule::UnquotedGlobsInFind));
         assert_eq!(code_to_rule("C006"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("SH-039"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("C076"), Some(Rule::CommentedContinuationLine));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -151,6 +151,7 @@ declare_rules! {
     ("C077", Category::Correctness, Severity::Warning, SubshellInArithmetic),
     ("C078", Category::Correctness, Severity::Warning, UnquotedGlobsInFind),
     ("C080", Category::Correctness, Severity::Warning, GlobInGrepPattern),
+    ("C081", Category::Correctness, Severity::Warning, GlobInStringComparison),
     (
         "C079",
         Category::Correctness,
@@ -622,6 +623,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-195" => Some(Rule::SubshellInArithmetic),
         "SH-200" => Some(Rule::UnquotedGlobsInFind),
         "SH-204" => Some(Rule::GlobInGrepPattern),
+        "SH-206" => Some(Rule::GlobInStringComparison),
         "SH-229" => Some(Rule::SetFlagsWithoutDashes),
         "SH-233" => Some(Rule::CommandSubstitutionInAlias),
         "SH-235" => Some(Rule::FunctionInAlias),
@@ -918,6 +920,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-200"), Some(Rule::UnquotedGlobsInFind));
         assert_eq!(code_to_rule("C080"), Some(Rule::GlobInGrepPattern));
         assert_eq!(code_to_rule("SH-204"), Some(Rule::GlobInGrepPattern));
+        assert_eq!(code_to_rule("C081"), Some(Rule::GlobInStringComparison));
+        assert_eq!(code_to_rule("SH-206"), Some(Rule::GlobInStringComparison));
         assert_eq!(code_to_rule("C006"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("SH-039"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("C076"), Some(Rule::CommentedContinuationLine));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -153,6 +153,7 @@ declare_rules! {
     ("C080", Category::Correctness, Severity::Warning, GlobInGrepPattern),
     ("C081", Category::Correctness, Severity::Warning, GlobInStringComparison),
     ("C083", Category::Correctness, Severity::Warning, GlobInFindSubstitution),
+    ("C084", Category::Correctness, Severity::Warning, UnquotedGrepRegex),
     (
         "C079",
         Category::Correctness,
@@ -626,6 +627,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-204" => Some(Rule::GlobInGrepPattern),
         "SH-206" => Some(Rule::GlobInStringComparison),
         "SH-209" => Some(Rule::GlobInFindSubstitution),
+        "SH-210" => Some(Rule::UnquotedGrepRegex),
         "SH-229" => Some(Rule::SetFlagsWithoutDashes),
         "SH-233" => Some(Rule::CommandSubstitutionInAlias),
         "SH-235" => Some(Rule::FunctionInAlias),
@@ -926,6 +928,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-206"), Some(Rule::GlobInStringComparison));
         assert_eq!(code_to_rule("C083"), Some(Rule::GlobInFindSubstitution));
         assert_eq!(code_to_rule("SH-209"), Some(Rule::GlobInFindSubstitution));
+        assert_eq!(code_to_rule("C084"), Some(Rule::UnquotedGrepRegex));
+        assert_eq!(code_to_rule("SH-210"), Some(Rule::UnquotedGrepRegex));
         assert_eq!(code_to_rule("C006"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("SH-039"), Some(Rule::UndefinedVariable));
         assert_eq!(code_to_rule("C076"), Some(Rule::CommentedContinuationLine));

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -142,6 +142,12 @@ pub fn word_literal_scan_segments_excluding_expansions(word: &Word, source: &str
     scan_span_excluding(word.span, &excluded, source)
 }
 
+pub fn word_unquoted_glob_pattern_spans(word: &Word, source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_unquoted_glob_pattern_spans(&word.parts, source, false, &mut spans);
+    spans
+}
+
 pub fn word_standalone_literal_backslash_span(word: &Word, source: &str) -> Option<Span> {
     let [part] = word.parts.as_slice() else {
         return None;
@@ -770,6 +776,83 @@ fn collect_literal_scan_exclusions(parts: &[WordPartNode], excluded: &mut Vec<Sp
     }
 }
 
+fn collect_unquoted_glob_pattern_spans(
+    parts: &[WordPartNode],
+    source: &str,
+    in_double_quotes: bool,
+    spans: &mut Vec<Span>,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => {
+                collect_unquoted_glob_pattern_spans(parts, source, true, spans)
+            }
+            WordPart::Literal(_) if !in_double_quotes => {
+                spans.extend(literal_glob_pattern_spans(part.span, source));
+            }
+            WordPart::Literal(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::Transformation { .. }
+            | WordPart::ZshQualifiedGlob(_) => {}
+        }
+    }
+}
+
+fn literal_glob_pattern_spans(span: Span, source: &str) -> Vec<Span> {
+    let text = span.slice(source);
+    let bytes = text.as_bytes();
+    let mut spans = Vec::new();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'*' | b'?' => {
+                spans.push(span_within_literal(span, source, index, index + 1));
+                index += 1;
+            }
+            b'[' => {
+                let mut end = index + 1;
+                while end < bytes.len() && bytes[end] != b']' {
+                    end += 1;
+                }
+                if end < bytes.len() {
+                    spans.push(span_within_literal(span, source, index, end + 1));
+                    index = end + 1;
+                } else {
+                    index += 1;
+                }
+            }
+            _ => index += 1,
+        }
+    }
+
+    spans
+}
+
+fn span_within_literal(span: Span, source: &str, start: usize, end: usize) -> Span {
+    let start_pos = span
+        .start
+        .advanced_by(&source[span.start.offset..span.start.offset + start]);
+    let end_pos = span
+        .start
+        .advanced_by(&source[span.start.offset..span.start.offset + end]);
+    Span::from_positions(start_pos, end_pos)
+}
+
 fn scan_span_excluding(span: Span, excluded: &[Span], source: &str) -> Vec<Span> {
     if excluded.is_empty() {
         return vec![span];
@@ -1314,6 +1397,7 @@ mod tests {
         all_elements_array_expansion_part_spans, array_expansion_part_spans,
         command_substitution_part_spans, find_extglob_bounds, scalar_expansion_part_spans,
         word_caret_negated_bracket_spans, word_exactly_one_extglob_span,
+        word_unquoted_glob_pattern_spans,
     };
 
     #[test]
@@ -1477,6 +1561,42 @@ mod tests {
         };
 
         assert!(word_caret_negated_bracket_spans(&command.args[0], source).is_empty());
+    }
+
+    #[test]
+    fn word_unquoted_glob_pattern_spans_track_unquoted_segments_only() {
+        let source = "echo foo*.txt \"bar?\" [ab] \"${name}\"*.tmp\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        assert_eq!(
+            word_unquoted_glob_pattern_spans(&command.args[0], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*"]
+        );
+        assert!(
+            word_unquoted_glob_pattern_spans(&command.args[1], source).is_empty(),
+            "double-quoted wildcard should not be reported"
+        );
+        assert_eq!(
+            word_unquoted_glob_pattern_spans(&command.args[2], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["[ab]"]
+        );
+        assert_eq!(
+            word_unquoted_glob_pattern_spans(&command.args[3], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -148,6 +148,10 @@ pub fn word_unquoted_glob_pattern_spans(word: &Word, source: &str) -> Vec<Span> 
     spans
 }
 
+pub fn word_has_unquoted_brace_expansion(word: &Word, source: &str) -> bool {
+    parts_have_unquoted_brace_expansion(&word.parts, source, false)
+}
+
 pub fn word_standalone_literal_backslash_span(word: &Word, source: &str) -> Option<Span> {
     let [part] = word.parts.as_slice() else {
         return None;
@@ -782,12 +786,15 @@ fn collect_unquoted_glob_pattern_spans(
     in_double_quotes: bool,
     spans: &mut Vec<Span>,
 ) {
-    for part in parts {
+    for (index, part) in parts.iter().enumerate() {
         match &part.kind {
             WordPart::DoubleQuoted { parts, .. } => {
                 collect_unquoted_glob_pattern_spans(parts, source, true, spans)
             }
-            WordPart::Literal(_) if !in_double_quotes => {
+            WordPart::Literal(_)
+                if !in_double_quotes
+                    && !literal_part_is_parameter_operator_tail(parts, index, source) =>
+            {
                 spans.extend(literal_glob_pattern_spans(part.span, source));
             }
             WordPart::Literal(_)
@@ -810,6 +817,94 @@ fn collect_unquoted_glob_pattern_spans(
             | WordPart::ZshQualifiedGlob(_) => {}
         }
     }
+}
+
+fn parts_have_unquoted_brace_expansion(
+    parts: &[WordPartNode],
+    source: &str,
+    in_double_quotes: bool,
+) -> bool {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => {
+                if parts_have_unquoted_brace_expansion(parts, source, true) {
+                    return true;
+                }
+            }
+            WordPart::Literal(_) if !in_double_quotes => {
+                if literal_contains_brace_expansion(part.span.slice(source)) {
+                    return true;
+                }
+            }
+            WordPart::Literal(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::Transformation { .. }
+            | WordPart::ZshQualifiedGlob(_) => {}
+        }
+    }
+
+    false
+}
+
+fn literal_contains_brace_expansion(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+
+        if bytes[index] != b'{' {
+            index += 1;
+            continue;
+        }
+
+        let mut depth = 1usize;
+        let mut saw_comma = false;
+        let mut cursor = index + 1;
+        while cursor < bytes.len() {
+            if bytes[cursor] == b'\\' {
+                cursor = (cursor + 2).min(bytes.len());
+                continue;
+            }
+
+            match bytes[cursor] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        if saw_comma {
+                            return true;
+                        }
+                        break;
+                    }
+                }
+                b',' if depth == 1 => saw_comma = true,
+                _ => {}
+            }
+            cursor += 1;
+        }
+
+        index += 1;
+    }
+
+    false
 }
 
 fn literal_glob_pattern_spans(span: Span, source: &str) -> Vec<Span> {
@@ -1620,6 +1715,29 @@ mod tests {
         assert!(
             word_unquoted_glob_pattern_spans(&command.args[6], source).is_empty(),
             "escaped bracket expression should not be reported"
+        );
+    }
+
+    #[test]
+    fn word_unquoted_glob_pattern_spans_ignore_parameter_operator_tails() {
+        let source = r#"echo ${path/*\/} ${name#*:} ${name##*foo}"#;
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        assert!(
+            word_unquoted_glob_pattern_spans(&command.args[0], source).is_empty(),
+            "parameter replacement operator tails should not be reported as pathname globs"
+        );
+        assert!(
+            word_unquoted_glob_pattern_spans(&command.args[1], source).is_empty(),
+            "parameter prefix operator tails should not be reported as pathname globs"
+        );
+        assert!(
+            word_unquoted_glob_pattern_spans(&command.args[2], source).is_empty(),
+            "parameter longest-prefix operator tails should not be reported as pathname globs"
         );
     }
 

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -819,6 +819,11 @@ fn literal_glob_pattern_spans(span: Span, source: &str) -> Vec<Span> {
     let mut index = 0usize;
 
     while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+
         match bytes[index] {
             b'*' | b'?' => {
                 spans.push(span_within_literal(span, source, index, index + 1));
@@ -826,7 +831,14 @@ fn literal_glob_pattern_spans(span: Span, source: &str) -> Vec<Span> {
             }
             b'[' => {
                 let mut end = index + 1;
-                while end < bytes.len() && bytes[end] != b']' {
+                while end < bytes.len() {
+                    if bytes[end] == b'\\' {
+                        end = (end + 2).min(bytes.len());
+                        continue;
+                    }
+                    if bytes[end] == b']' {
+                        break;
+                    }
                     end += 1;
                 }
                 if end < bytes.len() {
@@ -1565,7 +1577,7 @@ mod tests {
 
     #[test]
     fn word_unquoted_glob_pattern_spans_track_unquoted_segments_only() {
-        let source = "echo foo*.txt \"bar?\" [ab] \"${name}\"*.tmp\n";
+        let source = "echo foo*.txt \"bar?\" [ab] \"${name}\"*.tmp \\*.bak foo\\?bar \\[ab\\]\n";
         let output = Parser::new(source).parse().unwrap();
         let command = &output.file.body[0].command;
         let shuck_ast::Command::Simple(command) = command else {
@@ -1596,6 +1608,18 @@ mod tests {
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["*"]
+        );
+        assert!(
+            word_unquoted_glob_pattern_spans(&command.args[4], source).is_empty(),
+            "escaped wildcard should not be reported"
+        );
+        assert!(
+            word_unquoted_glob_pattern_spans(&command.args[5], source).is_empty(),
+            "escaped question mark should not be reported"
+        );
+        assert!(
+            word_unquoted_glob_pattern_spans(&command.args[6], source).is_empty(),
+            "escaped bracket expression should not be reported"
         );
     }
 

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -877,6 +877,7 @@ fn literal_contains_brace_expansion(text: &str) -> bool {
 
         let mut depth = 1usize;
         let mut saw_comma = false;
+        let mut saw_range = false;
         let mut cursor = index + 1;
         while cursor < bytes.len() {
             if bytes[cursor] == b'\\' {
@@ -889,13 +890,22 @@ fn literal_contains_brace_expansion(text: &str) -> bool {
                 b'}' => {
                     depth = depth.saturating_sub(1);
                     if depth == 0 {
-                        if saw_comma {
+                        if saw_comma || saw_range {
                             return true;
                         }
                         break;
                     }
                 }
                 b',' if depth == 1 => saw_comma = true,
+                b'.' if depth == 1
+                    && cursor + 1 < bytes.len()
+                    && bytes[cursor + 1] == b'.'
+                    && !byte_is_backslash_escaped(bytes, cursor)
+                    && !byte_is_backslash_escaped(bytes, cursor + 1) =>
+                {
+                    saw_range = true;
+                    cursor += 1;
+                }
                 _ => {}
             }
             cursor += 1;
@@ -1504,7 +1514,7 @@ mod tests {
         all_elements_array_expansion_part_spans, array_expansion_part_spans,
         command_substitution_part_spans, find_extglob_bounds, scalar_expansion_part_spans,
         word_caret_negated_bracket_spans, word_exactly_one_extglob_span,
-        word_unquoted_glob_pattern_spans,
+        word_has_unquoted_brace_expansion, word_unquoted_glob_pattern_spans,
     };
 
     #[test]
@@ -1739,6 +1749,20 @@ mod tests {
             word_unquoted_glob_pattern_spans(&command.args[2], source).is_empty(),
             "parameter longest-prefix operator tails should not be reported as pathname globs"
         );
+    }
+
+    #[test]
+    fn word_has_unquoted_brace_expansion_detects_sequence_forms() {
+        let source = "echo {foo,bar} {1..3} ${dir}/{a..c}*.txt\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        assert!(word_has_unquoted_brace_expansion(&command.args[0], source));
+        assert!(word_has_unquoted_brace_expansion(&command.args[1], source));
+        assert!(word_has_unquoted_brace_expansion(&command.args[2], source));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/word.rs
+++ b/crates/shuck-linter/src/rules/common/word.rs
@@ -1,4 +1,6 @@
-use shuck_ast::{ConditionalExpr, Pattern, PatternPart, Word, WordPart, WordPartNode};
+use shuck_ast::{
+    ConditionalBinaryOp, ConditionalExpr, Pattern, PatternPart, Word, WordPart, WordPartNode,
+};
 
 pub use super::expansion::{
     ExpansionContext, WordExpansionKind, WordLiteralness, WordQuote, WordSubstitutionShape,
@@ -59,6 +61,36 @@ impl TestOperandClass {
 pub fn static_word_text(word: &Word, source: &str) -> Option<String> {
     let mut result = String::new();
     collect_static_word_text(&word.parts, source, &mut result).then_some(result)
+}
+
+pub fn conditional_binary_op_is_string_match(op: ConditionalBinaryOp) -> bool {
+    matches!(
+        op,
+        ConditionalBinaryOp::PatternEqShort
+            | ConditionalBinaryOp::PatternEq
+            | ConditionalBinaryOp::PatternNe
+    )
+}
+
+pub fn word_is_standalone_variable_like(word: &Word) -> bool {
+    match word.parts.as_slice() {
+        [part] => matches!(
+            part.kind,
+            WordPart::Variable(_)
+                | WordPart::Parameter(_)
+                | WordPart::ParameterExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayAccess(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::ArrayIndices(_)
+                | WordPart::Substring { .. }
+                | WordPart::ArraySlice { .. }
+                | WordPart::IndirectExpansion { .. }
+                | WordPart::PrefixMatch { .. }
+                | WordPart::Transformation { .. }
+        ),
+        _ => false,
+    }
 }
 
 pub(crate) fn classify_word(word: &Word, source: &str) -> WordClassification {

--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -35,6 +35,7 @@ mod tests {
         let source = "\
 #!/bin/bash
 find ./ -name *.jar
+find ./ -name \"$prefix\"*.jar
 for f in $(find ./ -name *.cfg); do :; done
 printf '%s\\n' \"$(find . -path */tmp/*)\"
 ";
@@ -48,7 +49,7 @@ printf '%s\\n' \"$(find . -path */tmp/*)\"
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["*.jar", "*.cfg", "*/tmp/*"]
+            vec!["*.jar", "\"$prefix\"*.jar", "*.cfg", "*/tmp/*"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -1,0 +1,73 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct GlobInFindSubstitution;
+
+impl Violation for GlobInFindSubstitution {
+    fn rule() -> Rule {
+        Rule::GlobInFindSubstitution
+    }
+
+    fn message(&self) -> String {
+        "quote glob patterns passed to `find` so the shell does not expand them early".to_owned()
+    }
+}
+
+pub fn glob_in_find_substitution(checker: &mut Checker) {
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("find") && fact.wrappers().is_empty())
+        .filter_map(|fact| fact.options().find())
+        .flat_map(|find| find.glob_pattern_operand_spans().iter().copied())
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || GlobInFindSubstitution);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_find_pattern_operands_that_can_glob_expand() {
+        let source = "\
+#!/bin/bash
+find ./ -name *.jar
+for f in $(find ./ -name *.cfg); do :; done
+printf '%s\\n' \"$(find . -path */tmp/*)\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInFindSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*.jar", "*.cfg", "*/tmp/*"]
+        );
+    }
+
+    #[test]
+    fn ignores_quoted_non_pattern_and_wrapped_find_operands() {
+        let source = "\
+#!/bin/bash
+find ./ -name '*.jar'
+find ./ -name \\*.tmp
+find ./ -path \\*/tmp/\\*
+find ./ -type f*
+command find ./ -name *.jar
+find ./ -name \"$pattern\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInFindSubstitution),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -36,6 +36,7 @@ mod tests {
 #!/bin/bash
 find ./ -name *.jar
 find ./ -name \"$prefix\"*.jar
+find ./ -wholename */tmp/*
 for f in $(find ./ -name *.cfg); do :; done
 printf '%s\\n' \"$(find . -path */tmp/*)\"
 ";
@@ -49,7 +50,7 @@ printf '%s\\n' \"$(find . -path */tmp/*)\"
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["*.jar", "\"$prefix\"*.jar", "*.cfg", "*/tmp/*"]
+            vec!["*.jar", "\"$prefix\"*.jar", "*/tmp/*", "*.cfg", "*/tmp/*"]
         );
     }
 
@@ -60,6 +61,7 @@ printf '%s\\n' \"$(find . -path */tmp/*)\"
 find ./ -name '*.jar'
 find ./ -name \\*.tmp
 find ./ -path \\*/tmp/\\*
+find ./ -wholename \\*/tmp/\\*
 find ./ -type f*
 command find ./ -name *.jar
 find ./ -name \"$pattern\"

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -1,0 +1,95 @@
+use crate::{Checker, Rule, Violation, word_unquoted_glob_pattern_spans};
+
+pub struct GlobInGrepPattern;
+
+impl Violation for GlobInGrepPattern {
+    fn rule() -> Rule {
+        Rule::GlobInGrepPattern
+    }
+
+    fn message(&self) -> String {
+        "quote grep patterns so the shell does not expand them first".to_owned()
+    }
+}
+
+pub fn glob_in_grep_pattern(checker: &mut Checker) {
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("grep"))
+        .filter_map(|fact| fact.options().grep())
+        .flat_map(|grep| grep.pattern_words().iter().copied())
+        .filter(|word| !word_unquoted_glob_pattern_spans(word, checker.source()).is_empty())
+        .map(|word| word.span)
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || GlobInGrepPattern);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_unquoted_globs_in_grep_patterns() {
+        let source = "\
+#!/bin/sh
+grep start* out.txt
+grep -e item? out.txt
+grep --regexp item,[0-4] out.txt
+grep -Eq item,[0-4] out.txt
+grep -eo item* out.txt
+grep -F -- item,[0-4] out.txt
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "start*",
+                "item?",
+                "item,[0-4]",
+                "item,[0-4]",
+                "item*",
+                "item,[0-4]"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_quoted_patterns_and_non_pattern_operands() {
+        let source = "\
+#!/bin/sh
+grep \"start*\" out.txt
+grep --regexp='item,[0-4]' out.txt
+grep --regexp=item,[0-4] out.txt
+grep -eitem* out.txt
+grep -f patterns.txt item,[0-4] out.txt
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_grep_patterns_inside_command_substitution() {
+        let source = "\
+#!/bin/sh
+checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["[0-9a-f]{40}"]
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation, word_unquoted_glob_pattern_spans};
+use crate::{Checker, Rule, Violation, static_word_text};
 
 pub struct GlobInGrepPattern;
 
@@ -8,7 +8,7 @@ impl Violation for GlobInGrepPattern {
     }
 
     fn message(&self) -> String {
-        "quote grep patterns so the shell does not expand them first".to_owned()
+        "use regex-style wildcards in grep patterns, not glob-style `*`".to_owned()
     }
 }
 
@@ -19,12 +19,85 @@ pub fn glob_in_grep_pattern(checker: &mut Checker) {
         .iter()
         .filter(|fact| fact.effective_name_is("grep"))
         .filter_map(|fact| fact.options().grep())
+        .filter(|grep| !grep.uses_fixed_strings)
         .flat_map(|grep| grep.pattern_words().iter().copied())
-        .filter(|word| !word_unquoted_glob_pattern_spans(word, checker.source()).is_empty())
+        .filter(|word| {
+            static_word_text(word, checker.source())
+                .is_some_and(|pattern| has_glob_style_star_confusion(&pattern))
+        })
         .map(|word| word.span)
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || GlobInGrepPattern);
+}
+
+fn has_glob_style_star_confusion(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+
+    if first_unescaped_star_index(bytes).is_some_and(|index| index == 0) {
+        return false;
+    }
+
+    let mut index = 0usize;
+    while let Some(star_index) = next_unescaped_star_index(bytes, index) {
+        let Some(previous) = previous_unescaped_byte(bytes, star_index) else {
+            index = star_index + 1;
+            continue;
+        };
+
+        if matches!(
+            previous,
+            b'.' | b']' | b')' | b'*' | b'+' | b'?' | b'|' | b'^' | b'$' | b'{' | b'(' | b'\\'
+        ) || previous.is_ascii_whitespace()
+        {
+            index = star_index + 1;
+            continue;
+        }
+
+        return true;
+    }
+
+    false
+}
+
+fn first_unescaped_star_index(bytes: &[u8]) -> Option<usize> {
+    next_unescaped_star_index(bytes, 0)
+}
+
+fn next_unescaped_star_index(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut index = start;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+        if bytes[index] == b'*' {
+            return Some(index);
+        }
+        index += 1;
+    }
+    None
+}
+
+fn previous_unescaped_byte(bytes: &[u8], index: usize) -> Option<u8> {
+    let mut candidate = index;
+    while candidate > 0 {
+        candidate -= 1;
+        if !is_escaped(bytes, candidate) {
+            return Some(bytes[candidate]);
+        }
+    }
+    None
+}
+
+fn is_escaped(bytes: &[u8], index: usize) -> bool {
+    let mut backslashes = 0usize;
+    let mut cursor = index;
+    while cursor > 0 && bytes[cursor - 1] == b'\\' {
+        backslashes += 1;
+        cursor -= 1;
+    }
+    backslashes % 2 == 1
 }
 
 #[cfg(test)]
@@ -33,15 +106,17 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_unquoted_globs_in_grep_patterns() {
+    fn reports_glob_style_stars_in_grep_patterns() {
         let source = "\
 #!/bin/sh
 grep start* out.txt
-grep -e item? out.txt
-grep --regexp item,[0-4] out.txt
-grep -Eq item,[0-4] out.txt
-grep -eo item* out.txt
-grep -F -- item,[0-4] out.txt
+grep \"start*\" out.txt
+grep 'foo*bar' out.txt
+grep foo*bar out.txt
+grep --regexp start* out.txt
+grep \"foo*bar\" out.txt
+grep item\\* out.txt
+grep -E \"foo*bar\" out.txt
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
 
@@ -52,44 +127,40 @@ grep -F -- item,[0-4] out.txt
                 .collect::<Vec<_>>(),
             vec![
                 "start*",
-                "item?",
-                "item,[0-4]",
-                "item,[0-4]",
-                "item*",
-                "item,[0-4]"
+                "\"start*\"",
+                "'foo*bar'",
+                "foo*bar",
+                "start*",
+                "\"foo*bar\"",
+                "item\\*",
+                "\"foo*bar\"",
             ]
         );
     }
 
     #[test]
-    fn ignores_quoted_patterns_and_non_pattern_operands() {
+    fn ignores_regex_operators_and_non_pattern_operands() {
         let source = "\
 #!/bin/sh
-grep \"start*\" out.txt
-grep --regexp='item,[0-4]' out.txt
-grep --regexp=item,[0-4] out.txt
-grep -eitem* out.txt
-grep -f patterns.txt item,[0-4] out.txt
+grep \"a.*\" out.txt
+grep a.* out.txt
+grep \"[ab]*\" out.txt
+grep [ab]* out.txt
+grep '*start' out.txt
+grep '*start*' out.txt
+grep item\\\\* out.txt
+grep '^ *#' out.txt
+grep '\"name\": *\"$x\"' out.txt
+grep -F foo*bar out.txt
+grep -F \"foo*bar\" out.txt
+grep --fixed-strings foo*bar out.txt
+grep --fixed-strings \"foo*bar\" out.txt
+grep --regexp='start*' out.txt
+grep --regexp=start* out.txt
+grep -estart* out.txt
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
-    }
-
-    #[test]
-    fn reports_grep_patterns_inside_command_substitution() {
-        let source = "\
-#!/bin/sh
-checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
-";
-        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
-
-        assert_eq!(
-            diagnostics
-                .iter()
-                .map(|diagnostic| diagnostic.span.slice(source))
-                .collect::<Vec<_>>(),
-            vec!["[0-9a-f]{40}"]
-        );
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -115,6 +115,8 @@ grep 'foo*bar' out.txt
 grep foo*bar out.txt
 grep -efoo* out.txt
 grep --regexp start* out.txt
+grep --exclude '*.txt' foo*bar out.txt
+grep --label stdin foo*bar out.txt
 grep \"foo*bar\" out.txt
 grep item\\* out.txt
 grep -E \"foo*bar\" out.txt
@@ -133,6 +135,8 @@ grep -E \"foo*bar\" out.txt
                 "foo*bar",
                 "-efoo*",
                 "start*",
+                "foo*bar",
+                "foo*bar",
                 "\"foo*bar\"",
                 "item\\*",
                 "\"foo*bar\"",

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
 
 pub struct GlobInGrepPattern;
 
@@ -20,12 +20,13 @@ pub fn glob_in_grep_pattern(checker: &mut Checker) {
         .filter(|fact| fact.effective_name_is("grep"))
         .filter_map(|fact| fact.options().grep())
         .filter(|grep| !grep.uses_fixed_strings)
-        .flat_map(|grep| grep.pattern_words().iter().copied())
-        .filter(|word| {
-            static_word_text(word, checker.source())
-                .is_some_and(|pattern| has_glob_style_star_confusion(&pattern))
+        .flat_map(|grep| grep.patterns().iter())
+        .filter(|pattern| {
+            pattern
+                .static_text()
+                .is_some_and(has_glob_style_star_confusion)
         })
-        .map(|word| word.span)
+        .map(|pattern| pattern.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || GlobInGrepPattern);
@@ -117,6 +118,7 @@ grep -efoo* out.txt
 grep --regexp start* out.txt
 grep --regexp='start*' out.txt
 grep --regexp=foo*bar out.txt
+grep --context 3 foo*bar out.txt
 grep --exclude '*.txt' foo*bar out.txt
 grep --label stdin foo*bar out.txt
 grep \"foo*bar\" out.txt
@@ -141,6 +143,7 @@ grep -E \"foo*bar\" out.txt
                 "--regexp=foo*bar",
                 "foo*bar",
                 "foo*bar",
+                "foo*bar",
                 "\"foo*bar\"",
                 "item\\*",
                 "\"foo*bar\"",
@@ -158,6 +161,8 @@ grep \"[ab]*\" out.txt
 grep [ab]* out.txt
 grep '*start' out.txt
 grep '*start*' out.txt
+grep -e'*start' out.txt
+grep --regexp='*start' out.txt
 grep item\\\\* out.txt
 grep '^ *#' out.txt
 grep '\"name\": *\"$x\"' out.txt

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -115,6 +115,8 @@ grep 'foo*bar' out.txt
 grep foo*bar out.txt
 grep -efoo* out.txt
 grep --regexp start* out.txt
+grep --regexp='start*' out.txt
+grep --regexp=foo*bar out.txt
 grep --exclude '*.txt' foo*bar out.txt
 grep --label stdin foo*bar out.txt
 grep \"foo*bar\" out.txt
@@ -135,6 +137,8 @@ grep -E \"foo*bar\" out.txt
                 "foo*bar",
                 "-efoo*",
                 "start*",
+                "--regexp='start*'",
+                "--regexp=foo*bar",
                 "foo*bar",
                 "foo*bar",
                 "\"foo*bar\"",
@@ -162,8 +166,6 @@ grep -F \"foo*bar\" out.txt
 grep --fixed-strings foo*bar out.txt
 grep --fixed-strings \"foo*bar\" out.txt
 grep -eo foo* out.txt
-grep --regexp='start*' out.txt
-grep --regexp=start* out.txt
 grep -efoo out.txt
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -113,6 +113,7 @@ grep start* out.txt
 grep \"start*\" out.txt
 grep 'foo*bar' out.txt
 grep foo*bar out.txt
+grep -efoo* out.txt
 grep --regexp start* out.txt
 grep \"foo*bar\" out.txt
 grep item\\* out.txt
@@ -130,6 +131,7 @@ grep -E \"foo*bar\" out.txt
                 "\"start*\"",
                 "'foo*bar'",
                 "foo*bar",
+                "-efoo*",
                 "start*",
                 "\"foo*bar\"",
                 "item\\*",
@@ -155,9 +157,10 @@ grep -F foo*bar out.txt
 grep -F \"foo*bar\" out.txt
 grep --fixed-strings foo*bar out.txt
 grep --fixed-strings \"foo*bar\" out.txt
+grep -eo foo* out.txt
 grep --regexp='start*' out.txt
 grep --regexp=start* out.txt
-grep -estart* out.txt
+grep -efoo out.txt
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
 

--- a/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
@@ -1,0 +1,125 @@
+use shuck_ast::{ConditionalBinaryOp, Word, WordPart};
+
+use crate::{Checker, ConditionalNodeFact, Rule, Violation, WordQuote};
+
+pub struct GlobInStringComparison;
+
+impl Violation for GlobInStringComparison {
+    fn rule() -> Rule {
+        Rule::GlobInStringComparison
+    }
+
+    fn message(&self) -> String {
+        "quote the right-hand side so string comparisons do not turn into glob matches".to_owned()
+    }
+}
+
+pub fn glob_in_string_comparison(checker: &mut Checker) {
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter_map(|fact| fact.conditional())
+        .flat_map(|conditional| conditional.nodes())
+        .filter_map(|node| match node {
+            ConditionalNodeFact::Binary(binary) if conditional_string_match_op(binary.op()) => {
+                Some(binary)
+            }
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
+        })
+        .filter_map(|binary| {
+            let right = binary.right();
+            if right.quote() != Some(WordQuote::Unquoted) {
+                return None;
+            }
+
+            let word = right.word()?;
+            standalone_variable_like_word(word).then_some(word.span)
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || GlobInStringComparison);
+}
+
+fn conditional_string_match_op(op: ConditionalBinaryOp) -> bool {
+    matches!(
+        op,
+        ConditionalBinaryOp::PatternEqShort
+            | ConditionalBinaryOp::PatternEq
+            | ConditionalBinaryOp::PatternNe
+    )
+}
+
+fn standalone_variable_like_word(word: &Word) -> bool {
+    match word.parts.as_slice() {
+        [part] => matches!(
+            part.kind,
+            WordPart::Variable(_)
+                | WordPart::Parameter(_)
+                | WordPart::ParameterExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayAccess(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::ArrayIndices(_)
+                | WordPart::Substring { .. }
+                | WordPart::ArraySlice { .. }
+                | WordPart::IndirectExpansion { .. }
+                | WordPart::PrefixMatch { .. }
+                | WordPart::Transformation { .. }
+        ),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_unquoted_standalone_variable_patterns() {
+        let source = "\
+#!/bin/bash
+if [[ $mirror == $pkgs ]]; then echo same; fi
+if [[ \"$a\" = $1 ]]; then :; fi
+if [[ \"$a\" != ${b%%x} ]]; then :; fi
+if [[ \"$a\" == ${arr[0]} ]]; then :; fi
+if [[ \"$a\" == \"$b\" ]]; then :; fi
+if [[ \"$a\" == $b* ]]; then :; fi
+if [[ \"$a\" == $b$c ]]; then :; fi
+if [[ \"$a\" == ${b}_x ]]; then :; fi
+if [[ \"$a\" < $b ]]; then :; fi
+if [ \"$a\" = $b ]; then :; fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInStringComparison),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$pkgs", "$1", "${b%%x}", "${arr[0]}"]
+        );
+    }
+
+    #[test]
+    fn reports_nested_string_comparisons_inside_command_substitutions() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"$( [[ $mirror == $pkgs ]] && echo same )\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInStringComparison),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "$pkgs");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
@@ -1,6 +1,7 @@
-use shuck_ast::{ConditionalBinaryOp, Word, WordPart};
-
-use crate::{Checker, ConditionalNodeFact, Rule, Violation, WordQuote};
+use crate::{
+    Checker, ConditionalNodeFact, Rule, Violation, WordQuote,
+    conditional_binary_op_is_string_match, word_is_standalone_variable_like,
+};
 
 pub struct GlobInStringComparison;
 
@@ -22,7 +23,9 @@ pub fn glob_in_string_comparison(checker: &mut Checker) {
         .filter_map(|fact| fact.conditional())
         .flat_map(|conditional| conditional.nodes())
         .filter_map(|node| match node {
-            ConditionalNodeFact::Binary(binary) if conditional_string_match_op(binary.op()) => {
+            ConditionalNodeFact::Binary(binary)
+                if conditional_binary_op_is_string_match(binary.op()) =>
+            {
                 Some(binary)
             }
             ConditionalNodeFact::BareWord(_)
@@ -37,41 +40,11 @@ pub fn glob_in_string_comparison(checker: &mut Checker) {
             }
 
             let word = right.word()?;
-            standalone_variable_like_word(word).then_some(word.span)
+            word_is_standalone_variable_like(word).then_some(word.span)
         })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || GlobInStringComparison);
-}
-
-fn conditional_string_match_op(op: ConditionalBinaryOp) -> bool {
-    matches!(
-        op,
-        ConditionalBinaryOp::PatternEqShort
-            | ConditionalBinaryOp::PatternEq
-            | ConditionalBinaryOp::PatternNe
-    )
-}
-
-fn standalone_variable_like_word(word: &Word) -> bool {
-    match word.parts.as_slice() {
-        [part] => matches!(
-            part.kind,
-            WordPart::Variable(_)
-                | WordPart::Parameter(_)
-                | WordPart::ParameterExpansion { .. }
-                | WordPart::Length(_)
-                | WordPart::ArrayAccess(_)
-                | WordPart::ArrayLength(_)
-                | WordPart::ArrayIndices(_)
-                | WordPart::Substring { .. }
-                | WordPart::ArraySlice { .. }
-                | WordPart::IndirectExpansion { .. }
-                | WordPart::PrefixMatch { .. }
-                | WordPart::Transformation { .. }
-        ),
-        _ => false,
-    }
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -1,0 +1,178 @@
+use crate::{
+    Checker, ExpansionContext, Rule, Violation, WordFact, word_unquoted_glob_pattern_spans,
+};
+use shuck_ast::{Span, Word, WordPart, WordPartNode};
+
+pub struct GlobWithExpansionInLoop;
+
+impl Violation for GlobWithExpansionInLoop {
+    fn rule() -> Rule {
+        Rule::GlobWithExpansionInLoop
+    }
+
+    fn message(&self) -> String {
+        "quote expansion prefixes when combining them with loop globs".to_owned()
+    }
+}
+
+pub fn glob_with_expansion_in_loop(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .expansion_word_facts(ExpansionContext::ForList)
+        .filter(|fact| !word_has_unquoted_brace_expansion(fact.word(), source))
+        .filter(|fact| !word_unquoted_glob_pattern_spans(fact.word(), source).is_empty())
+        .flat_map(unquoted_expansion_prefix_spans)
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || GlobWithExpansionInLoop);
+}
+
+fn unquoted_expansion_prefix_spans(fact: &WordFact<'_>) -> Vec<Span> {
+    let quoted = fact.double_quoted_expansion_spans();
+    let mut spans = fact
+        .scalar_expansion_spans()
+        .iter()
+        .copied()
+        .filter(|span| !quoted.contains(span))
+        .collect::<Vec<_>>();
+    spans.extend(fact.unquoted_command_substitution_spans().iter().copied());
+    spans
+}
+
+fn word_has_unquoted_brace_expansion(word: &Word, source: &str) -> bool {
+    parts_have_unquoted_brace_expansion(&word.parts, source, false)
+}
+
+fn parts_have_unquoted_brace_expansion(
+    parts: &[WordPartNode],
+    source: &str,
+    in_double_quotes: bool,
+) -> bool {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => {
+                if parts_have_unquoted_brace_expansion(parts, source, true) {
+                    return true;
+                }
+            }
+            WordPart::Literal(_) if !in_double_quotes => {
+                if literal_contains_brace_expansion(part.span.slice(source)) {
+                    return true;
+                }
+            }
+            WordPart::Literal(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::Transformation { .. }
+            | WordPart::ZshQualifiedGlob(_) => {}
+        }
+    }
+    false
+}
+
+fn literal_contains_brace_expansion(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+
+        if bytes[index] != b'{' {
+            index += 1;
+            continue;
+        }
+
+        let mut depth = 1usize;
+        let mut saw_comma = false;
+        let mut cursor = index + 1;
+        while cursor < bytes.len() {
+            if bytes[cursor] == b'\\' {
+                cursor = (cursor + 2).min(bytes.len());
+                continue;
+            }
+
+            match bytes[cursor] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        if saw_comma {
+                            return true;
+                        }
+                        break;
+                    }
+                }
+                b',' if depth == 1 => saw_comma = true,
+                _ => {}
+            }
+            cursor += 1;
+        }
+
+        index += 1;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_unquoted_expansion_prefixes_in_for_glob_words() {
+        let source = "\
+#!/bin/sh
+for i in $CWD/file.*pattern*; do :; done
+for i in ${CWD}/file.*pattern*; do :; done
+for i in $(pwd)/file.*pattern*; do :; done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobWithExpansionInLoop),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$CWD", "${CWD}", "$(pwd)"]
+        );
+    }
+
+    #[test]
+    fn ignores_quoted_prefixes_and_words_without_globs() {
+        let source = "\
+#!/bin/sh
+for i in \"$CWD\"/file.*pattern*; do :; done
+for i in file.*pattern*; do :; done
+for i in \"$CWD\"/*.txt; do :; done
+for i in $CWD/file.txt; do :; done
+for i in $DIR/setjmp-aarch64/{setjmp.S,private-*.h}; do :; done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobWithExpansionInLoop),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -1,7 +1,8 @@
 use crate::{
-    Checker, ExpansionContext, Rule, Violation, WordFact, word_unquoted_glob_pattern_spans,
+    Checker, ExpansionContext, Rule, Violation, WordFact, word_has_unquoted_brace_expansion,
+    word_unquoted_glob_pattern_spans,
 };
-use shuck_ast::{Span, Word, WordPart, WordPartNode};
+use shuck_ast::Span;
 
 pub struct GlobWithExpansionInLoop;
 
@@ -38,97 +39,6 @@ fn unquoted_expansion_prefix_spans(fact: &WordFact<'_>) -> Vec<Span> {
         .collect::<Vec<_>>();
     spans.extend(fact.unquoted_command_substitution_spans().iter().copied());
     spans
-}
-
-fn word_has_unquoted_brace_expansion(word: &Word, source: &str) -> bool {
-    parts_have_unquoted_brace_expansion(&word.parts, source, false)
-}
-
-fn parts_have_unquoted_brace_expansion(
-    parts: &[WordPartNode],
-    source: &str,
-    in_double_quotes: bool,
-) -> bool {
-    for part in parts {
-        match &part.kind {
-            WordPart::DoubleQuoted { parts, .. } => {
-                if parts_have_unquoted_brace_expansion(parts, source, true) {
-                    return true;
-                }
-            }
-            WordPart::Literal(_) if !in_double_quotes => {
-                if literal_contains_brace_expansion(part.span.slice(source)) {
-                    return true;
-                }
-            }
-            WordPart::Literal(_)
-            | WordPart::SingleQuoted { .. }
-            | WordPart::Variable(_)
-            | WordPart::CommandSubstitution { .. }
-            | WordPart::ProcessSubstitution { .. }
-            | WordPart::ArithmeticExpansion { .. }
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::ArrayAccess(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::ArrayIndices(_)
-            | WordPart::Substring { .. }
-            | WordPart::ArraySlice { .. }
-            | WordPart::IndirectExpansion { .. }
-            | WordPart::PrefixMatch { .. }
-            | WordPart::Transformation { .. }
-            | WordPart::ZshQualifiedGlob(_) => {}
-        }
-    }
-    false
-}
-
-fn literal_contains_brace_expansion(text: &str) -> bool {
-    let bytes = text.as_bytes();
-    let mut index = 0usize;
-
-    while index < bytes.len() {
-        if bytes[index] == b'\\' {
-            index = (index + 2).min(bytes.len());
-            continue;
-        }
-
-        if bytes[index] != b'{' {
-            index += 1;
-            continue;
-        }
-
-        let mut depth = 1usize;
-        let mut saw_comma = false;
-        let mut cursor = index + 1;
-        while cursor < bytes.len() {
-            if bytes[cursor] == b'\\' {
-                cursor = (cursor + 2).min(bytes.len());
-                continue;
-            }
-
-            match bytes[cursor] {
-                b'{' => depth += 1,
-                b'}' => {
-                    depth = depth.saturating_sub(1);
-                    if depth == 0 {
-                        if saw_comma {
-                            return true;
-                        }
-                        break;
-                    }
-                }
-                b',' if depth == 1 => saw_comma = true,
-                _ => {}
-            }
-            cursor += 1;
-        }
-
-        index += 1;
-    }
-
-    false
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -76,6 +76,7 @@ for i in \"$CWD\"/file.*pattern*; do :; done
 for i in file.*pattern*; do :; done
 for i in \"$CWD\"/*.txt; do :; done
 for i in $CWD/file.txt; do :; done
+for i in $DIR/{1..3}*.txt; do :; done
 for i in $DIR/setjmp-aarch64/{setjmp.S,private-*.h}; do :; done
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -35,6 +35,7 @@ pub mod find_output_loop;
 pub mod find_output_to_xargs;
 pub mod function_called_without_args;
 pub mod function_references_unset_param;
+pub mod glob_in_find_substitution;
 pub mod glob_in_grep_pattern;
 pub mod glob_in_string_comparison;
 pub mod heredoc_closer_not_alone;
@@ -166,6 +167,7 @@ mod tests {
     #[test_case(Rule::ShortCircuitFallthrough, Path::new("C079.sh"))]
     #[test_case(Rule::GlobInGrepPattern, Path::new("C080.sh"))]
     #[test_case(Rule::GlobInStringComparison, Path::new("C081.sh"))]
+    #[test_case(Rule::GlobInFindSubstitution, Path::new("C083.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
     #[test_case(Rule::FunctionCalledWithoutArgs, Path::new("C097.sh"))]
     #[test_case(Rule::SetFlagsWithoutDashes, Path::new("C098.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -38,6 +38,7 @@ pub mod function_references_unset_param;
 pub mod glob_in_find_substitution;
 pub mod glob_in_grep_pattern;
 pub mod glob_in_string_comparison;
+pub mod glob_with_expansion_in_loop;
 pub mod heredoc_closer_not_alone;
 pub mod heredoc_missing_end;
 pub mod if_bracket_glued;
@@ -170,6 +171,7 @@ mod tests {
     #[test_case(Rule::GlobInStringComparison, Path::new("C081.sh"))]
     #[test_case(Rule::GlobInFindSubstitution, Path::new("C083.sh"))]
     #[test_case(Rule::UnquotedGrepRegex, Path::new("C084.sh"))]
+    #[test_case(Rule::GlobWithExpansionInLoop, Path::new("C114.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
     #[test_case(Rule::FunctionCalledWithoutArgs, Path::new("C097.sh"))]
     #[test_case(Rule::SetFlagsWithoutDashes, Path::new("C098.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -35,6 +35,7 @@ pub mod find_output_loop;
 pub mod find_output_to_xargs;
 pub mod function_called_without_args;
 pub mod function_references_unset_param;
+pub mod glob_in_grep_pattern;
 pub mod heredoc_closer_not_alone;
 pub mod heredoc_missing_end;
 pub mod if_bracket_glued;
@@ -162,6 +163,7 @@ mod tests {
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
     #[test_case(Rule::UnquotedGlobsInFind, Path::new("C078.sh"))]
     #[test_case(Rule::ShortCircuitFallthrough, Path::new("C079.sh"))]
+    #[test_case(Rule::GlobInGrepPattern, Path::new("C080.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
     #[test_case(Rule::FunctionCalledWithoutArgs, Path::new("C097.sh"))]
     #[test_case(Rule::SetFlagsWithoutDashes, Path::new("C098.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -36,6 +36,7 @@ pub mod find_output_to_xargs;
 pub mod function_called_without_args;
 pub mod function_references_unset_param;
 pub mod glob_in_grep_pattern;
+pub mod glob_in_string_comparison;
 pub mod heredoc_closer_not_alone;
 pub mod heredoc_missing_end;
 pub mod if_bracket_glued;
@@ -164,6 +165,7 @@ mod tests {
     #[test_case(Rule::UnquotedGlobsInFind, Path::new("C078.sh"))]
     #[test_case(Rule::ShortCircuitFallthrough, Path::new("C079.sh"))]
     #[test_case(Rule::GlobInGrepPattern, Path::new("C080.sh"))]
+    #[test_case(Rule::GlobInStringComparison, Path::new("C081.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
     #[test_case(Rule::FunctionCalledWithoutArgs, Path::new("C097.sh"))]
     #[test_case(Rule::SetFlagsWithoutDashes, Path::new("C098.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -86,6 +86,7 @@ pub mod unchecked_directory_change_in_function;
 pub mod undefined_variable;
 pub mod unicode_quote_in_string;
 pub mod unicode_single_quote_in_single_quotes;
+pub mod unquoted_globs_in_find;
 pub mod unreachable_after_exit;
 pub mod unset_associative_array_element;
 pub mod until_missing_do;
@@ -159,6 +160,7 @@ mod tests {
     #[test_case(Rule::UnicodeQuoteInString, Path::new("C072.sh"))]
     #[test_case(Rule::CommentedContinuationLine, Path::new("C076.sh"))]
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
+    #[test_case(Rule::UnquotedGlobsInFind, Path::new("C078.sh"))]
     #[test_case(Rule::ShortCircuitFallthrough, Path::new("C079.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
     #[test_case(Rule::FunctionCalledWithoutArgs, Path::new("C097.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -90,6 +90,7 @@ pub mod undefined_variable;
 pub mod unicode_quote_in_string;
 pub mod unicode_single_quote_in_single_quotes;
 pub mod unquoted_globs_in_find;
+pub mod unquoted_grep_regex;
 pub mod unreachable_after_exit;
 pub mod unset_associative_array_element;
 pub mod until_missing_do;
@@ -168,6 +169,7 @@ mod tests {
     #[test_case(Rule::GlobInGrepPattern, Path::new("C080.sh"))]
     #[test_case(Rule::GlobInStringComparison, Path::new("C081.sh"))]
     #[test_case(Rule::GlobInFindSubstitution, Path::new("C083.sh"))]
+    #[test_case(Rule::UnquotedGrepRegex, Path::new("C084.sh"))]
     #[test_case(Rule::AssignmentLooksLikeComparison, Path::new("C095.sh"))]
     #[test_case(Rule::FunctionCalledWithoutArgs, Path::new("C097.sh"))]
     #[test_case(Rule::SetFlagsWithoutDashes, Path::new("C098.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C078_C078.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C078_C078.sh.snap
@@ -1,0 +1,38 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:2:19
+  |
+2 | find . -exec echo *.txt {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:3:22
+  |
+3 | find . -exec echo foo[ab]bar {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:4:19
+  |
+4 | find . -exec echo $(basename "$dir") {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:5:19
+  |
+5 | find . -exec echo $(basename "$dir")* {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:5:37
+  |
+5 | find . -exec echo $(basename "$dir")* {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:6:31
+  |
+6 | find . -execdir echo "$prefix"*.tmp {} \;
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
@@ -1,38 +1,50 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
 ---
-C080 quote grep patterns so the shell does not expand them first
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
  --> <source>:2:6
   |
 2 | grep start* out.txt
   |
 
-C080 quote grep patterns so the shell does not expand them first
- --> <source>:3:9
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:3:6
   |
-3 | grep -e item? out.txt
-  |
-
-C080 quote grep patterns so the shell does not expand them first
- --> <source>:4:15
-  |
-4 | grep --regexp item,[0-4] out.txt
+3 | grep "start*" out.txt
   |
 
-C080 quote grep patterns so the shell does not expand them first
- --> <source>:5:10
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:4:6
   |
-5 | grep -Eq item,[0-4] out.txt
-  |
-
-C080 quote grep patterns so the shell does not expand them first
- --> <source>:6:10
-  |
-6 | grep -eo item* out.txt
+4 | grep 'foo*bar' out.txt
   |
 
-C080 quote grep patterns so the shell does not expand them first
- --> <source>:7:12
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:5:6
   |
-7 | grep -F -- item,[0-4] out.txt
+5 | grep foo*bar out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:6:15
+  |
+6 | grep --regexp start* out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:7:6
+  |
+7 | grep "foo*bar" out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:8:6
+  |
+8 | grep item\* out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:9:9
+  |
+9 | grep -E "foo*bar" out.txt
   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
@@ -38,31 +38,43 @@ C080 use regex-style wildcards in grep patterns, not glob-style `*`
   |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
- --> <source>:8:24
+ --> <source>:8:6
   |
-8 | grep --exclude '*.txt' foo*bar out.txt
-  |
-
-C080 use regex-style wildcards in grep patterns, not glob-style `*`
- --> <source>:9:20
-  |
-9 | grep --label stdin foo*bar out.txt
+8 | grep --regexp='start*' out.txt
   |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
-  --> <source>:10:6
+ --> <source>:9:6
+  |
+9 | grep --regexp=foo*bar out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+  --> <source>:10:24
    |
-10 | grep "foo*bar" out.txt
+10 | grep --exclude '*.txt' foo*bar out.txt
    |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
-  --> <source>:11:6
+  --> <source>:11:20
    |
-11 | grep item\* out.txt
+11 | grep --label stdin foo*bar out.txt
    |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
-  --> <source>:12:9
+  --> <source>:12:6
    |
-12 | grep -E "foo*bar" out.txt
+12 | grep "foo*bar" out.txt
+   |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+  --> <source>:13:6
+   |
+13 | grep item\* out.txt
+   |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+  --> <source>:14:9
+   |
+14 | grep -E "foo*bar" out.txt
    |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
@@ -1,0 +1,38 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C080 quote grep patterns so the shell does not expand them first
+ --> <source>:2:6
+  |
+2 | grep start* out.txt
+  |
+
+C080 quote grep patterns so the shell does not expand them first
+ --> <source>:3:9
+  |
+3 | grep -e item? out.txt
+  |
+
+C080 quote grep patterns so the shell does not expand them first
+ --> <source>:4:15
+  |
+4 | grep --regexp item,[0-4] out.txt
+  |
+
+C080 quote grep patterns so the shell does not expand them first
+ --> <source>:5:10
+  |
+5 | grep -Eq item,[0-4] out.txt
+  |
+
+C080 quote grep patterns so the shell does not expand them first
+ --> <source>:6:10
+  |
+6 | grep -eo item* out.txt
+  |
+
+C080 quote grep patterns so the shell does not expand them first
+ --> <source>:7:12
+  |
+7 | grep -F -- item,[0-4] out.txt
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
@@ -26,25 +26,31 @@ C080 use regex-style wildcards in grep patterns, not glob-style `*`
   |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
- --> <source>:6:15
+ --> <source>:6:6
   |
-6 | grep --regexp start* out.txt
+6 | grep -efoo* out.txt
   |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
- --> <source>:7:6
+ --> <source>:7:15
   |
-7 | grep "foo*bar" out.txt
+7 | grep --regexp start* out.txt
   |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
  --> <source>:8:6
   |
-8 | grep item\* out.txt
+8 | grep "foo*bar" out.txt
   |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
- --> <source>:9:9
+ --> <source>:9:6
   |
-9 | grep -E "foo*bar" out.txt
+9 | grep item\* out.txt
   |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+  --> <source>:10:9
+   |
+10 | grep -E "foo*bar" out.txt
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C080_C080.sh.snap
@@ -38,19 +38,31 @@ C080 use regex-style wildcards in grep patterns, not glob-style `*`
   |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
- --> <source>:8:6
+ --> <source>:8:24
   |
-8 | grep "foo*bar" out.txt
-  |
-
-C080 use regex-style wildcards in grep patterns, not glob-style `*`
- --> <source>:9:6
-  |
-9 | grep item\* out.txt
+8 | grep --exclude '*.txt' foo*bar out.txt
   |
 
 C080 use regex-style wildcards in grep patterns, not glob-style `*`
-  --> <source>:10:9
+ --> <source>:9:20
+  |
+9 | grep --label stdin foo*bar out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+  --> <source>:10:6
    |
-10 | grep -E "foo*bar" out.txt
+10 | grep "foo*bar" out.txt
+   |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+  --> <source>:11:6
+   |
+11 | grep item\* out.txt
+   |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+  --> <source>:12:9
+   |
+12 | grep -E "foo*bar" out.txt
    |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C081_C081.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C081_C081.sh.snap
@@ -1,0 +1,32 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:2:18
+  |
+2 | if [[ $mirror == $pkgs ]]; then echo same; fi
+  |
+
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:3:14
+  |
+3 | if [[ "$a" = $1 ]]; then :; fi
+  |
+
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:4:15
+  |
+4 | if [[ "$a" != ${b%%x} ]]; then :; fi
+  |
+
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:5:15
+  |
+5 | if [[ "$a" == ${arr[0]} ]]; then :; fi
+  |
+
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:6:33
+  |
+6 | printf '%s\n' "$( [[ $mirror == $pkgs ]] && echo same )"
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C083_C083.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C083_C083.sh.snap
@@ -1,0 +1,20 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:2:15
+  |
+2 | find ./ -name *.jar
+  |
+
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:3:26
+  |
+3 | for f in $(find ./ -name *.cfg); do :; done
+  |
+
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:4:31
+  |
+4 | printf '%s\n' "$(find . -path */tmp/*)"
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C083_C083.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C083_C083.sh.snap
@@ -14,13 +14,19 @@ C083 quote glob patterns passed to `find` so the shell does not expand them earl
   |
 
 C083 quote glob patterns passed to `find` so the shell does not expand them early
- --> <source>:4:26
+ --> <source>:4:20
   |
-4 | for f in $(find ./ -name *.cfg); do :; done
+4 | find ./ -wholename */tmp/*
   |
 
 C083 quote glob patterns passed to `find` so the shell does not expand them early
- --> <source>:5:31
+ --> <source>:5:26
   |
-5 | printf '%s\n' "$(find . -path */tmp/*)"
+5 | for f in $(find ./ -name *.cfg); do :; done
+  |
+
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:6:31
+  |
+6 | printf '%s\n' "$(find . -path */tmp/*)"
   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C083_C083.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C083_C083.sh.snap
@@ -8,13 +8,19 @@ C083 quote glob patterns passed to `find` so the shell does not expand them earl
   |
 
 C083 quote glob patterns passed to `find` so the shell does not expand them early
- --> <source>:3:26
+ --> <source>:3:15
   |
-3 | for f in $(find ./ -name *.cfg); do :; done
+3 | find ./ -name "$prefix"*.jar
   |
 
 C083 quote glob patterns passed to `find` so the shell does not expand them early
- --> <source>:4:31
+ --> <source>:4:26
   |
-4 | printf '%s\n' "$(find . -path */tmp/*)"
+4 | for f in $(find ./ -name *.cfg); do :; done
+  |
+
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:5:31
+  |
+5 | printf '%s\n' "$(find . -path */tmp/*)"
   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C084_C084.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C084_C084.sh.snap
@@ -38,25 +38,37 @@ C084 quote grep regex patterns so the shell does not expand them first
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:8:12
+ --> <source>:8:24
   |
-8 | grep -F -- item,[0-4] out.txt
-  |
-
-C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:9:9
-  |
-9 | grep -F foo*bar out.txt
+8 | grep --exclude '*.txt' foo*bar out.txt
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
-  --> <source>:10:6
+ --> <source>:9:20
+  |
+9 | grep --label stdin item? out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:10:12
    |
-10 | grep [0-9a-f]{40} out.txt
+10 | grep -F -- item,[0-4] out.txt
    |
 
 C084 quote grep regex patterns so the shell does not expand them first
-  --> <source>:11:25
+  --> <source>:11:9
    |
-11 | checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
+11 | grep -F foo*bar out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:12:6
+   |
+12 | grep [0-9a-f]{40} out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:13:25
+   |
+13 | checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
    |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C084_C084.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C084_C084.sh.snap
@@ -1,0 +1,56 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:2:6
+  |
+2 | grep start* out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:3:9
+  |
+3 | grep -e item? out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:4:15
+  |
+4 | grep --regexp item,[0-4] out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:5:10
+  |
+5 | grep -Eq item,[0-4] out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:6:10
+  |
+6 | grep -eo item* out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:7:12
+  |
+7 | grep -F -- item,[0-4] out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:8:9
+  |
+8 | grep -F foo*bar out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:9:6
+  |
+9 | grep [0-9a-f]{40} out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:10:25
+   |
+10 | checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C084_C084.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C084_C084.sh.snap
@@ -38,37 +38,43 @@ C084 quote grep regex patterns so the shell does not expand them first
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:8:24
+ --> <source>:8:6
   |
-8 | grep --exclude '*.txt' foo*bar out.txt
-  |
-
-C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:9:20
-  |
-9 | grep --label stdin item? out.txt
+8 | grep --regexp=foo*bar out.txt
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
-  --> <source>:10:12
+ --> <source>:9:24
+  |
+9 | grep --exclude '*.txt' foo*bar out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:10:20
    |
-10 | grep -F -- item,[0-4] out.txt
+10 | grep --label stdin item? out.txt
    |
 
 C084 quote grep regex patterns so the shell does not expand them first
-  --> <source>:11:9
+  --> <source>:11:12
    |
-11 | grep -F foo*bar out.txt
-   |
-
-C084 quote grep regex patterns so the shell does not expand them first
-  --> <source>:12:6
-   |
-12 | grep [0-9a-f]{40} out.txt
+11 | grep -F -- item,[0-4] out.txt
    |
 
 C084 quote grep regex patterns so the shell does not expand them first
-  --> <source>:13:25
+  --> <source>:12:9
    |
-13 | checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
+12 | grep -F foo*bar out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:13:6
+   |
+13 | grep [0-9a-f]{40} out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:14:25
+   |
+14 | checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
    |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C084_C084.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C084_C084.sh.snap
@@ -14,43 +14,49 @@ C084 quote grep regex patterns so the shell does not expand them first
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:4:15
+ --> <source>:4:6
   |
-4 | grep --regexp item,[0-4] out.txt
+4 | grep -eitem* out.txt
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
  --> <source>:5:10
   |
-5 | grep -Eq item,[0-4] out.txt
+5 | grep -oe item* out.txt
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:6:10
+ --> <source>:6:15
   |
-6 | grep -eo item* out.txt
-  |
-
-C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:7:12
-  |
-7 | grep -F -- item,[0-4] out.txt
+6 | grep --regexp item,[0-4] out.txt
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:8:9
+ --> <source>:7:10
   |
-8 | grep -F foo*bar out.txt
-  |
-
-C084 quote grep regex patterns so the shell does not expand them first
- --> <source>:9:6
-  |
-9 | grep [0-9a-f]{40} out.txt
+7 | grep -Eq item,[0-4] out.txt
   |
 
 C084 quote grep regex patterns so the shell does not expand them first
-  --> <source>:10:25
+ --> <source>:8:12
+  |
+8 | grep -F -- item,[0-4] out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:9:9
+  |
+9 | grep -F foo*bar out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:10:6
    |
-10 | checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
+10 | grep [0-9a-f]{40} out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:11:25
+   |
+11 | checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
    |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C114_C114.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C114_C114.sh.snap
@@ -1,0 +1,20 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C114 quote expansion prefixes when combining them with loop globs
+ --> <source>:2:10
+  |
+2 | for i in $CWD/file.*pattern*; do :; done
+  |
+
+C114 quote expansion prefixes when combining them with loop globs
+ --> <source>:3:10
+  |
+3 | for i in ${CWD}/file.*pattern*; do :; done
+  |
+
+C114 quote expansion prefixes when combining them with loop globs
+ --> <source>:4:10
+  |
+4 | for i in $(pwd)/file.*pattern*; do :; done
+  |

--- a/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
@@ -1,0 +1,96 @@
+use rustc_hash::FxHashSet;
+
+use crate::{
+    Checker, ExpansionContext, Rule, Violation, WrapperKind, word_unquoted_glob_pattern_spans,
+};
+
+pub struct UnquotedGlobsInFind;
+
+impl Violation for UnquotedGlobsInFind {
+    fn rule() -> Rule {
+        Rule::UnquotedGlobsInFind
+    }
+
+    fn message(&self) -> String {
+        "patterns in `find -exec` arguments expand before `find` runs".to_owned()
+    }
+}
+
+pub fn unquoted_globs_in_find(checker: &mut Checker) {
+    let find_exec_command_ids = checker
+        .facts()
+        .structural_commands()
+        .filter(|fact| {
+            fact.has_wrapper(WrapperKind::FindExec) || fact.has_wrapper(WrapperKind::FindExecDir)
+        })
+        .map(|fact| fact.id())
+        .collect::<FxHashSet<_>>();
+
+    let spans = checker
+        .facts()
+        .expansion_word_facts(ExpansionContext::CommandArgument)
+        .filter(|fact| find_exec_command_ids.contains(&fact.command_id()))
+        .flat_map(|fact| {
+            fact.unquoted_command_substitution_spans()
+                .iter()
+                .copied()
+                .chain(word_unquoted_glob_pattern_spans(
+                    fact.word(),
+                    checker.source(),
+                ))
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || UnquotedGlobsInFind);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_globs_and_unquoted_substitutions_in_find_exec_arguments() {
+        let source = "\
+#!/bin/bash
+find . -exec echo *.txt {} +
+find . -exec echo foo[ab]bar {} +
+find . -exec echo $(basename \"$dir\") {} +
+find . -exec echo $(basename \"$dir\")* {} +
+find . -execdir echo \"$prefix\"*.tmp {} \\;
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedGlobsInFind));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "*",
+                "[ab]",
+                "$(basename \"$dir\")",
+                "$(basename \"$dir\")",
+                "*",
+                "*"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_quoted_or_non_find_exec_arguments() {
+        let source = "\
+#!/bin/bash
+find . -exec echo \"$file\" {} +
+find . -exec echo \"*.txt\" {} +
+find . -exec echo \"$(basename \"$dir\")\" {} +
+find . -name *.txt -print
+printf '*.txt'
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedGlobsInFind));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -19,9 +19,11 @@ pub fn unquoted_grep_regex(checker: &mut Checker) {
         .iter()
         .filter(|fact| fact.effective_name_is("grep"))
         .filter_map(|fact| fact.options().grep())
-        .flat_map(|grep| grep.pattern_words().iter().copied())
-        .filter(|word| !word_unquoted_glob_pattern_spans(word, checker.source()).is_empty())
-        .map(|word| word.span)
+        .flat_map(|grep| grep.patterns().iter())
+        .filter(|pattern| {
+            !word_unquoted_glob_pattern_spans(pattern.word(), checker.source()).is_empty()
+        })
+        .map(|pattern| pattern.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || UnquotedGrepRegex);
@@ -43,6 +45,7 @@ grep -oe item* out.txt
 grep --regexp item,[0-4] out.txt
 grep -Eq item,[0-4] out.txt
 grep --regexp=foo*bar out.txt
+grep --context 3 foo*bar out.txt
 grep --exclude '*.txt' foo*bar out.txt
 grep --label stdin item? out.txt
 grep -F -- item,[0-4] out.txt
@@ -65,6 +68,7 @@ checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
                 "item,[0-4]",
                 "item,[0-4]",
                 "--regexp=foo*bar",
+                "foo*bar",
                 "foo*bar",
                 "item?",
                 "item,[0-4]",

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -42,6 +42,7 @@ grep -eitem* out.txt
 grep -oe item* out.txt
 grep --regexp item,[0-4] out.txt
 grep -Eq item,[0-4] out.txt
+grep --regexp=foo*bar out.txt
 grep --exclude '*.txt' foo*bar out.txt
 grep --label stdin item? out.txt
 grep -F -- item,[0-4] out.txt
@@ -63,6 +64,7 @@ checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
                 "item*",
                 "item,[0-4]",
                 "item,[0-4]",
+                "--regexp=foo*bar",
                 "foo*bar",
                 "item?",
                 "item,[0-4]",
@@ -79,7 +81,6 @@ checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
 #!/bin/sh
 grep \"start*\" out.txt
 grep --regexp='item,[0-4]' out.txt
-grep --regexp=item,[0-4] out.txt
 grep -eo item* out.txt
 grep -f patterns.txt item,[0-4] out.txt
 grep --exclude '*.txt' \"foo*bar\" out.txt

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -42,6 +42,8 @@ grep -eitem* out.txt
 grep -oe item* out.txt
 grep --regexp item,[0-4] out.txt
 grep -Eq item,[0-4] out.txt
+grep --exclude '*.txt' foo*bar out.txt
+grep --label stdin item? out.txt
 grep -F -- item,[0-4] out.txt
 grep -F foo*bar out.txt
 grep [0-9a-f]{40} out.txt
@@ -61,6 +63,8 @@ checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
                 "item*",
                 "item,[0-4]",
                 "item,[0-4]",
+                "foo*bar",
+                "item?",
                 "item,[0-4]",
                 "foo*bar",
                 "[0-9a-f]{40}",
@@ -78,6 +82,7 @@ grep --regexp='item,[0-4]' out.txt
 grep --regexp=item,[0-4] out.txt
 grep -eo item* out.txt
 grep -f patterns.txt item,[0-4] out.txt
+grep --exclude '*.txt' \"foo*bar\" out.txt
 grep \\[ab\\]\\* out.txt
 grep -F \"foo*bar\" out.txt
 ";

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -38,9 +38,10 @@ mod tests {
 #!/bin/sh
 grep start* out.txt
 grep -e item? out.txt
+grep -eitem* out.txt
+grep -oe item* out.txt
 grep --regexp item,[0-4] out.txt
 grep -Eq item,[0-4] out.txt
-grep -eo item* out.txt
 grep -F -- item,[0-4] out.txt
 grep -F foo*bar out.txt
 grep [0-9a-f]{40} out.txt
@@ -56,9 +57,10 @@ checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
             vec![
                 "start*",
                 "item?",
-                "item,[0-4]",
-                "item,[0-4]",
+                "-eitem*",
                 "item*",
+                "item,[0-4]",
+                "item,[0-4]",
                 "item,[0-4]",
                 "foo*bar",
                 "[0-9a-f]{40}",
@@ -74,7 +76,7 @@ checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
 grep \"start*\" out.txt
 grep --regexp='item,[0-4]' out.txt
 grep --regexp=item,[0-4] out.txt
-grep -eitem* out.txt
+grep -eo item* out.txt
 grep -f patterns.txt item,[0-4] out.txt
 grep \\[ab\\]\\* out.txt
 grep -F \"foo*bar\" out.txt

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -1,0 +1,86 @@
+use crate::{Checker, Rule, Violation, word_unquoted_glob_pattern_spans};
+
+pub struct UnquotedGrepRegex;
+
+impl Violation for UnquotedGrepRegex {
+    fn rule() -> Rule {
+        Rule::UnquotedGrepRegex
+    }
+
+    fn message(&self) -> String {
+        "quote grep regex patterns so the shell does not expand them first".to_owned()
+    }
+}
+
+pub fn unquoted_grep_regex(checker: &mut Checker) {
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("grep"))
+        .filter_map(|fact| fact.options().grep())
+        .flat_map(|grep| grep.pattern_words().iter().copied())
+        .filter(|word| !word_unquoted_glob_pattern_spans(word, checker.source()).is_empty())
+        .map(|word| word.span)
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || UnquotedGrepRegex);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_unquoted_grep_patterns_that_can_glob_expand() {
+        let source = "\
+#!/bin/sh
+grep start* out.txt
+grep -e item? out.txt
+grep --regexp item,[0-4] out.txt
+grep -Eq item,[0-4] out.txt
+grep -eo item* out.txt
+grep -F -- item,[0-4] out.txt
+grep -F foo*bar out.txt
+grep [0-9a-f]{40} out.txt
+checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedGrepRegex));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "start*",
+                "item?",
+                "item,[0-4]",
+                "item,[0-4]",
+                "item*",
+                "item,[0-4]",
+                "foo*bar",
+                "[0-9a-f]{40}",
+                "[0-9a-f]{40}"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_quoted_patterns_and_non_pattern_operands() {
+        let source = "\
+#!/bin/sh
+grep \"start*\" out.txt
+grep --regexp='item,[0-4]' out.txt
+grep --regexp=item,[0-4] out.txt
+grep -eitem* out.txt
+grep -f patterns.txt item,[0-4] out.txt
+grep \\[ab\\]\\* out.txt
+grep -F \"foo*bar\" out.txt
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedGrepRegex));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
+++ b/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
@@ -1,0 +1,98 @@
+use crate::{
+    Checker, ExpansionContext, Rule, Violation, WordFactHostKind, WordQuote,
+    word_unquoted_glob_pattern_spans,
+};
+
+pub struct GlobAssignedToVariable;
+
+impl Violation for GlobAssignedToVariable {
+    fn rule() -> Rule {
+        Rule::GlobAssignedToVariable
+    }
+
+    fn message(&self) -> String {
+        "quote assigned glob patterns so they stay literal".to_owned()
+    }
+}
+
+pub fn glob_assigned_to_variable(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .expansion_word_facts(ExpansionContext::AssignmentValue)
+        .chain(
+            checker
+                .facts()
+                .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue),
+        )
+        .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
+        .filter(|fact| !checker.facts().is_compound_assignment_value_word(fact))
+        .filter(|fact| fact.classification().quote != WordQuote::FullyQuoted)
+        .filter(|fact| !word_unquoted_glob_pattern_spans(fact.word(), source).is_empty())
+        .map(|fact| fact.span())
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || GlobAssignedToVariable);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_assignment_values_with_unquoted_globs() {
+        let source = "\
+#!/bin/bash
+LOCS=*.oxt
+LOCS=$dir/*.oxt
+LOCS=\"$dir\"/*.oxt
+LOCS=${dir}/*.oxt
+LOCS=$(pwd)/*.oxt
+readonly LOCS=foo*bar
+export LOCS=$dir/*.txt
+LOCS=${disk_info[${#disk_info[@]} - 1]/*\\/}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobAssignedToVariable),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "*.oxt",
+                "$dir/*.oxt",
+                "\"$dir\"/*.oxt",
+                "${dir}/*.oxt",
+                "$(pwd)/*.oxt",
+                "foo*bar",
+                "$dir/*.txt"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_fully_quoted_or_non_glob_assignment_values() {
+        let source = "\
+#!/bin/bash
+LOCS=\"*.oxt\"
+LOCS='*.oxt'
+LOCS=\\*.oxt
+LOCS=$dir/file.txt
+readonly LOCS=\"*.txt\"
+export LOCS='$dir/*.txt'
+LOCS=(*.oxt)
+LOCS=(\"$dir\"/*.oxt)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobAssignedToVariable),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -17,6 +17,7 @@ pub mod escaped_underscore;
 pub mod escaped_underscore_literal;
 pub mod export_command_substitution;
 pub mod function_in_alias;
+pub mod glob_assigned_to_variable;
 pub mod grep_output_in_test;
 pub mod heredoc_end_space;
 pub mod ifs_equals_ambiguity;
@@ -83,6 +84,7 @@ mod tests {
     #[test_case(Rule::UnquotedVariableInSed, Path::new("S044.sh"))]
     #[test_case(Rule::UnquotedTrClass, Path::new("S051.sh"))]
     #[test_case(Rule::SuWithoutFlag, Path::new("S054.sh"))]
+    #[test_case(Rule::GlobAssignedToVariable, Path::new("S055.sh"))]
     #[test_case(Rule::UnquotedTrRange, Path::new("S049.sh"))]
     #[test_case(Rule::LsPipedToXargs, Path::new("S046.sh"))]
     #[test_case(Rule::LsInSubstitution, Path::new("S047.sh"))]

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S055_S055.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S055_S055.sh.snap
@@ -1,0 +1,44 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:2:6
+  |
+2 | LOCS=*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:4:6
+  |
+4 | LOCS=$dir/*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:5:6
+  |
+5 | LOCS="$dir"/*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:6:6
+  |
+6 | LOCS=${dir}/*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:7:6
+  |
+7 | LOCS=$(pwd)/*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:9:15
+  |
+9 | readonly LOCS=foo*bar
+  |
+
+S055 quote assigned glob patterns so they stay literal
+  --> <source>:10:13
+   |
+10 | export LOCS=$dir/*.txt
+   |

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -222,6 +222,9 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports unquoted glob operands in `find` predicates as SC2061.
             // Keep SC2304 as a suppression alias for authored C083 metadata.
             (2061, Rule::GlobInFindSubstitution),
+            // ShellCheck 0.11.0 reports unquoted glob assignment values as SC2125.
+            // Keep SC2326 as a suppression alias for authored S055 metadata.
+            (2125, Rule::GlobAssignedToVariable),
             (1019, Rule::EmptyTest),
             (2024, Rule::SudoRedirectionOrder),
             (2034, Rule::UnusedAssignment),
@@ -565,6 +568,7 @@ impl Default for ShellCheckCodeMap {
                     (2115, Rule::RmGlobOnVariablePath),
                     (2104, Rule::LoopControlOutsideLoop),
                     (2112, Rule::FunctionKeyword),
+                    (2125, Rule::GlobAssignedToVariable),
                     (2216, Rule::PipeToKill),
                     (3005, Rule::CStyleForInSh),
                     (3006, Rule::StandaloneArithmetic),
@@ -712,6 +716,7 @@ impl Default for ShellCheckCodeMap {
                 (2304, Rule::GlobInFindSubstitution),
                 (2305, Rule::UnquotedGrepRegex),
                 (2349, Rule::GlobWithExpansionInLoop),
+                (2326, Rule::GlobAssignedToVariable),
                 (2060, Rule::UnquotedTrRange),
                 (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
@@ -936,6 +941,8 @@ mod tests {
         assert_eq!(map.resolve("SC2301"), Some(Rule::GlobInStringComparison));
         assert_eq!(map.resolve("SC2061"), Some(Rule::GlobInFindSubstitution));
         assert_eq!(map.resolve("SC2304"), Some(Rule::GlobInFindSubstitution));
+        assert_eq!(map.resolve("SC2125"), Some(Rule::GlobAssignedToVariable));
+        assert_eq!(map.resolve("SC2326"), Some(Rule::GlobAssignedToVariable));
         assert_eq!(map.resolve_all("SC2014"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(map.resolve_all("SC2295"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(
@@ -970,6 +977,14 @@ mod tests {
         assert_eq!(
             map.resolve_all("SC2304"),
             vec![Rule::GlobInFindSubstitution]
+        );
+        assert_eq!(
+            map.resolve_all("SC2125"),
+            vec![Rule::GlobAssignedToVariable]
+        );
+        assert_eq!(
+            map.resolve_all("SC2326"),
+            vec![Rule::GlobAssignedToVariable]
         );
         assert_eq!(map.resolve("SC1019"), Some(Rule::EmptyTest));
         assert_eq!(map.resolve("SC1045"), Some(Rule::AmpersandSemicolon));
@@ -1354,6 +1369,7 @@ mod tests {
             (2112, Rule::FunctionKeyword),
             (2398, Rule::KeywordFunctionName),
             (2115, Rule::RmGlobOnVariablePath),
+            (2125, Rule::GlobAssignedToVariable),
             (2126, Rule::GrepCountPipeline),
             (2127, Rule::BashCaseFallthrough),
             (2127, Rule::EchoHereDoc),
@@ -1440,6 +1456,7 @@ mod tests {
             (2054, Rule::CommaArrayElements),
             (2339, Rule::MapfileProcessSubstitution),
             (2324, Rule::SetFlagsWithoutDashes),
+            (2326, Rule::GlobAssignedToVariable),
             (2333, Rule::NonShellSyntaxInScript),
             (2389, Rule::LoopWithoutEnd),
             (2390, Rule::MissingDoneInForLoop),
@@ -1623,8 +1640,10 @@ mod tests {
         assert!(comparison.contains(&(2127, Rule::BashCaseFallthrough)));
         assert!(comparison.contains(&(2146, Rule::FindOrWithoutGrouping)));
         assert!(comparison.contains(&(2121, Rule::SetFlagsWithoutDashes)));
+        assert!(comparison.contains(&(2125, Rule::GlobAssignedToVariable)));
         assert!(comparison.contains(&(2054, Rule::CommaArrayElements)));
         assert!(comparison.contains(&(2399, Rule::BrokenAssocKey)));
+        assert!(!comparison.contains(&(2326, Rule::GlobAssignedToVariable)));
         assert!(comparison.contains(&(2336, Rule::AppendToArrayAsString)));
         assert!(comparison.contains(&(2339, Rule::MapfileProcessSubstitution)));
         assert!(comparison.contains(&(2380, Rule::MisspelledOptionName)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -207,6 +207,9 @@ impl Default for ShellCheckCodeMap {
             // Keep SC2295 as a suppression alias for authored C078 metadata.
             (2014, Rule::UnquotedGlobsInFind),
             (2296, Rule::ShortCircuitFallthrough),
+            // ShellCheck 0.11.0 reports unquoted grep-pattern glob expansion as SC2062.
+            // Keep SC2299 as a suppression alias for authored C080 metadata.
+            (2062, Rule::GlobInGrepPattern),
             (1019, Rule::EmptyTest),
             (2024, Rule::SudoRedirectionOrder),
             (2034, Rule::UnusedAssignment),
@@ -500,6 +503,7 @@ impl Default for ShellCheckCodeMap {
                     (2015, Rule::ChainedTestBranches),
                     (2014, Rule::UnquotedGlobsInFind),
                     (2296, Rule::ShortCircuitFallthrough),
+                    (2062, Rule::GlobInGrepPattern),
                     (1019, Rule::EmptyTest),
                     (2024, Rule::SudoRedirectionOrder),
                     (2034, Rule::UnusedAssignment),
@@ -687,6 +691,7 @@ impl Default for ShellCheckCodeMap {
                 // comparison slot that already belongs to C077.
                 (2290, Rule::SpacedAssignment),
                 (2295, Rule::UnquotedGlobsInFind),
+                (2299, Rule::GlobInGrepPattern),
                 (2060, Rule::UnquotedTrRange),
                 (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
@@ -901,6 +906,8 @@ mod tests {
         assert_eq!(map.resolve("SC2015"), Some(Rule::ChainedTestBranches));
         assert_eq!(map.resolve("SC2014"), Some(Rule::UnquotedGlobsInFind));
         assert_eq!(map.resolve("SC2295"), Some(Rule::UnquotedGlobsInFind));
+        assert_eq!(map.resolve("SC2062"), Some(Rule::GlobInGrepPattern));
+        assert_eq!(map.resolve("SC2299"), Some(Rule::GlobInGrepPattern));
         assert_eq!(map.resolve_all("SC2014"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(map.resolve_all("SC2295"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(
@@ -908,6 +915,8 @@ mod tests {
             vec![Rule::ChainedTestBranches, Rule::ShortCircuitFallthrough]
         );
         assert_eq!(map.resolve("SC2296"), Some(Rule::ShortCircuitFallthrough));
+        assert_eq!(map.resolve_all("SC2062"), vec![Rule::GlobInGrepPattern]);
+        assert_eq!(map.resolve_all("SC2299"), vec![Rule::GlobInGrepPattern]);
         assert_eq!(map.resolve("SC1019"), Some(Rule::EmptyTest));
         assert_eq!(map.resolve("SC1045"), Some(Rule::AmpersandSemicolon));
         assert_eq!(map.resolve("SC2024"), Some(Rule::SudoRedirectionOrder));
@@ -1254,6 +1263,7 @@ mod tests {
             (2296, Rule::ShortCircuitFallthrough),
             (2016, Rule::SingleQuotedLiteral),
             (2014, Rule::UnquotedGlobsInFind),
+            (2062, Rule::GlobInGrepPattern),
             (2024, Rule::SudoRedirectionOrder),
             (2034, Rule::UnusedAssignment),
             (2035, Rule::LeadingGlobArgument),
@@ -1320,6 +1330,7 @@ mod tests {
             (2257, Rule::ArithmeticRedirectionTarget),
             (2290, Rule::SubshellInArithmetic),
             (2295, Rule::UnquotedGlobsInFind),
+            (2299, Rule::GlobInGrepPattern),
             (2292, Rule::DollarInArithmetic),
             (2297, Rule::DollarInArithmeticContext),
             (2259, Rule::SubshellTestGroup),
@@ -1511,10 +1522,12 @@ mod tests {
         assert!(comparison.contains(&(2009, Rule::PsGrepPipeline)));
         assert!(comparison.contains(&(2010, Rule::LsGrepPipeline)));
         assert!(comparison.contains(&(2014, Rule::UnquotedGlobsInFind)));
+        assert!(comparison.contains(&(2062, Rule::GlobInGrepPattern)));
         assert!(comparison.contains(&(2293, Rule::LsPipedToXargs)));
         assert!(comparison.contains(&(2294, Rule::LsInSubstitution)));
         assert!(!comparison.contains(&(2294, Rule::EvalOnArray)));
         assert!(!comparison.contains(&(2295, Rule::UnquotedGlobsInFind)));
+        assert!(!comparison.contains(&(2299, Rule::GlobInGrepPattern)));
         assert!(comparison.contains(&(2263, Rule::RedundantSpacesInEcho)));
         assert!(comparison.contains(&(2291, Rule::UnquotedVariableInSed)));
         assert!(comparison.contains(&(2117, Rule::SuWithoutFlag)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -207,9 +207,12 @@ impl Default for ShellCheckCodeMap {
             // Keep SC2295 as a suppression alias for authored C078 metadata.
             (2014, Rule::UnquotedGlobsInFind),
             (2296, Rule::ShortCircuitFallthrough),
-            // ShellCheck 0.11.0 reports unquoted grep-pattern glob expansion as SC2062.
+            // ShellCheck 0.11.0 reports grep-pattern glob/regex confusion as SC2022.
             // Keep SC2299 as a suppression alias for authored C080 metadata.
-            (2062, Rule::GlobInGrepPattern),
+            (2022, Rule::GlobInGrepPattern),
+            // ShellCheck 0.11.0 reports unquoted grep regex shell expansion as SC2062.
+            // Keep SC2305 as a suppression alias for authored C084 metadata.
+            (2062, Rule::UnquotedGrepRegex),
             // ShellCheck 0.11.0 reports unquoted variable-backed `[[ ... == ... ]]` patterns as SC2053.
             // Keep SC2301 as a suppression alias for authored C081 metadata.
             (2053, Rule::GlobInStringComparison),
@@ -509,7 +512,8 @@ impl Default for ShellCheckCodeMap {
                     (2015, Rule::ChainedTestBranches),
                     (2014, Rule::UnquotedGlobsInFind),
                     (2296, Rule::ShortCircuitFallthrough),
-                    (2062, Rule::GlobInGrepPattern),
+                    (2022, Rule::GlobInGrepPattern),
+                    (2062, Rule::UnquotedGrepRegex),
                     (2053, Rule::GlobInStringComparison),
                     (2061, Rule::GlobInFindSubstitution),
                     (1019, Rule::EmptyTest),
@@ -702,6 +706,7 @@ impl Default for ShellCheckCodeMap {
                 (2299, Rule::GlobInGrepPattern),
                 (2301, Rule::GlobInStringComparison),
                 (2304, Rule::GlobInFindSubstitution),
+                (2305, Rule::UnquotedGrepRegex),
                 (2060, Rule::UnquotedTrRange),
                 (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
@@ -916,8 +921,10 @@ mod tests {
         assert_eq!(map.resolve("SC2015"), Some(Rule::ChainedTestBranches));
         assert_eq!(map.resolve("SC2014"), Some(Rule::UnquotedGlobsInFind));
         assert_eq!(map.resolve("SC2295"), Some(Rule::UnquotedGlobsInFind));
-        assert_eq!(map.resolve("SC2062"), Some(Rule::GlobInGrepPattern));
+        assert_eq!(map.resolve("SC2022"), Some(Rule::GlobInGrepPattern));
         assert_eq!(map.resolve("SC2299"), Some(Rule::GlobInGrepPattern));
+        assert_eq!(map.resolve("SC2062"), Some(Rule::UnquotedGrepRegex));
+        assert_eq!(map.resolve("SC2305"), Some(Rule::UnquotedGrepRegex));
         assert_eq!(map.resolve("SC2053"), Some(Rule::GlobInStringComparison));
         assert_eq!(map.resolve("SC2301"), Some(Rule::GlobInStringComparison));
         assert_eq!(map.resolve("SC2061"), Some(Rule::GlobInFindSubstitution));
@@ -929,8 +936,10 @@ mod tests {
             vec![Rule::ChainedTestBranches, Rule::ShortCircuitFallthrough]
         );
         assert_eq!(map.resolve("SC2296"), Some(Rule::ShortCircuitFallthrough));
-        assert_eq!(map.resolve_all("SC2062"), vec![Rule::GlobInGrepPattern]);
+        assert_eq!(map.resolve_all("SC2022"), vec![Rule::GlobInGrepPattern]);
         assert_eq!(map.resolve_all("SC2299"), vec![Rule::GlobInGrepPattern]);
+        assert_eq!(map.resolve_all("SC2062"), vec![Rule::UnquotedGrepRegex]);
+        assert_eq!(map.resolve_all("SC2305"), vec![Rule::UnquotedGrepRegex]);
         assert_eq!(
             map.resolve_all("SC2053"),
             vec![Rule::GlobInStringComparison]
@@ -1293,7 +1302,8 @@ mod tests {
             (2296, Rule::ShortCircuitFallthrough),
             (2016, Rule::SingleQuotedLiteral),
             (2014, Rule::UnquotedGlobsInFind),
-            (2062, Rule::GlobInGrepPattern),
+            (2022, Rule::GlobInGrepPattern),
+            (2062, Rule::UnquotedGrepRegex),
             (2053, Rule::GlobInStringComparison),
             (2061, Rule::GlobInFindSubstitution),
             (2024, Rule::SudoRedirectionOrder),
@@ -1365,6 +1375,7 @@ mod tests {
             (2299, Rule::GlobInGrepPattern),
             (2301, Rule::GlobInStringComparison),
             (2304, Rule::GlobInFindSubstitution),
+            (2305, Rule::UnquotedGrepRegex),
             (2292, Rule::DollarInArithmetic),
             (2297, Rule::DollarInArithmeticContext),
             (2259, Rule::SubshellTestGroup),
@@ -1556,7 +1567,8 @@ mod tests {
         assert!(comparison.contains(&(2009, Rule::PsGrepPipeline)));
         assert!(comparison.contains(&(2010, Rule::LsGrepPipeline)));
         assert!(comparison.contains(&(2014, Rule::UnquotedGlobsInFind)));
-        assert!(comparison.contains(&(2062, Rule::GlobInGrepPattern)));
+        assert!(comparison.contains(&(2022, Rule::GlobInGrepPattern)));
+        assert!(comparison.contains(&(2062, Rule::UnquotedGrepRegex)));
         assert!(comparison.contains(&(2053, Rule::GlobInStringComparison)));
         assert!(comparison.contains(&(2061, Rule::GlobInFindSubstitution)));
         assert!(comparison.contains(&(2293, Rule::LsPipedToXargs)));
@@ -1566,6 +1578,7 @@ mod tests {
         assert!(!comparison.contains(&(2299, Rule::GlobInGrepPattern)));
         assert!(!comparison.contains(&(2301, Rule::GlobInStringComparison)));
         assert!(!comparison.contains(&(2304, Rule::GlobInFindSubstitution)));
+        assert!(!comparison.contains(&(2305, Rule::UnquotedGrepRegex)));
         assert!(comparison.contains(&(2263, Rule::RedundantSpacesInEcho)));
         assert!(comparison.contains(&(2291, Rule::UnquotedVariableInSed)));
         assert!(comparison.contains(&(2117, Rule::SuWithoutFlag)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -203,6 +203,9 @@ impl Default for ShellCheckCodeMap {
             (2016, Rule::SingleQuotedLiteral),
             (2013, Rule::LineOrientedInput),
             (2015, Rule::ChainedTestBranches),
+            // ShellCheck 0.11.0 reports `find -exec` pre-expansion warnings as SC2014.
+            // Keep SC2295 as a suppression alias for authored C078 metadata.
+            (2014, Rule::UnquotedGlobsInFind),
             (2296, Rule::ShortCircuitFallthrough),
             (1019, Rule::EmptyTest),
             (2024, Rule::SudoRedirectionOrder),
@@ -495,6 +498,7 @@ impl Default for ShellCheckCodeMap {
                     (2016, Rule::SingleQuotedLiteral),
                     (2013, Rule::LineOrientedInput),
                     (2015, Rule::ChainedTestBranches),
+                    (2014, Rule::UnquotedGlobsInFind),
                     (2296, Rule::ShortCircuitFallthrough),
                     (1019, Rule::EmptyTest),
                     (2024, Rule::SudoRedirectionOrder),
@@ -682,6 +686,7 @@ impl Default for ShellCheckCodeMap {
                 // Preserve SC2290 for suppressing C139 without taking over the large-corpus
                 // comparison slot that already belongs to C077.
                 (2290, Rule::SpacedAssignment),
+                (2295, Rule::UnquotedGlobsInFind),
                 (2060, Rule::UnquotedTrRange),
                 (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
@@ -894,6 +899,10 @@ mod tests {
         assert_eq!(map.resolve("SC2016"), Some(Rule::SingleQuotedLiteral));
         assert_eq!(map.resolve("SC2013"), Some(Rule::LineOrientedInput));
         assert_eq!(map.resolve("SC2015"), Some(Rule::ChainedTestBranches));
+        assert_eq!(map.resolve("SC2014"), Some(Rule::UnquotedGlobsInFind));
+        assert_eq!(map.resolve("SC2295"), Some(Rule::UnquotedGlobsInFind));
+        assert_eq!(map.resolve_all("SC2014"), vec![Rule::UnquotedGlobsInFind]);
+        assert_eq!(map.resolve_all("SC2295"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(
             map.resolve_all("SC2015"),
             vec![Rule::ChainedTestBranches, Rule::ShortCircuitFallthrough]
@@ -1244,6 +1253,7 @@ mod tests {
             (2015, Rule::ShortCircuitFallthrough),
             (2296, Rule::ShortCircuitFallthrough),
             (2016, Rule::SingleQuotedLiteral),
+            (2014, Rule::UnquotedGlobsInFind),
             (2024, Rule::SudoRedirectionOrder),
             (2034, Rule::UnusedAssignment),
             (2035, Rule::LeadingGlobArgument),
@@ -1309,6 +1319,7 @@ mod tests {
             (2276, Rule::PlusPrefixInAssignment),
             (2257, Rule::ArithmeticRedirectionTarget),
             (2290, Rule::SubshellInArithmetic),
+            (2295, Rule::UnquotedGlobsInFind),
             (2292, Rule::DollarInArithmetic),
             (2297, Rule::DollarInArithmeticContext),
             (2259, Rule::SubshellTestGroup),
@@ -1499,9 +1510,11 @@ mod tests {
         assert!(comparison.contains(&(3042, Rule::LetCommand)));
         assert!(comparison.contains(&(2009, Rule::PsGrepPipeline)));
         assert!(comparison.contains(&(2010, Rule::LsGrepPipeline)));
+        assert!(comparison.contains(&(2014, Rule::UnquotedGlobsInFind)));
         assert!(comparison.contains(&(2293, Rule::LsPipedToXargs)));
         assert!(comparison.contains(&(2294, Rule::LsInSubstitution)));
         assert!(!comparison.contains(&(2294, Rule::EvalOnArray)));
+        assert!(!comparison.contains(&(2295, Rule::UnquotedGlobsInFind)));
         assert!(comparison.contains(&(2263, Rule::RedundantSpacesInEcho)));
         assert!(comparison.contains(&(2291, Rule::UnquotedVariableInSed)));
         assert!(comparison.contains(&(2117, Rule::SuWithoutFlag)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -213,6 +213,9 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports unquoted variable-backed `[[ ... == ... ]]` patterns as SC2053.
             // Keep SC2301 as a suppression alias for authored C081 metadata.
             (2053, Rule::GlobInStringComparison),
+            // ShellCheck 0.11.0 reports unquoted glob operands in `find` predicates as SC2061.
+            // Keep SC2304 as a suppression alias for authored C083 metadata.
+            (2061, Rule::GlobInFindSubstitution),
             (1019, Rule::EmptyTest),
             (2024, Rule::SudoRedirectionOrder),
             (2034, Rule::UnusedAssignment),
@@ -508,6 +511,7 @@ impl Default for ShellCheckCodeMap {
                     (2296, Rule::ShortCircuitFallthrough),
                     (2062, Rule::GlobInGrepPattern),
                     (2053, Rule::GlobInStringComparison),
+                    (2061, Rule::GlobInFindSubstitution),
                     (1019, Rule::EmptyTest),
                     (2024, Rule::SudoRedirectionOrder),
                     (2034, Rule::UnusedAssignment),
@@ -697,6 +701,7 @@ impl Default for ShellCheckCodeMap {
                 (2295, Rule::UnquotedGlobsInFind),
                 (2299, Rule::GlobInGrepPattern),
                 (2301, Rule::GlobInStringComparison),
+                (2304, Rule::GlobInFindSubstitution),
                 (2060, Rule::UnquotedTrRange),
                 (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
@@ -915,6 +920,8 @@ mod tests {
         assert_eq!(map.resolve("SC2299"), Some(Rule::GlobInGrepPattern));
         assert_eq!(map.resolve("SC2053"), Some(Rule::GlobInStringComparison));
         assert_eq!(map.resolve("SC2301"), Some(Rule::GlobInStringComparison));
+        assert_eq!(map.resolve("SC2061"), Some(Rule::GlobInFindSubstitution));
+        assert_eq!(map.resolve("SC2304"), Some(Rule::GlobInFindSubstitution));
         assert_eq!(map.resolve_all("SC2014"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(map.resolve_all("SC2295"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(
@@ -931,6 +938,14 @@ mod tests {
         assert_eq!(
             map.resolve_all("SC2301"),
             vec![Rule::GlobInStringComparison]
+        );
+        assert_eq!(
+            map.resolve_all("SC2061"),
+            vec![Rule::GlobInFindSubstitution]
+        );
+        assert_eq!(
+            map.resolve_all("SC2304"),
+            vec![Rule::GlobInFindSubstitution]
         );
         assert_eq!(map.resolve("SC1019"), Some(Rule::EmptyTest));
         assert_eq!(map.resolve("SC1045"), Some(Rule::AmpersandSemicolon));
@@ -1280,6 +1295,7 @@ mod tests {
             (2014, Rule::UnquotedGlobsInFind),
             (2062, Rule::GlobInGrepPattern),
             (2053, Rule::GlobInStringComparison),
+            (2061, Rule::GlobInFindSubstitution),
             (2024, Rule::SudoRedirectionOrder),
             (2034, Rule::UnusedAssignment),
             (2035, Rule::LeadingGlobArgument),
@@ -1348,6 +1364,7 @@ mod tests {
             (2295, Rule::UnquotedGlobsInFind),
             (2299, Rule::GlobInGrepPattern),
             (2301, Rule::GlobInStringComparison),
+            (2304, Rule::GlobInFindSubstitution),
             (2292, Rule::DollarInArithmetic),
             (2297, Rule::DollarInArithmeticContext),
             (2259, Rule::SubshellTestGroup),
@@ -1541,12 +1558,14 @@ mod tests {
         assert!(comparison.contains(&(2014, Rule::UnquotedGlobsInFind)));
         assert!(comparison.contains(&(2062, Rule::GlobInGrepPattern)));
         assert!(comparison.contains(&(2053, Rule::GlobInStringComparison)));
+        assert!(comparison.contains(&(2061, Rule::GlobInFindSubstitution)));
         assert!(comparison.contains(&(2293, Rule::LsPipedToXargs)));
         assert!(comparison.contains(&(2294, Rule::LsInSubstitution)));
         assert!(!comparison.contains(&(2294, Rule::EvalOnArray)));
         assert!(!comparison.contains(&(2295, Rule::UnquotedGlobsInFind)));
         assert!(!comparison.contains(&(2299, Rule::GlobInGrepPattern)));
         assert!(!comparison.contains(&(2301, Rule::GlobInStringComparison)));
+        assert!(!comparison.contains(&(2304, Rule::GlobInFindSubstitution)));
         assert!(comparison.contains(&(2263, Rule::RedundantSpacesInEcho)));
         assert!(comparison.contains(&(2291, Rule::UnquotedVariableInSed)));
         assert!(comparison.contains(&(2117, Rule::SuWithoutFlag)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -210,6 +210,9 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports unquoted grep-pattern glob expansion as SC2062.
             // Keep SC2299 as a suppression alias for authored C080 metadata.
             (2062, Rule::GlobInGrepPattern),
+            // ShellCheck 0.11.0 reports unquoted variable-backed `[[ ... == ... ]]` patterns as SC2053.
+            // Keep SC2301 as a suppression alias for authored C081 metadata.
+            (2053, Rule::GlobInStringComparison),
             (1019, Rule::EmptyTest),
             (2024, Rule::SudoRedirectionOrder),
             (2034, Rule::UnusedAssignment),
@@ -504,6 +507,7 @@ impl Default for ShellCheckCodeMap {
                     (2014, Rule::UnquotedGlobsInFind),
                     (2296, Rule::ShortCircuitFallthrough),
                     (2062, Rule::GlobInGrepPattern),
+                    (2053, Rule::GlobInStringComparison),
                     (1019, Rule::EmptyTest),
                     (2024, Rule::SudoRedirectionOrder),
                     (2034, Rule::UnusedAssignment),
@@ -692,6 +696,7 @@ impl Default for ShellCheckCodeMap {
                 (2290, Rule::SpacedAssignment),
                 (2295, Rule::UnquotedGlobsInFind),
                 (2299, Rule::GlobInGrepPattern),
+                (2301, Rule::GlobInStringComparison),
                 (2060, Rule::UnquotedTrRange),
                 (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
@@ -908,6 +913,8 @@ mod tests {
         assert_eq!(map.resolve("SC2295"), Some(Rule::UnquotedGlobsInFind));
         assert_eq!(map.resolve("SC2062"), Some(Rule::GlobInGrepPattern));
         assert_eq!(map.resolve("SC2299"), Some(Rule::GlobInGrepPattern));
+        assert_eq!(map.resolve("SC2053"), Some(Rule::GlobInStringComparison));
+        assert_eq!(map.resolve("SC2301"), Some(Rule::GlobInStringComparison));
         assert_eq!(map.resolve_all("SC2014"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(map.resolve_all("SC2295"), vec![Rule::UnquotedGlobsInFind]);
         assert_eq!(
@@ -917,6 +924,14 @@ mod tests {
         assert_eq!(map.resolve("SC2296"), Some(Rule::ShortCircuitFallthrough));
         assert_eq!(map.resolve_all("SC2062"), vec![Rule::GlobInGrepPattern]);
         assert_eq!(map.resolve_all("SC2299"), vec![Rule::GlobInGrepPattern]);
+        assert_eq!(
+            map.resolve_all("SC2053"),
+            vec![Rule::GlobInStringComparison]
+        );
+        assert_eq!(
+            map.resolve_all("SC2301"),
+            vec![Rule::GlobInStringComparison]
+        );
         assert_eq!(map.resolve("SC1019"), Some(Rule::EmptyTest));
         assert_eq!(map.resolve("SC1045"), Some(Rule::AmpersandSemicolon));
         assert_eq!(map.resolve("SC2024"), Some(Rule::SudoRedirectionOrder));
@@ -1264,6 +1279,7 @@ mod tests {
             (2016, Rule::SingleQuotedLiteral),
             (2014, Rule::UnquotedGlobsInFind),
             (2062, Rule::GlobInGrepPattern),
+            (2053, Rule::GlobInStringComparison),
             (2024, Rule::SudoRedirectionOrder),
             (2034, Rule::UnusedAssignment),
             (2035, Rule::LeadingGlobArgument),
@@ -1331,6 +1347,7 @@ mod tests {
             (2290, Rule::SubshellInArithmetic),
             (2295, Rule::UnquotedGlobsInFind),
             (2299, Rule::GlobInGrepPattern),
+            (2301, Rule::GlobInStringComparison),
             (2292, Rule::DollarInArithmetic),
             (2297, Rule::DollarInArithmeticContext),
             (2259, Rule::SubshellTestGroup),
@@ -1523,11 +1540,13 @@ mod tests {
         assert!(comparison.contains(&(2010, Rule::LsGrepPipeline)));
         assert!(comparison.contains(&(2014, Rule::UnquotedGlobsInFind)));
         assert!(comparison.contains(&(2062, Rule::GlobInGrepPattern)));
+        assert!(comparison.contains(&(2053, Rule::GlobInStringComparison)));
         assert!(comparison.contains(&(2293, Rule::LsPipedToXargs)));
         assert!(comparison.contains(&(2294, Rule::LsInSubstitution)));
         assert!(!comparison.contains(&(2294, Rule::EvalOnArray)));
         assert!(!comparison.contains(&(2295, Rule::UnquotedGlobsInFind)));
         assert!(!comparison.contains(&(2299, Rule::GlobInGrepPattern)));
+        assert!(!comparison.contains(&(2301, Rule::GlobInStringComparison)));
         assert!(comparison.contains(&(2263, Rule::RedundantSpacesInEcho)));
         assert!(comparison.contains(&(2291, Rule::UnquotedVariableInSed)));
         assert!(comparison.contains(&(2117, Rule::SuWithoutFlag)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -207,6 +207,9 @@ impl Default for ShellCheckCodeMap {
             // Keep SC2295 as a suppression alias for authored C078 metadata.
             (2014, Rule::UnquotedGlobsInFind),
             (2296, Rule::ShortCircuitFallthrough),
+            // ShellCheck 0.11.0 reports loop-list glob+expansion mixes as SC2231.
+            // Keep SC2349 as a suppression alias for authored C114 metadata.
+            (2231, Rule::GlobWithExpansionInLoop),
             // ShellCheck 0.11.0 reports grep-pattern glob/regex confusion as SC2022.
             // Keep SC2299 as a suppression alias for authored C080 metadata.
             (2022, Rule::GlobInGrepPattern),
@@ -512,6 +515,7 @@ impl Default for ShellCheckCodeMap {
                     (2015, Rule::ChainedTestBranches),
                     (2014, Rule::UnquotedGlobsInFind),
                     (2296, Rule::ShortCircuitFallthrough),
+                    (2231, Rule::GlobWithExpansionInLoop),
                     (2022, Rule::GlobInGrepPattern),
                     (2062, Rule::UnquotedGrepRegex),
                     (2053, Rule::GlobInStringComparison),
@@ -707,6 +711,7 @@ impl Default for ShellCheckCodeMap {
                 (2301, Rule::GlobInStringComparison),
                 (2304, Rule::GlobInFindSubstitution),
                 (2305, Rule::UnquotedGrepRegex),
+                (2349, Rule::GlobWithExpansionInLoop),
                 (2060, Rule::UnquotedTrRange),
                 (2280, Rule::IfsEqualsAmbiguity),
                 (2270, Rule::IfMissingThen),
@@ -921,6 +926,8 @@ mod tests {
         assert_eq!(map.resolve("SC2015"), Some(Rule::ChainedTestBranches));
         assert_eq!(map.resolve("SC2014"), Some(Rule::UnquotedGlobsInFind));
         assert_eq!(map.resolve("SC2295"), Some(Rule::UnquotedGlobsInFind));
+        assert_eq!(map.resolve("SC2231"), Some(Rule::GlobWithExpansionInLoop));
+        assert_eq!(map.resolve("SC2349"), Some(Rule::GlobWithExpansionInLoop));
         assert_eq!(map.resolve("SC2022"), Some(Rule::GlobInGrepPattern));
         assert_eq!(map.resolve("SC2299"), Some(Rule::GlobInGrepPattern));
         assert_eq!(map.resolve("SC2062"), Some(Rule::UnquotedGrepRegex));
@@ -936,6 +943,14 @@ mod tests {
             vec![Rule::ChainedTestBranches, Rule::ShortCircuitFallthrough]
         );
         assert_eq!(map.resolve("SC2296"), Some(Rule::ShortCircuitFallthrough));
+        assert_eq!(
+            map.resolve_all("SC2231"),
+            vec![Rule::GlobWithExpansionInLoop]
+        );
+        assert_eq!(
+            map.resolve_all("SC2349"),
+            vec![Rule::GlobWithExpansionInLoop]
+        );
         assert_eq!(map.resolve_all("SC2022"), vec![Rule::GlobInGrepPattern]);
         assert_eq!(map.resolve_all("SC2299"), vec![Rule::GlobInGrepPattern]);
         assert_eq!(map.resolve_all("SC2062"), vec![Rule::UnquotedGrepRegex]);
@@ -1302,6 +1317,7 @@ mod tests {
             (2296, Rule::ShortCircuitFallthrough),
             (2016, Rule::SingleQuotedLiteral),
             (2014, Rule::UnquotedGlobsInFind),
+            (2231, Rule::GlobWithExpansionInLoop),
             (2022, Rule::GlobInGrepPattern),
             (2062, Rule::UnquotedGrepRegex),
             (2053, Rule::GlobInStringComparison),
@@ -1376,6 +1392,7 @@ mod tests {
             (2301, Rule::GlobInStringComparison),
             (2304, Rule::GlobInFindSubstitution),
             (2305, Rule::UnquotedGrepRegex),
+            (2349, Rule::GlobWithExpansionInLoop),
             (2292, Rule::DollarInArithmetic),
             (2297, Rule::DollarInArithmeticContext),
             (2259, Rule::SubshellTestGroup),
@@ -1567,6 +1584,7 @@ mod tests {
         assert!(comparison.contains(&(2009, Rule::PsGrepPipeline)));
         assert!(comparison.contains(&(2010, Rule::LsGrepPipeline)));
         assert!(comparison.contains(&(2014, Rule::UnquotedGlobsInFind)));
+        assert!(comparison.contains(&(2231, Rule::GlobWithExpansionInLoop)));
         assert!(comparison.contains(&(2022, Rule::GlobInGrepPattern)));
         assert!(comparison.contains(&(2062, Rule::UnquotedGrepRegex)));
         assert!(comparison.contains(&(2053, Rule::GlobInStringComparison)));
@@ -1579,6 +1597,7 @@ mod tests {
         assert!(!comparison.contains(&(2301, Rule::GlobInStringComparison)));
         assert!(!comparison.contains(&(2304, Rule::GlobInFindSubstitution)));
         assert!(!comparison.contains(&(2305, Rule::UnquotedGrepRegex)));
+        assert!(!comparison.contains(&(2349, Rule::GlobWithExpansionInLoop)));
         assert!(comparison.contains(&(2263, Rule::RedundantSpacesInEcho)));
         assert!(comparison.contains(&(2291, Rule::UnquotedVariableInSed)));
         assert!(comparison.contains(&(2117, Rule::SuWithoutFlag)));

--- a/crates/shuck/tests/testdata/corpus-metadata/c114.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c114.yaml
@@ -1,0 +1,3 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2349"
+    reason: "In the current oracle environment, loop-list glob-plus-expansion findings for this behavior surface as SC2231 instead of the authored SC2349 code."

--- a/crates/shuck/tests/testdata/corpus-metadata/s055.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s055.yaml
@@ -1,0 +1,3 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2326"
+    reason: "In the current oracle environment, unquoted glob assignment warnings for this behavior surface as SC2125 instead of the authored SC2326 code."

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -226,7 +226,7 @@ Filter command facts and word facts for unquoted glob characters.
 - [x] **M** C083 (SC2304) `glob-in-find-substitution` — glob in find command substitution
 - [x] **M** C084 (SC2305) `unquoted-grep-regex` — grep regex may be glob-expanded
 - [x] **M** C114 (SC2349) `glob-with-expansion-in-loop` — glob+variable in for loop
-- [ ] **M** S055 (SC2326) `glob-assigned-to-variable` — glob pattern assigned without quoting
+- [x] **M** S055 (SC2326) `glob-assigned-to-variable` — glob pattern assigned without quoting
 
 ### Quoting and Expansion
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -223,7 +223,7 @@ Filter command facts and word facts for unquoted glob characters.
 - [x] **M** C078 (SC2295) `unquoted-globs-in-find` — unquoted variable+glob in find -exec
 - [x] **M** C080 (SC2299) `glob-in-grep-pattern` — glob character in grep pattern
 - [x] **M** C081 (SC2301) `glob-in-string-comparison` — variable in string comparison treated as glob
-- [ ] **M** C083 (SC2304) `glob-in-find-substitution` — glob in find command substitution
+- [x] **M** C083 (SC2304) `glob-in-find-substitution` — glob in find command substitution
 - [ ] **M** C084 (SC2305) `unquoted-grep-regex` — grep regex may be glob-expanded
 - [ ] **M** C114 (SC2349) `glob-with-expansion-in-loop` — glob+variable in for loop
 - [ ] **M** S055 (SC2326) `glob-assigned-to-variable` — glob pattern assigned without quoting

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -221,7 +221,7 @@ Rules about glob expansion in command arguments, find, grep, and comparisons.
 Filter command facts and word facts for unquoted glob characters.
 
 - [x] **M** C078 (SC2295) `unquoted-globs-in-find` — unquoted variable+glob in find -exec
-- [ ] **M** C080 (SC2299) `glob-in-grep-pattern` — glob character in grep pattern
+- [x] **M** C080 (SC2299) `glob-in-grep-pattern` — glob character in grep pattern
 - [ ] **M** C081 (SC2301) `glob-in-string-comparison` — variable in string comparison treated as glob
 - [ ] **M** C083 (SC2304) `glob-in-find-substitution` — glob in find command substitution
 - [ ] **M** C084 (SC2305) `unquoted-grep-regex` — grep regex may be glob-expanded

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -224,7 +224,7 @@ Filter command facts and word facts for unquoted glob characters.
 - [x] **M** C080 (SC2299) `glob-in-grep-pattern` — glob character in grep pattern
 - [x] **M** C081 (SC2301) `glob-in-string-comparison` — variable in string comparison treated as glob
 - [x] **M** C083 (SC2304) `glob-in-find-substitution` — glob in find command substitution
-- [ ] **M** C084 (SC2305) `unquoted-grep-regex` — grep regex may be glob-expanded
+- [x] **M** C084 (SC2305) `unquoted-grep-regex` — grep regex may be glob-expanded
 - [ ] **M** C114 (SC2349) `glob-with-expansion-in-loop` — glob+variable in for loop
 - [ ] **M** S055 (SC2326) `glob-assigned-to-variable` — glob pattern assigned without quoting
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -225,7 +225,7 @@ Filter command facts and word facts for unquoted glob characters.
 - [x] **M** C081 (SC2301) `glob-in-string-comparison` — variable in string comparison treated as glob
 - [x] **M** C083 (SC2304) `glob-in-find-substitution` — glob in find command substitution
 - [x] **M** C084 (SC2305) `unquoted-grep-regex` — grep regex may be glob-expanded
-- [ ] **M** C114 (SC2349) `glob-with-expansion-in-loop` — glob+variable in for loop
+- [x] **M** C114 (SC2349) `glob-with-expansion-in-loop` — glob+variable in for loop
 - [ ] **M** S055 (SC2326) `glob-assigned-to-variable` — glob pattern assigned without quoting
 
 ### Quoting and Expansion

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -220,7 +220,7 @@ Rules about `[`, `[[`, test operators, and conditional structure. Use
 Rules about glob expansion in command arguments, find, grep, and comparisons.
 Filter command facts and word facts for unquoted glob characters.
 
-- [ ] **M** C078 (SC2295) `unquoted-globs-in-find` — unquoted variable+glob in find -exec
+- [x] **M** C078 (SC2295) `unquoted-globs-in-find` — unquoted variable+glob in find -exec
 - [ ] **M** C080 (SC2299) `glob-in-grep-pattern` — glob character in grep pattern
 - [ ] **M** C081 (SC2301) `glob-in-string-comparison` — variable in string comparison treated as glob
 - [ ] **M** C083 (SC2304) `glob-in-find-substitution` — glob in find command substitution

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -222,7 +222,7 @@ Filter command facts and word facts for unquoted glob characters.
 
 - [x] **M** C078 (SC2295) `unquoted-globs-in-find` — unquoted variable+glob in find -exec
 - [x] **M** C080 (SC2299) `glob-in-grep-pattern` — glob character in grep pattern
-- [ ] **M** C081 (SC2301) `glob-in-string-comparison` — variable in string comparison treated as glob
+- [x] **M** C081 (SC2301) `glob-in-string-comparison` — variable in string comparison treated as glob
 - [ ] **M** C083 (SC2304) `glob-in-find-substitution` — glob in find command substitution
 - [ ] **M** C084 (SC2305) `unquoted-grep-regex` — grep regex may be glob-expanded
 - [ ] **M** C114 (SC2349) `glob-with-expansion-in-loop` — glob+variable in for loop


### PR DESCRIPTION
## What changed

This PR implements the remaining glob and pattern matching rules in the linter:

- `C078` unquoted globs in `find -exec`
- `C080` glob-like `grep` patterns
- `C081` glob behavior in string comparisons
- `C083` glob use in `find` substitutions
- `C084` unquoted grep regex expansion
- `C114` glob-plus-expansion `for` loop patterns
- `S055` glob patterns assigned to variables

It also updates the shared expansion and span helpers so these rules reuse existing glob/expansion logic where possible instead of open-coding AST walks in rule modules.

## Why

These rules cover a cluster of pathname-expansion and pattern-matching mistakes that were still unchecked. Two of them also needed oracle-aligned comparison handling because the current pinned ShellCheck environment surfaces different comparison codes than the authored metadata:

- `C114` compares against current `SC2231` behavior while keeping `SC2349` as a suppression alias
- `S055` compares against current `SC2125` behavior while keeping `SC2326` as a suppression alias

## Impact

- expands glob/pattern coverage in correctness and style checks
- keeps rule implementations aligned with the repo's fact-driven architecture
- updates `docs/rules.md` to mark the completed rules

## Validation

- `make ensure-cache`
- targeted large-corpus runs for each implemented rule
- final reruns:
  - `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C080`
  - `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C084`
  - `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C114`
  - `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S055`
- `cargo test -p shuck-linter`
