### PR TITLE
Implement echo and tr portability rules

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/portability/X027.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X027.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Should trigger: echo flag handling depends on the shell implementation
+echo -n hi
+echo -e hi
+echo -nn hi
+value=$(echo -ne "hello")
+echo "-s" hi
+echo '-e' hi
+
+# Should not trigger: these are plain operands, non-portable-lookalike literals, or wrapped echo calls
+echo -- hi
+echo -x hi
+echo -nfoo hi
+echo '-I' hi
+command echo -n hi
+builtin echo -n hi

--- a/crates/shuck-linter/resources/test/fixtures/portability/X028.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X028.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Should trigger: exact lower-case ranges in tr operands are locale-dependent
+tr a-z xyz < foo
+tr abc a-z < foo
+tr a-z A-Z < foo
+tr -d a-z < foo
+tr -s 'a-z' < foo
+tr -- "a-z" xyz < foo
+
+# Should not trigger: bracketed forms and lookalikes are different tr diagnostics
+tr '[a-z]' xyz < foo
+tr aa-z xyz < foo
+tr a-zA xyz < foo
+command tr a-z xyz < foo
+builtin tr a-z xyz < foo

--- a/crates/shuck-linter/resources/test/fixtures/portability/X029.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X029.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Should trigger: exact upper-case ranges in tr operands are locale-dependent
+tr A-Z xyz < foo
+tr abc A-Z < foo
+tr A-Z a-z < foo
+tr -d A-Z < foo
+tr -s 'A-Z' < foo
+tr -- "A-Z" xyz < foo
+
+# Should not trigger: bracketed forms and lookalikes are different tr diagnostics
+tr '[A-Z]' xyz < foo
+tr AA-Z xyz < foo
+tr A-ZA xyz < foo
+command tr A-Z xyz < foo
+builtin tr A-Z xyz < foo

--- a/crates/shuck-linter/resources/test/fixtures/portability/X030.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X030.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Should trigger: echo backslash escapes depend on the shell
+echo \n
+echo "\\n"
+echo '\n'
+echo foo\nbar
+echo "foo\nbar"
+echo 'foo\nbar'
+echo \x41
+echo \077
+
+# Should not trigger: these are different cases
+echo \c
+echo \u1234
+command echo \n
+builtin echo \n
+printf '%s\n' \n

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -404,6 +404,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::TrUpperRange) {
             rules::portability::tr_upper_range::tr_upper_range(self);
         }
