### PR TITLE
Refactor recorded CFG IR into arena-backed storage

### DIFF
--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -14,8 +14,9 @@ use shuck_parser::{ShellProfile, ZshEmulationMode, parser::Parser};
 use crate::binding::{Binding, BindingAttributes, BindingKind};
 use crate::call_graph::{CallGraph, CallSite, OverwrittenFunction};
 use crate::cfg::{
-    FlowContext, IsolatedRegion, RecordedCaseArm, RecordedCommand, RecordedCommandInfo,
-    RecordedCommandKind, RecordedListOperator, RecordedPipelineSegment, RecordedProgram,
+    FlowContext, IsolatedRegion, RecordedCaseArm, RecordedCommand, RecordedCommandId,
+    RecordedCommandInfo, RecordedCommandKind, RecordedCommandRange, RecordedElifBranch,
+    RecordedListItem, RecordedListOperator, RecordedPipelineSegment, RecordedProgram,
     RecordedZshCommandEffect, RecordedZshOptionUpdate,
 };
 use crate::declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
@@ -70,9 +71,7 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     indirect_target_hints: FxHashMap<BindingId, IndirectTargetHint>,
     indirect_expansion_refs: FxHashSet<ReferenceId>,
     flow_contexts: Vec<(Span, FlowContext)>,
-    recorded_function_bodies: FxHashMap<ScopeId, Vec<RecordedCommand>>,
-    recorded_command_infos: FxHashMap<SpanKey, RecordedCommandInfo>,
-    function_body_scopes: FxHashMap<BindingId, ScopeId>,
+    recorded_program: RecordedProgram,
     command_bindings: FxHashMap<SpanKey, Vec<BindingId>>,
     command_references: FxHashMap<SpanKey, Vec<ReferenceId>>,
     source_directives: FxHashMap<usize, SourceDirectiveOverride>,
@@ -140,9 +139,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             indirect_target_hints: FxHashMap::default(),
             indirect_expansion_refs: FxHashSet::default(),
             flow_contexts: Vec::new(),
-            recorded_function_bodies: FxHashMap::default(),
-            recorded_command_infos: FxHashMap::default(),
-            function_body_scopes: FxHashMap::default(),
+            recorded_program: RecordedProgram::default(),
             command_bindings: FxHashMap::default(),
             command_references: FxHashMap::default(),
             source_directives: parse_source_directives(source, indexer),
@@ -153,6 +150,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             command_stack: Vec::new(),
         };
         let file_commands = builder.visit_stmt_seq(&file.body, FlowState::default());
+        builder.recorded_program.set_file_commands(file_commands);
         builder.mark_scope_completed(ScopeId(0));
         builder.drain_deferred_functions();
 
@@ -178,12 +176,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             indirect_target_hints: builder.indirect_target_hints,
             indirect_expansion_refs: builder.indirect_expansion_refs,
             flow_contexts: builder.flow_contexts,
-            recorded_program: RecordedProgram {
-                file_commands,
-                function_bodies: builder.recorded_function_bodies,
-                command_infos: builder.recorded_command_infos,
-                function_body_scopes: builder.function_body_scopes,
-            },
+            recorded_program: builder.recorded_program,
             command_bindings: builder.command_bindings,
             command_references: builder.command_references,
             heuristic_unused_assignments,
