### PR TITLE
Implement style rules S061, S063, S064, and S068

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/style/S061.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S061.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+fgrep foo file
+fgrep
+command fgrep foo file
+sudo fgrep foo file
+grep -F foo file

--- a/crates/shuck-linter/resources/test/fixtures/style/S063.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S063.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+ln -s ../../share/doc/guide.pdf
+ln -s ../share/doc/guide.pdf guide.pdf
+ln -snf ../../etc/defaults cfg-link
+ln ../../share/doc/guide.pdf guide-hardlink
+ln -st /tmp ../../alpha ../../beta
+ln -s "$base"/../../guide.pdf guide.pdf
+command ln -s ../../wrapped/value wrapped

--- a/crates/shuck-linter/resources/test/fixtures/style/S064.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S064.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+find . -type d -name CVS | xargs -iX rm -rf X
+find . -type d -name CVS | xargs -0iX rm -rf X
+find . -type d -name CVS | xargs -i{} rm -rf '{}'
+command xargs -i echo {}
+sudo xargs -i echo {}
+find . -type d -name CVS | xargs -I{} rm -rf {}
+find . -type d -name CVS | xargs --replace rm -rf {}
+find . -type d -name CVS | xargs --replace={} rm -rf '{}'
+find . -type d -name CVS | xargs -0 rm -rf
+find . -type d -name CVS | xargs --null rm -rf

--- a/crates/shuck-linter/resources/test/fixtures/style/S068.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S068.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+trap 'echo caught signal' 1 2 13 15
+trap -- '' 0
+trap -p 2
+trap '' HUP
+command trap '' 9

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -293,6 +293,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::FgrepDeprecated) {
             rules::style::fgrep_deprecated::fgrep_deprecated(self);
         }
