### PR TITLE
Implement shebang and script structure rules

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C073.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C073.sh
@@ -1,0 +1,8 @@
+ #!/bin/sh
+:
+
+# should not trigger: only the file header counts as the shebang
+#!/bin/sh
+
+# should not trigger: spacing after `#!` is a different rule
+#! /bin/sh

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C074.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C074.sh
@@ -1,0 +1,8 @@
+# !/bin/sh
+:
+
+# should not trigger: a real shebang
+#!/bin/sh
+
+# should not trigger: only the first line is header metadata
+# !/bin/sh

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C075.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C075.sh
@@ -1,0 +1,7 @@
+
+#!/bin/sh
+:
+
+# should not trigger: shebang belongs on the first line, not later lines
+echo ok
+#!/bin/sh

--- a/crates/shuck-linter/resources/test/fixtures/style/S043.txt
+++ b/crates/shuck-linter/resources/test/fixtures/style/S043.txt
@@ -1,0 +1,10 @@
+# /etc/config/myapp.conf
+echo hello
+
+# should not trigger: actual shebang
+#!/bin/sh
+echo hello
+
+# should not trigger: shellcheck shell directive is an explicit shell hint
+# shellcheck shell=sh
+echo hello

--- a/crates/shuck-linter/resources/test/fixtures/style/S053.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S053.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -u -u
+echo hello
+
+#!/bin/sh -u -e
+echo hello

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -984,6 +984,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::MissingShebangLine) {
             rules::style::missing_shebang_line::missing_shebang_line(self);
         }