+        if self.is_rule_enabled(Rule::EchoBackslashEscapes) {
+            rules::portability::echo_backslash_escapes::echo_backslash_escapes(self);
+        }
         if self.is_rule_enabled(Rule::TrapErr) {
             rules::portability::trap_err::trap_err(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -398,6 +398,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::EchoFlags) {
             rules::portability::echo_flags::echo_flags(self);
         }
+        if self.is_rule_enabled(Rule::TrLowerRange) {
+            rules::portability::tr_lower_range::tr_lower_range(self);
+        }
         if self.is_rule_enabled(Rule::TrapErr) {
             rules::portability::trap_err::trap_err(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -401,6 +401,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::TrLowerRange) {
             rules::portability::tr_lower_range::tr_lower_range(self);
         }
+        if self.is_rule_enabled(Rule::TrUpperRange) {
+            rules::portability::tr_upper_range::tr_upper_range(self);
+        }
         if self.is_rule_enabled(Rule::TrapErr) {
             rules::portability::trap_err::trap_err(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -395,6 +395,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::ReplacementExpansion) {
             rules::portability::replacement_expansion::replacement_expansion(self);
         }
+        if self.is_rule_enabled(Rule::EchoFlags) {
+            rules::portability::echo_flags::echo_flags(self);
+        }
         if self.is_rule_enabled(Rule::TrapErr) {
             rules::portability::trap_err::trap_err(self);
         }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1242,6 +1242,17 @@ impl<'a> EchoCommandFacts<'a> {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TrCommandFacts<'a> {
+    operand_words: Box<[&'a Word]>,
+}
+
+impl<'a> TrCommandFacts<'a> {
+    pub fn operand_words(&self) -> &[&'a Word] {
+        &self.operand_words
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct PrintfCommandFacts<'a> {
     pub format_word: Option<&'a Word>,
@@ -1488,6 +1499,7 @@ pub struct CommandOptionFacts<'a> {
     ssh: Option<SshCommandFacts>,
     read: Option<ReadCommandFacts>,
     echo: Option<EchoCommandFacts<'a>>,
+    tr: Option<TrCommandFacts<'a>>,
     printf: Option<PrintfCommandFacts<'a>>,
     unset: Option<UnsetCommandFacts<'a>>,
     find: Option<FindCommandFacts>,
@@ -1519,6 +1531,10 @@ impl<'a> CommandOptionFacts<'a> {
 
     pub fn echo(&self) -> Option<&EchoCommandFacts<'a>> {
         self.echo.as_ref()
+    }
+
+    pub fn tr(&self) -> Option<&TrCommandFacts<'a>> {
+        self.tr.as_ref()
     }
 
     pub fn printf(&self) -> Option<&PrintfCommandFacts<'a>> {
@@ -1596,6 +1612,8 @@ impl<'a> CommandOptionFacts<'a> {
             echo: normalized
                 .effective_name_is("echo")
                 .then(|| parse_echo_command(normalized.body_args(), source)),
+            tr: (normalized.effective_name_is("tr") && normalized.wrappers.is_empty())
+                .then(|| parse_tr_command(normalized.body_args(), source)),
             printf: normalized.effective_name_is("printf").then(|| {
                 let format_word = printf_format_word(normalized.body_args(), source);
                 PrintfCommandFacts {
@@ -6786,6 +6804,40 @@ fn is_echo_portability_flag(text: &str) -> bool {
             .all(|byte| matches!(byte, b'n' | b'e' | b'E' | b's'))
 }
 
+fn parse_tr_command<'a>(args: &[&'a Word], source: &str) -> TrCommandFacts<'a> {
+    let mut index = 0usize;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+
+        if text == "--" {
+            index += 1;
+            break;
+        }
+
+        if !is_tr_option(text.as_str()) {
+            break;
+        }
+
+        index += 1;
+    }
+
+    TrCommandFacts {
+        operand_words: args[index..].iter().copied().collect(),
+    }
+}
+
+fn is_tr_option(text: &str) -> bool {
+    text.starts_with('-')
+        && text != "-"
+        && !text.starts_with("--")
+        && text[1..]
+            .bytes()
+            .all(|byte| matches!(byte, b'c' | b'C' | b'd' | b's' | b't'))
+}
+
 fn word_starts_with_literal_dash(word: &Word, source: &str) -> bool {
     matches!(
         word.parts_with_spans().next(),
@@ -9147,7 +9199,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn summarizes_command_options_and_invokers() {
-        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
+        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -9192,6 +9244,35 @@ complex[$((i+=1))]+=x
                 .and_then(|echo| echo.portability_flag_word())
                 .map(|word| word.span.slice(source)),
             None
+        );
+
+        let tr = facts
+            .commands()
+            .iter()
+            .find(|fact| fact.effective_name_is("tr") && fact.options().tr().is_some())
+            .and_then(|fact| fact.options().tr())
+            .expect("expected tr facts");
+        assert_eq!(
+            tr.operand_words()
+                .iter()
+                .map(|word| word.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["a-z", "A-Z"]
+        );
+        let quoted_tr = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("tr"))
+            .nth(1)
+            .and_then(|fact| fact.options().tr())
+            .expect("expected second tr facts");
+        assert_eq!(
+            quoted_tr
+                .operand_words()
+                .iter()
+                .map(|word| word.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["'a-z'", "xyz"]
         );
 
         let printf = facts

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1232,6 +1232,17 @@ pub struct ReadCommandFacts {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub struct EchoCommandFacts<'a> {
+    portability_flag_word: Option<&'a Word>,
+}
+
+impl<'a> EchoCommandFacts<'a> {
+    pub fn portability_flag_word(self) -> Option<&'a Word> {
+        self.portability_flag_word
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct PrintfCommandFacts<'a> {
     pub format_word: Option<&'a Word>,
     pub uses_q_format: bool,
@@ -1476,6 +1487,7 @@ pub struct CommandOptionFacts<'a> {
     rm: Option<RmCommandFacts>,
     ssh: Option<SshCommandFacts>,
     read: Option<ReadCommandFacts>,
+    echo: Option<EchoCommandFacts<'a>>,
     printf: Option<PrintfCommandFacts<'a>>,
     unset: Option<UnsetCommandFacts<'a>>,
     find: Option<FindCommandFacts>,
@@ -1503,6 +1515,10 @@ impl<'a> CommandOptionFacts<'a> {
 
     pub fn read(&self) -> Option<&ReadCommandFacts> {
         self.read.as_ref()
+    }
+
+    pub fn echo(&self) -> Option<&EchoCommandFacts<'a>> {
+        self.echo.as_ref()
     }
 
     pub fn printf(&self) -> Option<&PrintfCommandFacts<'a>> {
@@ -1577,6 +1593,9 @@ impl<'a> CommandOptionFacts<'a> {
                 .then(|| ReadCommandFacts {
                     uses_raw_input: read_uses_raw_input(normalized.body_args(), source),
                 }),
+            echo: normalized
+                .effective_name_is("echo")
+                .then(|| parse_echo_command(normalized.body_args(), source)),
             printf: normalized.effective_name_is("printf").then(|| {
                 let format_word = printf_format_word(normalized.body_args(), source);
                 PrintfCommandFacts {
@@ -6746,6 +6765,27 @@ fn read_uses_raw_input(args: &[&Word], source: &str) -> bool {
     false
 }
 
+fn parse_echo_command<'a>(args: &[&'a Word], source: &str) -> EchoCommandFacts<'a> {
+    EchoCommandFacts {
+        portability_flag_word: args.first().copied().filter(|word| {
+            classify_word(word, source).is_fixed_literal()
+                && static_word_text(word, source)
+                    .is_some_and(|text| is_echo_portability_flag(text.as_str()))
+        }),
+    }
+}
+
+fn is_echo_portability_flag(text: &str) -> bool {
+    let Some(flags) = text.strip_prefix('-') else {
+        return false;
+    };
+
+    !flags.is_empty()
+        && flags
+            .bytes()
+            .all(|byte| matches!(byte, b'n' | b'e' | b'E' | b's'))
+}
+
 fn word_starts_with_literal_dash(word: &Word, source: &str) -> bool {
     matches!(
         word.parts_with_spans().next(),
@@ -9107,7 +9147,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn summarizes_command_options_and_invokers() {
-        let source = "#!/bin/bash\nread -r name\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
+        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -9122,6 +9162,36 @@ complex[$((i+=1))]+=x
         assert_eq!(
             read.options().read().map(|read| read.uses_raw_input),
             Some(true)
+        );
+
+        let echo = facts
+            .commands()
+            .iter()
+            .find(|fact| {
+                fact.effective_name_is("echo")
+                    && fact
+                        .options()
+                        .echo()
+                        .and_then(|echo| echo.portability_flag_word())
+                        .is_some()
+            })
+            .and_then(|fact| fact.options().echo())
+            .expect("expected echo facts");
+        assert_eq!(
+            echo.portability_flag_word()
+                .map(|word| word.span.slice(source)),
+            Some("-ne")
+        );
+        assert_eq!(
+            facts
+                .commands()
+                .iter()
+                .filter(|fact| fact.effective_name_is("echo"))
+                .nth(1)
+                .and_then(|fact| fact.options().echo())
+                .and_then(|echo| echo.portability_flag_word())
+                .map(|word| word.span.slice(source)),
+            None
         );
 
         let printf = facts

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1234,11 +1234,16 @@ pub struct ReadCommandFacts {
 #[derive(Debug, Clone, Copy)]
 pub struct EchoCommandFacts<'a> {
     portability_flag_word: Option<&'a Word>,
+    uses_escape_interpreting_flag: bool,
 }
 
 impl<'a> EchoCommandFacts<'a> {
     pub fn portability_flag_word(self) -> Option<&'a Word> {
         self.portability_flag_word
+    }
+
+    pub fn uses_escape_interpreting_flag(self) -> bool {
+        self.uses_escape_interpreting_flag
     }
 }
 
@@ -2554,7 +2559,7 @@ fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: 
     let mut spans = commands
         .iter()
         .filter(|fact| fact.effective_name_is("echo") && fact.wrappers().is_empty())
-        .filter(|fact| !echo_uses_escape_interpreting_flag(fact, source))
+        .filter(|fact| !echo_uses_escape_interpreting_flag(fact))
         .flat_map(|fact| fact.body_args().iter().copied())
         .filter(|word| word_contains_echo_backslash_escape(word, source))
         .map(|word| word.span)
@@ -2565,13 +2570,11 @@ fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: 
     spans
 }
 
-fn echo_uses_escape_interpreting_flag(command: &CommandFact<'_>, source: &str) -> bool {
+fn echo_uses_escape_interpreting_flag(command: &CommandFact<'_>) -> bool {
     command
         .options()
         .echo()
-        .and_then(|echo| echo.portability_flag_word())
-        .and_then(|word| static_word_text(word, source))
-        .is_some_and(|text| text.contains('e'))
+        .is_some_and(|echo| echo.uses_escape_interpreting_flag())
 }
 
 fn word_contains_echo_backslash_escape(word: &Word, source: &str) -> bool {
@@ -6885,12 +6888,29 @@ fn read_uses_raw_input(args: &[&Word], source: &str) -> bool {
 }
 
 fn parse_echo_command<'a>(args: &[&'a Word], source: &str) -> EchoCommandFacts<'a> {
+    let mut portability_flag_word = None;
+    let mut uses_escape_interpreting_flag = false;
+
+    for word in args {
+        if !classify_word(word, source).is_fixed_literal() {
+            break;
+        }
+
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+
+        if !is_echo_portability_flag(text.as_str()) {
+            break;
+        }
+
+        portability_flag_word.get_or_insert(*word);
+        uses_escape_interpreting_flag |= text.contains('e');
+    }
+
     EchoCommandFacts {
-        portability_flag_word: args.first().copied().filter(|word| {
-            classify_word(word, source).is_fixed_literal()
-                && static_word_text(word, source)
-                    .is_some_and(|text| is_echo_portability_flag(text.as_str()))
-        }),
+        portability_flag_word,
+        uses_escape_interpreting_flag,
     }
 }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1871,6 +1871,7 @@ pub struct LinterFacts<'a> {
     arithmetic_for_update_operator_spans: Vec<Span>,
     base_prefix_arithmetic_spans: Vec<Span>,
     escape_scan_matches: Vec<EscapeScanMatch>,
+    echo_backslash_escape_word_spans: Vec<Span>,
     unicode_smart_quote_spans: Vec<Span>,
     pattern_exactly_one_extglob_spans: Vec<Span>,
     pattern_literal_spans: Vec<Span>,
@@ -2151,6 +2152,10 @@ impl<'a> LinterFacts<'a> {
 
     pub(crate) fn escape_scan_matches(&self) -> &[EscapeScanMatch] {
         &self.escape_scan_matches
+    }
+
+    pub fn echo_backslash_escape_word_spans(&self) -> &[Span] {
+        &self.echo_backslash_escape_word_spans
     }
 
     pub fn arithmetic_command_substitution_spans(&self) -> &[Span] {
@@ -2452,6 +2457,8 @@ impl<'a> LinterFactsBuilder<'a> {
                 file_context: self._file_context,
             },
         );
+        let echo_backslash_escape_word_spans =
+            build_echo_backslash_escape_word_spans(&commands, self.source);
         let nested_pattern_charclass_spans = nested_pattern_charclass_spans
             .into_iter()
             .map(FactSpan::new)
@@ -2525,6 +2532,7 @@ impl<'a> LinterFactsBuilder<'a> {
             arithmetic_for_update_operator_spans,
             base_prefix_arithmetic_spans,
             escape_scan_matches,
+            echo_backslash_escape_word_spans,
             unicode_smart_quote_spans,
             pattern_exactly_one_extglob_spans,
             pattern_literal_spans,
@@ -2540,6 +2548,99 @@ impl<'a> LinterFactsBuilder<'a> {
             conditional_portability,
         }
     }
+}
+
+fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+    let mut spans = commands
+        .iter()
+        .filter(|fact| fact.effective_name_is("echo") && fact.wrappers().is_empty())
+        .filter(|fact| !echo_uses_escape_interpreting_flag(fact, source))
+        .flat_map(|fact| fact.body_args().iter().copied())
+        .filter(|word| word_contains_echo_backslash_escape(word, source))
+        .map(|word| word.span)
+        .collect::<Vec<_>>();
+
+    let mut seen = FxHashSet::default();
+    spans.retain(|span| seen.insert(FactSpan::new(*span)));
+    spans
+}
+
+fn echo_uses_escape_interpreting_flag(command: &CommandFact<'_>, source: &str) -> bool {
+    command
+        .options()
+        .echo()
+        .and_then(|echo| echo.portability_flag_word())
+        .and_then(|word| static_word_text(word, source))
+        .is_some_and(|text| text.contains('e'))
+}
+
+fn word_contains_echo_backslash_escape(word: &Word, source: &str) -> bool {
+    word_parts_contain_echo_backslash_escape(&word.parts, source, false)
+}
+
+fn word_parts_contain_echo_backslash_escape(
+    parts: &[WordPartNode],
+    source: &str,
+    in_double_quotes: bool,
+) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Literal(text) => {
+            let core_text = if in_double_quotes {
+                text.as_str(source, part.span)
+            } else {
+                part.span.slice(source)
+            };
+            let quote_like_text = text.as_str(source, part.span);
+
+            text_contains_echo_backslash_escape(core_text, echo_escape_is_core_family)
+                || text_contains_echo_backslash_escape(quote_like_text, echo_escape_is_quote_like)
+        }
+        WordPart::SingleQuoted { value, .. } => {
+            text_contains_echo_backslash_escape(value.slice(source), echo_escape_is_core_family)
+        }
+        WordPart::DoubleQuoted { parts, .. } => {
+            word_parts_contain_echo_backslash_escape(parts, source, true)
+        }
+        _ => false,
+    })
+}
+
+fn echo_escape_is_core_family(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'a' | b'b' | b'e' | b'f' | b'n' | b'r' | b't' | b'v' | b'x' | b'0'..=b'9'
+    )
+}
+
+fn echo_escape_is_quote_like(byte: u8) -> bool {
+    matches!(byte, b'`' | b'\'')
+}
+
+fn text_contains_echo_backslash_escape(text: &str, is_sensitive: fn(u8) -> bool) -> bool {
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b'\\' {
+            index += 1;
+            continue;
+        }
+
+        let run_start = index;
+        while index < bytes.len() && bytes[index] == b'\\' {
+            index += 1;
+        }
+
+        let Some(&escaped_byte) = bytes.get(index) else {
+            continue;
+        };
+
+        if index > run_start && is_sensitive(escaped_byte) {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn build_heredoc_fact_summary(
@@ -9199,7 +9300,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn summarizes_command_options_and_invokers() {
-        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
+        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -9244,6 +9345,14 @@ complex[$((i+=1))]+=x
                 .and_then(|echo| echo.portability_flag_word())
                 .map(|word| word.span.slice(source)),
             None
+        );
+        assert_eq!(
+            facts
+                .echo_backslash_escape_word_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"\\\\n\"", "\\x41", "\"prefix $VAR \\\\0 suffix\""]
         );
 
         let tr = facts

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -379,6 +379,7 @@ declare_rules! {
     ("X025", Category::Portability, Severity::Warning, ReplacementExpansion),
     ("X026", Category::Portability, Severity::Warning, BashFileSlurp),
     ("X027", Category::Portability, Severity::Warning, EchoFlags),
+    ("X028", Category::Portability, Severity::Warning, TrLowerRange),
     ("X031", Category::Portability, Severity::Warning, SourceBuiltinInSh),
     ("X032", Category::Portability, Severity::Warning, PrintfQFormatInSh),
     ("X033", Category::Portability, Severity::Warning, IfElifBashTest),
@@ -553,6 +554,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-080" => Some(Rule::SourceBuiltinInSh),
         "SH-081" => Some(Rule::PrintfQFormatInSh),
         "SH-054" => Some(Rule::EchoFlags),
+        "SH-058" => Some(Rule::TrLowerRange),
         "SH-226" => Some(Rule::FunctionKeywordInSh),
         "SH-234" => Some(Rule::IfsSetToLiteralBackslashN),
         "SH-304" => Some(Rule::SourceInsideFunctionInSh),
@@ -1215,5 +1217,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-053"), Some(Rule::BashFileSlurp));
         assert_eq!(code_to_rule("X027"), Some(Rule::EchoFlags));
         assert_eq!(code_to_rule("SH-054"), Some(Rule::EchoFlags));
+        assert_eq!(code_to_rule("X028"), Some(Rule::TrLowerRange));
+        assert_eq!(code_to_rule("SH-058"), Some(Rule::TrLowerRange));
     }
 }

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -378,6 +378,7 @@ declare_rules! {
     ("X024", Category::Portability, Severity::Warning, CaseModificationExpansion),
     ("X025", Category::Portability, Severity::Warning, ReplacementExpansion),
     ("X026", Category::Portability, Severity::Warning, BashFileSlurp),
+    ("X027", Category::Portability, Severity::Warning, EchoFlags),
     ("X031", Category::Portability, Severity::Warning, SourceBuiltinInSh),
     ("X032", Category::Portability, Severity::Warning, PrintfQFormatInSh),
     ("X033", Category::Portability, Severity::Warning, IfElifBashTest),
@@ -551,6 +552,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-022" => Some(Rule::TrapErr),
         "SH-080" => Some(Rule::SourceBuiltinInSh),
         "SH-081" => Some(Rule::PrintfQFormatInSh),
+        "SH-054" => Some(Rule::EchoFlags),
         "SH-226" => Some(Rule::FunctionKeywordInSh),
         "SH-234" => Some(Rule::IfsSetToLiteralBackslashN),
         "SH-304" => Some(Rule::SourceInsideFunctionInSh),
@@ -1211,5 +1213,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-033"), Some(Rule::ReplacementExpansion));
         assert_eq!(code_to_rule("X026"), Some(Rule::BashFileSlurp));
         assert_eq!(code_to_rule("SH-053"), Some(Rule::BashFileSlurp));
+        assert_eq!(code_to_rule("X027"), Some(Rule::EchoFlags));
+        assert_eq!(code_to_rule("SH-054"), Some(Rule::EchoFlags));
     }
 }

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -381,6 +381,7 @@ declare_rules! {
     ("X027", Category::Portability, Severity::Warning, EchoFlags),
     ("X028", Category::Portability, Severity::Warning, TrLowerRange),
     ("X029", Category::Portability, Severity::Warning, TrUpperRange),
+    ("X030", Category::Portability, Severity::Warning, EchoBackslashEscapes),
     ("X031", Category::Portability, Severity::Warning, SourceBuiltinInSh),
     ("X032", Category::Portability, Severity::Warning, PrintfQFormatInSh),
     ("X033", Category::Portability, Severity::Warning, IfElifBashTest),
@@ -557,6 +558,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-054" => Some(Rule::EchoFlags),
         "SH-058" => Some(Rule::TrLowerRange),
         "SH-059" => Some(Rule::TrUpperRange),
+        "SH-061" => Some(Rule::EchoBackslashEscapes),
         "SH-226" => Some(Rule::FunctionKeywordInSh),
         "SH-234" => Some(Rule::IfsSetToLiteralBackslashN),
         "SH-304" => Some(Rule::SourceInsideFunctionInSh),
@@ -1223,5 +1225,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-058"), Some(Rule::TrLowerRange));
         assert_eq!(code_to_rule("X029"), Some(Rule::TrUpperRange));
         assert_eq!(code_to_rule("SH-059"), Some(Rule::TrUpperRange));
+        assert_eq!(code_to_rule("X030"), Some(Rule::EchoBackslashEscapes));
+        assert_eq!(code_to_rule("SH-061"), Some(Rule::EchoBackslashEscapes));
     }
 }

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -380,6 +380,7 @@ declare_rules! {
     ("X026", Category::Portability, Severity::Warning, BashFileSlurp),
     ("X027", Category::Portability, Severity::Warning, EchoFlags),
     ("X028", Category::Portability, Severity::Warning, TrLowerRange),
+    ("X029", Category::Portability, Severity::Warning, TrUpperRange),
     ("X031", Category::Portability, Severity::Warning, SourceBuiltinInSh),
     ("X032", Category::Portability, Severity::Warning, PrintfQFormatInSh),
     ("X033", Category::Portability, Severity::Warning, IfElifBashTest),
@@ -555,6 +556,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-081" => Some(Rule::PrintfQFormatInSh),
         "SH-054" => Some(Rule::EchoFlags),
         "SH-058" => Some(Rule::TrLowerRange),
+        "SH-059" => Some(Rule::TrUpperRange),
         "SH-226" => Some(Rule::FunctionKeywordInSh),
         "SH-234" => Some(Rule::IfsSetToLiteralBackslashN),
         "SH-304" => Some(Rule::SourceInsideFunctionInSh),
@@ -1219,5 +1221,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-054"), Some(Rule::EchoFlags));
         assert_eq!(code_to_rule("X028"), Some(Rule::TrLowerRange));
         assert_eq!(code_to_rule("SH-058"), Some(Rule::TrLowerRange));
+        assert_eq!(code_to_rule("X029"), Some(Rule::TrUpperRange));
+        assert_eq!(code_to_rule("SH-059"), Some(Rule::TrUpperRange));
     }
 }

--- a/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
@@ -48,6 +48,8 @@ echo "  echo You may need to get \\\`FluidR3_GM.sf2\\' from somewhere"
 echo "sed -e 's|^\\(CertStore=\\).*|\\1X|g'"
 echo "prefix $VAR \\0 suffix"
 echo -e "\n"
+echo -n -e "\n"
+echo -n "$flag" -e \x41
 echo \c
 echo \u1234
 command echo \n
@@ -76,6 +78,7 @@ printf '%s\n' \n
                 "\"  echo You may need to get \\\\\\`FluidR3_GM.sf2\\\\' from somewhere\"",
                 "\"sed -e 's|^\\\\(CertStore=\\\\).*|\\\\1X|g'\"",
                 "\"prefix $VAR \\\\0 suffix\"",
+                "\\x41",
             ]
         );
     }

