### PR TITLE
Implement subshell and pipeline side-effect rules

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C107.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C107.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Invalid: output commands overwrite the status that later `$?` reads.
+run
+echo status
+if [ $? -ne 0 ]; then :; fi
+
+run
+printf '%s\n' status
+case $? in
+  0) : ;;
+esac
+
+check_status() {
+  run
+  printf '%s\n' status
+  return $?
+}
+
+run
+echo status
+saved=$?
+
+# Valid: immediate status checks are handled by other rules.
+run
+if [ $? -ne 0 ]; then :; fi
+
+# Valid: saving the status before another command keeps the intended value.
+run
+saved=$?
+echo status
+if [ "$saved" -ne 0 ]; then :; fi
+
+# Valid: non-output commands stay outside this narrower C107 check.
+run
+pwd >/dev/null
+if [ $? -ne 0 ]; then :; fi

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C150.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C150.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Invalid: the subshell assignment does not update the outer shell binding.
+count=0
+(count=1)
+echo "$count"
+
+items=old
+(items=new)
+printf '%s\n' "$items"
+
+# Valid: pipeline-child updates belong to the pipeline-specific rule.
+count=0
+printf '%s\n' x | while read -r _; do count=1; done
+echo "$count"
+
+# Valid: a parent-shell reassignment after the subshell changes the visible value.
+items=old
+(items=new)
+items=latest
+echo "$items"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C155.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C155.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+count=0
+(count=1)
+echo "$count"
+
+value=outer
+printf '%s\n' x | while read -r _; do value=inner; done
+printf '%s\n' "$value"
+
+(
+  export path_prefix=/opt/demo
+)
+export path_prefix="$HOME/bin:$path_prefix"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C156.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C156.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+package_name=demo
+echo "$PACKAGE_NAME"
+echo "$PACKAGE_NAME"
+
+FooBar=demo
+echo "$FOOBAR"
+
+foo1=demo
+echo "$FOO1"
+
+path=1
+echo "$PATH"
+
+foo_bar=demo
+echo "$FOOBAR"
+
+f() { PACKAGE_NAME=demo; }
+echo "$PACKAGE_NAME"

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -170,7 +170,11 @@ impl<'a> Checker<'a> {
         }
     }
 