+        if self.is_rule_enabled(Rule::RelativeSymlinkTarget) {
+            rules::style::relative_symlink_target::relative_symlink_target(self);
+        }
         if self.is_rule_enabled(Rule::UnquotedTrRange) {
             rules::style::unquoted_tr_range::unquoted_tr_range(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -299,6 +299,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::XargsWithInlineReplace) {
             rules::style::xargs_with_inline_replace::xargs_with_inline_replace(self);
         }
+        if self.is_rule_enabled(Rule::TrapSignalNumbers) {
+            rules::style::trap_signal_numbers::trap_signal_numbers(self);
+        }
         if self.is_rule_enabled(Rule::UnquotedTrRange) {
             rules::style::unquoted_tr_range::unquoted_tr_range(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -296,6 +296,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::RelativeSymlinkTarget) {
             rules::style::relative_symlink_target::relative_symlink_target(self);
         }
+        if self.is_rule_enabled(Rule::XargsWithInlineReplace) {
+            rules::style::xargs_with_inline_replace::xargs_with_inline_replace(self);
+        }
         if self.is_rule_enabled(Rule::UnquotedTrRange) {
             rules::style::unquoted_tr_range::unquoted_tr_range(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -290,6 +290,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::EgrepDeprecated) {
             rules::style::egrep_deprecated::egrep_deprecated(self);
         }
+        if self.is_rule_enabled(Rule::FgrepDeprecated) {
+            rules::style::fgrep_deprecated::fgrep_deprecated(self);
+        }
         if self.is_rule_enabled(Rule::UnquotedTrRange) {
             rules::style::unquoted_tr_range::unquoted_tr_range(self);
         }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -10494,7 +10494,7 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
                 uses_null_input = true;
             }
 
-            let consume_next_argument = xargs_long_option_takes_argument(long);
+            let consume_next_argument = xargs_long_option_requires_separate_argument(long);
             index += 1;
             if consume_next_argument {
                 index += 1;
@@ -10551,7 +10551,7 @@ fn xargs_short_option_argument_style(flag: char) -> XargsShortOptionArgumentStyl
     }
 }
 
-fn xargs_long_option_takes_argument(option: &str) -> bool {
+fn xargs_long_option_requires_separate_argument(option: &str) -> bool {
     if option.contains('=') {
         return false;
     }
@@ -12187,6 +12187,25 @@ xargs -i0 echo
                 .collect::<Vec<_>>(),
             vec!["-i0"]
         );
+    }
+
+    #[test]
+    fn does_not_consume_null_mode_after_optional_long_eof() {
+        let source = "#!/bin/bash\nfind . -print0 | xargs --eof --null rm\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let xargs = facts
+            .commands()
+            .iter()
+            .find(|fact| fact.effective_name_is("xargs"))
+            .and_then(|fact| fact.options().xargs())
+            .expect("expected xargs facts");
+
+        assert!(xargs.uses_null_input);
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1489,9 +1489,16 @@ impl MapfileCommandFacts {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct XargsCommandFacts {
     pub uses_null_input: bool,
+    inline_replace_option_spans: Box<[Span]>,
+}
+
+impl XargsCommandFacts {
+    pub fn inline_replace_option_spans(&self) -> &[Span] {
+        &self.inline_replace_option_spans
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1781,18 +1788,7 @@ impl<'a> CommandOptionFacts<'a> {
             .then(|| parse_mapfile_command(normalized.body_args(), source)),
             xargs: normalized
                 .effective_name_is("xargs")
-                .then(|| XargsCommandFacts {
-                    uses_null_input: normalized
-                        .body_args()
-                        .iter()
-                        .filter_map(|word| static_word_text(word, source))
-                        .any(|arg| {
-                            arg == "--null"
-                                || (arg.starts_with('-')
-                                    && !arg.starts_with("--")
-                                    && arg[1..].contains('0'))
-                        }),
-                }),
+                .then(|| parse_xargs_command(normalized.body_args(), source)),
             wait: normalized
                 .effective_name_is("wait")
                 .then(|| parse_wait_command(normalized.body_args(), source)),
@@ -10472,6 +10468,92 @@ fn mapfile_option_takes_argument(flag: char) -> bool {
     matches!(flag, 'u' | 'C' | 'c' | 'd' | 'n' | 'O' | 's')
 }
 
+fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
+    let mut uses_null_input = false;
+    let mut inline_replace_option_spans = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            if word_starts_with_literal_dash(word, source) {
+                break;
+            }
+            break;
+        };
+
+        if text == "--" {
+            break;
+        }
+
+        if !text.starts_with('-') || text == "-" {
+            break;
+        }
+
+        if let Some(long) = text.strip_prefix("--") {
+            if long == "null" {
+                uses_null_input = true;
+            }
+
+            let consume_next_argument = xargs_long_option_takes_argument(long);
+            index += 1;
+            if consume_next_argument {
+                index += 1;
+            }
+            continue;
+        }
+
+        let mut chars = text[1..].chars().peekable();
+        let mut consume_next_argument = false;
+        while let Some(flag) = chars.next() {
+            if flag == '0' {
+                uses_null_input = true;
+            }
+            if flag == 'i' {
+                inline_replace_option_spans.push(word.span);
+            }
+
+            if xargs_short_option_takes_argument(flag) {
+                if chars.peek().is_none() {
+                    consume_next_argument = true;
+                }
+                break;
+            }
+        }
+
+        index += 1;
+        if consume_next_argument {
+            index += 1;
+        }
+    }
+
+    XargsCommandFacts {
+        uses_null_input,
+        inline_replace_option_spans: inline_replace_option_spans.into_boxed_slice(),
+    }
+}
+
+fn xargs_short_option_takes_argument(flag: char) -> bool {
+    matches!(flag, 'I' | 'L' | 'l' | 'n' | 'P' | 's' | 'd')
+}
+
+fn xargs_long_option_takes_argument(option: &str) -> bool {
+    if option.contains('=') {
+        return false;
+    }
+
+    matches!(
+        option,
+        "arg-file"
+            | "delimiter"
+            | "eof"
+            | "max-args"
+            | "max-chars"
+            | "max-lines"
+            | "max-procs"
+            | "process-slot-var"
+    )
+}
+
 fn parse_expr_command(args: &[&Word], source: &str) -> Option<ExprCommandFacts> {
     if expr_uses_string_form(args, source) {
         return None;
@@ -11214,7 +11296,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn summarizes_command_options_and_invokers() {
-        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
+        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -type d -name CVS | xargs -iX rm -rf X\nfind . -type d -name CVS | xargs --replace rm -rf {}\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -11408,6 +11490,15 @@ complex[$((i+=1))]+=x
             .and_then(|fact| fact.options().xargs())
             .expect("expected xargs facts");
         assert!(xargs.uses_null_input);
+        let inline_replace_option_spans = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("xargs"))
+            .filter_map(|fact| fact.options().xargs())
+            .flat_map(|xargs| xargs.inline_replace_option_spans().iter().copied())
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+        assert_eq!(inline_replace_option_spans, vec!["-iX"]);
 
         let wait = facts
             .commands()
@@ -12033,6 +12124,7 @@ command run0 --version
             .and_then(|fact| fact.options().xargs())
             .expect("expected xargs facts");
         assert!(xargs.uses_null_input);
+        assert!(xargs.inline_replace_option_spans().is_empty());
 
         let exit = facts
             .commands()

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -10512,11 +10512,15 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
                 inline_replace_option_spans.push(word.span);
             }
 
-            if xargs_short_option_takes_argument(flag) {
-                if chars.peek().is_none() {
-                    consume_next_argument = true;
+            match xargs_short_option_argument_style(flag) {
+                XargsShortOptionArgumentStyle::None => {}
+                XargsShortOptionArgumentStyle::OptionalInlineOnly => break,
+                XargsShortOptionArgumentStyle::Required => {
+                    if chars.peek().is_none() {
+                        consume_next_argument = true;
+                    }
+                    break;
                 }
-                break;
             }
         }
 
@@ -10532,8 +10536,19 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
     }
 }
 
-fn xargs_short_option_takes_argument(flag: char) -> bool {
-    matches!(flag, 'I' | 'L' | 'l' | 'n' | 'P' | 's' | 'd')
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum XargsShortOptionArgumentStyle {
+    None,
+    OptionalInlineOnly,
+    Required,
+}
+
+fn xargs_short_option_argument_style(flag: char) -> XargsShortOptionArgumentStyle {
+    match flag {
+        'e' | 'i' | 'l' => XargsShortOptionArgumentStyle::OptionalInlineOnly,
+        'E' | 'I' | 'L' | 'n' | 'P' | 's' | 'd' => XargsShortOptionArgumentStyle::Required,
+        _ => XargsShortOptionArgumentStyle::None,
+    }
 }
 
 fn xargs_long_option_takes_argument(option: &str) -> bool {
@@ -10545,7 +10560,6 @@ fn xargs_long_option_takes_argument(option: &str) -> bool {
         option,
         "arg-file"
             | "delimiter"
-            | "eof"
             | "max-args"
             | "max-chars"
             | "max-lines"
@@ -12138,6 +12152,41 @@ command run0 --version
         );
         assert!(exit.has_static_status());
         assert!(exit.is_numeric_literal);
+    }
+
+    #[test]
+    fn keeps_parsing_xargs_flags_after_optional_argument_forms() {
+        let source = "\
+#!/bin/bash
+find . -print0 | xargs -l -0 rm
+find . -print0 | xargs --eof --null rm
+xargs -i0 echo
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let xargs_facts = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("xargs"))
+            .filter_map(|fact| fact.options().xargs())
+            .collect::<Vec<_>>();
+
+        assert_eq!(xargs_facts.len(), 3);
+        assert!(xargs_facts[0].uses_null_input);
+        assert!(xargs_facts[1].uses_null_input);
+        assert!(!xargs_facts[2].uses_null_input);
+        assert_eq!(
+            xargs_facts[2]
+                .inline_replace_option_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-i0"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -10546,9 +10546,7 @@ enum XargsShortOptionArgumentStyle {
 fn xargs_short_option_argument_style(flag: char) -> XargsShortOptionArgumentStyle {
     match flag {
         'e' | 'i' | 'l' => XargsShortOptionArgumentStyle::OptionalInlineOnly,
-        'a' | 'E' | 'I' | 'L' | 'n' | 'P' | 's' | 'd' => {
-            XargsShortOptionArgumentStyle::Required
-        }
+        'a' | 'E' | 'I' | 'L' | 'n' | 'P' | 's' | 'd' => XargsShortOptionArgumentStyle::Required,
         _ => XargsShortOptionArgumentStyle::None,
     }
 }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -10546,7 +10546,9 @@ enum XargsShortOptionArgumentStyle {
 fn xargs_short_option_argument_style(flag: char) -> XargsShortOptionArgumentStyle {
     match flag {
         'e' | 'i' | 'l' => XargsShortOptionArgumentStyle::OptionalInlineOnly,
-        'E' | 'I' | 'L' | 'n' | 'P' | 's' | 'd' => XargsShortOptionArgumentStyle::Required,
+        'a' | 'E' | 'I' | 'L' | 'n' | 'P' | 's' | 'd' => {
+            XargsShortOptionArgumentStyle::Required
+        }
         _ => XargsShortOptionArgumentStyle::None,
     }
 }
@@ -12206,6 +12208,38 @@ xargs -i0 echo
             .expect("expected xargs facts");
 
         assert!(xargs.uses_null_input);
+    }
+
+    #[test]
+    fn keeps_parsing_xargs_flags_after_arg_file() {
+        let source = "\
+#!/bin/bash
+find . -print0 | xargs -a inputs -0 rm
+xargs -a inputs -iX echo X
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let xargs_facts = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("xargs"))
+            .filter_map(|fact| fact.options().xargs())
+            .collect::<Vec<_>>();
+
+        assert_eq!(xargs_facts.len(), 2);
+        assert!(xargs_facts[0].uses_null_input);
+        assert_eq!(
+            xargs_facts[1]
+                .inline_replace_option_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-iX"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -568,6 +568,7 @@ declare_rules! {
     ("S060", Category::Style, Severity::Warning, EgrepDeprecated),
     ("S061", Category::Style, Severity::Warning, FgrepDeprecated),
     ("S062", Category::Style, Severity::Warning, DefaultValueInColonAssign),
+    ("S063", Category::Style, Severity::Warning, RelativeSymlinkTarget),
     ("S067", Category::Style, Severity::Warning, BacktickOutputToCommand),
     ("S069", Category::Style, Severity::Hint, SingleLetterCaseLabel),
     ("S070", Category::Style, Severity::Warning, DoubleQuoteNesting),
@@ -716,6 +717,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-245" => Some(Rule::DeprecatedTempfileCommand),
         "SH-247" => Some(Rule::EgrepDeprecated),
         "SH-248" => Some(Rule::FgrepDeprecated),
+        "SH-252" => Some(Rule::RelativeSymlinkTarget),
         "SH-306" => Some(Rule::DoubleQuoteNesting),
         "SH-309" => Some(Rule::EnvPrefixQuoting),
         "SH-350" => Some(Rule::MixedQuoteWord),
@@ -1007,6 +1009,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-212"), Some(Rule::UnquotedVariableInTest));
         assert_eq!(code_to_rule("S058"), Some(Rule::UnquotedPathInMkdir));
         assert_eq!(code_to_rule("S062"), Some(Rule::DefaultValueInColonAssign));
+        assert_eq!(code_to_rule("S063"), Some(Rule::RelativeSymlinkTarget));
         assert_eq!(
             code_to_rule("SH-251"),
             Some(Rule::DefaultValueInColonAssign)
@@ -1091,6 +1094,7 @@ mod tests {
         );
         assert_eq!(code_to_rule("SH-247"), Some(Rule::EgrepDeprecated));
         assert_eq!(code_to_rule("SH-248"), Some(Rule::FgrepDeprecated));
+        assert_eq!(code_to_rule("SH-252"), Some(Rule::RelativeSymlinkTarget));
         assert_eq!(code_to_rule("S029"), Some(Rule::LiteralBraces));
         assert_eq!(code_to_rule("SH-116"), Some(Rule::LiteralBraces));
         assert_eq!(code_to_rule("S030"), Some(Rule::HeredocEndSpace));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -569,6 +569,7 @@ declare_rules! {
     ("S061", Category::Style, Severity::Warning, FgrepDeprecated),
     ("S062", Category::Style, Severity::Warning, DefaultValueInColonAssign),
     ("S063", Category::Style, Severity::Warning, RelativeSymlinkTarget),
+    ("S064", Category::Style, Severity::Warning, XargsWithInlineReplace),
     ("S067", Category::Style, Severity::Warning, BacktickOutputToCommand),
     ("S069", Category::Style, Severity::Hint, SingleLetterCaseLabel),
     ("S070", Category::Style, Severity::Warning, DoubleQuoteNesting),
@@ -718,6 +719,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-247" => Some(Rule::EgrepDeprecated),
         "SH-248" => Some(Rule::FgrepDeprecated),
         "SH-252" => Some(Rule::RelativeSymlinkTarget),
+        "SH-255" => Some(Rule::XargsWithInlineReplace),
         "SH-306" => Some(Rule::DoubleQuoteNesting),
         "SH-309" => Some(Rule::EnvPrefixQuoting),
         "SH-350" => Some(Rule::MixedQuoteWord),
@@ -1010,6 +1012,7 @@ mod tests {
         assert_eq!(code_to_rule("S058"), Some(Rule::UnquotedPathInMkdir));
         assert_eq!(code_to_rule("S062"), Some(Rule::DefaultValueInColonAssign));
         assert_eq!(code_to_rule("S063"), Some(Rule::RelativeSymlinkTarget));
+        assert_eq!(code_to_rule("S064"), Some(Rule::XargsWithInlineReplace));
         assert_eq!(
             code_to_rule("SH-251"),
             Some(Rule::DefaultValueInColonAssign)
@@ -1095,6 +1098,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-247"), Some(Rule::EgrepDeprecated));
         assert_eq!(code_to_rule("SH-248"), Some(Rule::FgrepDeprecated));
         assert_eq!(code_to_rule("SH-252"), Some(Rule::RelativeSymlinkTarget));
+        assert_eq!(code_to_rule("SH-255"), Some(Rule::XargsWithInlineReplace));
         assert_eq!(code_to_rule("S029"), Some(Rule::LiteralBraces));
         assert_eq!(code_to_rule("SH-116"), Some(Rule::LiteralBraces));
         assert_eq!(code_to_rule("S030"), Some(Rule::HeredocEndSpace));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -566,6 +566,7 @@ declare_rules! {
     ("S058", Category::Style, Severity::Warning, UnquotedPathInMkdir),
     ("S059", Category::Style, Severity::Warning, DeprecatedTempfileCommand),
     ("S060", Category::Style, Severity::Warning, EgrepDeprecated),
+    ("S061", Category::Style, Severity::Warning, FgrepDeprecated),
     ("S062", Category::Style, Severity::Warning, DefaultValueInColonAssign),
     ("S067", Category::Style, Severity::Warning, BacktickOutputToCommand),
     ("S069", Category::Style, Severity::Hint, SingleLetterCaseLabel),
@@ -714,6 +715,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-163" => Some(Rule::BareRead),
         "SH-245" => Some(Rule::DeprecatedTempfileCommand),
         "SH-247" => Some(Rule::EgrepDeprecated),
+        "SH-248" => Some(Rule::FgrepDeprecated),
         "SH-306" => Some(Rule::DoubleQuoteNesting),
         "SH-309" => Some(Rule::EnvPrefixQuoting),
         "SH-350" => Some(Rule::MixedQuoteWord),
@@ -1088,6 +1090,7 @@ mod tests {
             Some(Rule::DeprecatedTempfileCommand)
         );
         assert_eq!(code_to_rule("SH-247"), Some(Rule::EgrepDeprecated));
+        assert_eq!(code_to_rule("SH-248"), Some(Rule::FgrepDeprecated));
         assert_eq!(code_to_rule("S029"), Some(Rule::LiteralBraces));
         assert_eq!(code_to_rule("SH-116"), Some(Rule::LiteralBraces));
         assert_eq!(code_to_rule("S030"), Some(Rule::HeredocEndSpace));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -571,6 +571,7 @@ declare_rules! {
     ("S063", Category::Style, Severity::Warning, RelativeSymlinkTarget),
     ("S064", Category::Style, Severity::Warning, XargsWithInlineReplace),
     ("S067", Category::Style, Severity::Warning, BacktickOutputToCommand),
+    ("S068", Category::Style, Severity::Warning, TrapSignalNumbers),
     ("S069", Category::Style, Severity::Hint, SingleLetterCaseLabel),
     ("S070", Category::Style, Severity::Warning, DoubleQuoteNesting),
     ("S071", Category::Style, Severity::Warning, EnvPrefixQuoting),
@@ -667,6 +668,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-304" => Some(Rule::SourceInsideFunctionInSh),
         "SH-275" => Some(Rule::ErrexitTrapInSh),
         "SH-276" => Some(Rule::SignalNameInTrap),
+        "SH-297" => Some(Rule::TrapSignalNumbers),
         "SH-277" => Some(Rule::BasePrefixInArithmetic),
         "SH-034" => Some(Rule::LegacyBackticks),
         "SH-035" => Some(Rule::LegacyArithmeticExpansion),
@@ -953,6 +955,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-068"), Some(Rule::CommandOutputArraySplit));
         assert_eq!(code_to_rule("S067"), Some(Rule::BacktickOutputToCommand));
         assert_eq!(code_to_rule("SH-294"), Some(Rule::BacktickOutputToCommand));
+        assert_eq!(code_to_rule("S068"), Some(Rule::TrapSignalNumbers));
+        assert_eq!(code_to_rule("SH-297"), Some(Rule::TrapSignalNumbers));
         assert_eq!(code_to_rule("S069"), Some(Rule::SingleLetterCaseLabel));
         assert_eq!(code_to_rule("SH-300"), Some(Rule::SingleLetterCaseLabel));
         assert_eq!(code_to_rule("S071"), Some(Rule::EnvPrefixQuoting));

--- a/crates/shuck-linter/src/rules/portability/mod.rs
+++ b/crates/shuck-linter/src/rules/portability/mod.rs
@@ -50,7 +50,7 @@ pub mod substring_expansion;
 mod tr_common;
 pub mod tr_lower_range;
 pub mod tr_upper_range;
-mod trap_common;
+pub(crate) mod trap_common;
 pub mod trap_err;
 pub mod unset_pattern_in_sh;
 pub mod uppercase_expansion;

--- a/crates/shuck-linter/src/rules/portability/trap_common.rs
+++ b/crates/shuck-linter/src/rules/portability/trap_common.rs
@@ -2,12 +2,12 @@ use shuck_ast::Word;
 
 use crate::static_word_text;
 
-pub(super) struct ParsedTrapArgs<'a> {
-    pub(super) signal_words: &'a [&'a Word],
-    pub(super) listing_mode: bool,
+pub(crate) struct ParsedTrapArgs<'a> {
+    pub(crate) signal_words: &'a [&'a Word],
+    pub(crate) listing_mode: bool,
 }
 
-pub(super) fn parse_trap_args<'a>(
+pub(crate) fn parse_trap_args<'a>(
     args: &'a [&'a Word],
     source: &str,
 ) -> Option<ParsedTrapArgs<'a>> {

--- a/crates/shuck-linter/src/rules/style/fgrep_deprecated.rs
+++ b/crates/shuck-linter/src/rules/style/fgrep_deprecated.rs
@@ -1,0 +1,62 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct FgrepDeprecated;
+
+impl Violation for FgrepDeprecated {
+    fn rule() -> Rule {
+        Rule::FgrepDeprecated
+    }
+
+    fn message(&self) -> String {
+        "use `grep -F` instead of `fgrep`".to_owned()
+    }
+}
+
+pub fn fgrep_deprecated(checker: &mut Checker) {
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("fgrep") && fact.wrappers().is_empty())
+        .filter_map(|fact| fact.body_name_word().map(|word| word.span))
+        .collect::<Vec<_>>();
+
+    checker.report_all(spans, || FgrepDeprecated);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_plain_fgrep_invocations() {
+        let source = "\
+#!/bin/sh
+fgrep foo file
+fgrep
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FgrepDeprecated));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["fgrep", "fgrep"]
+        );
+    }
+
+    #[test]
+    fn ignores_wrapped_fgrep_invocations() {
+        let source = "\
+#!/bin/sh
+command fgrep foo file
+sudo fgrep foo file
+grep -F foo file
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FgrepDeprecated));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -45,6 +45,7 @@ pub mod ps_grep_pipeline;
 pub mod quoted_dollar_star_loop;
 pub mod read_without_raw;
 pub mod redundant_spaces_in_echo;
+pub mod relative_symlink_target;
 pub mod single_iteration_loop;
 pub mod single_letter_case_label;
 pub mod single_quote_backslash;
@@ -90,6 +91,7 @@ mod tests {
     #[test_case(Rule::EgrepDeprecated, Path::new("S060.sh"))]
     #[test_case(Rule::FgrepDeprecated, Path::new("S061.sh"))]
     #[test_case(Rule::DefaultValueInColonAssign, Path::new("S062.sh"))]
+    #[test_case(Rule::RelativeSymlinkTarget, Path::new("S063.sh"))]
     #[test_case(Rule::BacktickOutputToCommand, Path::new("S067.sh"))]
     #[test_case(Rule::SingleLetterCaseLabel, Path::new("S069.sh"))]
     #[test_case(Rule::DoubleQuoteNesting, Path::new("S070.sh"))]

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -65,6 +65,7 @@ pub mod unquoted_tr_range;
 pub mod unquoted_variable_in_sed;
 pub mod unquoted_variable_in_test;
 pub mod unquoted_word_between_quotes;
+pub mod xargs_with_inline_replace;
 
 #[cfg(test)]
 mod tests {
@@ -92,6 +93,7 @@ mod tests {
     #[test_case(Rule::FgrepDeprecated, Path::new("S061.sh"))]
     #[test_case(Rule::DefaultValueInColonAssign, Path::new("S062.sh"))]
     #[test_case(Rule::RelativeSymlinkTarget, Path::new("S063.sh"))]
+    #[test_case(Rule::XargsWithInlineReplace, Path::new("S064.sh"))]
     #[test_case(Rule::BacktickOutputToCommand, Path::new("S067.sh"))]
     #[test_case(Rule::SingleLetterCaseLabel, Path::new("S069.sh"))]
     #[test_case(Rule::DoubleQuoteNesting, Path::new("S070.sh"))]

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -21,6 +21,7 @@ pub mod env_prefix_quoting;
 pub mod escaped_underscore;
 pub mod escaped_underscore_literal;
 pub mod export_command_substitution;
+pub mod fgrep_deprecated;
 pub mod function_in_alias;
 pub mod glob_assigned_to_variable;
 pub mod grep_output_in_test;
@@ -87,6 +88,7 @@ mod tests {
     #[test_case(Rule::CommandSubstitutionInAlias, Path::new("S056.sh"))]
     #[test_case(Rule::DeprecatedTempfileCommand, Path::new("S059.sh"))]
     #[test_case(Rule::EgrepDeprecated, Path::new("S060.sh"))]
+    #[test_case(Rule::FgrepDeprecated, Path::new("S061.sh"))]
     #[test_case(Rule::DefaultValueInColonAssign, Path::new("S062.sh"))]
     #[test_case(Rule::BacktickOutputToCommand, Path::new("S067.sh"))]
     #[test_case(Rule::SingleLetterCaseLabel, Path::new("S069.sh"))]

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -54,6 +54,7 @@ pub mod su_without_flag;
 pub mod suspect_closing_quote;
 pub mod syntax;
 pub mod trailing_directive;
+pub mod trap_signal_numbers;
 pub mod unquoted_array_expansion;
 pub mod unquoted_array_split;
 pub mod unquoted_command_substitution;
@@ -95,6 +96,7 @@ mod tests {
     #[test_case(Rule::RelativeSymlinkTarget, Path::new("S063.sh"))]
     #[test_case(Rule::XargsWithInlineReplace, Path::new("S064.sh"))]
     #[test_case(Rule::BacktickOutputToCommand, Path::new("S067.sh"))]
+    #[test_case(Rule::TrapSignalNumbers, Path::new("S068.sh"))]
     #[test_case(Rule::SingleLetterCaseLabel, Path::new("S069.sh"))]
     #[test_case(Rule::DoubleQuoteNesting, Path::new("S070.sh"))]
     #[test_case(Rule::EnvPrefixQuoting, Path::new("S071.sh"))]

--- a/crates/shuck-linter/src/rules/style/relative_symlink_target.rs
+++ b/crates/shuck-linter/src/rules/style/relative_symlink_target.rs
@@ -1,0 +1,261 @@
+use crate::{
+    Checker, CommandFact, ExpansionContext, Rule, ShellDialect, Violation, WordFactContext,
+    static_word_text,
+};
+
+pub struct RelativeSymlinkTarget;
+
+impl Violation for RelativeSymlinkTarget {
+    fn rule() -> Rule {
+        Rule::RelativeSymlinkTarget
+    }
+
+    fn message(&self) -> String {
+        "avoid deep relative paths in symlink targets".to_owned()
+    }
+}
+
+pub fn relative_symlink_target(checker: &mut Checker) {
+    if !matches!(
+        checker.shell(),
+        ShellDialect::Sh | ShellDialect::Bash | ShellDialect::Dash | ShellDialect::Ksh
+    ) {
+        return;
+    }
+
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|command| ln_symlink_target_words(command, source))
+        .filter_map(|word| {
+            let fact = checker.facts().word_fact(
+                word.span,
+                WordFactContext::Expansion(ExpansionContext::CommandArgument),
+            )?;
+            if !fact.classification().is_fixed_literal()
+                || fact.runtime_literal().is_runtime_sensitive()
+            {
+                return None;
+            }
+
+            let text = fact.static_text()?;
+            is_deep_relative_target(text).then_some(word.span)
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || RelativeSymlinkTarget);
+}
+
+fn ln_symlink_target_words<'a>(
+    command: &'a CommandFact<'a>,
+    source: &str,
+) -> Vec<&'a shuck_ast::Word> {
+    if !command.effective_name_is("ln") {
+        return Vec::new();
+    }
+
+    let args = command.body_args();
+    let mut index = 0usize;
+    let mut saw_symbolic_flag = false;
+    let mut target_directory_mode = false;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+
+        if text == "--" {
+            index += 1;
+            break;
+        }
+
+        if !text.starts_with('-') || text == "-" {
+            break;
+        }
+
+        if let Some(long) = text.strip_prefix("--") {
+            match long {
+                "symbolic" => saw_symbolic_flag = true,
+                "target-directory" => {
+                    target_directory_mode = true;
+                    index += 1;
+                    if args.get(index).is_none() {
+                        return Vec::new();
+                    }
+                }
+                "suffix" => {
+                    index += 1;
+                    if args.get(index).is_none() {
+                        return Vec::new();
+                    }
+                }
+                "backup"
+                | "directory"
+                | "force"
+                | "interactive"
+                | "logical"
+                | "no-dereference"
+                | "no-target-directory"
+                | "physical"
+                | "relative"
+                | "verbose" => {}
+                _ if long.starts_with("target-directory=") => {
+                    target_directory_mode = true;
+                }
+                _ if long.starts_with("suffix=") => {}
+                _ => return Vec::new(),
+            }
+
+            index += 1;
+            continue;
+        }
+
+        let mut chars = text[1..].chars().peekable();
+        while let Some(flag) = chars.next() {
+            match flag {
+                's' => saw_symbolic_flag = true,
+                't' => {
+                    target_directory_mode = true;
+                    if chars.peek().is_none() {
+                        index += 1;
+                        if args.get(index).is_none() {
+                            return Vec::new();
+                        }
+                    }
+                    break;
+                }
+                'S' => {
+                    if chars.peek().is_none() {
+                        index += 1;
+                        if args.get(index).is_none() {
+                            return Vec::new();
+                        }
+                    }
+                    break;
+                }
+                'b' | 'd' | 'f' | 'F' | 'i' | 'L' | 'n' | 'P' | 'r' | 'T' | 'v' => {}
+                _ => return Vec::new(),
+            }
+        }
+
+        index += 1;
+    }
+
+    if !saw_symbolic_flag {
+        return Vec::new();
+    }
+
+    let operands = &args[index..];
+    if operands.is_empty() {
+        return Vec::new();
+    }
+
+    if target_directory_mode {
+        operands.to_vec()
+    } else {
+        operands.first().copied().into_iter().collect()
+    }
+}
+
+fn is_deep_relative_target(text: &str) -> bool {
+    let mut offset = 0usize;
+    let mut parents = 0usize;
+
+    while let Some(remaining) = text.get(offset..) {
+        if !remaining.starts_with("..") {
+            break;
+        }
+        let suffix = &remaining[2..];
+        if !suffix.is_empty() && !suffix.starts_with('/') {
+            break;
+        }
+
+        parents += 1;
+        offset += 2;
+        if text.get(offset..).is_some_and(|tail| tail.starts_with('/')) {
+            offset += 1;
+        }
+    }
+
+    parents >= 2
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_deep_relative_symlink_targets() {
+        let source = "\
+#!/bin/sh
+ln -s ../../share/doc/guide.pdf
+ln -s ../.. parent-only
+ln -s ../../.. parent-only-3
+ln -snf ../../etc/defaults cfg-link
+ln --symbolic ../../lib/pkg app
+ln -st /tmp ../../alpha ../../beta
+ln -s -- ../../share/doc/guide.pdf guide
+command ln -s ../../wrapped/value wrapped
+sudo ln -s ../../wrapped/value wrapped
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RelativeSymlinkTarget),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "../../share/doc/guide.pdf",
+                "../..",
+                "../../..",
+                "../../etc/defaults",
+                "../../lib/pkg",
+                "../../alpha",
+                "../../beta",
+                "../../share/doc/guide.pdf",
+                "../../wrapped/value",
+                "../../wrapped/value",
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_non_deep_or_dynamic_or_non_symbolic_targets() {
+        let source = "\
+#!/bin/sh
+ln -s ../share/doc/guide.pdf guide
+ln -s ./share/doc/guide.pdf guide
+ln -s /usr/share/doc/guide.pdf guide
+ln ../../share/doc/guide.pdf guide
+ln -s \"$base\"/../../guide.pdf guide
+ln -s .. parent-only
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RelativeSymlinkTarget),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn does_not_run_for_zsh() {
+        let source = "\
+#!/bin/zsh
+ln -s ../../share/doc/guide.pdf guide
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RelativeSymlinkTarget).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S061_S061.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S061_S061.sh.snap
@@ -1,0 +1,14 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S061 use `grep -F` instead of `fgrep`
+ --> <source>:2:1
+  |
+2 | fgrep foo file
+  |
+
+S061 use `grep -F` instead of `fgrep`
+ --> <source>:3:1
+  |
+3 | fgrep
+  |

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S063_S063.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S063_S063.sh.snap
@@ -1,0 +1,32 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S063 avoid deep relative paths in symlink targets
+ --> <source>:2:7
+  |
+2 | ln -s ../../share/doc/guide.pdf
+  |
+
+S063 avoid deep relative paths in symlink targets
+ --> <source>:4:9
+  |
+4 | ln -snf ../../etc/defaults cfg-link
+  |
+
+S063 avoid deep relative paths in symlink targets
+ --> <source>:6:13
+  |
+6 | ln -st /tmp ../../alpha ../../beta
+  |
+
+S063 avoid deep relative paths in symlink targets
+ --> <source>:6:25
+  |
+6 | ln -st /tmp ../../alpha ../../beta
+  |
+
+S063 avoid deep relative paths in symlink targets
+ --> <source>:8:15
+  |
+8 | command ln -s ../../wrapped/value wrapped
+  |

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S064_S064.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S064_S064.sh.snap
@@ -1,0 +1,33 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+assertion_line: 152
+---
+S064 replace deprecated `xargs -i` with `xargs -I{}`
+ --> <source>:2:34
+  |
+2 | find . -type d -name CVS | xargs -iX rm -rf X
+  |
+
+S064 replace deprecated `xargs -i` with `xargs -I{}`
+ --> <source>:3:34
+  |
+3 | find . -type d -name CVS | xargs -0iX rm -rf X
+  |
+
+S064 replace deprecated `xargs -i` with `xargs -I{}`
+ --> <source>:4:34
+  |
+4 | find . -type d -name CVS | xargs -i{} rm -rf '{}'
+  |
+
+S064 replace deprecated `xargs -i` with `xargs -I{}`
+ --> <source>:5:15
+  |
+5 | command xargs -i echo {}
+  |
+
+S064 replace deprecated `xargs -i` with `xargs -I{}`
+ --> <source>:6:12
+  |
+6 | sudo xargs -i echo {}
+  |

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S068_S068.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S068_S068.sh.snap
@@ -1,0 +1,39 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+assertion_line: 154
+---
+S068 prefer symbolic signal names in `trap` instead of numeric IDs
+ --> <source>:2:27
+  |
+2 | trap 'echo caught signal' 1 2 13 15
+  |
+
+S068 prefer symbolic signal names in `trap` instead of numeric IDs
+ --> <source>:2:29
+  |
+2 | trap 'echo caught signal' 1 2 13 15
+  |
+
+S068 prefer symbolic signal names in `trap` instead of numeric IDs
+ --> <source>:2:31
+  |
+2 | trap 'echo caught signal' 1 2 13 15
+  |
+
+S068 prefer symbolic signal names in `trap` instead of numeric IDs
+ --> <source>:2:34
+  |
+2 | trap 'echo caught signal' 1 2 13 15
+  |
+
+S068 prefer symbolic signal names in `trap` instead of numeric IDs
+ --> <source>:3:12
+  |
+3 | trap -- '' 0
+  |
+
+S068 prefer symbolic signal names in `trap` instead of numeric IDs
+ --> <source>:6:17
+  |
+6 | command trap '' 9
+  |

--- a/crates/shuck-linter/src/rules/style/trap_signal_numbers.rs
+++ b/crates/shuck-linter/src/rules/style/trap_signal_numbers.rs
@@ -1,0 +1,113 @@
+use shuck_ast::{Span, Word};
+
+use crate::rules::portability::trap_common::parse_trap_args;
+use crate::{Checker, Rule, ShellDialect, Violation, static_word_text};
+
+pub struct TrapSignalNumbers;
+
+impl Violation for TrapSignalNumbers {
+    fn rule() -> Rule {
+        Rule::TrapSignalNumbers
+    }
+
+    fn message(&self) -> String {
+        "prefer symbolic signal names in `trap` instead of numeric IDs".to_owned()
+    }
+}
+
+pub fn trap_signal_numbers(checker: &mut Checker) {
+    if !matches!(
+        checker.shell(),
+        ShellDialect::Sh | ShellDialect::Bash | ShellDialect::Dash | ShellDialect::Ksh
+    ) {
+        return;
+    }
+
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("trap"))
+        .flat_map(|fact| trap_numeric_signal_spans(fact.body_args(), checker.source()))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || TrapSignalNumbers);
+}
+
+fn trap_numeric_signal_spans(args: &[&Word], source: &str) -> Vec<Span> {
+    let Some(parsed) = parse_trap_args(args, source) else {
+        return Vec::new();
+    };
+    if parsed.listing_mode {
+        return Vec::new();
+    }
+
+    parsed
+        .signal_words
+        .iter()
+        .filter_map(|word| {
+            static_word_text(word, source)
+                .as_deref()
+                .is_some_and(is_numeric_signal_name)
+                .then_some(word.span)
+        })
+        .collect()
+}
+
+fn is_numeric_signal_name(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|character| character.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_numeric_trap_signals() {
+        let source = "\
+#!/bin/sh
+trap 'echo caught signal' 1 2 13 15
+trap -- '' 0
+trap -- '' 9 10
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrapSignalNumbers));
+
+        assert_eq!(diagnostics.len(), 7);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["1", "2", "13", "15", "0", "9", "10"]
+        );
+    }
+
+    #[test]
+    fn ignores_symbolic_and_listing_modes() {
+        let source = "\
+#!/bin/sh
+trap '' HUP INT TERM
+trap -l 1
+trap -p 2
+trap -lp 15
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrapSignalNumbers));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn does_not_run_for_other_shells() {
+        let source = "\
+#!/bin/zsh
+trap 'echo caught signal' 1 2
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::TrapSignalNumbers).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
+++ b/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
@@ -1,0 +1,80 @@
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct XargsWithInlineReplace;
+
+impl Violation for XargsWithInlineReplace {
+    fn rule() -> Rule {
+        Rule::XargsWithInlineReplace
+    }
+
+    fn message(&self) -> String {
+        "replace deprecated `xargs -i` with `xargs -I{}`".to_owned()
+    }
+}
+
+pub fn xargs_with_inline_replace(checker: &mut Checker) {
+    if !matches!(
+        checker.shell(),
+        ShellDialect::Sh | ShellDialect::Bash | ShellDialect::Dash | ShellDialect::Ksh
+    ) {
+        return;
+    }
+
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter_map(|fact| fact.options().xargs())
+        .flat_map(|xargs| xargs.inline_replace_option_spans().iter().copied())
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || XargsWithInlineReplace);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_inline_replace_xargs_flags() {
+        let source = "\
+#!/bin/sh
+find . -type d -name CVS | xargs -iX rm -rf X
+find . -type d -name CVS | xargs -0iX rm -rf X
+find . -type d -name CVS | xargs -i{} rm -rf '{}'
+command xargs -i echo {}
+sudo xargs -i echo {}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::XargsWithInlineReplace),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-iX", "-0iX", "-i{}", "-i", "-i"]
+        );
+    }
+
+    #[test]
+    fn ignores_modern_xargs_replace_flags() {
+        let source = "\
+#!/bin/sh
+find . -type d -name CVS | xargs -I{} rm -rf {}
+find . -type d -name CVS | xargs --replace rm -rf {}
+find . -type d -name CVS | xargs --replace={} rm -rf '{}'
+find . -type d -name CVS | xargs -0 rm -rf
+find . -type d -name CVS | xargs --null rm -rf
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::XargsWithInlineReplace),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -77,6 +77,12 @@ impl ShellCheckCodeMap {
         if number == 2196 {
             return vec![Rule::EgrepDeprecated];
         }
+        if number == 2343 {
+            return vec![Rule::FgrepDeprecated];
+        }
+        if number == 2197 {
+            return vec![Rule::FgrepDeprecated];
+        }
         if number == 2303 {
             return vec![Rule::UnquotedTrClass];
         }
@@ -165,6 +171,9 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports egrep deprecation warnings as SC2196.
             // Keep SC2342 as a suppression alias for the authored S060 rule code.
             (2196, Rule::EgrepDeprecated),
+            // ShellCheck 0.11.0 reports fgrep deprecation warnings as SC2197.
+            // Keep SC2343 as a suppression alias for the authored S061 rule code.
+            (2197, Rule::FgrepDeprecated),
             // ShellCheck 0.11.0 reports command substitutions inside alias definitions as SC2139.
             // Keep SC2328 as a suppression alias for historical compatibility.
             (2139, Rule::CommandSubstitutionInAlias),
@@ -504,6 +513,7 @@ impl Default for ShellCheckCodeMap {
                     (2293, Rule::LsPipedToXargs),
                     (2117, Rule::SuWithoutFlag),
                     (2196, Rule::EgrepDeprecated),
+                    (2197, Rule::FgrepDeprecated),
                     (2139, Rule::CommandSubstitutionInAlias),
                     (2142, Rule::FunctionInAlias),
                     (2283, Rule::DoubleParenGrouping),
@@ -808,6 +818,7 @@ impl Default for ShellCheckCodeMap {
                 (2322, Rule::SuWithoutFlag),
                 (2340, Rule::DeprecatedTempfileCommand),
                 (2342, Rule::EgrepDeprecated),
+                (2343, Rule::FgrepDeprecated),
                 (2328, Rule::CommandSubstitutionInAlias),
                 (2330, Rule::FunctionInAlias),
                 (2376, Rule::DoubleQuoteNesting),
@@ -946,6 +957,8 @@ mod tests {
         assert_eq!(map.resolve("SC2186"), Some(Rule::DeprecatedTempfileCommand));
         assert_eq!(map.resolve("SC2342"), Some(Rule::EgrepDeprecated));
         assert_eq!(map.resolve("SC2196"), Some(Rule::EgrepDeprecated));
+        assert_eq!(map.resolve("SC2343"), Some(Rule::FgrepDeprecated));
+        assert_eq!(map.resolve("SC2197"), Some(Rule::FgrepDeprecated));
         assert_eq!(
             map.resolve("SC2139"),
             Some(Rule::CommandSubstitutionInAlias)
@@ -1013,6 +1026,8 @@ mod tests {
         );
         assert_eq!(map.resolve_all("SC2342"), vec![Rule::EgrepDeprecated]);
         assert_eq!(map.resolve_all("SC2196"), vec![Rule::EgrepDeprecated]);
+        assert_eq!(map.resolve_all("SC2343"), vec![Rule::FgrepDeprecated]);
+        assert_eq!(map.resolve_all("SC2197"), vec![Rule::FgrepDeprecated]);
         assert_eq!(
             map.resolve_all("SC2139"),
             vec![Rule::CommandSubstitutionInAlias]
@@ -1576,6 +1591,7 @@ mod tests {
             (2117, Rule::SuWithoutFlag),
             (2186, Rule::DeprecatedTempfileCommand),
             (2196, Rule::EgrepDeprecated),
+            (2197, Rule::FgrepDeprecated),
             (2139, Rule::CommandSubstitutionInAlias),
             (2142, Rule::FunctionInAlias),
             (2021, Rule::UnquotedTrRange),
@@ -1596,6 +1612,7 @@ mod tests {
             (2322, Rule::SuWithoutFlag),
             (2340, Rule::DeprecatedTempfileCommand),
             (2342, Rule::EgrepDeprecated),
+            (2343, Rule::FgrepDeprecated),
             (2344, Rule::AtSignInStringCompare),
             (2345, Rule::ArraySliceInComparison),
             (2325, Rule::QuotedArraySlice),
@@ -1956,6 +1973,7 @@ mod tests {
         assert!(comparison.contains(&(2117, Rule::SuWithoutFlag)));
         assert!(comparison.contains(&(2186, Rule::DeprecatedTempfileCommand)));
         assert!(comparison.contains(&(2196, Rule::EgrepDeprecated)));
+        assert!(comparison.contains(&(2197, Rule::FgrepDeprecated)));
         assert!(comparison.contains(&(2184, Rule::UnsetAssociativeArrayElement)));
         assert!(comparison.contains(&(2178, Rule::ArrayToStringConversion)));
         assert!(comparison.contains(&(2139, Rule::CommandSubstitutionInAlias)));
@@ -1966,6 +1984,7 @@ mod tests {
         assert!(!comparison.contains(&(2322, Rule::SuWithoutFlag)));
         assert!(!comparison.contains(&(2340, Rule::DeprecatedTempfileCommand)));
         assert!(!comparison.contains(&(2342, Rule::EgrepDeprecated)));
+        assert!(!comparison.contains(&(2343, Rule::FgrepDeprecated)));
         assert!(!comparison.contains(&(2328, Rule::CommandSubstitutionInAlias)));
         assert!(!comparison.contains(&(2330, Rule::FunctionInAlias)));
         assert!(!comparison.contains(&(2376, Rule::DoubleQuoteNesting)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -83,6 +83,9 @@ impl ShellCheckCodeMap {
         if number == 2197 {
             return vec![Rule::FgrepDeprecated];
         }
+        if number == 2347 {
+            return vec![Rule::RelativeSymlinkTarget];
+        }
         if number == 2303 {
             return vec![Rule::UnquotedTrClass];
         }
@@ -174,6 +177,8 @@ impl Default for ShellCheckCodeMap {
             // ShellCheck 0.11.0 reports fgrep deprecation warnings as SC2197.
             // Keep SC2343 as a suppression alias for the authored S061 rule code.
             (2197, Rule::FgrepDeprecated),
+            // SC2347 remains the authored compatibility code for deep relative symlink targets.
+            (2347, Rule::RelativeSymlinkTarget),
             // ShellCheck 0.11.0 reports command substitutions inside alias definitions as SC2139.
             // Keep SC2328 as a suppression alias for historical compatibility.
             (2139, Rule::CommandSubstitutionInAlias),
@@ -514,6 +519,7 @@ impl Default for ShellCheckCodeMap {
                     (2117, Rule::SuWithoutFlag),
                     (2196, Rule::EgrepDeprecated),
                     (2197, Rule::FgrepDeprecated),
+                    (2347, Rule::RelativeSymlinkTarget),
                     (2139, Rule::CommandSubstitutionInAlias),
                     (2142, Rule::FunctionInAlias),
                     (2283, Rule::DoubleParenGrouping),
@@ -959,6 +965,7 @@ mod tests {
         assert_eq!(map.resolve("SC2196"), Some(Rule::EgrepDeprecated));
         assert_eq!(map.resolve("SC2343"), Some(Rule::FgrepDeprecated));
         assert_eq!(map.resolve("SC2197"), Some(Rule::FgrepDeprecated));
+        assert_eq!(map.resolve("SC2347"), Some(Rule::RelativeSymlinkTarget));
         assert_eq!(
             map.resolve("SC2139"),
             Some(Rule::CommandSubstitutionInAlias)
@@ -1028,6 +1035,7 @@ mod tests {
         assert_eq!(map.resolve_all("SC2196"), vec![Rule::EgrepDeprecated]);
         assert_eq!(map.resolve_all("SC2343"), vec![Rule::FgrepDeprecated]);
         assert_eq!(map.resolve_all("SC2197"), vec![Rule::FgrepDeprecated]);
+        assert_eq!(map.resolve_all("SC2347"), vec![Rule::RelativeSymlinkTarget]);
         assert_eq!(
             map.resolve_all("SC2139"),
             vec![Rule::CommandSubstitutionInAlias]
@@ -1592,6 +1600,7 @@ mod tests {
             (2186, Rule::DeprecatedTempfileCommand),
             (2196, Rule::EgrepDeprecated),
             (2197, Rule::FgrepDeprecated),
+            (2347, Rule::RelativeSymlinkTarget),
             (2139, Rule::CommandSubstitutionInAlias),
             (2142, Rule::FunctionInAlias),
             (2021, Rule::UnquotedTrRange),
@@ -1613,6 +1622,7 @@ mod tests {
             (2340, Rule::DeprecatedTempfileCommand),
             (2342, Rule::EgrepDeprecated),
             (2343, Rule::FgrepDeprecated),
+            (2347, Rule::RelativeSymlinkTarget),
             (2344, Rule::AtSignInStringCompare),
             (2345, Rule::ArraySliceInComparison),
             (2325, Rule::QuotedArraySlice),
@@ -1974,6 +1984,7 @@ mod tests {
         assert!(comparison.contains(&(2186, Rule::DeprecatedTempfileCommand)));
         assert!(comparison.contains(&(2196, Rule::EgrepDeprecated)));
         assert!(comparison.contains(&(2197, Rule::FgrepDeprecated)));
+        assert!(comparison.contains(&(2347, Rule::RelativeSymlinkTarget)));
         assert!(comparison.contains(&(2184, Rule::UnsetAssociativeArrayElement)));
         assert!(comparison.contains(&(2178, Rule::ArrayToStringConversion)));
         assert!(comparison.contains(&(2139, Rule::CommandSubstitutionInAlias)));

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -86,6 +86,9 @@ impl ShellCheckCodeMap {
         if number == 2347 {
             return vec![Rule::RelativeSymlinkTarget];
         }
+        if number == 2350 {
+            return vec![Rule::XargsWithInlineReplace];
+        }
         if number == 2303 {
             return vec![Rule::UnquotedTrClass];
         }
@@ -179,6 +182,10 @@ impl Default for ShellCheckCodeMap {
             (2197, Rule::FgrepDeprecated),
             // SC2347 remains the authored compatibility code for deep relative symlink targets.
             (2347, Rule::RelativeSymlinkTarget),
+            // SC2350 remains the authored compatibility code for `xargs -i` deprecations.
+            // Current ShellCheck releases emit SC2267 for this behavior, recorded in S064
+            // corpus metadata to preserve existing SC2267 suppression semantics.
+            (2350, Rule::XargsWithInlineReplace),
             // ShellCheck 0.11.0 reports command substitutions inside alias definitions as SC2139.
             // Keep SC2328 as a suppression alias for historical compatibility.
             (2139, Rule::CommandSubstitutionInAlias),
@@ -520,6 +527,7 @@ impl Default for ShellCheckCodeMap {
                     (2196, Rule::EgrepDeprecated),
                     (2197, Rule::FgrepDeprecated),
                     (2347, Rule::RelativeSymlinkTarget),
+                    (2350, Rule::XargsWithInlineReplace),
                     (2139, Rule::CommandSubstitutionInAlias),
                     (2142, Rule::FunctionInAlias),
                     (2283, Rule::DoubleParenGrouping),
@@ -966,6 +974,7 @@ mod tests {
         assert_eq!(map.resolve("SC2343"), Some(Rule::FgrepDeprecated));
         assert_eq!(map.resolve("SC2197"), Some(Rule::FgrepDeprecated));
         assert_eq!(map.resolve("SC2347"), Some(Rule::RelativeSymlinkTarget));
+        assert_eq!(map.resolve("SC2350"), Some(Rule::XargsWithInlineReplace));
         assert_eq!(
             map.resolve("SC2139"),
             Some(Rule::CommandSubstitutionInAlias)
@@ -1036,6 +1045,10 @@ mod tests {
         assert_eq!(map.resolve_all("SC2343"), vec![Rule::FgrepDeprecated]);
         assert_eq!(map.resolve_all("SC2197"), vec![Rule::FgrepDeprecated]);
         assert_eq!(map.resolve_all("SC2347"), vec![Rule::RelativeSymlinkTarget]);
+        assert_eq!(
+            map.resolve_all("SC2350"),
+            vec![Rule::XargsWithInlineReplace]
+        );
         assert_eq!(
             map.resolve_all("SC2139"),
             vec![Rule::CommandSubstitutionInAlias]
@@ -1601,6 +1614,7 @@ mod tests {
             (2196, Rule::EgrepDeprecated),
             (2197, Rule::FgrepDeprecated),
             (2347, Rule::RelativeSymlinkTarget),
+            (2350, Rule::XargsWithInlineReplace),
             (2139, Rule::CommandSubstitutionInAlias),
             (2142, Rule::FunctionInAlias),
             (2021, Rule::UnquotedTrRange),

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -89,6 +89,9 @@ impl ShellCheckCodeMap {
         if number == 2350 {
             return vec![Rule::XargsWithInlineReplace];
         }
+        if number == 2369 {
+            return vec![Rule::TrapSignalNumbers];
+        }
         if number == 2303 {
             return vec![Rule::UnquotedTrClass];
         }
@@ -186,6 +189,9 @@ impl Default for ShellCheckCodeMap {
             // Current ShellCheck releases emit SC2267 for this behavior, recorded in S064
             // corpus metadata to preserve existing SC2267 suppression semantics.
             (2350, Rule::XargsWithInlineReplace),
+            // SC2369 remains the authored compatibility code for numeric trap signals.
+            // Current oracle runs are recorded as reviewed metadata for S068.
+            (2369, Rule::TrapSignalNumbers),
             // ShellCheck 0.11.0 reports command substitutions inside alias definitions as SC2139.
             // Keep SC2328 as a suppression alias for historical compatibility.
             (2139, Rule::CommandSubstitutionInAlias),
@@ -528,6 +534,7 @@ impl Default for ShellCheckCodeMap {
                     (2197, Rule::FgrepDeprecated),
                     (2347, Rule::RelativeSymlinkTarget),
                     (2350, Rule::XargsWithInlineReplace),
+                    (2369, Rule::TrapSignalNumbers),
                     (2139, Rule::CommandSubstitutionInAlias),
                     (2142, Rule::FunctionInAlias),
                     (2283, Rule::DoubleParenGrouping),
@@ -975,6 +982,7 @@ mod tests {
         assert_eq!(map.resolve("SC2197"), Some(Rule::FgrepDeprecated));
         assert_eq!(map.resolve("SC2347"), Some(Rule::RelativeSymlinkTarget));
         assert_eq!(map.resolve("SC2350"), Some(Rule::XargsWithInlineReplace));
+        assert_eq!(map.resolve("SC2369"), Some(Rule::TrapSignalNumbers));
         assert_eq!(
             map.resolve("SC2139"),
             Some(Rule::CommandSubstitutionInAlias)
@@ -1049,6 +1057,7 @@ mod tests {
             map.resolve_all("SC2350"),
             vec![Rule::XargsWithInlineReplace]
         );
+        assert_eq!(map.resolve_all("SC2369"), vec![Rule::TrapSignalNumbers]);
         assert_eq!(
             map.resolve_all("SC2139"),
             vec![Rule::CommandSubstitutionInAlias]
@@ -1615,6 +1624,7 @@ mod tests {
             (2197, Rule::FgrepDeprecated),
             (2347, Rule::RelativeSymlinkTarget),
             (2350, Rule::XargsWithInlineReplace),
+            (2369, Rule::TrapSignalNumbers),
             (2139, Rule::CommandSubstitutionInAlias),
             (2142, Rule::FunctionInAlias),
             (2021, Rule::UnquotedTrRange),

--- a/crates/shuck/tests/testdata/corpus-metadata/s063.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s063.yaml
@@ -1,0 +1,6 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2347"
+    reason: "In the nix-pinned ShellCheck oracle used by the corpus harness, the authored SC2347 symlink-target warning is currently silent, so it does not provide a stable live comparison signal for S063."
+reviewed_divergences:
+  - side: shuck-only
+    reason: "S063 intentionally keeps flagging deep `../` symlink targets on literal `ln -s` operands, while the pinned ShellCheck oracle currently emits no matching diagnostics for this warning family."

--- a/crates/shuck/tests/testdata/corpus-metadata/s064.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s064.yaml
@@ -1,0 +1,6 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2267"
+    reason: "Current ShellCheck releases report deprecated short `xargs -i` usage as SC2267, while S064 keeps authored SC2350 to avoid changing SC2267 suppression behavior shared with other rules."
+reviewed_divergences:
+  - side: shuck-only
+    reason: "S064 intentionally reports deprecated short `xargs -i` forms while the corpus comparison target remains authored SC2350 and current ShellCheck emits this warning family under SC2267."

--- a/crates/shuck/tests/testdata/corpus-metadata/s068.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s068.yaml
@@ -1,0 +1,6 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2369"
+    reason: "In the nix-pinned ShellCheck oracle used by the corpus harness, authored SC2369 numeric trap-signal warnings are currently silent and do not provide a stable live comparison signal for S068."
+reviewed_divergences:
+  - side: shuck-only
+    reason: "S068 intentionally flags literal numeric trap signal IDs, while the pinned ShellCheck oracle currently emits no matching diagnostics for this warning family."

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -303,10 +303,10 @@ Filter command facts by `effective_name_is()` and check options/arguments.
 - [x] [x] **L** S057 (SC2330) `function-in-alias` — function definition inside alias
 - [x] [x] **L** S059 (SC2340) `deprecated-tempfile-command` — deprecated `tempfile` command
 - [x] [x] **L** S060 (SC2342) `egrep-deprecated` — `egrep` instead of `grep -E`
-- [ ] **L** S061 (SC2343) `fgrep-deprecated` — `fgrep` instead of `grep -F`
-- [ ] **L** S063 (SC2347) `relative-symlink-target` — deep relative symlink path
-- [ ] **L** S064 (SC2350) `xargs-with-inline-replace` — deprecated `-i` flag for xargs
-- [ ] **L** S068 (SC2369) `trap-signal-numbers` — numeric signal IDs in trap
+- [x] **L** S061 (SC2343) `fgrep-deprecated` — `fgrep` instead of `grep -F`
+- [x] **L** S063 (SC2347) `relative-symlink-target` — deep relative symlink path
+- [x] **L** S064 (SC2350) `xargs-with-inline-replace` — deprecated `-i` flag for xargs
+- [x] **L** S068 (SC2369) `trap-signal-numbers` — numeric signal IDs in trap
 
 ### Shebang and Script Structure
 


### PR DESCRIPTION
## What Changed

Implemented four style rules and marked them complete in `docs/rules.md`:
- `S061` `fgrep-deprecated`
- `S063` `relative-symlink-target`
- `S064` `xargs-with-inline-replace`
- `S068` `trap-signal-numbers`

The implementations reuse shared logic instead of adding one-off parsing where possible:
- `S061` follows the existing command-fact pattern used by the nearby deprecated grep rule.
- `S063` uses existing `WordFact` literal/runtime analysis to limit findings to stable literal symlink targets.
- `S064` extends `XargsCommandFacts` so the rule reads a fact-layer summary of deprecated short `-i` usage.
- `S068` reuses the shared trap argument parser from `trap_common`.

## Why

These rules were still unchecked in the style rules list. This fills in the authored rule coverage while keeping the implementations aligned with the linter's shared fact and parsing layers.

## Impact

Users now get dedicated diagnostics for these four warning families, and the rule tracker in `docs/rules.md` is updated to reflect that they are implemented.

## Root Cause

The repo had rule specs for these checks, but the corresponding linter implementations, fixtures, snapshots, and corpus metadata were still missing.

## Validation

Ran targeted validation for each rule:
- `cargo test -p shuck-linter` for the rule-specific unit tests and fixture snapshot tests
- registry and shellcheck-map targeted tests for the new rule wiring
- targeted large corpus conformance runs with `SHUCK_LARGE_CORPUS_RULES=S061`, `S063`, `S064`, and `S068`

Notes:
- The targeted large-corpus conformance run passed for each individual rule.
- The full `make test-large-corpus` flow is still blocked in this environment by the unrelated `large_corpus_zsh_fixtures_parse` timeout on the `ohmyzsh` `emoji-char-definitions.zsh` fixture.
- I did not rerun the full workspace test suite.