--- a/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
@@ -1,0 +1,96 @@
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct EchoBackslashEscapes;
+
+impl Violation for EchoBackslashEscapes {
+    fn rule() -> Rule {
+        Rule::EchoBackslashEscapes
+    }
+
+    fn message(&self) -> String {
+        "use `printf` instead of relying on backslash escapes in `echo`".to_owned()
+    }
+}
+
+pub fn echo_backslash_escapes(checker: &mut Checker) {
+    if !matches!(
+        checker.shell(),
+        ShellDialect::Sh | ShellDialect::Bash | ShellDialect::Ksh
+    ) {
+        return;
+    }
+
+    checker.report_all_dedup(
+        checker.facts().echo_backslash_escape_word_spans().to_vec(),
+        || EchoBackslashEscapes,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_literal_echo_operands_with_portability_sensitive_backslash_escapes() {
+        let source = r#"#!/bin/sh
+echo \n
+echo "\\n"
+echo '\\n'
+echo foo\nbar
+echo "foo\nbar"
+echo 'foo\\nbar'
+echo \x41
+echo \077
+echo "See \`pyenv help <command>' for information on a specific command."
+echo 'It'\''s just quote plumbing'
+echo "  echo You may need to get \\\`FluidR3_GM.sf2\\' from somewhere"
+echo "sed -e 's|^\\(CertStore=\\).*|\\1X|g'"
+echo "prefix $VAR \\0 suffix"
+echo -e "\n"
+echo \c
+echo \u1234
+command echo \n
+builtin echo \n
+printf '%s\n' \n
+"#;
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::EchoBackslashEscapes),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "\\n",
+                "\"\\\\n\"",
+                "'\\\\n'",
+                "foo\\nbar",
+                "\"foo\\nbar\"",
+                "'foo\\\\nbar'",
+                "\\x41",
+                "\\077",
+                "\"  echo You may need to get \\\\\\`FluidR3_GM.sf2\\\\' from somewhere\"",
+                "\"sed -e 's|^\\\\(CertStore=\\\\).*|\\\\1X|g'\"",
+                "\"prefix $VAR \\\\0 suffix\"",
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_shells_outside_the_rule_target_set() {
+        let source = "\
+#!/bin/dash
+echo \\n
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::EchoBackslashEscapes),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/portability/echo_flags.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_flags.rs
@@ -1,0 +1,95 @@
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct EchoFlags;
+
+impl Violation for EchoFlags {
+    fn rule() -> Rule {
+        Rule::EchoFlags
+    }
+
+    fn message(&self) -> String {
+        "echo flags are not portable in `sh` scripts".to_owned()
+    }
+}
+
+pub fn echo_flags(checker: &mut Checker) {
+    if !matches!(checker.shell(), ShellDialect::Sh | ShellDialect::Dash) {
+        return;
+    }
+
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("echo") && fact.wrappers().is_empty())
+        .filter_map(|fact| {
+            fact.options()
+                .echo()
+                .and_then(|echo| echo.portability_flag_word())
+                .map(|word| word.span)
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || EchoFlags);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_portability_sensitive_echo_flags_in_sh() {
+        let source = "\
+#!/bin/sh
+echo -n hi
+echo -e hi
+echo -E hi
+echo -nn hi
+echo -neE hi
+value=$(echo -en hi)
+echo \"-s\"
+echo '-e'
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EchoFlags));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-n", "-e", "-E", "-nn", "-neE", "-en", "\"-s\"", "'-e'"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_flag_operands_and_wrapped_echoes() {
+        let source = "\
+#!/bin/sh
+echo -- hi
+echo - hello
+echo -x hi
+echo -nfoo hi
+echo \"-I\" hi
+echo '-F' hi
+command echo -n hi
+builtin echo -n hi
+echo \"$flag\" hi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EchoFlags));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_echo_flags_in_bash() {
+        let source = "\
+#!/bin/bash
+echo -n hi
+echo \"-s\" hi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EchoFlags));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/portability/mod.rs
+++ b/crates/shuck-linter/src/rules/portability/mod.rs
@@ -45,6 +45,7 @@ pub mod star_glob_removal_in_sh;
 pub mod substring_expansion;
 mod tr_common;
 pub mod tr_lower_range;
+pub mod tr_upper_range;
 mod trap_common;
 pub mod trap_err;
 pub mod uppercase_expansion;
@@ -108,6 +109,7 @@ mod tests {
     #[test_case(Rule::BashFileSlurp, Path::new("X026.sh"))]
     #[test_case(Rule::EchoFlags, Path::new("X027.sh"))]
     #[test_case(Rule::TrLowerRange, Path::new("X028.sh"))]
+    #[test_case(Rule::TrUpperRange, Path::new("X029.sh"))]
     #[test_case(Rule::SourceBuiltinInSh, Path::new("X031.sh"))]
     #[test_case(Rule::PrintfQFormatInSh, Path::new("X032.sh"))]
     #[test_case(Rule::IfElifBashTest, Path::new("X033.sh"))]

--- a/crates/shuck-linter/src/rules/portability/mod.rs
+++ b/crates/shuck-linter/src/rules/portability/mod.rs
@@ -16,6 +16,7 @@ pub mod coproc;
 pub mod csh_syntax_in_sh;
 pub mod declare_command;
 pub mod dollar_string_in_sh;
+pub mod echo_backslash_escapes;
 pub mod echo_flags;
 pub mod errexit_trap_in_sh;
 pub mod function_keyword;
@@ -110,6 +111,7 @@ mod tests {
     #[test_case(Rule::EchoFlags, Path::new("X027.sh"))]
     #[test_case(Rule::TrLowerRange, Path::new("X028.sh"))]
     #[test_case(Rule::TrUpperRange, Path::new("X029.sh"))]
+    #[test_case(Rule::EchoBackslashEscapes, Path::new("X030.sh"))]
     #[test_case(Rule::SourceBuiltinInSh, Path::new("X031.sh"))]
     #[test_case(Rule::PrintfQFormatInSh, Path::new("X032.sh"))]
     #[test_case(Rule::IfElifBashTest, Path::new("X033.sh"))]

--- a/crates/shuck-linter/src/rules/portability/mod.rs
+++ b/crates/shuck-linter/src/rules/portability/mod.rs
@@ -43,6 +43,8 @@ pub mod sourced_with_args;
 pub mod standalone_arithmetic;
 pub mod star_glob_removal_in_sh;
 pub mod substring_expansion;
+mod tr_common;
+pub mod tr_lower_range;
 mod trap_common;
 pub mod trap_err;
 pub mod uppercase_expansion;
@@ -105,6 +107,7 @@ mod tests {
     #[test_case(Rule::ReplacementExpansion, Path::new("X025.sh"))]
     #[test_case(Rule::BashFileSlurp, Path::new("X026.sh"))]
     #[test_case(Rule::EchoFlags, Path::new("X027.sh"))]
+    #[test_case(Rule::TrLowerRange, Path::new("X028.sh"))]
     #[test_case(Rule::SourceBuiltinInSh, Path::new("X031.sh"))]
     #[test_case(Rule::PrintfQFormatInSh, Path::new("X032.sh"))]
     #[test_case(Rule::IfElifBashTest, Path::new("X033.sh"))]

--- a/crates/shuck-linter/src/rules/portability/mod.rs
+++ b/crates/shuck-linter/src/rules/portability/mod.rs
@@ -16,6 +16,7 @@ pub mod coproc;
 pub mod csh_syntax_in_sh;
 pub mod declare_command;
 pub mod dollar_string_in_sh;
+pub mod echo_flags;
 pub mod errexit_trap_in_sh;
 pub mod function_keyword;
 pub mod function_keyword_in_sh;
@@ -103,6 +104,7 @@ mod tests {
     #[test_case(Rule::CaseModificationExpansion, Path::new("X024.sh"))]
     #[test_case(Rule::ReplacementExpansion, Path::new("X025.sh"))]
     #[test_case(Rule::BashFileSlurp, Path::new("X026.sh"))]
+    #[test_case(Rule::EchoFlags, Path::new("X027.sh"))]
     #[test_case(Rule::SourceBuiltinInSh, Path::new("X031.sh"))]
     #[test_case(Rule::PrintfQFormatInSh, Path::new("X032.sh"))]
     #[test_case(Rule::IfElifBashTest, Path::new("X033.sh"))]

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X027_X027.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X027_X027.sh.snap
@@ -1,0 +1,39 @@
+---
+source: crates/shuck-linter/src/rules/portability/mod.rs
+assertion_line: 160
+---
+X027 echo flags are not portable in `sh` scripts
+ --> <source>:4:6
+  |
+4 | echo -n hi
+  |
+
+X027 echo flags are not portable in `sh` scripts
+ --> <source>:5:6
+  |
+5 | echo -e hi
+  |
+
+X027 echo flags are not portable in `sh` scripts
+ --> <source>:6:6
+  |
+6 | echo -nn hi
+  |
+
+X027 echo flags are not portable in `sh` scripts
+ --> <source>:7:14
+  |
+7 | value=$(echo -ne "hello")
+  |
+
+X027 echo flags are not portable in `sh` scripts
+ --> <source>:8:6
+  |
+8 | echo "-s" hi
+  |
+
+X027 echo flags are not portable in `sh` scripts
+ --> <source>:9:6
+  |
+9 | echo '-e' hi
+  |

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X028_X028.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X028_X028.sh.snap
@@ -1,0 +1,39 @@
+---
+source: crates/shuck-linter/src/rules/portability/mod.rs
+assertion_line: 163
+---
+X028 use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching
+ --> <source>:4:4
+  |
+4 | tr a-z xyz < foo
+  |
+
+X028 use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching
+ --> <source>:5:8
+  |
+5 | tr abc a-z < foo
+  |
+
+X028 use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching
+ --> <source>:6:4
+  |
+6 | tr a-z A-Z < foo
+  |
+
+X028 use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching
+ --> <source>:7:7
+  |
+7 | tr -d a-z < foo
+  |
+
+X028 use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching
+ --> <source>:8:7
+  |
+8 | tr -s 'a-z' < foo
+  |
+
+X028 use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching
+ --> <source>:9:7
+  |
+9 | tr -- "a-z" xyz < foo
+  |

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X029_X029.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X029_X029.sh.snap
@@ -1,0 +1,39 @@
+---
+source: crates/shuck-linter/src/rules/portability/mod.rs
+assertion_line: 165
+---
+X029 use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching
+ --> <source>:4:4
+  |
+4 | tr A-Z xyz < foo
+  |
+
+X029 use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching
+ --> <source>:5:8
+  |
+5 | tr abc A-Z < foo
+  |
+
+X029 use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching
+ --> <source>:6:4
+  |
+6 | tr A-Z a-z < foo
+  |
+
+X029 use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching
+ --> <source>:7:7
+  |
+7 | tr -d A-Z < foo
+  |
+
+X029 use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching
+ --> <source>:8:7
+  |
+8 | tr -s 'A-Z' < foo
+  |
+
+X029 use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching
+ --> <source>:9:7
+  |
+9 | tr -- "A-Z" xyz < foo
+  |

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X030_X030.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X030_X030.sh.snap
@@ -1,0 +1,51 @@
+---
+source: crates/shuck-linter/src/rules/portability/mod.rs
+assertion_line: 167
+---
+X030 use `printf` instead of relying on backslash escapes in `echo`
+ --> <source>:4:6
+  |
+4 | echo \n
+  |
+
+X030 use `printf` instead of relying on backslash escapes in `echo`
+ --> <source>:5:6
+  |
+5 | echo "\\n"
+  |
+
+X030 use `printf` instead of relying on backslash escapes in `echo`
+ --> <source>:6:6
+  |
+6 | echo '\n'
+  |
+
+X030 use `printf` instead of relying on backslash escapes in `echo`
+ --> <source>:7:6
+  |
+7 | echo foo\nbar
+  |
+
+X030 use `printf` instead of relying on backslash escapes in `echo`
+ --> <source>:8:6
+  |
+8 | echo "foo\nbar"
+  |
+
+X030 use `printf` instead of relying on backslash escapes in `echo`
+ --> <source>:9:6
+  |
+9 | echo 'foo\nbar'
+  |
+
+X030 use `printf` instead of relying on backslash escapes in `echo`
+  --> <source>:10:6
+   |
+10 | echo \x41
+   |
+
+X030 use `printf` instead of relying on backslash escapes in `echo`
+  --> <source>:11:6
+   |
+11 | echo \077
+   |

--- a/crates/shuck-linter/src/rules/portability/tr_common.rs
+++ b/crates/shuck-linter/src/rules/portability/tr_common.rs
@@ -1,0 +1,27 @@
+use shuck_ast::Span;
+
+use crate::{Checker, ShellDialect, static_word_text};
+
+pub(super) fn tr_exact_operand_spans(checker: &Checker<'_>, exact_text: &str) -> Vec<Span> {
+    if !matches!(
+        checker.shell(),
+        ShellDialect::Sh | ShellDialect::Bash | ShellDialect::Dash | ShellDialect::Ksh
+    ) {
+        return Vec::new();
+    }
+
+    checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("tr") && fact.wrappers().is_empty())
+        .flat_map(|fact| {
+            fact.options()
+                .tr()
+                .into_iter()
+                .flat_map(|tr| tr.operand_words().iter().copied())
+        })
+        .filter(|word| static_word_text(word, checker.source()).as_deref() == Some(exact_text))
+        .map(|word| word.span)
+        .collect()
+}

--- a/crates/shuck-linter/src/rules/portability/tr_lower_range.rs
+++ b/crates/shuck-linter/src/rules/portability/tr_lower_range.rs
@@ -1,0 +1,76 @@
+use crate::{Checker, Rule, Violation};
+
+use super::tr_common::tr_exact_operand_spans;
+
+pub struct TrLowerRange;
+
+impl Violation for TrLowerRange {
+    fn rule() -> Rule {
+        Rule::TrLowerRange
+    }
+
+    fn message(&self) -> String {
+        "use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching".to_owned()
+    }
+}
+
+pub fn tr_lower_range(checker: &mut Checker) {
+    let spans = tr_exact_operand_spans(checker, "a-z");
+    checker.report_all_dedup(spans, || TrLowerRange);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_exact_lowercase_ranges_in_tr_operands() {
+        let source = "\
+#!/bin/sh
+tr a-z xyz < foo
+tr abc a-z < foo
+tr a-z A-Z < foo
+tr -d a-z < foo
+tr -s 'a-z' < foo
+tr -- \"a-z\" xyz < foo
+tr 0-9 a-z < foo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrLowerRange));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["a-z", "a-z", "a-z", "a-z", "'a-z'", "\"a-z\"", "a-z"]
+        );
+    }
+
+    #[test]
+    fn ignores_bracketed_and_lookalike_ranges_or_wrapped_tr() {
+        let source = "\
+#!/bin/sh
+tr '[a-z]' xyz < foo
+tr aa-z xyz < foo
+tr a-zA xyz < foo
+tr - xyz < foo
+command tr a-z xyz < foo
+builtin tr a-z xyz < foo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrLowerRange));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_shells_outside_the_rule_target_set() {
+        let source = "\
+#!/bin/mksh
+tr a-z xyz < foo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrLowerRange));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/portability/tr_upper_range.rs
+++ b/crates/shuck-linter/src/rules/portability/tr_upper_range.rs
@@ -1,0 +1,76 @@
+use crate::{Checker, Rule, Violation};
+
+use super::tr_common::tr_exact_operand_spans;
+
+pub struct TrUpperRange;
+
+impl Violation for TrUpperRange {
+    fn rule() -> Rule {
+        Rule::TrUpperRange
+    }
+
+    fn message(&self) -> String {
+        "use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching".to_owned()
+    }
+}
+
+pub fn tr_upper_range(checker: &mut Checker) {
+    let spans = tr_exact_operand_spans(checker, "A-Z");
+    checker.report_all_dedup(spans, || TrUpperRange);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_exact_uppercase_ranges_in_tr_operands() {
+        let source = "\
+#!/bin/sh
+tr A-Z xyz < foo
+tr abc A-Z < foo
+tr A-Z a-z < foo
+tr -d A-Z < foo
+tr -s 'A-Z' < foo
+tr -- \"A-Z\" xyz < foo
+tr 0-9 A-Z < foo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrUpperRange));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["A-Z", "A-Z", "A-Z", "A-Z", "'A-Z'", "\"A-Z\"", "A-Z"]
+        );
+    }
+
+    #[test]
+    fn ignores_bracketed_and_lookalike_ranges_or_wrapped_tr() {
+        let source = "\
+#!/bin/sh
+tr '[A-Z]' xyz < foo
+tr AA-Z xyz < foo
+tr A-ZA xyz < foo
+tr - xyz < foo
+command tr A-Z xyz < foo
+builtin tr A-Z xyz < foo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrUpperRange));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_shells_outside_the_rule_target_set() {
+        let source = "\
+#!/bin/mksh
+tr A-Z xyz < foo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrUpperRange));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -286,6 +286,7 @@ impl Default for ShellCheckCodeMap {
             (3034, Rule::BashFileSlurp),
             (3037, Rule::EchoFlags),
             (2018, Rule::TrLowerRange),
+            (2019, Rule::TrUpperRange),
             (3025, Rule::PrintfQFormatInSh),
             (3026, Rule::CaretNegationInBracket),
             (3077, Rule::BasePrefixInArithmetic),
@@ -561,6 +562,7 @@ impl Default for ShellCheckCodeMap {
                     (3034, Rule::BashFileSlurp),
                     (3037, Rule::EchoFlags),
                     (2018, Rule::TrLowerRange),
+                    (2019, Rule::TrUpperRange),
                     (3025, Rule::PrintfQFormatInSh),
                     (3052, Rule::AmpersandRedirection),
                     (3050, Rule::BraceFdRedirection),
@@ -1158,6 +1160,7 @@ mod tests {
         assert_eq!(map.resolve("SC3034"), Some(Rule::BashFileSlurp));
         assert_eq!(map.resolve("SC3037"), Some(Rule::EchoFlags));
         assert_eq!(map.resolve("SC2018"), Some(Rule::TrLowerRange));
+        assert_eq!(map.resolve("SC2019"), Some(Rule::TrUpperRange));
         assert_eq!(map.resolve("SC3024"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3055"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3071"), Some(Rule::PlusEqualsInSh));
@@ -1690,6 +1693,7 @@ mod tests {
             (3034, Rule::BashFileSlurp),
             (3037, Rule::EchoFlags),
             (2018, Rule::TrLowerRange),
+            (2019, Rule::TrUpperRange),
             (3025, Rule::PrintfQFormatInSh),
             (3026, Rule::CaretNegationInBracket),
             (3028, Rule::ArrayReference),
@@ -1832,6 +1836,7 @@ mod tests {
         assert!(comparison.contains(&(2223, Rule::DefaultValueInColonAssign)));
         assert!(comparison.contains(&(2021, Rule::UnquotedTrRange)));
         assert!(comparison.contains(&(2018, Rule::TrLowerRange)));
+        assert!(comparison.contains(&(2019, Rule::TrUpperRange)));
         assert!(!comparison.contains(&(2300, Rule::UnquotedWordBetweenQuotes)));
         assert!(!comparison.contains(&(2307, Rule::UnquotedVariableInTest)));
         assert!(!comparison.contains(&(2346, Rule::DefaultValueInColonAssign)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -287,6 +287,7 @@ impl Default for ShellCheckCodeMap {
             (3037, Rule::EchoFlags),
             (2018, Rule::TrLowerRange),
             (2019, Rule::TrUpperRange),
+            (2028, Rule::EchoBackslashEscapes),
             (3025, Rule::PrintfQFormatInSh),
             (3026, Rule::CaretNegationInBracket),
             (3077, Rule::BasePrefixInArithmetic),
@@ -563,6 +564,7 @@ impl Default for ShellCheckCodeMap {
                     (3037, Rule::EchoFlags),
                     (2018, Rule::TrLowerRange),
                     (2019, Rule::TrUpperRange),
+                    (2028, Rule::EchoBackslashEscapes),
                     (3025, Rule::PrintfQFormatInSh),
                     (3052, Rule::AmpersandRedirection),
                     (3050, Rule::BraceFdRedirection),
@@ -1161,6 +1163,7 @@ mod tests {
         assert_eq!(map.resolve("SC3037"), Some(Rule::EchoFlags));
         assert_eq!(map.resolve("SC2018"), Some(Rule::TrLowerRange));
         assert_eq!(map.resolve("SC2019"), Some(Rule::TrUpperRange));
+        assert_eq!(map.resolve("SC2028"), Some(Rule::EchoBackslashEscapes));
         assert_eq!(map.resolve("SC3024"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3055"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3071"), Some(Rule::PlusEqualsInSh));
@@ -1694,6 +1697,7 @@ mod tests {
             (3037, Rule::EchoFlags),
             (2018, Rule::TrLowerRange),
             (2019, Rule::TrUpperRange),
+            (2028, Rule::EchoBackslashEscapes),
             (3025, Rule::PrintfQFormatInSh),
             (3026, Rule::CaretNegationInBracket),
             (3028, Rule::ArrayReference),
@@ -1837,6 +1841,7 @@ mod tests {
         assert!(comparison.contains(&(2021, Rule::UnquotedTrRange)));
         assert!(comparison.contains(&(2018, Rule::TrLowerRange)));
         assert!(comparison.contains(&(2019, Rule::TrUpperRange)));
+        assert!(comparison.contains(&(2028, Rule::EchoBackslashEscapes)));
         assert!(!comparison.contains(&(2300, Rule::UnquotedWordBetweenQuotes)));
         assert!(!comparison.contains(&(2307, Rule::UnquotedVariableInTest)));
         assert!(!comparison.contains(&(2346, Rule::DefaultValueInColonAssign)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -285,6 +285,7 @@ impl Default for ShellCheckCodeMap {
             // Keep SC3024 as a legacy alias for suppression compatibility.
             (3034, Rule::BashFileSlurp),
             (3037, Rule::EchoFlags),
+            (2018, Rule::TrLowerRange),
             (3025, Rule::PrintfQFormatInSh),
             (3026, Rule::CaretNegationInBracket),
             (3077, Rule::BasePrefixInArithmetic),
@@ -559,6 +560,7 @@ impl Default for ShellCheckCodeMap {
                     (3071, Rule::PlusEqualsInSh),
                     (3034, Rule::BashFileSlurp),
                     (3037, Rule::EchoFlags),
+                    (2018, Rule::TrLowerRange),
                     (3025, Rule::PrintfQFormatInSh),
                     (3052, Rule::AmpersandRedirection),
                     (3050, Rule::BraceFdRedirection),
@@ -1155,6 +1157,7 @@ mod tests {
         assert_eq!(map.resolve("SC3025"), Some(Rule::PrintfQFormatInSh));
         assert_eq!(map.resolve("SC3034"), Some(Rule::BashFileSlurp));
         assert_eq!(map.resolve("SC3037"), Some(Rule::EchoFlags));
+        assert_eq!(map.resolve("SC2018"), Some(Rule::TrLowerRange));
         assert_eq!(map.resolve("SC3024"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3055"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3071"), Some(Rule::PlusEqualsInSh));
@@ -1686,6 +1689,7 @@ mod tests {
             (3024, Rule::PlusEqualsInSh),
             (3034, Rule::BashFileSlurp),
             (3037, Rule::EchoFlags),
+            (2018, Rule::TrLowerRange),
             (3025, Rule::PrintfQFormatInSh),
             (3026, Rule::CaretNegationInBracket),
             (3028, Rule::ArrayReference),
@@ -1827,6 +1831,7 @@ mod tests {
         assert!(comparison.contains(&(2320, Rule::UnquotedPipeInEcho)));
         assert!(comparison.contains(&(2223, Rule::DefaultValueInColonAssign)));
         assert!(comparison.contains(&(2021, Rule::UnquotedTrRange)));
+        assert!(comparison.contains(&(2018, Rule::TrLowerRange)));
         assert!(!comparison.contains(&(2300, Rule::UnquotedWordBetweenQuotes)));
         assert!(!comparison.contains(&(2307, Rule::UnquotedVariableInTest)));
         assert!(!comparison.contains(&(2346, Rule::DefaultValueInColonAssign)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -284,6 +284,7 @@ impl Default for ShellCheckCodeMap {
             // The pinned ShellCheck oracle reports `$(< file)` as SC3034.
             // Keep SC3024 as a legacy alias for suppression compatibility.
             (3034, Rule::BashFileSlurp),
+            (3037, Rule::EchoFlags),
             (3025, Rule::PrintfQFormatInSh),
             (3026, Rule::CaretNegationInBracket),
             (3077, Rule::BasePrefixInArithmetic),
@@ -557,6 +558,7 @@ impl Default for ShellCheckCodeMap {
                     (3024, Rule::PlusEqualsAppend),
                     (3071, Rule::PlusEqualsInSh),
                     (3034, Rule::BashFileSlurp),
+                    (3037, Rule::EchoFlags),
                     (3025, Rule::PrintfQFormatInSh),
                     (3052, Rule::AmpersandRedirection),
                     (3050, Rule::BraceFdRedirection),
@@ -1152,6 +1154,7 @@ mod tests {
         assert_eq!(map.resolve("SC2352"), Some(Rule::DefaultElseInShortCircuit));
         assert_eq!(map.resolve("SC3025"), Some(Rule::PrintfQFormatInSh));
         assert_eq!(map.resolve("SC3034"), Some(Rule::BashFileSlurp));
+        assert_eq!(map.resolve("SC3037"), Some(Rule::EchoFlags));
         assert_eq!(map.resolve("SC3024"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3055"), Some(Rule::PlusEqualsAppend));
         assert_eq!(map.resolve("SC3071"), Some(Rule::PlusEqualsInSh));
@@ -1682,6 +1685,7 @@ mod tests {
             (3024, Rule::BashFileSlurp),
             (3024, Rule::PlusEqualsInSh),
             (3034, Rule::BashFileSlurp),
+            (3037, Rule::EchoFlags),
             (3025, Rule::PrintfQFormatInSh),
             (3026, Rule::CaretNegationInBracket),
             (3028, Rule::ArrayReference),
@@ -1859,6 +1863,7 @@ mod tests {
         assert!(comparison.contains(&(3040, Rule::PipefailOption)));
         assert!(comparison.contains(&(3025, Rule::PrintfQFormatInSh)));
         assert!(comparison.contains(&(3048, Rule::WaitOption)));
+        assert!(comparison.contains(&(3037, Rule::EchoFlags)));
         assert!(comparison.contains(&(2217, Rule::EchoHereDoc)));
         assert!(comparison.contains(&(3046, Rule::SourceBuiltinInSh)));
         assert!(comparison.contains(&(3024, Rule::PlusEqualsAppend)));

--- a/crates/shuck/tests/testdata/corpus-metadata/x027.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x027.yaml
@@ -1,0 +1,25 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "nvm-sh__nvm__test__install_script__install_nvm_from_git"
+    line: 14
+    end_line: 14
+    labels:
+      - test-harness
+    reason: "The shell-collapse comparison forces this NVM test helper through POSIX sh, but the pinned ShellCheck oracle stops at a later malformed test expression and never reports the earlier `echo -e` site. Shuck still reaches the echo command facts, so this harness-only gap is reviewed narrowly on the affected test file."
+  - side: shuck-only
+    path_suffix: "nvm-sh__nvm__test__install_script__install_nvm_from_git"
+    line: 24
+    end_line: 24
+    labels:
+      - test-harness
+    reason: "The shell-collapse comparison forces this NVM test helper through POSIX sh, but the pinned ShellCheck oracle stops at a later malformed test expression and never reports the earlier `echo -e` site. Shuck still reaches the echo command facts, so this harness-only gap is reviewed narrowly on the affected test file."
+  - side: shuck-only
+    path_suffix: "romkatv__powerlevel10k__gitstatus__install"
+    line: 343
+    end_line: 343
+    reason: "This install helper hits forced-sh parse failures earlier in the file, so the pinned ShellCheck oracle stops before it reaches the later `echo -n` redirection sites. Shuck still analyzes those echo calls, so the missed oracle report is treated as a narrow reviewed divergence."
+  - side: shuck-only
+    path_suffix: "romkatv__powerlevel10k__gitstatus__install"
+    line: 370
+    end_line: 370
+    reason: "This install helper hits forced-sh parse failures earlier in the file, so the pinned ShellCheck oracle stops before it reaches the later `echo -n` redirection sites. Shuck still analyzes those echo calls, so the missed oracle report is treated as a narrow reviewed divergence."

--- a/crates/shuck/tests/testdata/corpus-metadata/x028.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x028.yaml
@@ -1,0 +1,9 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 96
+    end_line: 96
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This helper is a Bash library entrypoint, but the shell-collapse comparison path still feeds it through a POSIX sh oracle. The pinned ShellCheck run aborts later on sh-incompatible syntax before it ever reaches this `tr a-z A-Z` helper, so the missed SC2018 report is treated as a narrow reviewed divergence."

--- a/crates/shuck/tests/testdata/corpus-metadata/x029.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x029.yaml
@@ -1,0 +1,9 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 96
+    end_line: 96
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This helper is a Bash library entrypoint, but the shell-collapse comparison path still feeds it through a POSIX sh oracle. The pinned ShellCheck run aborts later on sh-incompatible syntax before it ever reaches this `tr a-z A-Z` helper, so the missed SC2019 report is treated as a narrow reviewed divergence."

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -159,7 +159,7 @@ Detect extended glob syntax in contexts where it is not supported.
 
 Detect locale-dependent and non-portable echo/tr behavior.
 
-- [ ] **L** X027 (SC3037) `echo-flags` — echo flags depend on shell implementation
+- [x] **L** X027 (SC3037) `echo-flags` — echo flags depend on shell implementation
 - [ ] **L** X028 (SC2018) `tr-lower-range` — locale-dependent lower-case tr range
 - [ ] **L** X029 (SC2019) `tr-upper-range` — locale-dependent upper-case tr range
 - [ ] **M** X030 (SC2028) `echo-backslash-escapes` — echo backslash escapes are non-portable

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -162,7 +162,7 @@ Detect locale-dependent and non-portable echo/tr behavior.
 - [x] **L** X027 (SC3037) `echo-flags` — echo flags depend on shell implementation
 - [x] **L** X028 (SC2018) `tr-lower-range` — locale-dependent lower-case tr range
 - [x] **L** X029 (SC2019) `tr-upper-range` — locale-dependent upper-case tr range
-- [ ] **M** X030 (SC2028) `echo-backslash-escapes` — echo backslash escapes are non-portable
+- [x] **M** X030 (SC2028) `echo-backslash-escapes` — echo backslash escapes are non-portable
 
 ### Portability — POSIX sh Function and Variable Syntax
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -160,7 +160,7 @@ Detect extended glob syntax in contexts where it is not supported.
 Detect locale-dependent and non-portable echo/tr behavior.
 
 - [x] **L** X027 (SC3037) `echo-flags` — echo flags depend on shell implementation
-- [ ] **L** X028 (SC2018) `tr-lower-range` — locale-dependent lower-case tr range
+- [x] **L** X028 (SC2018) `tr-lower-range` — locale-dependent lower-case tr range
 - [ ] **L** X029 (SC2019) `tr-upper-range` — locale-dependent upper-case tr range
 - [ ] **M** X030 (SC2028) `echo-backslash-escapes` — echo backslash escapes are non-portable
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -161,7 +161,7 @@ Detect locale-dependent and non-portable echo/tr behavior.
 
 - [x] **L** X027 (SC3037) `echo-flags` — echo flags depend on shell implementation
 - [x] **L** X028 (SC2018) `tr-lower-range` — locale-dependent lower-case tr range
-- [ ] **L** X029 (SC2019) `tr-upper-range` — locale-dependent upper-case tr range
+- [x] **L** X029 (SC2019) `tr-upper-range` — locale-dependent upper-case tr range
 - [ ] **M** X030 (SC2028) `echo-backslash-escapes` — echo backslash escapes are non-portable
 
 ### Portability — POSIX sh Function and Variable Syntax


### PR DESCRIPTION
## Summary
- implement portability rules X027 through X030 for `echo`/`tr` locale and escape behavior
- reuse shared command and expansion logic in linter facts instead of duplicating per-rule traversal
- mark the four rules complete in `docs/rules.md`

## Why
These portability checks were still missing from the roadmap and needed to align shuck's behavior with the expected ShellCheck-compatible rule set while keeping the implementation fact-driven and reusable.

## Validation
- `make ensure-cache`
- focused `cargo test -p shuck-linter` coverage for X027, X028, X029, and X030
- isolated large-corpus conformance runs for `SHUCK_LARGE_CORPUS_RULES=X027`, `X028`, `X029`, and `X030`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X030` still reproduces the existing unrelated `large_corpus_zsh_fixtures_parse` timeout pair, while `large_corpus_conforms_with_shellcheck` passes for X030