+        if self.is_rule_enabled(Rule::DuplicateShebangFlag) {
+            rules::style::duplicate_shebang_flag::duplicate_shebang_flag(self);
+        }
         if self.is_rule_enabled(Rule::NonAbsoluteShebang) {
             rules::correctness::non_absolute_shebang::non_absolute_shebang(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -978,6 +978,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::SpaceAfterHashBang) {
             rules::correctness::space_after_hash_bang::space_after_hash_bang(self);
         }
+        if self.is_rule_enabled(Rule::ShebangNotOnFirstLine) {
+            rules::correctness::shebang_not_on_first_line::shebang_not_on_first_line(self);
+        }
         if self.is_rule_enabled(Rule::NonAbsoluteShebang) {
             rules::correctness::non_absolute_shebang::non_absolute_shebang(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -975,6 +975,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::IndentedShebang) {
             rules::correctness::indented_shebang::indented_shebang(self);
         }
+        if self.is_rule_enabled(Rule::SpaceAfterHashBang) {
+            rules::correctness::space_after_hash_bang::space_after_hash_bang(self);
+        }
         if self.is_rule_enabled(Rule::NonAbsoluteShebang) {
             rules::correctness::non_absolute_shebang::non_absolute_shebang(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -972,6 +972,9 @@ impl<'a> Checker<'a> {
     }
 
     fn check_flow(&mut self) {
+        if self.is_rule_enabled(Rule::IndentedShebang) {
+            rules::correctness::indented_shebang::indented_shebang(self);
+        }
         if self.is_rule_enabled(Rule::NonAbsoluteShebang) {
             rules::correctness::non_absolute_shebang::non_absolute_shebang(self);
         }

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -981,6 +981,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::ShebangNotOnFirstLine) {
             rules::correctness::shebang_not_on_first_line::shebang_not_on_first_line(self);
         }
+        if self.is_rule_enabled(Rule::MissingShebangLine) {
+            rules::style::missing_shebang_line::missing_shebang_line(self);
+        }
         if self.is_rule_enabled(Rule::NonAbsoluteShebang) {
             rules::correctness::non_absolute_shebang::non_absolute_shebang(self);
         }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1980,6 +1980,7 @@ pub struct LinterFacts<'a> {
     lists: Vec<ListFact<'a>>,
     single_test_subshell_spans: Vec<Span>,
     subshell_test_group_spans: Vec<Span>,
+    indented_shebang_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
     commented_continuation_comment_spans: Vec<Span>,
     trailing_directive_comment_spans: Vec<Span>,
@@ -2189,6 +2190,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn subshell_test_group_spans(&self) -> &[Span] {
         &self.subshell_test_group_spans
+    }
+
+    pub fn indented_shebang_span(&self) -> Option<Span> {
+        self.indented_shebang_span
     }
 
     pub fn non_absolute_shebang_span(&self) -> Option<Span> {
@@ -2578,7 +2583,7 @@ impl<'a> LinterFactsBuilder<'a> {
             build_single_test_subshell_spans(&commands, &command_ids_by_span, self.source);
         let subshell_test_group_spans =
             build_subshell_test_group_spans(&commands, &command_ids_by_span, self.source);
-        let non_absolute_shebang_span = build_non_absolute_shebang_span(self.source);
+        let shebang_header_facts = build_shebang_header_facts(self.source);
         let commented_continuation_comment_spans =
             build_commented_continuation_comment_spans(self.source, self._indexer);
         let trailing_directive_comment_spans =
@@ -2687,7 +2692,8 @@ impl<'a> LinterFactsBuilder<'a> {
             lists,
             single_test_subshell_spans,
             subshell_test_group_spans,
-            non_absolute_shebang_span,
+            indented_shebang_span: shebang_header_facts.indented_shebang_span,
+            non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
             commented_continuation_comment_spans,
             trailing_directive_comment_spans,
             condition_status_capture_spans,
@@ -3801,26 +3807,47 @@ fn special_positional_parameter_name(name: &str) -> Option<bool> {
     }
 }
 
-fn build_non_absolute_shebang_span(source: &str) -> Option<Span> {
-    let first_line = source.lines().next()?;
-    let shebang = first_line.strip_prefix("#!")?;
-    let interpreter = shebang.split_whitespace().next()?;
+#[derive(Debug, Clone, Copy, Default)]
+struct ShebangHeaderFacts {
+    indented_shebang_span: Option<Span>,
+    non_absolute_shebang_span: Option<Span>,
+}
 
-    if interpreter.starts_with('/') || interpreter == "/usr/bin/env" {
-        return None;
-    }
-    if has_header_shellcheck_shell_directive(source) {
-        return None;
-    }
-
+fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
+    let Some(first_line) = source.lines().next() else {
+        return ShebangHeaderFacts::default();
+    };
     let line = first_line.trim_end_matches('\r');
+
+    let trimmed = line.trim_start_matches(char::is_whitespace);
+    let indented_shebang_span =
+        (trimmed.len() != line.len() && trimmed.starts_with("#!")).then(|| first_line_span(line));
+
+    let non_absolute_shebang_span = line.strip_prefix("#!").and_then(|shebang| {
+        let interpreter = shebang.split_whitespace().next()?;
+        if interpreter.starts_with('/') || interpreter == "/usr/bin/env" {
+            return None;
+        }
+        if has_header_shellcheck_shell_directive(source) {
+            return None;
+        }
+        Some(first_line_span(line))
+    });
+
+    ShebangHeaderFacts {
+        indented_shebang_span,
+        non_absolute_shebang_span,
+    }
+}
+
+fn first_line_span(line: &str) -> Span {
     let start = Position {
         line: 1,
         column: 1,
         offset: 0,
     };
     let end = start.advanced_by(line);
-    Some(Span::from_positions(start, end))
+    Span::from_positions(start, end)
 }
 
 fn build_commented_continuation_comment_spans(source: &str, indexer: &Indexer) -> Vec<Span> {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1982,6 +1982,7 @@ pub struct LinterFacts<'a> {
     subshell_test_group_spans: Vec<Span>,
     indented_shebang_span: Option<Span>,
     space_after_hash_bang_span: Option<Span>,
+    shebang_not_on_first_line_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
     commented_continuation_comment_spans: Vec<Span>,
     trailing_directive_comment_spans: Vec<Span>,
@@ -2199,6 +2200,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn space_after_hash_bang_span(&self) -> Option<Span> {
         self.space_after_hash_bang_span
+    }
+
+    pub fn shebang_not_on_first_line_span(&self) -> Option<Span> {
+        self.shebang_not_on_first_line_span
     }
 
     pub fn non_absolute_shebang_span(&self) -> Option<Span> {
@@ -2699,6 +2704,7 @@ impl<'a> LinterFactsBuilder<'a> {
             subshell_test_group_spans,
             indented_shebang_span: shebang_header_facts.indented_shebang_span,
             space_after_hash_bang_span: shebang_header_facts.space_after_hash_bang_span,
+            shebang_not_on_first_line_span: shebang_header_facts.shebang_not_on_first_line_span,
             non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
             commented_continuation_comment_spans,
             trailing_directive_comment_spans,
@@ -3817,18 +3823,19 @@ fn special_positional_parameter_name(name: &str) -> Option<bool> {
 struct ShebangHeaderFacts {
     indented_shebang_span: Option<Span>,
     space_after_hash_bang_span: Option<Span>,
+    shebang_not_on_first_line_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
 }
 
 fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
-    let Some(first_line) = source.lines().next() else {
+    let Some((first_line_offset, first_line_text)) = nth_source_line(source, 0) else {
         return ShebangHeaderFacts::default();
     };
-    let line = first_line.trim_end_matches('\r');
+    let line = first_line_text.trim_end_matches('\r');
 
     let trimmed = line.trim_start_matches(char::is_whitespace);
-    let indented_shebang_span =
-        (trimmed.len() != line.len() && trimmed.starts_with("#!")).then(|| first_line_span(line));
+    let indented_shebang_span = (trimmed.len() != line.len() && trimmed.starts_with("#!"))
+        .then(|| line_span(1, first_line_offset, line));
 
     let space_after_hash_bang_span = line
         .strip_prefix('#')
@@ -3838,7 +3845,13 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
                 .starts_with('!')
                 .then_some(())
         })
-        .map(|()| first_line_span(line));
+        .map(|()| line_span(1, first_line_offset, line));
+
+    let first_line_header_like = line.trim_start().is_empty() || line.trim_start().starts_with('#');
+    let shebang_not_on_first_line_span = nth_source_line(source, 1).and_then(|(offset, line)| {
+        let line = line.trim_end_matches('\r');
+        (first_line_header_like && line.starts_with("#!")).then(|| line_span(2, offset, line))
+    });
 
     let non_absolute_shebang_span = line.strip_prefix("#!").and_then(|shebang| {
         let interpreter = shebang.split_whitespace().next()?;
@@ -3848,21 +3861,41 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         if has_header_shellcheck_shell_directive(source) {
             return None;
         }
-        Some(first_line_span(line))
+        Some(line_span(1, first_line_offset, line))
     });
 
     ShebangHeaderFacts {
         indented_shebang_span,
         space_after_hash_bang_span,
+        shebang_not_on_first_line_span,
         non_absolute_shebang_span,
     }
 }
 
-fn first_line_span(line: &str) -> Span {
+fn nth_source_line(source: &str, index: usize) -> Option<(usize, &str)> {
+    let mut offset = 0;
+
+    for (line_index, raw_line) in source.split_inclusive('\n').enumerate() {
+        let line = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+        if line_index == index {
+            return Some((offset, line));
+        }
+        offset += raw_line.len();
+    }
+
+    if source.is_empty() {
+        return None;
+    }
+
+    let total_lines = source.split_inclusive('\n').count();
+    (total_lines == index + 1 && !source.ends_with('\n')).then_some((offset, &source[offset..]))
+}
+
+fn line_span(line_number: usize, offset: usize, line: &str) -> Span {
     let start = Position {
-        line: 1,
+        line: line_number,
         column: 1,
-        offset: 0,
+        offset,
     };
     let end = start.advanced_by(line);
     Span::from_positions(start, end)

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1981,6 +1981,7 @@ pub struct LinterFacts<'a> {
     single_test_subshell_spans: Vec<Span>,
     subshell_test_group_spans: Vec<Span>,
     indented_shebang_span: Option<Span>,
+    space_after_hash_bang_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
     commented_continuation_comment_spans: Vec<Span>,
     trailing_directive_comment_spans: Vec<Span>,
@@ -2194,6 +2195,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn indented_shebang_span(&self) -> Option<Span> {
         self.indented_shebang_span
+    }
+
+    pub fn space_after_hash_bang_span(&self) -> Option<Span> {
+        self.space_after_hash_bang_span
     }
 
     pub fn non_absolute_shebang_span(&self) -> Option<Span> {
@@ -2693,6 +2698,7 @@ impl<'a> LinterFactsBuilder<'a> {
             single_test_subshell_spans,
             subshell_test_group_spans,
             indented_shebang_span: shebang_header_facts.indented_shebang_span,
+            space_after_hash_bang_span: shebang_header_facts.space_after_hash_bang_span,
             non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
             commented_continuation_comment_spans,
             trailing_directive_comment_spans,
@@ -3810,6 +3816,7 @@ fn special_positional_parameter_name(name: &str) -> Option<bool> {
 #[derive(Debug, Clone, Copy, Default)]
 struct ShebangHeaderFacts {
     indented_shebang_span: Option<Span>,
+    space_after_hash_bang_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
 }
 
@@ -3822,6 +3829,16 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
     let trimmed = line.trim_start_matches(char::is_whitespace);
     let indented_shebang_span =
         (trimmed.len() != line.len() && trimmed.starts_with("#!")).then(|| first_line_span(line));
+
+    let space_after_hash_bang_span = line
+        .strip_prefix('#')
+        .and_then(|rest| rest.starts_with(char::is_whitespace).then_some(rest))
+        .and_then(|rest| {
+            rest.trim_start_matches(char::is_whitespace)
+                .starts_with('!')
+                .then_some(())
+        })
+        .map(|()| first_line_span(line));
 
     let non_absolute_shebang_span = line.strip_prefix("#!").and_then(|shebang| {
         let interpreter = shebang.split_whitespace().next()?;
@@ -3836,6 +3853,7 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
 
     ShebangHeaderFacts {
         indented_shebang_span,
+        space_after_hash_bang_span,
         non_absolute_shebang_span,
     }
 }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1983,6 +1983,7 @@ pub struct LinterFacts<'a> {
     indented_shebang_span: Option<Span>,
     space_after_hash_bang_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
+    missing_shebang_line_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
     commented_continuation_comment_spans: Vec<Span>,
     trailing_directive_comment_spans: Vec<Span>,
@@ -2204,6 +2205,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn shebang_not_on_first_line_span(&self) -> Option<Span> {
         self.shebang_not_on_first_line_span
+    }
+
+    pub fn missing_shebang_line_span(&self) -> Option<Span> {
+        self.missing_shebang_line_span
     }
 
     pub fn non_absolute_shebang_span(&self) -> Option<Span> {
@@ -2705,6 +2710,7 @@ impl<'a> LinterFactsBuilder<'a> {
             indented_shebang_span: shebang_header_facts.indented_shebang_span,
             space_after_hash_bang_span: shebang_header_facts.space_after_hash_bang_span,
             shebang_not_on_first_line_span: shebang_header_facts.shebang_not_on_first_line_span,
+            missing_shebang_line_span: shebang_header_facts.missing_shebang_line_span,
             non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
             commented_continuation_comment_spans,
             trailing_directive_comment_spans,
@@ -3824,6 +3830,7 @@ struct ShebangHeaderFacts {
     indented_shebang_span: Option<Span>,
     space_after_hash_bang_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
+    missing_shebang_line_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
 }
 
@@ -3847,11 +3854,25 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         })
         .map(|()| line_span(1, first_line_offset, line));
 
+    let first_line_shellcheck_shell_directive = line
+        .strip_prefix('#')
+        .map(str::trim_start)
+        .is_some_and(|comment| {
+            comment
+                .to_ascii_lowercase()
+                .starts_with("shellcheck shell=")
+        });
     let first_line_header_like = line.trim_start().is_empty() || line.trim_start().starts_with('#');
     let shebang_not_on_first_line_span = nth_source_line(source, 1).and_then(|(offset, line)| {
         let line = line.trim_end_matches('\r');
         (first_line_header_like && line.starts_with("#!")).then(|| line_span(2, offset, line))
     });
+    let missing_shebang_line_span = (!line.trim_start().starts_with("#!")
+        && space_after_hash_bang_span.is_none()
+        && shebang_not_on_first_line_span.is_none()
+        && !first_line_shellcheck_shell_directive
+        && line.trim_start().starts_with('#'))
+    .then(|| line_span(1, first_line_offset, line));
 
     let non_absolute_shebang_span = line.strip_prefix("#!").and_then(|shebang| {
         let interpreter = shebang.split_whitespace().next()?;
@@ -3868,6 +3889,7 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         indented_shebang_span,
         space_after_hash_bang_span,
         shebang_not_on_first_line_span,
+        missing_shebang_line_span,
         non_absolute_shebang_span,
     }
 }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1984,6 +1984,7 @@ pub struct LinterFacts<'a> {
     space_after_hash_bang_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
     missing_shebang_line_span: Option<Span>,
+    duplicate_shebang_flag_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
     commented_continuation_comment_spans: Vec<Span>,
     trailing_directive_comment_spans: Vec<Span>,
@@ -2209,6 +2210,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn missing_shebang_line_span(&self) -> Option<Span> {
         self.missing_shebang_line_span
+    }
+
+    pub fn duplicate_shebang_flag_span(&self) -> Option<Span> {
+        self.duplicate_shebang_flag_span
     }
 
     pub fn non_absolute_shebang_span(&self) -> Option<Span> {
@@ -2711,6 +2716,7 @@ impl<'a> LinterFactsBuilder<'a> {
             space_after_hash_bang_span: shebang_header_facts.space_after_hash_bang_span,
             shebang_not_on_first_line_span: shebang_header_facts.shebang_not_on_first_line_span,
             missing_shebang_line_span: shebang_header_facts.missing_shebang_line_span,
+            duplicate_shebang_flag_span: shebang_header_facts.duplicate_shebang_flag_span,
             non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
             commented_continuation_comment_spans,
             trailing_directive_comment_spans,
@@ -3831,6 +3837,7 @@ struct ShebangHeaderFacts {
     space_after_hash_bang_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
     missing_shebang_line_span: Option<Span>,
+    duplicate_shebang_flag_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
 }
 
@@ -3874,9 +3881,16 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         && line.trim_start().starts_with('#'))
     .then(|| line_span(1, first_line_offset, line));
 
-    let non_absolute_shebang_span = line.strip_prefix("#!").and_then(|shebang| {
-        let interpreter = shebang.split_whitespace().next()?;
-        if interpreter.starts_with('/') || interpreter == "/usr/bin/env" {
+    let shebang_words = line
+        .strip_prefix("#!")
+        .map(parse_shebang_words)
+        .unwrap_or_default();
+
+    let duplicate_shebang_flag_span =
+        shebang_duplicate_flag(&shebang_words).map(|_| line_span(1, first_line_offset, line));
+
+    let non_absolute_shebang_span = shebang_words.first().and_then(|interpreter| {
+        if interpreter.starts_with('/') || *interpreter == "/usr/bin/env" {
             return None;
         }
         if has_header_shellcheck_shell_directive(source) {
@@ -3890,8 +3904,23 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         space_after_hash_bang_span,
         shebang_not_on_first_line_span,
         missing_shebang_line_span,
+        duplicate_shebang_flag_span,
         non_absolute_shebang_span,
     }
+}
+
+fn parse_shebang_words(shebang: &str) -> Vec<&str> {
+    shebang.split_whitespace().collect()
+}
+
+fn shebang_duplicate_flag<'a>(shebang_words: &[&'a str]) -> Option<&'a str> {
+    let mut seen = FxHashSet::default();
+
+    shebang_words
+        .iter()
+        .copied()
+        .skip(1)
+        .find(|word| word.starts_with('-') && !seen.insert(*word))
 }
 
 fn nth_source_line(source: &str, index: usize) -> Option<(usize, &str)> {

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -144,6 +144,7 @@ declare_rules! {
     ("C072", Category::Correctness, Severity::Warning, UnicodeQuoteInString),
     ("C073", Category::Correctness, Severity::Warning, IndentedShebang),
     ("C074", Category::Correctness, Severity::Warning, SpaceAfterHashBang),
+    ("C075", Category::Correctness, Severity::Warning, ShebangNotOnFirstLine),
     (
         "C076",
         Category::Correctness,
@@ -805,6 +806,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-189" => Some(Rule::UnicodeQuoteInString),
         "SH-191" => Some(Rule::IndentedShebang),
         "SH-192" => Some(Rule::SpaceAfterHashBang),
+        "SH-193" => Some(Rule::ShebangNotOnFirstLine),
         "SH-224" => Some(Rule::AssignmentLooksLikeComparison),
         "SH-225" => Some(Rule::UnquotedPipeInEcho),
         "SH-227" => Some(Rule::SuWithoutFlag),
@@ -1152,6 +1154,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-189"), Some(Rule::UnicodeQuoteInString));
         assert_eq!(code_to_rule("SH-191"), Some(Rule::IndentedShebang));
         assert_eq!(code_to_rule("SH-192"), Some(Rule::SpaceAfterHashBang));
+        assert_eq!(code_to_rule("SH-193"), Some(Rule::ShebangNotOnFirstLine));
         assert_eq!(code_to_rule("SH-079"), Some(Rule::AvoidLetBuiltin));
         assert_eq!(
             code_to_rule("SH-224"),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -619,6 +619,7 @@ declare_rules! {
     ("S040", Category::Style, Severity::Warning, BackslashBeforeCommand),
     ("S042", Category::Style, Severity::Warning, IfsEqualsAmbiguity),
     ("S043", Category::Style, Severity::Warning, MissingShebangLine),
+    ("S053", Category::Style, Severity::Warning, DuplicateShebangFlag),
     ("S072", Category::Style, Severity::Warning, LinebreakBeforeAnd),
     ("S073", Category::Style, Severity::Warning, SpacedTabstripClose),
     ("S074", Category::Style, Severity::Warning, AmpersandSemicolon),
@@ -809,6 +810,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-191" => Some(Rule::IndentedShebang),
         "SH-192" => Some(Rule::SpaceAfterHashBang),
         "SH-193" => Some(Rule::ShebangNotOnFirstLine),
+        "SH-223" => Some(Rule::DuplicateShebangFlag),
         "SH-224" => Some(Rule::AssignmentLooksLikeComparison),
         "SH-225" => Some(Rule::UnquotedPipeInEcho),
         "SH-227" => Some(Rule::SuWithoutFlag),
@@ -1158,6 +1160,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-191"), Some(Rule::IndentedShebang));
         assert_eq!(code_to_rule("SH-192"), Some(Rule::SpaceAfterHashBang));
         assert_eq!(code_to_rule("SH-193"), Some(Rule::ShebangNotOnFirstLine));
+        assert_eq!(code_to_rule("SH-223"), Some(Rule::DuplicateShebangFlag));
         assert_eq!(code_to_rule("SH-079"), Some(Rule::AvoidLetBuiltin));
         assert_eq!(
             code_to_rule("SH-224"),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -142,6 +142,7 @@ declare_rules! {
     ("C070", Category::Correctness, Severity::Warning, PositionalParamAsOperator),
     ("C071", Category::Correctness, Severity::Warning, DoubleParenGrouping),
     ("C072", Category::Correctness, Severity::Warning, UnicodeQuoteInString),
+    ("C073", Category::Correctness, Severity::Warning, IndentedShebang),
     (
         "C076",
         Category::Correctness,
@@ -801,6 +802,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-187" => Some(Rule::PositionalParamAsOperator),
         "SH-188" => Some(Rule::DoubleParenGrouping),
         "SH-189" => Some(Rule::UnicodeQuoteInString),
+        "SH-191" => Some(Rule::IndentedShebang),
         "SH-224" => Some(Rule::AssignmentLooksLikeComparison),
         "SH-225" => Some(Rule::UnquotedPipeInEcho),
         "SH-227" => Some(Rule::SuWithoutFlag),
@@ -1146,6 +1148,7 @@ mod tests {
         );
         assert_eq!(code_to_rule("SH-188"), Some(Rule::DoubleParenGrouping));
         assert_eq!(code_to_rule("SH-189"), Some(Rule::UnicodeQuoteInString));
+        assert_eq!(code_to_rule("SH-191"), Some(Rule::IndentedShebang));
         assert_eq!(code_to_rule("SH-079"), Some(Rule::AvoidLetBuiltin));
         assert_eq!(
             code_to_rule("SH-224"),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -143,6 +143,7 @@ declare_rules! {
     ("C071", Category::Correctness, Severity::Warning, DoubleParenGrouping),
     ("C072", Category::Correctness, Severity::Warning, UnicodeQuoteInString),
     ("C073", Category::Correctness, Severity::Warning, IndentedShebang),
+    ("C074", Category::Correctness, Severity::Warning, SpaceAfterHashBang),
     (
         "C076",
         Category::Correctness,
@@ -803,6 +804,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-188" => Some(Rule::DoubleParenGrouping),
         "SH-189" => Some(Rule::UnicodeQuoteInString),
         "SH-191" => Some(Rule::IndentedShebang),
+        "SH-192" => Some(Rule::SpaceAfterHashBang),
         "SH-224" => Some(Rule::AssignmentLooksLikeComparison),
         "SH-225" => Some(Rule::UnquotedPipeInEcho),
         "SH-227" => Some(Rule::SuWithoutFlag),
@@ -1149,6 +1151,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-188"), Some(Rule::DoubleParenGrouping));
         assert_eq!(code_to_rule("SH-189"), Some(Rule::UnicodeQuoteInString));
         assert_eq!(code_to_rule("SH-191"), Some(Rule::IndentedShebang));
+        assert_eq!(code_to_rule("SH-192"), Some(Rule::SpaceAfterHashBang));
         assert_eq!(code_to_rule("SH-079"), Some(Rule::AvoidLetBuiltin));
         assert_eq!(
             code_to_rule("SH-224"),

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -618,6 +618,7 @@ declare_rules! {
     ),
     ("S040", Category::Style, Severity::Warning, BackslashBeforeCommand),
     ("S042", Category::Style, Severity::Warning, IfsEqualsAmbiguity),
+    ("S043", Category::Style, Severity::Warning, MissingShebangLine),
     ("S072", Category::Style, Severity::Warning, LinebreakBeforeAnd),
     ("S073", Category::Style, Severity::Warning, SpacedTabstripClose),
     ("S074", Category::Style, Severity::Warning, AmpersandSemicolon),
@@ -804,6 +805,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-187" => Some(Rule::PositionalParamAsOperator),
         "SH-188" => Some(Rule::DoubleParenGrouping),
         "SH-189" => Some(Rule::UnicodeQuoteInString),
+        "SH-190" => Some(Rule::MissingShebangLine),
         "SH-191" => Some(Rule::IndentedShebang),
         "SH-192" => Some(Rule::SpaceAfterHashBang),
         "SH-193" => Some(Rule::ShebangNotOnFirstLine),
@@ -1152,6 +1154,7 @@ mod tests {
         );
         assert_eq!(code_to_rule("SH-188"), Some(Rule::DoubleParenGrouping));
         assert_eq!(code_to_rule("SH-189"), Some(Rule::UnicodeQuoteInString));
+        assert_eq!(code_to_rule("SH-190"), Some(Rule::MissingShebangLine));
         assert_eq!(code_to_rule("SH-191"), Some(Rule::IndentedShebang));
         assert_eq!(code_to_rule("SH-192"), Some(Rule::SpaceAfterHashBang));
         assert_eq!(code_to_rule("SH-193"), Some(Rule::ShebangNotOnFirstLine));

--- a/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
@@ -1,0 +1,50 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct IndentedShebang;
+
+impl Violation for IndentedShebang {
+    fn rule() -> Rule {
+        Rule::IndentedShebang
+    }
+
+    fn message(&self) -> String {
+        "shebang must start in column 1".to_owned()
+    }
+}
+
+pub fn indented_shebang(checker: &mut Checker) {
+    if let Some(span) = checker.facts().indented_shebang_span() {
+        checker.report(IndentedShebang, span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_indented_shebang_on_first_line() {
+        let source = " #!/bin/sh\n:\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::IndentedShebang));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.slice(source), " #!/bin/sh");
+    }
+
+    #[test]
+    fn ignores_non_indented_or_non_header_shebangs() {
+        for source in [
+            "#!/bin/sh\n:\n",
+            "#! /bin/sh\n:\n",
+            "\n#!/bin/sh\n:\n",
+            "# comment\n #!/bin/sh\n:\n",
+            "\t# not a shebang\n:\n",
+        ] {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::IndentedShebang));
+            assert!(diagnostics.is_empty());
+        }
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -92,6 +92,7 @@ pub mod quoted_command_in_test;
 pub mod redirect_to_command_name;
 pub mod script_scope_local;
 pub mod set_flags_without_dashes;
+pub mod shebang_not_on_first_line;
 pub mod short_circuit_fallthrough;
 pub mod single_quoted_literal;
 pub mod space_after_hash_bang;
@@ -191,6 +192,7 @@ mod tests {
     #[test_case(Rule::UnicodeQuoteInString, Path::new("C072.sh"))]
     #[test_case(Rule::IndentedShebang, Path::new("C073.sh"))]
     #[test_case(Rule::SpaceAfterHashBang, Path::new("C074.sh"))]
+    #[test_case(Rule::ShebangNotOnFirstLine, Path::new("C075.sh"))]
     #[test_case(Rule::CommentedContinuationLine, Path::new("C076.sh"))]
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
     #[test_case(Rule::UnquotedGlobsInFind, Path::new("C078.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -57,6 +57,7 @@ pub mod if_bracket_glued;
 pub mod if_dollar_command;
 pub mod if_missing_then;
 pub mod ifs_set_to_literal_backslash_n;
+pub mod indented_shebang;
 pub mod invalid_exit_status;
 pub mod keyword_function_name;
 pub mod leading_glob_argument;
@@ -187,6 +188,7 @@ mod tests {
     #[test_case(Rule::PositionalParamAsOperator, Path::new("C070.sh"))]
     #[test_case(Rule::DoubleParenGrouping, Path::new("C071.sh"))]
     #[test_case(Rule::UnicodeQuoteInString, Path::new("C072.sh"))]
+    #[test_case(Rule::IndentedShebang, Path::new("C073.sh"))]
     #[test_case(Rule::CommentedContinuationLine, Path::new("C076.sh"))]
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
     #[test_case(Rule::UnquotedGlobsInFind, Path::new("C078.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -94,6 +94,7 @@ pub mod script_scope_local;
 pub mod set_flags_without_dashes;
 pub mod short_circuit_fallthrough;
 pub mod single_quoted_literal;
+pub mod space_after_hash_bang;
 pub mod spaced_assignment;
 pub mod status_capture_after_branch_test;
 pub mod string_comparison_for_version;
@@ -189,6 +190,7 @@ mod tests {
     #[test_case(Rule::DoubleParenGrouping, Path::new("C071.sh"))]
     #[test_case(Rule::UnicodeQuoteInString, Path::new("C072.sh"))]
     #[test_case(Rule::IndentedShebang, Path::new("C073.sh"))]
+    #[test_case(Rule::SpaceAfterHashBang, Path::new("C074.sh"))]
     #[test_case(Rule::CommentedContinuationLine, Path::new("C076.sh"))]
     #[test_case(Rule::SubshellInArithmetic, Path::new("C077.sh"))]
     #[test_case(Rule::UnquotedGlobsInFind, Path::new("C078.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
@@ -1,0 +1,77 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct ShebangNotOnFirstLine;
+
+impl Violation for ShebangNotOnFirstLine {
+    fn rule() -> Rule {
+        Rule::ShebangNotOnFirstLine
+    }
+
+    fn message(&self) -> String {
+        "move the shebang to the first line of the file".to_owned()
+    }
+}
+
+pub fn shebang_not_on_first_line(checker: &mut Checker) {
+    if let Some(span) = checker.facts().shebang_not_on_first_line_span() {
+        checker.report(ShebangNotOnFirstLine, span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_shebang_on_second_line() {
+        let source = "\n#!/bin/sh\n:\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.slice(source), "#!/bin/sh");
+    }
+
+    #[test]
+    fn reports_second_line_shebang_after_other_prelude_text() {
+        let source = "# comment\n#!/bin/sh\n:\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn ignores_non_header_second_line_shebangs() {
+        for source in ["echo hi\n#!/bin/sh\n:\n", "cat <<EOF\n#!/bin/sh\nEOF\n"] {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+            );
+            assert!(diagnostics.is_empty());
+        }
+    }
+
+    #[test]
+    fn ignores_first_line_or_malformed_second_line_shebangs() {
+        for source in [
+            "#!/bin/sh\n:\n",
+            "\n# !/bin/sh\n:\n",
+            "\n #!/bin/sh\n:\n",
+            "\n\n#!/bin/sh\n:\n",
+        ] {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+            );
+            assert!(diagnostics.is_empty());
+        }
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C073_C073.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C073_C073.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 266
+---
+C073 shebang must start in column 1
+ --> <source>:1:1
+  |
+1 |  #!/bin/sh
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C074_C074.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C074_C074.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 268
+---
+C074 remove the space so the shebang starts with `#!`
+ --> <source>:1:1
+  |
+1 | # !/bin/sh
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C075_C075.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C075_C075.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 270
+---
+C075 move the shebang to the first line of the file
+ --> <source>:2:1
+  |
+2 | #!/bin/sh
+  |

--- a/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
+++ b/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
@@ -1,0 +1,58 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct SpaceAfterHashBang;
+
+impl Violation for SpaceAfterHashBang {
+    fn rule() -> Rule {
+        Rule::SpaceAfterHashBang
+    }
+
+    fn message(&self) -> String {
+        "remove the space so the shebang starts with `#!`".to_owned()
+    }
+}
+
+pub fn space_after_hash_bang(checker: &mut Checker) {
+    if let Some(span) = checker.facts().space_after_hash_bang_span() {
+        checker.report(SpaceAfterHashBang, span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_space_after_hash_bang_on_first_line() {
+        let source = "# !/bin/sh\n:\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.slice(source), "# !/bin/sh");
+    }
+
+    #[test]
+    fn ignores_valid_or_non_header_comment_lines() {
+        for source in [
+            "#!/bin/sh\n:\n",
+            " #!/bin/sh\n:\n",
+            "# comment\n# !/bin/sh\n",
+            "\n# !/bin/sh\n",
+        ] {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
+            assert!(diagnostics.is_empty());
+        }
+    }
+
+    #[test]
+    fn reports_other_whitespace_between_hash_and_bang() {
+        let source = "#\t!/bin/sh\n:\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "#\t!/bin/sh");
+    }
+}

--- a/crates/shuck-linter/src/rules/style/duplicate_shebang_flag.rs
+++ b/crates/shuck-linter/src/rules/style/duplicate_shebang_flag.rs
@@ -1,0 +1,61 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct DuplicateShebangFlag;
+
+impl Violation for DuplicateShebangFlag {
+    fn rule() -> Rule {
+        Rule::DuplicateShebangFlag
+    }
+
+    fn message(&self) -> String {
+        "remove the repeated shebang flag".to_owned()
+    }
+}
+
+pub fn duplicate_shebang_flag(checker: &mut Checker) {
+    if let Some(span) = checker.facts().duplicate_shebang_flag_span() {
+        checker.report(DuplicateShebangFlag, span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_repeated_shebang_flags() {
+        for source in [
+            "#!/bin/sh -u -u\necho hello\n",
+            "#!/usr/bin/env bash -u -u\necho hello\n",
+            "#!/usr/bin/env bash -o pipefail -o pipefail\necho hello\n",
+        ] {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::DuplicateShebangFlag),
+            );
+
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(diagnostics[0].span.start.line, 1);
+        }
+    }
+
+    #[test]
+    fn ignores_distinct_or_missing_shebang_flags() {
+        for source in [
+            "#!/bin/sh -u\n",
+            "#!/bin/sh -u -e\n",
+            "#!/usr/bin/env bash -u -e\n",
+            " #!/bin/sh -u -u\n",
+            "# !/bin/sh -u -u\n",
+            "# comment\n#!/bin/sh -u -u\n",
+        ] {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::DuplicateShebangFlag),
+            );
+
+            assert!(diagnostics.is_empty());
+        }
+    }
+}

--- a/crates/shuck-linter/src/rules/style/missing_shebang_line.rs
+++ b/crates/shuck-linter/src/rules/style/missing_shebang_line.rs
@@ -1,0 +1,78 @@
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct MissingShebangLine;
+
+impl Violation for MissingShebangLine {
+    fn rule() -> Rule {
+        Rule::MissingShebangLine
+    }
+
+    fn message(&self) -> String {
+        "add a shebang as the first line of the file".to_owned()
+    }
+}
+
+pub fn missing_shebang_line(checker: &mut Checker) {
+    if checker.shell() != ShellDialect::Unknown {
+        return;
+    }
+
+    if let Some(span) = checker.facts().missing_shebang_line_span() {
+        checker.report(MissingShebangLine, span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_comment_first_line_without_shebang() {
+        let source = "# /etc/config/myapp.conf\necho hello\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MissingShebangLine));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "# /etc/config/myapp.conf"
+        );
+    }
+
+    #[test]
+    fn ignores_real_or_malformed_shebang_headers_and_directives() {
+        for source in [
+            "#!/bin/sh\necho hello\n",
+            " #!/bin/sh\necho hello\n",
+            "# !/bin/sh\necho hello\n",
+            "# comment\n#!/bin/sh\n",
+            "# shellcheck shell=sh\necho hello\n",
+            "\n# comment\necho hello\n",
+        ] {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::MissingShebangLine));
+            assert!(diagnostics.is_empty());
+        }
+    }
+
+    #[test]
+    fn ignores_when_shell_is_known_from_context() {
+        let source = "# comment\necho hello\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingShebangLine).with_shell(ShellDialect::Bash),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_indented_comment_first_line_without_shebang() {
+        let source = " # comment\necho hello\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MissingShebangLine));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), " # comment");
+    }
+}

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -36,6 +36,7 @@ pub mod loop_from_command_output;
 pub mod ls_grep_pipeline;
 pub mod ls_in_substitution;
 pub mod ls_piped_to_xargs;
+pub mod missing_shebang_line;
 pub mod mixed_quote_word;
 pub mod needless_backslash_underscore;
 pub mod positional_args_in_string;
@@ -127,6 +128,7 @@ mod tests {
     #[test_case(Rule::SingleQuoteBackslash, Path::new("S024.sh"))]
     #[test_case(Rule::LiteralBackslash, Path::new("S025.sh"))]
     #[test_case(Rule::LiteralBackslashInSingleQuotes, Path::new("S039.sh"))]
+    #[test_case(Rule::MissingShebangLine, Path::new("S043.txt"))]
     #[test_case(Rule::NeedlessBackslashUnderscore, Path::new("S026.sh"))]
     #[test_case(Rule::BackslashBeforeCommand, Path::new("S040.sh"))]
     #[test_case(Rule::IfsEqualsAmbiguity, Path::new("S042.sh"))]

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -13,6 +13,7 @@ pub mod deprecated_tempfile_command;
 pub mod dollar_in_arithmetic;
 pub mod dollar_in_arithmetic_context;
 pub mod double_quote_nesting;
+pub mod duplicate_shebang_flag;
 pub mod echo_here_doc;
 pub mod echo_inside_command_substitution;
 pub mod echoed_command_substitution;
@@ -129,6 +130,7 @@ mod tests {
     #[test_case(Rule::LiteralBackslash, Path::new("S025.sh"))]
     #[test_case(Rule::LiteralBackslashInSingleQuotes, Path::new("S039.sh"))]
     #[test_case(Rule::MissingShebangLine, Path::new("S043.txt"))]
+    #[test_case(Rule::DuplicateShebangFlag, Path::new("S053.sh"))]
     #[test_case(Rule::NeedlessBackslashUnderscore, Path::new("S026.sh"))]
     #[test_case(Rule::BackslashBeforeCommand, Path::new("S040.sh"))]
     #[test_case(Rule::IfsEqualsAmbiguity, Path::new("S042.sh"))]

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S043_S043.txt.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S043_S043.txt.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+expression: "print_diagnostics(&diagnostics, &source)"
+---
+S043 add a shebang as the first line of the file
+ --> <source>:1:1
+  |
+1 | # /etc/config/myapp.conf
+  |

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S053_S053.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S053_S053.sh.snap
@@ -1,0 +1,9 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+expression: "print_diagnostics(&diagnostics, &source)"
+---
+S053 remove the repeated shebang flag
+ --> <source>:1:1
+  |
+1 | #!/bin/sh -u -u
+  |

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -844,6 +844,9 @@ impl Default for ShellCheckCodeMap {
                 (2368, Rule::ContinueOutsideLoopInFunction),
                 (2378, Rule::VariableAsCommandName),
                 (2384, Rule::LocalCrossReference),
+                // Keep SC2318 mapped primarily to LocalCrossReference, but still accept the
+                // authored duplicate-shebang compatibility code as a suppression alias.
+                (2318, Rule::DuplicateShebangFlag),
                 (2387, Rule::SpacedAssignment),
                 (2388, Rule::BadVarName),
                 (2344, Rule::AtSignInStringCompare),
@@ -851,6 +854,9 @@ impl Default for ShellCheckCodeMap {
                 (2325, Rule::QuotedArraySlice),
                 (2327, Rule::QuotedBashSource),
                 (2398, Rule::KeywordFunctionName),
+                // ShellCheck 0.11.0 reports repeated shebang flags under SC2096's broader
+                // "single shebang parameter" warning family.
+                (2096, Rule::DuplicateShebangFlag),
                 // Preserve SC2290 for suppressing C139 without taking over the large-corpus
                 // comparison slot that already belongs to C077.
                 (2290, Rule::SpacedAssignment),
@@ -1429,6 +1435,7 @@ mod tests {
         assert_eq!(map.resolve("SC2264"), Some(Rule::NestedParameterExpansion));
         assert_eq!(map.resolve("SC2089"), Some(Rule::AppendWithEscapedQuotes));
         assert_eq!(map.resolve("SC2318"), Some(Rule::LocalCrossReference));
+        assert_eq!(map.resolve("SC2096"), Some(Rule::DuplicateShebangFlag));
         assert_eq!(map.resolve("SC2276"), Some(Rule::PlusPrefixInAssignment));
         assert_eq!(
             map.resolve("SC2270"),
@@ -1455,6 +1462,10 @@ mod tests {
         assert_eq!(map.resolve("SC2284"), Some(Rule::UnicodeQuoteInString));
         assert_eq!(map.resolve("SC2148"), Some(Rule::MissingShebangLine));
         assert_eq!(map.resolve("SC2285"), Some(Rule::MissingShebangLine));
+        assert_eq!(
+            map.resolve_all("SC2318"),
+            vec![Rule::LocalCrossReference, Rule::DuplicateShebangFlag]
+        );
         assert_eq!(map.resolve("SC2286"), Some(Rule::IndentedShebang));
         assert_eq!(map.resolve("SC2287"), Some(Rule::SpaceAfterHashBang));
         assert_eq!(map.resolve("SC2288"), Some(Rule::TemplateBraceInCommand));
@@ -1728,6 +1739,8 @@ mod tests {
             (2270, Rule::AssignmentToNumericVariable),
             (2270, Rule::IfMissingThen),
             (2318, Rule::LocalCrossReference),
+            (2318, Rule::DuplicateShebangFlag),
+            (2096, Rule::DuplicateShebangFlag),
             (2290, Rule::SpacedAssignment),
             (2384, Rule::LocalCrossReference),
             (2387, Rule::SpacedAssignment),

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -408,6 +408,9 @@ impl Default for ShellCheckCodeMap {
             (2194, Rule::ConstantCaseSubject),
             (2210, Rule::BadRedirectionFdOrder),
             (2154, Rule::UndefinedVariable),
+            // ShellCheck 0.11.0 reports missing shebangs on comment-first scripts as SC2148.
+            // Keep SC2285 as a suppression alias for the authored S043 rule code.
+            (2148, Rule::MissingShebangLine),
             (2239, Rule::NonAbsoluteShebang),
             (2286, Rule::IndentedShebang),
             (2287, Rule::SpaceAfterHashBang),
@@ -665,6 +668,8 @@ impl Default for ShellCheckCodeMap {
                     (2112, Rule::FunctionKeyword),
                     (2125, Rule::GlobAssignedToVariable),
                     (2216, Rule::PipeToKill),
+                    (2148, Rule::MissingShebangLine),
+                    (2285, Rule::MissingShebangLine),
                     (3005, Rule::CStyleForInSh),
                     (3006, Rule::StandaloneArithmetic),
                     (3007, Rule::LegacyArithmeticInSh),
@@ -705,6 +710,7 @@ impl Default for ShellCheckCodeMap {
                     (2210, Rule::BadRedirectionFdOrder),
                     (2217, Rule::EchoHereDoc),
                     (2154, Rule::UndefinedVariable),
+                    (2148, Rule::MissingShebangLine),
                     (2239, Rule::NonAbsoluteShebang),
                     (2286, Rule::IndentedShebang),
                     (2287, Rule::SpaceAfterHashBang),
@@ -1447,6 +1453,8 @@ mod tests {
         );
         assert_eq!(map.resolve("SC2283"), Some(Rule::DoubleParenGrouping));
         assert_eq!(map.resolve("SC2284"), Some(Rule::UnicodeQuoteInString));
+        assert_eq!(map.resolve("SC2148"), Some(Rule::MissingShebangLine));
+        assert_eq!(map.resolve("SC2285"), Some(Rule::MissingShebangLine));
         assert_eq!(map.resolve("SC2286"), Some(Rule::IndentedShebang));
         assert_eq!(map.resolve("SC2287"), Some(Rule::SpaceAfterHashBang));
         assert_eq!(map.resolve("SC2288"), Some(Rule::TemplateBraceInCommand));
@@ -1733,6 +1741,8 @@ mod tests {
             (2280, Rule::IfsEqualsAmbiguity),
             (2282, Rule::BadVarName),
             (2283, Rule::DoubleParenGrouping),
+            (2148, Rule::MissingShebangLine),
+            (2285, Rule::MissingShebangLine),
             (2286, Rule::IndentedShebang),
             (2287, Rule::SpaceAfterHashBang),
             (2288, Rule::TemplateBraceInCommand),
@@ -1884,6 +1894,7 @@ mod tests {
             (3084, Rule::SourceInsideFunctionInSh),
             (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::AssignmentLooksLikeComparison),
+            (2148, Rule::MissingShebangLine),
             (2286, Rule::IndentedShebang),
             (2287, Rule::SpaceAfterHashBang),
             (2277, Rule::ExtglobInCasePattern),

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -1913,6 +1913,7 @@ mod tests {
             Rule::ArraySubscriptCondition,
             Rule::ExtglobInTest,
             Rule::BackslashBeforeCommand,
+            Rule::ShebangNotOnFirstLine,
         ]);
 
         let unmapped: Vec<&str> = Rule::iter()

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -410,6 +410,7 @@ impl Default for ShellCheckCodeMap {
             (2154, Rule::UndefinedVariable),
             (2239, Rule::NonAbsoluteShebang),
             (2286, Rule::IndentedShebang),
+            (2287, Rule::SpaceAfterHashBang),
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (1133, Rule::LinebreakBeforeAnd),
@@ -706,6 +707,7 @@ impl Default for ShellCheckCodeMap {
                     (2154, Rule::UndefinedVariable),
                     (2239, Rule::NonAbsoluteShebang),
                     (2286, Rule::IndentedShebang),
+                    (2287, Rule::SpaceAfterHashBang),
                     (2288, Rule::TemplateBraceInCommand),
                     (2289, Rule::CommentedContinuationLine),
                     (1133, Rule::LinebreakBeforeAnd),
@@ -1446,6 +1448,7 @@ mod tests {
         assert_eq!(map.resolve("SC2283"), Some(Rule::DoubleParenGrouping));
         assert_eq!(map.resolve("SC2284"), Some(Rule::UnicodeQuoteInString));
         assert_eq!(map.resolve("SC2286"), Some(Rule::IndentedShebang));
+        assert_eq!(map.resolve("SC2287"), Some(Rule::SpaceAfterHashBang));
         assert_eq!(map.resolve("SC2288"), Some(Rule::TemplateBraceInCommand));
         assert_eq!(map.resolve("SC2289"), Some(Rule::CommentedContinuationLine));
         assert_eq!(map.resolve("SC2333"), Some(Rule::NonShellSyntaxInScript));
@@ -1731,6 +1734,7 @@ mod tests {
             (2282, Rule::BadVarName),
             (2283, Rule::DoubleParenGrouping),
             (2286, Rule::IndentedShebang),
+            (2287, Rule::SpaceAfterHashBang),
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (2294, Rule::EvalOnArray),
@@ -1881,6 +1885,7 @@ mod tests {
             (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::AssignmentLooksLikeComparison),
             (2286, Rule::IndentedShebang),
+            (2287, Rule::SpaceAfterHashBang),
             (2277, Rule::ExtglobInCasePattern),
         ]
         .into_iter()

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -409,6 +409,7 @@ impl Default for ShellCheckCodeMap {
             (2210, Rule::BadRedirectionFdOrder),
             (2154, Rule::UndefinedVariable),
             (2239, Rule::NonAbsoluteShebang),
+            (2286, Rule::IndentedShebang),
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (1133, Rule::LinebreakBeforeAnd),
@@ -704,6 +705,7 @@ impl Default for ShellCheckCodeMap {
                     (2217, Rule::EchoHereDoc),
                     (2154, Rule::UndefinedVariable),
                     (2239, Rule::NonAbsoluteShebang),
+                    (2286, Rule::IndentedShebang),
                     (2288, Rule::TemplateBraceInCommand),
                     (2289, Rule::CommentedContinuationLine),
                     (1133, Rule::LinebreakBeforeAnd),
@@ -1443,6 +1445,7 @@ mod tests {
         );
         assert_eq!(map.resolve("SC2283"), Some(Rule::DoubleParenGrouping));
         assert_eq!(map.resolve("SC2284"), Some(Rule::UnicodeQuoteInString));
+        assert_eq!(map.resolve("SC2286"), Some(Rule::IndentedShebang));
         assert_eq!(map.resolve("SC2288"), Some(Rule::TemplateBraceInCommand));
         assert_eq!(map.resolve("SC2289"), Some(Rule::CommentedContinuationLine));
         assert_eq!(map.resolve("SC2333"), Some(Rule::NonShellSyntaxInScript));
@@ -1727,6 +1730,7 @@ mod tests {
             (2280, Rule::IfsEqualsAmbiguity),
             (2282, Rule::BadVarName),
             (2283, Rule::DoubleParenGrouping),
+            (2286, Rule::IndentedShebang),
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (2294, Rule::EvalOnArray),
@@ -1876,6 +1880,7 @@ mod tests {
             (3084, Rule::SourceInsideFunctionInSh),
             (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::AssignmentLooksLikeComparison),
+            (2286, Rule::IndentedShebang),
             (2277, Rule::ExtglobInCasePattern),
         ]
         .into_iter()

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -2282,7 +2282,7 @@ fn build_rule_to_shellcheck_index(
         return selected_rules
             .iter()
             .filter_map(|rule| {
-                selected_rule_shellcheck_code(rule)
+                selected_rule_shellcheck_code(rule, Some(selected_rules))
                     .map(|sc_code| (rule.code().to_owned(), format!("SC{sc_code}")))
             })
             .collect();
@@ -2307,7 +2307,7 @@ fn build_shellcheck_to_rule_index(
     if let Some(selected_rules) = selected_rules {
         let mut index = HashMap::<u32, Vec<String>>::new();
         for rule in selected_rules.iter() {
-            for sc_code in selected_rule_shellcheck_codes(rule) {
+            for sc_code in selected_rule_shellcheck_codes(rule, Some(selected_rules)) {
                 index
                     .entry(sc_code)
                     .or_default()
@@ -2377,7 +2377,7 @@ fn build_mapped_shellcheck_codes() -> HashSet<u32> {
 fn build_selected_shellcheck_codes(selected_rules: &shuck_linter::RuleSet) -> HashSet<u32> {
     selected_rules
         .iter()
-        .flat_map(selected_rule_shellcheck_codes)
+        .flat_map(|rule| selected_rule_shellcheck_codes(rule, Some(selected_rules)))
         .collect()
 }
 
@@ -2387,7 +2387,7 @@ fn validate_selected_rules_for_large_corpus(
     let comparable_rules: HashSet<_> = selected_rules
         .iter()
         .filter(|rule| {
-            !selected_rule_shellcheck_codes(*rule).is_empty()
+            !selected_rule_shellcheck_codes(*rule, Some(selected_rules)).is_empty()
                 || selected_rule_has_reviewed_comparison_target(*rule)
         })
         .collect();
@@ -2414,11 +2414,19 @@ fn selected_rule_has_reviewed_comparison_target(rule: shuck_linter::Rule) -> boo
         .is_empty()
 }
 
-fn selected_rule_shellcheck_code(rule: shuck_linter::Rule) -> Option<u32> {
-    selected_rule_shellcheck_codes(rule).into_iter().next()
+fn selected_rule_shellcheck_code(
+    rule: shuck_linter::Rule,
+    selected_rules: Option<&shuck_linter::RuleSet>,
+) -> Option<u32> {
+    selected_rule_shellcheck_codes(rule, selected_rules)
+        .into_iter()
+        .next()
 }
 
-fn selected_rule_shellcheck_codes(rule: shuck_linter::Rule) -> Vec<u32> {
+fn selected_rule_shellcheck_codes(
+    rule: shuck_linter::Rule,
+    selected_rules: Option<&shuck_linter::RuleSet>,
+) -> Vec<u32> {
     let metadata = load_rule_corpus_metadata(rule.code());
     let has_comparison_target_notes = !metadata.comparison_target_notes.is_empty();
     let excluded_codes = metadata
@@ -2431,8 +2439,7 @@ fn selected_rule_shellcheck_codes(rule: shuck_linter::Rule) -> Vec<u32> {
         })
         .collect::<HashSet<u32>>();
 
-    let comparison_candidates = shuck_linter::ShellCheckCodeMap::default()
-        .comparison_mappings()
+    let comparison_candidates = large_corpus_comparison_mappings(selected_rules)
         .filter_map(|(sc_code, mapped_rule)| {
             (mapped_rule == rule && !excluded_codes.contains(&sc_code)).then_some(sc_code)
         })
@@ -2465,6 +2472,10 @@ fn large_corpus_comparison_mappings(
     let mut mappings: Vec<_> = shuck_linter::ShellCheckCodeMap::default()
         .comparison_mappings()
         .collect();
+    if selected_rules.is_some_and(|rules| rules.contains(shuck_linter::Rule::ShebangNotOnFirstLine))
+    {
+        mappings.push((1128, shuck_linter::Rule::ShebangNotOnFirstLine));
+    }
     if selected_rules.is_some_and(|rules| {
         rules.contains(shuck_linter::Rule::UncheckedDirectoryChangeInFunction)
             && !rules.contains(shuck_linter::Rule::UncheckedDirectoryChange)
@@ -3371,6 +3382,34 @@ mod tests {
         let rules = parse_large_corpus_rule_set("C001,X080").unwrap();
 
         assert_eq!(validate_selected_rules_for_large_corpus(&rules), Ok(()));
+    }
+
+    #[test]
+    fn selected_rule_filter_accepts_c075_when_template_brace_is_not_selected() {
+        let rules = parse_large_corpus_rule_set("C075").unwrap();
+
+        assert_eq!(validate_selected_rules_for_large_corpus(&rules), Ok(()));
+        assert_eq!(
+            build_rule_to_shellcheck_index(Some(&rules))
+                .get("C075")
+                .map(String::as_str),
+            Some("SC1128")
+        );
+        assert_eq!(
+            build_shellcheck_filter_codes(Some(rules), true),
+            Some(HashSet::from([1128]))
+        );
+    }
+
+    #[test]
+    fn selected_rule_filter_accepts_c075_alongside_template_brace() {
+        let rules = parse_large_corpus_rule_set("C061,C075").unwrap();
+
+        assert_eq!(validate_selected_rules_for_large_corpus(&rules), Ok(()));
+        assert_eq!(
+            build_shellcheck_filter_codes(Some(rules), true),
+            Some(HashSet::from([1128, 2288]))
+        );
     }
 
     #[test]

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -3413,6 +3413,23 @@ mod tests {
     }
 
     #[test]
+    fn selected_rule_filter_uses_oracle_code_for_s053() {
+        let rules = parse_large_corpus_rule_set("S053").unwrap();
+
+        assert_eq!(validate_selected_rules_for_large_corpus(&rules), Ok(()));
+        assert_eq!(
+            build_rule_to_shellcheck_index(Some(&rules))
+                .get("S053")
+                .map(String::as_str),
+            Some("SC2096")
+        );
+        assert_eq!(
+            build_shellcheck_filter_codes(Some(rules), true),
+            Some(HashSet::from([2096]))
+        );
+    }
+
+    #[test]
     fn selected_rule_filter_accepts_reviewed_metadata_only_rules() {
         let rules = parse_large_corpus_rule_set("C096,S071").unwrap();
 

--- a/crates/shuck/tests/testdata/corpus-metadata/c075.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c075.yaml
@@ -1,0 +1,3 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2288"
+    reason: "The nix-pinned ShellCheck oracle used by the large-corpus harness reports second-line shebang warnings as SC1128, while SC2288 is currently used for a different apostrophe-in-command warning family."

--- a/crates/shuck/tests/testdata/corpus-metadata/s043.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s043.yaml
@@ -1,0 +1,3 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2285"
+    reason: "The nix-pinned ShellCheck oracle reports comment-first scripts without a shebang under SC2148, while SC2285 remains the authored legacy code for this rule."

--- a/crates/shuck/tests/testdata/corpus-metadata/s053.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s053.yaml
@@ -1,0 +1,3 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2318"
+    reason: "The authored duplicate-shebang compatibility code conflicts with LocalCrossReference in the repo's primary mapping, while the nix-pinned ShellCheck oracle currently reports duplicate shebang flags as SC2096."

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,9 +4,9 @@
 
 | Status | Count |
 |--------|-------|
-| Implemented | 94 |
+| Implemented | 95 |
 | Scheduled (Tranches 1-3) | 18 |
-| Remaining | 206 |
+| Remaining | 205 |
 | **Total** | **318** |
 
 ## Difficulty Legend
@@ -312,7 +312,7 @@ Filter command facts by `effective_name_is()` and check options/arguments.
 
 Rules about shebang lines and script-level metadata.
 
-- [ ] **L** C073 (SC2286) `indented-shebang` — shebang has leading whitespace
+- [x] **L** C073 (SC2286) `indented-shebang` — shebang has leading whitespace
 - [ ] **L** C074 (SC2287) `space-after-hash-bang` — space between `#` and `!`
 - [ ] **L** C075 (SC2288) `shebang-not-on-first-line` — shebang on second line
 - [ ] **L** S043 (SC2285) `missing-shebang-line` — no shebang, starts with comment

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,9 +4,9 @@
 
 | Status | Count |
 |--------|-------|
-| Implemented | 96 |
+| Implemented | 97 |
 | Scheduled (Tranches 1-3) | 18 |
-| Remaining | 204 |
+| Remaining | 203 |
 | **Total** | **318** |
 
 ## Difficulty Legend
@@ -314,7 +314,7 @@ Rules about shebang lines and script-level metadata.
 
 - [x] **L** C073 (SC2286) `indented-shebang` — shebang has leading whitespace
 - [x] **L** C074 (SC2287) `space-after-hash-bang` — space between `#` and `!`
-- [ ] **L** C075 (SC2288) `shebang-not-on-first-line` — shebang on second line
+- [x] **L** C075 (SC2288) `shebang-not-on-first-line` — shebang on second line
 - [ ] **L** S043 (SC2285) `missing-shebang-line` — no shebang, starts with comment
 - [ ] **L** S053 (SC2318) `duplicate-shebang-flag` — repeated flag in shebang
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,9 +4,9 @@
 
 | Status | Count |
 |--------|-------|
-| Implemented | 97 |
+| Implemented | 98 |
 | Scheduled (Tranches 1-3) | 18 |
-| Remaining | 203 |
+| Remaining | 202 |
 | **Total** | **318** |
 
 ## Difficulty Legend
@@ -315,7 +315,7 @@ Rules about shebang lines and script-level metadata.
 - [x] **L** C073 (SC2286) `indented-shebang` — shebang has leading whitespace
 - [x] **L** C074 (SC2287) `space-after-hash-bang` — space between `#` and `!`
 - [x] **L** C075 (SC2288) `shebang-not-on-first-line` — shebang on second line
-- [ ] **L** S043 (SC2285) `missing-shebang-line` — no shebang, starts with comment
+- [x] **L** S043 (SC2285) `missing-shebang-line` — no shebang, starts with comment
 - [ ] **L** S053 (SC2318) `duplicate-shebang-flag` — repeated flag in shebang
 
 ### Escape and Backslash Sequences

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,9 +4,9 @@
 
 | Status | Count |
 |--------|-------|
-| Implemented | 95 |
+| Implemented | 96 |
 | Scheduled (Tranches 1-3) | 18 |
-| Remaining | 205 |
+| Remaining | 204 |
 | **Total** | **318** |
 
 ## Difficulty Legend
@@ -313,7 +313,7 @@ Filter command facts by `effective_name_is()` and check options/arguments.
 Rules about shebang lines and script-level metadata.
 
 - [x] **L** C073 (SC2286) `indented-shebang` — shebang has leading whitespace
-- [ ] **L** C074 (SC2287) `space-after-hash-bang` — space between `#` and `!`
+- [x] **L** C074 (SC2287) `space-after-hash-bang` — space between `#` and `!`
 - [ ] **L** C075 (SC2288) `shebang-not-on-first-line` — shebang on second line
 - [ ] **L** S043 (SC2285) `missing-shebang-line` — no shebang, starts with comment
 - [ ] **L** S053 (SC2318) `duplicate-shebang-flag` — repeated flag in shebang

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,9 +4,9 @@
 
 | Status | Count |
 |--------|-------|
-| Implemented | 98 |
+| Implemented | 99 |
 | Scheduled (Tranches 1-3) | 18 |
-| Remaining | 202 |
+| Remaining | 201 |
 | **Total** | **318** |
 
 ## Difficulty Legend
@@ -316,7 +316,7 @@ Rules about shebang lines and script-level metadata.
 - [x] **L** C074 (SC2287) `space-after-hash-bang` — space between `#` and `!`
 - [x] **L** C075 (SC2288) `shebang-not-on-first-line` — shebang on second line
 - [x] **L** S043 (SC2285) `missing-shebang-line` — no shebang, starts with comment
-- [ ] **L** S053 (SC2318) `duplicate-shebang-flag` — repeated flag in shebang
+- [x] **L** S053 (SC2318) `duplicate-shebang-flag` — repeated flag in shebang
 
 ### Escape and Backslash Sequences
 


### PR DESCRIPTION
## Summary
- implement `C073`, `C074`, `C075`, `S043`, and `S053`
- consolidate shebang/header analysis in `crates/shuck-linter/src/facts.rs` so nearby rules share parsing logic
- add selected-rule large-corpus compatibility handling for current oracle codes while preserving existing repo-wide suppression mappings
- check off the completed rules in `docs/rules.md`

## Testing
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=C073 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --exact --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=C074 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --exact --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=C075 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --exact --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=S043 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --exact --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=S053 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --exact --nocapture`