@@ -200,17 +193,43 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
-    fn visit_stmt_seq(&mut self, commands: &StmtSeq, flow: FlowState) -> Vec<RecordedCommand> {
+    fn record_command(
+        &mut self,
+        span: Span,
+        nested_regions: Vec<IsolatedRegion>,
+        kind: RecordedCommandKind,
+    ) -> RecordedCommandId {
+        let nested_regions = self.recorded_program.push_regions(nested_regions);
+        self.recorded_program.push_command(RecordedCommand {
+            span,
+            nested_regions,
+            kind,
+        })
+    }
+
+    fn prepend_nested_regions(&mut self, command: RecordedCommandId, regions: Vec<IsolatedRegion>) {
+        if regions.is_empty() {
+            return;
+        }
+
+        let existing = self.recorded_program.command(command).nested_regions;
+        let mut merged = regions;
+        merged.extend_from_slice(self.recorded_program.nested_regions(existing));
+        self.recorded_program.command_mut(command).nested_regions =
+            self.recorded_program.push_regions(merged);
+    }
+
+    fn visit_stmt_seq(&mut self, commands: &StmtSeq, flow: FlowState) -> RecordedCommandRange {
         let mut recorded = Vec::with_capacity(commands.len());
         self.visit_stmt_seq_into(commands, flow, &mut recorded);
-        recorded
+        self.recorded_program.push_command_ids(recorded)
     }
 
     fn visit_stmt_seq_into(
         &mut self,
         commands: &StmtSeq,
         flow: FlowState,
-        recorded: &mut Vec<RecordedCommand>,
+        recorded: &mut Vec<RecordedCommandId>,
     ) {
         recorded.reserve(commands.len());
         for stmt in commands.iter() {
@@ -218,7 +237,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
-    fn visit_stmt(&mut self, stmt: &Stmt, flow: FlowState) -> RecordedCommand {
+    fn visit_stmt(&mut self, stmt: &Stmt, flow: FlowState) -> RecordedCommandId {
         let span = stmt.span;
         let scope = self.current_scope();
         let context = Self::flow_context(flow);
@@ -226,13 +245,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.observer.enter_command(&stmt.command, scope, context);
         self.command_stack.push(span);
 
-        let mut recorded = self.visit_command(&stmt.command, flow);
+        let recorded = self.visit_command(&stmt.command, flow);
         let redirects = self.visit_redirects(&stmt.redirects, flow);
         if !redirects.is_empty() {
-            recorded.nested_regions.splice(0..0, redirects);
+            self.prepend_nested_regions(recorded, redirects);
         }
-        recorded.span = span;
-        self.recorded_command_infos.insert(
+        self.recorded_program.command_mut(recorded).span = span;
+        self.recorded_program.command_infos.insert(
             SpanKey::new(span),
             recorded_command_info(&stmt.command, self.source),
         );
@@ -242,7 +261,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         recorded
     }
 
-    fn visit_command(&mut self, command: &Command, flow: FlowState) -> RecordedCommand {
+    fn visit_command(&mut self, command: &Command, flow: FlowState) -> RecordedCommandId {
         match command {
             Command::Simple(command) => self.visit_simple_command(command, flow),
             Command::Builtin(command) => self.visit_builtin(command, flow),
@@ -258,7 +277,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         &mut self,
         command: &shuck_ast::SimpleCommand,
         flow: FlowState,
-    ) -> RecordedCommand {
+    ) -> RecordedCommandId {
         let mut nested_regions = Vec::new();
         let command_has_name = simple_command_has_name(command, self.source);
         for assignment in &command.assignments {
@@ -309,59 +328,59 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             self.classify_special_simple_command(&callee, command, flow);
         }
 
-        RecordedCommand {
-            span: command.span,
-            nested_regions,
-            kind: RecordedCommandKind::Linear,
-        }
+        self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
     }
 
-    fn visit_builtin(&mut self, command: &BuiltinCommand, flow: FlowState) -> RecordedCommand {
+    fn visit_builtin(&mut self, command: &BuiltinCommand, flow: FlowState) -> RecordedCommandId {
         match command {
-            BuiltinCommand::Break(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: self.visit_builtin_parts(
+            BuiltinCommand::Break(command) => {
+                let nested_regions = self.visit_builtin_parts(
                     &command.assignments,
                     command.depth.as_ref(),
                     &command.extra_args,
                     flow,
-                ),
-                kind: RecordedCommandKind::Break {
-                    depth: depth_from_word(command.depth.as_ref()),
-                },
-            },
-            BuiltinCommand::Continue(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: self.visit_builtin_parts(
+                );
+                self.record_command(
+                    command.span,
+                    nested_regions,
+                    RecordedCommandKind::Break {
+                        depth: depth_from_word(command.depth.as_ref()),
+                    },
+                )
+            }
+            BuiltinCommand::Continue(command) => {
+                let nested_regions = self.visit_builtin_parts(
                     &command.assignments,
                     command.depth.as_ref(),
                     &command.extra_args,
                     flow,
-                ),
-                kind: RecordedCommandKind::Continue {
-                    depth: depth_from_word(command.depth.as_ref()),
-                },
-            },
-            BuiltinCommand::Return(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: self.visit_builtin_parts(
+                );
+                self.record_command(
+                    command.span,
+                    nested_regions,
+                    RecordedCommandKind::Continue {
+                        depth: depth_from_word(command.depth.as_ref()),
+                    },
+                )
+            }
+            BuiltinCommand::Return(command) => {
+                let nested_regions = self.visit_builtin_parts(
                     &command.assignments,
                     command.code.as_ref(),
                     &command.extra_args,
                     flow,
-                ),
-                kind: RecordedCommandKind::Return,
-            },
-            BuiltinCommand::Exit(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: self.visit_builtin_parts(
+                );
+                self.record_command(command.span, nested_regions, RecordedCommandKind::Return)
+            }
+            BuiltinCommand::Exit(command) => {
+                let nested_regions = self.visit_builtin_parts(
                     &command.assignments,
                     command.code.as_ref(),
                     &command.extra_args,
                     flow,
-                ),
-                kind: RecordedCommandKind::Exit,
-            },
+                );
+                self.record_command(command.span, nested_regions, RecordedCommandKind::Exit)
+            }
         }
     }
 
@@ -394,7 +413,11 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         nested_regions
     }
 
-    fn visit_decl(&mut self, command: &shuck_ast::DeclClause, flow: FlowState) -> RecordedCommand {
+    fn visit_decl(
+        &mut self,
+        command: &shuck_ast::DeclClause,
+        flow: FlowState,
+    ) -> RecordedCommandId {
         let mut nested_regions = Vec::new();
         for assignment in &command.assignments {
             self.visit_assignment_into(
@@ -451,14 +474,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
         }
 
-        RecordedCommand {
-            span: command.span,
-            nested_regions,
-            kind: RecordedCommandKind::Linear,
-        }
+        self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
     }
 
-    fn visit_binary(&mut self, command: &BinaryCommand, flow: FlowState) -> RecordedCommand {
+    fn visit_binary(&mut self, command: &BinaryCommand, flow: FlowState) -> RecordedCommandId {
         match command.op {
             BinaryOp::And | BinaryOp::Or => self.visit_logical_binary(command, flow),
             BinaryOp::Pipe | BinaryOp::PipeAll => self.visit_pipeline_binary(command, flow),
@@ -469,7 +488,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         &mut self,
         command: &BinaryCommand,
         mut flow: FlowState,
-    ) -> RecordedCommand {
+    ) -> RecordedCommandId {
         flow.in_subshell = true;
         let mut commands = Vec::new();
         collect_pipeline_segments(&command.left, &mut commands);
@@ -487,18 +506,19 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             });
         }
 
-        RecordedCommand {
-            span: command.span,
-            nested_regions: Vec::new(),
-            kind: RecordedCommandKind::Pipeline { segments },
-        }
+        let segments = self.recorded_program.push_pipeline_segments(segments);
+        self.record_command(
+            command.span,
+            Vec::new(),
+            RecordedCommandKind::Pipeline { segments },
+        )
     }
 
     fn visit_logical_binary(
         &mut self,
         command: &BinaryCommand,
         flow: FlowState,
-    ) -> RecordedCommand {
+    ) -> RecordedCommandId {
         let mut operators = Vec::new();
         let mut commands = Vec::new();
         collect_logical_segments(&command.left, &mut commands, &mut operators);
@@ -513,57 +533,67 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
 
         let mut recorded = recorded.into_iter();
-        let first = Box::new(
-            recorded
-                .next()
-                .expect("logical lists have at least one command"),
+        let first = recorded
+            .next()
+            .expect("logical lists have at least one command");
+        let rest = self.recorded_program.push_list_items(
+            operators
+                .into_iter()
+                .zip(recorded)
+                .map(|(operator, command)| RecordedListItem { operator, command })
+                .collect(),
         );
-        let rest = operators.into_iter().zip(recorded).collect();
 
-        RecordedCommand {
-            span: command.span,
-            nested_regions: Vec::new(),
-            kind: RecordedCommandKind::List { first, rest },
-        }
+        self.record_command(
+            command.span,
+            Vec::new(),
+            RecordedCommandKind::List { first, rest },
+        )
     }
 
-    fn visit_compound(&mut self, command: &CompoundCommand, flow: FlowState) -> RecordedCommand {
+    fn visit_compound(&mut self, command: &CompoundCommand, flow: FlowState) -> RecordedCommandId {
         match command {
-            CompoundCommand::If(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: Vec::new(),
-                kind: RecordedCommandKind::If {
-                    condition: self.visit_stmt_seq(
-                        &command.condition,
-                        FlowState {
-                            exit_status_checked: true,
-                            ..flow
-                        },
-                    ),
-                    then_branch: self.visit_stmt_seq(&command.then_branch, flow),
-                    elif_branches: command
-                        .elif_branches
-                        .iter()
-                        .map(|(condition, body)| {
-                            (
-                                self.visit_stmt_seq(
-                                    condition,
-                                    FlowState {
-                                        exit_status_checked: true,
-                                        ..flow
-                                    },
-                                ),
-                                self.visit_stmt_seq(body, flow),
-                            )
-                        })
-                        .collect(),
-                    else_branch: command
-                        .else_branch
-                        .as_ref()
-                        .map(|body| self.visit_stmt_seq(body, flow))
-                        .unwrap_or_default(),
-                },
-            },
+            CompoundCommand::If(command) => {
+                let condition = self.visit_stmt_seq(
+                    &command.condition,
+                    FlowState {
+                        exit_status_checked: true,
+                        ..flow
+                    },
+                );
+                let then_branch = self.visit_stmt_seq(&command.then_branch, flow);
+                let elif_branches = command
+                    .elif_branches
+                    .iter()
+                    .map(|(condition, body)| RecordedElifBranch {
+                        condition: self.visit_stmt_seq(
+                            condition,
+                            FlowState {
+                                exit_status_checked: true,
+                                ..flow
+                            },
+                        ),
+                        body: self.visit_stmt_seq(body, flow),
+                    })
+                    .collect();
+                let elif_branches = self.recorded_program.push_elif_branches(elif_branches);
+                let else_branch = command
+                    .else_branch
+                    .as_ref()
+                    .map(|body| self.visit_stmt_seq(body, flow))
+                    .unwrap_or_default();
+
+                self.record_command(
+                    command.span,
+                    Vec::new(),
+                    RecordedCommandKind::If {
+                        condition,
+                        then_branch,
+                        elif_branches,
+                        else_branch,
+                    },
+                )
+            }
             CompoundCommand::For(command) => {
                 let nested_regions = command
                     .words
@@ -582,33 +612,35 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     }
                 }
 
-                RecordedCommand {
-                    span: command.span,
-                    nested_regions,
-                    kind: RecordedCommandKind::For {
-                        body: self.visit_stmt_seq(
-                            &command.body,
-                            FlowState {
-                                loop_depth: flow.loop_depth + 1,
-                                ..flow
-                            },
-                        ),
+                let body = self.visit_stmt_seq(
+                    &command.body,
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow
                     },
-                }
+                );
+                self.record_command(
+                    command.span,
+                    nested_regions,
+                    RecordedCommandKind::For { body },
+                )
             }
-            CompoundCommand::Repeat(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: self.visit_word(&command.count, WordVisitKind::Expansion, flow),
-                kind: RecordedCommandKind::For {
-                    body: self.visit_stmt_seq(
-                        &command.body,
-                        FlowState {
-                            loop_depth: flow.loop_depth + 1,
-                            ..flow
-                        },
-                    ),
-                },
-            },
+            CompoundCommand::Repeat(command) => {
+                let nested_regions =
+                    self.visit_word(&command.count, WordVisitKind::Expansion, flow);
+                let body = self.visit_stmt_seq(
+                    &command.body,
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow
+                    },
+                );
+                self.record_command(
+                    command.span,
+                    nested_regions,
+                    RecordedCommandKind::For { body },
+                )
+            }
             CompoundCommand::Foreach(command) => {
                 let nested_regions =
                     self.visit_words(&command.words, WordVisitKind::Expansion, flow);
@@ -620,19 +652,18 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     BindingAttributes::empty(),
                 );
 
-                RecordedCommand {
-                    span: command.span,
-                    nested_regions,
-                    kind: RecordedCommandKind::For {
-                        body: self.visit_stmt_seq(
-                            &command.body,
-                            FlowState {
-                                loop_depth: flow.loop_depth + 1,
-                                ..flow
-                            },
-                        ),
+                let body = self.visit_stmt_seq(
+                    &command.body,
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow
                     },
-                }
+                );
+                self.record_command(
+                    command.span,
+                    nested_regions,
+                    RecordedCommandKind::For { body },
+                )
             }
             CompoundCommand::ArithmeticFor(command) => {
                 let mut nested_regions = Vec::new();
@@ -651,60 +682,61 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     flow,
                     &mut nested_regions,
                 );
-                RecordedCommand {
-                    span: command.span,
-                    nested_regions,
-                    kind: RecordedCommandKind::ArithmeticFor {
-                        body: self.visit_stmt_seq(
-                            &command.body,
-                            FlowState {
-                                loop_depth: flow.loop_depth + 1,
-                                ..flow
-                            },
-                        ),
+                let body = self.visit_stmt_seq(
+                    &command.body,
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow
                     },
-                }
+                );
+                self.record_command(
+                    command.span,
+                    nested_regions,
+                    RecordedCommandKind::ArithmeticFor { body },
+                )
             }
-            CompoundCommand::While(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: Vec::new(),
-                kind: RecordedCommandKind::While {
-                    condition: self.visit_stmt_seq(
-                        &command.condition,
-                        FlowState {
-                            exit_status_checked: true,
-                            ..flow
-                        },
-                    ),
-                    body: self.visit_stmt_seq(
-                        &command.body,
-                        FlowState {
-                            loop_depth: flow.loop_depth + 1,
-                            ..flow
-                        },
-                    ),
-                },
-            },
-            CompoundCommand::Until(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: Vec::new(),
-                kind: RecordedCommandKind::Until {
-                    condition: self.visit_stmt_seq(
-                        &command.condition,
-                        FlowState {
-                            exit_status_checked: true,
-                            ..flow
-                        },
-                    ),
-                    body: self.visit_stmt_seq(
-                        &command.body,
-                        FlowState {
-                            loop_depth: flow.loop_depth + 1,
-                            ..flow
-                        },
-                    ),
-                },
-            },
+            CompoundCommand::While(command) => {
+                let condition = self.visit_stmt_seq(
+                    &command.condition,
+                    FlowState {
+                        exit_status_checked: true,
+                        ..flow
+                    },
+                );
+                let body = self.visit_stmt_seq(
+                    &command.body,
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow
+                    },
+                );
+                self.record_command(
+                    command.span,
+                    Vec::new(),
+                    RecordedCommandKind::While { condition, body },
+                )
+            }
+            CompoundCommand::Until(command) => {
+                let condition = self.visit_stmt_seq(
+                    &command.condition,
+                    FlowState {
+                        exit_status_checked: true,
+                        ..flow
+                    },
+                );
+                let body = self.visit_stmt_seq(
+                    &command.body,
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow
+                    },
+                );
+                self.record_command(
+                    command.span,
+                    Vec::new(),
+                    RecordedCommandKind::Until { condition, body },
+                )
+            }
             CompoundCommand::Case(command) => {
                 let nested_regions = self.visit_word(&command.word, WordVisitKind::Expansion, flow);
 
@@ -714,31 +746,33 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     .map(|case| {
                         let pattern_regions =
                             self.visit_patterns(&case.patterns, WordVisitKind::Conditional, flow);
-                        let mut commands = self.visit_stmt_seq(&case.body, flow);
+                        let mut commands = Vec::with_capacity(case.body.len());
+                        self.visit_stmt_seq_into(&case.body, flow, &mut commands);
                         if !pattern_regions.is_empty() {
-                            if let Some(first) = commands.first_mut() {
-                                first.nested_regions.splice(0..0, pattern_regions);
+                            if let Some(&first) = commands.first() {
+                                self.prepend_nested_regions(first, pattern_regions);
                             } else {
-                                commands.push(RecordedCommand {
-                                    span: command.span,
-                                    nested_regions: pattern_regions,
-                                    kind: RecordedCommandKind::Linear,
-                                });
+                                commands.push(self.record_command(
+                                    command.span,
+                                    pattern_regions,
+                                    RecordedCommandKind::Linear,
+                                ));
                             }
                         }
                         RecordedCaseArm {
                             terminator: case.terminator,
                             matches_anything: case_arm_matches_anything(&case.patterns),
-                            commands,
+                            commands: self.recorded_program.push_command_ids(commands),
                         }
                     })
                     .collect();
 
-                RecordedCommand {
-                    span: command.span,
+                let arms = self.recorded_program.push_case_arms(arms);
+                self.record_command(
+                    command.span,
                     nested_regions,
-                    kind: RecordedCommandKind::Case { arms },
-                }
+                    RecordedCommandKind::Case { arms },
+                )
             }
             CompoundCommand::Select(command) => {
                 let nested_regions =
@@ -751,19 +785,18 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     BindingAttributes::empty(),
                 );
 
-                RecordedCommand {
-                    span: command.span,
-                    nested_regions,
-                    kind: RecordedCommandKind::Select {
-                        body: self.visit_stmt_seq(
-                            &command.body,
-                            FlowState {
-                                loop_depth: flow.loop_depth + 1,
-                                ..flow
-                            },
-                        ),
+                let body = self.visit_stmt_seq(
+                    &command.body,
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow
                     },
-                }
+                );
+                self.record_command(
+                    command.span,
+                    nested_regions,
+                    RecordedCommandKind::Select { body },
+                )
             }
             CompoundCommand::Subshell(commands) => {
                 let scope = self.push_scope(
@@ -781,87 +814,73 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.pop_scope(scope);
                 self.mark_scope_completed(scope);
 
-                RecordedCommand {
-                    span: command_span_from_compound(command),
-                    nested_regions: Vec::new(),
-                    kind: RecordedCommandKind::Subshell { body },
-                }
+                self.record_command(
+                    command_span_from_compound(command),
+                    Vec::new(),
+                    RecordedCommandKind::Subshell { body },
+                )
             }
-            CompoundCommand::BraceGroup(commands) => RecordedCommand {
-                span: command_span_from_compound(command),
-                nested_regions: Vec::new(),
-                kind: RecordedCommandKind::BraceGroup {
-                    body: self.visit_stmt_seq(
-                        commands,
-                        FlowState {
-                            in_block: true,
-                            ..flow
-                        },
-                    ),
-                },
-            },
-            CompoundCommand::Always(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: Vec::new(),
-                kind: RecordedCommandKind::BraceGroup {
-                    body: {
-                        let block_flow = FlowState {
-                            in_block: true,
-                            ..flow
-                        };
-                        let mut body =
-                            Vec::with_capacity(command.body.len() + command.always_body.len());
-                        self.visit_stmt_seq_into(&command.body, block_flow, &mut body);
-                        self.visit_stmt_seq_into(&command.always_body, block_flow, &mut body);
-                        body
+            CompoundCommand::BraceGroup(commands) => {
+                let body = self.visit_stmt_seq(
+                    commands,
+                    FlowState {
+                        in_block: true,
+                        ..flow
                     },
-                },
-            },
+                );
+                self.record_command(
+                    command_span_from_compound(command),
+                    Vec::new(),
+                    RecordedCommandKind::BraceGroup { body },
+                )
+            }
+            CompoundCommand::Always(command) => {
+                let block_flow = FlowState {
+                    in_block: true,
+                    ..flow
+                };
+                let mut body = Vec::with_capacity(command.body.len() + command.always_body.len());
+                self.visit_stmt_seq_into(&command.body, block_flow, &mut body);
+                self.visit_stmt_seq_into(&command.always_body, block_flow, &mut body);
+                let body = self.recorded_program.push_command_ids(body);
+                self.record_command(
+                    command.span,
+                    Vec::new(),
+                    RecordedCommandKind::BraceGroup { body },
+                )
+            }
             CompoundCommand::Arithmetic(command) => {
                 let nested_regions =
                     self.visit_optional_arithmetic_expr(command.expr_ast.as_ref(), flow);
-                RecordedCommand {
-                    span: command.span,
-                    nested_regions,
-                    kind: RecordedCommandKind::Linear,
-                }
+                self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
             }
             CompoundCommand::Time(command) => {
                 let mut nested_regions = Vec::new();
                 if let Some(command) = &command.command {
-                    nested_regions.extend(Self::flatten_recorded_regions(
-                        self.visit_stmt(command, flow),
-                    ));
+                    let command_id = self.visit_stmt(command, flow);
+                    nested_regions.extend(self.flatten_recorded_regions(command_id));
                 }
-                RecordedCommand {
-                    span: command.span,
-                    nested_regions,
-                    kind: RecordedCommandKind::Linear,
-                }
+                self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
             }
             CompoundCommand::Conditional(command) => {
                 let nested_regions = self.visit_conditional_expr(&command.expression, flow);
-                RecordedCommand {
-                    span: command.span,
-                    nested_regions,
-                    kind: RecordedCommandKind::Linear,
-                }
+                self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
             }
-            CompoundCommand::Coproc(command) => RecordedCommand {
-                span: command.span,
-                nested_regions: Self::flatten_recorded_regions(self.visit_stmt(
+            CompoundCommand::Coproc(command) => {
+                let body_command = self.visit_stmt(
                     &command.body,
                     FlowState {
                         in_subshell: true,
                         ..flow
                     },
-                )),
-                kind: RecordedCommandKind::Linear,
-            },
+                );
+                let nested_regions = self.flatten_recorded_regions(body_command);
+                self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
+            }
         }
     }
 
-    fn visit_function(&mut self, function: &FunctionDef, flow: FlowState) -> RecordedCommand {
+    fn visit_function(&mut self, function: &FunctionDef, flow: FlowState) -> RecordedCommandId {
         let mut nested_regions = Vec::new();
         for entry in &function.header.entries {
             self.visit_word_into(
@@ -886,7 +905,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 span,
                 BindingAttributes::empty(),
             );
-            self.function_body_scopes.insert(binding_id, scope);
+            self.recorded_program
+                .function_body_scopes
+                .insert(binding_id, scope);
         }
         self.deferred_functions.push(DeferredFunction {
             function: function as *const FunctionDef,
@@ -895,18 +916,14 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         });
         self.pop_scope(scope);
 
-        RecordedCommand {
-            span: function.span,
-            nested_regions,
-            kind: RecordedCommandKind::Linear,
-        }
+        self.record_command(function.span, nested_regions, RecordedCommandKind::Linear)
     }
 
     fn visit_anonymous_function(
         &mut self,
         function: &AnonymousFunctionCommand,
         flow: FlowState,
-    ) -> RecordedCommand {
+    ) -> RecordedCommandId {
         let nested_regions = self.visit_words(&function.args, WordVisitKind::Expansion, flow);
         let scope = self.push_scope(
             ScopeKind::Function(FunctionScopeKind::Anonymous),
@@ -917,11 +934,11 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.pop_scope(scope);
         self.mark_scope_completed(scope);
 
-        RecordedCommand {
-            span: function.span,
+        self.record_command(
+            function.span,
             nested_regions,
-            kind: RecordedCommandKind::BraceGroup { body },
-        }
+            RecordedCommandKind::BraceGroup { body },
+        )
     }
 
     fn visit_assignment_into(
@@ -1268,7 +1285,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 );
                 self.pop_scope(scope);
                 self.mark_scope_completed(scope);
-                nested_regions.push(IsolatedRegion { scope, commands });
+                nested_regions.push(IsolatedRegion {
+                    scope,
+                    commands: self.recorded_program.push_command_ids(commands),
+                });
             }
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
                 self.visit_optional_arithmetic_expr_into(
@@ -2354,8 +2374,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 // passed into `build`, and we only dereference them while that AST is still alive.
                 let function = unsafe { &*deferred.function };
                 let commands = self.visit_function_like_body(&function.body, deferred.flow);
-                self.recorded_function_bodies
-                    .insert(deferred.scope, commands);
+                self.recorded_program
+                    .set_function_body(deferred.scope, commands);
                 self.mark_scope_completed(deferred.scope);
             }
         }
@@ -2363,7 +2383,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.command_stack.clear();
     }
 
-    fn visit_function_like_body(&mut self, body: &Stmt, flow: FlowState) -> Vec<RecordedCommand> {
+    fn visit_function_like_body(&mut self, body: &Stmt, flow: FlowState) -> RecordedCommandRange {
         let flow = FlowState {
             in_function: true,
             ..flow
@@ -2373,7 +2393,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             Command::Compound(CompoundCommand::BraceGroup(commands)) => {
                 self.visit_stmt_seq(commands, flow)
             }
-            _ => vec![self.visit_stmt(body, flow)],
+            _ => {
+                let command = self.visit_stmt(body, flow);
+                self.recorded_program.push_command_ids(vec![command])
+            }
         }
     }
 
@@ -2382,24 +2405,23 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.scope_stack.reverse();
     }
 
-    fn flatten_recorded_regions(recorded: RecordedCommand) -> Vec<IsolatedRegion> {
-        let RecordedCommand {
-            nested_regions,
-            kind,
-            ..
-        } = recorded;
-        let mut regions = nested_regions;
+    fn flatten_recorded_regions(&self, recorded: RecordedCommandId) -> Vec<IsolatedRegion> {
+        let recorded = self.recorded_program.command(recorded);
+        let mut regions = self
+            .recorded_program
+            .nested_regions(recorded.nested_regions)
+            .to_vec();
 
-        match kind {
+        match recorded.kind {
             RecordedCommandKind::Linear
             | RecordedCommandKind::Break { .. }
             | RecordedCommandKind::Continue { .. }
             | RecordedCommandKind::Return
             | RecordedCommandKind::Exit => {}
             RecordedCommandKind::List { first, rest } => {
-                regions.extend(Self::flatten_recorded_regions(*first));
-                for (_, command) in rest {
-                    regions.extend(Self::flatten_recorded_regions(command));
+                regions.extend(self.flatten_recorded_regions(first));
+                for item in self.recorded_program.list_items(rest) {
+                    regions.extend(self.flatten_recorded_regions(item.command));
                 }
             }
             RecordedCommandKind::If {
@@ -2408,31 +2430,31 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 elif_branches,
                 else_branch,
             } => {
-                for command in condition {
-                    regions.extend(Self::flatten_recorded_regions(command));
+                for &command in self.recorded_program.commands_in(condition) {
+                    regions.extend(self.flatten_recorded_regions(command));
                 }
-                for command in then_branch {
-                    regions.extend(Self::flatten_recorded_regions(command));
+                for &command in self.recorded_program.commands_in(then_branch) {
+                    regions.extend(self.flatten_recorded_regions(command));
                 }
-                for (condition, branch) in elif_branches {
-                    for command in condition {
-                        regions.extend(Self::flatten_recorded_regions(command));
+                for branch in self.recorded_program.elif_branches(elif_branches) {
+                    for &command in self.recorded_program.commands_in(branch.condition) {
+                        regions.extend(self.flatten_recorded_regions(command));
                     }
-                    for command in branch {
-                        regions.extend(Self::flatten_recorded_regions(command));
+                    for &command in self.recorded_program.commands_in(branch.body) {
+                        regions.extend(self.flatten_recorded_regions(command));
                     }
                 }
-                for command in else_branch {
-                    regions.extend(Self::flatten_recorded_regions(command));
+                for &command in self.recorded_program.commands_in(else_branch) {
+                    regions.extend(self.flatten_recorded_regions(command));
                 }
             }
             RecordedCommandKind::While { condition, body }
             | RecordedCommandKind::Until { condition, body } => {
-                for command in condition {
-                    regions.extend(Self::flatten_recorded_regions(command));
+                for &command in self.recorded_program.commands_in(condition) {
+                    regions.extend(self.flatten_recorded_regions(command));
                 }
-                for command in body {
-                    regions.extend(Self::flatten_recorded_regions(command));
+                for &command in self.recorded_program.commands_in(body) {
+                    regions.extend(self.flatten_recorded_regions(command));
                 }
             }
             RecordedCommandKind::For { body }
@@ -2440,20 +2462,20 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             | RecordedCommandKind::ArithmeticFor { body }
             | RecordedCommandKind::BraceGroup { body }
             | RecordedCommandKind::Subshell { body } => {
-                for command in body {
-                    regions.extend(Self::flatten_recorded_regions(command));
+                for &command in self.recorded_program.commands_in(body) {
+                    regions.extend(self.flatten_recorded_regions(command));
                 }
             }
             RecordedCommandKind::Case { arms } => {
-                for arm in arms {
-                    for command in arm.commands {
-                        regions.extend(Self::flatten_recorded_regions(command));
+                for arm in self.recorded_program.case_arms(arms) {
+                    for &command in self.recorded_program.commands_in(arm.commands) {
+                        regions.extend(self.flatten_recorded_regions(command));
                     }
                 }
             }
             RecordedCommandKind::Pipeline { segments } => {
-                for segment in segments {
-                    regions.extend(Self::flatten_recorded_regions(segment.command));
+                for segment in self.recorded_program.pipeline_segments(segments) {
+                    regions.extend(self.flatten_recorded_regions(segment.command));
                 }
             }
         }

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -102,7 +102,7 @@ impl ControlFlowGraph {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct RecordedProgram {
     file_commands: RecordedCommandRange,
     function_bodies: FxHashMap<ScopeId, RecordedCommandRange>,
@@ -154,11 +154,11 @@ impl<T> RecordedRange<T> {
         self.len as usize
     }
 
-    pub(crate) fn is_empty(self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.len == 0
     }
 
-    fn as_slice<'a>(self, store: &'a [T]) -> &'a [T] {
+    fn slice(self, store: &[T]) -> &[T] {
         let start = self.start as usize;
         &store[start..start + self.len()]
     }
@@ -296,24 +296,6 @@ pub(crate) enum RecordedListOperator {
     Or,
 }
 
-impl Default for RecordedProgram {
-    fn default() -> Self {
-        Self {
-            file_commands: RecordedCommandRange::empty(),
-            function_bodies: FxHashMap::default(),
-            commands: Vec::new(),
-            command_sequence_items: Vec::new(),
-            isolated_regions: Vec::new(),
-            case_arms: Vec::new(),
-            pipeline_segments: Vec::new(),
-            list_items: Vec::new(),
-            elif_branches: Vec::new(),
-            command_infos: FxHashMap::default(),
-            function_body_scopes: FxHashMap::default(),
-        }
-    }
-}
-
 impl RecordedProgram {
     pub(crate) fn file_commands(&self) -> RecordedCommandRange {
         self.file_commands
@@ -347,30 +329,30 @@ impl RecordedProgram {
     }
 
     pub(crate) fn commands_in(&self, range: RecordedCommandRange) -> &[RecordedCommandId] {
-        range.as_slice(&self.command_sequence_items)
+        range.slice(&self.command_sequence_items)
     }
 
     pub(crate) fn nested_regions(&self, range: RecordedRegionRange) -> &[IsolatedRegion] {
-        range.as_slice(&self.isolated_regions)
+        range.slice(&self.isolated_regions)
     }
 
     pub(crate) fn case_arms(&self, range: RecordedCaseArmRange) -> &[RecordedCaseArm] {
-        range.as_slice(&self.case_arms)
+        range.slice(&self.case_arms)
     }
 
     pub(crate) fn pipeline_segments(
         &self,
         range: RecordedPipelineSegmentRange,
     ) -> &[RecordedPipelineSegment] {
-        range.as_slice(&self.pipeline_segments)
+        range.slice(&self.pipeline_segments)
     }
 
     pub(crate) fn list_items(&self, range: RecordedListItemRange) -> &[RecordedListItem] {
-        range.as_slice(&self.list_items)
+        range.slice(&self.list_items)
     }
 
     pub(crate) fn elif_branches(&self, range: RecordedElifBranchRange) -> &[RecordedElifBranch] {
-        range.as_slice(&self.elif_branches)
+        range.slice(&self.elif_branches)
     }
 
     pub(crate) fn push_command(&mut self, command: RecordedCommand) -> RecordedCommandId {

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap;
 use shuck_ast::{CaseTerminator, Span};
 use shuck_parser::ZshEmulationMode;
+use std::marker::PhantomData;
 
 use crate::{BindingId, ReferenceId, ScopeId, SpanKey};
 
@@ -103,26 +104,93 @@ impl ControlFlowGraph {
 
 #[derive(Debug, Clone)]
 pub(crate) struct RecordedProgram {
-    pub(crate) file_commands: Vec<RecordedCommand>,
-    pub(crate) function_bodies: FxHashMap<ScopeId, Vec<RecordedCommand>>,
+    file_commands: RecordedCommandRange,
+    function_bodies: FxHashMap<ScopeId, RecordedCommandRange>,
+    commands: Vec<RecordedCommand>,
+    command_sequence_items: Vec<RecordedCommandId>,
+    isolated_regions: Vec<IsolatedRegion>,
+    case_arms: Vec<RecordedCaseArm>,
+    pipeline_segments: Vec<RecordedPipelineSegment>,
+    list_items: Vec<RecordedListItem>,
+    elif_branches: Vec<RecordedElifBranch>,
     pub(crate) command_infos: FxHashMap<SpanKey, RecordedCommandInfo>,
     pub(crate) function_body_scopes: FxHashMap<BindingId, ScopeId>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct RecordedCommandId(u32);
+
+impl RecordedCommandId {
+    pub(crate) fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RecordedRange<T> {
+    start: u32,
+    len: u32,
+    marker: PhantomData<fn() -> T>,
+}
+
+impl<T> RecordedRange<T> {
+    pub(crate) const fn empty() -> Self {
+        Self {
+            start: 0,
+            len: 0,
+            marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn new(start: usize, len: usize) -> Self {
+        Self {
+            start: u32::try_from(start).expect("recorded IR start fits in u32"),
+            len: u32::try_from(len).expect("recorded IR length fits in u32"),
+            marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn len(self) -> usize {
+        self.len as usize
+    }
+
+    pub(crate) fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
+    fn as_slice<'a>(self, store: &'a [T]) -> &'a [T] {
+        let start = self.start as usize;
+        &store[start..start + self.len()]
+    }
+}
+
+impl<T> Default for RecordedRange<T> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+pub(crate) type RecordedCommandRange = RecordedRange<RecordedCommandId>;
+pub(crate) type RecordedRegionRange = RecordedRange<IsolatedRegion>;
+pub(crate) type RecordedCaseArmRange = RecordedRange<RecordedCaseArm>;
+pub(crate) type RecordedPipelineSegmentRange = RecordedRange<RecordedPipelineSegment>;
+pub(crate) type RecordedListItemRange = RecordedRange<RecordedListItem>;
+pub(crate) type RecordedElifBranchRange = RecordedRange<RecordedElifBranch>;
+
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct RecordedCommand {
     pub(crate) span: Span,
-    pub(crate) nested_regions: Vec<IsolatedRegion>,
+    pub(crate) nested_regions: RecordedRegionRange,
     pub(crate) kind: RecordedCommandKind,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct IsolatedRegion {
     pub(crate) scope: ScopeId,
-    pub(crate) commands: Vec<RecordedCommand>,
+    pub(crate) commands: RecordedCommandRange,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum RecordedCommandKind {
     Linear,
     Break {
@@ -134,57 +202,69 @@ pub(crate) enum RecordedCommandKind {
     Return,
     Exit,
     List {
-        first: Box<RecordedCommand>,
-        rest: Vec<(RecordedListOperator, RecordedCommand)>,
+        first: RecordedCommandId,
+        rest: RecordedListItemRange,
     },
     If {
-        condition: Vec<RecordedCommand>,
-        then_branch: Vec<RecordedCommand>,
-        elif_branches: Vec<(Vec<RecordedCommand>, Vec<RecordedCommand>)>,
-        else_branch: Vec<RecordedCommand>,
+        condition: RecordedCommandRange,
+        then_branch: RecordedCommandRange,
+        elif_branches: RecordedElifBranchRange,
+        else_branch: RecordedCommandRange,
     },
     While {
-        condition: Vec<RecordedCommand>,
-        body: Vec<RecordedCommand>,
+        condition: RecordedCommandRange,
+        body: RecordedCommandRange,
     },
     Until {
-        condition: Vec<RecordedCommand>,
-        body: Vec<RecordedCommand>,
+        condition: RecordedCommandRange,
+        body: RecordedCommandRange,
     },
     For {
-        body: Vec<RecordedCommand>,
+        body: RecordedCommandRange,
     },
     Select {
-        body: Vec<RecordedCommand>,
+        body: RecordedCommandRange,
     },
     ArithmeticFor {
-        body: Vec<RecordedCommand>,
+        body: RecordedCommandRange,
     },
     Case {
-        arms: Vec<RecordedCaseArm>,
+        arms: RecordedCaseArmRange,
     },
     BraceGroup {
-        body: Vec<RecordedCommand>,
+        body: RecordedCommandRange,
     },
     Subshell {
-        body: Vec<RecordedCommand>,
+        body: RecordedCommandRange,
     },
     Pipeline {
-        segments: Vec<RecordedPipelineSegment>,
+        segments: RecordedPipelineSegmentRange,
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct RecordedCaseArm {
     pub(crate) terminator: CaseTerminator,
     pub(crate) matches_anything: bool,
-    pub(crate) commands: Vec<RecordedCommand>,
+    pub(crate) commands: RecordedCommandRange,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct RecordedPipelineSegment {
     pub(crate) scope: ScopeId,
-    pub(crate) command: RecordedCommand,
+    pub(crate) command: RecordedCommandId,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RecordedListItem {
+    pub(crate) operator: RecordedListOperator,
+    pub(crate) command: RecordedCommandId,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RecordedElifBranch {
+    pub(crate) condition: RecordedCommandRange,
+    pub(crate) body: RecordedCommandRange,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -216,6 +296,138 @@ pub(crate) enum RecordedListOperator {
     Or,
 }
 
+impl Default for RecordedProgram {
+    fn default() -> Self {
+        Self {
+            file_commands: RecordedCommandRange::empty(),
+            function_bodies: FxHashMap::default(),
+            commands: Vec::new(),
+            command_sequence_items: Vec::new(),
+            isolated_regions: Vec::new(),
+            case_arms: Vec::new(),
+            pipeline_segments: Vec::new(),
+            list_items: Vec::new(),
+            elif_branches: Vec::new(),
+            command_infos: FxHashMap::default(),
+            function_body_scopes: FxHashMap::default(),
+        }
+    }
+}
+
+impl RecordedProgram {
+    pub(crate) fn file_commands(&self) -> RecordedCommandRange {
+        self.file_commands
+    }
+
+    pub(crate) fn set_file_commands(&mut self, commands: RecordedCommandRange) {
+        self.file_commands = commands;
+    }
+
+    pub(crate) fn function_body(&self, scope: ScopeId) -> RecordedCommandRange {
+        self.function_bodies
+            .get(&scope)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn set_function_body(&mut self, scope: ScopeId, commands: RecordedCommandRange) {
+        self.function_bodies.insert(scope, commands);
+    }
+
+    pub(crate) fn function_bodies(&self) -> &FxHashMap<ScopeId, RecordedCommandRange> {
+        &self.function_bodies
+    }
+
+    pub(crate) fn command(&self, id: RecordedCommandId) -> &RecordedCommand {
+        &self.commands[id.index()]
+    }
+
+    pub(crate) fn command_mut(&mut self, id: RecordedCommandId) -> &mut RecordedCommand {
+        &mut self.commands[id.index()]
+    }
+
+    pub(crate) fn commands_in(&self, range: RecordedCommandRange) -> &[RecordedCommandId] {
+        range.as_slice(&self.command_sequence_items)
+    }
+
+    pub(crate) fn nested_regions(&self, range: RecordedRegionRange) -> &[IsolatedRegion] {
+        range.as_slice(&self.isolated_regions)
+    }
+
+    pub(crate) fn case_arms(&self, range: RecordedCaseArmRange) -> &[RecordedCaseArm] {
+        range.as_slice(&self.case_arms)
+    }
+
+    pub(crate) fn pipeline_segments(
+        &self,
+        range: RecordedPipelineSegmentRange,
+    ) -> &[RecordedPipelineSegment] {
+        range.as_slice(&self.pipeline_segments)
+    }
+
+    pub(crate) fn list_items(&self, range: RecordedListItemRange) -> &[RecordedListItem] {
+        range.as_slice(&self.list_items)
+    }
+
+    pub(crate) fn elif_branches(&self, range: RecordedElifBranchRange) -> &[RecordedElifBranch] {
+        range.as_slice(&self.elif_branches)
+    }
+
+    pub(crate) fn push_command(&mut self, command: RecordedCommand) -> RecordedCommandId {
+        let id = RecordedCommandId(
+            u32::try_from(self.commands.len()).expect("recorded command count fits in u32"),
+        );
+        self.commands.push(command);
+        id
+    }
+
+    pub(crate) fn push_command_ids(
+        &mut self,
+        command_ids: Vec<RecordedCommandId>,
+    ) -> RecordedCommandRange {
+        push_range(&mut self.command_sequence_items, command_ids)
+    }
+
+    pub(crate) fn push_regions(&mut self, regions: Vec<IsolatedRegion>) -> RecordedRegionRange {
+        push_range(&mut self.isolated_regions, regions)
+    }
+
+    pub(crate) fn push_case_arms(&mut self, arms: Vec<RecordedCaseArm>) -> RecordedCaseArmRange {
+        push_range(&mut self.case_arms, arms)
+    }
+
+    pub(crate) fn push_pipeline_segments(
+        &mut self,
+        segments: Vec<RecordedPipelineSegment>,
+    ) -> RecordedPipelineSegmentRange {
+        push_range(&mut self.pipeline_segments, segments)
+    }
+
+    pub(crate) fn push_list_items(
+        &mut self,
+        list_items: Vec<RecordedListItem>,
+    ) -> RecordedListItemRange {
+        push_range(&mut self.list_items, list_items)
+    }
+
+    pub(crate) fn push_elif_branches(
+        &mut self,
+        elif_branches: Vec<RecordedElifBranch>,
+    ) -> RecordedElifBranchRange {
+        push_range(&mut self.elif_branches, elif_branches)
+    }
+}
+
+fn push_range<T>(store: &mut Vec<T>, mut items: Vec<T>) -> RecordedRange<T> {
+    if items.is_empty() {
+        return RecordedRange::empty();
+    }
+
+    let start = store.len();
+    store.append(&mut items);
+    RecordedRange::new(start, store.len() - start)
+}
+
 struct SequenceResult {
     entry: Option<BlockId>,
     exits: Vec<BlockId>,
@@ -228,6 +440,7 @@ struct LoopTarget {
 }
 
 struct GraphBuilder<'a> {
+    program: &'a RecordedProgram,
     command_bindings: &'a FxHashMap<SpanKey, Vec<BindingId>>,
     command_references: &'a FxHashMap<SpanKey, Vec<ReferenceId>>,
     blocks: Vec<BasicBlock>,
@@ -243,6 +456,7 @@ pub(crate) fn build_control_flow_graph(
     command_references: &FxHashMap<SpanKey, Vec<ReferenceId>>,
 ) -> ControlFlowGraph {
     let mut builder = GraphBuilder {
+        program,
         command_bindings,
         command_references,
         blocks: Vec::new(),
@@ -252,7 +466,7 @@ pub(crate) fn build_control_flow_graph(
         scope_entries: FxHashMap::default(),
     };
 
-    let file = builder.build_sequence(&program.file_commands, &[]);
+    let file = builder.build_sequence(program.file_commands(), &[]);
     let entry = file.entry.unwrap_or_else(|| builder.empty_block());
     builder.scope_entries.insert(ScopeId(0), entry);
     let file_exits = if file.exits.is_empty() {
@@ -265,8 +479,8 @@ pub(crate) fn build_control_flow_graph(
 
     let mut exits = file_exits;
 
-    for (scope, commands) in &program.function_bodies {
-        let function = builder.build_sequence(commands, &[]);
+    for (scope, commands) in program.function_bodies() {
+        let function = builder.build_sequence(*commands, &[]);
         let function_entry = function.entry.unwrap_or_else(|| builder.empty_block());
         builder.scope_entries.insert(*scope, function_entry);
         let function_exits = if function.exits.is_empty() {
@@ -299,16 +513,17 @@ pub(crate) fn build_control_flow_graph(
 impl<'a> GraphBuilder<'a> {
     fn build_sequence(
         &mut self,
-        commands: &[RecordedCommand],
+        commands: RecordedCommandRange,
         loops: &[LoopTarget],
     ) -> SequenceResult {
         let mut entry = None;
         let mut pending = Vec::new();
         let mut unreachable_cause = None;
 
-        for command in commands {
+        for &command_id in self.program.commands_in(commands) {
+            let command = self.program.command(command_id);
             let start = self.blocks.len();
-            let sequence = self.build_command(command, loops);
+            let sequence = self.build_command(command_id, loops);
             if entry.is_none() {
                 entry = sequence.entry;
             }
@@ -339,11 +554,16 @@ impl<'a> GraphBuilder<'a> {
         }
     }
 
-    fn build_command(&mut self, command: &RecordedCommand, loops: &[LoopTarget]) -> SequenceResult {
+    fn build_command(
+        &mut self,
+        command_id: RecordedCommandId,
+        loops: &[LoopTarget],
+    ) -> SequenceResult {
+        let command = self.program.command(command_id);
         match &command.kind {
             RecordedCommandKind::Linear => {
                 let block = self.command_block(command.span);
-                self.attach_nested_regions(block, &command.nested_regions, loops);
+                self.attach_nested_regions(block, command.nested_regions, loops);
                 SequenceResult {
                     entry: Some(block),
                     exits: vec![block],
@@ -377,7 +597,7 @@ impl<'a> GraphBuilder<'a> {
                 }
             }
             RecordedCommandKind::List { first, rest } => {
-                self.build_list(command, first, rest, loops)
+                self.build_list(command_id, *first, *rest, loops)
             }
             RecordedCommandKind::If {
                 condition,
@@ -385,30 +605,30 @@ impl<'a> GraphBuilder<'a> {
                 elif_branches,
                 else_branch,
             } => self.build_if(
-                command,
-                condition,
-                then_branch,
-                elif_branches,
-                else_branch,
+                command_id,
+                *condition,
+                *then_branch,
+                *elif_branches,
+                *else_branch,
                 loops,
             ),
             RecordedCommandKind::While { condition, body } => {
-                self.build_while_like(command, condition, body, loops, true)
+                self.build_while_like(command_id, *condition, *body, loops, true)
             }
             RecordedCommandKind::Until { condition, body } => {
-                self.build_while_like(command, condition, body, loops, false)
+                self.build_while_like(command_id, *condition, *body, loops, false)
             }
             RecordedCommandKind::For { body }
             | RecordedCommandKind::Select { body }
             | RecordedCommandKind::ArithmeticFor { body } => {
-                self.build_loop_command(command, body, loops)
+                self.build_loop_command(command_id, *body, loops)
             }
-            RecordedCommandKind::Case { arms } => self.build_case(command, arms, loops),
-            RecordedCommandKind::BraceGroup { body } => self.build_sequence(body, loops),
+            RecordedCommandKind::Case { arms } => self.build_case(command_id, *arms, loops),
+            RecordedCommandKind::BraceGroup { body } => self.build_sequence(*body, loops),
             RecordedCommandKind::Subshell { body, .. } => {
                 let block = self.command_block(command.span);
-                self.attach_nested_regions(block, &command.nested_regions, loops);
-                let body_sequence = self.build_sequence(body, loops);
+                self.attach_nested_regions(block, command.nested_regions, loops);
+                let body_sequence = self.build_sequence(*body, loops);
                 if let Some(body_entry) = body_sequence.entry {
                     self.add_edge(block, body_entry, EdgeKind::Sequential);
                 }
@@ -419,9 +639,9 @@ impl<'a> GraphBuilder<'a> {
             }
             RecordedCommandKind::Pipeline { segments } => {
                 let block = self.command_block(command.span);
-                self.attach_nested_regions(block, &command.nested_regions, loops);
-                for segment in segments {
-                    let sequence = self.build_command(&segment.command, loops);
+                self.attach_nested_regions(block, command.nested_regions, loops);
+                for segment in self.program.pipeline_segments(*segments) {
+                    let sequence = self.build_command(segment.command, loops);
                     if let Some(segment_entry) = sequence.entry {
                         self.scope_entries
                             .entry(segment.scope)
@@ -439,20 +659,20 @@ impl<'a> GraphBuilder<'a> {
 
     fn build_list(
         &mut self,
-        command: &RecordedCommand,
-        first: &RecordedCommand,
-        rest: &[(RecordedListOperator, RecordedCommand)],
+        command: RecordedCommandId,
+        first: RecordedCommandId,
+        rest: RecordedListItemRange,
         loops: &[LoopTarget],
     ) -> SequenceResult {
         let mut current = self.build_command(first, loops);
         let entry = current.entry;
         let mut shortcut_exits = Vec::new();
 
-        for (op, command) in rest {
-            let next = self.build_command(command, loops);
+        for item in self.program.list_items(rest) {
+            let next = self.build_command(item.command, loops);
             if let Some(next_entry) = next.entry {
                 for exit in &current.exits {
-                    let edge = match op {
+                    let edge = match item.operator {
                         RecordedListOperator::And => EdgeKind::ConditionalTrue,
                         RecordedListOperator::Or => EdgeKind::ConditionalFalse,
                     };
@@ -475,11 +695,11 @@ impl<'a> GraphBuilder<'a> {
 
     fn build_if(
         &mut self,
-        command: &RecordedCommand,
-        condition: &[RecordedCommand],
-        then_branch: &[RecordedCommand],
-        elif_branches: &[(Vec<RecordedCommand>, Vec<RecordedCommand>)],
-        else_branch: &[RecordedCommand],
+        command: RecordedCommandId,
+        condition: RecordedCommandRange,
+        then_branch: RecordedCommandRange,
+        elif_branches: RecordedElifBranchRange,
+        else_branch: RecordedCommandRange,
         loops: &[LoopTarget],
     ) -> SequenceResult {
         let condition_seq = self.build_sequence(condition, loops);
@@ -498,15 +718,15 @@ impl<'a> GraphBuilder<'a> {
 
         let mut branch_exits = then_seq.exits;
 
-        for (elif_condition, elif_body) in elif_branches {
-            let elif_cond = self.build_sequence(elif_condition, loops);
+        for elif_branch in self.program.elif_branches(elif_branches) {
+            let elif_cond = self.build_sequence(elif_branch.condition, loops);
             if let Some(elif_entry) = elif_cond.entry {
                 for exit in &false_exits {
                     self.add_edge(*exit, elif_entry, EdgeKind::ConditionalFalse);
                 }
             }
 
-            let elif_body_seq = self.build_sequence(elif_body, loops);
+            let elif_body_seq = self.build_sequence(elif_branch.body, loops);
             if let Some(body_entry) = elif_body_seq.entry {
                 for exit in &elif_cond.exits {
                     self.add_edge(*exit, body_entry, EdgeKind::ConditionalTrue);
@@ -536,9 +756,9 @@ impl<'a> GraphBuilder<'a> {
 
     fn build_while_like(
         &mut self,
-        command: &RecordedCommand,
-        condition: &[RecordedCommand],
-        body: &[RecordedCommand],
+        command: RecordedCommandId,
+        condition: RecordedCommandRange,
+        body: RecordedCommandRange,
         loops: &[LoopTarget],
         while_sense: bool,
     ) -> SequenceResult {
@@ -592,12 +812,13 @@ impl<'a> GraphBuilder<'a> {
 
     fn build_loop_command(
         &mut self,
-        command: &RecordedCommand,
-        body: &[RecordedCommand],
+        command: RecordedCommandId,
+        body: RecordedCommandRange,
         loops: &[LoopTarget],
     ) -> SequenceResult {
+        let command = self.program.command(command);
         let header = self.command_block(command.span);
-        self.attach_nested_regions(header, &command.nested_regions, loops);
+        self.attach_nested_regions(header, command.nested_regions, loops);
         let exit_block = self.empty_block();
         let mut next_loops = loops.to_vec();
         next_loops.push(LoopTarget {
@@ -622,12 +843,14 @@ impl<'a> GraphBuilder<'a> {
 
     fn build_case(
         &mut self,
-        command: &RecordedCommand,
-        arms: &[RecordedCaseArm],
+        command: RecordedCommandId,
+        arms: RecordedCaseArmRange,
         loops: &[LoopTarget],
     ) -> SequenceResult {
+        let command = self.program.command(command);
+        let arms = self.program.case_arms(arms);
         let head = self.command_block(command.span);
-        self.attach_nested_regions(head, &command.nested_regions, loops);
+        self.attach_nested_regions(head, command.nested_regions, loops);
         let exit_block = self.empty_block();
         let dispatch_count = arms.len().max(1);
         let mut dispatch_blocks = Vec::with_capacity(dispatch_count);
@@ -637,7 +860,7 @@ impl<'a> GraphBuilder<'a> {
         }
         let mut arm_sequences = Vec::with_capacity(arms.len());
         for arm in arms {
-            let mut arm_seq = self.build_sequence(&arm.commands, loops);
+            let mut arm_seq = self.build_sequence(arm.commands, loops);
             if arm_seq.entry.is_none() {
                 let empty_arm = self.empty_block();
                 arm_seq.entry = Some(empty_arm);
@@ -716,11 +939,11 @@ impl<'a> GraphBuilder<'a> {
     fn attach_nested_regions(
         &mut self,
         block: BlockId,
-        regions: &[IsolatedRegion],
+        regions: RecordedRegionRange,
         loops: &[LoopTarget],
     ) {
-        for region in regions {
-            let sequence = self.build_sequence(&region.commands, loops);
+        for region in self.program.nested_regions(regions) {
+            let sequence = self.build_sequence(region.commands, loops);
             if let Some(entry) = sequence.entry {
                 self.scope_entries.entry(region.scope).or_insert(entry);
                 self.add_edge(block, entry, EdgeKind::Sequential);
@@ -728,7 +951,8 @@ impl<'a> GraphBuilder<'a> {
         }
     }
 
-    fn attach_nested_regions_from_command(&mut self, command: &RecordedCommand) {
+    fn attach_nested_regions_from_command(&mut self, command: RecordedCommandId) {
+        let command = self.program.command(command);
         if command.nested_regions.is_empty() {
             return;
         }
@@ -738,7 +962,7 @@ impl<'a> GraphBuilder<'a> {
             .cloned()
         {
             for block in blocks {
-                self.attach_nested_regions(block, &command.nested_regions, &[]);
+                self.attach_nested_regions(block, command.nested_regions, &[]);
             }
         }
     }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1235,7 +1235,7 @@ fn indirect_target_matches(hint: &IndirectTargetHint, binding: &Binding) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cfg::build_control_flow_graph;
+    use crate::cfg::{RecordedCommandKind, build_control_flow_graph};
     use shuck_ast::{Command, CompoundCommand};
     use shuck_indexer::Indexer;
     use shuck_parser::parser::{Parser, ShellDialect};
@@ -1688,6 +1688,95 @@ done
             .filter(|scope| matches!(scope.kind, ScopeKind::Pipeline))
             .count();
         assert_eq!(pipeline_scopes, 3);
+    }
+
+    #[test]
+    fn recorded_program_preserves_logical_list_order_in_ranges() {
+        let source = "a && b || c\n";
+        let model = model(source);
+
+        let file_commands = model
+            .recorded_program
+            .commands_in(model.recorded_program.file_commands());
+        assert_eq!(file_commands.len(), 1);
+
+        let command = model.recorded_program.command(file_commands[0]);
+        let (first, rest) = match command.kind {
+            RecordedCommandKind::List { first, rest } => (first, rest),
+            other => panic!("expected list command, found {other:?}"),
+        };
+
+        assert!(
+            model
+                .recorded_program
+                .command(first)
+                .span
+                .slice(source)
+                .starts_with("a")
+        );
+        let rest = model.recorded_program.list_items(rest);
+        assert_eq!(rest.len(), 2);
+        assert!(
+            model
+                .recorded_program
+                .command(rest[0].command)
+                .span
+                .slice(source)
+                .starts_with("b")
+        );
+        assert!(
+            model
+                .recorded_program
+                .command(rest[1].command)
+                .span
+                .slice(source)
+                .starts_with("c")
+        );
+    }
+
+    #[test]
+    fn recorded_program_preserves_pipeline_segment_order_in_ranges() {
+        let source = "a | b | c\n";
+        let model = model(source);
+
+        let file_commands = model
+            .recorded_program
+            .commands_in(model.recorded_program.file_commands());
+        assert_eq!(file_commands.len(), 1);
+
+        let command = model.recorded_program.command(file_commands[0]);
+        let segments = match command.kind {
+            RecordedCommandKind::Pipeline { segments } => {
+                model.recorded_program.pipeline_segments(segments)
+            }
+            other => panic!("expected pipeline command, found {other:?}"),
+        };
+
+        assert_eq!(segments.len(), 3);
+        assert!(
+            model
+                .recorded_program
+                .command(segments[0].command)
+                .span
+                .slice(source)
+                .starts_with("a")
+        );
+        assert!(
+            model
+                .recorded_program
+                .command(segments[1].command)
+                .span
+                .slice(source)
+                .starts_with("b")
+        );
+        assert!(
+            model
+                .recorded_program
+                .command(segments[2].command)
+                .span
+                .slice(source)
+                .starts_with("c")
+        );
     }
 
     #[test]
@@ -4643,11 +4732,20 @@ echo done
         let indexer = Indexer::new(source, &output);
         let model = SemanticModel::build(&output.file, source, &indexer);
 
-        assert_eq!(model.recorded_program.file_commands.len(), 2);
-        let conditional = &model.recorded_program.file_commands[0];
-        assert_eq!(conditional.nested_regions.len(), 1);
-        assert_eq!(conditional.nested_regions[0].commands.len(), 1);
-        let nested = &conditional.nested_regions[0].commands[0];
+        let file_commands = model
+            .recorded_program
+            .commands_in(model.recorded_program.file_commands());
+        assert_eq!(file_commands.len(), 2);
+        let conditional = model.recorded_program.command(file_commands[0]);
+        let nested_regions = model
+            .recorded_program
+            .nested_regions(conditional.nested_regions);
+        assert_eq!(nested_regions.len(), 1);
+        let nested_commands = model
+            .recorded_program
+            .commands_in(nested_regions[0].commands);
+        assert_eq!(nested_commands.len(), 1);
+        let nested = model.recorded_program.command(nested_commands[0]);
         assert_eq!(nested.span.slice(source), "printf inner");
 
         let cfg = build_control_flow_graph(
@@ -4676,11 +4774,20 @@ echo done
         let indexer = Indexer::new(source, &output);
         let model = SemanticModel::build(&output.file, source, &indexer);
 
-        assert_eq!(model.recorded_program.file_commands.len(), 2);
-        let conditional = &model.recorded_program.file_commands[0];
-        assert_eq!(conditional.nested_regions.len(), 1);
-        assert_eq!(conditional.nested_regions[0].commands.len(), 1);
-        let nested = &conditional.nested_regions[0].commands[0];
+        let file_commands = model
+            .recorded_program
+            .commands_in(model.recorded_program.file_commands());
+        assert_eq!(file_commands.len(), 2);
+        let conditional = model.recorded_program.command(file_commands[0]);
+        let nested_regions = model
+            .recorded_program
+            .nested_regions(conditional.nested_regions);
+        assert_eq!(nested_regions.len(), 1);
+        let nested_commands = model
+            .recorded_program
+            .commands_in(nested_regions[0].commands);
+        assert_eq!(nested_commands.len(), 1);
+        let nested = model.recorded_program.command(nested_commands[0]);
         assert_eq!(nested.span.slice(source), "printf inner");
 
         let cfg = build_control_flow_graph(

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -2,8 +2,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionState};
 
 use crate::cfg::{
-    RecordedCaseArm, RecordedCommand, RecordedCommandKind, RecordedPipelineSegment,
-    RecordedProgram, RecordedZshCommandEffect, RecordedZshOptionUpdate,
+    RecordedCaseArmRange, RecordedCommand, RecordedCommandId, RecordedCommandKind,
+    RecordedCommandRange, RecordedElifBranchRange, RecordedPipelineSegmentRange, RecordedProgram,
+    RecordedZshCommandEffect, RecordedZshOptionUpdate,
 };
 use crate::{Binding, BindingKind, Scope, ScopeId, ScopeKind, SpanKey};
 
@@ -203,7 +204,7 @@ pub(crate) fn analyze(
 
     analyzer.analyze_sequence(
         ScopeId(0),
-        &recorded_program.file_commands,
+        recorded_program.file_commands(),
         EvalState::new(entry),
         LeakBehavior::Always,
     );
@@ -261,16 +262,30 @@ struct Analyzer<'a> {
 }
 
 impl<'a> Analyzer<'a> {
+    fn analyze_single_command_sequence(
+        &mut self,
+        scope: ScopeId,
+        command: RecordedCommandId,
+        state: EvalState,
+        leak: LeakBehavior,
+    ) -> EvalState {
+        self.record_scope_entry(scope, &state.current.public);
+        let recorded = self.recorded_program.command(command);
+        self.record_snapshot(scope, recorded.span.start.offset, &state.current.public);
+        self.analyze_command(scope, command, state, leak)
+    }
+
     fn analyze_sequence(
         &mut self,
         scope: ScopeId,
-        commands: &[RecordedCommand],
+        commands: RecordedCommandRange,
         mut state: EvalState,
         leak: LeakBehavior,
     ) -> EvalState {
         self.record_scope_entry(scope, &state.current.public);
-        for command in commands {
-            self.record_snapshot(scope, command.span.start.offset, &state.current.public);
+        for &command in self.recorded_program.commands_in(commands) {
+            let recorded = self.recorded_program.command(command);
+            self.record_snapshot(scope, recorded.span.start.offset, &state.current.public);
             state = self.analyze_command(scope, command, state, leak);
         }
         state
@@ -279,14 +294,15 @@ impl<'a> Analyzer<'a> {
     fn analyze_command(
         &mut self,
         scope: ScopeId,
-        command: &RecordedCommand,
+        command: RecordedCommandId,
         state: EvalState,
         leak: LeakBehavior,
     ) -> EvalState {
-        for region in &command.nested_regions {
+        let command = self.recorded_program.command(command);
+        for region in self.recorded_program.nested_regions(command.nested_regions) {
             self.analyze_sequence(
                 region.scope,
-                &region.commands,
+                region.commands,
                 EvalState::new(state.current.clone()),
                 LeakBehavior::Never,
             );
@@ -299,9 +315,10 @@ impl<'a> Analyzer<'a> {
             | RecordedCommandKind::Return
             | RecordedCommandKind::Exit => self.analyze_linear_command(scope, command, state, leak),
             RecordedCommandKind::List { first, rest } => {
-                let mut list_state = self.analyze_command(scope, first, state, leak);
-                for (_operator, command) in rest {
-                    let branch = self.analyze_command(scope, command, list_state.clone(), leak);
+                let mut list_state = self.analyze_command(scope, *first, state, leak);
+                for item in self.recorded_program.list_items(*rest) {
+                    let branch =
+                        self.analyze_command(scope, item.command, list_state.clone(), leak);
                     list_state = list_state.merge(&branch);
                 }
                 list_state
@@ -314,38 +331,38 @@ impl<'a> Analyzer<'a> {
             } => self.analyze_if(
                 scope,
                 &state,
-                condition,
-                then_branch,
-                elif_branches,
-                else_branch,
+                *condition,
+                *then_branch,
+                *elif_branches,
+                *else_branch,
                 leak,
             ),
             RecordedCommandKind::While { condition, body }
             | RecordedCommandKind::Until { condition, body } => {
-                let after_condition = self.analyze_sequence(scope, condition, state.clone(), leak);
-                let iterated = self.analyze_sequence(scope, body, after_condition.clone(), leak);
+                let after_condition = self.analyze_sequence(scope, *condition, state.clone(), leak);
+                let iterated = self.analyze_sequence(scope, *body, after_condition.clone(), leak);
                 after_condition.merge(&iterated)
             }
             RecordedCommandKind::For { body }
             | RecordedCommandKind::Select { body }
             | RecordedCommandKind::ArithmeticFor { body }
             | RecordedCommandKind::BraceGroup { body } => {
-                let iterated = self.analyze_sequence(scope, body, state.clone(), leak);
+                let iterated = self.analyze_sequence(scope, *body, state.clone(), leak);
                 state.merge(&iterated)
             }
-            RecordedCommandKind::Case { arms } => self.analyze_case(scope, &state, arms, leak),
+            RecordedCommandKind::Case { arms } => self.analyze_case(scope, &state, *arms, leak),
             RecordedCommandKind::Subshell { body } => {
                 self.analyze_sequence(
                     self.subshell_scope_for(command.span.start.offset)
                         .unwrap_or(scope),
-                    body,
+                    *body,
                     EvalState::new(state.current.clone()),
                     LeakBehavior::Never,
                 );
                 state
             }
             RecordedCommandKind::Pipeline { segments } => {
-                self.analyze_pipeline(scope, &state, segments, leak)
+                self.analyze_pipeline(scope, &state, *segments, leak)
             }
         }
     }
@@ -355,19 +372,20 @@ impl<'a> Analyzer<'a> {
         &mut self,
         scope: ScopeId,
         state: &EvalState,
-        condition: &[RecordedCommand],
-        then_branch: &[RecordedCommand],
-        elif_branches: &[(Vec<RecordedCommand>, Vec<RecordedCommand>)],
-        else_branch: &[RecordedCommand],
+        condition: RecordedCommandRange,
+        then_branch: RecordedCommandRange,
+        elif_branches: RecordedElifBranchRange,
+        else_branch: RecordedCommandRange,
         leak: LeakBehavior,
     ) -> EvalState {
         let after_condition = self.analyze_sequence(scope, condition, state.clone(), leak);
         let mut merged = self.analyze_sequence(scope, then_branch, after_condition.clone(), leak);
 
-        for (elif_condition, elif_body) in elif_branches {
+        for elif_branch in self.recorded_program.elif_branches(elif_branches) {
             let after_elif_condition =
-                self.analyze_sequence(scope, elif_condition, after_condition.clone(), leak);
-            let elif_result = self.analyze_sequence(scope, elif_body, after_elif_condition, leak);
+                self.analyze_sequence(scope, elif_branch.condition, after_condition.clone(), leak);
+            let elif_result =
+                self.analyze_sequence(scope, elif_branch.body, after_elif_condition, leak);
             merged = merged.merge(&elif_result);
         }
 
@@ -383,12 +401,12 @@ impl<'a> Analyzer<'a> {
         &mut self,
         scope: ScopeId,
         state: &EvalState,
-        arms: &[RecordedCaseArm],
+        arms: RecordedCaseArmRange,
         leak: LeakBehavior,
     ) -> EvalState {
         let mut merged = state.clone();
-        for arm in arms {
-            let arm_result = self.analyze_sequence(scope, &arm.commands, state.clone(), leak);
+        for arm in self.recorded_program.case_arms(arms) {
+            let arm_result = self.analyze_sequence(scope, arm.commands, state.clone(), leak);
             merged = merged.merge(&arm_result);
             if arm.matches_anything {
                 return merged;
@@ -401,18 +419,19 @@ impl<'a> Analyzer<'a> {
         &mut self,
         _scope: ScopeId,
         state: &EvalState,
-        segments: &[RecordedPipelineSegment],
+        segments: RecordedPipelineSegmentRange,
         leak: LeakBehavior,
     ) -> EvalState {
         let mut result = state.clone();
         let emulation = state.current.emulation;
+        let segments = self.recorded_program.pipeline_segments(segments);
 
         if emulation == EmulationState::Unknown {
             let mut touched = FxHashSet::default();
             for segment in segments {
-                let segment_result = self.analyze_sequence(
+                let segment_result = self.analyze_single_command_sequence(
                     segment.scope,
-                    std::slice::from_ref(&segment.command),
+                    segment.command,
                     EvalState::new(state.current.clone()),
                     LeakBehavior::Never,
                 );
@@ -430,9 +449,9 @@ impl<'a> Analyzer<'a> {
             } else {
                 leak
             };
-            let segment_result = self.analyze_sequence(
+            let segment_result = self.analyze_single_command_sequence(
                 segment.scope,
-                std::slice::from_ref(&segment.command),
+                segment.command,
                 EvalState::new(state.current.clone()),
                 segment_leak,
             );
@@ -510,12 +529,7 @@ impl<'a> Analyzer<'a> {
             };
         }
 
-        let body = self
-            .recorded_program
-            .function_bodies
-            .get(&scope)
-            .map(Vec::as_slice)
-            .unwrap_or(&[]);
+        let body = self.recorded_program.function_body(scope);
         let result = self.analyze_sequence(scope, body, entry, LeakBehavior::Function);
         self.active_function_scopes.remove(&scope);
         FunctionSummary {


### PR DESCRIPTION
## Summary
- replace the recursive recorded CFG IR with append-only arena-backed storage using typed IDs and contiguous ranges
- update semantic recording, lazy CFG construction, and zsh option analysis to traverse the new accessor-based IR
- add range-order tests for logical lists and pipeline segments while preserving existing CFG and zsh semantics

## Why
The old recorded program stored deeply owned command trees with nested `Vec<RecordedCommand>`, boxed subcommands, and repeated subtree replay. That made CFG input expensive to build and then expensive to walk again.

## Validation
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
- `make bench-linter`

## Benchmarks
`make bench-linter` improved across every case versus the April 11, 2026 baseline:

| Case | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `fzf-install` | 5.07 ms | 2.88 ms | ~43% faster |
| `homebrew-install` | 21.89 ms | 12.79 ms | ~42% faster |
| `ruby-build` | 26.72 ms | 21.91 ms | ~18% faster |
| `pyenv-python-build` | 76.75 ms | 61.31 ms | ~20% faster |
| `nvm` | 225.22 ms | 180.37 ms | ~20% faster |
| `all` | 392.99 ms | 281.12 ms | ~28% faster |
