### PR TITLE
Implement zsh option-state tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,14 @@ test-large-corpus: ensure-cache
 	SHUCK_LARGE_CORPUS_KEEP_GOING=$(SHUCK_LARGE_CORPUS_KEEP_GOING) \
 	$(NIX_DEVELOP) cargo test -p shuck --test large_corpus -- --ignored --nocapture
 
+test-large-corpus-zsh: ensure-cache
+	SHUCK_TEST_LARGE_CORPUS=1 \
+	SHUCK_LARGE_CORPUS_TIMEOUT_SECS=$(SHUCK_LARGE_CORPUS_TIMEOUT_SECS) \
+	SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=$(SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS) \
+	SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=$(SHUCK_LARGE_CORPUS_SAMPLE_PERCENT) \
+	SHUCK_LARGE_CORPUS_KEEP_GOING=$(SHUCK_LARGE_CORPUS_KEEP_GOING) \
+	$(NIX_DEVELOP) cargo test -p shuck --test large_corpus large_corpus_zsh_fixtures_parse -- --ignored --exact --nocapture
+
 large-corpus-report-from-log:
 	test -f "$(LARGE_CORPUS_REPORT_LOG)"
 	$(UV_PYTHON) ./scripts/large_corpus_report.py --log "$(LARGE_CORPUS_REPORT_LOG)" --output "$(LARGE_CORPUS_REPORT_HTML)"

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -27,7 +27,7 @@ use shuck_ast::{
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
-use shuck_semantic::{ScopeId, SemanticModel};
+use shuck_semantic::{ScopeId, SemanticModel, ZshOptionState};
 use std::borrow::Cow;
 
 use self::{
@@ -634,6 +634,7 @@ pub struct WordFact<'a> {
     nested_word_command: bool,
     context: WordFactContext,
     host_kind: WordFactHostKind,
+    zsh_options: Option<ZshOptionState>,
     analysis: ExpansionAnalysis,
     runtime_literal: RuntimeLiteralAnalysis,
     operand_class: Option<TestOperandClass>,
@@ -699,6 +700,10 @@ impl<'a> WordFact<'a> {
 
     pub fn runtime_literal(&self) -> RuntimeLiteralAnalysis {
         self.runtime_literal
+    }
+
+    pub fn zsh_options(&self) -> Option<&ZshOptionState> {
+        self.zsh_options.as_ref()
     }
 
     pub fn classification(&self) -> WordClassification {
@@ -1638,6 +1643,7 @@ pub struct CommandFact<'a> {
     visit: CommandVisit<'a>,
     nested_word_command: bool,
     normalized: NormalizedCommand<'a>,
+    zsh_options: Option<ZshOptionState>,
     redirect_facts: Box<[RedirectFact<'a>]>,
     substitution_facts: Box<[SubstitutionFact]>,
     options: CommandOptionFacts<'a>,
@@ -1676,6 +1682,10 @@ impl<'a> CommandFact<'a> {
 
     pub fn redirects(&self) -> &'a [Redirect] {
         self.visit.redirects
+    }
+
+    pub fn zsh_options(&self) -> Option<&ZshOptionState> {
+        self.zsh_options.as_ref()
     }
 
     pub fn redirect_facts(&self) -> &[RedirectFact<'a>] {
@@ -2145,7 +2155,7 @@ impl<'a> LinterFacts<'a> {
 struct LinterFactsBuilder<'a> {
     file: &'a File,
     source: &'a str,
-    _semantic: &'a SemanticModel,
+    semantic: &'a SemanticModel,
     _indexer: &'a Indexer,
     _file_context: &'a FileContext,
 }
@@ -2181,7 +2191,7 @@ impl<'a> LinterFactsBuilder<'a> {
         Self {
             file,
             source,
-            _semantic: semantic,
+            semantic,
             _indexer: indexer,
             _file_context: file_context,
         }
@@ -2234,12 +2244,23 @@ impl<'a> LinterFactsBuilder<'a> {
                 &mut comma_array_assignment_spans,
             );
             let normalized = command::normalize_command(visit.command, self.source);
+            let command_zsh_options = effective_command_zsh_options(
+                self.semantic,
+                command_span(visit.command).start.offset,
+                &normalized,
+            );
             let nested_word_command = !structural_commands.contains(&key);
             if !nested_word_command {
                 structural_command_ids.push(id);
             }
-            let collected_words =
-                build_word_facts_for_command(visit, self.source, id, nested_word_command);
+            let collected_words = build_word_facts_for_command(
+                visit,
+                self.source,
+                self.semantic,
+                id,
+                nested_word_command,
+                &normalized,
+            );
             compound_assignment_value_word_spans
                 .extend(collected_words.compound_assignment_value_word_spans);
             words.extend(collected_words.facts);
@@ -2268,7 +2289,8 @@ impl<'a> LinterFactsBuilder<'a> {
                         .arithmetic
                         .arithmetic_command_substitution_spans,
                 );
-            let redirect_facts = build_redirect_facts(visit.redirects, self.source);
+            let redirect_facts =
+                build_redirect_facts(visit.redirects, self.source, command_zsh_options.as_ref());
             let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
             let simple_test =
                 build_simple_test_fact(visit.command, self.source, self._file_context);
@@ -2279,6 +2301,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 visit,
                 nested_word_command,
                 normalized,
+                zsh_options: command_zsh_options,
                 redirect_facts,
                 substitution_facts: Vec::new().into_boxed_slice(),
                 options,
@@ -2298,7 +2321,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let presence_tested_names = build_presence_tested_names(&commands, self.source);
         let function_headers = build_function_header_facts(&self.file.body);
         let function_positional_parameter_facts =
-            build_function_positional_parameter_facts(self._semantic, &commands);
+            build_function_positional_parameter_facts(self.semantic, &commands);
         let for_headers = build_for_header_facts(&commands, &command_ids_by_span, self.source);
         let select_headers =
             build_select_header_facts(&commands, &command_ids_by_span, self.source);
@@ -2348,7 +2371,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let base_prefix_arithmetic_spans =
             build_base_prefix_arithmetic_spans(&self.file.body, self.source);
         let subscript_index_reference_spans =
-            build_subscript_index_reference_spans(self._semantic, &subscript_spans);
+            build_subscript_index_reference_spans(self.semantic, &subscript_spans);
         pattern_exactly_one_extglob_spans.extend(surface_pattern_exactly_one_extglob_spans);
         pattern_charclass_spans.extend(surface_pattern_charclass_spans);
         let escape_scan_matches = build_escape_scan_matches(
@@ -4826,25 +4849,46 @@ fn collect_status_parameter_spans_in_source_text(
     collect_status_parameter_spans_in_word(&word, source, spans);
 }
 
-fn build_redirect_facts<'a>(redirects: &'a [Redirect], source: &str) -> Box<[RedirectFact<'a>]> {
+fn build_redirect_facts<'a>(
+    redirects: &'a [Redirect],
+    source: &str,
+    zsh_options: Option<&ZshOptionState>,
+) -> Box<[RedirectFact<'a>]> {
     redirects
         .iter()
         .map(|redirect| RedirectFact {
             redirect,
             target_span: redirect.word_target().map(|word| word.span),
-            analysis: analyze_redirect_target(redirect, source),
+            analysis: analyze_redirect_target(redirect, source, zsh_options),
         })
         .collect::<Vec<_>>()
         .into_boxed_slice()
 }
 
+fn effective_command_zsh_options(
+    semantic: &SemanticModel,
+    offset: usize,
+    normalized: &NormalizedCommand<'_>,
+) -> Option<ZshOptionState> {
+    let mut options = semantic.zsh_options_at(offset).cloned();
+    if normalized.has_wrapper(WrapperKind::Noglob)
+        && let Some(options) = options.as_mut()
+    {
+        options.glob = shuck_semantic::OptionValue::Off;
+    }
+    options
+}
+
 fn build_word_facts_for_command<'a>(
     visit: CommandVisit<'a>,
     source: &'a str,
+    semantic: &'a SemanticModel,
     command_id: CommandId,
     nested_word_command: bool,
+    normalized: &NormalizedCommand<'a>,
 ) -> CollectedWordFacts<'a> {
-    let mut collector = WordFactCollector::new(source, command_id, nested_word_command);
+    let mut collector =
+        WordFactCollector::new(source, semantic, command_id, nested_word_command, normalized);
     collector.collect_command(visit.command, visit.redirects);
     collector.finish()
 }
@@ -4861,6 +4905,7 @@ struct WordFactCollector<'a> {
     source: &'a str,
     command_id: CommandId,
     nested_word_command: bool,
+    command_zsh_options: Option<ZshOptionState>,
     facts: Vec<WordFact<'a>>,
     seen: FxHashSet<(FactSpan, WordFactContext, WordFactHostKind)>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
@@ -4870,11 +4915,22 @@ struct WordFactCollector<'a> {
 }
 
 impl<'a> WordFactCollector<'a> {
-    fn new(source: &'a str, command_id: CommandId, nested_word_command: bool) -> Self {
+    fn new(
+        source: &'a str,
+        semantic: &'a SemanticModel,
+        command_id: CommandId,
+        nested_word_command: bool,
+        normalized: &NormalizedCommand<'a>,
+    ) -> Self {
         Self {
             source,
             command_id,
             nested_word_command,
+            command_zsh_options: effective_command_zsh_options(
+                semantic,
+                normalized.body_span.start.offset,
+                normalized,
+            ),
             facts: Vec::new(),
             seen: FxHashSet::default(),
             compound_assignment_value_word_spans: FxHashSet::default(),
@@ -5410,10 +5466,11 @@ impl<'a> WordFactCollector<'a> {
         self.collect_word_parameter_patterns(&word_ref.parts, host_kind);
         self.collect_arithmetic_summary(word_ref, context, host_kind);
 
-        let analysis = analyze_word(word_ref, self.source);
+        let zsh_options = self.command_zsh_options.clone();
+        let analysis = analyze_word(word_ref, self.source, zsh_options.as_ref());
         let runtime_literal = match context {
             WordFactContext::Expansion(context) => {
-                analyze_literal_runtime(word_ref, self.source, context)
+                analyze_literal_runtime(word_ref, self.source, context, zsh_options.as_ref())
             }
             WordFactContext::CaseSubject | WordFactContext::ArithmeticCommand => {
                 RuntimeLiteralAnalysis::default()
@@ -5467,6 +5524,7 @@ impl<'a> WordFactCollector<'a> {
             nested_word_command: self.nested_word_command,
             context,
             host_kind,
+            zsh_options,
             analysis,
             runtime_literal,
             operand_class,

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4887,8 +4887,13 @@ fn build_word_facts_for_command<'a>(
     nested_word_command: bool,
     normalized: &NormalizedCommand<'a>,
 ) -> CollectedWordFacts<'a> {
-    let mut collector =
-        WordFactCollector::new(source, semantic, command_id, nested_word_command, normalized);
+    let mut collector = WordFactCollector::new(
+        source,
+        semantic,
+        command_id,
+        nested_word_command,
+        normalized,
+    );
     collector.collect_command(visit.command, visit.redirects);
     collector.finish()
 }

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -265,7 +265,7 @@ fn classify_substitution_body<'a>(
         let state = if let Some(id) = command_id_for_command(visit.command, command_ids_by_span) {
             classify_redirect_facts(command_fact(commands, id).redirect_facts())
         } else {
-            let redirect_facts = build_redirect_facts(visit.redirects, source);
+            let redirect_facts = build_redirect_facts(visit.redirects, source, None);
             classify_redirect_facts(&redirect_facts)
         };
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -66,6 +66,7 @@ pub use violation::Violation;
 use rustc_hash::FxHashSet;
 use shuck_ast::{File, TextSize};
 use shuck_indexer::Indexer;
+use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
 use shuck_semantic::{
     SemanticBuildOptions, SemanticModel, SourcePathResolver, TraversalObserver,
     build_with_observer_with_options,
@@ -144,6 +145,7 @@ pub fn analyze_file_at_path_with_resolver(
         .or(analyzed_paths_fallback.as_ref());
 
     let mut observer = LintTraversalObserver::default();
+    let shell_profile = inferred_shell_profile(shell);
     let semantic = build_with_observer_with_options(
         file,
         source,
@@ -154,6 +156,7 @@ pub fn analyze_file_at_path_with_resolver(
             source_path_resolver,
             file_entry_contract,
             analyzed_paths,
+            shell_profile: Some(shell_profile),
         },
     );
     let checker = Checker::new(
@@ -183,6 +186,16 @@ pub fn analyze_file_at_path_with_resolver(
         semantic,
         diagnostics,
     }
+}
+
+fn inferred_shell_profile(shell: ShellDialect) -> ShellProfile {
+    let dialect = match shell {
+        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => ParseShellDialect::Posix,
+        ShellDialect::Mksh => ParseShellDialect::Mksh,
+        ShellDialect::Zsh => ParseShellDialect::Zsh,
+        ShellDialect::Unknown | ShellDialect::Bash => ParseShellDialect::Bash,
+    };
+    ShellProfile::native(dialect)
 }
 
 pub fn lint_file(

--- a/crates/shuck-linter/src/rules/common/command.rs
+++ b/crates/shuck-linter/src/rules/common/command.rs
@@ -5,6 +5,7 @@ use shuck_ast::{
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WrapperKind {
+    Noglob,
     Command,
     Builtin,
     Exec,
@@ -292,6 +293,10 @@ fn resolve_command_resolution(
     source: &str,
 ) -> Option<CommandResolution> {
     match current_name {
+        "noglob" => Some(CommandResolution::Wrapper {
+            kind: WrapperKind::Noglob,
+            target_index: words.get(current_index + 1).map(|_| current_index + 1),
+        }),
         "command" => Some(CommandResolution::Wrapper {
             kind: WrapperKind::Command,
             target_index: command_wrapper_target_index(words, current_index, source),
@@ -546,6 +551,13 @@ mod tests {
                 Some("printf"),
                 vec![WrapperKind::Command],
                 ("printf", Some("'%s\\n'")),
+            ),
+            (
+                "noglob rm *.txt\n",
+                Some("noglob"),
+                Some("rm"),
+                vec![WrapperKind::Noglob],
+                ("rm", Some("*.txt")),
             ),
             (
                 "builtin read line\n",

--- a/crates/shuck-linter/src/rules/common/expansion.rs
+++ b/crates/shuck-linter/src/rules/common/expansion.rs
@@ -2,6 +2,7 @@ use shuck_ast::{
     BourneParameterExpansion, ParameterExpansion, ParameterExpansionSyntax, PrefixMatchKind,
     Redirect, RedirectKind, SubscriptSelector, Word, WordPart, WordPartNode, ZshExpansionOperation,
 };
+use shuck_semantic::{OptionValue, ZshOptionState};
 
 use super::word::static_word_text;
 
@@ -244,9 +245,13 @@ struct AnalysisSummary {
     has_process_substitution: bool,
 }
 
-pub(crate) fn analyze_word(word: &Word, _source: &str) -> ExpansionAnalysis {
+pub(crate) fn analyze_word(
+    word: &Word,
+    _source: &str,
+    options: Option<&ZshOptionState>,
+) -> ExpansionAnalysis {
     let mut summary = AnalysisSummary::default();
-    analyze_parts(&word.parts, false, &mut summary);
+    analyze_parts(&word.parts, false, options, &mut summary);
 
     ExpansionAnalysis {
         quote: if is_fully_quoted(word) {
@@ -289,6 +294,7 @@ pub(crate) fn analyze_literal_runtime(
     word: &Word,
     source: &str,
     context: ExpansionContext,
+    options: Option<&ZshOptionState>,
 ) -> RuntimeLiteralAnalysis {
     if static_word_text(word, source).is_none() {
         return RuntimeLiteralAnalysis::default();
@@ -297,7 +303,14 @@ pub(crate) fn analyze_literal_runtime(
     let mut analysis = RuntimeLiteralAnalysis::default();
     let mut state = RuntimeLiteralState::default();
 
-    analyze_literal_runtime_parts(&word.parts, source, context, &mut state, &mut analysis);
+    analyze_literal_runtime_parts(
+        &word.parts,
+        source,
+        context,
+        options,
+        &mut state,
+        &mut analysis,
+    );
 
     analysis
 }
@@ -305,13 +318,15 @@ pub(crate) fn analyze_literal_runtime(
 pub(crate) fn analyze_redirect_target(
     redirect: &Redirect,
     source: &str,
+    options: Option<&ZshOptionState>,
 ) -> Option<RedirectTargetAnalysis> {
     let target = redirect.word_target()?;
-    let expansion = analyze_word(target, source);
+    let expansion = analyze_word(target, source, options);
     let runtime_literal = analyze_literal_runtime(
         target,
         source,
         ExpansionContext::RedirectTarget(redirect.kind),
+        options,
     );
 
     let (kind, dev_null_status, numeric_descriptor_target) = match redirect.kind {
@@ -361,13 +376,14 @@ fn analyze_literal_runtime_parts(
     parts: &[WordPartNode],
     source: &str,
     context: ExpansionContext,
+    options: Option<&ZshOptionState>,
     state: &mut RuntimeLiteralState,
     analysis: &mut RuntimeLiteralAnalysis,
 ) {
     for part in parts {
         match &part.kind {
             WordPart::Literal(_) => {
-                scan_literal_runtime_text(part.span.slice(source), context, state, analysis);
+                scan_literal_runtime_text(part.span.slice(source), context, options, state, analysis);
             }
             WordPart::SingleQuoted { value, .. } => {
                 if !value.slice(source).is_empty() {
@@ -389,6 +405,7 @@ fn analyze_literal_runtime_parts(
 fn scan_literal_runtime_text(
     text: &str,
     context: ExpansionContext,
+    options: Option<&ZshOptionState>,
     state: &mut RuntimeLiteralState,
     analysis: &mut RuntimeLiteralAnalysis,
 ) {
@@ -414,7 +431,10 @@ fn scan_literal_runtime_text(
             analysis.hazards.tilde_expansion = true;
         }
 
-        if context_allows_pathname_matching(context) && matches!(ch, '*' | '?' | '[') {
+        if context_allows_pathname_matching(context)
+            && glob_is_effectively_enabled(options)
+            && matches!(ch, '*' | '?' | '[')
+        {
             analysis.runtime_sensitive = true;
             analysis.hazards.pathname_matching = true;
         }
@@ -484,15 +504,20 @@ fn context_allows_brace_fanout(context: ExpansionContext) -> bool {
     )
 }
 
-fn analyze_parts(parts: &[WordPartNode], in_double_quotes: bool, summary: &mut AnalysisSummary) {
+fn analyze_parts(
+    parts: &[WordPartNode],
+    in_double_quotes: bool,
+    options: Option<&ZshOptionState>,
+    summary: &mut AnalysisSummary,
+) {
     for part in parts {
         match &part.kind {
             WordPart::Literal(_) | WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
-                analyze_parts(parts, true, summary);
+                analyze_parts(parts, true, options, summary);
             }
             kind => {
-                let analysis = analyze_part(kind, in_double_quotes);
+                let analysis = analyze_part(kind, in_double_quotes, options);
                 summary.has_non_literal = true;
                 summary.has_scalar_value |= analysis.value_shape == PartValueShape::Scalar;
                 summary.has_array_value |= analysis.array_valued;
@@ -513,25 +538,29 @@ fn analyze_parts(parts: &[WordPartNode], in_double_quotes: bool, summary: &mut A
     }
 }
 
-fn analyze_part(part: &WordPart, in_double_quotes: bool) -> PartAnalysis {
+fn analyze_part(
+    part: &WordPart,
+    in_double_quotes: bool,
+    options: Option<&ZshOptionState>,
+) -> PartAnalysis {
     match part {
         WordPart::ZshQualifiedGlob(_) => PartAnalysis {
             value_shape: PartValueShape::Unknown,
             array_valued: false,
-            can_expand_to_multiple_fields: !in_double_quotes,
+            can_expand_to_multiple_fields: !in_double_quotes && glob_is_effectively_enabled(options),
             hazards: ExpansionHazards {
-                pathname_matching: !in_double_quotes,
+                pathname_matching: !in_double_quotes && glob_is_effectively_enabled(options),
                 ..ExpansionHazards::default()
             },
             command_substitution: false,
             process_substitution: false,
         },
-        WordPart::Parameter(parameter) => analyze_parameter_part(parameter, in_double_quotes),
+        WordPart::Parameter(parameter) => analyze_parameter_part(parameter, in_double_quotes, options),
         WordPart::CommandSubstitution { .. } => scalar_part(
-            !in_double_quotes,
+            substitution_can_expand_to_multiple_fields(in_double_quotes, options),
             ExpansionHazards {
-                field_splitting: !in_double_quotes,
-                pathname_matching: !in_double_quotes,
+                field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                 command_or_process_substitution: true,
                 ..ExpansionHazards::default()
             },
@@ -558,10 +587,10 @@ fn analyze_part(part: &WordPart, in_double_quotes: bool) -> PartAnalysis {
         | WordPart::Length(_)
         | WordPart::ArrayLength(_)
         | WordPart::Substring { .. } => scalar_part(
-            !in_double_quotes,
+            substitution_can_expand_to_multiple_fields(in_double_quotes, options),
             ExpansionHazards {
-                field_splitting: !in_double_quotes,
-                pathname_matching: !in_double_quotes,
+                field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                 arithmetic_expansion: matches!(part, WordPart::ArithmeticExpansion { .. }),
                 ..ExpansionHazards::default()
             },
@@ -572,10 +601,10 @@ fn analyze_part(part: &WordPart, in_double_quotes: bool) -> PartAnalysis {
             scalar_part(false, ExpansionHazards::default(), false, false)
         }
         WordPart::ParameterExpansion { operator, .. } => scalar_part(
-            !in_double_quotes,
+            substitution_can_expand_to_multiple_fields(in_double_quotes, options),
             ExpansionHazards {
-                field_splitting: !in_double_quotes,
-                pathname_matching: !in_double_quotes,
+                field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                 runtime_pattern: parameter_operator_uses_pattern(operator),
                 ..ExpansionHazards::default()
             },
@@ -592,10 +621,10 @@ fn analyze_part(part: &WordPart, in_double_quotes: bool) -> PartAnalysis {
                 array_part(!in_double_quotes, !in_double_quotes, false, false)
             }
             None => scalar_part(
-                !in_double_quotes,
+                substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                 ExpansionHazards {
-                    field_splitting: !in_double_quotes,
-                    pathname_matching: !in_double_quotes,
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                     ..ExpansionHazards::default()
                 },
                 false,
@@ -616,8 +645,8 @@ fn analyze_part(part: &WordPart, in_double_quotes: bool) -> PartAnalysis {
                 array_valued: false,
                 can_expand_to_multiple_fields: multi_field,
                 hazards: ExpansionHazards {
-                    field_splitting: !in_double_quotes,
-                    pathname_matching: !in_double_quotes,
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                     ..ExpansionHazards::default()
                 },
                 command_substitution: false,
@@ -627,10 +656,13 @@ fn analyze_part(part: &WordPart, in_double_quotes: bool) -> PartAnalysis {
         WordPart::IndirectExpansion { operator, .. } => PartAnalysis {
             value_shape: PartValueShape::Unknown,
             array_valued: false,
-            can_expand_to_multiple_fields: !in_double_quotes,
+            can_expand_to_multiple_fields: substitution_can_expand_to_multiple_fields(
+                in_double_quotes,
+                options,
+            ),
             hazards: ExpansionHazards {
-                field_splitting: !in_double_quotes,
-                pathname_matching: !in_double_quotes,
+                field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                 runtime_pattern: operator
                     .as_ref()
                     .is_some_and(parameter_operator_uses_pattern),
@@ -645,7 +677,11 @@ fn analyze_part(part: &WordPart, in_double_quotes: bool) -> PartAnalysis {
     }
 }
 
-fn analyze_parameter_part(parameter: &ParameterExpansion, in_double_quotes: bool) -> PartAnalysis {
+fn analyze_parameter_part(
+    parameter: &ParameterExpansion,
+    in_double_quotes: bool,
+    options: Option<&ZshOptionState>,
+) -> PartAnalysis {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
             BourneParameterExpansion::Access { reference } => match reference
@@ -658,10 +694,10 @@ fn analyze_parameter_part(parameter: &ParameterExpansion, in_double_quotes: bool
                     array_part(!in_double_quotes, !in_double_quotes, false, false)
                 }
                 None => scalar_part(
-                    !in_double_quotes,
+                    substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                     ExpansionHazards {
-                        field_splitting: !in_double_quotes,
-                        pathname_matching: !in_double_quotes,
+                        field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                        pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                         ..ExpansionHazards::default()
                     },
                     false,
@@ -669,10 +705,10 @@ fn analyze_parameter_part(parameter: &ParameterExpansion, in_double_quotes: bool
                 ),
             },
             BourneParameterExpansion::Length { .. } => scalar_part(
-                !in_double_quotes,
+                substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                 ExpansionHazards {
-                    field_splitting: !in_double_quotes,
-                    pathname_matching: !in_double_quotes,
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                     ..ExpansionHazards::default()
                 },
                 false,
@@ -682,10 +718,13 @@ fn analyze_parameter_part(parameter: &ParameterExpansion, in_double_quotes: bool
             BourneParameterExpansion::Indirect { operator, .. } => PartAnalysis {
                 value_shape: PartValueShape::Unknown,
                 array_valued: false,
-                can_expand_to_multiple_fields: !in_double_quotes,
+                can_expand_to_multiple_fields: substitution_can_expand_to_multiple_fields(
+                    in_double_quotes,
+                    options,
+                ),
                 hazards: ExpansionHazards {
-                    field_splitting: !in_double_quotes,
-                    pathname_matching: !in_double_quotes,
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                     runtime_pattern: operator
                         .as_ref()
                         .is_some_and(parameter_operator_uses_pattern),
@@ -706,8 +745,8 @@ fn analyze_parameter_part(parameter: &ParameterExpansion, in_double_quotes: bool
                     array_valued: false,
                     can_expand_to_multiple_fields: multi_field,
                     hazards: ExpansionHazards {
-                        field_splitting: !in_double_quotes,
-                        pathname_matching: !in_double_quotes,
+                        field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                        pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                         ..ExpansionHazards::default()
                     },
                     command_substitution: false,
@@ -719,10 +758,10 @@ fn analyze_parameter_part(parameter: &ParameterExpansion, in_double_quotes: bool
                     array_part(true, false, false, false)
                 } else {
                     scalar_part(
-                        !in_double_quotes,
+                        substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                         ExpansionHazards {
-                            field_splitting: !in_double_quotes,
-                            pathname_matching: !in_double_quotes,
+                            field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                            pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                             ..ExpansionHazards::default()
                         },
                         false,
@@ -731,10 +770,10 @@ fn analyze_parameter_part(parameter: &ParameterExpansion, in_double_quotes: bool
                 }
             }
             BourneParameterExpansion::Operation { operator, .. } => scalar_part(
-                !in_double_quotes,
+                substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                 ExpansionHazards {
-                    field_splitting: !in_double_quotes,
-                    pathname_matching: !in_double_quotes,
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                     runtime_pattern: parameter_operator_uses_pattern(operator),
                     ..ExpansionHazards::default()
                 },
@@ -745,23 +784,109 @@ fn analyze_parameter_part(parameter: &ParameterExpansion, in_double_quotes: bool
                 scalar_part(false, ExpansionHazards::default(), false, false)
             }
         },
-        ParameterExpansionSyntax::Zsh(syntax) => PartAnalysis {
-            value_shape: PartValueShape::Unknown,
-            array_valued: false,
-            can_expand_to_multiple_fields: !in_double_quotes,
-            hazards: ExpansionHazards {
-                field_splitting: !in_double_quotes,
-                pathname_matching: !in_double_quotes,
-                runtime_pattern: syntax
-                    .operation
-                    .as_ref()
-                    .is_some_and(zsh_operation_uses_pattern),
-                ..ExpansionHazards::default()
-            },
-            command_substitution: false,
-            process_substitution: false,
-        },
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            let effective_options = overlay_zsh_modifier_overrides(options, syntax);
+            PartAnalysis {
+                value_shape: PartValueShape::Unknown,
+                array_valued: false,
+                can_expand_to_multiple_fields: substitution_can_expand_to_multiple_fields(
+                    in_double_quotes,
+                    effective_options.as_ref(),
+                ),
+                hazards: ExpansionHazards {
+                    field_splitting: substitution_field_splitting_hazard(
+                        in_double_quotes,
+                        effective_options.as_ref(),
+                    ),
+                    pathname_matching: substitution_pathname_matching_hazard(
+                        in_double_quotes,
+                        effective_options.as_ref(),
+                    ),
+                    runtime_pattern: syntax
+                        .operation
+                        .as_ref()
+                        .is_some_and(zsh_operation_uses_pattern),
+                    ..ExpansionHazards::default()
+                },
+                command_substitution: false,
+                process_substitution: false,
+            }
+        }
     }
+}
+
+fn substitution_can_expand_to_multiple_fields(
+    in_double_quotes: bool,
+    options: Option<&ZshOptionState>,
+) -> bool {
+    !in_double_quotes
+        && (substitution_field_splitting_hazard(false, options)
+            || substitution_pathname_matching_hazard(false, options)
+            || options.is_none())
+}
+
+fn substitution_field_splitting_hazard(
+    in_double_quotes: bool,
+    options: Option<&ZshOptionState>,
+) -> bool {
+    if in_double_quotes {
+        return false;
+    }
+
+    match options {
+        Some(options) => !matches!(options.sh_word_split, OptionValue::Off),
+        None => true,
+    }
+}
+
+fn substitution_pathname_matching_hazard(
+    in_double_quotes: bool,
+    options: Option<&ZshOptionState>,
+) -> bool {
+    if in_double_quotes || !glob_is_effectively_enabled(options) {
+        return false;
+    }
+
+    match options {
+        Some(options) => !matches!(options.glob_subst, OptionValue::Off),
+        None => true,
+    }
+}
+
+fn glob_is_effectively_enabled(options: Option<&ZshOptionState>) -> bool {
+    !matches!(options.map(|options| options.glob), Some(OptionValue::Off))
+}
+
+fn overlay_zsh_modifier_overrides(
+    options: Option<&ZshOptionState>,
+    syntax: &shuck_ast::ZshParameterExpansion,
+) -> Option<ZshOptionState> {
+    let mut effective = options.cloned()?;
+    apply_toggle_override(
+        &mut effective.sh_word_split,
+        syntax.modifiers.iter().filter(|modifier| modifier.name == '=').count(),
+    );
+    apply_toggle_override(
+        &mut effective.glob_subst,
+        syntax.modifiers.iter().filter(|modifier| modifier.name == '~').count(),
+    );
+    apply_toggle_override(
+        &mut effective.rc_expand_param,
+        syntax.modifiers.iter().filter(|modifier| modifier.name == '^').count(),
+    );
+    Some(effective)
+}
+
+fn apply_toggle_override(value: &mut OptionValue, count: usize) {
+    if count == 0 {
+        return;
+    }
+
+    *value = if count % 2 == 1 {
+        OptionValue::On
+    } else {
+        OptionValue::Off
+    };
 }
 
 fn scalar_part(
@@ -872,7 +997,7 @@ mod tests {
     fn analyze_argument_words(source: &str) -> Vec<ExpansionAnalysis> {
         parse_argument_words(source)
             .iter()
-            .map(|word| analyze_word(word, source))
+            .map(|word| analyze_word(word, source, None))
             .collect()
     }
 
@@ -887,7 +1012,7 @@ mod tests {
         command
             .args
             .iter()
-            .map(|word| analyze_word(word, source))
+            .map(|word| analyze_word(word, source, None))
             .collect()
     }
 
@@ -973,6 +1098,26 @@ mod tests {
     }
 
     #[test]
+    fn analyze_word_suppresses_zsh_glob_fanout_when_glob_is_disabled() {
+        let source = "print *.jpg\n";
+        let file = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
+        let Command::Simple(command) = &file.body[0].command else {
+            panic!("expected simple command");
+        };
+        let options = shuck_semantic::ZshOptionState {
+            glob: shuck_semantic::OptionValue::Off,
+            ..shuck_semantic::ZshOptionState::zsh_default()
+        };
+        let analysis = analyze_word(&command.args[0], source, Some(&options));
+
+        assert!(!analysis.hazards.pathname_matching);
+        assert!(!analysis.can_expand_to_multiple_fields);
+    }
+
+    #[test]
     fn analyze_redirect_target_distinguishes_descriptor_dups_and_dev_null() {
         let static_dup_source = "echo hi 2>&3\n";
         let static_dup_file = Parser::new(static_dup_source).parse().unwrap().file;
@@ -980,7 +1125,7 @@ mod tests {
             panic!("expected simple command");
         };
         let static_dup =
-            analyze_redirect_target(&static_dup_file.body[0].redirects[0], static_dup_source)
+            analyze_redirect_target(&static_dup_file.body[0].redirects[0], static_dup_source, None)
                 .expect("expected redirect analysis");
         assert!(static_dup.is_descriptor_dup());
         assert_eq!(static_dup.numeric_descriptor_target, Some(3));
@@ -991,7 +1136,7 @@ mod tests {
         let Command::Simple(_) = &file_commands.body[0].command else {
             panic!("expected simple command");
         };
-        let file = analyze_redirect_target(&file_commands.body[0].redirects[0], file_source)
+        let file = analyze_redirect_target(&file_commands.body[0].redirects[0], file_source, None)
             .expect("expected redirect analysis");
         assert!(file.is_file_target());
         assert!(file.is_definitely_dev_null());
@@ -1002,7 +1147,7 @@ mod tests {
         let Command::Simple(_) = &maybe_commands.body[0].command else {
             panic!("expected simple command");
         };
-        let maybe = analyze_redirect_target(&maybe_commands.body[0].redirects[0], maybe_source)
+        let maybe = analyze_redirect_target(&maybe_commands.body[0].redirects[0], maybe_source, None)
             .expect("expected redirect analysis");
         assert!(maybe.is_file_target());
         assert_eq!(
@@ -1016,7 +1161,7 @@ mod tests {
         let Command::Simple(_) = &fanout_commands.body[0].command else {
             panic!("expected simple command");
         };
-        let fanout = analyze_redirect_target(&fanout_commands.body[0].redirects[0], fanout_source)
+        let fanout = analyze_redirect_target(&fanout_commands.body[0].redirects[0], fanout_source, None)
             .expect("expected redirect analysis");
         assert!(fanout.can_expand_to_multiple_fields());
         assert!(fanout.is_runtime_sensitive());
@@ -1026,7 +1171,7 @@ mod tests {
         let Command::Simple(_) = &tilde_commands.body[0].command else {
             panic!("expected simple command");
         };
-        let tilde = analyze_redirect_target(&tilde_commands.body[0].redirects[0], tilde_source)
+        let tilde = analyze_redirect_target(&tilde_commands.body[0].redirects[0], tilde_source, None)
             .expect("expected redirect analysis");
         assert!(tilde.is_file_target());
         assert_eq!(
@@ -1043,60 +1188,60 @@ mod tests {
         let words = parse_argument_words(source);
 
         assert!(
-            analyze_literal_runtime(&words[0], source, ExpansionContext::CommandArgument)
+            analyze_literal_runtime(&words[0], source, ExpansionContext::CommandArgument, None)
                 .hazards
                 .tilde_expansion
         );
         assert!(
-            analyze_literal_runtime(&words[1], source, ExpansionContext::CommandArgument)
+            analyze_literal_runtime(&words[1], source, ExpansionContext::CommandArgument, None)
                 .hazards
                 .tilde_expansion
         );
         assert!(
-            analyze_literal_runtime(&words[2], source, ExpansionContext::CommandArgument)
+            analyze_literal_runtime(&words[2], source, ExpansionContext::CommandArgument, None)
                 .hazards
                 .tilde_expansion
         );
         assert!(
-            analyze_literal_runtime(&words[3], source, ExpansionContext::CommandArgument)
+            analyze_literal_runtime(&words[3], source, ExpansionContext::CommandArgument, None)
                 .hazards
                 .pathname_matching
         );
         assert!(
-            analyze_literal_runtime(&words[4], source, ExpansionContext::CommandArgument)
+            analyze_literal_runtime(&words[4], source, ExpansionContext::CommandArgument, None)
                 .hazards
                 .brace_fanout
         );
 
         assert!(
-            !analyze_literal_runtime(&words[5], source, ExpansionContext::CommandArgument)
+            !analyze_literal_runtime(&words[5], source, ExpansionContext::CommandArgument, None)
                 .is_runtime_sensitive()
         );
         assert!(
-            !analyze_literal_runtime(&words[6], source, ExpansionContext::CommandArgument)
+            !analyze_literal_runtime(&words[6], source, ExpansionContext::CommandArgument, None)
                 .is_runtime_sensitive()
         );
         assert!(
-            !analyze_literal_runtime(&words[7], source, ExpansionContext::CommandArgument)
+            !analyze_literal_runtime(&words[7], source, ExpansionContext::CommandArgument, None)
                 .is_runtime_sensitive()
         );
 
         assert!(
-            analyze_literal_runtime(&words[0], source, ExpansionContext::StringTestOperand)
+            analyze_literal_runtime(&words[0], source, ExpansionContext::StringTestOperand, None)
                 .hazards
                 .tilde_expansion
         );
         assert!(
-            analyze_literal_runtime(&words[0], source, ExpansionContext::RegexOperand)
+            analyze_literal_runtime(&words[0], source, ExpansionContext::RegexOperand, None)
                 .hazards
                 .tilde_expansion
         );
         assert!(
-            !analyze_literal_runtime(&words[3], source, ExpansionContext::StringTestOperand)
+            !analyze_literal_runtime(&words[3], source, ExpansionContext::StringTestOperand, None)
                 .is_runtime_sensitive()
         );
         assert!(
-            !analyze_literal_runtime(&words[4], source, ExpansionContext::CasePattern)
+            !analyze_literal_runtime(&words[4], source, ExpansionContext::CasePattern, None)
                 .is_runtime_sensitive()
         );
     }

--- a/crates/shuck-linter/src/rules/common/expansion.rs
+++ b/crates/shuck-linter/src/rules/common/expansion.rs
@@ -383,7 +383,13 @@ fn analyze_literal_runtime_parts(
     for part in parts {
         match &part.kind {
             WordPart::Literal(_) => {
-                scan_literal_runtime_text(part.span.slice(source), context, options, state, analysis);
+                scan_literal_runtime_text(
+                    part.span.slice(source),
+                    context,
+                    options,
+                    state,
+                    analysis,
+                );
             }
             WordPart::SingleQuoted { value, .. } => {
                 if !value.slice(source).is_empty() {
@@ -547,7 +553,8 @@ fn analyze_part(
         WordPart::ZshQualifiedGlob(_) => PartAnalysis {
             value_shape: PartValueShape::Unknown,
             array_valued: false,
-            can_expand_to_multiple_fields: !in_double_quotes && glob_is_effectively_enabled(options),
+            can_expand_to_multiple_fields: !in_double_quotes
+                && glob_is_effectively_enabled(options),
             hazards: ExpansionHazards {
                 pathname_matching: !in_double_quotes && glob_is_effectively_enabled(options),
                 ..ExpansionHazards::default()
@@ -555,7 +562,9 @@ fn analyze_part(
             command_substitution: false,
             process_substitution: false,
         },
-        WordPart::Parameter(parameter) => analyze_parameter_part(parameter, in_double_quotes, options),
+        WordPart::Parameter(parameter) => {
+            analyze_parameter_part(parameter, in_double_quotes, options)
+        }
         WordPart::CommandSubstitution { .. } => scalar_part(
             substitution_can_expand_to_multiple_fields(in_double_quotes, options),
             ExpansionHazards {
@@ -624,7 +633,10 @@ fn analyze_part(
                 substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                 ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(
+                        in_double_quotes,
+                        options,
+                    ),
                     ..ExpansionHazards::default()
                 },
                 false,
@@ -646,7 +658,10 @@ fn analyze_part(
                 can_expand_to_multiple_fields: multi_field,
                 hazards: ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(
+                        in_double_quotes,
+                        options,
+                    ),
                     ..ExpansionHazards::default()
                 },
                 command_substitution: false,
@@ -696,8 +711,14 @@ fn analyze_parameter_part(
                 None => scalar_part(
                     substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                     ExpansionHazards {
-                        field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                        pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                        field_splitting: substitution_field_splitting_hazard(
+                            in_double_quotes,
+                            options,
+                        ),
+                        pathname_matching: substitution_pathname_matching_hazard(
+                            in_double_quotes,
+                            options,
+                        ),
                         ..ExpansionHazards::default()
                     },
                     false,
@@ -708,7 +729,10 @@ fn analyze_parameter_part(
                 substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                 ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(
+                        in_double_quotes,
+                        options,
+                    ),
                     ..ExpansionHazards::default()
                 },
                 false,
@@ -724,7 +748,10 @@ fn analyze_parameter_part(
                 ),
                 hazards: ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(
+                        in_double_quotes,
+                        options,
+                    ),
                     runtime_pattern: operator
                         .as_ref()
                         .is_some_and(parameter_operator_uses_pattern),
@@ -745,8 +772,14 @@ fn analyze_parameter_part(
                     array_valued: false,
                     can_expand_to_multiple_fields: multi_field,
                     hazards: ExpansionHazards {
-                        field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                        pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                        field_splitting: substitution_field_splitting_hazard(
+                            in_double_quotes,
+                            options,
+                        ),
+                        pathname_matching: substitution_pathname_matching_hazard(
+                            in_double_quotes,
+                            options,
+                        ),
                         ..ExpansionHazards::default()
                     },
                     command_substitution: false,
@@ -760,8 +793,14 @@ fn analyze_parameter_part(
                     scalar_part(
                         substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                         ExpansionHazards {
-                            field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                            pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                            field_splitting: substitution_field_splitting_hazard(
+                                in_double_quotes,
+                                options,
+                            ),
+                            pathname_matching: substitution_pathname_matching_hazard(
+                                in_double_quotes,
+                                options,
+                            ),
                             ..ExpansionHazards::default()
                         },
                         false,
@@ -773,7 +812,10 @@ fn analyze_parameter_part(
                 substitution_can_expand_to_multiple_fields(in_double_quotes, options),
                 ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                    pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(
+                        in_double_quotes,
+                        options,
+                    ),
                     runtime_pattern: parameter_operator_uses_pattern(operator),
                     ..ExpansionHazards::default()
                 },
@@ -864,15 +906,27 @@ fn overlay_zsh_modifier_overrides(
     let mut effective = options.cloned()?;
     apply_toggle_override(
         &mut effective.sh_word_split,
-        syntax.modifiers.iter().filter(|modifier| modifier.name == '=').count(),
+        syntax
+            .modifiers
+            .iter()
+            .filter(|modifier| modifier.name == '=')
+            .count(),
     );
     apply_toggle_override(
         &mut effective.glob_subst,
-        syntax.modifiers.iter().filter(|modifier| modifier.name == '~').count(),
+        syntax
+            .modifiers
+            .iter()
+            .filter(|modifier| modifier.name == '~')
+            .count(),
     );
     apply_toggle_override(
         &mut effective.rc_expand_param,
-        syntax.modifiers.iter().filter(|modifier| modifier.name == '^').count(),
+        syntax
+            .modifiers
+            .iter()
+            .filter(|modifier| modifier.name == '^')
+            .count(),
     );
     Some(effective)
 }
@@ -1124,9 +1178,12 @@ mod tests {
         let Command::Simple(_) = &static_dup_file.body[0].command else {
             panic!("expected simple command");
         };
-        let static_dup =
-            analyze_redirect_target(&static_dup_file.body[0].redirects[0], static_dup_source, None)
-                .expect("expected redirect analysis");
+        let static_dup = analyze_redirect_target(
+            &static_dup_file.body[0].redirects[0],
+            static_dup_source,
+            None,
+        )
+        .expect("expected redirect analysis");
         assert!(static_dup.is_descriptor_dup());
         assert_eq!(static_dup.numeric_descriptor_target, Some(3));
         assert!(!static_dup.is_runtime_sensitive());
@@ -1147,8 +1204,9 @@ mod tests {
         let Command::Simple(_) = &maybe_commands.body[0].command else {
             panic!("expected simple command");
         };
-        let maybe = analyze_redirect_target(&maybe_commands.body[0].redirects[0], maybe_source, None)
-            .expect("expected redirect analysis");
+        let maybe =
+            analyze_redirect_target(&maybe_commands.body[0].redirects[0], maybe_source, None)
+                .expect("expected redirect analysis");
         assert!(maybe.is_file_target());
         assert_eq!(
             maybe.dev_null_status,
@@ -1161,8 +1219,9 @@ mod tests {
         let Command::Simple(_) = &fanout_commands.body[0].command else {
             panic!("expected simple command");
         };
-        let fanout = analyze_redirect_target(&fanout_commands.body[0].redirects[0], fanout_source, None)
-            .expect("expected redirect analysis");
+        let fanout =
+            analyze_redirect_target(&fanout_commands.body[0].redirects[0], fanout_source, None)
+                .expect("expected redirect analysis");
         assert!(fanout.can_expand_to_multiple_fields());
         assert!(fanout.is_runtime_sensitive());
 
@@ -1171,8 +1230,9 @@ mod tests {
         let Command::Simple(_) = &tilde_commands.body[0].command else {
             panic!("expected simple command");
         };
-        let tilde = analyze_redirect_target(&tilde_commands.body[0].redirects[0], tilde_source, None)
-            .expect("expected redirect analysis");
+        let tilde =
+            analyze_redirect_target(&tilde_commands.body[0].redirects[0], tilde_source, None)
+                .expect("expected redirect analysis");
         assert!(tilde.is_file_target());
         assert_eq!(
             tilde.dev_null_status,
@@ -1252,17 +1312,17 @@ mod tests {
         let words = parse_argument_words(source);
 
         assert!(
-            analyze_literal_runtime(&words[0], source, ExpansionContext::ForList)
+            analyze_literal_runtime(&words[0], source, ExpansionContext::ForList, None)
                 .hazards
                 .tilde_expansion
         );
         assert!(
-            analyze_literal_runtime(&words[1], source, ExpansionContext::ForList)
+            analyze_literal_runtime(&words[1], source, ExpansionContext::ForList, None)
                 .hazards
                 .pathname_matching
         );
         assert!(
-            analyze_literal_runtime(&words[2], source, ExpansionContext::ForList)
+            analyze_literal_runtime(&words[2], source, ExpansionContext::ForList, None)
                 .hazards
                 .brace_fanout
         );

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -171,7 +171,7 @@ impl<'a> SafeValueIndex<'a> {
             brace_syntax: Vec::new(),
         };
         if let Some(context) = query.operand_context()
-            && analyze_literal_runtime(&word, self.source, context).is_runtime_sensitive()
+            && analyze_literal_runtime(&word, self.source, context, None).is_runtime_sensitive()
         {
             return false;
         }

--- a/crates/shuck-linter/src/rules/common/word.rs
+++ b/crates/shuck-linter/src/rules/common/word.rs
@@ -114,8 +114,7 @@ pub(crate) fn classify_contextual_operand(
         return TestOperandClass::RuntimeSensitive;
     }
 
-    if super::expansion::analyze_literal_runtime(word, source, context, None)
-        .is_runtime_sensitive()
+    if super::expansion::analyze_literal_runtime(word, source, context, None).is_runtime_sensitive()
     {
         TestOperandClass::RuntimeSensitive
     } else {

--- a/crates/shuck-linter/src/rules/common/word.rs
+++ b/crates/shuck-linter/src/rules/common/word.rs
@@ -94,7 +94,7 @@ pub fn word_is_standalone_variable_like(word: &Word) -> bool {
 }
 
 pub(crate) fn classify_word(word: &Word, source: &str) -> WordClassification {
-    let analysis = super::expansion::analyze_word(word, source);
+    let analysis = super::expansion::analyze_word(word, source, None);
 
     WordClassification {
         quote: analysis.quote,
@@ -109,12 +109,14 @@ pub(crate) fn classify_contextual_operand(
     source: &str,
     context: ExpansionContext,
 ) -> TestOperandClass {
-    let analysis = super::expansion::analyze_word(word, source);
+    let analysis = super::expansion::analyze_word(word, source, None);
     if analysis.literalness == WordLiteralness::Expanded {
         return TestOperandClass::RuntimeSensitive;
     }
 
-    if super::expansion::analyze_literal_runtime(word, source, context).is_runtime_sensitive() {
+    if super::expansion::analyze_literal_runtime(word, source, context, None)
+        .is_runtime_sensitive()
+    {
         TestOperandClass::RuntimeSensitive
     } else {
         TestOperandClass::FixedLiteral

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -30,6 +30,12 @@ fn reportable_glob_span(checker: &Checker<'_>, fact: &crate::facts::WordFact<'_>
     if command_exempts_glob_warning(command.effective_name()) {
         return None;
     }
+    if fact
+        .zsh_options()
+        .is_some_and(|options| options.glob.is_definitely_off())
+    {
+        return None;
+    }
 
     let text = fact.span().slice(checker.source());
     let prefix = text.chars().next()?;
@@ -117,6 +123,30 @@ printf '%s\\n' *
 ";
         let diagnostics =
             test_snippet(source, &LinterSettings::for_rule(Rule::LeadingGlobArgument));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_globs_when_noglob_is_active() {
+        let source = "setopt no_glob\nrm *\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_noglob_wrapped_commands_in_zsh() {
+        let source = "noglob rm *\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -17,7 +17,11 @@ pub fn rm_glob_on_variable_path(checker: &mut Checker) {
         .facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("rm"))
-        .filter(|fact| !fact.zsh_options().is_some_and(|options| options.glob.is_definitely_off()))
+        .filter(|fact| {
+            !fact
+                .zsh_options()
+                .is_some_and(|options| options.glob.is_definitely_off())
+        })
         .filter_map(|fact| fact.options().rm())
         .flat_map(|rm| rm.dangerous_path_spans().iter().copied())
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -17,6 +17,7 @@ pub fn rm_glob_on_variable_path(checker: &mut Checker) {
         .facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("rm"))
+        .filter(|fact| !fact.zsh_options().is_some_and(|options| options.glob.is_definitely_off()))
         .filter_map(|fact| fact.options().rm())
         .flat_map(|rm| rm.dangerous_path_spans().iter().copied())
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -59,6 +59,10 @@ fn report_word_expansions(
     fact: &WordFact<'_>,
     context: ExpansionContext,
 ) {
+    if !fact.analysis().hazards.field_splitting && !fact.analysis().hazards.pathname_matching {
+        return;
+    }
+
     let scalar_spans = fact.scalar_expansion_spans();
     let array_spans = fact.unquoted_array_expansion_spans();
     let star_spans = word_unquoted_star_parameter_spans(fact.word(), array_spans);
@@ -89,7 +93,7 @@ mod tests {
     use std::path::Path;
 
     use crate::test::{test_snippet, test_snippet_at_path};
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_scalar_expansion_parts_instead_of_whole_words() {
@@ -187,7 +191,7 @@ printf '%s\\n' ok >&$fd
     fn reports_unquoted_zsh_parameter_modifiers() {
         let source = "\
 #!/usr/bin/env zsh
-print ${(m)foo}
+print ${~foo}
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
@@ -196,7 +200,7 @@ print ${(m)foo}
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["${(m)foo}"]
+            vec!["${~foo}"]
         );
     }
 
@@ -397,5 +401,61 @@ printf '%s\\n' ${!name} $a
                 .collect::<Vec<_>>(),
             vec!["${!name}", "$a"]
         );
+    }
+
+    #[test]
+    fn skips_plain_unquoted_scalars_in_native_zsh_mode() {
+        let source = "print $name\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_unquoted_scalars_after_setopt_sh_word_split_in_zsh() {
+        let source = "setopt sh_word_split\nprint $name\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$name"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_force_split_modifier_even_without_sh_word_split() {
+        let source = "print ${=name}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${=name}"]
+        );
+    }
+
+    #[test]
+    fn skips_zsh_double_tilde_modifier_when_it_forces_globbing_off() {
+        let source = "print ${~~name}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 }

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -3,24 +3,31 @@ use std::fs;
 use std::path::Path;
 
 use shuck_indexer::Indexer;
-use shuck_parser::parser::{ParseDiagnostic, ParseOutput, Parser, ShellDialect as ParseShellDialect};
 use shuck_parser::ShellProfile;
+use shuck_parser::parser::{
+    ParseDiagnostic, ParseOutput, Parser, ShellDialect as ParseShellDialect,
+};
 
 use crate::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_diagnostics};
 
-fn inferred_shell_profile(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ShellProfile {
+fn inferred_shell_profile(
+    source: &str,
+    settings: &LinterSettings,
+    path: Option<&Path>,
+) -> ShellProfile {
     let shell = if settings.shell == crate::ShellDialect::Unknown {
         crate::ShellDialect::infer(source, path)
     } else {
         settings.shell
     };
     let dialect = match shell {
-        crate::ShellDialect::Sh | crate::ShellDialect::Dash | crate::ShellDialect::Ksh => {
-            ParseShellDialect::Posix
-        }
-        crate::ShellDialect::Mksh => ParseShellDialect::Mksh,
         crate::ShellDialect::Zsh => ParseShellDialect::Zsh,
-        crate::ShellDialect::Unknown | crate::ShellDialect::Bash => ParseShellDialect::Bash,
+        crate::ShellDialect::Unknown
+        | crate::ShellDialect::Sh
+        | crate::ShellDialect::Dash
+        | crate::ShellDialect::Ksh
+        | crate::ShellDialect::Mksh
+        | crate::ShellDialect::Bash => ParseShellDialect::Bash,
     };
     ShellProfile::native(dialect)
 }

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -3,12 +3,35 @@ use std::fs;
 use std::path::Path;
 
 use shuck_indexer::Indexer;
-use shuck_parser::parser::{ParseDiagnostic, ParseOutput, Parser};
+use shuck_parser::parser::{ParseDiagnostic, ParseOutput, Parser, ShellDialect as ParseShellDialect};
+use shuck_parser::ShellProfile;
 
 use crate::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_diagnostics};
 
-fn parse_for_lint(source: &str) -> (ParseOutput, Vec<ParseDiagnostic>) {
-    let recovered = Parser::new(source).parse_recovered();
+fn inferred_shell_profile(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ShellProfile {
+    let shell = if settings.shell == crate::ShellDialect::Unknown {
+        crate::ShellDialect::infer(source, path)
+    } else {
+        settings.shell
+    };
+    let dialect = match shell {
+        crate::ShellDialect::Sh | crate::ShellDialect::Dash | crate::ShellDialect::Ksh => {
+            ParseShellDialect::Posix
+        }
+        crate::ShellDialect::Mksh => ParseShellDialect::Mksh,
+        crate::ShellDialect::Zsh => ParseShellDialect::Zsh,
+        crate::ShellDialect::Unknown | crate::ShellDialect::Bash => ParseShellDialect::Bash,
+    };
+    ShellProfile::native(dialect)
+}
+
+fn parse_for_lint(
+    source: &str,
+    settings: &LinterSettings,
+    path: Option<&Path>,
+) -> (ParseOutput, Vec<ParseDiagnostic>) {
+    let recovered = Parser::with_profile(source, inferred_shell_profile(source, settings, path))
+        .parse_recovered();
     (
         ParseOutput {
             file: recovered.file,
@@ -19,7 +42,7 @@ fn parse_for_lint(source: &str) -> (ParseOutput, Vec<ParseDiagnostic>) {
 
 /// Lint a source string directly (no file needed).
 pub fn test_snippet(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
-    let (output, parse_diagnostics) = parse_for_lint(source);
+    let (output, parse_diagnostics) = parse_for_lint(source, settings, None);
     let indexer = Indexer::new(source, &output);
     lint_file_at_path_with_parse_diagnostics(
         &output.file,
@@ -38,7 +61,7 @@ pub fn test_snippet_at_path(
     source: &str,
     settings: &LinterSettings,
 ) -> Vec<Diagnostic> {
-    let (output, parse_diagnostics) = parse_for_lint(source);
+    let (output, parse_diagnostics) = parse_for_lint(source, settings, Some(path));
     let indexer = Indexer::new(source, &output);
     lint_file_at_path_with_parse_diagnostics(
         &output.file,

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -4,4 +4,6 @@ mod error;
 pub mod parser;
 
 pub use error::{Error, Result};
-pub use parser::ShellDialect;
+pub use parser::{
+    OptionValue, ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState,
+};

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -4,6 +4,4 @@ mod error;
 pub mod parser;
 
 pub use error::{Error, Result};
-pub use parser::{
-    OptionValue, ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState,
-};
+pub use parser::{OptionValue, ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState};

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -444,8 +444,8 @@ impl<'a> Parser<'a> {
             | Some(Keyword::Time)
             | Some(Keyword::Coproc) => true,
             Some(Keyword::For) => self.dialect == ShellDialect::Zsh,
-            Some(Keyword::Repeat) => self.dialect.features().zsh_repeat_loop,
-            Some(Keyword::Foreach) => self.dialect.features().zsh_foreach_loop,
+            Some(Keyword::Repeat) => self.zsh_short_repeat_enabled(),
+            Some(Keyword::Foreach) => self.zsh_short_loops_enabled(),
             Some(Keyword::Function) => false,
             None => matches!(
                 self.current_token_kind,
@@ -722,10 +722,10 @@ impl<'a> Parser<'a> {
         self.maybe_expand_current_alias_chain();
         self.check_error_token()?;
 
-        if !self.dialect.features().zsh_repeat_loop && self.looks_like_disabled_repeat_loop()? {
+        if !self.zsh_short_repeat_enabled() && self.looks_like_disabled_repeat_loop()? {
             self.ensure_repeat_loop()?;
         }
-        if !self.dialect.features().zsh_foreach_loop && self.looks_like_disabled_foreach_loop()? {
+        if !self.zsh_short_loops_enabled() && self.looks_like_disabled_foreach_loop()? {
             self.ensure_foreach_loop()?;
         }
 
@@ -741,10 +741,10 @@ impl<'a> Parser<'a> {
         match self.current_keyword() {
             Some(Keyword::If) => return self.parse_compound_with_redirects(|s| s.parse_if()),
             Some(Keyword::For) => return self.parse_compound_with_redirects(|s| s.parse_for()),
-            Some(Keyword::Repeat) if self.dialect.features().zsh_repeat_loop => {
+            Some(Keyword::Repeat) if self.zsh_short_repeat_enabled() => {
                 return self.parse_compound_with_redirects(|s| s.parse_repeat());
             }
-            Some(Keyword::Foreach) if self.dialect.features().zsh_foreach_loop => {
+            Some(Keyword::Foreach) if self.zsh_short_loops_enabled() => {
                 return self.parse_compound_with_redirects(|s| s.parse_foreach());
             }
             Some(Keyword::While) => {
@@ -846,7 +846,7 @@ impl<'a> Parser<'a> {
 
         // Parse condition
         let condition_start = self.current_span.start;
-        let allow_brace_syntax = self.dialect.features().zsh_brace_if;
+        let allow_brace_syntax = self.zsh_brace_if_enabled();
         let condition = self.parse_if_condition_until_body_start(allow_brace_syntax)?;
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
         let condition = Self::stmt_seq_with_span(condition_span, condition);
@@ -2671,7 +2671,10 @@ impl<'a> Parser<'a> {
     }
 
     fn try_parse_compact_function_brace_body(&mut self) -> Result<Option<CompoundCommand>> {
-        if self.dialect != ShellDialect::Zsh || !self.at_word_like() {
+        if self.dialect != ShellDialect::Zsh
+            || !self.zsh_short_loops_enabled()
+            || !self.at_word_like()
+        {
             return Ok(None);
         }
 
@@ -2697,8 +2700,13 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
 
+        let nested_profile = self
+            .current_zsh_options()
+            .cloned()
+            .map(|options| ShellProfile::with_zsh_options(self.dialect, options))
+            .unwrap_or_else(|| self.shell_profile.clone());
         let mut nested =
-            Parser::with_limits_and_dialect(inner, self.max_depth, self.max_fuel, self.dialect);
+            Parser::with_limits_and_profile(inner, self.max_depth, self.max_fuel, nested_profile);
         nested.aliases = self.aliases.clone();
         nested.expand_aliases = self.expand_aliases;
         nested.expand_next_word = self.expand_next_word;
@@ -3549,14 +3557,10 @@ impl<'a> Parser<'a> {
         let compound = match self.current_keyword() {
             Some(Keyword::If) if allow_bare_compound => self.parse_if()?,
             Some(Keyword::For) if allow_bare_compound => self.parse_for()?,
-            Some(Keyword::Repeat)
-                if allow_bare_compound && self.dialect.features().zsh_repeat_loop =>
-            {
+            Some(Keyword::Repeat) if allow_bare_compound && self.zsh_short_repeat_enabled() => {
                 self.parse_repeat()?
             }
-            Some(Keyword::Foreach)
-                if allow_bare_compound && self.dialect.features().zsh_foreach_loop =>
-            {
+            Some(Keyword::Foreach) if allow_bare_compound && self.zsh_short_loops_enabled() => {
                 self.parse_foreach()?
             }
             Some(Keyword::While) if allow_bare_compound => self.parse_while()?,

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -7,6 +7,8 @@ use std::{collections::VecDeque, ops::Range, sync::Arc};
 use memchr::{memchr, memchr_iter, memrchr};
 use shuck_ast::{Position, Span, TokenKind};
 
+use super::{ShellProfile, ZshOptionState, ZshOptionTimeline};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) struct TokenFlags(u8);
 
@@ -680,6 +682,9 @@ pub struct Lexer<'a> {
     reinject_resume_offset: Option<usize>,
     /// Maximum allowed nesting depth for command substitution
     max_subst_depth: usize,
+    initial_zsh_options: Option<ZshOptionState>,
+    zsh_timeline: Option<Arc<ZshOptionTimeline>>,
+    zsh_timeline_index: usize,
     #[cfg(feature = "benchmarking")]
     benchmark_counters: Option<LexerBenchmarkCounters>,
 }
@@ -687,12 +692,44 @@ pub struct Lexer<'a> {
 impl<'a> Lexer<'a> {
     /// Create a new lexer for the given input.
     pub fn new(input: &'a str) -> Self {
-        Self::with_max_subst_depth(input, DEFAULT_MAX_SUBST_DEPTH)
+        Self::with_max_subst_depth_and_profile(
+            input,
+            DEFAULT_MAX_SUBST_DEPTH,
+            &ShellProfile::native(super::ShellDialect::Bash),
+            None,
+        )
     }
 
     /// Create a new lexer with a custom max substitution nesting depth.
     /// Limits recursion in read_command_subst_into().
     pub fn with_max_subst_depth(input: &'a str, max_depth: usize) -> Self {
+        Self::with_max_subst_depth_and_profile(
+            input,
+            max_depth,
+            &ShellProfile::native(super::ShellDialect::Bash),
+            None,
+        )
+    }
+
+    pub fn with_profile(input: &'a str, shell_profile: &ShellProfile) -> Self {
+        let zsh_timeline = (shell_profile.dialect == super::ShellDialect::Zsh)
+            .then(|| ZshOptionTimeline::build(input, shell_profile))
+            .flatten()
+            .map(Arc::new);
+        Self::with_max_subst_depth_and_profile(
+            input,
+            DEFAULT_MAX_SUBST_DEPTH,
+            shell_profile,
+            zsh_timeline,
+        )
+    }
+
+    pub(crate) fn with_max_subst_depth_and_profile(
+        input: &'a str,
+        max_depth: usize,
+        shell_profile: &ShellProfile,
+        zsh_timeline: Option<Arc<ZshOptionTimeline>>,
+    ) -> Self {
         Self {
             input,
             offset: 0,
@@ -701,6 +738,9 @@ impl<'a> Lexer<'a> {
             reinject_buf: VecDeque::new(),
             reinject_resume_offset: None,
             max_subst_depth: max_depth,
+            initial_zsh_options: shell_profile.zsh_options().cloned(),
+            zsh_timeline,
+            zsh_timeline_index: 0,
             #[cfg(feature = "benchmarking")]
             benchmark_counters: None,
         }
@@ -875,7 +915,51 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn should_treat_hash_as_word_char(&self) -> bool {
+    fn current_zsh_options(&mut self) -> Option<&ZshOptionState> {
+        if let Some(timeline) = self.zsh_timeline.as_ref() {
+            while self.zsh_timeline_index < timeline.entries.len()
+                && timeline.entries[self.zsh_timeline_index].offset <= self.offset
+            {
+                self.zsh_timeline_index += 1;
+            }
+            return if self.zsh_timeline_index == 0 {
+                self.initial_zsh_options.as_ref()
+            } else {
+                Some(&timeline.entries[self.zsh_timeline_index - 1].state)
+            };
+        }
+
+        self.initial_zsh_options.as_ref()
+    }
+
+    fn comments_enabled(&mut self) -> bool {
+        !self
+            .current_zsh_options()
+            .is_some_and(|options| options.interactive_comments.is_definitely_off())
+    }
+
+    fn rc_quotes_enabled(&mut self) -> bool {
+        self.current_zsh_options()
+            .is_some_and(|options| options.rc_quotes.is_definitely_on())
+    }
+
+    fn ignore_braces_enabled(&mut self) -> bool {
+        self.current_zsh_options()
+            .is_some_and(|options| options.ignore_braces.is_definitely_on())
+    }
+
+    fn ignore_close_braces_enabled(&mut self) -> bool {
+        self.current_zsh_options()
+            .is_some_and(|options| {
+                options.ignore_braces.is_definitely_on()
+                    || options.ignore_close_braces.is_definitely_on()
+            })
+    }
+
+    fn should_treat_hash_as_word_char(&mut self) -> bool {
+        if !self.comments_enabled() {
+            return true;
+        }
         self.reinject_buf.is_empty()
             && (self
                 .input
@@ -1042,10 +1126,19 @@ impl<'a> Lexer<'a> {
                 }
             }
             '{' => {
-                // Look ahead to see if this is a brace expansion like {a,b,c} or {1..5}
-                // vs a brace group like { cmd; }
-                // Note: { must be followed by space/newline to be a brace group
-                if self.looks_like_brace_expansion() {
+                if self.ignore_braces_enabled() {
+                    let start = self.current_position();
+                    self.consume_ascii_chars(1);
+                    match self.peek_char() {
+                        Some(' ') | Some('\t') | Some('\n') | None => {
+                            Some(LexedToken::borrowed_word(TokenKind::Word, "{", None))
+                        }
+                        _ => self.read_word_starting_with("{", start),
+                    }
+                } else if self.looks_like_brace_expansion() {
+                    // Look ahead to see if this is a brace expansion like {a,b,c} or {1..5}
+                    // vs a brace group like { cmd; }
+                    // Note: { must be followed by space/newline to be a brace group
                     self.read_brace_expansion_word()
                 } else if self.is_brace_group_start() {
                     self.advance();
@@ -1056,8 +1149,12 @@ impl<'a> Lexer<'a> {
                 }
             }
             '}' => {
-                self.advance();
-                Some(LexedToken::punctuation(TokenKind::RightBrace))
+                self.consume_ascii_chars(1);
+                if self.ignore_close_braces_enabled() {
+                    Some(LexedToken::borrowed_word(TokenKind::Word, "}", None))
+                } else {
+                    Some(LexedToken::punctuation(TokenKind::RightBrace))
+                }
             }
             '[' => {
                 let start = self.current_position();
@@ -1692,7 +1789,7 @@ impl<'a> Lexer<'a> {
         let wrapper_start = self.current_position();
         self.consume_ascii_chars(1); // consume opening '
         let content_start = self.current_position();
-        let can_borrow = self.reinject_buf.is_empty();
+        let can_borrow = self.reinject_buf.is_empty() && !self.rc_quotes_enabled();
         let mut content_end = content_start;
         let mut content = String::with_capacity(16);
         let mut closed = false;
@@ -1714,6 +1811,14 @@ impl<'a> Lexer<'a> {
                 break;
             }
             if ch == '\'' {
+                if self.rc_quotes_enabled() && self.second_char() == Some('\'') {
+                    if !can_borrow {
+                        content.push('\'');
+                    }
+                    self.advance();
+                    self.advance();
+                    continue;
+                }
                 content_end = self.current_position();
                 self.consume_ascii_chars(1); // consume closing '
                 closed = true;
@@ -4067,5 +4172,44 @@ EOF
         );
 
         assert_non_newline_tokens_stay_on_one_line(input);
+    }
+
+    #[test]
+    fn test_zsh_midfile_unsetopt_interactive_comments_keeps_hash_as_word() {
+        let source = "unsetopt interactive_comments\n#literal\n";
+        let profile = ShellProfile::native(crate::parser::ShellDialect::Zsh);
+        let mut lexer = Lexer::with_profile(source, &profile);
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("unsetopt"));
+        assert_next_token(&mut lexer, TokenKind::Word, Some("interactive_comments"));
+        assert_next_token(&mut lexer, TokenKind::Newline, None);
+        assert_next_token_with_comments(&mut lexer, TokenKind::Word, Some("#literal"));
+    }
+
+    #[test]
+    fn test_zsh_midfile_setopt_rc_quotes_merges_adjacent_single_quotes() {
+        let source = "setopt rc_quotes\nprint 'a''b'\n";
+        let profile = ShellProfile::native(crate::parser::ShellDialect::Zsh);
+        let mut lexer = Lexer::with_profile(source, &profile);
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("setopt"));
+        assert_next_token(&mut lexer, TokenKind::Word, Some("rc_quotes"));
+        assert_next_token(&mut lexer, TokenKind::Newline, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("print"));
+        assert_next_token(&mut lexer, TokenKind::LiteralWord, Some("a'b"));
+    }
+
+    #[test]
+    fn test_zsh_midfile_setopt_ignore_braces_lexes_braces_as_words() {
+        let source = "setopt ignore_braces\n{ echo }\n";
+        let profile = ShellProfile::native(crate::parser::ShellDialect::Zsh);
+        let mut lexer = Lexer::with_profile(source, &profile);
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("setopt"));
+        assert_next_token(&mut lexer, TokenKind::Word, Some("ignore_braces"));
+        assert_next_token(&mut lexer, TokenKind::Newline, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("{"));
+        assert_next_token(&mut lexer, TokenKind::Word, Some("echo"));
+        assert_next_token(&mut lexer, TokenKind::Word, Some("}"));
     }
 }

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -949,11 +949,10 @@ impl<'a> Lexer<'a> {
     }
 
     fn ignore_close_braces_enabled(&mut self) -> bool {
-        self.current_zsh_options()
-            .is_some_and(|options| {
-                options.ignore_braces.is_definitely_on()
-                    || options.ignore_close_braces.is_definitely_on()
-            })
+        self.current_zsh_options().is_some_and(|options| {
+            options.ignore_braces.is_definitely_on()
+                || options.ignore_close_braces.is_definitely_on()
+        })
     }
 
     fn should_treat_hash_as_word_char(&mut self) -> bool {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -165,6 +165,758 @@ pub enum ShellDialect {
     Zsh,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum OptionValue {
+    On,
+    Off,
+    #[default]
+    Unknown,
+}
+
+impl OptionValue {
+    pub const fn is_definitely_on(self) -> bool {
+        matches!(self, Self::On)
+    }
+
+    pub const fn is_definitely_off(self) -> bool {
+        matches!(self, Self::Off)
+    }
+
+    pub const fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::On, Self::On) => Self::On,
+            (Self::Off, Self::Off) => Self::Off,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ZshEmulationMode {
+    Zsh,
+    Sh,
+    Ksh,
+    Csh,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ZshOptionState {
+    pub sh_word_split: OptionValue,
+    pub glob_subst: OptionValue,
+    pub rc_expand_param: OptionValue,
+    pub glob: OptionValue,
+    pub nomatch: OptionValue,
+    pub null_glob: OptionValue,
+    pub csh_null_glob: OptionValue,
+    pub extended_glob: OptionValue,
+    pub ksh_glob: OptionValue,
+    pub sh_glob: OptionValue,
+    pub bare_glob_qual: OptionValue,
+    pub glob_dots: OptionValue,
+    pub equals: OptionValue,
+    pub magic_equal_subst: OptionValue,
+    pub sh_file_expansion: OptionValue,
+    pub glob_assign: OptionValue,
+    pub ignore_braces: OptionValue,
+    pub ignore_close_braces: OptionValue,
+    pub brace_ccl: OptionValue,
+    pub ksh_arrays: OptionValue,
+    pub ksh_zero_subscript: OptionValue,
+    pub short_loops: OptionValue,
+    pub short_repeat: OptionValue,
+    pub rc_quotes: OptionValue,
+    pub interactive_comments: OptionValue,
+    pub c_bases: OptionValue,
+    pub octal_zeroes: OptionValue,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ZshOptionField {
+    ShWordSplit,
+    GlobSubst,
+    RcExpandParam,
+    Glob,
+    Nomatch,
+    NullGlob,
+    CshNullGlob,
+    ExtendedGlob,
+    KshGlob,
+    ShGlob,
+    BareGlobQual,
+    GlobDots,
+    Equals,
+    MagicEqualSubst,
+    ShFileExpansion,
+    GlobAssign,
+    IgnoreBraces,
+    IgnoreCloseBraces,
+    BraceCcl,
+    KshArrays,
+    KshZeroSubscript,
+    ShortLoops,
+    ShortRepeat,
+    RcQuotes,
+    InteractiveComments,
+    CBases,
+    OctalZeroes,
+}
+
+impl ZshOptionState {
+    pub const fn zsh_default() -> Self {
+        Self {
+            sh_word_split: OptionValue::Off,
+            glob_subst: OptionValue::Off,
+            rc_expand_param: OptionValue::Off,
+            glob: OptionValue::On,
+            nomatch: OptionValue::On,
+            null_glob: OptionValue::Off,
+            csh_null_glob: OptionValue::Off,
+            extended_glob: OptionValue::Off,
+            ksh_glob: OptionValue::Off,
+            sh_glob: OptionValue::Off,
+            bare_glob_qual: OptionValue::On,
+            glob_dots: OptionValue::Off,
+            equals: OptionValue::On,
+            magic_equal_subst: OptionValue::Off,
+            sh_file_expansion: OptionValue::Off,
+            glob_assign: OptionValue::Off,
+            ignore_braces: OptionValue::Off,
+            ignore_close_braces: OptionValue::Off,
+            brace_ccl: OptionValue::Off,
+            ksh_arrays: OptionValue::Off,
+            ksh_zero_subscript: OptionValue::Off,
+            short_loops: OptionValue::On,
+            short_repeat: OptionValue::On,
+            rc_quotes: OptionValue::Off,
+            interactive_comments: OptionValue::On,
+            c_bases: OptionValue::Off,
+            octal_zeroes: OptionValue::Off,
+        }
+    }
+
+    pub fn for_emulate(mode: ZshEmulationMode) -> Self {
+        let mut state = Self::zsh_default();
+        match mode {
+            ZshEmulationMode::Zsh => {}
+            ZshEmulationMode::Sh => {
+                state.sh_word_split = OptionValue::On;
+                state.glob_subst = OptionValue::On;
+                state.sh_glob = OptionValue::On;
+                state.sh_file_expansion = OptionValue::On;
+                state.bare_glob_qual = OptionValue::Off;
+                state.ksh_arrays = OptionValue::Off;
+            }
+            ZshEmulationMode::Ksh => {
+                state.sh_word_split = OptionValue::On;
+                state.glob_subst = OptionValue::On;
+                state.ksh_glob = OptionValue::On;
+                state.ksh_arrays = OptionValue::On;
+                state.sh_glob = OptionValue::On;
+                state.bare_glob_qual = OptionValue::Off;
+            }
+            ZshEmulationMode::Csh => {
+                state.csh_null_glob = OptionValue::On;
+                state.sh_word_split = OptionValue::Off;
+                state.glob_subst = OptionValue::Off;
+            }
+        }
+        state
+    }
+
+    pub fn apply_setopt(&mut self, name: &str) -> bool {
+        self.apply_named_option(name, true)
+    }
+
+    pub fn apply_unsetopt(&mut self, name: &str) -> bool {
+        self.apply_named_option(name, false)
+    }
+
+    fn set_field(&mut self, field: ZshOptionField, value: OptionValue) {
+        match field {
+            ZshOptionField::ShWordSplit => self.sh_word_split = value,
+            ZshOptionField::GlobSubst => self.glob_subst = value,
+            ZshOptionField::RcExpandParam => self.rc_expand_param = value,
+            ZshOptionField::Glob => self.glob = value,
+            ZshOptionField::Nomatch => self.nomatch = value,
+            ZshOptionField::NullGlob => self.null_glob = value,
+            ZshOptionField::CshNullGlob => self.csh_null_glob = value,
+            ZshOptionField::ExtendedGlob => self.extended_glob = value,
+            ZshOptionField::KshGlob => self.ksh_glob = value,
+            ZshOptionField::ShGlob => self.sh_glob = value,
+            ZshOptionField::BareGlobQual => self.bare_glob_qual = value,
+            ZshOptionField::GlobDots => self.glob_dots = value,
+            ZshOptionField::Equals => self.equals = value,
+            ZshOptionField::MagicEqualSubst => self.magic_equal_subst = value,
+            ZshOptionField::ShFileExpansion => self.sh_file_expansion = value,
+            ZshOptionField::GlobAssign => self.glob_assign = value,
+            ZshOptionField::IgnoreBraces => self.ignore_braces = value,
+            ZshOptionField::IgnoreCloseBraces => self.ignore_close_braces = value,
+            ZshOptionField::BraceCcl => self.brace_ccl = value,
+            ZshOptionField::KshArrays => self.ksh_arrays = value,
+            ZshOptionField::KshZeroSubscript => self.ksh_zero_subscript = value,
+            ZshOptionField::ShortLoops => self.short_loops = value,
+            ZshOptionField::ShortRepeat => self.short_repeat = value,
+            ZshOptionField::RcQuotes => self.rc_quotes = value,
+            ZshOptionField::InteractiveComments => self.interactive_comments = value,
+            ZshOptionField::CBases => self.c_bases = value,
+            ZshOptionField::OctalZeroes => self.octal_zeroes = value,
+        }
+    }
+
+    fn field(&self, field: ZshOptionField) -> OptionValue {
+        match field {
+            ZshOptionField::ShWordSplit => self.sh_word_split,
+            ZshOptionField::GlobSubst => self.glob_subst,
+            ZshOptionField::RcExpandParam => self.rc_expand_param,
+            ZshOptionField::Glob => self.glob,
+            ZshOptionField::Nomatch => self.nomatch,
+            ZshOptionField::NullGlob => self.null_glob,
+            ZshOptionField::CshNullGlob => self.csh_null_glob,
+            ZshOptionField::ExtendedGlob => self.extended_glob,
+            ZshOptionField::KshGlob => self.ksh_glob,
+            ZshOptionField::ShGlob => self.sh_glob,
+            ZshOptionField::BareGlobQual => self.bare_glob_qual,
+            ZshOptionField::GlobDots => self.glob_dots,
+            ZshOptionField::Equals => self.equals,
+            ZshOptionField::MagicEqualSubst => self.magic_equal_subst,
+            ZshOptionField::ShFileExpansion => self.sh_file_expansion,
+            ZshOptionField::GlobAssign => self.glob_assign,
+            ZshOptionField::IgnoreBraces => self.ignore_braces,
+            ZshOptionField::IgnoreCloseBraces => self.ignore_close_braces,
+            ZshOptionField::BraceCcl => self.brace_ccl,
+            ZshOptionField::KshArrays => self.ksh_arrays,
+            ZshOptionField::KshZeroSubscript => self.ksh_zero_subscript,
+            ZshOptionField::ShortLoops => self.short_loops,
+            ZshOptionField::ShortRepeat => self.short_repeat,
+            ZshOptionField::RcQuotes => self.rc_quotes,
+            ZshOptionField::InteractiveComments => self.interactive_comments,
+            ZshOptionField::CBases => self.c_bases,
+            ZshOptionField::OctalZeroes => self.octal_zeroes,
+        }
+    }
+
+    pub fn merge(&self, other: &Self) -> Self {
+        let mut merged = Self::zsh_default();
+        for field in ZshOptionField::ALL {
+            merged.set_field(field, self.field(field).merge(other.field(field)));
+        }
+        merged
+    }
+
+    fn apply_named_option(&mut self, name: &str, enable: bool) -> bool {
+        let Some((field, value)) = parse_zsh_option_assignment(name, enable) else {
+            return false;
+        };
+        self.set_field(field, if value { OptionValue::On } else { OptionValue::Off });
+        true
+    }
+}
+
+impl ZshOptionField {
+    const ALL: [Self; 27] = [
+        Self::ShWordSplit,
+        Self::GlobSubst,
+        Self::RcExpandParam,
+        Self::Glob,
+        Self::Nomatch,
+        Self::NullGlob,
+        Self::CshNullGlob,
+        Self::ExtendedGlob,
+        Self::KshGlob,
+        Self::ShGlob,
+        Self::BareGlobQual,
+        Self::GlobDots,
+        Self::Equals,
+        Self::MagicEqualSubst,
+        Self::ShFileExpansion,
+        Self::GlobAssign,
+        Self::IgnoreBraces,
+        Self::IgnoreCloseBraces,
+        Self::BraceCcl,
+        Self::KshArrays,
+        Self::KshZeroSubscript,
+        Self::ShortLoops,
+        Self::ShortRepeat,
+        Self::RcQuotes,
+        Self::InteractiveComments,
+        Self::CBases,
+        Self::OctalZeroes,
+    ];
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShellProfile {
+    pub dialect: ShellDialect,
+    pub options: Option<ZshOptionState>,
+}
+
+impl ShellProfile {
+    pub fn native(dialect: ShellDialect) -> Self {
+        Self {
+            dialect,
+            options: (dialect == ShellDialect::Zsh).then(ZshOptionState::zsh_default),
+        }
+    }
+
+    pub fn with_zsh_options(dialect: ShellDialect, options: ZshOptionState) -> Self {
+        Self {
+            dialect,
+            options: (dialect == ShellDialect::Zsh).then_some(options),
+        }
+    }
+
+    pub fn zsh_options(&self) -> Option<&ZshOptionState> {
+        self.options.as_ref()
+    }
+}
+
+fn parse_zsh_option_assignment(name: &str, enable: bool) -> Option<(ZshOptionField, bool)> {
+    let mut normalized = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if matches!(ch, '_' | '-') {
+            continue;
+        }
+        normalized.push(ch.to_ascii_lowercase());
+    }
+
+    let (normalized, invert) = if let Some(rest) = normalized.strip_prefix("no") {
+        (rest, true)
+    } else {
+        (normalized.as_str(), false)
+    };
+
+    let field = match normalized {
+        "shwordsplit" => ZshOptionField::ShWordSplit,
+        "globsubst" => ZshOptionField::GlobSubst,
+        "rcexpandparam" => ZshOptionField::RcExpandParam,
+        "glob" | "noglob" => ZshOptionField::Glob,
+        "nomatch" => ZshOptionField::Nomatch,
+        "nullglob" => ZshOptionField::NullGlob,
+        "cshnullglob" => ZshOptionField::CshNullGlob,
+        "extendedglob" => ZshOptionField::ExtendedGlob,
+        "kshglob" => ZshOptionField::KshGlob,
+        "shglob" => ZshOptionField::ShGlob,
+        "bareglobqual" => ZshOptionField::BareGlobQual,
+        "globdots" => ZshOptionField::GlobDots,
+        "equals" => ZshOptionField::Equals,
+        "magicequalsubst" => ZshOptionField::MagicEqualSubst,
+        "shfileexpansion" => ZshOptionField::ShFileExpansion,
+        "globassign" => ZshOptionField::GlobAssign,
+        "ignorebraces" => ZshOptionField::IgnoreBraces,
+        "ignoreclosebraces" => ZshOptionField::IgnoreCloseBraces,
+        "braceccl" => ZshOptionField::BraceCcl,
+        "ksharrays" => ZshOptionField::KshArrays,
+        "kshzerosubscript" => ZshOptionField::KshZeroSubscript,
+        "shortloops" => ZshOptionField::ShortLoops,
+        "shortrepeat" => ZshOptionField::ShortRepeat,
+        "rcquotes" => ZshOptionField::RcQuotes,
+        "interactivecomments" => ZshOptionField::InteractiveComments,
+        "cbases" => ZshOptionField::CBases,
+        "octalzeroes" => ZshOptionField::OctalZeroes,
+        _ => return None,
+    };
+
+    Some((field, if invert { !enable } else { enable }))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ZshOptionTimeline {
+    initial: ZshOptionState,
+    entries: Arc<[ZshOptionTimelineEntry]>,
+}
+
+#[derive(Debug, Clone)]
+struct ZshOptionTimelineEntry {
+    offset: usize,
+    state: ZshOptionState,
+}
+
+impl ZshOptionTimeline {
+    fn build(input: &str, shell_profile: &ShellProfile) -> Option<Self> {
+        let initial = shell_profile.zsh_options()?.clone();
+        if !might_mutate_zsh_parser_options(input) {
+            return Some(Self {
+                initial,
+                entries: Arc::from([]),
+            });
+        }
+
+        let entries = ZshOptionPrescanner::new(input, initial.clone()).scan();
+        Some(Self {
+            initial,
+            entries: entries.into(),
+        })
+    }
+
+    fn options_at(&self, offset: usize) -> &ZshOptionState {
+        let next_index = self.entries.partition_point(|entry| entry.offset <= offset);
+        if next_index == 0 {
+            &self.initial
+        } else {
+            &self.entries[next_index - 1].state
+        }
+    }
+}
+
+fn might_mutate_zsh_parser_options(input: &str) -> bool {
+    input.contains("setopt")
+        || input.contains("unsetopt")
+        || input.contains("emulate")
+        || input.contains("set -o")
+        || input.contains("set +o")
+}
+
+#[derive(Debug, Clone)]
+struct ZshOptionPrescanner<'a> {
+    input: &'a str,
+    offset: usize,
+    state: ZshOptionState,
+    entries: Vec<ZshOptionTimelineEntry>,
+}
+
+#[derive(Debug, Clone)]
+enum PrescanToken {
+    Word { text: String, end: usize },
+    Separator { start: usize },
+}
+
+impl<'a> ZshOptionPrescanner<'a> {
+    fn new(input: &'a str, state: ZshOptionState) -> Self {
+        Self {
+            input,
+            offset: 0,
+            state,
+            entries: Vec::new(),
+        }
+    }
+
+    fn scan(mut self) -> Vec<ZshOptionTimelineEntry> {
+        let mut words = Vec::new();
+        let mut command_end = 0usize;
+
+        while let Some(token) = self.next_token() {
+            match token {
+                PrescanToken::Word { text, end } => {
+                    command_end = end;
+                    words.push(text);
+                }
+                PrescanToken::Separator { start } => {
+                    self.finish_command(&words, command_end.max(start));
+                    words.clear();
+                    command_end = start;
+                }
+            }
+        }
+
+        self.finish_command(&words, command_end.max(self.input.len()));
+        self.entries
+    }
+
+    fn finish_command(&mut self, words: &[String], end_offset: usize) {
+        let mut next = self.state.clone();
+        if !apply_prescan_command_effects(words, &mut next) || next == self.state {
+            return;
+        }
+
+        self.state = next.clone();
+        self.entries.push(ZshOptionTimelineEntry {
+            offset: end_offset,
+            state: next,
+        });
+    }
+
+    fn next_token(&mut self) -> Option<PrescanToken> {
+        loop {
+            self.skip_horizontal_whitespace();
+            let ch = self.peek_char()?;
+
+            if ch == '#'
+                && self
+                    .state
+                    .interactive_comments
+                    .is_definitely_on()
+            {
+                self.skip_comment();
+                continue;
+            }
+
+            return match ch {
+                '\n' => {
+                    let start = self.offset;
+                    self.advance_char();
+                    Some(PrescanToken::Separator { start })
+                }
+                ';' | '|' | '&' | '(' | ')' | '{' | '}' => {
+                    let start = self.offset;
+                    self.advance_char();
+                    if matches!(ch, '|' | '&' | ';')
+                        && self.peek_char() == Some(ch)
+                    {
+                        self.advance_char();
+                    }
+                    Some(PrescanToken::Separator { start })
+                }
+                _ => self.read_word().map(|(text, end)| PrescanToken::Word { text, end }),
+            };
+        }
+    }
+
+    fn skip_horizontal_whitespace(&mut self) {
+        while let Some(ch) = self.peek_char() {
+            match ch {
+                ' ' | '\t' => {
+                    self.advance_char();
+                }
+                '\\' if self.second_char() == Some('\n') => {
+                    self.advance_char();
+                    self.advance_char();
+                }
+                _ => break,
+            }
+        }
+    }
+
+    fn skip_comment(&mut self) {
+        while let Some(ch) = self.peek_char() {
+            if ch == '\n' {
+                break;
+            }
+            self.advance_char();
+        }
+    }
+
+    fn read_word(&mut self) -> Option<(String, usize)> {
+        let mut text = String::new();
+
+        while let Some(ch) = self.peek_char() {
+            if is_prescan_separator(ch) {
+                break;
+            }
+
+            match ch {
+                ' ' | '\t' => break,
+                '\\' => {
+                    self.advance_char();
+                    match self.peek_char() {
+                        Some('\n') => {
+                            self.advance_char();
+                        }
+                        Some(next) => {
+                            text.push(next);
+                            self.advance_char();
+                        }
+                        None => text.push('\\'),
+                    }
+                }
+                '\'' => {
+                    self.advance_char();
+                    while let Some(next) = self.peek_char() {
+                        if next == '\'' {
+                            if self.state.rc_quotes.is_definitely_on()
+                                && self.second_char() == Some('\'')
+                            {
+                                text.push('\'');
+                                self.advance_char();
+                                self.advance_char();
+                                continue;
+                            }
+                            self.advance_char();
+                            break;
+                        }
+                        text.push(next);
+                        self.advance_char();
+                    }
+                }
+                '"' => {
+                    self.advance_char();
+                    while let Some(next) = self.peek_char() {
+                        if next == '"' {
+                            self.advance_char();
+                            break;
+                        }
+                        if next == '\\' {
+                            self.advance_char();
+                            if let Some(escaped) = self.peek_char() {
+                                text.push(escaped);
+                                self.advance_char();
+                            }
+                            continue;
+                        }
+                        text.push(next);
+                        self.advance_char();
+                    }
+                }
+                _ => {
+                    text.push(ch);
+                    self.advance_char();
+                }
+            }
+        }
+
+        (!text.is_empty()).then_some((text, self.offset))
+    }
+
+    fn peek_char(&self) -> Option<char> {
+        self.input[self.offset..].chars().next()
+    }
+
+    fn second_char(&self) -> Option<char> {
+        let mut chars = self.input[self.offset..].chars();
+        chars.next()?;
+        chars.next()
+    }
+
+    fn advance_char(&mut self) -> Option<char> {
+        let ch = self.peek_char()?;
+        self.offset += ch.len_utf8();
+        Some(ch)
+    }
+}
+
+fn is_prescan_separator(ch: char) -> bool {
+    matches!(ch, '\n' | ';' | '|' | '&' | '(' | ')' | '{' | '}')
+}
+
+fn apply_prescan_command_effects(words: &[String], state: &mut ZshOptionState) -> bool {
+    let Some((command, args_index)) = normalize_prescan_command(words) else {
+        return false;
+    };
+
+    match command {
+        "setopt" => words[args_index..]
+            .iter()
+            .fold(false, |changed, arg| state.apply_setopt(arg) || changed),
+        "unsetopt" => words[args_index..]
+            .iter()
+            .fold(false, |changed, arg| state.apply_unsetopt(arg) || changed),
+        "set" => apply_prescan_set_builtin(&words[args_index..], state),
+        "emulate" => apply_prescan_emulate(&words[args_index..], state),
+        _ => false,
+    }
+}
+
+fn normalize_prescan_command(words: &[String]) -> Option<(&str, usize)> {
+    let mut index = 0usize;
+
+    while let Some(word) = words.get(index) {
+        if is_prescan_assignment_word(word) {
+            index += 1;
+            continue;
+        }
+        if word == "noglob" {
+            index += 1;
+            continue;
+        }
+        return Some((word.as_str(), index + 1));
+    }
+
+    None
+}
+
+fn is_prescan_assignment_word(word: &str) -> bool {
+    let Some((name, _value)) = word.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && !name.starts_with('-')
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+fn apply_prescan_set_builtin(words: &[String], state: &mut ZshOptionState) -> bool {
+    let mut changed = false;
+    let mut index = 0usize;
+
+    while let Some(word) = words.get(index) {
+        match word.as_str() {
+            "-o" | "+o" => {
+                let enable = word.starts_with('-');
+                if let Some(name) = words.get(index + 1) {
+                    changed = if enable {
+                        state.apply_setopt(name)
+                    } else {
+                        state.apply_unsetopt(name)
+                    } || changed;
+                }
+                index += 2;
+            }
+            _ => {
+                if let Some(name) = word.strip_prefix("-o") {
+                    changed = state.apply_setopt(name) || changed;
+                } else if let Some(name) = word.strip_prefix("+o") {
+                    changed = state.apply_unsetopt(name) || changed;
+                }
+                index += 1;
+            }
+        }
+    }
+
+    changed
+}
+
+fn apply_prescan_emulate(words: &[String], state: &mut ZshOptionState) -> bool {
+    let mut changed = false;
+    let mut mode = None;
+    let mut pending_option: Option<bool> = None;
+    let mut explicit_updates = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(word) = words.get(index) {
+        if let Some(enable) = pending_option.take() {
+            explicit_updates.push((word.clone(), enable));
+            index += 1;
+            continue;
+        }
+
+        match word.as_str() {
+            "-o" | "+o" => {
+                pending_option = Some(word.starts_with('-'));
+                index += 1;
+                continue;
+            }
+            "zsh" | "sh" | "ksh" | "csh" if mode.is_none() => {
+                mode = Some(match word.as_str() {
+                    "zsh" => ZshEmulationMode::Zsh,
+                    "sh" => ZshEmulationMode::Sh,
+                    "ksh" => ZshEmulationMode::Ksh,
+                    "csh" => ZshEmulationMode::Csh,
+                    _ => unreachable!(),
+                });
+                index += 1;
+                continue;
+            }
+            _ if mode.is_none() && word.starts_with('-') => {
+                for flag in word[1..].chars() {
+                    if flag == 'o' {
+                        pending_option = Some(true);
+                    }
+                }
+                index += 1;
+                continue;
+            }
+            _ => {}
+        }
+
+        index += 1;
+    }
+
+    if let Some(mode) = mode {
+        *state = ZshOptionState::for_emulate(mode);
+        changed = true;
+    }
+
+    for (name, enable) in explicit_updates {
+        changed = if enable {
+            state.apply_setopt(&name)
+        } else {
+            state.apply_unsetopt(&name)
+        } || changed;
+    }
+
+    changed
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DialectFeatures {
     double_bracket: bool,
@@ -295,6 +1047,8 @@ pub struct Parser<'a> {
     /// Active brace-body parsing contexts, used to distinguish compact zsh
     /// closers from literal `}` arguments.
     brace_body_stack: Vec<BraceBodyContext>,
+    shell_profile: ShellProfile,
+    zsh_timeline: Option<Arc<ZshOptionTimeline>>,
     dialect: ShellDialect,
     #[cfg(feature = "benchmarking")]
     benchmark_counters: Option<ParserBenchmarkCounters>,
@@ -516,37 +1270,47 @@ const IF_BODY_TERMINATORS: KeywordSet = keyword_set![Elif, Else, Fi];
 impl<'a> Parser<'a> {
     /// Create a new parser for the given input.
     pub fn new(input: &'a str) -> Self {
-        Self::with_limits_and_dialect(
+        Self::with_limits_and_profile(
             input,
             DEFAULT_MAX_AST_DEPTH,
             DEFAULT_MAX_PARSER_OPERATIONS,
-            ShellDialect::Bash,
+            ShellProfile::native(ShellDialect::Bash),
         )
     }
 
     /// Create a new parser for the given input and shell dialect.
     pub fn with_dialect(input: &'a str, dialect: ShellDialect) -> Self {
-        Self::with_limits_and_dialect(
+        Self::with_profile(input, ShellProfile::native(dialect))
+    }
+
+    /// Create a new parser for the given input and full shell profile.
+    pub fn with_profile(input: &'a str, shell_profile: ShellProfile) -> Self {
+        Self::with_limits_and_profile(
             input,
             DEFAULT_MAX_AST_DEPTH,
             DEFAULT_MAX_PARSER_OPERATIONS,
-            dialect,
+            shell_profile,
         )
     }
 
     /// Create a new parser with a custom maximum AST depth.
     pub fn with_max_depth(input: &'a str, max_depth: usize) -> Self {
-        Self::with_limits_and_dialect(
+        Self::with_limits_and_profile(
             input,
             max_depth,
             DEFAULT_MAX_PARSER_OPERATIONS,
-            ShellDialect::Bash,
+            ShellProfile::native(ShellDialect::Bash),
         )
     }
 
     /// Create a new parser with a custom fuel limit.
     pub fn with_fuel(input: &'a str, max_fuel: usize) -> Self {
-        Self::with_limits_and_dialect(input, DEFAULT_MAX_AST_DEPTH, max_fuel, ShellDialect::Bash)
+        Self::with_limits_and_profile(
+            input,
+            DEFAULT_MAX_AST_DEPTH,
+            max_fuel,
+            ShellProfile::native(ShellDialect::Bash),
+        )
     }
 
     /// Create a new parser with custom depth and fuel limits.
@@ -555,7 +1319,12 @@ impl<'a> Parser<'a> {
     /// to prevent stack overflow from misconfiguration. Even if the caller passes
     /// `max_depth = 1_000_000`, the parser will cap it at 500.
     pub fn with_limits(input: &'a str, max_depth: usize, max_fuel: usize) -> Self {
-        Self::with_limits_and_dialect(input, max_depth, max_fuel, ShellDialect::Bash)
+        Self::with_limits_and_profile(
+            input,
+            max_depth,
+            max_fuel,
+            ShellProfile::native(ShellDialect::Bash),
+        )
     }
 
     /// Create a new parser with custom depth, fuel, and dialect settings.
@@ -565,20 +1334,49 @@ impl<'a> Parser<'a> {
         max_fuel: usize,
         dialect: ShellDialect,
     ) -> Self {
-        Self::with_limits_and_dialect_and_benchmarking(input, max_depth, max_fuel, dialect, false)
+        Self::with_limits_and_profile(
+            input,
+            max_depth,
+            max_fuel,
+            ShellProfile::native(dialect),
+        )
     }
 
-    fn with_limits_and_dialect_and_benchmarking(
+    pub fn with_limits_and_profile(
         input: &'a str,
         max_depth: usize,
         max_fuel: usize,
-        dialect: ShellDialect,
+        shell_profile: ShellProfile,
+    ) -> Self {
+        Self::with_limits_and_profile_and_benchmarking(
+            input,
+            max_depth,
+            max_fuel,
+            shell_profile,
+            false,
+        )
+    }
+
+    fn with_limits_and_profile_and_benchmarking(
+        input: &'a str,
+        max_depth: usize,
+        max_fuel: usize,
+        shell_profile: ShellProfile,
         benchmark_counters_enabled: bool,
     ) -> Self {
         #[cfg(not(feature = "benchmarking"))]
         let _ = benchmark_counters_enabled;
 
-        let mut lexer = Lexer::with_max_subst_depth(input, max_depth.min(HARD_MAX_AST_DEPTH));
+        let zsh_timeline = (shell_profile.dialect == ShellDialect::Zsh)
+            .then(|| ZshOptionTimeline::build(input, &shell_profile))
+            .flatten()
+            .map(Arc::new);
+        let mut lexer = Lexer::with_max_subst_depth_and_profile(
+            input,
+            max_depth.min(HARD_MAX_AST_DEPTH),
+            &shell_profile,
+            zsh_timeline.clone(),
+        );
         #[cfg(feature = "benchmarking")]
         if benchmark_counters_enabled {
             lexer.enable_benchmark_counters();
@@ -623,7 +1421,9 @@ impl<'a> Parser<'a> {
             expand_next_word: false,
             brace_group_depth: 0,
             brace_body_stack: Vec::new(),
-            dialect,
+            dialect: shell_profile.dialect,
+            shell_profile,
+            zsh_timeline,
             #[cfg(feature = "benchmarking")]
             benchmark_counters: benchmark_counters_enabled.then(ParserBenchmarkCounters::default),
         }
@@ -631,17 +1431,73 @@ impl<'a> Parser<'a> {
 
     #[cfg(feature = "benchmarking")]
     fn rebuild_with_benchmark_counters(&self) -> Self {
-        Self::with_limits_and_dialect_and_benchmarking(
+        Self::with_limits_and_profile_and_benchmarking(
             self.input,
             self.max_depth,
             self.max_fuel,
-            self.dialect,
+            self.shell_profile.clone(),
             true,
         )
     }
 
     pub fn dialect(&self) -> ShellDialect {
         self.dialect
+    }
+
+    pub fn shell_profile(&self) -> &ShellProfile {
+        &self.shell_profile
+    }
+
+    fn zsh_options_at_offset(&self, offset: usize) -> Option<&ZshOptionState> {
+        self.zsh_timeline
+            .as_ref()
+            .map(|timeline| timeline.options_at(offset))
+            .or_else(|| self.shell_profile.zsh_options())
+    }
+
+    fn current_zsh_options(&self) -> Option<&ZshOptionState> {
+        self.zsh_options_at_offset(self.current_span.start.offset)
+    }
+
+    fn zsh_short_loops_enabled(&self) -> bool {
+        self.dialect.features().zsh_foreach_loop
+            && !self
+                .current_zsh_options()
+                .is_some_and(|options| options.short_loops.is_definitely_off())
+    }
+
+    fn zsh_short_repeat_enabled(&self) -> bool {
+        self.dialect.features().zsh_repeat_loop
+            && !self
+                .current_zsh_options()
+                .is_some_and(|options| options.short_repeat.is_definitely_off())
+    }
+
+    fn zsh_brace_if_enabled(&self) -> bool {
+        self.dialect.features().zsh_brace_if
+            && self.zsh_short_loops_enabled()
+            && !self
+                .current_zsh_options()
+                .is_some_and(|options| options.ignore_braces.is_definitely_on())
+    }
+
+    fn zsh_glob_qualifiers_enabled_at(&self, offset: usize) -> bool {
+        self.dialect.features().zsh_glob_qualifiers
+            && !self
+                .zsh_options_at_offset(offset)
+                .is_some_and(|options| {
+                    options.ignore_braces.is_definitely_on()
+                        || options.bare_glob_qual.is_definitely_off()
+                })
+    }
+
+    fn brace_syntax_enabled_at(&self, offset: usize) -> bool {
+        !self
+            .zsh_options_at_offset(offset)
+            .is_some_and(|options| {
+                options.ignore_braces.is_definitely_on()
+                    || options.ignore_close_braces.is_definitely_on()
+            })
     }
 
     /// Get the current token's span.
@@ -680,8 +1536,8 @@ impl<'a> Parser<'a> {
         max_fuel: usize,
         dialect: ShellDialect,
     ) -> Word {
-        let mut parser = Parser::with_limits(input, max_depth, max_fuel);
-        parser.dialect = dialect;
+        let mut parser =
+            Parser::with_limits_and_profile(input, max_depth, max_fuel, ShellProfile::native(dialect));
         let start = Position::new();
         parser.parse_word_with_context(
             input,
@@ -712,7 +1568,7 @@ impl<'a> Parser<'a> {
     }
 
     fn word_with_parts(&self, parts: Vec<WordPartNode>, span: Span) -> Word {
-        let brace_syntax = self.brace_syntax_from_parts(&parts);
+        let brace_syntax = self.brace_syntax_from_parts(&parts, span.start.offset);
         Word {
             parts,
             span,
@@ -720,7 +1576,10 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn brace_syntax_from_parts(&self, parts: &[WordPartNode]) -> Vec<BraceSyntax> {
+    fn brace_syntax_from_parts(&self, parts: &[WordPartNode], offset: usize) -> Vec<BraceSyntax> {
+        if !self.brace_syntax_enabled_at(offset) {
+            return Vec::new();
+        }
         let mut brace_syntax = Vec::new();
         self.collect_brace_syntax_from_parts(parts, BraceQuoteContext::Unquoted, &mut brace_syntax);
         brace_syntax
@@ -982,7 +1841,7 @@ impl<'a> Parser<'a> {
         span: Span,
         source_backed: bool,
     ) -> Option<Word> {
-        if !self.dialect.features().zsh_glob_qualifiers
+        if !self.zsh_glob_qualifiers_enabled_at(span.start.offset)
             || text.is_empty()
             || text.contains('=')
             || text.contains(['\x00', '\\', '\'', '"', '$', '`'])
@@ -1368,7 +2227,7 @@ impl<'a> Parser<'a> {
         let word = token.word()?;
         let source_backed = !token.flags.is_synthetic();
 
-        if self.dialect.features().zsh_glob_qualifiers
+        if self.zsh_glob_qualifiers_enabled_at(span.start.offset)
             && let Some(segment) = word.single_segment()
             && segment.kind() == LexedWordSegmentKind::Plain
             && let Some(word) = self.maybe_parse_zsh_qualified_glob_word(
@@ -1728,7 +2587,7 @@ impl<'a> Parser<'a> {
             return None;
         }
         let span = Span::from_positions(start, end);
-        if self.dialect.features().zsh_glob_qualifiers
+        if self.zsh_glob_qualifiers_enabled_at(span.start.offset)
             && let Some(word) = self.maybe_parse_zsh_qualified_glob_word(&text, span, true)
         {
             return Some(word);
@@ -1916,8 +2775,13 @@ impl<'a> Parser<'a> {
 
     fn nested_stmt_seq_from_source(&mut self, source: &str, base: Position) -> StmtSeq {
         let remaining_depth = self.max_depth.saturating_sub(self.current_depth);
+        let nested_profile = self
+            .current_zsh_options()
+            .cloned()
+            .map(|options| ShellProfile::with_zsh_options(self.dialect, options))
+            .unwrap_or_else(|| self.shell_profile.clone());
         let inner_parser =
-            Parser::with_limits_and_dialect(source, remaining_depth, self.fuel, self.dialect);
+            Parser::with_limits_and_profile(source, remaining_depth, self.fuel, nested_profile);
         match inner_parser.parse() {
             Ok(mut output) => {
                 Self::rebase_file(&mut output.file, base);
@@ -3176,11 +4040,30 @@ impl<'a> Parser<'a> {
             index = next_index;
         }
 
-        if text[index..].starts_with('#') {
-            let prefix_start = base.advanced_by(&text[..index]);
-            let prefix_end = prefix_start.advanced_by("#");
-            length_prefix = Some(Span::from_positions(prefix_start, prefix_end));
-            index += '#'.len_utf8();
+        while index < text.len() {
+            let Some(flag) = text[index..].chars().next() else {
+                break;
+            };
+            match flag {
+                '=' | '~' | '^' => {
+                    let modifier_start = base.advanced_by(&text[..index]);
+                    let modifier_end = modifier_start.advanced_by(&text[index..index + flag.len_utf8()]);
+                    modifiers.push(ZshModifier {
+                        name: flag,
+                        argument: None,
+                        argument_delimiter: None,
+                        span: Span::from_positions(modifier_start, modifier_end),
+                    });
+                    index += flag.len_utf8();
+                }
+                '#' if length_prefix.is_none() => {
+                    let prefix_start = base.advanced_by(&text[..index]);
+                    let prefix_end = prefix_start.advanced_by("#");
+                    length_prefix = Some(Span::from_positions(prefix_start, prefix_end));
+                    index += '#'.len_utf8();
+                }
+                _ => break,
+            }
         }
 
         let (target, operation_index) = if text[index..].starts_with("${") {
@@ -3205,7 +4088,7 @@ impl<'a> Parser<'a> {
                 let leading = raw_target
                     .len()
                     .saturating_sub(raw_target.trim_start().len());
-                let target_base = base.advanced_by(&raw_target[..leading]);
+                let target_base = base.advanced_by(&text[..index + leading]);
                 self.parse_zsh_target_from_text(
                     trimmed,
                     target_base,
@@ -3303,6 +4186,7 @@ impl<'a> Parser<'a> {
             })
         } else if raw_body_text.starts_with('(')
             || raw_body_text.starts_with(':')
+            || raw_body_text.starts_with('=')
             || raw_body_text.starts_with('^')
             || raw_body_text.starts_with('~')
             || raw_body_text.starts_with('.')
@@ -3987,7 +4871,7 @@ impl<'a> Parser<'a> {
 
     fn ensure_repeat_loop(&self) -> Result<()> {
         self.ensure_feature(
-            self.dialect.features().zsh_repeat_loop,
+            self.zsh_short_repeat_enabled(),
             "repeat loops",
             "are not available in this shell mode",
         )
@@ -3995,7 +4879,7 @@ impl<'a> Parser<'a> {
 
     fn ensure_foreach_loop(&self) -> Result<()> {
         self.ensure_feature(
-            self.dialect.features().zsh_foreach_loop,
+            self.zsh_short_loops_enabled(),
             "foreach loops",
             "are not available in this shell mode",
         )

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -610,6 +610,71 @@ enum PrescanSeparator {
 struct PrescanLocalScope {
     saved_state: ZshOptionState,
     brace_depth: usize,
+    paren_depth: usize,
+    compounds: Vec<PrescanCompound>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrescanCompound {
+    If,
+    Loop,
+    Case,
+}
+
+impl PrescanLocalScope {
+    fn simple(saved_state: ZshOptionState) -> Self {
+        Self {
+            saved_state,
+            brace_depth: 0,
+            paren_depth: 0,
+            compounds: Vec::new(),
+        }
+    }
+
+    fn brace_group(saved_state: ZshOptionState) -> Self {
+        Self {
+            brace_depth: 1,
+            ..Self::simple(saved_state)
+        }
+    }
+
+    fn subshell(saved_state: ZshOptionState) -> Self {
+        Self {
+            paren_depth: 1,
+            ..Self::simple(saved_state)
+        }
+    }
+
+    fn update_for_command(&mut self, words: &[String]) {
+        let Some(command) = words.first().map(String::as_str) else {
+            return;
+        };
+
+        match command {
+            "if" => self.compounds.push(PrescanCompound::If),
+            "case" => self.compounds.push(PrescanCompound::Case),
+            "for" | "select" | "while" | "until" => {
+                self.compounds.push(PrescanCompound::Loop);
+            }
+            "repeat" if words.iter().any(|word| word == "do") => {
+                self.compounds.push(PrescanCompound::Loop);
+            }
+            "fi" => self.pop_compound(PrescanCompound::If),
+            "done" => self.pop_compound(PrescanCompound::Loop),
+            "esac" => self.pop_compound(PrescanCompound::Case),
+            _ => {}
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.brace_depth == 0 && self.paren_depth == 0 && self.compounds.is_empty()
+    }
+
+    fn pop_compound(&mut self, compound: PrescanCompound) {
+        if self.compounds.last().copied() == Some(compound) {
+            self.compounds.pop();
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -642,6 +707,10 @@ impl<'a> ZshOptionPrescanner<'a> {
         while let Some(token) = self.next_token() {
             match token {
                 PrescanToken::Word { text, end } => {
+                    if is_prescan_function_body_start(function_header) {
+                        local_scopes.push(PrescanLocalScope::simple(self.state.clone()));
+                        function_header = PrescanFunctionHeaderState::None;
+                    }
                     command_end = end;
                     function_header = match function_header {
                         PrescanFunctionHeaderState::None => {
@@ -660,6 +729,15 @@ impl<'a> ZshOptionPrescanner<'a> {
                 }
                 PrescanToken::Separator { kind, start, end } => {
                     self.finish_command(&words, command_end.max(start));
+                    if let Some(scope) = local_scopes.last_mut() {
+                        scope.update_for_command(&words);
+                    }
+                    if matches!(
+                        kind,
+                        PrescanSeparator::Newline | PrescanSeparator::Semicolon
+                    ) {
+                        self.restore_completed_local_scopes(&mut local_scopes, end);
+                    }
                     words.clear();
                     command_end = end;
 
@@ -679,15 +757,23 @@ impl<'a> ZshOptionPrescanner<'a> {
                             function_header = PrescanFunctionHeaderState::None;
                         }
                         PrescanSeparator::OpenParen => {
-                            function_header = match function_header {
-                                PrescanFunctionHeaderState::AfterWord => {
-                                    PrescanFunctionHeaderState::AfterWordOpenParen
+                            if is_prescan_function_body_start(function_header) {
+                                local_scopes.push(PrescanLocalScope::subshell(self.state.clone()));
+                                function_header = PrescanFunctionHeaderState::None;
+                            } else {
+                                function_header = match function_header {
+                                    PrescanFunctionHeaderState::AfterWord => {
+                                        PrescanFunctionHeaderState::AfterWordOpenParen
+                                    }
+                                    PrescanFunctionHeaderState::AfterFunctionName => {
+                                        PrescanFunctionHeaderState::AfterFunctionNameOpenParen
+                                    }
+                                    _ => PrescanFunctionHeaderState::None,
+                                };
+                                if let Some(scope) = local_scopes.last_mut() {
+                                    scope.paren_depth += 1;
                                 }
-                                PrescanFunctionHeaderState::AfterFunctionName => {
-                                    PrescanFunctionHeaderState::AfterFunctionNameOpenParen
-                                }
-                                _ => PrescanFunctionHeaderState::None,
-                            };
+                            }
                         }
                         PrescanSeparator::CloseParen => {
                             function_header = match function_header {
@@ -697,38 +783,29 @@ impl<'a> ZshOptionPrescanner<'a> {
                                 }
                                 _ => PrescanFunctionHeaderState::None,
                             };
+                            if let Some(scope) = local_scopes.last_mut()
+                                && scope.paren_depth > 0
+                            {
+                                scope.paren_depth -= 1;
+                            }
+                            self.restore_completed_local_scopes(&mut local_scopes, end);
                         }
                         PrescanSeparator::OpenBrace => {
-                            if matches!(
-                                function_header,
-                                PrescanFunctionHeaderState::AfterFunctionName
-                                    | PrescanFunctionHeaderState::ReadyForBrace
-                            ) {
-                                local_scopes.push(PrescanLocalScope {
-                                    saved_state: self.state.clone(),
-                                    brace_depth: 1,
-                                });
+                            if is_prescan_function_body_start(function_header) {
+                                local_scopes
+                                    .push(PrescanLocalScope::brace_group(self.state.clone()));
                             } else if let Some(scope) = local_scopes.last_mut() {
                                 scope.brace_depth += 1;
                             }
                             function_header = PrescanFunctionHeaderState::None;
                         }
                         PrescanSeparator::CloseBrace => {
-                            if let Some(scope) = local_scopes.last_mut() {
+                            if let Some(scope) = local_scopes.last_mut()
+                                && scope.brace_depth > 0
+                            {
                                 scope.brace_depth -= 1;
-                                if scope.brace_depth == 0 {
-                                    let scope = local_scopes.pop().expect("scope just matched");
-                                    if self.state != scope.saved_state {
-                                        self.state = scope.saved_state.clone();
-                                        self.entries.push(ZshOptionTimelineEntry {
-                                            offset: end,
-                                            state: scope.saved_state,
-                                        });
-                                    } else {
-                                        self.state = scope.saved_state;
-                                    }
-                                }
                             }
+                            self.restore_completed_local_scopes(&mut local_scopes, end);
                             function_header = PrescanFunctionHeaderState::None;
                         }
                     }
@@ -737,6 +814,10 @@ impl<'a> ZshOptionPrescanner<'a> {
         }
 
         self.finish_command(&words, command_end.max(self.input.len()));
+        if let Some(scope) = local_scopes.last_mut() {
+            scope.update_for_command(&words);
+        }
+        self.restore_completed_local_scopes(&mut local_scopes, self.input.len());
         self.entries
     }
 
@@ -912,10 +993,39 @@ impl<'a> ZshOptionPrescanner<'a> {
         self.offset += ch.len_utf8();
         Some(ch)
     }
+
+    fn restore_completed_local_scopes(
+        &mut self,
+        local_scopes: &mut Vec<PrescanLocalScope>,
+        offset: usize,
+    ) {
+        while local_scopes
+            .last()
+            .is_some_and(PrescanLocalScope::is_complete)
+        {
+            let scope = local_scopes.pop().expect("scope just matched");
+            if self.state != scope.saved_state {
+                self.state = scope.saved_state.clone();
+                self.entries.push(ZshOptionTimelineEntry {
+                    offset,
+                    state: scope.saved_state,
+                });
+            } else {
+                self.state = scope.saved_state;
+            }
+        }
+    }
 }
 
 fn is_prescan_separator(ch: char) -> bool {
     matches!(ch, '\n' | ';' | '|' | '&' | '(' | ')' | '{' | '}')
+}
+
+fn is_prescan_function_body_start(state: PrescanFunctionHeaderState) -> bool {
+    matches!(
+        state,
+        PrescanFunctionHeaderState::AfterFunctionName | PrescanFunctionHeaderState::ReadyForBrace
+    )
 }
 
 fn apply_prescan_command_effects(words: &[String], state: &mut ZshOptionState) -> bool {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -761,7 +761,7 @@ impl<'a> ZshOptionPrescanner<'a> {
                                 local_scopes.push(PrescanLocalScope::subshell(self.state.clone()));
                                 function_header = PrescanFunctionHeaderState::None;
                             } else {
-                                function_header = match function_header {
+                                let next_header = match function_header {
                                     PrescanFunctionHeaderState::AfterWord => {
                                         PrescanFunctionHeaderState::AfterWordOpenParen
                                     }
@@ -770,25 +770,36 @@ impl<'a> ZshOptionPrescanner<'a> {
                                     }
                                     _ => PrescanFunctionHeaderState::None,
                                 };
-                                if let Some(scope) = local_scopes.last_mut() {
-                                    scope.paren_depth += 1;
+                                if !matches!(
+                                    next_header,
+                                    PrescanFunctionHeaderState::AfterWordOpenParen
+                                        | PrescanFunctionHeaderState::AfterFunctionNameOpenParen
+                                ) {
+                                    local_scopes
+                                        .push(PrescanLocalScope::subshell(self.state.clone()));
                                 }
+                                function_header = next_header;
                             }
                         }
                         PrescanSeparator::CloseParen => {
-                            function_header = match function_header {
+                            let closes_function_header = matches!(
+                                function_header,
                                 PrescanFunctionHeaderState::AfterWordOpenParen
-                                | PrescanFunctionHeaderState::AfterFunctionNameOpenParen => {
-                                    PrescanFunctionHeaderState::ReadyForBrace
-                                }
-                                _ => PrescanFunctionHeaderState::None,
+                                    | PrescanFunctionHeaderState::AfterFunctionNameOpenParen
+                            );
+                            function_header = if closes_function_header {
+                                PrescanFunctionHeaderState::ReadyForBrace
+                            } else {
+                                PrescanFunctionHeaderState::None
                             };
-                            if let Some(scope) = local_scopes.last_mut()
-                                && scope.paren_depth > 0
-                            {
-                                scope.paren_depth -= 1;
+                            if !closes_function_header {
+                                if let Some(scope) = local_scopes.last_mut()
+                                    && scope.paren_depth > 0
+                                {
+                                    scope.paren_depth -= 1;
+                                }
+                                self.restore_completed_local_scopes(&mut local_scopes, end);
                             }
-                            self.restore_completed_local_scopes(&mut local_scopes, end);
                         }
                         PrescanSeparator::OpenBrace => {
                             if is_prescan_function_body_start(function_header) {
@@ -1059,7 +1070,11 @@ fn normalize_prescan_command(words: &[String]) -> Option<(&str, usize)> {
                 index += 1;
                 continue;
             }
-            "command" | "builtin" => {
+            "command" => {
+                index = skip_prescan_command_wrapper_options(words, index + 1)?;
+                continue;
+            }
+            "builtin" => {
                 index = skip_prescan_wrapper_options(words, index + 1);
                 continue;
             }
@@ -1073,6 +1088,27 @@ fn normalize_prescan_command(words: &[String]) -> Option<(&str, usize)> {
     }
 
     None
+}
+
+fn skip_prescan_command_wrapper_options(words: &[String], mut index: usize) -> Option<usize> {
+    while let Some(word) = words.get(index) {
+        if word == "--" {
+            index += 1;
+            break;
+        }
+        if word.starts_with('-') && word != "-" {
+            if word
+                .strip_prefix('-')
+                .is_some_and(|flags| flags.chars().any(|flag| matches!(flag, 'v' | 'V')))
+            {
+                return None;
+            }
+            index += 1;
+            continue;
+        }
+        break;
+    }
+    Some(index)
 }
 
 fn skip_prescan_wrapper_options(words: &[String], mut index: usize) -> usize {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -944,14 +944,59 @@ fn normalize_prescan_command(words: &[String]) -> Option<(&str, usize)> {
             index += 1;
             continue;
         }
-        if word == "noglob" {
-            index += 1;
-            continue;
+        match word.as_str() {
+            "noglob" => {
+                index += 1;
+                continue;
+            }
+            "command" | "builtin" => {
+                index = skip_prescan_wrapper_options(words, index + 1);
+                continue;
+            }
+            "exec" => {
+                index = skip_prescan_exec_wrapper_options(words, index + 1);
+                continue;
+            }
+            _ => {}
         }
         return Some((word.as_str(), index + 1));
     }
 
     None
+}
+
+fn skip_prescan_wrapper_options(words: &[String], mut index: usize) -> usize {
+    while let Some(word) = words.get(index) {
+        if word == "--" {
+            index += 1;
+            break;
+        }
+        if word.starts_with('-') && word != "-" {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+    index
+}
+
+fn skip_prescan_exec_wrapper_options(words: &[String], mut index: usize) -> usize {
+    while let Some(word) = words.get(index) {
+        if word == "--" {
+            index += 1;
+            break;
+        }
+        if word == "-a" {
+            index = (index + 2).min(words.len());
+            continue;
+        }
+        if word.starts_with('-') && word != "-" {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+    index
 }
 
 fn is_prescan_assignment_word(word: &str) -> bool {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -407,7 +407,14 @@ impl ZshOptionState {
         let Some((field, value)) = parse_zsh_option_assignment(name, enable) else {
             return false;
         };
-        self.set_field(field, if value { OptionValue::On } else { OptionValue::Off });
+        self.set_field(
+            field,
+            if value {
+                OptionValue::On
+            } else {
+                OptionValue::Off
+            },
+        );
         true
     }
 }
@@ -576,8 +583,44 @@ struct ZshOptionPrescanner<'a> {
 
 #[derive(Debug, Clone)]
 enum PrescanToken {
-    Word { text: String, end: usize },
-    Separator { start: usize },
+    Word {
+        text: String,
+        end: usize,
+    },
+    Separator {
+        kind: PrescanSeparator,
+        start: usize,
+        end: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrescanSeparator {
+    Newline,
+    Semicolon,
+    Pipe,
+    Ampersand,
+    OpenParen,
+    CloseParen,
+    OpenBrace,
+    CloseBrace,
+}
+
+#[derive(Debug, Clone)]
+struct PrescanLocalScope {
+    saved_state: ZshOptionState,
+    brace_depth: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrescanFunctionHeaderState {
+    None,
+    AfterWord,
+    AfterFunctionKeyword,
+    AfterFunctionName,
+    AfterWordOpenParen,
+    AfterFunctionNameOpenParen,
+    ReadyForBrace,
 }
 
 impl<'a> ZshOptionPrescanner<'a> {
@@ -593,17 +636,102 @@ impl<'a> ZshOptionPrescanner<'a> {
     fn scan(mut self) -> Vec<ZshOptionTimelineEntry> {
         let mut words = Vec::new();
         let mut command_end = 0usize;
+        let mut local_scopes = Vec::new();
+        let mut function_header = PrescanFunctionHeaderState::None;
 
         while let Some(token) = self.next_token() {
             match token {
                 PrescanToken::Word { text, end } => {
                     command_end = end;
+                    function_header = match function_header {
+                        PrescanFunctionHeaderState::None => {
+                            if text == "function" {
+                                PrescanFunctionHeaderState::AfterFunctionKeyword
+                            } else {
+                                PrescanFunctionHeaderState::AfterWord
+                            }
+                        }
+                        PrescanFunctionHeaderState::AfterFunctionKeyword => {
+                            PrescanFunctionHeaderState::AfterFunctionName
+                        }
+                        _ => PrescanFunctionHeaderState::None,
+                    };
                     words.push(text);
                 }
-                PrescanToken::Separator { start } => {
+                PrescanToken::Separator { kind, start, end } => {
                     self.finish_command(&words, command_end.max(start));
                     words.clear();
-                    command_end = start;
+                    command_end = end;
+
+                    match kind {
+                        PrescanSeparator::Newline => {
+                            if !matches!(
+                                function_header,
+                                PrescanFunctionHeaderState::AfterFunctionName
+                                    | PrescanFunctionHeaderState::ReadyForBrace
+                            ) {
+                                function_header = PrescanFunctionHeaderState::None;
+                            }
+                        }
+                        PrescanSeparator::Semicolon
+                        | PrescanSeparator::Pipe
+                        | PrescanSeparator::Ampersand => {
+                            function_header = PrescanFunctionHeaderState::None;
+                        }
+                        PrescanSeparator::OpenParen => {
+                            function_header = match function_header {
+                                PrescanFunctionHeaderState::AfterWord => {
+                                    PrescanFunctionHeaderState::AfterWordOpenParen
+                                }
+                                PrescanFunctionHeaderState::AfterFunctionName => {
+                                    PrescanFunctionHeaderState::AfterFunctionNameOpenParen
+                                }
+                                _ => PrescanFunctionHeaderState::None,
+                            };
+                        }
+                        PrescanSeparator::CloseParen => {
+                            function_header = match function_header {
+                                PrescanFunctionHeaderState::AfterWordOpenParen
+                                | PrescanFunctionHeaderState::AfterFunctionNameOpenParen => {
+                                    PrescanFunctionHeaderState::ReadyForBrace
+                                }
+                                _ => PrescanFunctionHeaderState::None,
+                            };
+                        }
+                        PrescanSeparator::OpenBrace => {
+                            if matches!(
+                                function_header,
+                                PrescanFunctionHeaderState::AfterFunctionName
+                                    | PrescanFunctionHeaderState::ReadyForBrace
+                            ) {
+                                local_scopes.push(PrescanLocalScope {
+                                    saved_state: self.state.clone(),
+                                    brace_depth: 1,
+                                });
+                            } else if let Some(scope) = local_scopes.last_mut() {
+                                scope.brace_depth += 1;
+                            }
+                            function_header = PrescanFunctionHeaderState::None;
+                        }
+                        PrescanSeparator::CloseBrace => {
+                            if let Some(scope) = local_scopes.last_mut() {
+                                scope.brace_depth -= 1;
+                                if scope.brace_depth == 0 {
+                                    let scope = local_scopes.pop().expect("scope just matched");
+                                    if self.state != scope.saved_state {
+                                        self.state = scope.saved_state.clone();
+                                        self.entries.push(ZshOptionTimelineEntry {
+                                            offset: end,
+                                            state: scope.saved_state,
+                                        });
+                                    } else {
+                                        self.state = scope.saved_state;
+                                    }
+                                }
+                            }
+                            function_header = PrescanFunctionHeaderState::None;
+                        }
+                    }
                 }
             }
         }
@@ -630,12 +758,7 @@ impl<'a> ZshOptionPrescanner<'a> {
             self.skip_horizontal_whitespace();
             let ch = self.peek_char()?;
 
-            if ch == '#'
-                && self
-                    .state
-                    .interactive_comments
-                    .is_definitely_on()
-            {
+            if ch == '#' && self.state.interactive_comments.is_definitely_on() {
                 self.skip_comment();
                 continue;
             }
@@ -644,19 +767,37 @@ impl<'a> ZshOptionPrescanner<'a> {
                 '\n' => {
                     let start = self.offset;
                     self.advance_char();
-                    Some(PrescanToken::Separator { start })
+                    Some(PrescanToken::Separator {
+                        kind: PrescanSeparator::Newline,
+                        start,
+                        end: self.offset,
+                    })
                 }
                 ';' | '|' | '&' | '(' | ')' | '{' | '}' => {
                     let start = self.offset;
                     self.advance_char();
-                    if matches!(ch, '|' | '&' | ';')
-                        && self.peek_char() == Some(ch)
-                    {
+                    if matches!(ch, '|' | '&' | ';') && self.peek_char() == Some(ch) {
                         self.advance_char();
                     }
-                    Some(PrescanToken::Separator { start })
+                    let kind = match ch {
+                        ';' => PrescanSeparator::Semicolon,
+                        '|' => PrescanSeparator::Pipe,
+                        '&' => PrescanSeparator::Ampersand,
+                        '(' => PrescanSeparator::OpenParen,
+                        ')' => PrescanSeparator::CloseParen,
+                        '{' => PrescanSeparator::OpenBrace,
+                        '}' => PrescanSeparator::CloseBrace,
+                        _ => unreachable!(),
+                    };
+                    Some(PrescanToken::Separator {
+                        kind,
+                        start,
+                        end: self.offset,
+                    })
                 }
-                _ => self.read_word().map(|(text, end)| PrescanToken::Word { text, end }),
+                _ => self
+                    .read_word()
+                    .map(|(text, end)| PrescanToken::Word { text, end }),
             };
         }
     }
@@ -1334,12 +1475,7 @@ impl<'a> Parser<'a> {
         max_fuel: usize,
         dialect: ShellDialect,
     ) -> Self {
-        Self::with_limits_and_profile(
-            input,
-            max_depth,
-            max_fuel,
-            ShellProfile::native(dialect),
-        )
+        Self::with_limits_and_profile(input, max_depth, max_fuel, ShellProfile::native(dialect))
     }
 
     pub fn with_limits_and_profile(
@@ -1483,21 +1619,17 @@ impl<'a> Parser<'a> {
 
     fn zsh_glob_qualifiers_enabled_at(&self, offset: usize) -> bool {
         self.dialect.features().zsh_glob_qualifiers
-            && !self
-                .zsh_options_at_offset(offset)
-                .is_some_and(|options| {
-                    options.ignore_braces.is_definitely_on()
-                        || options.bare_glob_qual.is_definitely_off()
-                })
+            && !self.zsh_options_at_offset(offset).is_some_and(|options| {
+                options.ignore_braces.is_definitely_on()
+                    || options.bare_glob_qual.is_definitely_off()
+            })
     }
 
     fn brace_syntax_enabled_at(&self, offset: usize) -> bool {
-        !self
-            .zsh_options_at_offset(offset)
-            .is_some_and(|options| {
-                options.ignore_braces.is_definitely_on()
-                    || options.ignore_close_braces.is_definitely_on()
-            })
+        !self.zsh_options_at_offset(offset).is_some_and(|options| {
+            options.ignore_braces.is_definitely_on()
+                || options.ignore_close_braces.is_definitely_on()
+        })
     }
 
     /// Get the current token's span.
@@ -1536,8 +1668,12 @@ impl<'a> Parser<'a> {
         max_fuel: usize,
         dialect: ShellDialect,
     ) -> Word {
-        let mut parser =
-            Parser::with_limits_and_profile(input, max_depth, max_fuel, ShellProfile::native(dialect));
+        let mut parser = Parser::with_limits_and_profile(
+            input,
+            max_depth,
+            max_fuel,
+            ShellProfile::native(dialect),
+        );
         let start = Position::new();
         parser.parse_word_with_context(
             input,
@@ -4047,7 +4183,8 @@ impl<'a> Parser<'a> {
             match flag {
                 '=' | '~' | '^' => {
                     let modifier_start = base.advanced_by(&text[..index]);
-                    let modifier_end = modifier_start.advanced_by(&text[index..index + flag.len_utf8()]);
+                    let modifier_end =
+                        modifier_start.advanced_by(&text[index..index + flag.len_utf8()]);
                     modifiers.push(ZshModifier {
                         name: flag,
                         argument: None,

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3181,6 +3181,18 @@ repeat 2 echo global
 }
 
 #[test]
+fn test_parse_zsh_wrapped_unsetopt_short_repeat_demotes_repeat_to_simple_command() {
+    let source = "command unsetopt short_repeat\nrepeat 2 echo hi\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let command = expect_simple(&output.body[1]);
+    assert_eq!(command.name.render(source), "repeat");
+}
+
+#[test]
 fn test_parse_zsh_midfile_unsetopt_short_loops_rejects_foreach_loop() {
     Parser::with_dialect("foreach x (a b c) { echo $x; }\n", ShellDialect::Zsh)
         .parse()

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3193,6 +3193,42 @@ fn test_parse_zsh_wrapped_unsetopt_short_repeat_demotes_repeat_to_simple_command
 }
 
 #[test]
+fn test_parse_zsh_plain_subshell_does_not_leak_short_repeat_prescan() {
+    let source = "( unsetopt short_repeat )\nrepeat 2 echo global\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&output.body[0]);
+    assert!(matches!(compound, AstCompoundCommand::Subshell(_)));
+
+    let (compound, _) = expect_compound(&output.body[1]);
+    let AstCompoundCommand::Repeat(command) = compound else {
+        panic!("expected top-level repeat command");
+    };
+    assert_eq!(command.count.render(source), "2");
+}
+
+#[test]
+fn test_parse_zsh_command_v_does_not_fake_short_repeat_effects() {
+    let source = "command -v unsetopt short_repeat\nrepeat 2 echo global\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let command = expect_simple(&output.body[0]);
+    assert_eq!(command.name.render(source), "command");
+
+    let (compound, _) = expect_compound(&output.body[1]);
+    let AstCompoundCommand::Repeat(repeat) = compound else {
+        panic!("expected top-level repeat command");
+    };
+    assert_eq!(repeat.count.render(source), "2");
+}
+
+#[test]
 fn test_parse_zsh_function_subshell_body_does_not_leak_short_repeat_prescan() {
     let source = "f() ( unsetopt short_repeat )\nrepeat 2 echo global\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3193,6 +3193,44 @@ fn test_parse_zsh_wrapped_unsetopt_short_repeat_demotes_repeat_to_simple_command
 }
 
 #[test]
+fn test_parse_zsh_function_subshell_body_does_not_leak_short_repeat_prescan() {
+    let source = "f() ( unsetopt short_repeat )\nrepeat 2 echo global\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let function = expect_function(&output.body[0]);
+    let (compound, _) = expect_compound(function.body.as_ref());
+    assert!(matches!(compound, AstCompoundCommand::Subshell(_)));
+
+    let (compound, _) = expect_compound(&output.body[1]);
+    let AstCompoundCommand::Repeat(command) = compound else {
+        panic!("expected top-level repeat command");
+    };
+    assert_eq!(command.count.render(source), "2");
+}
+
+#[test]
+fn test_parse_zsh_function_if_body_does_not_leak_short_repeat_prescan() {
+    let source = "f() if true; then unsetopt short_repeat; fi\nrepeat 2 echo global\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let function = expect_function(&output.body[0]);
+    let (compound, _) = expect_compound(function.body.as_ref());
+    assert!(matches!(compound, AstCompoundCommand::If(_)));
+
+    let (compound, _) = expect_compound(&output.body[1]);
+    let AstCompoundCommand::Repeat(command) = compound else {
+        panic!("expected top-level repeat command");
+    };
+    assert_eq!(command.count.render(source), "2");
+}
+
+#[test]
 fn test_parse_zsh_midfile_unsetopt_short_loops_rejects_foreach_loop() {
     Parser::with_dialect("foreach x (a b c) { echo $x; }\n", ShellDialect::Zsh)
         .parse()

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3151,6 +3151,36 @@ fn test_parse_zsh_midfile_unsetopt_short_repeat_demotes_repeat_to_simple_command
 }
 
 #[test]
+fn test_parse_zsh_function_local_unsetopt_short_repeat_does_not_leak_to_top_level() {
+    let source = "\
+fn() {
+  unsetopt short_repeat
+  repeat 2 echo local
+}
+repeat 2 echo global
+";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let function = expect_function(&output.body[0]);
+    let (compound, _) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    let local_repeat = expect_simple(&body[1]);
+    assert_eq!(local_repeat.name.render(source), "repeat");
+
+    let (compound, _) = expect_compound(&output.body[1]);
+    let AstCompoundCommand::Repeat(command) = compound else {
+        panic!("expected top-level repeat command");
+    };
+    assert_eq!(command.count.render(source), "2");
+    assert_eq!(command.body.len(), 1);
+}
+
+#[test]
 fn test_parse_zsh_midfile_unsetopt_short_loops_rejects_foreach_loop() {
     Parser::with_dialect("foreach x (a b c) { echo $x; }\n", ShellDialect::Zsh)
         .parse()

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3138,3 +3138,60 @@ fn test_brace_group_command_can_use_right_brace_as_literal_argument() {
     assert_eq!(command.args.len(), 1);
     assert_eq!(command.args[0].render(source), "}");
 }
+
+#[test]
+fn test_parse_zsh_midfile_unsetopt_short_repeat_demotes_repeat_to_simple_command() {
+    let source = "unsetopt short_repeat\nrepeat 2 echo hi\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[1]);
+
+    assert_eq!(command.name.render(source), "repeat");
+}
+
+#[test]
+fn test_parse_zsh_midfile_unsetopt_short_loops_rejects_foreach_loop() {
+    Parser::with_dialect("foreach x (a b c) { echo $x; }\n", ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let source = "unsetopt short_loops\nforeach x (a b c) { echo $x; }\n";
+    let error = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::Parse { message, .. } if message.contains("foreach loops")
+    ));
+}
+
+#[test]
+fn test_parse_zsh_midfile_setopt_ignore_braces_treats_braces_as_words() {
+    let source = "setopt ignore_braces\n{ echo hi }\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let command = expect_simple(&output.file.body[1]);
+    assert_eq!(command.name.render(source), "{");
+    assert_eq!(
+        command
+            .args
+            .iter()
+            .map(|word| word.render(source))
+            .collect::<Vec<_>>(),
+        vec!["echo", "hi", "}"]
+    );
+}
+
+#[test]
+fn test_parse_zsh_midfile_setopt_ignore_braces_disables_brace_syntax_collection() {
+    let source = "setopt ignore_braces\nprint {a,b}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let command = expect_simple(&output.file.body[1]);
+    assert!(command.args[0].brace_syntax.is_empty());
+}

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3718,10 +3718,18 @@ fn test_zsh_parameter_word_target_preserves_non_reference_target_text() {
     let ParameterExpansionSyntax::Zsh(parameter) = &parameter.syntax else {
         panic!("expected zsh parameter syntax");
     };
+    assert_eq!(
+        parameter
+            .modifiers
+            .iter()
+            .map(|modifier| modifier.name)
+            .collect::<Vec<_>>(),
+        vec!['^']
+    );
     let ZshExpansionTarget::Word(word) = &parameter.target else {
         panic!("expected word target");
     };
-    assert_eq!(word.render(source), "^$(pidof zsh)");
+    assert_eq!(word.render(source), "$(pidof zsh)");
     assert!(matches!(
         parameter.operation,
         Some(ZshExpansionOperation::PatternOperation {
@@ -3729,6 +3737,82 @@ fn test_zsh_parameter_word_target_preserves_non_reference_target_text() {
             ref operand,
         }) if operand.slice(source) == "$$"
     ));
+}
+
+#[test]
+fn test_zsh_parameter_bare_prefix_flags_record_modifier_sequence() {
+    let source = "print ${=name} ${~foo} ${^^bar} ${~~baz}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let split = expect_parameter(&command.args[0]);
+    let ParameterExpansionSyntax::Zsh(split) = &split.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        split
+            .modifiers
+            .iter()
+            .map(|modifier| modifier.name)
+            .collect::<Vec<_>>(),
+        vec!['=']
+    );
+    let ZshExpansionTarget::Reference(reference) = &split.target else {
+        panic!("expected split target reference");
+    };
+    assert_eq!(reference.name.as_str(), "name");
+
+    let glob = expect_parameter(&command.args[1]);
+    let ParameterExpansionSyntax::Zsh(glob) = &glob.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        glob.modifiers
+            .iter()
+            .map(|modifier| modifier.name)
+            .collect::<Vec<_>>(),
+        vec!['~']
+    );
+    let ZshExpansionTarget::Reference(reference) = &glob.target else {
+        panic!("expected glob target reference");
+    };
+    assert_eq!(reference.name.as_str(), "foo");
+
+    let rc_expand = expect_parameter(&command.args[2]);
+    let ParameterExpansionSyntax::Zsh(rc_expand) = &rc_expand.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        rc_expand
+            .modifiers
+            .iter()
+            .map(|modifier| modifier.name)
+            .collect::<Vec<_>>(),
+        vec!['^', '^']
+    );
+    let ZshExpansionTarget::Reference(reference) = &rc_expand.target else {
+        panic!("expected rc-expand target reference");
+    };
+    assert_eq!(reference.name.as_str(), "bar");
+
+    let glob_off = expect_parameter(&command.args[3]);
+    let ParameterExpansionSyntax::Zsh(glob_off) = &glob_off.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        glob_off
+            .modifiers
+            .iter()
+            .map(|modifier| modifier.name)
+            .collect::<Vec<_>>(),
+        vec!['~', '~']
+    );
+    let ZshExpansionTarget::Reference(reference) = &glob_off.target else {
+        panic!("expected glob-off target reference");
+    };
+    assert_eq!(reference.name.as_str(), "baz");
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2953,12 +2953,7 @@ impl<'a> Parser<'a> {
 
                 if matches!(
                     chars.peek(),
-                    Some(&'(')
-                        | Some(&':')
-                        | Some(&'=')
-                        | Some(&'^')
-                        | Some(&'~')
-                        | Some(&'.')
+                    Some(&'(') | Some(&':') | Some(&'=') | Some(&'^') | Some(&'~') | Some(&'.')
                 ) {
                     let raw_body = self.read_brace_operand(&mut chars, &mut cursor, source_backed);
                     let parameter = self.zsh_parameter_word_part(raw_body, part_start, cursor);

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2953,7 +2953,12 @@ impl<'a> Parser<'a> {
 
                 if matches!(
                     chars.peek(),
-                    Some(&'(') | Some(&':') | Some(&'^') | Some(&'~') | Some(&'.')
+                    Some(&'(')
+                        | Some(&':')
+                        | Some(&'=')
+                        | Some(&'^')
+                        | Some(&'~')
+                        | Some(&'.')
                 ) {
                     let raw_body = self.read_brace_operand(&mut chars, &mut cursor, source_backed);
                     let parameter = self.zsh_parameter_word_part(raw_body, part_start, cursor);

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -9,7 +9,7 @@ use shuck_ast::{
     ZshExpansionTarget, ZshGlobSegment,
 };
 use shuck_indexer::Indexer;
-use shuck_parser::{parser::Parser, ShellProfile, ZshEmulationMode};
+use shuck_parser::{ShellProfile, ZshEmulationMode, parser::Parser};
 
 use crate::binding::{Binding, BindingAttributes, BindingKind};
 use crate::call_graph::{CallGraph, CallSite, OverwrittenFunction};
@@ -2836,7 +2836,9 @@ fn recorded_simple_command_info(
 
     if static_callee.as_deref() == Some("noglob") {
         name_index = 1;
-        static_callee = words.get(name_index).and_then(|word| static_word_text(word, source));
+        static_callee = words
+            .get(name_index)
+            .and_then(|word| static_word_text(word, source));
     }
 
     let mut info = RecordedCommandInfo {
@@ -2891,7 +2893,9 @@ fn parse_emulate_effects(args: &[&Word], source: &str) -> Vec<RecordedZshCommand
             }
             "-o" | "+o" => {
                 let enable = text.starts_with('-');
-                if let Some(option) = args.get(index + 1).and_then(|word| static_word_text(word, source))
+                if let Some(option) = args
+                    .get(index + 1)
+                    .and_then(|word| static_word_text(word, source))
                     && let Some(update) = parse_recorded_zsh_option_update(&option, enable)
                 {
                     updates.push(update);
@@ -2937,10 +2941,7 @@ fn parse_emulate_effects(args: &[&Word], source: &str) -> Vec<RecordedZshCommand
 
     let mut effects = Vec::new();
     if let Some(mode) = mode {
-        effects.push(RecordedZshCommandEffect::Emulate {
-            mode,
-            local,
-        });
+        effects.push(RecordedZshCommandEffect::Emulate { mode, local });
     }
     if !updates.is_empty() {
         effects.push(RecordedZshCommandEffect::SetOptions { updates });
@@ -2973,7 +2974,9 @@ fn parse_set_builtin_option_updates(args: &[&Word], source: &str) -> Vec<Recorde
         match text.as_str() {
             "-o" | "+o" => {
                 let enable = text.starts_with('-');
-                if let Some(name) = args.get(index + 1).and_then(|word| static_word_text(word, source))
+                if let Some(name) = args
+                    .get(index + 1)
+                    .and_then(|word| static_word_text(word, source))
                     && let Some(update) = parse_recorded_zsh_option_update(&name, enable)
                 {
                     updates.push(update);
@@ -2994,10 +2997,7 @@ fn parse_set_builtin_option_updates(args: &[&Word], source: &str) -> Vec<Recorde
     updates
 }
 
-fn parse_recorded_zsh_option_update(
-    name: &str,
-    enable: bool,
-) -> Option<RecordedZshOptionUpdate> {
+fn parse_recorded_zsh_option_update(name: &str, enable: bool) -> Option<RecordedZshOptionUpdate> {
     let (normalized, inverted) = normalize_recorded_zsh_option_name(name)?;
     let enable = if inverted { !enable } else { enable };
 

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2831,35 +2831,35 @@ fn recorded_simple_command_info(
     let words = std::iter::once(&command.name)
         .chain(command.args.iter())
         .collect::<Vec<_>>();
-    let mut name_index = 0usize;
     let mut static_callee = static_word_text(&command.name, source);
 
     if static_callee.as_deref() == Some("noglob") {
-        name_index = 1;
-        static_callee = words
-            .get(name_index)
-            .and_then(|word| static_word_text(word, source));
+        static_callee = words.get(1).and_then(|word| static_word_text(word, source));
     }
 
     let mut info = RecordedCommandInfo {
         static_callee,
         zsh_effects: Vec::new(),
     };
-    let args = words.get(name_index + 1..).unwrap_or(&[]);
+    let Some((effect_callee, effect_index)) = normalize_recorded_zsh_effect_command(&words, source)
+    else {
+        return info;
+    };
+    let args = words.get(effect_index + 1..).unwrap_or(&[]);
 
-    match info.static_callee.as_deref() {
-        Some("emulate") => info.zsh_effects = parse_emulate_effects(args, source),
-        Some("setopt") => {
+    match effect_callee.as_str() {
+        "emulate" => info.zsh_effects = parse_emulate_effects(args, source),
+        "setopt" => {
             info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
                 updates: parse_setopt_updates(args, source, true),
             }];
         }
-        Some("unsetopt") => {
+        "unsetopt" => {
             info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
                 updates: parse_setopt_updates(args, source, false),
             }];
         }
-        Some("set") => {
+        "set" => {
             let updates = parse_set_builtin_option_updates(args, source);
             if !updates.is_empty() {
                 info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions { updates }];
@@ -2873,6 +2873,87 @@ fn recorded_simple_command_info(
         RecordedZshCommandEffect::SetOptions { updates } => !updates.is_empty(),
     });
     info
+}
+
+fn normalize_recorded_zsh_effect_command(words: &[&Word], source: &str) -> Option<(String, usize)> {
+    let mut index = 0usize;
+
+    while let Some(word) = words.get(index) {
+        let text = static_word_text(word, source)?;
+        if is_recorded_assignment_word(&text) {
+            index += 1;
+            continue;
+        }
+
+        match text.as_str() {
+            "noglob" => {
+                index += 1;
+                continue;
+            }
+            "command" | "builtin" => {
+                index = skip_recorded_wrapper_options(words, source, index + 1);
+                continue;
+            }
+            "exec" => {
+                index = skip_recorded_exec_wrapper_options(words, source, index + 1);
+                continue;
+            }
+            _ => return Some((text, index)),
+        }
+    }
+
+    None
+}
+
+fn skip_recorded_wrapper_options(words: &[&Word], source: &str, mut index: usize) -> usize {
+    while let Some(word) = words.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+        if text == "--" {
+            index += 1;
+            break;
+        }
+        if text.starts_with('-') && text != "-" {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+    index
+}
+
+fn skip_recorded_exec_wrapper_options(words: &[&Word], source: &str, mut index: usize) -> usize {
+    while let Some(word) = words.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+        if text == "--" {
+            index += 1;
+            break;
+        }
+        if text == "-a" {
+            index = (index + 2).min(words.len());
+            continue;
+        }
+        if text.starts_with('-') && text != "-" {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+    index
+}
+
+fn is_recorded_assignment_word(word: &str) -> bool {
+    let Some((name, _value)) = word.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && !name.starts_with('-')
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 fn parse_emulate_effects(args: &[&Word], source: &str) -> Vec<RecordedZshCommandEffect> {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -9,13 +9,14 @@ use shuck_ast::{
     ZshExpansionTarget, ZshGlobSegment,
 };
 use shuck_indexer::Indexer;
-use shuck_parser::parser::Parser;
+use shuck_parser::{parser::Parser, ShellProfile, ZshEmulationMode};
 
 use crate::binding::{Binding, BindingAttributes, BindingKind};
 use crate::call_graph::{CallGraph, CallSite, OverwrittenFunction};
 use crate::cfg::{
-    FlowContext, IsolatedRegion, RecordedCaseArm, RecordedCommand, RecordedCommandKind,
-    RecordedListOperator, RecordedPipelineSegment, RecordedProgram,
+    FlowContext, IsolatedRegion, RecordedCaseArm, RecordedCommand, RecordedCommandInfo,
+    RecordedCommandKind, RecordedListOperator, RecordedPipelineSegment, RecordedProgram,
+    RecordedZshCommandEffect, RecordedZshOptionUpdate,
 };
 use crate::declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 use crate::reference::{Reference, ReferenceKind};
@@ -27,6 +28,7 @@ use crate::{
 };
 
 pub(crate) struct BuildOutput {
+    pub(crate) shell_profile: ShellProfile,
     pub(crate) scopes: Vec<Scope>,
     pub(crate) bindings: Vec<Binding>,
     pub(crate) references: Vec<Reference>,
@@ -69,6 +71,8 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     indirect_expansion_refs: FxHashSet<ReferenceId>,
     flow_contexts: Vec<(Span, FlowContext)>,
     recorded_function_bodies: FxHashMap<ScopeId, Vec<RecordedCommand>>,
+    recorded_command_infos: FxHashMap<SpanKey, RecordedCommandInfo>,
+    function_body_scopes: FxHashMap<BindingId, ScopeId>,
     command_bindings: FxHashMap<SpanKey, Vec<BindingId>>,
     command_references: FxHashMap<SpanKey, Vec<ReferenceId>>,
     source_directives: FxHashMap<usize, SourceDirectiveOverride>,
@@ -108,6 +112,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         indexer: &'a Indexer,
         observer: &'observer mut dyn TraversalObserver,
         bash_runtime_vars_enabled: bool,
+        shell_profile: ShellProfile,
     ) -> BuildOutput {
         let file_scope = Scope {
             id: ScopeId(0),
@@ -136,6 +141,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             indirect_expansion_refs: FxHashSet::default(),
             flow_contexts: Vec::new(),
             recorded_function_bodies: FxHashMap::default(),
+            recorded_command_infos: FxHashMap::default(),
+            function_body_scopes: FxHashMap::default(),
             command_bindings: FxHashMap::default(),
             command_references: FxHashMap::default(),
             source_directives: parse_source_directives(source, indexer),
@@ -153,6 +160,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let heuristic_unused_assignments = builder.compute_heuristic_unused_assignments();
 
         BuildOutput {
+            shell_profile,
             scopes: builder.scopes,
             bindings: builder.bindings,
             references: builder.references,
@@ -173,6 +181,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             recorded_program: RecordedProgram {
                 file_commands,
                 function_bodies: builder.recorded_function_bodies,
+                command_infos: builder.recorded_command_infos,
+                function_body_scopes: builder.function_body_scopes,
             },
             command_bindings: builder.command_bindings,
             command_references: builder.command_references,
@@ -222,6 +232,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             recorded.nested_regions.splice(0..0, redirects);
         }
         recorded.span = span;
+        self.recorded_command_infos.insert(
+            SpanKey::new(span),
+            recorded_command_info(&stmt.command, self.source),
+        );
 
         self.command_stack.pop();
         self.observer.exit_command(&stmt.command, scope);
@@ -858,21 +872,22 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             );
         }
 
+        let parent_scope = self.current_scope();
+        let scope = self.push_scope(
+            ScopeKind::Function(function_scope_kind(function)),
+            parent_scope,
+            body_span(&function.body),
+        );
         for (name, span) in function.static_name_entries() {
-            self.add_binding(
+            let binding_id = self.add_binding(
                 name,
                 BindingKind::FunctionDefinition,
-                self.current_scope(),
+                parent_scope,
                 span,
                 BindingAttributes::empty(),
             );
+            self.function_body_scopes.insert(binding_id, scope);
         }
-
-        let scope = self.push_scope(
-            ScopeKind::Function(function_scope_kind(function)),
-            self.current_scope(),
-            body_span(&function.body),
-        );
         self.deferred_functions.push(DeferredFunction {
             function: function as *const FunctionDef,
             scope,
@@ -2795,6 +2810,227 @@ fn line_bounds(source: &str, line_number: usize) -> Option<(usize, usize)> {
 fn static_word_text(word: &Word, source: &str) -> Option<String> {
     let mut result = String::new();
     collect_static_word_text(&word.parts, source, &mut result).then_some(result)
+}
+
+fn recorded_command_info(command: &Command, source: &str) -> RecordedCommandInfo {
+    match command {
+        Command::Simple(command) => recorded_simple_command_info(command, source),
+        Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => RecordedCommandInfo::default(),
+    }
+}
+
+fn recorded_simple_command_info(
+    command: &shuck_ast::SimpleCommand,
+    source: &str,
+) -> RecordedCommandInfo {
+    let words = std::iter::once(&command.name)
+        .chain(command.args.iter())
+        .collect::<Vec<_>>();
+    let mut name_index = 0usize;
+    let mut static_callee = static_word_text(&command.name, source);
+
+    if static_callee.as_deref() == Some("noglob") {
+        name_index = 1;
+        static_callee = words.get(name_index).and_then(|word| static_word_text(word, source));
+    }
+
+    let mut info = RecordedCommandInfo {
+        static_callee,
+        zsh_effects: Vec::new(),
+    };
+    let args = words.get(name_index + 1..).unwrap_or(&[]);
+
+    match info.static_callee.as_deref() {
+        Some("emulate") => info.zsh_effects = parse_emulate_effects(args, source),
+        Some("setopt") => {
+            info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
+                updates: parse_setopt_updates(args, source, true),
+            }];
+        }
+        Some("unsetopt") => {
+            info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
+                updates: parse_setopt_updates(args, source, false),
+            }];
+        }
+        Some("set") => {
+            let updates = parse_set_builtin_option_updates(args, source);
+            if !updates.is_empty() {
+                info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions { updates }];
+            }
+        }
+        _ => {}
+    }
+
+    info.zsh_effects.retain(|effect| match effect {
+        RecordedZshCommandEffect::Emulate { .. } => true,
+        RecordedZshCommandEffect::SetOptions { updates } => !updates.is_empty(),
+    });
+    info
+}
+
+fn parse_emulate_effects(args: &[&Word], source: &str) -> Vec<RecordedZshCommandEffect> {
+    let mut local = false;
+    let mut mode = None;
+    let mut updates = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            index += 1;
+            continue;
+        };
+
+        match text.as_str() {
+            "--" => {
+                break;
+            }
+            "-o" | "+o" => {
+                let enable = text.starts_with('-');
+                if let Some(option) = args.get(index + 1).and_then(|word| static_word_text(word, source))
+                    && let Some(update) = parse_recorded_zsh_option_update(&option, enable)
+                {
+                    updates.push(update);
+                }
+                index += 2;
+                continue;
+            }
+            _ => {}
+        }
+
+        if text.starts_with("-o") || text.starts_with("+o") {
+            let enable = text.starts_with('-');
+            if let Some(update) = parse_recorded_zsh_option_update(&text[2..], enable) {
+                updates.push(update);
+            }
+            index += 1;
+            continue;
+        }
+
+        if let Some(flags) = text.strip_prefix('-') {
+            for flag in flags.chars() {
+                match flag {
+                    'L' => local = true,
+                    'R' => {}
+                    _ => {}
+                }
+            }
+            index += 1;
+            continue;
+        }
+
+        if mode.is_none() {
+            mode = match text.to_ascii_lowercase().as_str() {
+                "zsh" => Some(ZshEmulationMode::Zsh),
+                "sh" => Some(ZshEmulationMode::Sh),
+                "ksh" => Some(ZshEmulationMode::Ksh),
+                "csh" => Some(ZshEmulationMode::Csh),
+                _ => None,
+            };
+        }
+        index += 1;
+    }
+
+    let mut effects = Vec::new();
+    if let Some(mode) = mode {
+        effects.push(RecordedZshCommandEffect::Emulate {
+            mode,
+            local,
+        });
+    }
+    if !updates.is_empty() {
+        effects.push(RecordedZshCommandEffect::SetOptions { updates });
+    }
+    effects
+}
+
+fn parse_setopt_updates(
+    args: &[&Word],
+    source: &str,
+    enable: bool,
+) -> Vec<RecordedZshOptionUpdate> {
+    args.iter()
+        .filter_map(|word| static_word_text(word, source))
+        .filter(|text| text != "--")
+        .filter_map(|text| parse_recorded_zsh_option_update(&text, enable))
+        .collect()
+}
+
+fn parse_set_builtin_option_updates(args: &[&Word], source: &str) -> Vec<RecordedZshOptionUpdate> {
+    let mut updates = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            index += 1;
+            continue;
+        };
+
+        match text.as_str() {
+            "-o" | "+o" => {
+                let enable = text.starts_with('-');
+                if let Some(name) = args.get(index + 1).and_then(|word| static_word_text(word, source))
+                    && let Some(update) = parse_recorded_zsh_option_update(&name, enable)
+                {
+                    updates.push(update);
+                }
+                index += 2;
+            }
+            _ if text.starts_with("-o") || text.starts_with("+o") => {
+                let enable = text.starts_with('-');
+                if let Some(update) = parse_recorded_zsh_option_update(&text[2..], enable) {
+                    updates.push(update);
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    updates
+}
+
+fn parse_recorded_zsh_option_update(
+    name: &str,
+    enable: bool,
+) -> Option<RecordedZshOptionUpdate> {
+    let (normalized, inverted) = normalize_recorded_zsh_option_name(name)?;
+    let enable = if inverted { !enable } else { enable };
+
+    if normalized == "localoptions" {
+        return Some(RecordedZshOptionUpdate::LocalOptions { enable });
+    }
+
+    Some(RecordedZshOptionUpdate::Named {
+        name: normalized.into_boxed_str(),
+        enable,
+    })
+}
+
+fn normalize_recorded_zsh_option_name(name: &str) -> Option<(String, bool)> {
+    let mut normalized = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if matches!(ch, '_' | '-') {
+            continue;
+        }
+        normalized.push(ch.to_ascii_lowercase());
+    }
+
+    if normalized.is_empty() {
+        return None;
+    }
+
+    if let Some(stripped) = normalized.strip_prefix("no")
+        && !stripped.is_empty()
+    {
+        return Some((stripped.to_string(), true));
+    }
+
+    Some((normalized, false))
 }
 
 fn collect_static_word_text(parts: &[WordPartNode], source: &str, out: &mut String) -> bool {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2890,7 +2890,11 @@ fn normalize_recorded_zsh_effect_command(words: &[&Word], source: &str) -> Optio
                 index += 1;
                 continue;
             }
-            "command" | "builtin" => {
+            "command" => {
+                index = skip_recorded_command_wrapper_options(words, source, index + 1)?;
+                continue;
+            }
+            "builtin" => {
                 index = skip_recorded_wrapper_options(words, source, index + 1);
                 continue;
             }
@@ -2903,6 +2907,34 @@ fn normalize_recorded_zsh_effect_command(words: &[&Word], source: &str) -> Optio
     }
 
     None
+}
+
+fn skip_recorded_command_wrapper_options(
+    words: &[&Word],
+    source: &str,
+    mut index: usize,
+) -> Option<usize> {
+    while let Some(word) = words.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+        if text == "--" {
+            index += 1;
+            break;
+        }
+        if text.starts_with('-') && text != "-" {
+            if text
+                .strip_prefix('-')
+                .is_some_and(|flags| flags.chars().any(|flag| matches!(flag, 'v' | 'V')))
+            {
+                return None;
+            }
+            index += 1;
+            continue;
+        }
+        break;
+    }
+    Some(index)
 }
 
 fn skip_recorded_wrapper_options(words: &[&Word], source: &str, mut index: usize) -> usize {

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -1,5 +1,6 @@
 use rustc_hash::FxHashMap;
 use shuck_ast::{CaseTerminator, Span};
+use shuck_parser::ZshEmulationMode;
 
 use crate::{BindingId, ReferenceId, ScopeId, SpanKey};
 
@@ -104,6 +105,8 @@ impl ControlFlowGraph {
 pub(crate) struct RecordedProgram {
     pub(crate) file_commands: Vec<RecordedCommand>,
     pub(crate) function_bodies: FxHashMap<ScopeId, Vec<RecordedCommand>>,
+    pub(crate) command_infos: FxHashMap<SpanKey, RecordedCommandInfo>,
+    pub(crate) function_body_scopes: FxHashMap<BindingId, ScopeId>,
 }
 
 #[derive(Debug, Clone)]
@@ -182,6 +185,34 @@ pub(crate) struct RecordedCaseArm {
 pub(crate) struct RecordedPipelineSegment {
     pub(crate) scope: ScopeId,
     pub(crate) command: RecordedCommand,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RecordedCommandInfo {
+    pub(crate) static_callee: Option<String>,
+    pub(crate) zsh_effects: Vec<RecordedZshCommandEffect>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RecordedZshCommandEffect {
+    Emulate {
+        mode: ZshEmulationMode,
+        local: bool,
+    },
+    SetOptions {
+        updates: Vec<RecordedZshOptionUpdate>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecordedZshOptionUpdate {
+    Named {
+        name: Box<str>,
+        enable: bool,
+    },
+    LocalOptions {
+        enable: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -206,13 +206,8 @@ pub(crate) enum RecordedZshCommandEffect {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RecordedZshOptionUpdate {
-    Named {
-        name: Box<str>,
-        enable: bool,
-    },
-    LocalOptions {
-        enable: bool,
-    },
+    Named { name: Box<str>, enable: bool },
+    LocalOptions { enable: bool },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
-use shuck_parser::ShellProfile;
 use shuck_ast::Name;
+use shuck_parser::ShellProfile;
 use std::path::{Path, PathBuf};
 
 use crate::SourcePathResolver;

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -1,4 +1,5 @@
 use rustc_hash::FxHashMap;
+use shuck_parser::ShellProfile;
 use shuck_ast::Name;
 use std::path::{Path, PathBuf};
 
@@ -216,4 +217,5 @@ pub struct SemanticBuildOptions<'a> {
     pub source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
     pub file_entry_contract: Option<FileContract>,
     pub analyzed_paths: Option<&'a rustc_hash::FxHashSet<PathBuf>>,
+    pub shell_profile: Option<ShellProfile>,
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -10,6 +10,7 @@ mod runtime;
 mod scope;
 mod source_closure;
 mod source_ref;
+mod zsh_options;
 
 pub use binding::{Binding, BindingAttributes, BindingId, BindingKind};
 pub use call_graph::{CallGraph, CallSite, OverwrittenFunction};
@@ -25,6 +26,7 @@ pub use dataflow::{
 pub use declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 pub use reference::{Reference, ReferenceId, ReferenceKind};
 pub use scope::{FunctionScopeKind, Scope, ScopeId, ScopeKind};
+pub use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionState};
 pub use source_ref::{SourceRef, SourceRefKind, SourceRefResolution};
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -37,6 +39,7 @@ use crate::builder::SemanticModelBuilder;
 use crate::cfg::{RecordedProgram, build_control_flow_graph};
 use crate::dataflow::{DataflowContext, DataflowResult};
 use crate::runtime::RuntimePrelude;
+use crate::zsh_options::ZshOptionAnalysis;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct SpanKey {
@@ -199,6 +202,7 @@ fn is_in_named_function_scope(scopes: &[Scope], scope: ScopeId, name: &Name) -> 
 
 #[derive(Debug)]
 pub struct SemanticModel {
+    shell_profile: ShellProfile,
     scopes: Vec<Scope>,
     bindings: Vec<Binding>,
     references: Vec<Reference>,
@@ -222,6 +226,7 @@ pub struct SemanticModel {
     command_bindings: FxHashMap<SpanKey, Vec<BindingId>>,
     command_references: FxHashMap<SpanKey, Vec<ReferenceId>>,
     heuristic_unused_assignments: Vec<BindingId>,
+    zsh_option_analysis: Option<ZshOptionAnalysis>,
 }
 
 #[derive(Debug)]
@@ -259,7 +264,14 @@ impl SemanticModel {
             &built.indirect_expansion_refs,
             &indirect_targets_by_binding,
         );
+        let zsh_option_analysis = zsh_options::analyze(
+            &built.shell_profile,
+            &built.scopes,
+            &built.bindings,
+            &built.recorded_program,
+        );
         Self {
+            shell_profile: built.shell_profile,
             scopes: built.scopes,
             bindings: built.bindings,
             references: built.references,
@@ -283,11 +295,22 @@ impl SemanticModel {
             command_bindings: built.command_bindings,
             command_references: built.command_references,
             heuristic_unused_assignments: built.heuristic_unused_assignments,
+            zsh_option_analysis,
         }
     }
 
     pub fn analysis(&self) -> SemanticAnalysis<'_> {
         SemanticAnalysis::new(self)
+    }
+
+    pub fn shell_profile(&self) -> &ShellProfile {
+        &self.shell_profile
+    }
+
+    pub fn zsh_options_at(&self, offset: usize) -> Option<&ZshOptionState> {
+        self.zsh_option_analysis
+            .as_ref()
+            .and_then(|analysis| analysis.options_at(&self.scopes, offset))
     }
 
     pub fn scopes(&self) -> &[Scope] {
@@ -939,6 +962,7 @@ pub fn build_with_observer_at_path_with_resolver(
             source_path_resolver,
             file_entry_contract: None,
             analyzed_paths: None,
+            shell_profile: None,
         },
     )
 }
@@ -950,7 +974,14 @@ fn build_semantic_model(
     observer: &mut dyn TraversalObserver,
     options: SemanticBuildOptions<'_>,
 ) -> SemanticModel {
-    let mut model = build_semantic_model_base(file, source, indexer, observer, options.source_path);
+    let mut model = build_semantic_model_base(
+        file,
+        source,
+        indexer,
+        observer,
+        options.source_path,
+        options.shell_profile.clone(),
+    );
     if let Some(contract) = options.file_entry_contract {
         model.apply_file_entry_contract(contract, file);
     }
@@ -980,15 +1011,59 @@ pub(crate) fn build_semantic_model_base(
     indexer: &Indexer,
     observer: &mut dyn TraversalObserver,
     source_path: Option<&Path>,
+    shell_profile: Option<ShellProfile>,
 ) -> SemanticModel {
+    let shell_profile =
+        shell_profile.unwrap_or_else(|| infer_shell_profile(source, source_path));
     let built = SemanticModelBuilder::build(
         file,
         source,
         indexer,
         observer,
         bash_runtime_vars_enabled(source, source_path),
+        shell_profile,
     );
     SemanticModel::from_build_output(built)
+}
+
+fn infer_shell_profile(source: &str, path: Option<&Path>) -> ShellProfile {
+    let dialect = infer_parse_dialect_from_source(source, path);
+    ShellProfile::native(dialect)
+}
+
+fn infer_parse_dialect_from_source(source: &str, path: Option<&Path>) -> shuck_parser::ShellDialect {
+    if let Some(line) = source.lines().next().map(str::trim)
+        && let Some(line) = line.strip_prefix("#!").map(str::trim)
+    {
+        let mut parts = line.split_whitespace();
+        let first = parts.next();
+        let interpreter = first
+            .and_then(|first| {
+                if Path::new(first).file_name()?.to_str()? == "env" {
+                    parts.next()
+                } else {
+                    Path::new(first).file_name()?.to_str()
+                }
+            })
+            .unwrap_or_default();
+        return match interpreter.to_ascii_lowercase().as_str() {
+            "sh" | "dash" | "ksh" | "posix" => shuck_parser::ShellDialect::Posix,
+            "mksh" => shuck_parser::ShellDialect::Mksh,
+            "zsh" => shuck_parser::ShellDialect::Zsh,
+            _ => shuck_parser::ShellDialect::Bash,
+        };
+    }
+
+    match path
+        .and_then(|path| path.extension().and_then(|ext| ext.to_str()))
+        .map(|ext| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("sh" | "dash" | "ksh") => shuck_parser::ShellDialect::Posix,
+        Some("mksh") => shuck_parser::ShellDialect::Mksh,
+        Some("zsh") => shuck_parser::ShellDialect::Zsh,
+        _ => shuck_parser::ShellDialect::Bash,
+    }
 }
 
 fn bash_runtime_vars_enabled(source: &str, path: Option<&Path>) -> bool {
@@ -1174,6 +1249,20 @@ mod tests {
         let output = Parser::with_dialect(source, dialect).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         SemanticModel::build(&output.file, source, &indexer)
+    }
+
+    fn model_with_profile(source: &str, profile: ShellProfile) -> SemanticModel {
+        let output = Parser::with_profile(source, profile.clone()).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        SemanticModel::build_with_options(
+            &output.file,
+            source,
+            &indexer,
+            SemanticBuildOptions {
+                shell_profile: Some(profile),
+                ..SemanticBuildOptions::default()
+            },
+        )
     }
 
     fn model_at_path_with_parse_dialect(path: &Path, dialect: ShellDialect) -> SemanticModel {
@@ -4604,5 +4693,93 @@ echo done
                 .flat_map(|block| block.commands.iter())
                 .any(|span| span.slice(source) == "printf inner")
         );
+    }
+
+    #[test]
+    fn zsh_option_analysis_exposes_native_defaults() {
+        let source = "print $name\n";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected zsh options");
+
+        assert_eq!(options.sh_word_split, OptionValue::Off);
+        assert_eq!(options.glob, OptionValue::On);
+        assert_eq!(options.short_loops, OptionValue::On);
+    }
+
+    #[test]
+    fn zsh_option_analysis_tracks_setopt_updates_by_offset() {
+        let source = "setopt no_glob\nprint *\n";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected zsh options");
+
+        assert_eq!(options.glob, OptionValue::Off);
+    }
+
+    #[test]
+    fn zsh_option_analysis_merges_conditionals_to_unknown_on_divergence() {
+        let source = "if test \"$x\" = y; then\n  setopt no_glob\nfi\nprint *\n";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected zsh options");
+
+        assert_eq!(options.glob, OptionValue::Unknown);
+    }
+
+    #[test]
+    fn zsh_option_analysis_respects_local_options_in_functions() {
+        let source = "\
+fn() {
+  setopt local_options no_glob
+}
+fn
+print *
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected zsh options");
+
+        assert_eq!(options.glob, OptionValue::On);
+    }
+
+    #[test]
+    fn zsh_option_analysis_leaks_function_option_updates_by_default() {
+        let source = "\
+fn() {
+  setopt sh_word_split
+}
+fn
+print $name
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        assert!(
+            model.scopes[0]
+                .bindings
+                .keys()
+                .any(|name| name.as_str() == "fn"),
+            "expected top-level function binding for `fn`"
+        );
+        assert!(
+            model.recorded_program.function_body_scopes.len() == 1,
+            "expected one recorded function body scope"
+        );
+        assert!(
+            model
+                .recorded_program
+                .command_infos
+                .values()
+                .any(|info| info.static_callee.as_deref() == Some("fn")),
+            "expected a static callee for the function call"
+        );
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected zsh options");
+
+        assert_eq!(options.sh_word_split, OptionValue::On);
     }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4802,4 +4802,22 @@ fn() {
         assert_eq!(options.sh_word_split, OptionValue::Off);
         assert_eq!(options.glob, OptionValue::On);
     }
+
+    #[test]
+    fn zsh_option_analysis_merges_function_snapshots_from_multiple_call_contexts() {
+        let source = "\
+fn() {
+  print $name
+}
+fn
+setopt sh_word_split
+fn
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected merged function zsh options");
+
+        assert_eq!(options.sh_word_split, OptionValue::Unknown);
+    }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4854,4 +4854,18 @@ print *
         assert_eq!(options.glob, OptionValue::Off);
         assert_eq!(options.short_loops, OptionValue::Off);
     }
+
+    #[test]
+    fn zsh_option_analysis_ignores_command_lookup_modes() {
+        let source = "\
+command -v setopt no_glob
+print *
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected wrapped zsh options");
+
+        assert_eq!(options.glob, OptionValue::On);
+    }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1013,8 +1013,7 @@ pub(crate) fn build_semantic_model_base(
     source_path: Option<&Path>,
     shell_profile: Option<ShellProfile>,
 ) -> SemanticModel {
-    let shell_profile =
-        shell_profile.unwrap_or_else(|| infer_shell_profile(source, source_path));
+    let shell_profile = shell_profile.unwrap_or_else(|| infer_shell_profile(source, source_path));
     let built = SemanticModelBuilder::build(
         file,
         source,
@@ -1031,7 +1030,10 @@ fn infer_shell_profile(source: &str, path: Option<&Path>) -> ShellProfile {
     ShellProfile::native(dialect)
 }
 
-fn infer_parse_dialect_from_source(source: &str, path: Option<&Path>) -> shuck_parser::ShellDialect {
+fn infer_parse_dialect_from_source(
+    source: &str,
+    path: Option<&Path>,
+) -> shuck_parser::ShellDialect {
     if let Some(line) = source.lines().next().map(str::trim)
         && let Some(line) = line.strip_prefix("#!").map(str::trim)
     {
@@ -1252,7 +1254,9 @@ mod tests {
     }
 
     fn model_with_profile(source: &str, profile: ShellProfile) -> SemanticModel {
-        let output = Parser::with_profile(source, profile.clone()).parse().unwrap();
+        let output = Parser::with_profile(source, profile.clone())
+            .parse()
+            .unwrap();
         let indexer = Indexer::new(source, &output);
         SemanticModel::build_with_options(
             &output.file,
@@ -4781,5 +4785,21 @@ print $name
             .expect("expected zsh options");
 
         assert_eq!(options.sh_word_split, OptionValue::On);
+    }
+
+    #[test]
+    fn zsh_option_analysis_falls_back_to_ancestor_state_in_uncalled_function_bodies() {
+        let source = "\
+fn() {
+  print $name
+}
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected inherited zsh options");
+
+        assert_eq!(options.sh_word_split, OptionValue::Off);
+        assert_eq!(options.glob, OptionValue::On);
     }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4752,6 +4752,24 @@ print *
     }
 
     #[test]
+    fn zsh_option_analysis_applies_top_level_local_options_to_function_leaks() {
+        let source = "\
+setopt localoptions
+fn() {
+  setopt no_glob
+}
+fn
+print *
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected zsh options");
+
+        assert_eq!(options.glob, OptionValue::On);
+    }
+
+    #[test]
     fn zsh_option_analysis_leaks_function_option_updates_by_default() {
         let source = "\
 fn() {
@@ -4819,5 +4837,21 @@ fn
             .expect("expected merged function zsh options");
 
         assert_eq!(options.sh_word_split, OptionValue::Unknown);
+    }
+
+    #[test]
+    fn zsh_option_analysis_tracks_wrapped_option_builtins() {
+        let source = "\
+command setopt no_glob
+builtin unsetopt short_loops
+print *
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected wrapped zsh option effects");
+
+        assert_eq!(options.glob, OptionValue::Off);
+        assert_eq!(options.short_loops, OptionValue::Off);
     }
 }

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1670,15 +1670,14 @@ fn summarize_helper_uncached(
     };
     let indexer = Indexer::new(&source, &output);
     let mut observer = crate::NoopTraversalObserver;
-    let mut semantic =
-        build_semantic_model_base(
-            &output.file,
-            &source,
-            &indexer,
-            &mut observer,
-            Some(path),
-            None,
-        );
+    let mut semantic = build_semantic_model_base(
+        &output.file,
+        &source,
+        &indexer,
+        &mut observer,
+        Some(path),
+        None,
+    );
     let collected = collect_source_closure_contracts_with_cache(
         &semantic,
         &output.file,

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1671,7 +1671,14 @@ fn summarize_helper_uncached(
     let indexer = Indexer::new(&source, &output);
     let mut observer = crate::NoopTraversalObserver;
     let mut semantic =
-        build_semantic_model_base(&output.file, &source, &indexer, &mut observer, Some(path));
+        build_semantic_model_base(
+            &output.file,
+            &source,
+            &indexer,
+            &mut observer,
+            Some(path),
+            None,
+        );
     let collected = collect_source_closure_contracts_with_cache(
         &semantic,
         &output.file,

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -219,23 +219,35 @@ pub(crate) fn analyze(
 }
 
 impl ZshOptionAnalysis {
-    pub(crate) fn options_at<'a>(&'a self, scopes: &[Scope], offset: usize) -> Option<&'a ZshOptionState> {
-        let scope = scopes
+    pub(crate) fn options_at<'a>(
+        &'a self,
+        scopes: &[Scope],
+        offset: usize,
+    ) -> Option<&'a ZshOptionState> {
+        let mut scope = scopes
             .iter()
             .filter(|scope| contains_offset(scope.span, offset))
             .min_by_key(|scope| scope.span.end.offset - scope.span.start.offset)
-            .map(|scope| scope.id)?;
+            .map(|scope| scope.id);
 
-        if let Some(snapshots) = self.snapshots.get(&scope)
-            && let Some(snapshot) = snapshots
-                .iter()
-                .rev()
-                .find(|snapshot| snapshot.offset <= offset)
-        {
-            return Some(&snapshot.state);
+        while let Some(scope_id) = scope {
+            if let Some(snapshots) = self.snapshots.get(&scope_id)
+                && let Some(snapshot) = snapshots
+                    .iter()
+                    .rev()
+                    .find(|snapshot| snapshot.offset <= offset)
+            {
+                return Some(&snapshot.state);
+            }
+
+            if let Some(entry) = self.scope_entries.get(&scope_id) {
+                return Some(entry);
+            }
+
+            scope = scopes[scope_id.index()].parent;
         }
 
-        self.scope_entries.get(&scope)
+        None
     }
 }
 
@@ -285,9 +297,7 @@ impl<'a> Analyzer<'a> {
             | RecordedCommandKind::Break { .. }
             | RecordedCommandKind::Continue { .. }
             | RecordedCommandKind::Return
-            | RecordedCommandKind::Exit => {
-                self.analyze_linear_command(scope, command, state, leak)
-            }
+            | RecordedCommandKind::Exit => self.analyze_linear_command(scope, command, state, leak),
             RecordedCommandKind::List { first, rest } => {
                 let mut list_state = self.analyze_command(scope, first, state, leak);
                 for (_operator, command) in rest {
@@ -301,11 +311,18 @@ impl<'a> Analyzer<'a> {
                 then_branch,
                 elif_branches,
                 else_branch,
-            } => self.analyze_if(scope, &state, condition, then_branch, elif_branches, else_branch, leak),
+            } => self.analyze_if(
+                scope,
+                &state,
+                condition,
+                then_branch,
+                elif_branches,
+                else_branch,
+                leak,
+            ),
             RecordedCommandKind::While { condition, body }
             | RecordedCommandKind::Until { condition, body } => {
-                let after_condition =
-                    self.analyze_sequence(scope, condition, state.clone(), leak);
+                let after_condition = self.analyze_sequence(scope, condition, state.clone(), leak);
                 let iterated = self.analyze_sequence(scope, body, after_condition.clone(), leak);
                 after_condition.merge(&iterated)
             }
@@ -319,17 +336,21 @@ impl<'a> Analyzer<'a> {
             RecordedCommandKind::Case { arms } => self.analyze_case(scope, &state, arms, leak),
             RecordedCommandKind::Subshell { body } => {
                 self.analyze_sequence(
-                    self.subshell_scope_for(command.span.start.offset).unwrap_or(scope),
+                    self.subshell_scope_for(command.span.start.offset)
+                        .unwrap_or(scope),
                     body,
                     EvalState::new(state.current.clone()),
                     LeakBehavior::Never,
                 );
                 state
             }
-            RecordedCommandKind::Pipeline { segments } => self.analyze_pipeline(scope, &state, segments, leak),
+            RecordedCommandKind::Pipeline { segments } => {
+                self.analyze_pipeline(scope, &state, segments, leak)
+            }
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn analyze_if(
         &mut self,
         scope: ScopeId,
@@ -346,8 +367,7 @@ impl<'a> Analyzer<'a> {
         for (elif_condition, elif_body) in elif_branches {
             let after_elif_condition =
                 self.analyze_sequence(scope, elif_condition, after_condition.clone(), leak);
-            let elif_result =
-                self.analyze_sequence(scope, elif_body, after_elif_condition, leak);
+            let elif_result = self.analyze_sequence(scope, elif_body, after_elif_condition, leak);
             merged = merged.merge(&elif_result);
         }
 
@@ -399,12 +419,7 @@ impl<'a> Analyzer<'a> {
                 touched.extend(segment_result.outward_touched.iter().copied());
             }
             for field in touched {
-                self.apply_explicit_public_field(
-                    &mut result,
-                    leak,
-                    field,
-                    OptionValue::Unknown,
-                );
+                self.apply_explicit_public_field(&mut result, leak, field, OptionValue::Unknown);
             }
             return result;
         }
@@ -436,16 +451,19 @@ impl<'a> Analyzer<'a> {
         mut state: EvalState,
         leak: LeakBehavior,
     ) -> EvalState {
-        let info = self.recorded_program.command_infos.get(&SpanKey::new(command.span));
+        let info = self
+            .recorded_program
+            .command_infos
+            .get(&SpanKey::new(command.span));
 
         if let Some(function_scope) = info
             .and_then(|info| info.static_callee.as_deref())
-            .and_then(|name| self.resolve_visible_function_scope(scope, command.span.start.offset, name))
+            .and_then(|name| {
+                self.resolve_visible_function_scope(scope, command.span.start.offset, name)
+            })
         {
-            let summary = self.analyze_function_scope(
-                function_scope,
-                EvalState::new(state.current.clone()),
-            );
+            let summary =
+                self.analyze_function_scope(function_scope, EvalState::new(state.current.clone()));
             for field in &summary.outward_touched {
                 let value = get_option_field(&summary.final_outward.public, *field);
                 set_option_field(&mut state.current.public, *field, value);
@@ -459,11 +477,22 @@ impl<'a> Analyzer<'a> {
             for effect in &info.zsh_effects {
                 match effect {
                     RecordedZshCommandEffect::Emulate { mode, local } => {
-                        self.apply_emulate(&mut state, leak, *mode, *local, is_function_scope(self.scopes, scope));
+                        self.apply_emulate(
+                            &mut state,
+                            leak,
+                            *mode,
+                            *local,
+                            is_function_scope(self.scopes, scope),
+                        );
                     }
                     RecordedZshCommandEffect::SetOptions { updates } => {
                         for update in updates {
-                            self.apply_option_update(&mut state, leak, update, is_function_scope(self.scopes, scope));
+                            self.apply_option_update(
+                                &mut state,
+                                leak,
+                                update,
+                                is_function_scope(self.scopes, scope),
+                            );
                         }
                     }
                 }
@@ -529,7 +558,10 @@ impl<'a> Analyzer<'a> {
             .filter(|scope| {
                 scope.span.start.offset <= offset
                     && offset <= scope.span.end.offset
-                    && matches!(scope.kind, ScopeKind::Subshell | ScopeKind::CommandSubstitution)
+                    && matches!(
+                        scope.kind,
+                        ScopeKind::Subshell | ScopeKind::CommandSubstitution
+                    )
             })
             .min_by_key(|scope| scope.span.end.offset - scope.span.start.offset)
             .map(|scope| scope.id)
@@ -554,7 +586,10 @@ impl<'a> Analyzer<'a> {
         }
 
         self.apply_explicit_public_state(state, leak, &fields, &next_public);
-        state.outward.emulation = state.outward.emulation.merge(EmulationState::from_mode(mode));
+        state.outward.emulation = state
+            .outward
+            .emulation
+            .merge(EmulationState::from_mode(mode));
         if leak == LeakBehavior::Always
             || (leak == LeakBehavior::Function && state.current.local_options.is_definitely_off())
         {

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -602,17 +602,16 @@ impl<'a> Analyzer<'a> {
         state: &mut EvalState,
         leak: LeakBehavior,
         update: &RecordedZshOptionUpdate,
-        in_function: bool,
+        _in_function: bool,
     ) {
         match update {
-            RecordedZshOptionUpdate::LocalOptions { enable } if in_function => {
+            RecordedZshOptionUpdate::LocalOptions { enable } => {
                 state.current.local_options = if *enable {
                     OptionValue::On
                 } else {
                     OptionValue::Off
                 };
             }
-            RecordedZshOptionUpdate::LocalOptions { .. } => {}
             RecordedZshOptionUpdate::Named { name, enable } => {
                 let Some(field) = field_for_option_name(name) else {
                     return;

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -711,17 +711,24 @@ impl<'a> Analyzer<'a> {
     fn record_scope_entry(&mut self, scope: ScopeId, state: &ZshOptionState) {
         self.scope_entries
             .entry(scope)
+            .and_modify(|current| *current = current.merge(state))
             .or_insert_with(|| state.clone());
     }
 
     fn record_snapshot(&mut self, scope: ScopeId, offset: usize, state: &ZshOptionState) {
-        self.snapshots
-            .entry(scope)
-            .or_default()
-            .push(ZshOptionSnapshot {
-                offset,
-                state: state.clone(),
-            });
+        let snapshots = self.snapshots.entry(scope).or_default();
+        if let Some(existing) = snapshots
+            .iter_mut()
+            .find(|snapshot| snapshot.offset == offset)
+        {
+            existing.state = existing.state.merge(state);
+            return;
+        }
+
+        snapshots.push(ZshOptionSnapshot {
+            offset,
+            state: state.clone(),
+        });
     }
 }
 

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -1,0 +1,803 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionState};
+
+use crate::cfg::{
+    RecordedCaseArm, RecordedCommand, RecordedCommandKind, RecordedPipelineSegment,
+    RecordedProgram, RecordedZshCommandEffect, RecordedZshOptionUpdate,
+};
+use crate::{Binding, BindingKind, Scope, ScopeId, ScopeKind, SpanKey};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ZshOptionAnalysis {
+    scope_entries: FxHashMap<ScopeId, ZshOptionState>,
+    snapshots: FxHashMap<ScopeId, Vec<ZshOptionSnapshot>>,
+}
+
+#[derive(Debug, Clone)]
+struct ZshOptionSnapshot {
+    offset: usize,
+    state: ZshOptionState,
+}
+
+#[derive(Debug, Clone)]
+struct FunctionSummary {
+    final_outward: InternalState,
+    outward_touched: FxHashSet<ZshOptionField>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LeakBehavior {
+    Always,
+    Function,
+    Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmulationState {
+    Zsh,
+    Sh,
+    Ksh,
+    Csh,
+    Unknown,
+}
+
+impl EmulationState {
+    fn from_mode(mode: ZshEmulationMode) -> Self {
+        match mode {
+            ZshEmulationMode::Zsh => Self::Zsh,
+            ZshEmulationMode::Sh => Self::Sh,
+            ZshEmulationMode::Ksh => Self::Ksh,
+            ZshEmulationMode::Csh => Self::Csh,
+        }
+    }
+
+    fn merge(self, other: Self) -> Self {
+        if self == other { self } else { Self::Unknown }
+    }
+
+    fn is_definitely_sh(self) -> bool {
+        matches!(self, Self::Sh)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct InternalState {
+    public: ZshOptionState,
+    local_options: OptionValue,
+    emulation: EmulationState,
+}
+
+impl InternalState {
+    fn from_profile(profile: &ShellProfile) -> Option<Self> {
+        let public = profile.zsh_options()?.clone();
+        let emulation = if public == ZshOptionState::for_emulate(ZshEmulationMode::Sh) {
+            EmulationState::Sh
+        } else if public == ZshOptionState::for_emulate(ZshEmulationMode::Ksh) {
+            EmulationState::Ksh
+        } else if public == ZshOptionState::for_emulate(ZshEmulationMode::Csh) {
+            EmulationState::Csh
+        } else {
+            EmulationState::Zsh
+        };
+        Some(Self {
+            public,
+            local_options: OptionValue::Off,
+            emulation,
+        })
+    }
+
+    fn merge(&self, other: &Self) -> Self {
+        Self {
+            public: self.public.merge(&other.public),
+            local_options: self.local_options.merge(other.local_options),
+            emulation: self.emulation.merge(other.emulation),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EvalState {
+    current: InternalState,
+    outward: InternalState,
+    outward_touched: FxHashSet<ZshOptionField>,
+}
+
+impl EvalState {
+    fn new(entry: InternalState) -> Self {
+        Self {
+            current: entry.clone(),
+            outward: entry,
+            outward_touched: FxHashSet::default(),
+        }
+    }
+
+    fn merge(&self, other: &Self) -> Self {
+        let mut outward_touched = self.outward_touched.clone();
+        outward_touched.extend(other.outward_touched.iter().copied());
+        Self {
+            current: self.current.merge(&other.current),
+            outward: self.outward.merge(&other.outward),
+            outward_touched,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ZshOptionField {
+    ShWordSplit,
+    GlobSubst,
+    RcExpandParam,
+    Glob,
+    Nomatch,
+    NullGlob,
+    CshNullGlob,
+    ExtendedGlob,
+    KshGlob,
+    ShGlob,
+    BareGlobQual,
+    GlobDots,
+    Equals,
+    MagicEqualSubst,
+    ShFileExpansion,
+    GlobAssign,
+    IgnoreBraces,
+    IgnoreCloseBraces,
+    BraceCcl,
+    KshArrays,
+    KshZeroSubscript,
+    ShortLoops,
+    ShortRepeat,
+    RcQuotes,
+    InteractiveComments,
+    CBases,
+    OctalZeroes,
+}
+
+impl ZshOptionField {
+    const ALL: [Self; 27] = [
+        Self::ShWordSplit,
+        Self::GlobSubst,
+        Self::RcExpandParam,
+        Self::Glob,
+        Self::Nomatch,
+        Self::NullGlob,
+        Self::CshNullGlob,
+        Self::ExtendedGlob,
+        Self::KshGlob,
+        Self::ShGlob,
+        Self::BareGlobQual,
+        Self::GlobDots,
+        Self::Equals,
+        Self::MagicEqualSubst,
+        Self::ShFileExpansion,
+        Self::GlobAssign,
+        Self::IgnoreBraces,
+        Self::IgnoreCloseBraces,
+        Self::BraceCcl,
+        Self::KshArrays,
+        Self::KshZeroSubscript,
+        Self::ShortLoops,
+        Self::ShortRepeat,
+        Self::RcQuotes,
+        Self::InteractiveComments,
+        Self::CBases,
+        Self::OctalZeroes,
+    ];
+}
+
+pub(crate) fn analyze(
+    shell_profile: &ShellProfile,
+    scopes: &[Scope],
+    bindings: &[Binding],
+    recorded_program: &RecordedProgram,
+) -> Option<ZshOptionAnalysis> {
+    let entry = InternalState::from_profile(shell_profile)?;
+    let mut analyzer = Analyzer {
+        scopes,
+        bindings,
+        recorded_program,
+        scope_entries: FxHashMap::default(),
+        snapshots: FxHashMap::default(),
+        active_function_scopes: FxHashSet::default(),
+    };
+
+    analyzer.analyze_sequence(
+        ScopeId(0),
+        &recorded_program.file_commands,
+        EvalState::new(entry),
+        LeakBehavior::Always,
+    );
+
+    for snapshots in analyzer.snapshots.values_mut() {
+        snapshots.sort_by_key(|snapshot| snapshot.offset);
+    }
+
+    Some(ZshOptionAnalysis {
+        scope_entries: analyzer.scope_entries,
+        snapshots: analyzer.snapshots,
+    })
+}
+
+impl ZshOptionAnalysis {
+    pub(crate) fn options_at<'a>(&'a self, scopes: &[Scope], offset: usize) -> Option<&'a ZshOptionState> {
+        let scope = scopes
+            .iter()
+            .filter(|scope| contains_offset(scope.span, offset))
+            .min_by_key(|scope| scope.span.end.offset - scope.span.start.offset)
+            .map(|scope| scope.id)?;
+
+        if let Some(snapshots) = self.snapshots.get(&scope)
+            && let Some(snapshot) = snapshots
+                .iter()
+                .rev()
+                .find(|snapshot| snapshot.offset <= offset)
+        {
+            return Some(&snapshot.state);
+        }
+
+        self.scope_entries.get(&scope)
+    }
+}
+
+struct Analyzer<'a> {
+    scopes: &'a [Scope],
+    bindings: &'a [Binding],
+    recorded_program: &'a RecordedProgram,
+    scope_entries: FxHashMap<ScopeId, ZshOptionState>,
+    snapshots: FxHashMap<ScopeId, Vec<ZshOptionSnapshot>>,
+    active_function_scopes: FxHashSet<ScopeId>,
+}
+
+impl<'a> Analyzer<'a> {
+    fn analyze_sequence(
+        &mut self,
+        scope: ScopeId,
+        commands: &[RecordedCommand],
+        mut state: EvalState,
+        leak: LeakBehavior,
+    ) -> EvalState {
+        self.record_scope_entry(scope, &state.current.public);
+        for command in commands {
+            self.record_snapshot(scope, command.span.start.offset, &state.current.public);
+            state = self.analyze_command(scope, command, state, leak);
+        }
+        state
+    }
+
+    fn analyze_command(
+        &mut self,
+        scope: ScopeId,
+        command: &RecordedCommand,
+        state: EvalState,
+        leak: LeakBehavior,
+    ) -> EvalState {
+        for region in &command.nested_regions {
+            self.analyze_sequence(
+                region.scope,
+                &region.commands,
+                EvalState::new(state.current.clone()),
+                LeakBehavior::Never,
+            );
+        }
+
+        match &command.kind {
+            RecordedCommandKind::Linear
+            | RecordedCommandKind::Break { .. }
+            | RecordedCommandKind::Continue { .. }
+            | RecordedCommandKind::Return
+            | RecordedCommandKind::Exit => {
+                self.analyze_linear_command(scope, command, state, leak)
+            }
+            RecordedCommandKind::List { first, rest } => {
+                let mut list_state = self.analyze_command(scope, first, state, leak);
+                for (_operator, command) in rest {
+                    let branch = self.analyze_command(scope, command, list_state.clone(), leak);
+                    list_state = list_state.merge(&branch);
+                }
+                list_state
+            }
+            RecordedCommandKind::If {
+                condition,
+                then_branch,
+                elif_branches,
+                else_branch,
+            } => self.analyze_if(scope, &state, condition, then_branch, elif_branches, else_branch, leak),
+            RecordedCommandKind::While { condition, body }
+            | RecordedCommandKind::Until { condition, body } => {
+                let after_condition =
+                    self.analyze_sequence(scope, condition, state.clone(), leak);
+                let iterated = self.analyze_sequence(scope, body, after_condition.clone(), leak);
+                after_condition.merge(&iterated)
+            }
+            RecordedCommandKind::For { body }
+            | RecordedCommandKind::Select { body }
+            | RecordedCommandKind::ArithmeticFor { body }
+            | RecordedCommandKind::BraceGroup { body } => {
+                let iterated = self.analyze_sequence(scope, body, state.clone(), leak);
+                state.merge(&iterated)
+            }
+            RecordedCommandKind::Case { arms } => self.analyze_case(scope, &state, arms, leak),
+            RecordedCommandKind::Subshell { body } => {
+                self.analyze_sequence(
+                    self.subshell_scope_for(command.span.start.offset).unwrap_or(scope),
+                    body,
+                    EvalState::new(state.current.clone()),
+                    LeakBehavior::Never,
+                );
+                state
+            }
+            RecordedCommandKind::Pipeline { segments } => self.analyze_pipeline(scope, &state, segments, leak),
+        }
+    }
+
+    fn analyze_if(
+        &mut self,
+        scope: ScopeId,
+        state: &EvalState,
+        condition: &[RecordedCommand],
+        then_branch: &[RecordedCommand],
+        elif_branches: &[(Vec<RecordedCommand>, Vec<RecordedCommand>)],
+        else_branch: &[RecordedCommand],
+        leak: LeakBehavior,
+    ) -> EvalState {
+        let after_condition = self.analyze_sequence(scope, condition, state.clone(), leak);
+        let mut merged = self.analyze_sequence(scope, then_branch, after_condition.clone(), leak);
+
+        for (elif_condition, elif_body) in elif_branches {
+            let after_elif_condition =
+                self.analyze_sequence(scope, elif_condition, after_condition.clone(), leak);
+            let elif_result =
+                self.analyze_sequence(scope, elif_body, after_elif_condition, leak);
+            merged = merged.merge(&elif_result);
+        }
+
+        if else_branch.is_empty() {
+            merged.merge(&after_condition)
+        } else {
+            let else_result = self.analyze_sequence(scope, else_branch, after_condition, leak);
+            merged.merge(&else_result)
+        }
+    }
+
+    fn analyze_case(
+        &mut self,
+        scope: ScopeId,
+        state: &EvalState,
+        arms: &[RecordedCaseArm],
+        leak: LeakBehavior,
+    ) -> EvalState {
+        let mut merged = state.clone();
+        for arm in arms {
+            let arm_result = self.analyze_sequence(scope, &arm.commands, state.clone(), leak);
+            merged = merged.merge(&arm_result);
+            if arm.matches_anything {
+                return merged;
+            }
+        }
+        merged
+    }
+
+    fn analyze_pipeline(
+        &mut self,
+        _scope: ScopeId,
+        state: &EvalState,
+        segments: &[RecordedPipelineSegment],
+        leak: LeakBehavior,
+    ) -> EvalState {
+        let mut result = state.clone();
+        let emulation = state.current.emulation;
+
+        if emulation == EmulationState::Unknown {
+            let mut touched = FxHashSet::default();
+            for segment in segments {
+                let segment_result = self.analyze_sequence(
+                    segment.scope,
+                    std::slice::from_ref(&segment.command),
+                    EvalState::new(state.current.clone()),
+                    LeakBehavior::Never,
+                );
+                touched.extend(segment_result.outward_touched.iter().copied());
+            }
+            for field in touched {
+                self.apply_explicit_public_field(
+                    &mut result,
+                    leak,
+                    field,
+                    OptionValue::Unknown,
+                );
+            }
+            return result;
+        }
+
+        for (index, segment) in segments.iter().enumerate() {
+            let segment_leak = if emulation.is_definitely_sh() || index + 1 != segments.len() {
+                LeakBehavior::Never
+            } else {
+                leak
+            };
+            let segment_result = self.analyze_sequence(
+                segment.scope,
+                std::slice::from_ref(&segment.command),
+                EvalState::new(state.current.clone()),
+                segment_leak,
+            );
+            if segment_leak != LeakBehavior::Never {
+                result = segment_result;
+            }
+        }
+
+        result
+    }
+
+    fn analyze_linear_command(
+        &mut self,
+        scope: ScopeId,
+        command: &RecordedCommand,
+        mut state: EvalState,
+        leak: LeakBehavior,
+    ) -> EvalState {
+        let info = self.recorded_program.command_infos.get(&SpanKey::new(command.span));
+
+        if let Some(function_scope) = info
+            .and_then(|info| info.static_callee.as_deref())
+            .and_then(|name| self.resolve_visible_function_scope(scope, command.span.start.offset, name))
+        {
+            let summary = self.analyze_function_scope(
+                function_scope,
+                EvalState::new(state.current.clone()),
+            );
+            for field in &summary.outward_touched {
+                let value = get_option_field(&summary.final_outward.public, *field);
+                set_option_field(&mut state.current.public, *field, value);
+                self.apply_explicit_public_field(&mut state, leak, *field, value);
+            }
+            self.apply_emulation_state(&mut state, leak, summary.final_outward.emulation);
+            return state;
+        }
+
+        if let Some(info) = info {
+            for effect in &info.zsh_effects {
+                match effect {
+                    RecordedZshCommandEffect::Emulate { mode, local } => {
+                        self.apply_emulate(&mut state, leak, *mode, *local, is_function_scope(self.scopes, scope));
+                    }
+                    RecordedZshCommandEffect::SetOptions { updates } => {
+                        for update in updates {
+                            self.apply_option_update(&mut state, leak, update, is_function_scope(self.scopes, scope));
+                        }
+                    }
+                }
+            }
+        }
+
+        state
+    }
+
+    fn analyze_function_scope(&mut self, scope: ScopeId, entry: EvalState) -> FunctionSummary {
+        if !self.active_function_scopes.insert(scope) {
+            return FunctionSummary {
+                final_outward: entry.outward,
+                outward_touched: FxHashSet::default(),
+            };
+        }
+
+        let body = self
+            .recorded_program
+            .function_bodies
+            .get(&scope)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let result = self.analyze_sequence(scope, body, entry, LeakBehavior::Function);
+        self.active_function_scopes.remove(&scope);
+        FunctionSummary {
+            final_outward: result.outward,
+            outward_touched: result.outward_touched,
+        }
+    }
+
+    fn resolve_visible_function_scope(
+        &self,
+        scope: ScopeId,
+        offset: usize,
+        name: &str,
+    ) -> Option<ScopeId> {
+        let mut current = Some(scope);
+        while let Some(scope_id) = current {
+            if let Some(bindings) = self.scopes[scope_id.index()].bindings.get(name) {
+                for binding_id in bindings.iter().rev().copied() {
+                    let binding = &self.bindings[binding_id.index()];
+                    if binding.span.start.offset > offset
+                        || binding.kind != BindingKind::FunctionDefinition
+                    {
+                        continue;
+                    }
+                    if let Some(body_scope) =
+                        self.recorded_program.function_body_scopes.get(&binding_id)
+                    {
+                        return Some(*body_scope);
+                    }
+                }
+            }
+            current = self.scopes[scope_id.index()].parent;
+        }
+        None
+    }
+
+    fn subshell_scope_for(&self, offset: usize) -> Option<ScopeId> {
+        self.scopes
+            .iter()
+            .filter(|scope| {
+                scope.span.start.offset <= offset
+                    && offset <= scope.span.end.offset
+                    && matches!(scope.kind, ScopeKind::Subshell | ScopeKind::CommandSubstitution)
+            })
+            .min_by_key(|scope| scope.span.end.offset - scope.span.start.offset)
+            .map(|scope| scope.id)
+    }
+
+    fn apply_emulate(
+        &self,
+        state: &mut EvalState,
+        leak: LeakBehavior,
+        mode: ZshEmulationMode,
+        local: bool,
+        in_function: bool,
+    ) {
+        let localize = local && in_function;
+        let fields = ZshOptionField::ALL;
+        let next_public = ZshOptionState::for_emulate(mode);
+        state.current.public = next_public.clone();
+        state.current.emulation = EmulationState::from_mode(mode);
+        if localize {
+            state.current.local_options = OptionValue::On;
+            return;
+        }
+
+        self.apply_explicit_public_state(state, leak, &fields, &next_public);
+        state.outward.emulation = state.outward.emulation.merge(EmulationState::from_mode(mode));
+        if leak == LeakBehavior::Always
+            || (leak == LeakBehavior::Function && state.current.local_options.is_definitely_off())
+        {
+            state.outward.emulation = EmulationState::from_mode(mode);
+        }
+    }
+
+    fn apply_option_update(
+        &self,
+        state: &mut EvalState,
+        leak: LeakBehavior,
+        update: &RecordedZshOptionUpdate,
+        in_function: bool,
+    ) {
+        match update {
+            RecordedZshOptionUpdate::LocalOptions { enable } if in_function => {
+                state.current.local_options = if *enable {
+                    OptionValue::On
+                } else {
+                    OptionValue::Off
+                };
+            }
+            RecordedZshOptionUpdate::LocalOptions { .. } => {}
+            RecordedZshOptionUpdate::Named { name, enable } => {
+                let Some(field) = field_for_option_name(name) else {
+                    return;
+                };
+                let value = if *enable {
+                    OptionValue::On
+                } else {
+                    OptionValue::Off
+                };
+                set_option_field(&mut state.current.public, field, value);
+                self.apply_explicit_public_field(state, leak, field, value);
+            }
+        }
+    }
+
+    fn apply_explicit_public_state(
+        &self,
+        state: &mut EvalState,
+        leak: LeakBehavior,
+        fields: &[ZshOptionField],
+        next: &ZshOptionState,
+    ) {
+        match leak {
+            LeakBehavior::Never => {}
+            LeakBehavior::Always => {
+                state.outward.public = next.clone();
+                state.outward_touched.extend(fields.iter().copied());
+            }
+            LeakBehavior::Function => match state.current.local_options {
+                OptionValue::On => {}
+                OptionValue::Off => {
+                    state.outward.public = next.clone();
+                    state.outward_touched.extend(fields.iter().copied());
+                }
+                OptionValue::Unknown => {
+                    let merged = state.outward.public.merge(next);
+                    state.outward.public = merged;
+                    state.outward_touched.extend(fields.iter().copied());
+                }
+            },
+        }
+    }
+
+    fn apply_explicit_public_field(
+        &self,
+        state: &mut EvalState,
+        leak: LeakBehavior,
+        field: ZshOptionField,
+        value: OptionValue,
+    ) {
+        match leak {
+            LeakBehavior::Never => {}
+            LeakBehavior::Always => {
+                set_option_field(&mut state.outward.public, field, value);
+                state.outward_touched.insert(field);
+            }
+            LeakBehavior::Function => match state.current.local_options {
+                OptionValue::On => {}
+                OptionValue::Off => {
+                    set_option_field(&mut state.outward.public, field, value);
+                    state.outward_touched.insert(field);
+                }
+                OptionValue::Unknown => {
+                    let merged = get_option_field(&state.outward.public, field).merge(value);
+                    set_option_field(&mut state.outward.public, field, merged);
+                    state.outward_touched.insert(field);
+                }
+            },
+        }
+    }
+
+    fn apply_emulation_state(
+        &self,
+        state: &mut EvalState,
+        leak: LeakBehavior,
+        emulation: EmulationState,
+    ) {
+        state.current.emulation = emulation;
+        match leak {
+            LeakBehavior::Never => {}
+            LeakBehavior::Always => {
+                state.outward.emulation = emulation;
+            }
+            LeakBehavior::Function => match state.current.local_options {
+                OptionValue::On => {}
+                OptionValue::Off => {
+                    state.outward.emulation = emulation;
+                }
+                OptionValue::Unknown => {
+                    state.outward.emulation = state.outward.emulation.merge(emulation);
+                }
+            },
+        }
+    }
+
+    fn record_scope_entry(&mut self, scope: ScopeId, state: &ZshOptionState) {
+        self.scope_entries
+            .entry(scope)
+            .or_insert_with(|| state.clone());
+    }
+
+    fn record_snapshot(&mut self, scope: ScopeId, offset: usize, state: &ZshOptionState) {
+        self.snapshots
+            .entry(scope)
+            .or_default()
+            .push(ZshOptionSnapshot {
+                offset,
+                state: state.clone(),
+            });
+    }
+}
+
+fn is_function_scope(scopes: &[Scope], scope: ScopeId) -> bool {
+    let mut current = Some(scope);
+    while let Some(scope_id) = current {
+        if matches!(scopes[scope_id.index()].kind, ScopeKind::Function(_)) {
+            return true;
+        }
+        current = scopes[scope_id.index()].parent;
+    }
+    false
+}
+
+fn contains_offset(span: shuck_ast::Span, offset: usize) -> bool {
+    span.start.offset <= offset && offset <= span.end.offset
+}
+
+fn field_for_option_name(name: &str) -> Option<ZshOptionField> {
+    match name {
+        "shwordsplit" => Some(ZshOptionField::ShWordSplit),
+        "globsubst" => Some(ZshOptionField::GlobSubst),
+        "rcexpandparam" => Some(ZshOptionField::RcExpandParam),
+        "glob" => Some(ZshOptionField::Glob),
+        "nomatch" => Some(ZshOptionField::Nomatch),
+        "nullglob" => Some(ZshOptionField::NullGlob),
+        "cshnullglob" => Some(ZshOptionField::CshNullGlob),
+        "extendedglob" => Some(ZshOptionField::ExtendedGlob),
+        "kshglob" => Some(ZshOptionField::KshGlob),
+        "shglob" => Some(ZshOptionField::ShGlob),
+        "bareglobqual" => Some(ZshOptionField::BareGlobQual),
+        "globdots" => Some(ZshOptionField::GlobDots),
+        "equals" => Some(ZshOptionField::Equals),
+        "magicequalsubst" => Some(ZshOptionField::MagicEqualSubst),
+        "shfileexpansion" => Some(ZshOptionField::ShFileExpansion),
+        "globassign" => Some(ZshOptionField::GlobAssign),
+        "ignorebraces" => Some(ZshOptionField::IgnoreBraces),
+        "ignoreclosebraces" => Some(ZshOptionField::IgnoreCloseBraces),
+        "braceccl" => Some(ZshOptionField::BraceCcl),
+        "ksharrays" => Some(ZshOptionField::KshArrays),
+        "kshzerosubscript" => Some(ZshOptionField::KshZeroSubscript),
+        "shortloops" => Some(ZshOptionField::ShortLoops),
+        "shortrepeat" => Some(ZshOptionField::ShortRepeat),
+        "rcquotes" => Some(ZshOptionField::RcQuotes),
+        "interactivecomments" => Some(ZshOptionField::InteractiveComments),
+        "cbases" => Some(ZshOptionField::CBases),
+        "octalzeroes" => Some(ZshOptionField::OctalZeroes),
+        _ => None,
+    }
+}
+
+fn get_option_field(state: &ZshOptionState, field: ZshOptionField) -> OptionValue {
+    match field {
+        ZshOptionField::ShWordSplit => state.sh_word_split,
+        ZshOptionField::GlobSubst => state.glob_subst,
+        ZshOptionField::RcExpandParam => state.rc_expand_param,
+        ZshOptionField::Glob => state.glob,
+        ZshOptionField::Nomatch => state.nomatch,
+        ZshOptionField::NullGlob => state.null_glob,
+        ZshOptionField::CshNullGlob => state.csh_null_glob,
+        ZshOptionField::ExtendedGlob => state.extended_glob,
+        ZshOptionField::KshGlob => state.ksh_glob,
+        ZshOptionField::ShGlob => state.sh_glob,
+        ZshOptionField::BareGlobQual => state.bare_glob_qual,
+        ZshOptionField::GlobDots => state.glob_dots,
+        ZshOptionField::Equals => state.equals,
+        ZshOptionField::MagicEqualSubst => state.magic_equal_subst,
+        ZshOptionField::ShFileExpansion => state.sh_file_expansion,
+        ZshOptionField::GlobAssign => state.glob_assign,
+        ZshOptionField::IgnoreBraces => state.ignore_braces,
+        ZshOptionField::IgnoreCloseBraces => state.ignore_close_braces,
+        ZshOptionField::BraceCcl => state.brace_ccl,
+        ZshOptionField::KshArrays => state.ksh_arrays,
+        ZshOptionField::KshZeroSubscript => state.ksh_zero_subscript,
+        ZshOptionField::ShortLoops => state.short_loops,
+        ZshOptionField::ShortRepeat => state.short_repeat,
+        ZshOptionField::RcQuotes => state.rc_quotes,
+        ZshOptionField::InteractiveComments => state.interactive_comments,
+        ZshOptionField::CBases => state.c_bases,
+        ZshOptionField::OctalZeroes => state.octal_zeroes,
+    }
+}
+
+fn set_option_field(state: &mut ZshOptionState, field: ZshOptionField, value: OptionValue) {
+    match field {
+        ZshOptionField::ShWordSplit => state.sh_word_split = value,
+        ZshOptionField::GlobSubst => state.glob_subst = value,
+        ZshOptionField::RcExpandParam => state.rc_expand_param = value,
+        ZshOptionField::Glob => state.glob = value,
+        ZshOptionField::Nomatch => state.nomatch = value,
+        ZshOptionField::NullGlob => state.null_glob = value,
+        ZshOptionField::CshNullGlob => state.csh_null_glob = value,
+        ZshOptionField::ExtendedGlob => state.extended_glob = value,
+        ZshOptionField::KshGlob => state.ksh_glob = value,
+        ZshOptionField::ShGlob => state.sh_glob = value,
+        ZshOptionField::BareGlobQual => state.bare_glob_qual = value,
+        ZshOptionField::GlobDots => state.glob_dots = value,
+        ZshOptionField::Equals => state.equals = value,
+        ZshOptionField::MagicEqualSubst => state.magic_equal_subst = value,
+        ZshOptionField::ShFileExpansion => state.sh_file_expansion = value,
+        ZshOptionField::GlobAssign => state.glob_assign = value,
+        ZshOptionField::IgnoreBraces => state.ignore_braces = value,
+        ZshOptionField::IgnoreCloseBraces => state.ignore_close_braces = value,
+        ZshOptionField::BraceCcl => state.brace_ccl = value,
+        ZshOptionField::KshArrays => state.ksh_arrays = value,
+        ZshOptionField::KshZeroSubscript => state.ksh_zero_subscript = value,
+        ZshOptionField::ShortLoops => state.short_loops = value,
+        ZshOptionField::ShortRepeat => state.short_repeat = value,
+        ZshOptionField::RcQuotes => state.rc_quotes = value,
+        ZshOptionField::InteractiveComments => state.interactive_comments = value,
+        ZshOptionField::CBases => state.c_bases = value,
+        ZshOptionField::OctalZeroes => state.octal_zeroes = value,
+    }
+}

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -776,7 +776,7 @@ fn large_corpus_conforms_with_shellcheck() {
 }
 
 #[test]
-#[ignore = "requires the large corpus; run `make test-large-corpus`"]
+#[ignore = "requires the large corpus; run `make test-large-corpus-zsh`"]
 fn large_corpus_zsh_fixtures_parse() {
     let cfg = match resolve_large_corpus_config() {
         Some(cfg) => cfg,
@@ -1146,10 +1146,13 @@ fn evaluate_fixture_zsh_parse(
             }
         };
 
-    if let Err(err) = parse_result {
+        if let Err(err) = parse_result {
         evaluation.harness_failure = Some(FixtureFailure {
             kind: FixtureFailureKind::Other,
-            message: format_fixture_failure(&fixture.path, &[format!("shuck parse error: {err}")]),
+            message: format_fixture_failure(
+                &fixture.path,
+                &[format!("shuck zsh parse/option extraction error: {err}")],
+            ),
         });
     }
 
@@ -2069,6 +2072,10 @@ fn parser_dialect_for_large_corpus_shell(shell: &str) -> shuck_parser::ShellDial
     }
 }
 
+fn shell_profile_for_large_corpus_shell(shell: &str) -> shuck_parser::ShellProfile {
+    shuck_parser::ShellProfile::native(parser_dialect_for_large_corpus_shell(shell))
+}
+
 fn run_shuck_with_parse_dialect(
     fixture: &LargeCorpusFixture,
     linter_settings: &shuck_linter::LinterSettings,
@@ -2221,12 +2228,51 @@ fn parse_fixture_for_effective_large_corpus_shell_with_timeout(
         let source =
             fs::read_to_string(&fixture.path).map_err(|err| format!("read error: {err}"))?;
         let shell = effective_large_corpus_shell(&fixture);
-        let parse_dialect = parser_dialect_for_large_corpus_shell(shell);
-        shuck_parser::parser::Parser::with_dialect(&source, parse_dialect)
+        let shell_profile = shell_profile_for_large_corpus_shell(shell);
+        let parsed = shuck_parser::parser::Parser::with_profile(&source, shell_profile.clone())
             .parse()
-            .map(|_| ())
-            .map_err(|err| err.to_string())
+            .map_err(|err| err.to_string())?;
+
+        if shell == "zsh" {
+            extract_large_corpus_zsh_option_state(&fixture.path, &source, &parsed, shell_profile)?;
+        }
+
+        Ok(())
     })
+}
+
+fn extract_large_corpus_zsh_option_state(
+    path: &Path,
+    source: &str,
+    output: &shuck_parser::parser::ParseOutput,
+    shell_profile: shuck_parser::ShellProfile,
+) -> Result<(), String> {
+    let indexer = shuck_indexer::Indexer::new(source, output);
+    let semantic = shuck_semantic::SemanticModel::build_with_options(
+        &output.file,
+        source,
+        &indexer,
+        shuck_semantic::SemanticBuildOptions {
+            source_path: Some(path),
+            shell_profile: Some(shell_profile),
+            ..shuck_semantic::SemanticBuildOptions::default()
+        },
+    );
+
+    if semantic.shell_profile().zsh_options().is_none() {
+        return Err("semantic model did not retain a zsh shell profile".to_owned());
+    }
+
+    for stmt in output.file.body.iter() {
+        if semantic.zsh_options_at(stmt.span.start.offset).is_none() {
+            return Err(format!(
+                "missing zsh option snapshot at {}:{}",
+                stmt.span.start.line, stmt.span.start.column
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 fn build_rule_to_shellcheck_index(

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1146,7 +1146,7 @@ fn evaluate_fixture_zsh_parse(
             }
         };
 
-        if let Err(err) = parse_result {
+    if let Err(err) = parse_result {
         evaluation.harness_failure = Some(FixtureFailure {
             kind: FixtureFailureKind::Other,
             message: format_fixture_failure(

--- a/crates/shuck/tests/testdata/zsh-option-state/globbing.toml
+++ b/crates/shuck/tests/testdata/zsh-option-state/globbing.toml
@@ -1,0 +1,73 @@
+name = "globbing, noglob, and per-expansion glob flags"
+source = '''
+pattern='*.txt'
+setopt glob_subst
+__shuck_probe_options glob_on globsubst glob
+__shuck_probe_fields globbed $pattern
+setopt no_glob
+__shuck_probe_options glob_off globsubst glob
+__shuck_probe_fields glob_disabled $pattern
+unsetopt no_glob
+noglob __shuck_probe_fields wrapped *.txt
+__shuck_probe_fields force_glob ${~pattern}
+__shuck_probe_fields force_glob_off ${~~pattern}
+'''
+
+[[files]]
+path = "alpha.txt"
+
+[[files]]
+path = "beta.txt"
+
+[option_probes.glob_on]
+globsubst = "on"
+glob = "on"
+
+[option_probes.glob_off]
+globsubst = "on"
+glob = "off"
+
+[field_probes.globbed]
+count = 2
+values = ["alpha.txt", "beta.txt"]
+
+[field_probes.globbed.shuck]
+multi = true
+field_splitting = false
+pathname_matching = true
+
+[field_probes.glob_disabled]
+count = 1
+values = ["*.txt"]
+
+[field_probes.glob_disabled.shuck]
+multi = false
+field_splitting = false
+pathname_matching = false
+
+[field_probes.wrapped]
+count = 1
+values = ["*.txt"]
+
+[field_probes.wrapped.shuck]
+multi = false
+field_splitting = false
+pathname_matching = false
+
+[field_probes.force_glob]
+count = 2
+values = ["alpha.txt", "beta.txt"]
+
+[field_probes.force_glob.shuck]
+multi = true
+field_splitting = false
+pathname_matching = true
+
+[field_probes.force_glob_off]
+count = 1
+values = ["*.txt"]
+
+[field_probes.force_glob_off.shuck]
+multi = false
+field_splitting = false
+pathname_matching = false

--- a/crates/shuck/tests/testdata/zsh-option-state/scope-and-arrays.toml
+++ b/crates/shuck/tests/testdata/zsh-option-state/scope-and-arrays.toml
@@ -1,0 +1,56 @@
+name = "function scoping and ksh array mode"
+source = '''
+values=(one two)
+__shuck_probe_options array_native ksharrays
+__shuck_probe_fields array_native $values
+setopt ksh_arrays
+__shuck_probe_options array_ksh ksharrays
+__shuck_probe_fields array_ksh $values
+unsetopt ksh_arrays
+
+__shuck_probe_options scope_before shwordsplit globsubst shglob
+scoped() {
+  emulate -L sh
+  __shuck_probe_options scope_local shwordsplit globsubst shglob
+}
+scoped
+__shuck_probe_options scope_after shwordsplit globsubst shglob
+
+leaky() {
+  setopt sh_word_split
+}
+leaky
+__shuck_probe_options leaked shwordsplit
+'''
+
+[option_probes.array_native]
+ksharrays = "off"
+
+[option_probes.array_ksh]
+ksharrays = "on"
+
+[option_probes.scope_before]
+shwordsplit = "off"
+globsubst = "off"
+shglob = "off"
+
+[option_probes.scope_local]
+shwordsplit = "on"
+globsubst = "on"
+shglob = "on"
+
+[option_probes.scope_after]
+shwordsplit = "off"
+globsubst = "off"
+shglob = "off"
+
+[option_probes.leaked]
+shwordsplit = "on"
+
+[field_probes.array_native]
+count = 2
+values = ["one", "two"]
+
+[field_probes.array_ksh]
+count = 1
+values = ["one"]

--- a/crates/shuck/tests/testdata/zsh-option-state/word-splitting.toml
+++ b/crates/shuck/tests/testdata/zsh-option-state/word-splitting.toml
@@ -1,0 +1,45 @@
+name = "word splitting and force-split modifier"
+source = '''
+value="alpha beta"
+__shuck_probe_options native shwordsplit globsubst
+__shuck_probe_fields plain $value
+setopt sh_word_split
+__shuck_probe_options split_on shwordsplit
+__shuck_probe_fields split_on $value
+unsetopt sh_word_split
+__shuck_probe_fields force_split ${=value}
+'''
+
+[option_probes.native]
+shwordsplit = "off"
+globsubst = "off"
+
+[option_probes.split_on]
+shwordsplit = "on"
+
+[field_probes.plain]
+count = 1
+values = ["alpha beta"]
+
+[field_probes.plain.shuck]
+multi = false
+field_splitting = false
+pathname_matching = false
+
+[field_probes.split_on]
+count = 2
+values = ["alpha", "beta"]
+
+[field_probes.split_on.shuck]
+multi = true
+field_splitting = true
+pathname_matching = false
+
+[field_probes.force_split]
+count = 2
+values = ["alpha", "beta"]
+
+[field_probes.force_split.shuck]
+multi = true
+field_splitting = true
+pathname_matching = false

--- a/crates/shuck/tests/zsh_option_state.rs
+++ b/crates/shuck/tests/zsh_option_state.rs
@@ -1,0 +1,400 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use shuck_indexer::Indexer;
+use shuck_linter::{
+    Checker, ExpansionContext, RuleSet, ShellDialect, WordFactContext, classify_file_context,
+    static_word_text,
+};
+use shuck_parser::parser::Parser;
+use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
+use shuck_semantic::{OptionValue, SemanticBuildOptions, SemanticModel, ZshOptionState};
+use tempfile::tempdir;
+
+const OPTION_PROBE_PREFIX: &str = "__SHUCK_OPTIONS__";
+const FIELD_PROBE_PREFIX: &str = "__SHUCK_FIELDS__";
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    name: String,
+    source: String,
+    #[serde(default)]
+    files: Vec<FixtureFile>,
+    #[serde(default)]
+    option_probes: BTreeMap<String, BTreeMap<String, String>>,
+    #[serde(default)]
+    field_probes: BTreeMap<String, FieldProbeExpectation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureFile {
+    path: String,
+    #[serde(default)]
+    contents: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FieldProbeExpectation {
+    count: usize,
+    #[serde(default)]
+    values: Vec<String>,
+    #[serde(default)]
+    shuck: Option<ShuckFieldExpectation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ShuckFieldExpectation {
+    multi: bool,
+    field_splitting: bool,
+    pathname_matching: bool,
+}
+
+#[derive(Debug, Default)]
+struct ProbeRun {
+    option_probes: BTreeMap<String, BTreeMap<String, String>>,
+    field_probes: BTreeMap<String, FieldObservation>,
+}
+
+#[derive(Debug, Default)]
+struct FieldObservation {
+    count: usize,
+    values: Vec<String>,
+}
+
+#[test]
+fn zsh_option_state_fixtures_match_black_box_behavior() -> Result<()> {
+    if !zsh_is_available()? {
+        eprintln!("zsh option-state black-box fixtures skipped (`zsh` is unavailable)");
+        return Ok(());
+    }
+
+    for fixture_path in fixture_paths()? {
+        let fixture = load_fixture(&fixture_path)?;
+        run_fixture(&fixture).with_context(|| format!("fixture {}", fixture.name))?;
+    }
+
+    Ok(())
+}
+
+fn zsh_is_available() -> Result<bool> {
+    match Command::new("zsh")
+        .args(["-fc", "emulate -R zsh; print -r -- ok"])
+        .output()
+    {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(true)
+            } else {
+                bail!(
+                    "`zsh` was found but could not execute fixtures successfully: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                );
+            }
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err).context("failed to probe `zsh` availability"),
+    }
+}
+
+fn fixture_paths() -> Result<Vec<PathBuf>> {
+    let mut paths = fs::read_dir(fixture_dir())
+        .with_context(|| format!("failed to read {}", fixture_dir().display()))?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()
+        .context("failed to enumerate zsh option-state fixtures")?;
+    paths.retain(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"));
+    paths.sort();
+    Ok(paths)
+}
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("testdata")
+        .join("zsh-option-state")
+}
+
+fn load_fixture(path: &Path) -> Result<Fixture> {
+    let text =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    toml::from_str(&text).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn run_fixture(fixture: &Fixture) -> Result<()> {
+    let observed = run_fixture_in_zsh(fixture)?;
+    let profile = ShellProfile::native(ParseShellDialect::Zsh);
+    let parsed = Parser::with_profile(&fixture.source, profile.clone())
+        .parse()
+        .map_err(|err| anyhow::anyhow!("parse error: {err}"))?;
+    let indexer = Indexer::new(&fixture.source, &parsed);
+    let semantic = SemanticModel::build_with_options(
+        &parsed.file,
+        &fixture.source,
+        &indexer,
+        SemanticBuildOptions {
+            shell_profile: Some(profile),
+            ..SemanticBuildOptions::default()
+        },
+    );
+    let file_context = classify_file_context(&fixture.source, None, ShellDialect::Zsh);
+    let rules = RuleSet::EMPTY;
+    let checker = Checker::new(
+        &parsed.file,
+        &fixture.source,
+        &semantic,
+        &indexer,
+        &rules,
+        ShellDialect::Zsh,
+        &file_context,
+    );
+
+    for (probe_id, expected) in &fixture.option_probes {
+        let actual = observed
+            .option_probes
+            .get(probe_id)
+            .with_context(|| format!("missing zsh option probe `{probe_id}`"))?;
+        assert_eq!(
+            actual, expected,
+            "fixture `{}` probe `{probe_id}` zsh option output mismatch",
+            fixture.name
+        );
+
+        let fact = find_probe_command(&checker, "__shuck_probe_options", probe_id)?;
+        let predicted = expected
+            .keys()
+            .map(|name| {
+                let options = fact
+                    .zsh_options()
+                    .with_context(|| format!("missing zsh option state for `{probe_id}`"))?;
+                Ok((name.clone(), option_value_string(lookup_option(options, name)?)))
+            })
+            .collect::<Result<BTreeMap<_, _>>>()?;
+        assert_eq!(
+            predicted, *expected,
+            "fixture `{}` probe `{probe_id}` shuck option state mismatch",
+            fixture.name
+        );
+    }
+
+    for (probe_id, expected) in &fixture.field_probes {
+        let actual = observed
+            .field_probes
+            .get(probe_id)
+            .with_context(|| format!("missing zsh field probe `{probe_id}`"))?;
+        assert_eq!(
+            actual.count, expected.count,
+            "fixture `{}` probe `{probe_id}` zsh field-count mismatch",
+            fixture.name
+        );
+        assert_eq!(
+            actual.values, expected.values,
+            "fixture `{}` probe `{probe_id}` zsh field-value mismatch",
+            fixture.name
+        );
+
+        let Some(shuck) = &expected.shuck else {
+            continue;
+        };
+
+        let fact = find_probe_command(&checker, "__shuck_probe_fields", probe_id)?;
+        let target = fact.body_args().get(1).with_context(|| {
+            format!(
+                "fixture `{}` probe `{probe_id}` did not expose a field target word",
+                fixture.name
+            )
+        })?;
+        let word_fact = checker
+            .facts()
+            .word_fact(
+                target.span,
+                WordFactContext::Expansion(ExpansionContext::CommandArgument),
+            )
+            .with_context(|| {
+                format!(
+                    "fixture `{}` probe `{probe_id}` missing command-argument word fact",
+                    fixture.name
+                )
+            })?;
+        let analysis = word_fact.analysis();
+        assert_eq!(
+            analysis.can_expand_to_multiple_fields, shuck.multi,
+            "fixture `{}` probe `{probe_id}` shuck multi-field mismatch",
+            fixture.name
+        );
+        assert_eq!(
+            analysis.hazards.field_splitting, shuck.field_splitting,
+            "fixture `{}` probe `{probe_id}` shuck field-splitting mismatch",
+            fixture.name
+        );
+        assert_eq!(
+            analysis.hazards.pathname_matching, shuck.pathname_matching,
+            "fixture `{}` probe `{probe_id}` shuck pathname-matching mismatch",
+            fixture.name
+        );
+    }
+
+    Ok(())
+}
+
+fn run_fixture_in_zsh(fixture: &Fixture) -> Result<ProbeRun> {
+    let tempdir = tempdir().context("failed to create temp dir for zsh fixture")?;
+    for file in &fixture.files {
+        let path = tempdir.path().join(&file.path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        fs::write(&path, &file.contents)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+
+    let script = format!(
+        r#"emulate -R zsh
+__shuck_probe_options() {{
+  local id=$1
+  shift
+  printf '%s\t%s' '{OPTION_PROBE_PREFIX}' "$id"
+  local opt
+  for opt in "$@"; do
+    if [[ -o "$opt" ]]; then
+      printf '\t%s=on' "$opt"
+    else
+      printf '\t%s=off' "$opt"
+    fi
+  done
+  printf '\n'
+}}
+__shuck_probe_fields() {{
+  local id=$1
+  shift
+  printf '%s\t%s\t%s' '{FIELD_PROBE_PREFIX}' "$id" "$#"
+  local arg
+  for arg in "$@"; do
+    printf '\t%s' "$arg"
+  done
+  printf '\n'
+}}
+{}
+"#,
+        fixture.source
+    );
+
+    let output = Command::new("zsh")
+        .args(["-fc", &script])
+        .current_dir(tempdir.path())
+        .output()
+        .context("failed to execute zsh fixture")?;
+    if !output.status.success() {
+        bail!(
+            "zsh fixture failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    parse_probe_output(&String::from_utf8(output.stdout).context("zsh fixture stdout was not utf-8")?)
+}
+
+fn parse_probe_output(stdout: &str) -> Result<ProbeRun> {
+    let mut run = ProbeRun::default();
+    for line in stdout.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let fields = line.split('\t').collect::<Vec<_>>();
+        match fields.as_slice() {
+            [OPTION_PROBE_PREFIX, probe_id, rest @ ..] => {
+                let options = rest
+                    .iter()
+                    .map(|entry| {
+                        let (name, value) = entry.split_once('=').with_context(|| {
+                            format!("invalid option probe entry `{entry}` in `{line}`")
+                        })?;
+                        Ok((name.to_owned(), value.to_owned()))
+                    })
+                    .collect::<Result<BTreeMap<_, _>>>()?;
+                run.option_probes.insert((*probe_id).to_owned(), options);
+            }
+            [FIELD_PROBE_PREFIX, probe_id, count, values @ ..] => {
+                run.field_probes.insert(
+                    (*probe_id).to_owned(),
+                    FieldObservation {
+                        count: count
+                            .parse()
+                            .with_context(|| format!("invalid field count `{count}` in `{line}`"))?,
+                        values: values.iter().map(|value| (*value).to_owned()).collect(),
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+    Ok(run)
+}
+
+fn find_probe_command<'a>(
+    checker: &'a Checker<'_>,
+    command_name: &str,
+    probe_id: &str,
+) -> Result<&'a shuck_linter::CommandFact<'a>> {
+    checker
+        .facts()
+        .structural_commands()
+        .find(|fact| {
+            fact.effective_name_is(command_name)
+                && fact
+                    .body_args()
+                    .first()
+                    .and_then(|word| static_word_text(word, checker.source()))
+                    .as_deref()
+                    == Some(probe_id)
+        })
+        .with_context(|| format!("missing `{command_name}` probe command for `{probe_id}`"))
+}
+
+fn lookup_option<'a>(options: &'a ZshOptionState, name: &str) -> Result<&'a OptionValue> {
+    match name {
+        "shwordsplit" => Ok(&options.sh_word_split),
+        "globsubst" => Ok(&options.glob_subst),
+        "rcexpandparam" => Ok(&options.rc_expand_param),
+        "glob" => Ok(&options.glob),
+        "nomatch" => Ok(&options.nomatch),
+        "nullglob" => Ok(&options.null_glob),
+        "cshnullglob" => Ok(&options.csh_null_glob),
+        "extendedglob" => Ok(&options.extended_glob),
+        "kshglob" => Ok(&options.ksh_glob),
+        "shglob" => Ok(&options.sh_glob),
+        "bareglobqual" => Ok(&options.bare_glob_qual),
+        "globdots" => Ok(&options.glob_dots),
+        "equals" => Ok(&options.equals),
+        "magicequalsubst" => Ok(&options.magic_equal_subst),
+        "shfileexpansion" => Ok(&options.sh_file_expansion),
+        "globassign" => Ok(&options.glob_assign),
+        "ignorebraces" => Ok(&options.ignore_braces),
+        "ignoreclosebraces" => Ok(&options.ignore_close_braces),
+        "braceccl" => Ok(&options.brace_ccl),
+        "ksharrays" => Ok(&options.ksh_arrays),
+        "kshzerosubscript" => Ok(&options.ksh_zero_subscript),
+        "shortloops" => Ok(&options.short_loops),
+        "shortrepeat" => Ok(&options.short_repeat),
+        "rcquotes" => Ok(&options.rc_quotes),
+        "interactivecomments" => Ok(&options.interactive_comments),
+        "cbases" => Ok(&options.c_bases),
+        "octalzeroes" => Ok(&options.octal_zeroes),
+        _ => bail!("unsupported fixture option name `{name}`"),
+    }
+}
+
+fn option_value_string(value: &OptionValue) -> String {
+    match value {
+        OptionValue::On => "on",
+        OptionValue::Off => "off",
+        OptionValue::Unknown => "unknown",
+    }
+    .to_owned()
+}

--- a/crates/shuck/tests/zsh_option_state.rs
+++ b/crates/shuck/tests/zsh_option_state.rs
@@ -171,7 +171,10 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
                 let options = fact
                     .zsh_options()
                     .with_context(|| format!("missing zsh option state for `{probe_id}`"))?;
-                Ok((name.clone(), option_value_string(lookup_option(options, name)?)))
+                Ok((
+                    name.clone(),
+                    option_value_string(lookup_option(options, name)?),
+                ))
             })
             .collect::<Result<BTreeMap<_, _>>>()?;
         assert_eq!(
@@ -297,7 +300,9 @@ __shuck_probe_fields() {{
         );
     }
 
-    parse_probe_output(&String::from_utf8(output.stdout).context("zsh fixture stdout was not utf-8")?)
+    parse_probe_output(
+        &String::from_utf8(output.stdout).context("zsh fixture stdout was not utf-8")?,
+    )
 }
 
 fn parse_probe_output(stdout: &str) -> Result<ProbeRun> {
@@ -324,9 +329,9 @@ fn parse_probe_output(stdout: &str) -> Result<ProbeRun> {
                 run.field_probes.insert(
                     (*probe_id).to_owned(),
                     FieldObservation {
-                        count: count
-                            .parse()
-                            .with_context(|| format!("invalid field count `{count}` in `{line}`"))?,
+                        count: count.parse().with_context(|| {
+                            format!("invalid field count `{count}` in `{line}`")
+                        })?,
                         values: values.iter().map(|value| (*value).to_owned()).collect(),
                     },
                 );


### PR DESCRIPTION
## Summary
- add shell-profile and per-offset zsh option-state tracking through the parser, semantic model, and linter
- gate zsh parser and lexer features from a lightweight option prescan so mid-file `setopt` and `emulate` changes parse correctly
- add zsh option-state integration coverage, black-box fixtures, and a large-corpus zsh track for semantic extraction

## Why
This feature lets shuck model zsh behavior at the point where code executes instead of assuming one file-wide mode. That improves rule accuracy for word splitting, globbing, arrays, and grammar-sensitive zsh constructs while keeping parser performance under an explicit benchmark gate.

## Validation
- `cargo check -p shuck-parser -p shuck-semantic -p shuck-linter -p shuck --tests`
- `cargo test -p shuck-parser midfile -- --nocapture`
- `cargo test -p shuck-semantic zsh_option_analysis_ -- --nocapture`
- `cargo test -p shuck-linter zsh_ -- --nocapture`
- `cargo test -p shuck --test zsh_option_state -- --nocapture`
- `cargo test -p shuck --test large_corpus large_corpus_zsh_fixtures_parse -- --ignored --exact --nocapture`

## Benchmark
- compared `cargo bench -p shuck-benchmark --bench parser -- --baseline=zsh-option-state-before --noplot` against the saved pre-change baseline
- no parser case regressed by more than 3%
- `parser/all` improved by about 40.9%, and all reported parser cases improved rather than slowed down in the comparison output