-    fn check_scopes(&mut self) {}
+    fn check_scopes(&mut self) {
+        if self.is_rule_enabled(Rule::SubshellLocalAssignment) {
+            rules::correctness::subshell_local_assignment::subshell_local_assignment(self);
+        }
+    }
 
     fn check_declarations(&mut self) {
         if self.is_rule_enabled(Rule::LocalTopLevel) {

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -318,6 +318,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::SetFlagsWithoutDashes) {
             rules::correctness::set_flags_without_dashes::set_flags_without_dashes(self);
         }
+        if self.is_rule_enabled(Rule::DollarQuestionAfterCommand) {
+            rules::correctness::dollar_question_after_command::dollar_question_after_command(self);
+        }
         if self.is_rule_enabled(Rule::QuotedArraySlice) {
             rules::correctness::quoted_array_slice::quoted_array_slice(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -168,6 +168,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::UndefinedVariable) {
             rules::correctness::undefined_variable::undefined_variable(self);
         }
+        if self.is_rule_enabled(Rule::PossibleVariableMisspelling) {
+            rules::correctness::possible_variable_misspelling::possible_variable_misspelling(self);
+        }
     }
 
     fn check_scopes(&mut self) {

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -174,6 +174,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::SubshellLocalAssignment) {
             rules::correctness::subshell_local_assignment::subshell_local_assignment(self);
         }
+        if self.is_rule_enabled(Rule::SubshellSideEffect) {
+            rules::correctness::subshell_side_effect::subshell_side_effect(self);
+        }
     }
 
     fn check_declarations(&mut self) {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1881,6 +1881,7 @@ pub struct LinterFacts<'a> {
     condition_status_capture_spans: Vec<Span>,
     condition_command_substitution_spans: Vec<Span>,
     backtick_command_name_spans: Vec<Span>,
+    dollar_question_after_command_spans: Vec<Span>,
     unused_heredoc_spans: Vec<Span>,
     heredoc_missing_end_spans: Vec<Span>,
     heredoc_closer_not_alone_spans: Vec<Span>,
@@ -2097,6 +2098,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn backtick_command_name_spans(&self) -> &[Span] {
         &self.backtick_command_name_spans
+    }
+
+    pub fn dollar_question_after_command_spans(&self) -> &[Span] {
+        &self.dollar_question_after_command_spans
     }
 
     pub fn unused_heredoc_spans(&self) -> &[Span] {
@@ -2458,6 +2463,12 @@ impl<'a> LinterFactsBuilder<'a> {
         let condition_command_substitution_spans =
             build_condition_command_substitution_spans(&self.file.body, self.source);
         let backtick_command_name_spans = build_backtick_command_name_spans(&commands);
+        let dollar_question_after_command_spans = build_dollar_question_after_command_spans(
+            &self.file.body,
+            &commands,
+            &command_ids_by_span,
+            self.source,
+        );
         let heredoc_summary =
             build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
@@ -2553,6 +2564,7 @@ impl<'a> LinterFactsBuilder<'a> {
             condition_status_capture_spans,
             condition_command_substitution_spans,
             backtick_command_name_spans,
+            dollar_question_after_command_spans,
             unused_heredoc_spans: heredoc_summary.unused_heredoc_spans,
             heredoc_missing_end_spans: heredoc_summary.heredoc_missing_end_spans,
             heredoc_closer_not_alone_spans: heredoc_summary.heredoc_closer_not_alone_spans,
@@ -4698,6 +4710,371 @@ fn command_name_is_plain_command_substitution(word: &Word, source: &str) -> bool
                 ..
             }]
         )
+}
+
+fn build_dollar_question_after_command_spans(
+    commands: &StmtSeq,
+    command_facts: &[CommandFact<'_>],
+    command_ids_by_span: &CommandLookupIndex,
+    source: &str,
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_dollar_question_after_command_spans_in_seq(
+        commands,
+        command_facts,
+        command_ids_by_span,
+        source,
+        &mut spans,
+    );
+
+    let mut seen = FxHashSet::default();
+    spans.retain(|span| seen.insert(FactSpan::new(*span)));
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans
+}
+
+fn collect_dollar_question_after_command_spans_in_seq(
+    commands: &StmtSeq,
+    command_facts: &[CommandFact<'_>],
+    command_ids_by_span: &CommandLookupIndex,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for pair in commands.as_slice().windows(2) {
+        if !stmt_is_intervening_output_command(&pair[0], command_facts, command_ids_by_span) {
+            continue;
+        }
+
+        spans.extend(followup_status_parameter_spans_in_stmt(&pair[1], source));
+    }
+
+    for stmt in commands.iter() {
+        collect_nested_dollar_question_after_command_spans_in_command(
+            &stmt.command,
+            command_facts,
+            command_ids_by_span,
+            source,
+            spans,
+        );
+    }
+}
+
+fn collect_nested_dollar_question_after_command_spans_in_command(
+    command: &Command,
+    command_facts: &[CommandFact<'_>],
+    command_ids_by_span: &CommandLookupIndex,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match command {
+        Command::Compound(command) => match command {
+            CompoundCommand::If(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.condition,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.then_branch,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+                for (condition, body) in &command.elif_branches {
+                    collect_dollar_question_after_command_spans_in_seq(
+                        condition,
+                        command_facts,
+                        command_ids_by_span,
+                        source,
+                        spans,
+                    );
+                    collect_dollar_question_after_command_spans_in_seq(
+                        body,
+                        command_facts,
+                        command_ids_by_span,
+                        source,
+                        spans,
+                    );
+                }
+                if let Some(else_branch) = &command.else_branch {
+                    collect_dollar_question_after_command_spans_in_seq(
+                        else_branch,
+                        command_facts,
+                        command_ids_by_span,
+                        source,
+                        spans,
+                    );
+                }
+            }
+            CompoundCommand::For(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::Repeat(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::Foreach(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::ArithmeticFor(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::While(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.condition,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::Until(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.condition,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::Case(command) => {
+                for case in &command.cases {
+                    collect_dollar_question_after_command_spans_in_seq(
+                        &case.body,
+                        command_facts,
+                        command_ids_by_span,
+                        source,
+                        spans,
+                    );
+                }
+            }
+            CompoundCommand::Select(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::Subshell(body) | CompoundCommand::BraceGroup(body) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::Time(command) => {
+                if let Some(command) = &command.command {
+                    collect_nested_dollar_question_after_command_spans_in_command(
+                        &command.command,
+                        command_facts,
+                        command_ids_by_span,
+                        source,
+                        spans,
+                    );
+                }
+            }
+            CompoundCommand::Conditional(_) | CompoundCommand::Arithmetic(_) => {}
+            CompoundCommand::Coproc(command) => {
+                collect_nested_dollar_question_after_command_spans_in_command(
+                    &command.body.command,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+            CompoundCommand::Always(command) => {
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+                collect_dollar_question_after_command_spans_in_seq(
+                    &command.always_body,
+                    command_facts,
+                    command_ids_by_span,
+                    source,
+                    spans,
+                );
+            }
+        },
+        Command::Binary(command) => {
+            collect_nested_dollar_question_after_command_spans_in_command(
+                &command.left.command,
+                command_facts,
+                command_ids_by_span,
+                source,
+                spans,
+            );
+            collect_nested_dollar_question_after_command_spans_in_command(
+                &command.right.command,
+                command_facts,
+                command_ids_by_span,
+                source,
+                spans,
+            );
+        }
+        Command::AnonymousFunction(command) => {
+            collect_nested_dollar_question_after_command_spans_in_command(
+                &command.body.command,
+                command_facts,
+                command_ids_by_span,
+                source,
+                spans,
+            );
+        }
+        Command::Function(command) => {
+            collect_nested_dollar_question_after_command_spans_in_command(
+                &command.body.command,
+                command_facts,
+                command_ids_by_span,
+                source,
+                spans,
+            );
+        }
+        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => {}
+    }
+}
+
+fn stmt_is_intervening_output_command(
+    stmt: &Stmt,
+    command_facts: &[CommandFact<'_>],
+    command_ids_by_span: &CommandLookupIndex,
+) -> bool {
+    let Some(command_id) = command_id_for_command(&stmt.command, command_ids_by_span) else {
+        return false;
+    };
+    let fact = &command_facts[command_id.index()];
+    fact.effective_name_is("echo") || fact.effective_name_is("printf")
+}
+
+fn status_parameter_spans_in_stmt(stmt: &Stmt, source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_status_parameter_spans_in_stmt(stmt, source, &mut spans);
+    spans
+}
+
+fn status_parameter_spans_in_word(word: &Word, source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_status_parameter_spans_in_word(word, source, &mut spans);
+    spans
+}
+
+fn followup_status_parameter_spans_in_stmt(stmt: &Stmt, source: &str) -> Vec<Span> {
+    let mut spans = status_parameter_spans_in_stmt(stmt, source);
+    collect_followup_status_parameter_spans_in_command(&stmt.command, source, &mut spans);
+    spans
+}
+
+fn collect_followup_status_parameter_spans_in_command(
+    command: &Command,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    if let Command::Compound(command) = command {
+        match command {
+            CompoundCommand::For(command) => {
+                if let Some(words) = command.words.as_deref() {
+                    for word in words {
+                        spans.extend(status_parameter_spans_in_word(word, source));
+                    }
+                }
+            }
+            CompoundCommand::Repeat(command) => {
+                spans.extend(status_parameter_spans_in_word(&command.count, source));
+            }
+            CompoundCommand::Foreach(command) => {
+                for word in &command.words {
+                    spans.extend(status_parameter_spans_in_word(word, source));
+                }
+            }
+            CompoundCommand::ArithmeticFor(command) => {
+                if let Some(init) = command.init_ast.as_ref() {
+                    query::visit_arithmetic_words(init, &mut |word| {
+                        spans.extend(status_parameter_spans_in_word(word, source));
+                    });
+                }
+                if let Some(condition) = command.condition_ast.as_ref() {
+                    query::visit_arithmetic_words(condition, &mut |word| {
+                        spans.extend(status_parameter_spans_in_word(word, source));
+                    });
+                }
+                if let Some(step) = command.step_ast.as_ref() {
+                    query::visit_arithmetic_words(step, &mut |word| {
+                        spans.extend(status_parameter_spans_in_word(word, source));
+                    });
+                }
+            }
+            CompoundCommand::Case(command) => {
+                spans.extend(status_parameter_spans_in_word(&command.word, source));
+            }
+            CompoundCommand::Select(command) => {
+                for word in &command.words {
+                    spans.extend(status_parameter_spans_in_word(word, source));
+                }
+            }
+            CompoundCommand::Time(command) => {
+                if let Some(command) = &command.command {
+                    spans.extend(status_parameter_spans_in_stmt(command, source));
+                }
+            }
+            CompoundCommand::If(_)
+            | CompoundCommand::While(_)
+            | CompoundCommand::Until(_)
+            | CompoundCommand::Subshell(_)
+            | CompoundCommand::BraceGroup(_)
+            | CompoundCommand::Arithmetic(_)
+            | CompoundCommand::Conditional(_)
+            | CompoundCommand::Coproc(_)
+            | CompoundCommand::Always(_) => {}
+        }
+    }
 }
 
 fn collect_condition_status_capture_from_body(

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1883,6 +1883,7 @@ pub struct LinterFacts<'a> {
     backtick_command_name_spans: Vec<Span>,
     dollar_question_after_command_spans: Vec<Span>,
     subshell_local_assignment_spans: Vec<Span>,
+    subshell_side_effect_spans: Vec<Span>,
     unused_heredoc_spans: Vec<Span>,
     heredoc_missing_end_spans: Vec<Span>,
     heredoc_closer_not_alone_spans: Vec<Span>,
@@ -2107,6 +2108,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn subshell_local_assignment_spans(&self) -> &[Span] {
         &self.subshell_local_assignment_spans
+    }
+
+    pub fn subshell_side_effect_spans(&self) -> &[Span] {
+        &self.subshell_side_effect_spans
     }
 
     pub fn unused_heredoc_spans(&self) -> &[Span] {
@@ -2474,8 +2479,8 @@ impl<'a> LinterFactsBuilder<'a> {
             &command_ids_by_span,
             self.source,
         );
-        let subshell_local_assignment_spans =
-            build_subshell_local_assignment_spans(self.semantic, &commands);
+        let nonpersistent_assignment_spans =
+            build_nonpersistent_assignment_spans(self.semantic, &commands);
         let heredoc_summary =
             build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
@@ -2572,7 +2577,9 @@ impl<'a> LinterFactsBuilder<'a> {
             condition_command_substitution_spans,
             backtick_command_name_spans,
             dollar_question_after_command_spans,
-            subshell_local_assignment_spans,
+            subshell_local_assignment_spans: nonpersistent_assignment_spans
+                .subshell_local_assignment_spans,
+            subshell_side_effect_spans: nonpersistent_assignment_spans.subshell_side_effect_spans,
             unused_heredoc_spans: heredoc_summary.unused_heredoc_spans,
             heredoc_missing_end_spans: heredoc_summary.heredoc_missing_end_spans,
             heredoc_closer_not_alone_spans: heredoc_summary.heredoc_closer_not_alone_spans,
@@ -4741,10 +4748,10 @@ fn build_dollar_question_after_command_spans(
     spans
 }
 
-fn build_subshell_local_assignment_spans(
+fn build_nonpersistent_assignment_spans(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
-) -> Vec<Span> {
+) -> NonpersistentAssignmentSpans {
     let mut candidate_bindings_by_name: FxHashMap<Name, Vec<CandidateSubshellAssignment>> =
         FxHashMap::default();
     let mut persistent_reset_offsets_by_name: FxHashMap<Name, Vec<PersistentReset>> =
@@ -4755,8 +4762,8 @@ fn build_subshell_local_assignment_spans(
             continue;
         }
 
-        let Some(nonpersistent_span) =
-            innermost_nonpipeline_subshell_span(semantic, binding.span.start.offset)
+        let Some(nonpersistent_scope) =
+            innermost_nonpersistent_scope_span(semantic, binding.span.start.offset)
         else {
             continue;
         };
@@ -4766,8 +4773,10 @@ fn build_subshell_local_assignment_spans(
             .or_default()
             .push(CandidateSubshellAssignment {
                 binding_id: binding.id,
-                subshell_start: nonpersistent_span.start.offset,
-                subshell_end: nonpersistent_span.end.offset,
+                assignment_span: binding.span,
+                kind: nonpersistent_scope.kind,
+                subshell_start: nonpersistent_scope.span.start.offset,
+                subshell_end: nonpersistent_scope.span.end.offset,
             });
     }
 
@@ -4789,7 +4798,8 @@ fn build_subshell_local_assignment_spans(
             });
     }
 
-    let mut spans = Vec::new();
+    let mut later_use_spans = Vec::new();
+    let mut side_effect_spans = Vec::new();
     for reference in semantic.references() {
         if matches!(
             reference.kind,
@@ -4809,20 +4819,31 @@ fn build_subshell_local_assignment_spans(
         let event_command_span =
             innermost_command_span_containing_offset(commands, reference.span.start.offset);
         let resolved = semantic.resolved_binding(reference.id);
-        if candidate_ids.iter().any(|candidate| {
-            reference.span.start.offset > candidate.subshell_end
-                && !has_intervening_persistent_reset(
+        let mut matched_nonpipeline_candidate = false;
+        for candidate in candidate_ids {
+            if reference.span.start.offset <= candidate.subshell_end
+                || has_intervening_persistent_reset(
                     reset_offsets,
                     candidate.subshell_end,
                     reference.span.start.offset,
                     event_command_span,
                 )
-                && resolved.is_none_or(|resolved| {
+                || !resolved.is_none_or(|resolved| {
                     resolved.id != candidate.binding_id
                         && resolved.span.start.offset < candidate.subshell_start
                 })
-        }) {
-            spans.push(reference.span);
+            {
+                continue;
+            }
+
+            side_effect_spans.push(candidate.assignment_span);
+            if !matches!(candidate.kind, NonpersistentAssignmentKind::Pipeline) {
+                matched_nonpipeline_candidate = true;
+            }
+        }
+
+        if matched_nonpipeline_candidate {
+            later_use_spans.push(reference.span);
         }
     }
 
@@ -4839,23 +4860,42 @@ fn build_subshell_local_assignment_spans(
             .get(&binding.name)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
-        if candidate_ids.iter().any(|candidate| {
-            binding.span.start.offset > candidate.subshell_end
-                && !has_intervening_persistent_reset(
+        let mut matched_nonpipeline_candidate = false;
+        for candidate in candidate_ids {
+            if binding.span.start.offset <= candidate.subshell_end
+                || has_intervening_persistent_reset(
                     reset_offsets,
                     candidate.subshell_end,
                     binding.span.start.offset,
                     None,
                 )
-        }) {
-            spans.push(binding.span);
+            {
+                continue;
+            }
+
+            side_effect_spans.push(candidate.assignment_span);
+            if !matches!(candidate.kind, NonpersistentAssignmentKind::Pipeline) {
+                matched_nonpipeline_candidate = true;
+            }
+        }
+
+        if matched_nonpipeline_candidate {
+            later_use_spans.push(binding.span);
         }
     }
 
     let mut seen = FxHashSet::default();
-    spans.retain(|span| seen.insert(FactSpan::new(*span)));
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
-    spans
+    later_use_spans.retain(|span| seen.insert(FactSpan::new(*span)));
+    later_use_spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+
+    seen.clear();
+    side_effect_spans.retain(|span| seen.insert(FactSpan::new(*span)));
+    side_effect_spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+
+    NonpersistentAssignmentSpans {
+        subshell_local_assignment_spans: later_use_spans,
+        subshell_side_effect_spans: side_effect_spans,
+    }
 }
 
 fn is_reportable_subshell_assignment(kind: BindingKind, attributes: BindingAttributes) -> bool {
@@ -4907,8 +4947,28 @@ fn is_reportable_subshell_later_use_binding(
 #[derive(Debug, Clone, Copy)]
 struct CandidateSubshellAssignment {
     binding_id: shuck_semantic::BindingId,
+    assignment_span: Span,
+    kind: NonpersistentAssignmentKind,
     subshell_start: usize,
     subshell_end: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NonpersistentAssignmentKind {
+    Pipeline,
+    Subshell,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NonpersistentScopeSpan {
+    span: Span,
+    kind: NonpersistentAssignmentKind,
+}
+
+#[derive(Debug, Default)]
+struct NonpersistentAssignmentSpans {
+    subshell_local_assignment_spans: Vec<Span>,
+    subshell_side_effect_spans: Vec<Span>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -4917,25 +4977,25 @@ struct PersistentReset {
     command_span: Option<Span>,
 }
 
-fn innermost_nonpipeline_subshell_span(semantic: &SemanticModel, offset: usize) -> Option<Span> {
-    let scope = semantic.scope_at(offset);
-
-    for scope in semantic.ancestor_scopes(scope) {
-        match semantic.scope_kind(scope) {
-            shuck_semantic::ScopeKind::Subshell
-            | shuck_semantic::ScopeKind::CommandSubstitution => {
-                return semantic
-                    .scopes()
-                    .iter()
-                    .find(|candidate| candidate.id == scope)
-                    .map(|candidate| candidate.span);
-            }
-            shuck_semantic::ScopeKind::Pipeline => return None,
-            shuck_semantic::ScopeKind::Function(_) | shuck_semantic::ScopeKind::File => {}
+fn innermost_nonpersistent_scope_span(
+    semantic: &SemanticModel,
+    offset: usize,
+) -> Option<NonpersistentScopeSpan> {
+    let scope = innermost_nonpersistent_scope_within_function(semantic, offset)?;
+    let span = semantic
+        .scopes()
+        .iter()
+        .find(|candidate| candidate.id == scope)
+        .map(|candidate| candidate.span)?;
+    let kind = match semantic.scope_kind(scope) {
+        shuck_semantic::ScopeKind::Pipeline => NonpersistentAssignmentKind::Pipeline,
+        shuck_semantic::ScopeKind::Subshell | shuck_semantic::ScopeKind::CommandSubstitution => {
+            NonpersistentAssignmentKind::Subshell
         }
-    }
+        shuck_semantic::ScopeKind::Function(_) | shuck_semantic::ScopeKind::File => return None,
+    };
 
-    None
+    Some(NonpersistentScopeSpan { span, kind })
 }
 
 fn is_within_any_nonpersistent_scope(semantic: &SemanticModel, offset: usize) -> bool {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -27,7 +27,7 @@ use shuck_ast::{
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
-use shuck_semantic::{ScopeId, SemanticModel, ZshOptionState};
+use shuck_semantic::{BindingAttributes, BindingKind, ScopeId, SemanticModel, ZshOptionState};
 use std::borrow::Cow;
 
 use self::{
@@ -1882,6 +1882,7 @@ pub struct LinterFacts<'a> {
     condition_command_substitution_spans: Vec<Span>,
     backtick_command_name_spans: Vec<Span>,
     dollar_question_after_command_spans: Vec<Span>,
+    subshell_local_assignment_spans: Vec<Span>,
     unused_heredoc_spans: Vec<Span>,
     heredoc_missing_end_spans: Vec<Span>,
     heredoc_closer_not_alone_spans: Vec<Span>,
@@ -2102,6 +2103,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn dollar_question_after_command_spans(&self) -> &[Span] {
         &self.dollar_question_after_command_spans
+    }
+
+    pub fn subshell_local_assignment_spans(&self) -> &[Span] {
+        &self.subshell_local_assignment_spans
     }
 
     pub fn unused_heredoc_spans(&self) -> &[Span] {
@@ -2469,6 +2474,8 @@ impl<'a> LinterFactsBuilder<'a> {
             &command_ids_by_span,
             self.source,
         );
+        let subshell_local_assignment_spans =
+            build_subshell_local_assignment_spans(self.semantic, &commands);
         let heredoc_summary =
             build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
@@ -2565,6 +2572,7 @@ impl<'a> LinterFactsBuilder<'a> {
             condition_command_substitution_spans,
             backtick_command_name_spans,
             dollar_question_after_command_spans,
+            subshell_local_assignment_spans,
             unused_heredoc_spans: heredoc_summary.unused_heredoc_spans,
             heredoc_missing_end_spans: heredoc_summary.heredoc_missing_end_spans,
             heredoc_closer_not_alone_spans: heredoc_summary.heredoc_closer_not_alone_spans,
@@ -4731,6 +4739,260 @@ fn build_dollar_question_after_command_spans(
     spans.retain(|span| seen.insert(FactSpan::new(*span)));
     spans.sort_by_key(|span| (span.start.offset, span.end.offset));
     spans
+}
+
+fn build_subshell_local_assignment_spans(
+    semantic: &SemanticModel,
+    commands: &[CommandFact<'_>],
+) -> Vec<Span> {
+    let mut candidate_bindings_by_name: FxHashMap<Name, Vec<CandidateSubshellAssignment>> =
+        FxHashMap::default();
+    let mut persistent_reset_offsets_by_name: FxHashMap<Name, Vec<PersistentReset>> =
+        FxHashMap::default();
+
+    for binding in semantic.bindings() {
+        if !is_reportable_subshell_assignment(binding.kind, binding.attributes) {
+            continue;
+        }
+
+        let Some(nonpersistent_span) =
+            innermost_nonpipeline_subshell_span(semantic, binding.span.start.offset)
+        else {
+            continue;
+        };
+
+        candidate_bindings_by_name
+            .entry(binding.name.clone())
+            .or_default()
+            .push(CandidateSubshellAssignment {
+                binding_id: binding.id,
+                subshell_start: nonpersistent_span.start.offset,
+                subshell_end: nonpersistent_span.end.offset,
+            });
+    }
+
+    for binding in semantic.bindings() {
+        if !is_persistent_subshell_reset_binding(binding.kind, binding.attributes) {
+            continue;
+        }
+        if is_within_any_nonpersistent_scope(semantic, binding.span.start.offset) {
+            continue;
+        }
+        let command_span =
+            innermost_command_span_containing_offset(commands, binding.span.start.offset);
+        persistent_reset_offsets_by_name
+            .entry(binding.name.clone())
+            .or_default()
+            .push(PersistentReset {
+                offset: binding.span.start.offset,
+                command_span,
+            });
+    }
+
+    let mut spans = Vec::new();
+    for reference in semantic.references() {
+        if matches!(
+            reference.kind,
+            shuck_semantic::ReferenceKind::DeclarationName
+        ) {
+            continue;
+        }
+
+        let Some(candidate_ids) = candidate_bindings_by_name.get(&reference.name) else {
+            continue;
+        };
+
+        let reset_offsets = persistent_reset_offsets_by_name
+            .get(&reference.name)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let event_command_span =
+            innermost_command_span_containing_offset(commands, reference.span.start.offset);
+        let resolved = semantic.resolved_binding(reference.id);
+        if candidate_ids.iter().any(|candidate| {
+            reference.span.start.offset > candidate.subshell_end
+                && !has_intervening_persistent_reset(
+                    reset_offsets,
+                    candidate.subshell_end,
+                    reference.span.start.offset,
+                    event_command_span,
+                )
+                && resolved.is_none_or(|resolved| {
+                    resolved.id != candidate.binding_id
+                        && resolved.span.start.offset < candidate.subshell_start
+                })
+        }) {
+            spans.push(reference.span);
+        }
+    }
+
+    for binding in semantic.bindings() {
+        if !is_reportable_subshell_later_use_binding(binding.kind, binding.attributes) {
+            continue;
+        }
+
+        let Some(candidate_ids) = candidate_bindings_by_name.get(&binding.name) else {
+            continue;
+        };
+
+        let reset_offsets = persistent_reset_offsets_by_name
+            .get(&binding.name)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        if candidate_ids.iter().any(|candidate| {
+            binding.span.start.offset > candidate.subshell_end
+                && !has_intervening_persistent_reset(
+                    reset_offsets,
+                    candidate.subshell_end,
+                    binding.span.start.offset,
+                    None,
+                )
+        }) {
+            spans.push(binding.span);
+        }
+    }
+
+    let mut seen = FxHashSet::default();
+    spans.retain(|span| seen.insert(FactSpan::new(*span)));
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans
+}
+
+fn is_reportable_subshell_assignment(kind: BindingKind, attributes: BindingAttributes) -> bool {
+    match kind {
+        BindingKind::Assignment
+        | BindingKind::AppendAssignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment => !attributes.contains(BindingAttributes::LOCAL),
+        BindingKind::Declaration(_) => {
+            attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
+                && !attributes.contains(BindingAttributes::LOCAL)
+        }
+        BindingKind::ParameterDefaultAssignment => false,
+        BindingKind::Imported => false,
+        BindingKind::FunctionDefinition | BindingKind::Nameref => false,
+    }
+}
+
+fn is_reportable_subshell_later_use_binding(
+    kind: BindingKind,
+    attributes: BindingAttributes,
+) -> bool {
+    match kind {
+        BindingKind::AppendAssignment => true,
+        BindingKind::Declaration(_) => {
+            attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
+                && !attributes.contains(BindingAttributes::LOCAL)
+        }
+        BindingKind::Assignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment
+        | BindingKind::ParameterDefaultAssignment
+        | BindingKind::FunctionDefinition
+        | BindingKind::Imported
+        | BindingKind::Nameref => false,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CandidateSubshellAssignment {
+    binding_id: shuck_semantic::BindingId,
+    subshell_start: usize,
+    subshell_end: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PersistentReset {
+    offset: usize,
+    command_span: Option<Span>,
+}
+
+fn innermost_nonpipeline_subshell_span(semantic: &SemanticModel, offset: usize) -> Option<Span> {
+    let scope = semantic.scope_at(offset);
+
+    for scope in semantic.ancestor_scopes(scope) {
+        match semantic.scope_kind(scope) {
+            shuck_semantic::ScopeKind::Subshell
+            | shuck_semantic::ScopeKind::CommandSubstitution => {
+                return semantic
+                    .scopes()
+                    .iter()
+                    .find(|candidate| candidate.id == scope)
+                    .map(|candidate| candidate.span);
+            }
+            shuck_semantic::ScopeKind::Pipeline => return None,
+            shuck_semantic::ScopeKind::Function(_) | shuck_semantic::ScopeKind::File => {}
+        }
+    }
+
+    None
+}
+
+fn is_within_any_nonpersistent_scope(semantic: &SemanticModel, offset: usize) -> bool {
+    let scope = semantic.scope_at(offset);
+
+    semantic.ancestor_scopes(scope).any(|scope| {
+        matches!(
+            semantic.scope_kind(scope),
+            shuck_semantic::ScopeKind::Subshell
+                | shuck_semantic::ScopeKind::CommandSubstitution
+                | shuck_semantic::ScopeKind::Pipeline
+        )
+    })
+}
+
+fn is_persistent_subshell_reset_binding(kind: BindingKind, attributes: BindingAttributes) -> bool {
+    match kind {
+        BindingKind::Assignment
+        | BindingKind::AppendAssignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment => !attributes.contains(BindingAttributes::LOCAL),
+        BindingKind::Declaration(_) => {
+            attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
+                && !attributes.contains(BindingAttributes::LOCAL)
+        }
+        BindingKind::ParameterDefaultAssignment => false,
+        BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref => false,
+    }
+}
+
+fn has_intervening_persistent_reset(
+    resets: &[PersistentReset],
+    candidate_end: usize,
+    event_offset: usize,
+    event_command_span: Option<Span>,
+) -> bool {
+    resets.iter().any(|reset| {
+        reset.offset > candidate_end
+            && reset.offset < event_offset
+            && event_command_span.is_none_or(|event_span| reset.command_span != Some(event_span))
+    })
+}
+
+fn innermost_command_span_containing_offset(
+    commands: &[CommandFact<'_>],
+    offset: usize,
+) -> Option<Span> {
+    commands
+        .iter()
+        .map(CommandFact::span)
+        .filter(|span| span.start.offset <= offset && offset <= span.end.offset)
+        .min_by_key(|span| span.end.offset - span.start.offset)
 }
 
 fn collect_dollar_question_after_command_spans_in_seq(

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5267,6 +5267,19 @@ fn collect_nested_dollar_question_after_command_spans_in_command(
             }
         },
         Command::Binary(command) => {
+            if matches!(command.op, BinaryOp::And | BinaryOp::Or)
+                && stmt_is_intervening_output_command(
+                    &command.left,
+                    command_facts,
+                    command_ids_by_span,
+                )
+            {
+                spans.extend(followup_status_parameter_spans_in_stmt(
+                    &command.right,
+                    source,
+                ));
+            }
+
             collect_nested_dollar_question_after_command_spans_in_command(
                 &command.left.command,
                 command_facts,

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5329,12 +5329,6 @@ fn stmt_is_intervening_output_command(
     fact.effective_name_is("echo") || fact.effective_name_is("printf")
 }
 
-fn status_parameter_spans_in_stmt(stmt: &Stmt, source: &str) -> Vec<Span> {
-    let mut spans = Vec::new();
-    collect_status_parameter_spans_in_stmt(stmt, source, &mut spans);
-    spans
-}
-
 fn status_parameter_spans_in_word(word: &Word, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_status_parameter_spans_in_word(word, source, &mut spans);
@@ -5342,9 +5336,18 @@ fn status_parameter_spans_in_word(word: &Word, source: &str) -> Vec<Span> {
 }
 
 fn followup_status_parameter_spans_in_stmt(stmt: &Stmt, source: &str) -> Vec<Span> {
-    let mut spans = status_parameter_spans_in_stmt(stmt, source);
-    collect_followup_status_parameter_spans_in_command(&stmt.command, source, &mut spans);
+    let mut spans = Vec::new();
+    collect_followup_status_parameter_spans_in_stmt(stmt, source, &mut spans);
     spans
+}
+
+fn collect_followup_status_parameter_spans_in_stmt(
+    stmt: &Stmt,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_status_parameter_spans_in_stmt(stmt, source, spans);
+    collect_followup_status_parameter_spans_in_command(&stmt.command, source, spans);
 }
 
 fn collect_followup_status_parameter_spans_in_command(
@@ -5352,8 +5355,11 @@ fn collect_followup_status_parameter_spans_in_command(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    if let Command::Compound(command) = command {
-        match command {
+    match command {
+        Command::Binary(command) if matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
+            collect_followup_status_parameter_spans_in_stmt(&command.right, source, spans);
+        }
+        Command::Compound(command) => match command {
             CompoundCommand::For(command) => {
                 if let Some(words) = command.words.as_deref() {
                     for word in words {
@@ -5396,19 +5402,50 @@ fn collect_followup_status_parameter_spans_in_command(
             }
             CompoundCommand::Time(command) => {
                 if let Some(command) = &command.command {
-                    spans.extend(status_parameter_spans_in_stmt(command, source));
+                    collect_followup_status_parameter_spans_in_stmt(command, source, spans);
                 }
             }
-            CompoundCommand::If(_)
-            | CompoundCommand::While(_)
-            | CompoundCommand::Until(_)
-            | CompoundCommand::Subshell(_)
-            | CompoundCommand::BraceGroup(_)
-            | CompoundCommand::Arithmetic(_)
-            | CompoundCommand::Conditional(_)
-            | CompoundCommand::Coproc(_)
-            | CompoundCommand::Always(_) => {}
+            CompoundCommand::If(command) => {
+                if let Some(first_stmt) = command.condition.first() {
+                    collect_followup_status_parameter_spans_in_stmt(first_stmt, source, spans);
+                }
+            }
+            CompoundCommand::While(command) => {
+                if let Some(first_stmt) = command.condition.first() {
+                    collect_followup_status_parameter_spans_in_stmt(first_stmt, source, spans);
+                }
+            }
+            CompoundCommand::Until(command) => {
+                if let Some(first_stmt) = command.condition.first() {
+                    collect_followup_status_parameter_spans_in_stmt(first_stmt, source, spans);
+                }
+            }
+            CompoundCommand::Subshell(body) | CompoundCommand::BraceGroup(body) => {
+                if let Some(first_stmt) = body.first() {
+                    collect_followup_status_parameter_spans_in_stmt(first_stmt, source, spans);
+                }
+            }
+            CompoundCommand::Coproc(command) => {
+                collect_followup_status_parameter_spans_in_stmt(&command.body, source, spans);
+            }
+            CompoundCommand::Always(command) => {
+                if let Some(first_stmt) = command.body.first() {
+                    collect_followup_status_parameter_spans_in_stmt(first_stmt, source, spans);
+                }
+            }
+            CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => {}
+        },
+        Command::AnonymousFunction(command) => {
+            collect_followup_status_parameter_spans_in_stmt(&command.body, source, spans);
+            for word in &command.args {
+                spans.extend(status_parameter_spans_in_word(word, source));
+            }
         }
+        Command::Binary(_)
+        | Command::Simple(_)
+        | Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Function(_) => {}
     }
 }
 

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -401,6 +401,12 @@ declare_rules! {
     ("C146", Category::Correctness, Severity::Error, UntilMissingDo),
     ("C147", Category::Correctness, Severity::Warning, KeywordFunctionName),
     ("C148", Category::Correctness, Severity::Warning, BrokenAssocKey),
+    (
+        "C150",
+        Category::Correctness,
+        Severity::Warning,
+        SubshellLocalAssignment
+    ),
     ("C151", Category::Correctness, Severity::Warning, CommaArrayElements),
     ("C157", Category::Correctness, Severity::Error, IfBracketGlued),
     ("P001", Category::Performance, Severity::Warning, ExprArithmetic),
@@ -723,6 +729,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-329" => Some(Rule::LinebreakBeforeAnd),
         "SH-330" => Some(Rule::SpacedTabstripClose),
         "SH-335" => Some(Rule::AmpersandSemicolon),
+        "SH-339" => Some(Rule::SubshellLocalAssignment),
         "SH-121" => Some(Rule::CStyleComment),
         "SH-123" => Some(Rule::CPrototypeFragment),
         "SH-129" => Some(Rule::BadRedirectionFdOrder),
@@ -1199,6 +1206,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-336"), Some(Rule::KeywordFunctionName));
         assert_eq!(code_to_rule("C148"), Some(Rule::BrokenAssocKey));
         assert_eq!(code_to_rule("SH-337"), Some(Rule::BrokenAssocKey));
+        assert_eq!(code_to_rule("C150"), Some(Rule::SubshellLocalAssignment));
+        assert_eq!(code_to_rule("SH-339"), Some(Rule::SubshellLocalAssignment));
         assert_eq!(code_to_rule("C151"), Some(Rule::CommaArrayElements));
         assert_eq!(code_to_rule("SH-340"), Some(Rule::CommaArrayElements));
         assert_eq!(code_to_rule("SH-283"), Some(Rule::FindExecDirWithShell));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -271,6 +271,12 @@ declare_rules! {
         AppendToArrayAsString
     ),
     (
+        "C107",
+        Category::Correctness,
+        Severity::Warning,
+        DollarQuestionAfterCommand
+    ),
+    (
         "C108",
         Category::Correctness,
         Severity::Warning,
@@ -770,6 +776,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-250" => Some(Rule::ArraySliceInComparison),
         "SH-251" => Some(Rule::DefaultValueInColonAssign),
         "SH-241" => Some(Rule::AppendToArrayAsString),
+        "SH-242" => Some(Rule::DollarQuestionAfterCommand),
         "SH-243" => Some(Rule::UnsetAssociativeArrayElement),
         "SH-244" => Some(Rule::MapfileProcessSubstitution),
         "SH-254" => Some(Rule::GlobWithExpansionInLoop),
@@ -1135,6 +1142,11 @@ mod tests {
         assert_eq!(code_to_rule("SH-250"), Some(Rule::ArraySliceInComparison));
         assert_eq!(code_to_rule("C106"), Some(Rule::AppendToArrayAsString));
         assert_eq!(code_to_rule("SH-241"), Some(Rule::AppendToArrayAsString));
+        assert_eq!(code_to_rule("C107"), Some(Rule::DollarQuestionAfterCommand));
+        assert_eq!(
+            code_to_rule("SH-242"),
+            Some(Rule::DollarQuestionAfterCommand)
+        );
         assert_eq!(
             code_to_rule("C108"),
             Some(Rule::UnsetAssociativeArrayElement)

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -666,6 +666,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-311" => Some(Rule::ArrayToStringConversion),
         "SH-336" => Some(Rule::KeywordFunctionName),
         "SH-337" => Some(Rule::BrokenAssocKey),
+        "SH-347" => Some(Rule::SubshellSideEffect),
         "SH-340" => Some(Rule::CommaArrayElements),
         "SH-351" => Some(Rule::PossibleVariableMisspelling),
         "SH-036" => Some(Rule::SingleQuotedLiteral),
@@ -1214,6 +1215,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-336"), Some(Rule::KeywordFunctionName));
         assert_eq!(code_to_rule("C148"), Some(Rule::BrokenAssocKey));
         assert_eq!(code_to_rule("SH-337"), Some(Rule::BrokenAssocKey));
+        assert_eq!(code_to_rule("SH-347"), Some(Rule::SubshellSideEffect));
         assert_eq!(code_to_rule("C150"), Some(Rule::SubshellLocalAssignment));
         assert_eq!(code_to_rule("SH-339"), Some(Rule::SubshellLocalAssignment));
         assert_eq!(code_to_rule("C151"), Some(Rule::CommaArrayElements));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -409,6 +409,12 @@ declare_rules! {
     ),
     ("C151", Category::Correctness, Severity::Warning, CommaArrayElements),
     ("C155", Category::Correctness, Severity::Warning, SubshellSideEffect),
+    (
+        "C156",
+        Category::Correctness,
+        Severity::Warning,
+        PossibleVariableMisspelling
+    ),
     ("C157", Category::Correctness, Severity::Error, IfBracketGlued),
     ("P001", Category::Performance, Severity::Warning, ExprArithmetic),
     ("P002", Category::Performance, Severity::Warning, GrepCountPipeline),
@@ -661,6 +667,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-336" => Some(Rule::KeywordFunctionName),
         "SH-337" => Some(Rule::BrokenAssocKey),
         "SH-340" => Some(Rule::CommaArrayElements),
+        "SH-351" => Some(Rule::PossibleVariableMisspelling),
         "SH-036" => Some(Rule::SingleQuotedLiteral),
         "SH-037" => Some(Rule::PrintfFormatVariable),
         "SH-038" => Some(Rule::UnquotedArrayExpansion),
@@ -1211,6 +1218,10 @@ mod tests {
         assert_eq!(code_to_rule("SH-339"), Some(Rule::SubshellLocalAssignment));
         assert_eq!(code_to_rule("C151"), Some(Rule::CommaArrayElements));
         assert_eq!(code_to_rule("SH-340"), Some(Rule::CommaArrayElements));
+        assert_eq!(
+            code_to_rule("SH-351"),
+            Some(Rule::PossibleVariableMisspelling)
+        );
         assert_eq!(code_to_rule("SH-283"), Some(Rule::FindExecDirWithShell));
         assert_eq!(
             code_to_rule("C137"),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -408,6 +408,7 @@ declare_rules! {
         SubshellLocalAssignment
     ),
     ("C151", Category::Correctness, Severity::Warning, CommaArrayElements),
+    ("C155", Category::Correctness, Severity::Warning, SubshellSideEffect),
     ("C157", Category::Correctness, Severity::Error, IfBracketGlued),
     ("P001", Category::Performance, Severity::Warning, ExprArithmetic),
     ("P002", Category::Performance, Severity::Warning, GrepCountPipeline),

--- a/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
@@ -125,4 +125,29 @@ printf '%s\\n' status || return $?
             vec!["$?", "$?"]
         );
     }
+
+    #[test]
+    fn reports_pipeline_followups_after_output_commands() {
+        let source = "\
+#!/bin/bash
+run
+echo status
+true | printf '%s\\n' \"$?\"
+run
+printf '%s\\n' status
+time true | printf '%s\\n' \"$?\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::DollarQuestionAfterCommand),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$?", "$?"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
@@ -1,0 +1,105 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct DollarQuestionAfterCommand;
+
+impl Violation for DollarQuestionAfterCommand {
+    fn rule() -> Rule {
+        Rule::DollarQuestionAfterCommand
+    }
+
+    fn message(&self) -> String {
+        "`$?` here reflects a later command, not the status you likely meant to keep".to_owned()
+    }
+}
+
+pub fn dollar_question_after_command(checker: &mut Checker) {
+    checker.report_all(
+        checker
+            .facts()
+            .dollar_question_after_command_spans()
+            .to_vec(),
+        || DollarQuestionAfterCommand,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_status_uses_after_output_commands() {
+        let source = "\
+#!/bin/bash
+run
+echo status
+if [ $? -ne 0 ]; then :; fi
+run
+printf '%s\\n' status
+case $? in 0) : ;; esac
+check_status() {
+  run
+  printf '%s\\n' status
+  return $?
+}
+run
+echo status
+saved=$?
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::DollarQuestionAfterCommand),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$?", "$?", "$?", "$?"]
+        );
+    }
+
+    #[test]
+    fn ignores_immediate_checks_and_saved_status() {
+        let source = "\
+#!/bin/bash
+run
+if [ $? -ne 0 ]; then :; fi
+run
+saved=$?
+echo status
+if [ \"$saved\" -ne 0 ]; then :; fi
+run
+pwd >/dev/null
+if [ $? -ne 0 ]; then :; fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::DollarQuestionAfterCommand),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_case_subjects_without_a_qualifying_intervening_output_command() {
+        let source = "\
+#!/bin/bash
+awk 'BEGIN { exit 0 }'
+case $? in
+  0) : ;;
+esac
+groupadd demo
+case $? in
+  0) : ;;
+esac
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::DollarQuestionAfterCommand),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
@@ -102,4 +102,27 @@ esac
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn reports_short_circuit_followups_after_output_commands() {
+        let source = "\
+#!/bin/bash
+run
+echo status && [ $? -ne 0 ]
+run
+printf '%s\\n' status || return $?
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::DollarQuestionAfterCommand),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$?", "$?"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -93,6 +93,7 @@ pub mod status_capture_after_branch_test;
 pub mod string_comparison_for_version;
 pub mod subshell_in_arithmetic;
 pub mod subshell_local_assignment;
+pub mod subshell_side_effect;
 pub mod subst_with_redirect;
 pub mod subst_with_redirect_err;
 pub mod sudo_redirection_order;
@@ -241,6 +242,7 @@ mod tests {
     #[test_case(Rule::BrokenAssocKey, Path::new("C148.sh"))]
     #[test_case(Rule::SubshellLocalAssignment, Path::new("C150.sh"))]
     #[test_case(Rule::CommaArrayElements, Path::new("C151.sh"))]
+    #[test_case(Rule::SubshellSideEffect, Path::new("C155.sh"))]
     #[test_case(Rule::IfBracketGlued, Path::new("C157.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {
         let snapshot = format!("{}_{}", rule.code(), path.display());

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -79,6 +79,7 @@ pub mod pipe_to_kill;
 pub mod plus_prefix_in_assignment;
 pub mod positional_param_as_operator;
 pub mod positional_ten_braces;
+pub mod possible_variable_misspelling;
 pub mod quoted_array_slice;
 pub mod quoted_bash_regex;
 pub mod quoted_bash_source;
@@ -117,6 +118,7 @@ pub mod untracked_source_file;
 pub mod unused_assignment;
 pub mod unused_heredoc;
 pub mod variable_as_command_name;
+mod variable_reference_common;
 
 #[cfg(test)]
 mod tests {
@@ -243,6 +245,7 @@ mod tests {
     #[test_case(Rule::SubshellLocalAssignment, Path::new("C150.sh"))]
     #[test_case(Rule::CommaArrayElements, Path::new("C151.sh"))]
     #[test_case(Rule::SubshellSideEffect, Path::new("C155.sh"))]
+    #[test_case(Rule::PossibleVariableMisspelling, Path::new("C156.sh"))]
     #[test_case(Rule::IfBracketGlued, Path::new("C157.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {
         let snapshot = format!("{}_{}", rule.code(), path.display());

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -27,6 +27,7 @@ pub mod constant_comparison_test;
 pub mod continue_outside_loop_in_function;
 pub mod dangling_else;
 pub mod default_else_in_short_circuit;
+pub mod dollar_question_after_command;
 pub mod double_paren_grouping;
 pub mod dynamic_source_path;
 pub mod else_if;
@@ -209,6 +210,7 @@ mod tests {
     #[test_case(Rule::AtSignInStringCompare, Path::new("C111.sh"))]
     #[test_case(Rule::ArraySliceInComparison, Path::new("C112.sh"))]
     #[test_case(Rule::AppendToArrayAsString, Path::new("C106.sh"))]
+    #[test_case(Rule::DollarQuestionAfterCommand, Path::new("C107.sh"))]
     #[test_case(Rule::UnsetAssociativeArrayElement, Path::new("C108.sh"))]
     #[test_case(Rule::MapfileProcessSubstitution, Path::new("C109.sh"))]
     #[test_case(Rule::DefaultElseInShortCircuit, Path::new("C115.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -92,6 +92,7 @@ pub mod spaced_assignment;
 pub mod status_capture_after_branch_test;
 pub mod string_comparison_for_version;
 pub mod subshell_in_arithmetic;
+pub mod subshell_local_assignment;
 pub mod subst_with_redirect;
 pub mod subst_with_redirect_err;
 pub mod sudo_redirection_order;
@@ -238,6 +239,7 @@ mod tests {
     #[test_case(Rule::UntilMissingDo, Path::new("C146.sh"))]
     #[test_case(Rule::KeywordFunctionName, Path::new("C147.sh"))]
     #[test_case(Rule::BrokenAssocKey, Path::new("C148.sh"))]
+    #[test_case(Rule::SubshellLocalAssignment, Path::new("C150.sh"))]
     #[test_case(Rule::CommaArrayElements, Path::new("C151.sh"))]
     #[test_case(Rule::IfBracketGlued, Path::new("C157.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -1,0 +1,316 @@
+use rustc_hash::FxHashSet;
+use shuck_semantic::Binding;
+
+use crate::{Checker, Rule, Violation};
+
+use super::variable_reference_common::{
+    VariableReferenceFilter, has_same_name_defining_bindings, is_environment_style_name,
+    is_reportable_variable_reference, is_sc2154_defining_binding,
+};
+
+pub struct PossibleVariableMisspelling {
+    pub reference: String,
+    pub candidate: String,
+}
+
+impl Violation for PossibleVariableMisspelling {
+    fn rule() -> Rule {
+        Rule::PossibleVariableMisspelling
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "reference to `{}` looks like it may mean `{}`",
+            self.reference, self.candidate
+        )
+    }
+}
+
+pub fn possible_variable_misspelling(checker: &mut Checker) {
+    let mut findings = checker
+        .semantic()
+        .unresolved_references()
+        .iter()
+        .copied()
+        .filter_map(|reference_id| {
+            let reference = checker.semantic().reference(reference_id);
+            if !is_reportable_variable_reference(
+                checker,
+                reference,
+                VariableReferenceFilter {
+                    suppress_environment_style_names: false,
+                },
+            ) {
+                return None;
+            }
+            if !looks_like_case_mismatch_reference(reference.name.as_str()) {
+                return None;
+            }
+            if is_known_runtime_name(reference.name.as_str()) {
+                return None;
+            }
+            if has_same_name_defining_bindings(checker, &reference.name) {
+                return None;
+            }
+
+            let candidate = preferred_candidate_binding(checker, reference.name.as_str())?;
+            Some((
+                reference.span,
+                reference.name.to_string(),
+                candidate.name.to_string(),
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    findings.sort_by_key(|(span, _, _)| (span.start.offset, span.end.offset));
+    let mut reported_names = FxHashSet::default();
+
+    for (span, reference, candidate) in findings {
+        if !reported_names.insert(reference.clone()) {
+            continue;
+        }
+        checker.report(
+            PossibleVariableMisspelling {
+                reference,
+                candidate,
+            },
+            span,
+        );
+    }
+}
+
+fn looks_like_case_mismatch_reference(name: &str) -> bool {
+    is_environment_style_name(name)
+        && name.len() >= 4
+        && name.chars().any(|char| char.is_ascii_uppercase())
+}
+
+fn preferred_candidate_binding<'a>(
+    checker: &'a Checker<'_>,
+    target_name: &str,
+) -> Option<&'a Binding> {
+    let candidates = checker
+        .semantic()
+        .bindings()
+        .iter()
+        .filter(|binding| is_sc2154_defining_binding(binding.kind))
+        .filter(|binding| binding.name.as_str() != target_name)
+        .filter(|binding| binding.name.as_str().len() >= 4)
+        .filter_map(|binding| {
+            candidate_match_rank(target_name, binding.name.as_str()).map(|rank| (rank, binding))
+        })
+        .collect::<Vec<_>>();
+
+    let best_rank = candidates.iter().map(|(rank, _)| *rank).min()?;
+    let unique_best_candidates = candidates
+        .iter()
+        .filter(|(rank, _)| *rank == best_rank)
+        .map(|(_, binding)| canonical_uppercase_name(binding.name.as_str()))
+        .collect::<FxHashSet<_>>();
+    if unique_best_candidates.len() > 1 {
+        return None;
+    }
+
+    candidates
+        .into_iter()
+        .filter(|(rank, _)| *rank == best_rank)
+        .min_by_key(|(_, binding)| (binding.span.start.offset, binding.span.end.offset))
+        .map(|(_, binding)| binding)
+}
+
+fn canonical_uppercase_name(name: &str) -> String {
+    name.chars().map(|char| char.to_ascii_uppercase()).collect()
+}
+
+fn candidate_match_rank(target_name: &str, candidate_name: &str) -> Option<u8> {
+    let candidate_upper = canonical_uppercase_name(candidate_name);
+    if candidate_upper == target_name {
+        return Some(0);
+    }
+    if candidate_upper == format!("X{target_name}") {
+        return Some(1);
+    }
+
+    None
+}
+
+fn is_known_runtime_name(name: &str) -> bool {
+    matches!(
+        name,
+        "IFS"
+            | "USER"
+            | "HOME"
+            | "SHELL"
+            | "PWD"
+            | "TERM"
+            | "PATH"
+            | "CDPATH"
+            | "LANG"
+            | "SUDO_USER"
+            | "DOAS_USER"
+            | "PPID"
+            | "LINENO"
+            | "FUNCNAME"
+            | "BASH_SOURCE"
+            | "BASH_LINENO"
+            | "RANDOM"
+            | "BASH_REMATCH"
+            | "READLINE_LINE"
+            | "BASH_VERSION"
+            | "BASH_VERSINFO"
+            | "OSTYPE"
+            | "HISTCONTROL"
+            | "HISTSIZE"
+    ) || name.starts_with("LC_")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_exact_uppercase_fold_matches() {
+        let source = "\
+#!/bin/sh
+package_name=demo
+echo \"$PACKAGE_NAME\"
+FooBar=demo
+echo \"$FOOBAR\"
+foo1=demo
+echo \"$FOO1\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$PACKAGE_NAME", "$FOOBAR", "$FOO1"]
+        );
+    }
+
+    #[test]
+    fn reports_only_the_first_occurrence_of_a_name() {
+        let source = "\
+#!/bin/sh
+package_name=demo
+echo \"$PACKAGE_NAME\"
+echo \"$PACKAGE_NAME\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$PACKAGE_NAME"]
+        );
+    }
+
+    #[test]
+    fn ignores_short_names_mixed_case_refs_and_underscore_removal() {
+        let source = "\
+#!/bin/sh
+bar=demo
+echo \"$BAR\"
+foo=demo
+echo \"$Foo\"
+echo \"$fOo\"
+foo_bar=demo
+echo \"$FOOBAR\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_runtime_environment_names() {
+        let source = "\
+#!/bin/sh
+path=1
+echo \"$PATH\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_xprefixed_candidates() {
+        let source = "\
+#!/bin/sh
+XCPPFLAGS=1
+XCFLAGS=1
+XLDFLAGS=1
+CXXFLAGS=1
+echo \"$CPPFLAGS\"
+echo \"$CFLAGS\"
+echo \"$LDFLAGS\"
+echo \"$CXXFLAGS\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$CPPFLAGS", "$CFLAGS", "$LDFLAGS"]
+        );
+    }
+
+    #[test]
+    fn ignores_references_when_the_exact_same_name_is_defined_elsewhere() {
+        let source = "\
+#!/bin/sh
+f() { PACKAGE_NAME=demo; }
+echo \"$PACKAGE_NAME\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_candidates_even_when_the_assigned_name_is_in_a_function_or_later() {
+        let source = "\
+#!/bin/sh
+echo \"$PACKAGE_NAME\"
+f() { package_name=demo; }
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$PACKAGE_NAME"]
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C107_C107.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C107_C107.sh.snap
@@ -1,0 +1,27 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 231
+---
+C107 `$?` here reflects a later command, not the status you likely meant to keep
+ --> <source>:6:6
+  |
+6 | if [ $? -ne 0 ]; then :; fi
+  |
+
+C107 `$?` here reflects a later command, not the status you likely meant to keep
+  --> <source>:10:6
+   |
+10 | case $? in
+   |
+
+C107 `$?` here reflects a later command, not the status you likely meant to keep
+  --> <source>:17:10
+   |
+17 |   return $?
+   |
+
+C107 `$?` here reflects a later command, not the status you likely meant to keep
+  --> <source>:22:7
+   |
+22 | saved=$?
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C150_C150.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C150_C150.sh.snap
@@ -1,0 +1,15 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 233
+---
+C150 assignment to `$count` inside a subshell does not update the outer shell
+ --> <source>:6:7
+  |
+6 | echo "$count"
+  |
+
+C150 assignment to `$items` inside a subshell does not update the outer shell
+  --> <source>:10:16
+   |
+10 | printf '%s\n' "$items"
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C155_C155.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C155_C155.sh.snap
@@ -1,0 +1,21 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 235
+---
+C155 assignment to `count` only affects the child shell here
+ --> <source>:4:2
+  |
+4 | (count=1)
+  |
+
+C155 assignment to `value` only affects the child shell here
+ --> <source>:8:39
+  |
+8 | printf '%s\n' x | while read -r _; do value=inner; done
+  |
+
+C155 assignment to `path_prefix` only affects the child shell here
+  --> <source>:12:10
+   |
+12 |   export path_prefix=/opt/demo
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C156_C156.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C156_C156.sh.snap
@@ -1,0 +1,15 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 238
+---
+C156 reference to `FOOBAR` looks like it may mean `FooBar`
+ --> <source>:8:7
+  |
+8 | echo "$FOOBAR"
+  |
+
+C156 reference to `FOO1` looks like it may mean `foo1`
+  --> <source>:11:7
+   |
+11 | echo "$FOO1"
+   |

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -1,0 +1,263 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct SubshellLocalAssignment {
+    pub name: String,
+}
+
+impl Violation for SubshellLocalAssignment {
+    fn rule() -> Rule {
+        Rule::SubshellLocalAssignment
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "assignment to `{}` inside a subshell does not update the outer shell",
+            self.name
+        )
+    }
+}
+
+pub fn subshell_local_assignment(checker: &mut Checker) {
+    let spans = checker.facts().subshell_local_assignment_spans().to_vec();
+
+    for span in spans {
+        let name = span.slice(checker.source()).to_owned();
+        checker.report(SubshellLocalAssignment { name }, span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_reads_that_still_see_the_outer_binding_after_a_subshell_assignment() {
+        let source = "\
+#!/bin/sh
+count=0
+(count=1)
+echo \"$count\"
+items=old
+(items=new)
+printf '%s\\n' \"$items\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$count", "$items"]
+        );
+    }
+
+    #[test]
+    fn ignores_pipeline_cases_and_parent_reassignments() {
+        let source = "\
+#!/bin/sh
+count=0
+printf '%s\\n' x | while read -r _; do count=1; done
+echo \"$count\"
+items=old
+(items=new)
+items=latest
+echo \"$items\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_local_declarations_inside_subshells() {
+        let source = "\
+#!/bin/bash
+demo() {
+  value=outer
+  (local value=inner)
+  echo \"$value\"
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_command_substitution_assignments_that_do_not_escape() {
+        let source = "\
+#!/bin/bash
+value=outer
+snapshot=\"$(
+  value=inner
+  printf '%s\\n' done
+)\"
+echo \"$value\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$value"]
+        );
+    }
+
+    #[test]
+    fn ignores_reads_that_stay_inside_the_same_command_substitution() {
+        let source = "\
+#!/bin/bash
+value=outer
+snapshot=\"$(
+  value=inner
+  printf '%s\\n' \"$value\"
+)\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_later_reads_when_the_only_assignment_was_exported_inside_a_subshell() {
+        let source = "\
+#!/bin/sh
+(
+  export value=inner
+)
+printf '%s\\n' \"$value\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$value"]
+        );
+    }
+
+    #[test]
+    fn ignores_cross_function_reads_after_a_parent_shell_reset() {
+        let source = "\
+#!/bin/sh
+first() {
+  (
+    export value=inner
+  )
+}
+second() {
+  value=outer
+}
+third() {
+  printf '%s\\n' \"$value\"
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_later_export_reassignments_after_a_subshell_assignment() {
+        let source = "\
+#!/bin/sh
+demo() {
+  (
+    export value=inner
+  )
+  export value=outer
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["value"]
+        );
+    }
+
+    #[test]
+    fn reports_later_append_assignments_after_a_subshell_assignment() {
+        let source = "\
+#!/bin/bash
+demo() {
+  (
+    value=inner
+  )
+  value+=-suffix
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["value"]
+        );
+    }
+
+    #[test]
+    fn reports_self_reference_inside_later_export_after_a_subshell_assignment() {
+        let source = "\
+#!/bin/sh
+first() {
+  (
+    export PATH=/usr/bin:$PATH
+  )
+}
+second() {
+  export PATH=$HOME/bin:$PATH
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["PATH", "$PATH"]
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -1,0 +1,139 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct SubshellSideEffect {
+    pub name: String,
+}
+
+impl Violation for SubshellSideEffect {
+    fn rule() -> Rule {
+        Rule::SubshellSideEffect
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "assignment to `{}` only affects the child shell here",
+            self.name
+        )
+    }
+}
+
+pub fn subshell_side_effect(checker: &mut Checker) {
+    let spans = checker.facts().subshell_side_effect_spans().to_vec();
+
+    for span in spans {
+        let name = span.slice(checker.source()).to_owned();
+        checker.report(SubshellSideEffect { name }, span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_subshell_assignment_sites_that_have_later_outer_reads() {
+        let source = "\
+#!/bin/sh
+count=0
+(count=1)
+echo \"$count\"
+items=old
+(items=new)
+printf '%s\\n' \"$items\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["count", "items"]
+        );
+    }
+
+    #[test]
+    fn reports_pipeline_child_assignments_that_do_not_escape() {
+        let source = "\
+#!/bin/sh
+count=0
+printf '%s\\n' x | while read -r _; do count=1; done
+echo \"$count\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["count"]
+        );
+    }
+
+    #[test]
+    fn reports_command_substitution_assignment_sites_that_have_later_outer_reads() {
+        let source = "\
+#!/bin/bash
+value=outer
+snapshot=\"$(
+  value=inner
+  printf '%s\\n' done
+)\"
+echo \"$value\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["value"]
+        );
+    }
+
+    #[test]
+    fn ignores_child_shell_assignments_without_later_outer_uses() {
+        let source = "\
+#!/bin/sh
+count=0
+(count=1)
+printf '%s\\n' done
+printf '%s\\n' x | while read -r _; do items=1; done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_local_declarations_inside_subshells() {
+        let source = "\
+#!/bin/bash
+demo() {
+  value=outer
+  (local value=inner)
+  echo \"$value\"
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_child_shell_assignments_when_the_parent_resets_before_reuse() {
+        let source = "\
+#!/bin/sh
+count=0
+printf '%s\\n' x | while read -r _; do count=1; done
+count=2
+echo \"$count\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1,7 +1,12 @@
 use rustc_hash::FxHashSet;
-use shuck_semantic::{BindingKind, ReferenceKind, UninitializedCertainty};
+use shuck_semantic::UninitializedCertainty;
 
 use crate::{Checker, Rule, Violation};
+
+use super::variable_reference_common::{
+    VariableReferenceFilter, has_same_name_defining_bindings, is_reportable_variable_reference,
+    is_sc2154_defining_binding,
+};
 
 pub struct UndefinedVariable {
     pub name: String,
@@ -46,48 +51,31 @@ pub fn undefined_variable(checker: &mut Checker) {
         if reported_names.contains(&reference.name) || suppressed_names.contains(&reference.name) {
             continue;
         }
-        if matches!(
-            reference.kind,
-            ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
+        if !is_reportable_variable_reference(
+            checker,
+            reference,
+            VariableReferenceFilter {
+                suppress_environment_style_names: true,
+            },
         ) {
             continue;
         }
-        if is_shell_special_parameter(reference.name.as_str()) {
-            suppressed_names.insert(reference.name.clone());
-            continue;
-        }
-        if is_environment_style_name(reference.name.as_str()) {
-            suppressed_names.insert(reference.name.clone());
-            continue;
-        }
-        if checker
-            .facts()
-            .presence_tested_names()
-            .contains(&reference.name)
+        if has_same_name_defining_bindings(checker, &reference.name)
+            && !checker
+                .semantic()
+                .bindings_for(&reference.name)
+                .iter()
+                .copied()
+                .filter(|binding_id| {
+                    is_sc2154_defining_binding(checker.semantic().binding(*binding_id).kind)
+                })
+                .all(|binding_id| {
+                    let binding = checker.semantic().binding(binding_id);
+                    binding.span.start.line == reference.span.start.line
+                        && binding.span.start.offset < reference.span.start.offset
+                })
         {
             suppressed_names.insert(reference.name.clone());
-            continue;
-        }
-        let defining_bindings: Vec<_> = checker
-            .semantic()
-            .bindings_for(&reference.name)
-            .iter()
-            .copied()
-            .filter(|binding_id| {
-                is_sc2154_defining_binding(checker.semantic().binding(*binding_id).kind)
-            })
-            .collect();
-        if !defining_bindings.is_empty()
-            && !defining_bindings.iter().all(|binding_id| {
-                let binding = checker.semantic().binding(*binding_id);
-                binding.span.start.line == reference.span.start.line
-                    && binding.span.start.offset < reference.span.start.offset
-            })
-        {
-            suppressed_names.insert(reference.name.clone());
-            continue;
-        }
-        if checker.facts().is_subscript_index_reference(reference.span) {
             continue;
         }
         if !reported_names.insert(reference.name.clone()) {
@@ -102,23 +90,4 @@ pub fn undefined_variable(checker: &mut Checker) {
             reference.span,
         );
     }
-}
-
-fn is_shell_special_parameter(name: &str) -> bool {
-    matches!(name, "@" | "*" | "#" | "?" | "-" | "$" | "!" | "0")
-        || (!name.is_empty() && name.chars().all(|char| char.is_ascii_digit()))
-}
-
-fn is_environment_style_name(name: &str) -> bool {
-    !name.is_empty()
-        && name
-            .chars()
-            .all(|char| char.is_ascii_uppercase() || char.is_ascii_digit() || char == '_')
-}
-
-fn is_sc2154_defining_binding(kind: BindingKind) -> bool {
-    !matches!(
-        kind,
-        BindingKind::FunctionDefinition | BindingKind::Imported
-    )
 }

--- a/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
@@ -1,0 +1,75 @@
+use shuck_ast::Name;
+use shuck_semantic::{BindingKind, Reference, ReferenceKind};
+
+use crate::Checker;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct VariableReferenceFilter {
+    pub suppress_environment_style_names: bool,
+}
+
+pub(super) fn is_reportable_variable_reference(
+    checker: &Checker<'_>,
+    reference: &Reference,
+    filter: VariableReferenceFilter,
+) -> bool {
+    if matches!(
+        reference.kind,
+        ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
+    ) {
+        return false;
+    }
+    if is_shell_special_parameter(reference.name.as_str()) {
+        return false;
+    }
+    if filter.suppress_environment_style_names && is_environment_style_name(reference.name.as_str())
+    {
+        return false;
+    }
+    if checker
+        .facts()
+        .presence_tested_names()
+        .contains(&reference.name)
+    {
+        return false;
+    }
+    if checker.facts().is_subscript_index_reference(reference.span) {
+        return false;
+    }
+    if checker
+        .semantic()
+        .is_guarded_parameter_reference(reference.id)
+    {
+        return false;
+    }
+
+    true
+}
+
+pub(super) fn is_environment_style_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|char| char.is_ascii_uppercase() || char.is_ascii_digit() || char == '_')
+}
+
+pub(super) fn is_sc2154_defining_binding(kind: BindingKind) -> bool {
+    !matches!(
+        kind,
+        BindingKind::FunctionDefinition | BindingKind::Imported
+    )
+}
+
+pub(super) fn has_same_name_defining_bindings(checker: &Checker<'_>, name: &Name) -> bool {
+    checker
+        .semantic()
+        .bindings_for(name)
+        .iter()
+        .copied()
+        .any(|binding_id| is_sc2154_defining_binding(checker.semantic().binding(binding_id).kind))
+}
+
+fn is_shell_special_parameter(name: &str) -> bool {
+    matches!(name, "@" | "*" | "#" | "?" | "-" | "$" | "!" | "0")
+        || (!name.is_empty() && name.chars().all(|char| char.is_ascii_digit()))
+}

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -446,6 +446,7 @@ impl Default for ShellCheckCodeMap {
             (2277, Rule::ExtglobInCasePattern),
             (2030, Rule::SubshellSideEffect),
             (2031, Rule::SubshellLocalAssignment),
+            (2153, Rule::PossibleVariableMisspelling),
             (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::StatusCaptureAfterBranchTest),
             (2337, Rule::DollarQuestionAfterCommand),
@@ -579,6 +580,7 @@ impl Default for ShellCheckCodeMap {
                     (2016, Rule::SingleQuotedLiteral),
                     (2030, Rule::SubshellSideEffect),
                     (2031, Rule::SubshellLocalAssignment),
+                    (2153, Rule::PossibleVariableMisspelling),
                     (2013, Rule::LineOrientedInput),
                     (2015, Rule::ChainedTestBranches),
                     (2014, Rule::UnquotedGlobsInFind),
@@ -1328,6 +1330,10 @@ mod tests {
         assert_eq!(map.resolve("SC2168"), Some(Rule::LocalTopLevel));
         assert_eq!(map.resolve("SC2194"), Some(Rule::ConstantCaseSubject));
         assert_eq!(map.resolve("SC2210"), Some(Rule::BadRedirectionFdOrder));
+        assert_eq!(
+            map.resolve("SC2153"),
+            Some(Rule::PossibleVariableMisspelling)
+        );
         assert_eq!(map.resolve("sc2154"), Some(Rule::UndefinedVariable));
         assert_eq!(map.resolve("SC2241"), Some(Rule::InvalidExitStatus));
         assert_eq!(map.resolve("SC2242"), Some(Rule::CasePatternVar));
@@ -1672,6 +1678,7 @@ mod tests {
             (2294, Rule::EvalOnArray),
             (2030, Rule::SubshellSideEffect),
             (2031, Rule::SubshellLocalAssignment),
+            (2153, Rule::PossibleVariableMisspelling),
             (2302, Rule::EscapedNegationInTest),
             (2308, Rule::GreaterThanInTest),
             (2309, Rule::StringComparisonForVersion),

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -444,6 +444,7 @@ impl Default for ShellCheckCodeMap {
             (2120, Rule::FunctionCalledWithoutArgs),
             (2364, Rule::FunctionReferencesUnsetParam),
             (2277, Rule::ExtglobInCasePattern),
+            (2030, Rule::SubshellSideEffect),
             (2031, Rule::SubshellLocalAssignment),
             (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::StatusCaptureAfterBranchTest),
@@ -576,6 +577,7 @@ impl Default for ShellCheckCodeMap {
                     (3070, Rule::AmpersandRedirectInSh),
                     (3073, Rule::PipeStderrInSh),
                     (2016, Rule::SingleQuotedLiteral),
+                    (2030, Rule::SubshellSideEffect),
                     (2031, Rule::SubshellLocalAssignment),
                     (2013, Rule::LineOrientedInput),
                     (2015, Rule::ChainedTestBranches),
@@ -920,6 +922,7 @@ mod tests {
         assert_eq!(map.resolve("SC2307"), Some(Rule::UnquotedVariableInTest));
         assert_eq!(map.resolve("SC2379"), Some(Rule::EnvPrefixQuoting));
         assert_eq!(map.resolve("SC2140"), Some(Rule::MixedQuoteWord));
+        assert_eq!(map.resolve("SC2030"), Some(Rule::SubshellSideEffect));
         assert_eq!(map.resolve("SC2031"), Some(Rule::SubshellLocalAssignment));
         assert_eq!(map.resolve("SC2320"), Some(Rule::UnquotedPipeInEcho));
         assert_eq!(
@@ -1667,6 +1670,7 @@ mod tests {
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (2294, Rule::EvalOnArray),
+            (2030, Rule::SubshellSideEffect),
             (2031, Rule::SubshellLocalAssignment),
             (2302, Rule::EscapedNegationInTest),
             (2308, Rule::GreaterThanInTest),

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -444,6 +444,7 @@ impl Default for ShellCheckCodeMap {
             (2120, Rule::FunctionCalledWithoutArgs),
             (2364, Rule::FunctionReferencesUnsetParam),
             (2277, Rule::ExtglobInCasePattern),
+            (2031, Rule::SubshellLocalAssignment),
             (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::StatusCaptureAfterBranchTest),
             (2337, Rule::DollarQuestionAfterCommand),
@@ -575,6 +576,7 @@ impl Default for ShellCheckCodeMap {
                     (3070, Rule::AmpersandRedirectInSh),
                     (3073, Rule::PipeStderrInSh),
                     (2016, Rule::SingleQuotedLiteral),
+                    (2031, Rule::SubshellLocalAssignment),
                     (2013, Rule::LineOrientedInput),
                     (2015, Rule::ChainedTestBranches),
                     (2014, Rule::UnquotedGlobsInFind),
@@ -726,6 +728,7 @@ impl Default for ShellCheckCodeMap {
                     (2277, Rule::ExtglobInCasePattern),
                     (2100, Rule::AssignmentLooksLikeComparison),
                     (2319, Rule::StatusCaptureAfterBranchTest),
+                    (2337, Rule::DollarQuestionAfterCommand),
                     (2141, Rule::IfsSetToLiteralBackslashN),
                     (2365, Rule::UnreachableAfterExit),
                     (2370, Rule::UnusedHeredoc),
@@ -917,6 +920,7 @@ mod tests {
         assert_eq!(map.resolve("SC2307"), Some(Rule::UnquotedVariableInTest));
         assert_eq!(map.resolve("SC2379"), Some(Rule::EnvPrefixQuoting));
         assert_eq!(map.resolve("SC2140"), Some(Rule::MixedQuoteWord));
+        assert_eq!(map.resolve("SC2031"), Some(Rule::SubshellLocalAssignment));
         assert_eq!(map.resolve("SC2320"), Some(Rule::UnquotedPipeInEcho));
         assert_eq!(
             map.resolve("SC2337"),
@@ -1663,6 +1667,7 @@ mod tests {
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (2294, Rule::EvalOnArray),
+            (2031, Rule::SubshellLocalAssignment),
             (2302, Rule::EscapedNegationInTest),
             (2308, Rule::GreaterThanInTest),
             (2309, Rule::StringComparisonForVersion),

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -446,6 +446,7 @@ impl Default for ShellCheckCodeMap {
             (2277, Rule::ExtglobInCasePattern),
             (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::StatusCaptureAfterBranchTest),
+            (2337, Rule::DollarQuestionAfterCommand),
             (2141, Rule::IfsSetToLiteralBackslashN),
             (2365, Rule::UnreachableAfterExit),
             (2370, Rule::UnusedHeredoc),
@@ -917,6 +918,10 @@ mod tests {
         assert_eq!(map.resolve("SC2379"), Some(Rule::EnvPrefixQuoting));
         assert_eq!(map.resolve("SC2140"), Some(Rule::MixedQuoteWord));
         assert_eq!(map.resolve("SC2320"), Some(Rule::UnquotedPipeInEcho));
+        assert_eq!(
+            map.resolve("SC2337"),
+            Some(Rule::DollarQuestionAfterCommand)
+        );
         assert_eq!(map.resolve("SC2223"), Some(Rule::DefaultValueInColonAssign));
         assert_eq!(map.resolve("SC2346"), Some(Rule::DefaultValueInColonAssign));
         assert_eq!(map.resolve("SC2298"), Some(Rule::UnquotedTrRange));
@@ -1333,6 +1338,10 @@ mod tests {
             Some(Rule::StatusCaptureAfterBranchTest)
         );
         assert_eq!(
+            map.resolve("SC2337"),
+            Some(Rule::DollarQuestionAfterCommand)
+        );
+        assert_eq!(
             map.resolve_all("SC2319"),
             vec![
                 Rule::StatusCaptureAfterBranchTest,
@@ -1665,6 +1674,7 @@ mod tests {
             (2316, Rule::BacktickInCommandPosition),
             (2313, Rule::ZshNestedExpansion),
             (2319, Rule::StatusCaptureAfterBranchTest),
+            (2337, Rule::DollarQuestionAfterCommand),
             (2120, Rule::FunctionCalledWithoutArgs),
             (2141, Rule::IfsSetToLiteralBackslashN),
             (2364, Rule::FunctionReferencesUnsetParam),

--- a/crates/shuck/tests/testdata/corpus-metadata/c107.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c107.yaml
@@ -1,0 +1,30 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2337"
+    reason: "The pinned ShellCheck build does not compare this echo-or-printf status-clobber pattern under SC2337 in the corpus run, so the remaining reviewed sites stay fixture-scoped."
+
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "scripts/rvm__rvm__contrib__gemset_snapshot"
+    line: 26
+    column: 6
+    end_line: 26
+    end_column: 8
+    reason: "This trailing `exit $?` reads the completion message `printf` status instead of preserving the earlier snapshot work result. Shuck keeps that status-clobber warning even though the pinned ShellCheck comparison is silent here."
+  - side: shuck-only
+    path_suffix: "scripts/rvm__rvm__scripts__gemsets"
+    line: 122
+    column: 10
+    end_line: 122
+    end_column: 12
+    labels:
+      - project-closure
+    reason: "This helper returns `$?` immediately after `echo`, so it propagates the output command status rather than a prior operation result. Shuck keeps that warning for this reviewed project-closure site."
+  - side: shuck-only
+    path_suffix: "scripts/rvm__rvm__scripts__gemsets"
+    line: 128
+    column: 10
+    end_line: 128
+    end_column: 12
+    labels:
+      - project-closure
+    reason: "This helper returns `$?` immediately after `echo`, so it propagates the output command status rather than a prior operation result. Shuck keeps that warning for this reviewed project-closure site."

--- a/crates/shuck/tests/testdata/corpus-metadata/c150.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c150.yaml
@@ -1,0 +1,110 @@
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "acmesh-official__acme.sh__acme.sh"
+    line: 5908
+    end_line: 5908
+    column: 69
+    end_column: 76
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This renewal-list helper compares through directive-handling and project-closure, and the remaining C150 difference is the exact anchor inside one dense formatted expansion. The warning shape matches, but the oracle pins the later-use span on the `Le_Alt` expansion while shuck currently lands slightly earlier in the same output expression."
+  - side: shuck-only
+    path_suffix: "acmesh-official__acme.sh__acme.sh"
+    line: 5908
+    end_line: 5908
+    column: 67
+    end_column: 74
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This renewal-list helper compares through directive-handling and project-closure, and the remaining C150 difference is the exact anchor inside one dense formatted expansion. The warning shape matches, but shuck currently lands slightly earlier in the same output expression than the oracle."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 1318
+    labels:
+      - helper-library
+      - project-closure
+    reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 1502
+    labels:
+      - helper-library
+      - project-closure
+    reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 1520
+    labels:
+      - helper-library
+      - project-closure
+    reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 1521
+    labels:
+      - helper-library
+      - project-closure
+    reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 1883
+    labels:
+      - helper-library
+      - project-closure
+    reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__cli"
+    line: 404
+    labels:
+      - project-closure
+    reason: "This project-closure helper gets its effective `__search_list` mutation through sourced helper behavior that shuck still does not promote into a later-read C150 fact."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__installer"
+    line: 236
+    labels:
+      - project-closure
+    reason: "This installer helper's remaining C150 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__installer"
+    line: 280
+    labels:
+      - project-closure
+    reason: "This installer helper's remaining C150 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__installer"
+    line: 285
+    labels:
+      - project-closure
+    reason: "This installer helper's remaining C150 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__gemsets"
+    line: 379
+    labels:
+      - project-closure
+    reason: "This gemset helper's remaining C150 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__gemsets"
+    line: 510
+    labels:
+      - project-closure
+    reason: "This gemset helper's remaining C150 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__gemsets"
+    line: 514
+    labels:
+      - project-closure
+    reason: "This gemset helper's remaining C150 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__tools"
+    line: 106
+    labels:
+      - project-closure
+    reason: "This tools helper's remaining C150 hits depend on sourced helper-side effects for `HOME` inside project-closure analysis, which shuck does not yet lift into later-read facts."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__tools"
+    line: 128
+    labels:
+      - project-closure
+    reason: "This tools helper's remaining C150 hits depend on sourced helper-side effects for `HOME` inside project-closure analysis, which shuck does not yet lift into later-read facts."

--- a/crates/shuck/tests/testdata/corpus-metadata/c155.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c155.yaml
@@ -1,0 +1,47 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 916
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C155 hit comes from file-wide later-use inference across helper-library and project-closure analysis where the pinned oracle stays silent."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 919
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C155 hit comes from file-wide later-use inference across helper-library and project-closure analysis where the pinned oracle stays silent."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 922
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C155 hit comes from file-wide later-use inference across helper-library and project-closure analysis where the pinned oracle stays silent."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 925
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C155 hit comes from file-wide later-use inference across helper-library and project-closure analysis where the pinned oracle stays silent."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__cli"
+    line: 385
+    labels:
+      - project-closure
+    reason: "This function-style subshell relies on helper-side mutation flow through sourced project-closure behavior, which shuck does not yet promote into a later-read C155 fact."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__installer"
+    line: 226
+    labels:
+      - project-closure
+    reason: "This installer subshell mutates `rvm_path` only for a helper path that is compared through project-closure analysis, and shuck does not currently lift that sourced helper dependency into C155."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__tools"
+    line: 69
+    labels:
+      - project-closure
+    reason: "This HOME reassignment sits in a helper path whose observable effect depends on project-closure context from sibling helper execution, which shuck does not currently model as a C155 side effect."

--- a/crates/shuck/tests/testdata/corpus-metadata/c156.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c156.yaml
@@ -1,0 +1,387 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "dylanaraps__neofetch__neofetch"
+    line: 4919
+    end_line: 4919
+    column: 33
+    end_column: 38
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "PPID is a shell-provided parent-process variable here, so the uppercase read can be intentional even though a lowercase helper binding exists elsewhere in the script."
+  - side: shellcheck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__drush__drush.complete.sh"
+    line: 24
+    end_line: 24
+    column: 20
+    end_column: 32
+    labels:
+      - helper-library
+      - shell-collapse
+    reason: "This helper intentionally mirrors a project-specific double-underscore variable name, and shuck keeps C156 narrower than ShellCheck's helper-name guessing in collapsed plugin code."
+  - side: shellcheck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
+    line: 197
+    end_line: 197
+    column: 67
+    end_column: 85
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This is a one-off string typo inside helper code, but shuck does not broaden C156 into a general edit-distance spell checker for arbitrary uppercase names."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 116
+    end_line: 116
+    column: 11
+    end_column: 16
+    labels:
+      - helper-library
+      - project-closure
+    reason: "NAME is populated by the sourced os-release file in this branch, so matching it against an unrelated lowercase helper name elsewhere in the file is misleading."
+  - side: shellcheck-only
+    path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
+    line: 423
+    end_line: 423
+    column: 35
+    end_column: 67
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "The trailing-underscore variant is a project-specific helper naming convention, and shuck intentionally avoids teaching C156 every collapsed helper suffix pattern."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__gemset"
+    line: 146
+    end_line: 146
+    column: 38
+    end_column: 47
+    reason: "GEM_HOME is a standard runtime variable in this Ruby tooling flow, so treating it as a misspelling of a lowercase helper binding is too aggressive."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__alpine__build.sh"
+    line: 27
+    end_line: 27
+    column: 17
+    end_column: 24
+    reason: "Shuck keeps C156 focused on close naming conventions rather than arbitrary single-character insertions between distinct toolchain variable names."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__ghostscript__build.sh"
+    line: 36
+    end_line: 36
+    column: 21
+    end_column: 32
+    reason: "This underscore-free alias is a broader fuzzy-match case than shuck intentionally handles for C156."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__nethack__build.sh"
+    line: 30
+    end_line: 30
+    column: 13
+    end_column: 21
+    reason: "This warning depends on a loose single-letter omission heuristic, and shuck intentionally keeps C156 narrower to avoid false positives."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__restic-server__build.sh"
+    line: 14
+    end_line: 14
+    column: 11
+    end_column: 20
+    reason: "The underscore-prefixed alias here is a packaging-specific helper name, and shuck does not treat every prefixed variant as a misspelling."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__syncthing__build.sh"
+    line: 27
+    end_line: 27
+    column: 18
+    end_column: 27
+    reason: "This underscore-inserted helper alias is intentionally outside shuck's narrower C156 matching policy."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__syncthing__build.sh"
+    line: 29
+    end_line: 29
+    column: 16
+    end_column: 23
+    reason: "This underscore-inserted helper alias is intentionally outside shuck's narrower C156 matching policy."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__virglrenderer-android__build.sh"
+    line: 28
+    end_line: 28
+    column: 34
+    end_column: 55
+    reason: "The doubled-prefix helper name here is a packaging-specific convention, not a C156 pattern that shuck deliberately guesses."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__root-packages__lvm2__build.sh"
+    line: 28
+    end_line: 28
+    column: 19
+    end_column: 27
+    reason: "This warning relies on a custom helper alias with an inserted prefix character, which shuck intentionally leaves outside the core C156 heuristic."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_zig.sh"
+    line: 11
+    end_line: 11
+    column: 76
+    end_column: 97
+    labels:
+      - directive-handling
+    reason: "This sourced build helper intentionally threads different TERMUX_* variables together, and shuck does not treat those project-specific name shifts as misspellings."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__build__toolchain__termux_setup_toolchain_23c.sh"
+    line: 6
+    end_line: 6
+    column: 12
+    end_column: 33
+    reason: "The prefixed toolchain helper variable in this packaging script is outside shuck's deliberately narrow C156 matching rules."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__build__toolchain__termux_setup_toolchain_29.sh"
+    line: 6
+    end_line: 6
+    column: 12
+    end_column: 33
+    reason: "The prefixed toolchain helper variable in this packaging script is outside shuck's deliberately narrow C156 matching rules."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__build__toolchain__termux_setup_toolchain_gnu.sh"
+    line: 6
+    end_line: 6
+    column: 12
+    end_column: 33
+    reason: "The prefixed toolchain helper variable in this packaging script is outside shuck's deliberately narrow C156 matching rules."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
+    line: 417
+    end_line: 417
+    column: 70
+    end_column: 87
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
+    line: 418
+    end_line: 418
+    column: 68
+    end_column: 83
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
+    line: 419
+    end_line: 419
+    column: 74
+    end_column: 95
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
+    line: 420
+    end_line: 420
+    column: 69
+    end_column: 85
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
+    line: 421
+    end_line: 421
+    column: 69
+    end_column: 85
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
+    line: 435
+    end_line: 435
+    column: 28
+    end_column: 45
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
+    line: 436
+    end_line: 436
+    column: 30
+    end_column: 49
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
+    line: 128
+    end_line: 128
+    column: 17
+    end_column: 32
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "FUNCNAME is a Bash runtime array in this error helper, so matching it against an unrelated lowercase helper variable elsewhere in the file is too aggressive."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__cross.sh"
+    line: 131
+    end_line: 131
+    column: 5
+    end_column: 21
+    labels:
+      - shell-collapse
+    reason: "This cross-build helper intentionally distinguishes *_XCMD from *_CMD names, and shuck keeps C156 narrower than ShellCheck's project-specific helper guess."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__disabled-packages__botan2__build.sh"
+    line: 27
+    end_line: 27
+    column: 14
+    end_column: 23
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__disabled-packages__odin__build.sh"
+    line: 26
+    end_line: 26
+    column: 18
+    end_column: 27
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__aria2__build.sh"
+    line: 30
+    end_line: 30
+    column: 13
+    end_column: 30
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__botan3__build.sh"
+    line: 27
+    end_line: 27
+    column: 14
+    end_column: 23
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__dar__build.sh"
+    line: 19
+    end_line: 19
+    column: 14
+    end_column: 23
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__libnss__build.sh"
+    line: 51
+    end_line: 51
+    column: 12
+    end_column: 19
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__libpluto__build.sh"
+    line: 50
+    end_line: 50
+    column: 12
+    end_column: 23
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__libt3widget__build.sh"
+    line: 39
+    end_line: 39
+    column: 14
+    end_column: 23
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__libtsduck__build.sh"
+    line: 79
+    end_line: 79
+    column: 29
+    end_column: 38
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__nginx__build.sh"
+    line: 50
+    end_line: 50
+    column: 28
+    end_column: 35
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__ninja__build.sh"
+    line: 12
+    end_line: 12
+    column: 14
+    end_column: 23
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__nmon__build.sh"
+    line: 26
+    end_line: 26
+    column: 6
+    end_column: 13
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__oma__build.sh"
+    line: 49
+    end_line: 49
+    column: 14
+    end_column: 23
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__p7zip__build.sh"
+    line: 15
+    end_line: 15
+    column: 29
+    end_column: 38
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__p7zip__build.sh"
+    line: 21
+    end_line: 21
+    column: 28
+    end_column: 35
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__samba__build.sh"
+    line: 94
+    end_line: 94
+    column: 10
+    end_column: 17
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__tilde__build.sh"
+    line: 37
+    end_line: 37
+    column: 14
+    end_column: 23
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__tracepath__build.sh"
+    line: 23
+    end_line: 23
+    column: 6
+    end_column: 13
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__root-packages__nfs-utils__build.sh"
+    line: 38
+    end_line: 38
+    column: 7
+    end_column: 14
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__root-packages__v4l-utils__build.sh"
+    line: 33
+    end_line: 33
+    column: 6
+    end_column: 13
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__x11-packages__azpainter__build.sh"
+    line: 22
+    end_line: 22
+    column: 21
+    end_column: 28
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__x11-packages__scrot__build.sh"
+    line: 25
+    end_line: 25
+    column: 6
+    end_column: 13
+    reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -394,7 +394,7 @@ propagate. Require semantic scope analysis and are high complexity.
 
 - [x] **H** C107 (SC2337) `dollar-question-after-command` — `$?` checked after intervening command
 - [x] **H** C150 (SC2031) `subshell-local-assignment` — variable assigned in subshell does not propagate
-- [ ] **H** C155 (SC2030) `subshell-side-effect` — value updated in pipeline child, read afterward
+- [x] **H** C155 (SC2030) `subshell-side-effect` — value updated in pipeline child, read afterward
 - [ ] **H** C156 (SC2153) `possible-variable-misspelling` — referenced variable looks like misspelling
 
 ### Heredoc Issues

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -395,7 +395,7 @@ propagate. Require semantic scope analysis and are high complexity.
 - [x] **H** C107 (SC2337) `dollar-question-after-command` — `$?` checked after intervening command
 - [x] **H** C150 (SC2031) `subshell-local-assignment` — variable assigned in subshell does not propagate
 - [x] **H** C155 (SC2030) `subshell-side-effect` — value updated in pipeline child, read afterward
-- [ ] **H** C156 (SC2153) `possible-variable-misspelling` — referenced variable looks like misspelling
+- [x] **H** C156 (SC2153) `possible-variable-misspelling` — referenced variable looks like misspelling
 
 ### Heredoc Issues
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -392,7 +392,7 @@ rules require pattern analysis and are high complexity.
 Rules about variable mutations inside subshells and pipelines that do not
 propagate. Require semantic scope analysis and are high complexity.
 
-- [ ] **H** C107 (SC2337) `dollar-question-after-command` — `$?` checked after intervening command
+- [x] **H** C107 (SC2337) `dollar-question-after-command` — `$?` checked after intervening command
 - [ ] **H** C150 (SC2031) `subshell-local-assignment` — variable assigned in subshell does not propagate
 - [ ] **H** C155 (SC2030) `subshell-side-effect` — value updated in pipeline child, read afterward
 - [ ] **H** C156 (SC2153) `possible-variable-misspelling` — referenced variable looks like misspelling

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -393,7 +393,7 @@ Rules about variable mutations inside subshells and pipelines that do not
 propagate. Require semantic scope analysis and are high complexity.
 
 - [x] **H** C107 (SC2337) `dollar-question-after-command` — `$?` checked after intervening command
-- [ ] **H** C150 (SC2031) `subshell-local-assignment` — variable assigned in subshell does not propagate
+- [x] **H** C150 (SC2031) `subshell-local-assignment` — variable assigned in subshell does not propagate
 - [ ] **H** C155 (SC2030) `subshell-side-effect` — value updated in pipeline child, read afterward
 - [ ] **H** C156 (SC2153) `possible-variable-misspelling` — referenced variable looks like misspelling
 


### PR DESCRIPTION
## Summary
- implement C107 (`dollar-question-after-command`) so `$?` is only flagged when an intervening command actually clobbers the status being checked
- implement C150 (`subshell-local-assignment`) and C155 (`subshell-side-effect`) on top of shared nonpersistent-assignment analysis in `facts.rs`
- implement C156 (`possible-variable-misspelling`) with shared variable-reference filtering reused with `undefined_variable`, keeping the misspelling heuristic intentionally narrow and recording reviewed corpus divergences separately
- check off the completed rules in `docs/rules.md` and add targeted corpus metadata for reviewed divergences

## Why
These correctness rules were still missing from the subshell/pipeline side-effects group. The main risk here was duplicating scope and expansion/reference logic in individual rules, so this stacks the behavior on shared facts and shared reference filtering instead.

## Validation
- `cargo test -p shuck-linter subshell_side_effect -- --nocapture`
- `cargo test -p shuck-linter subshell_local_assignment -- --nocapture`
- `cargo test -p shuck-linter possible_variable_misspelling -- --nocapture`
- `cargo test -p shuck-linter undefined_variable -- --nocapture`
- `cargo test -p shuck-linter rule_possiblevariablemisspelling_path_new_c156_sh_expects -- --nocapture`
- 100% compatibility-side large-corpus validation for `C107`, `C150`, `C155`, and `C156` using `SHUCK_LARGE_CORPUS_RULES=<rule>` with `SHUCK_LARGE_CORPUS_MAPPED_ONLY=1` and `SHUCK_LARGE_CORPUS_KEEP_GOING=1`
