### PR TITLE
Share exact variable dataflow between SH-003 and SH-039

### DIFF
--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -53,6 +53,10 @@ name = "semantic"
 harness = false
 
 [[bench]]
+name = "unused_assignment"
+harness = false
+
+[[bench]]
 name = "linter"
 harness = false
 

--- a/crates/shuck-benchmark/benches/unused_assignment.rs
+++ b/crates/shuck-benchmark/benches/unused_assignment.rs
@@ -71,6 +71,39 @@ fn bench_uninitialized_reference(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_variable_dataflow_combined(c: &mut Criterion) {
+    let mut group = c.benchmark_group("variable_dataflow_combined");
+
+    for case in benchmark_cases() {
+        group.sample_size(case.speed.sample_size());
+        group.throughput(Throughput::Bytes(case.total_bytes()));
+        group.bench_with_input(BenchmarkId::from_parameter(case.name), &case, |b, case| {
+            b.iter_batched(
+                || {
+                    case.files
+                        .iter()
+                        .map(|file| build_semantic(file.source))
+                        .collect::<Vec<_>>()
+                },
+                |models| {
+                    let combined_count: usize = models
+                        .iter()
+                        .map(|model| {
+                            let analysis = model.analysis();
+                            analysis.unused_assignments().len()
+                                + analysis.uninitialized_references().len()
+                        })
+                        .sum();
+                    black_box(combined_count);
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_dead_code(c: &mut Criterion) {
     let mut group = c.benchmark_group("dead_code");
 
@@ -104,6 +137,7 @@ criterion_group!(
     benches,
     bench_unused_assignment,
     bench_uninitialized_reference,
+    bench_variable_dataflow_combined,
     bench_dead_code
 );
 criterion_main!(benches);

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -8,6 +8,7 @@ use crate::{
     ControlFlowGraph, FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, Reference,
     ReferenceId, ReferenceKind, Scope, ScopeId, ScopeKind, SpanKey, SyntheticRead,
 };
+use std::sync::OnceLock;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReachingDefinitions {
@@ -76,85 +77,102 @@ pub(crate) struct DataflowContext<'a> {
     pub(crate) entry_bindings: &'a [BindingId],
 }
 
+#[derive(Debug)]
+pub(crate) struct ExactVariableDataflow {
+    names: NameTable,
+    binding_data: DenseBindingData,
+    binding_blocks: Vec<Option<BlockId>>,
+    reference_blocks: Vec<Option<BlockId>>,
+    unreachable_blocks: DenseBitSet,
+    reaching_definitions: OnceLock<DenseReachingDefinitions>,
+    initialized_name_states: OnceLock<DenseInitializedNameStates>,
+}
+
+impl ExactVariableDataflow {
+    fn reaching_definitions<'a>(
+        &'a self,
+        context: &DataflowContext<'_>,
+    ) -> &'a DenseReachingDefinitions {
+        self.reaching_definitions.get_or_init(|| {
+            compute_reaching_definitions_dense(
+                context.cfg,
+                context.bindings,
+                &self.binding_data,
+                context.entry_bindings,
+            )
+        })
+    }
+
+    fn initialized_name_states<'a>(
+        &'a self,
+        context: &DataflowContext<'_>,
+    ) -> &'a DenseInitializedNameStates {
+        self.initialized_name_states.get_or_init(|| {
+            compute_initialized_name_states_dense(
+                context.cfg,
+                context.bindings,
+                &self.binding_data,
+                context.entry_bindings,
+            )
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct UnusedAssignmentsResult {
     unused_assignments: Vec<UnusedAssignment>,
     unused_assignment_ids: Vec<BindingId>,
 }
 
-#[derive(Debug, Clone, Default)]
-struct BindingNameData {
-    bindings_by_name: FxHashMap<Name, Vec<BindingId>>,
-}
-
-pub(crate) fn analyze_unused_assignments(context: &DataflowContext<'_>) -> Vec<BindingId> {
-    analyze_unused_assignments_exact(context).unused_assignment_ids
-}
-
 pub(crate) fn analyze_uninitialized_references(
     context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
 ) -> Vec<UninitializedReference> {
-    let names = build_uninitialized_name_table(context.bindings, context.references);
-    let binding_data = build_dense_binding_data_for_scope_count(
-        context.bindings,
-        context
-            .bindings
-            .iter()
-            .map(|binding| binding.scope.index() + 1)
-            .max()
-            .unwrap_or(0),
-        &names,
-    );
-    analyze_uninitialized_references_dense(
-        context.cfg,
-        context.bindings,
-        context.references,
-        context.entry_bindings,
-        context.predefined_runtime_refs,
-        context.guarded_parameter_refs,
-        context.resolved,
-        context.indirect_targets_by_reference,
-        &names,
-        &binding_data,
-    )
+    analyze_uninitialized_references_exact(context, exact)
 }
 
-pub(crate) fn analyze_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
-    build_dead_code(cfg)
+pub(crate) fn analyze_unused_assignments(
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
+) -> Vec<BindingId> {
+    analyze_unused_assignments_exact(context, exact).unused_assignment_ids
 }
 
-#[allow(dead_code)]
-pub(crate) fn analyze(context: &DataflowContext<'_>) -> DataflowResult {
-    let binding_name_data = build_binding_name_data(context.bindings);
-    let reaching_definitions = compute_reaching_definitions(
-        context.cfg,
-        context.bindings,
-        &binding_name_data.bindings_by_name,
-        context.entry_bindings,
-    );
+pub(crate) fn build_exact_variable_dataflow(
+    context: &DataflowContext<'_>,
+) -> ExactVariableDataflow {
     let names = build_name_table(
         context.bindings,
         context.references,
         context.synthetic_reads,
     );
-    let dense_binding_data = build_dense_binding_data(context.bindings, context.scopes, &names);
-    let unused_assignments = analyze_unused_assignments_exact(context);
-    let uninitialized_references = analyze_uninitialized_references_dense(
-        context.cfg,
-        context.bindings,
-        context.references,
-        context.entry_bindings,
-        context.predefined_runtime_refs,
-        context.guarded_parameter_refs,
-        context.resolved,
-        context.indirect_targets_by_reference,
-        &names,
-        &dense_binding_data,
-    );
+    let binding_data = build_dense_binding_data(context.bindings, context.scopes, &names);
+    let binding_blocks = build_binding_block_index(context.cfg, context.bindings.len());
+    let reference_blocks = build_reference_block_index(context.cfg, context.references.len());
+    let unreachable_blocks = build_unreachable_block_set(context.cfg);
+
+    ExactVariableDataflow {
+        names,
+        binding_data,
+        binding_blocks,
+        reference_blocks,
+        unreachable_blocks,
+        reaching_definitions: OnceLock::new(),
+        initialized_name_states: OnceLock::new(),
+    }
+}
+
+pub(crate) fn analyze(
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
+) -> DataflowResult {
+    let unused_assignments = analyze_unused_assignments_exact(context, exact);
+    let uninitialized_references = analyze_uninitialized_references_exact(context, exact);
     let dead_code = build_dead_code(context.cfg);
+    let reaching_definitions = exact.reaching_definitions(context);
 
     DataflowResult {
-        reaching_definitions,
+        reaching_definitions: materialize_reaching_definitions(context.cfg, reaching_definitions),
         unused_assignments: unused_assignments.unused_assignments,
         uninitialized_references,
         dead_code,
@@ -162,49 +180,43 @@ pub(crate) fn analyze(context: &DataflowContext<'_>) -> DataflowResult {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn analyze_uninitialized_references_dense(
-    cfg: &ControlFlowGraph,
-    bindings: &[Binding],
-    references: &[Reference],
-    entry_bindings: &[BindingId],
-    predefined_runtime_refs: &FxHashSet<ReferenceId>,
-    guarded_parameter_refs: &FxHashSet<ReferenceId>,
-    resolved: &FxHashMap<ReferenceId, BindingId>,
-    indirect_targets_by_reference: &FxHashMap<ReferenceId, Vec<BindingId>>,
-    names: &NameTable,
-    binding_data: &DenseBindingData,
+pub(crate) fn analyze_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
+    build_dead_code(cfg)
+}
+
+fn analyze_uninitialized_references_exact(
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
 ) -> Vec<UninitializedReference> {
-    let reference_blocks = build_reference_block_index(cfg, references.len());
-    let unreachable = build_unreachable_block_set(cfg);
-    let initialized_states =
-        compute_initialized_name_states_dense(cfg, bindings, binding_data, entry_bindings);
-    let maybe_defined = &initialized_states.maybe_in;
-    let definitely_defined = &initialized_states.definite_in;
+    let initialized_name_states = exact.initialized_name_states(context);
+    let maybe_defined = &initialized_name_states.maybe_in;
+    let definitely_defined = &initialized_name_states.definite_in;
 
     let mut uninitialized_references = Vec::new();
-    for reference in references {
+    for reference in context.references {
         if matches!(
             reference.kind,
             ReferenceKind::ImplicitRead | ReferenceKind::DeclarationName
-        ) || predefined_runtime_refs.contains(&reference.id)
-            || guarded_parameter_refs.contains(&reference.id)
+        ) || context.predefined_runtime_refs.contains(&reference.id)
+            || context.guarded_parameter_refs.contains(&reference.id)
         {
             continue;
         }
         if matches!(reference.kind, ReferenceKind::IndirectExpansion)
-            && (resolved.contains_key(&reference.id)
-                || indirect_targets_by_reference.contains_key(&reference.id))
+            && (context.resolved.contains_key(&reference.id)
+                || context
+                    .indirect_targets_by_reference
+                    .contains_key(&reference.id))
         {
             continue;
         }
-        let Some(block_id) = reference_blocks[reference.id.index()] else {
+        let Some(block_id) = exact.reference_blocks[reference.id.index()] else {
             continue;
         };
-        if unreachable.contains(block_id.index()) {
+        if exact.unreachable_blocks.contains(block_id.index()) {
             continue;
         }
-        let Some(name_id) = names.get(&reference.name) else {
+        let Some(name_id) = exact.names.get(&reference.name) else {
             continue;
         };
         let maybe = maybe_defined[block_id.index()].contains(name_id.index());
@@ -248,116 +260,42 @@ fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
         .collect()
 }
 
-fn build_binding_name_data(bindings: &[Binding]) -> BindingNameData {
-    let mut bindings_by_name: FxHashMap<Name, Vec<BindingId>> = FxHashMap::default();
+fn build_bindings_by_name(bindings: &[Binding]) -> FxHashMap<Name, Vec<BindingId>> {
+    let mut bindings_by_name = FxHashMap::default();
     for binding in bindings {
         bindings_by_name
             .entry(binding.name.clone())
-            .or_default()
+            .or_insert_with(Vec::new)
             .push(binding.id);
     }
-
-    BindingNameData { bindings_by_name }
+    bindings_by_name
 }
 
-fn compute_reaching_definitions(
-    cfg: &ControlFlowGraph,
-    bindings: &[Binding],
-    bindings_by_name: &FxHashMap<Name, Vec<BindingId>>,
-    entry_bindings: &[BindingId],
-) -> ReachingDefinitions {
-    let entry_blocks = entry_binding_root_blocks(cfg);
-    let block_ids = cfg
-        .blocks()
-        .iter()
-        .map(|block| block.id)
-        .collect::<Vec<_>>();
-    let mut reaching_in: FxHashMap<BlockId, FxHashSet<BindingId>> = FxHashMap::default();
-    let mut reaching_out: FxHashMap<BlockId, FxHashSet<BindingId>> = FxHashMap::default();
-
-    let gen_sets = block_ids
-        .iter()
-        .map(|block_id| (*block_id, gen_set(cfg, *block_id, bindings)))
-        .collect::<FxHashMap<_, _>>();
-    let kill_sets = block_ids
-        .iter()
-        .map(|block_id| {
-            (
-                *block_id,
-                kill_set(cfg, *block_id, bindings, bindings_by_name),
-            )
-        })
-        .collect::<FxHashMap<_, _>>();
-
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for block_id in &block_ids {
-            let mut incoming = cfg
-                .predecessors(*block_id)
-                .iter()
-                .flat_map(|predecessor| {
-                    reaching_out.get(predecessor).into_iter().flatten().copied()
-                })
-                .collect::<FxHashSet<_>>();
-            if entry_blocks.contains(block_id) {
-                incoming.extend(entry_bindings.iter().copied());
-            }
-            let outgoing = gen_sets
-                .get(block_id)
-                .cloned()
-                .unwrap_or_default()
-                .into_iter()
-                .chain(incoming.iter().copied().filter(|binding| {
-                    !kill_sets
-                        .get(block_id)
-                        .is_some_and(|kills| kills.contains(binding))
-                }))
-                .collect::<FxHashSet<_>>();
-
-            if reaching_in.get(block_id) != Some(&incoming) {
-                reaching_in.insert(*block_id, incoming);
-                changed = true;
-            }
-            if reaching_out.get(block_id) != Some(&outgoing) {
-                reaching_out.insert(*block_id, outgoing);
-                changed = true;
-            }
-        }
-    }
-
-    ReachingDefinitions {
-        reaching_in,
-        reaching_out,
-    }
-}
-
-fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssignmentsResult {
-    let names = build_name_table(
-        context.bindings,
-        context.references,
-        context.synthetic_reads,
-    );
-    let binding_data = build_dense_binding_data(context.bindings, context.scopes, &names);
+fn analyze_unused_assignments_exact(
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
+) -> UnusedAssignmentsResult {
+    let reaching_definitions = exact.reaching_definitions(context);
     let reference_name_ids = context
         .references
         .iter()
-        .map(|reference| names.get(&reference.name).expect("reference name interned"))
+        .map(|reference| {
+            exact
+                .names
+                .get(&reference.name)
+                .expect("reference name interned")
+        })
         .collect::<Vec<_>>();
     let synthetic_read_name_ids = context
         .synthetic_reads
         .iter()
-        .map(|read| names.get(&read.name).expect("synthetic read name interned"))
+        .map(|read| {
+            exact
+                .names
+                .get(&read.name)
+                .expect("synthetic read name interned")
+        })
         .collect::<Vec<_>>();
-    let binding_blocks = build_binding_block_index(context.cfg, context.bindings.len());
-    let reference_blocks = build_reference_block_index(context.cfg, context.references.len());
-    let unreachable_blocks = build_unreachable_block_set(context.cfg);
-    let reaching_definitions = compute_reaching_definitions_dense(
-        context.cfg,
-        context.bindings,
-        &binding_data,
-        context.entry_bindings,
-    );
     let scope_components = compute_scope_components_dense(
         context.cfg,
         context.scopes.len(),
@@ -376,13 +314,13 @@ fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssi
             &reference_name_ids,
             &synthetic_read_name_ids,
             context.call_sites,
-            names.len(),
+            exact.names.len(),
         );
         let interprocedural = compute_interprocedural_read_sets(
             &read_plans,
             &callers_by_callee,
             context.scopes,
-            names.len(),
+            exact.names.len(),
         );
         Some((read_plans, interprocedural))
     };
@@ -395,17 +333,19 @@ fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssi
     }
 
     for (reference_index, reference) in context.references.iter().enumerate() {
-        let Some(block_id) = reference_blocks[reference_index] else {
+        let Some(block_id) = exact.reference_blocks[reference_index] else {
             continue;
         };
-        if unreachable_blocks.contains(block_id.index()) {
+        if exact.unreachable_blocks.contains(block_id.index()) {
             continue;
         }
 
         let incoming = &reaching_definitions.reaching_in[block_id.index()];
         let name_id = reference_name_ids[reference_index];
-        used_bindings
-            .or_intersection_with(incoming, &binding_data.bindings_for_name[name_id.index()]);
+        used_bindings.or_intersection_with(
+            incoming,
+            &exact.binding_data.bindings_for_name[name_id.index()],
+        );
 
         let Some(resolved_binding_id) = context.resolved.get(&reference.id).copied() else {
             continue;
@@ -415,8 +355,8 @@ fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssi
         if !component.blocks.contains(block_id.index()) {
             used_bindings.or_intersection3_with(
                 &component.exit_defs,
-                &binding_data.bindings_for_name[name_id.index()],
-                &binding_data.bindings_in_scope[resolved_binding.scope.index()],
+                &exact.binding_data.bindings_for_name[name_id.index()],
+                &exact.binding_data.bindings_in_scope[resolved_binding.scope.index()],
             );
         }
 
@@ -438,12 +378,12 @@ fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssi
         let Some(block_id) = command_block_for_span(context.cfg, synthetic_read.span) else {
             continue;
         };
-        if unreachable_blocks.contains(block_id.index()) {
+        if exact.unreachable_blocks.contains(block_id.index()) {
             continue;
         }
         used_bindings.or_intersection_with(
             &reaching_definitions.reaching_in[block_id.index()],
-            &binding_data.bindings_for_name[synthetic_read_name_ids[read_index].index()],
+            &exact.binding_data.bindings_for_name[synthetic_read_name_ids[read_index].index()],
         );
     }
 
@@ -453,13 +393,13 @@ fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssi
                 let Some(block_id) = command_block_for_span(context.cfg, call.span) else {
                     continue;
                 };
-                if unreachable_blocks.contains(block_id.index()) {
+                if exact.unreachable_blocks.contains(block_id.index()) {
                     continue;
                 }
                 mark_reaching_defs_for_names_used(
                     &mut used_bindings,
                     &reaching_definitions.reaching_in[block_id.index()],
-                    &binding_data.binding_name_ids,
+                    &exact.binding_data.binding_name_ids,
                     &interprocedural.transitive_reads[call.callee_scope.index()],
                 );
             }
@@ -470,7 +410,7 @@ fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssi
                 && future_reads_contain_after(
                     binding.scope,
                     binding.span.start.offset,
-                    binding_data.binding_name_ids[binding.id.index()],
+                    exact.binding_data.binding_name_ids[binding.id.index()],
                     read_plans,
                     &interprocedural.future_reads,
                     &interprocedural.escape_reads,
@@ -483,20 +423,20 @@ fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssi
 
     let mut unused_assignments = Vec::new();
     for binding in context.bindings {
-        let Some(block_id) = binding_blocks[binding.id.index()] else {
+        let Some(block_id) = exact.binding_blocks[binding.id.index()] else {
             continue;
         };
         if matches!(
             binding.kind,
             BindingKind::FunctionDefinition | BindingKind::Imported
         ) || context.runtime.is_always_used_binding(&binding.name)
-            || unreachable_blocks.contains(block_id.index())
+            || exact.unreachable_blocks.contains(block_id.index())
             || used_bindings.contains(binding.id.index())
         {
             continue;
         }
 
-        let reason = binding_data.next_overwrite[binding.id.index()]
+        let reason = exact.binding_data.next_overwrite[binding.id.index()]
             .map(|by| UnusedReason::Overwritten { by })
             .unwrap_or(UnusedReason::ScopeEnd);
         unused_assignments.push(UnusedAssignment {
@@ -507,8 +447,8 @@ fn analyze_unused_assignments_exact(context: &DataflowContext<'_>) -> UnusedAssi
     let unused_assignment_ids = collapse_redundant_branch_unused_assignment_ids(
         context.cfg,
         context.bindings,
-        &binding_blocks,
-        &unreachable_blocks,
+        &exact.binding_blocks,
+        &exact.unreachable_blocks,
         &unused_assignments,
     );
 
@@ -532,7 +472,7 @@ fn collapse_redundant_branch_unused_assignment_ids(
             .collect();
     }
 
-    let binding_name_data = build_binding_name_data(bindings);
+    let bindings_by_name = build_bindings_by_name(bindings);
     let unused_binding_ids = unused_assignments
         .iter()
         .map(|unused| unused.binding)
@@ -541,7 +481,7 @@ fn collapse_redundant_branch_unused_assignment_ids(
     let mut suppression_context = RedundantBranchUnusedAssignmentContext {
         cfg,
         bindings,
-        bindings_by_name: &binding_name_data.bindings_by_name,
+        bindings_by_name: &bindings_by_name,
         binding_blocks,
         unreachable_blocks,
         unused_binding_ids: &unused_binding_ids,
@@ -830,6 +770,36 @@ struct DenseReachingDefinitions {
     reaching_out: Vec<DenseBitSet>,
 }
 
+fn materialize_reaching_definitions(
+    cfg: &ControlFlowGraph,
+    dense: &DenseReachingDefinitions,
+) -> ReachingDefinitions {
+    let mut reaching_in = FxHashMap::default();
+    let mut reaching_out = FxHashMap::default();
+
+    for block in cfg.blocks() {
+        reaching_in.insert(
+            block.id,
+            dense.reaching_in[block.id.index()]
+                .iter_ones()
+                .map(|binding_index| BindingId(binding_index as u32))
+                .collect::<FxHashSet<_>>(),
+        );
+        reaching_out.insert(
+            block.id,
+            dense.reaching_out[block.id.index()]
+                .iter_ones()
+                .map(|binding_index| BindingId(binding_index as u32))
+                .collect::<FxHashSet<_>>(),
+        );
+    }
+
+    ReachingDefinitions {
+        reaching_in,
+        reaching_out,
+    }
+}
+
 #[derive(Debug, Clone)]
 struct DenseInitializedNameStates {
     maybe_in: Vec<DenseBitSet>,
@@ -923,17 +893,6 @@ fn build_name_table(
     }
     for synthetic_read in synthetic_reads {
         names.intern(&synthetic_read.name);
-    }
-    names
-}
-
-fn build_uninitialized_name_table(bindings: &[Binding], references: &[Reference]) -> NameTable {
-    let mut names = NameTable::default();
-    for binding in bindings {
-        names.intern(&binding.name);
-    }
-    for reference in references {
-        names.intern(&reference.name);
     }
     names
 }
@@ -1742,58 +1701,6 @@ fn mark_reaching_candidate_bindings_used(
             used_bindings.insert(candidate.index());
         }
     }
-}
-
-fn gen_set(
-    cfg: &ControlFlowGraph,
-    block_id: BlockId,
-    bindings: &[Binding],
-) -> FxHashSet<BindingId> {
-    let mut generated = FxHashSet::default();
-    for binding in &cfg.block(block_id).bindings {
-        let binding_data = &bindings[binding.index()];
-        if matches!(binding_data.kind, BindingKind::AppendAssignment) {
-            generated.insert(*binding);
-            continue;
-        }
-
-        generated.retain(|candidate| bindings[candidate.index()].name != binding_data.name);
-        generated.insert(*binding);
-    }
-    generated
-}
-
-fn kill_set(
-    cfg: &ControlFlowGraph,
-    block_id: BlockId,
-    bindings: &[Binding],
-    bindings_by_name: &FxHashMap<Name, Vec<BindingId>>,
-) -> FxHashSet<BindingId> {
-    let block = cfg.block(block_id);
-    let overwritten_names = block
-        .bindings
-        .iter()
-        .filter(|binding| {
-            !matches!(
-                bindings[binding.index()].kind,
-                BindingKind::AppendAssignment
-            )
-        })
-        .map(|binding| bindings[binding.index()].name.clone())
-        .collect::<FxHashSet<_>>();
-
-    let mut killed = FxHashSet::default();
-    for name in overwritten_names {
-        let Some(binding_ids) = bindings_by_name.get(&name) else {
-            continue;
-        };
-        for binding_id in binding_ids {
-            if !block.bindings.contains(binding_id) {
-                killed.insert(*binding_id);
-            }
-        }
-    }
-    killed
 }
 
 fn binding_initializes_name(binding: &Binding) -> Option<ContractCertainty> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -37,7 +37,7 @@ use std::sync::OnceLock;
 
 use crate::builder::SemanticModelBuilder;
 use crate::cfg::{RecordedProgram, build_control_flow_graph};
-use crate::dataflow::{DataflowContext, DataflowResult};
+use crate::dataflow::{DataflowContext, DataflowResult, ExactVariableDataflow};
 use crate::runtime::RuntimePrelude;
 use crate::zsh_options::ZshOptionAnalysis;
 
@@ -233,6 +233,7 @@ pub struct SemanticModel {
 pub struct SemanticAnalysis<'model> {
     model: &'model SemanticModel,
     cfg: OnceLock<ControlFlowGraph>,
+    exact_variable_dataflow: OnceLock<ExactVariableDataflow>,
     dataflow: OnceLock<DataflowResult>,
     unused_assignments: OnceLock<Vec<BindingId>>,
     uninitialized_references: OnceLock<Vec<UninitializedReference>>,
@@ -719,6 +720,7 @@ impl<'model> SemanticAnalysis<'model> {
         Self {
             model,
             cfg: OnceLock::new(),
+            exact_variable_dataflow: OnceLock::new(),
             dataflow: OnceLock::new(),
             unused_assignments: OnceLock::new(),
             uninitialized_references: OnceLock::new(),
@@ -737,12 +739,21 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    fn exact_variable_dataflow(&self) -> &ExactVariableDataflow {
+        self.exact_variable_dataflow.get_or_init(|| {
+            let cfg = self.cfg();
+            let context = self.model.dataflow_context(cfg);
+            dataflow::build_exact_variable_dataflow(&context)
+        })
+    }
+
     #[allow(dead_code)]
     fn dataflow(&self) -> &DataflowResult {
         self.dataflow.get_or_init(|| {
             let cfg = self.cfg();
             let context = self.model.dataflow_context(cfg);
-            dataflow::analyze(&context)
+            let exact = self.exact_variable_dataflow();
+            dataflow::analyze(&context, exact)
         })
     }
 
@@ -761,7 +772,8 @@ impl<'model> SemanticAnalysis<'model> {
                     return self.model.heuristic_unused_assignments.clone();
                 }
                 let context = self.model.dataflow_context(cfg);
-                dataflow::analyze_unused_assignments(&context)
+                let exact = self.exact_variable_dataflow();
+                dataflow::analyze_unused_assignments(&context, exact)
             })
             .as_slice()
     }
@@ -771,7 +783,8 @@ impl<'model> SemanticAnalysis<'model> {
             .get_or_init(|| {
                 let cfg = self.cfg();
                 let context = self.model.dataflow_context(cfg);
-                dataflow::analyze_uninitialized_references(&context)
+                let exact = self.exact_variable_dataflow();
+                dataflow::analyze_uninitialized_references(&context, exact)
             })
             .as_slice()
     }
@@ -1354,6 +1367,26 @@ mod tests {
         ids.iter()
             .map(|binding_id| model.binding(*binding_id).name.to_string())
             .collect()
+    }
+
+    fn sorted_binding_names<I>(model: &SemanticModel, ids: I) -> Vec<String>
+    where
+        I: IntoIterator<Item = BindingId>,
+    {
+        let mut names = ids
+            .into_iter()
+            .map(|binding_id| model.binding(binding_id).name.to_string())
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        names
+    }
+
+    fn block_with_reference(cfg: &ControlFlowGraph, reference: ReferenceId) -> BlockId {
+        cfg.blocks()
+            .iter()
+            .find(|block| block.references.contains(&reference))
+            .map(|block| block.id)
+            .expect("reference should be assigned to a CFG block")
     }
 
     fn unresolved_names(model: &SemanticModel) -> Vec<String> {
@@ -2080,6 +2113,86 @@ emoji[smile]=2
 
         let exact = analysis.dataflow().unused_assignment_ids().to_vec();
         assert_eq!(precise, exact);
+    }
+
+    #[test]
+    fn heuristic_unused_assignment_path_skips_exact_variable_dataflow_bundle() {
+        let model = model("unused=1\n");
+        let analysis = model.analysis();
+
+        let precise = analysis.unused_assignments().to_vec();
+
+        assert!(analysis.exact_variable_dataflow.get().is_none());
+        assert!(analysis.dataflow.get().is_none());
+        assert_eq!(binding_names(&model, &precise), vec!["unused"]);
+    }
+
+    #[test]
+    fn variable_dataflow_results_do_not_depend_on_query_order() {
+        let source = "VAR=x\nVAR=y\necho $VAR\necho $UNDEF\n";
+        let model = model(source);
+
+        let unused_then_uninitialized = {
+            let analysis = model.analysis();
+            let unused = analysis.unused_assignments().to_vec();
+            let uninitialized = analysis.uninitialized_references().to_vec();
+            (unused, uninitialized)
+        };
+        let uninitialized_then_unused = {
+            let analysis = model.analysis();
+            let uninitialized = analysis.uninitialized_references().to_vec();
+            let unused = analysis.unused_assignments().to_vec();
+            (unused, uninitialized)
+        };
+
+        assert_eq!(unused_then_uninitialized.0, uninitialized_then_unused.0);
+        assert_eq!(unused_then_uninitialized.1, uninitialized_then_unused.1);
+    }
+
+    #[test]
+    fn shared_exact_variable_dataflow_is_reused_across_accessors() {
+        let model = model("VAR=x\nVAR=y\necho $VAR\necho $UNDEF\n");
+        let analysis = model.analysis();
+
+        assert!(analysis.exact_variable_dataflow.get().is_none());
+
+        let unused = analysis.unused_assignments().to_vec();
+        let bundle_ptr = analysis.exact_variable_dataflow() as *const ExactVariableDataflow;
+        let uninitialized = analysis.uninitialized_references().to_vec();
+        let reused_ptr = analysis.exact_variable_dataflow() as *const ExactVariableDataflow;
+
+        assert_eq!(bundle_ptr, reused_ptr);
+        assert_eq!(binding_names(&model, &unused), vec!["VAR"]);
+        assert_eq!(
+            uninitialized
+                .iter()
+                .map(|reference| model.reference(reference.reference).name.to_string())
+                .collect::<Vec<_>>(),
+            vec!["UNDEF"]
+        );
+    }
+
+    #[test]
+    fn materialized_reaching_definitions_match_dense_exact_results() {
+        let model = model("VAR=outer\nif cond; then VAR=inner; fi\necho $VAR\n");
+        let analysis = model.analysis();
+        let dataflow = analysis.dataflow();
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.name.as_str() == "VAR")
+            .expect("expected a VAR reference");
+        let block_id = block_with_reference(analysis.cfg(), reference.id);
+
+        assert_eq!(
+            sorted_binding_names(
+                &model,
+                dataflow.reaching_definitions.reaching_in[&block_id]
+                    .iter()
+                    .copied()
+            ),
+            vec!["VAR", "VAR"]
+        );
     }
 
     #[test]

--- a/specs/004-semantic-model.md
+++ b/specs/004-semantic-model.md
@@ -486,6 +486,8 @@ pub struct ReachingDefinitions {
 }
 ```
 
+Internally, the semantic layer uses a dense bitset-based reaching-definitions representation and other shared dense indexes for exact variable dataflow. The exported `ReachingDefinitions` value above is materialized from that dense state only when the public `DataflowResult` is requested.
+
 Computed via standard iterative worklist algorithm over the CFG:
 - **Gen set:** Bindings created in the block.
 - **Kill set:** Bindings for the same variable name created in the block (overwrite earlier definitions).
@@ -535,6 +537,8 @@ pub enum UninitializedCertainty {
 ```
 
 Computed from reaching definitions: if `reaching_in` at the block containing the reference has no binding for the variable name, it is definitely uninitialized. If some predecessor paths have a binding and others don't, it is possibly uninitialized.
+
+The exact SH-003 and SH-039 queries share one cached internal variable-dataflow bundle: name interning, dense binding data, block indexes, unreachable-block tracking, dense reaching definitions, and dense initialized-name states are built once per `SemanticAnalysis` and reused across both queries.
 
 #### Dead Code Detection (SH-351)
 

--- a/specs/007-benchmarks.md
+++ b/specs/007-benchmarks.md
@@ -49,6 +49,7 @@ crates/shuck-benchmark/
 │   ├── lexer.rs          # Criterion: lex throughput per file
 │   ├── parser.rs         # Criterion: parse throughput per file
 │   ├── semantic.rs       # Criterion: semantic-model throughput per file
+│   ├── unused_assignment.rs # Criterion: exact variable-dataflow throughput per file
 │   └── linter.rs         # Criterion: full lint pipeline per file
 ├── src/
 │   └── lib.rs            # TestCase, TestFile, load helpers
@@ -99,8 +100,26 @@ name = "semantic"
 harness = false
 
 [[bench]]
+name = "unused_assignment"
+harness = false
+
+[[bench]]
 name = "linter"
 harness = false
+```
+
+`unused_assignment.rs` is the dedicated Criterion harness for exact variable-dataflow work. It keeps the isolated `unused_assignment` and `uninitialized_reference` groups and also provides a combined `variable_dataflow_combined` group that measures the real shared-cache access pattern on one `SemanticAnalysis`.
+
+Before/after exact-dataflow comparisons should use explicit Criterion baseline commands against that bench target:
+
+```bash
+env CARGO_TARGET_DIR="$SCRATCH/target" \
+  cargo bench -p shuck-benchmark --bench unused_assignment \
+  -- --save-baseline=exact-dataflow-before --noplot
+
+env CARGO_TARGET_DIR="$SCRATCH/target" \
+  cargo bench -p shuck-benchmark --bench unused_assignment \
+  -- --baseline=exact-dataflow-before --noplot
 ```
 
 #### src/lib.rs — Test Case Infrastructure


### PR DESCRIPTION
## Summary
- share one cached exact variable-dataflow bundle between SH-003 and SH-039 in `shuck-semantic`
- remove the legacy hash-set reaching-definitions pass and materialize the public `ReachingDefinitions` view from dense state on demand
- extend the Criterion harness with a combined `variable_dataflow_combined` benchmark and document the exact-dataflow benchmark workflow

## Validation
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
- `env CARGO_TARGET_DIR="$SCRATCH/target" cargo bench -p shuck-benchmark --bench unused_assignment -- --save-baseline=exact-dataflow-before --noplot`
- `env CARGO_TARGET_DIR="$SCRATCH/target" cargo bench -p shuck-benchmark --bench unused_assignment -- --baseline=exact-dataflow-before --noplot`

## Criterion
- `unused_assignment/all`: `29.20 ms -> 10.35 ms` (`-64.55%`)
- `uninitialized_reference/all`: `14.05 ms -> 9.45 ms` (`-32.73%`)
- `variable_dataflow_combined/all`: `26.49 ms -> 17.63 ms` (`-33.46%`)

## Notes
- `dead_code/all` in the same bench file regressed during the comparison run even though this change keeps `dead_code()` on its direct path; I left that as a follow-up rather than folding unrelated work into this refactor.
