### PR TITLE
Unify linter fact and surface scanning

### DIFF
--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -1,12 +1,61 @@
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
 use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixture};
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    LinterSettings, ShellCheckCodeMap, SuppressionIndex, first_statement_line, lint_file,
-    parse_directives,
+    LinterFacts, LinterSettings, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
+    classify_file_context, first_statement_line, lint_file, parse_directives,
 };
+use shuck_parser::parser::ParseOutput;
+use shuck_semantic::SemanticModel;
 
 configure_benchmark_allocator!();
+
+struct PreparedFactsInput {
+    source: &'static str,
+    output: ParseOutput,
+    indexer: Indexer,
+    semantic: SemanticModel,
+    file_context: shuck_linter::FileContext,
+}
+
+fn prepare_facts_input(source: &'static str) -> PreparedFactsInput {
+    let output = parse_fixture(source);
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let shell = ShellDialect::infer(source, None);
+    let file_context = classify_file_context(source, None, shell);
+
+    PreparedFactsInput {
+        source,
+        output,
+        indexer,
+        semantic,
+        file_context,
+    }
+}
+
+fn build_linter_facts(input: &PreparedFactsInput) -> usize {
+    let facts = LinterFacts::build(
+        &input.output.file,
+        input.source,
+        &input.semantic,
+        &input.indexer,
+        &input.file_context,
+    );
+
+    black_box(
+        facts.commands().len()
+            + facts.word_facts().len()
+            + facts.single_quoted_fragments().len()
+            + facts.backtick_fragments().len()
+            + facts.pattern_charclass_spans().len()
+            + facts.substring_expansion_fragments().len()
+            + facts.case_modification_fragments().len()
+            + facts.replacement_expansion_fragments().len(),
+    )
+}
 
 fn lint_source(
     source: &str,
@@ -34,6 +83,32 @@ fn lint_source(
     black_box(diagnostics.len())
 }
 
+fn bench_linter_facts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("linter_facts");
+
+    for case in benchmark_cases() {
+        group.sample_size(case.speed.sample_size());
+        group.throughput(Throughput::Bytes(case.total_bytes()));
+        group.bench_with_input(BenchmarkId::from_parameter(case.name), &case, |b, case| {
+            b.iter_batched(
+                || {
+                    case.files
+                        .iter()
+                        .map(|file| prepare_facts_input(file.source))
+                        .collect::<Vec<_>>()
+                },
+                |inputs| {
+                    let facts_size: usize = inputs.iter().map(build_linter_facts).sum();
+                    black_box(facts_size);
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_linter(c: &mut Criterion) {
     let mut group = c.benchmark_group("linter");
     let settings = LinterSettings::default();
@@ -57,5 +132,5 @@ fn bench_linter(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_linter);
+criterion_group!(benches, bench_linter_facts, bench_linter);
 criterion_main!(benches);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -41,7 +41,8 @@ use self::{
     escape_scan::{EscapeScanContext, EscapeScanMatch, build_escape_scan_matches},
     presence::build_presence_tested_names,
     surface::{
-        SurfaceFragmentFacts, build_subscript_index_reference_spans, build_surface_fragment_facts,
+        SurfaceFragmentFacts, SurfaceFragmentSink, SurfaceScanContext,
+        build_subscript_index_reference_spans,
     },
 };
 use crate::FileContext;
@@ -2494,6 +2495,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut pattern_literal_spans = Vec::new();
         let mut pattern_charclass_spans = Vec::new();
         let mut arithmetic_summary = ArithmeticFactSummary::default();
+        let mut surface_fragments = SurfaceFragmentFacts::default();
 
         for visit in query::iter_commands(
             &self.file.body,
@@ -2572,6 +2574,7 @@ impl<'a> LinterFactsBuilder<'a> {
                         .arithmetic
                         .arithmetic_command_substitution_spans,
                 );
+            extend_surface_fragment_facts(&mut surface_fragments, collected_words.surface);
             let redirect_facts =
                 build_redirect_facts(visit.redirects, self.source, command_zsh_options.as_ref());
             let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
@@ -2664,7 +2667,7 @@ impl<'a> LinterFactsBuilder<'a> {
             replacement_expansions,
             star_glob_removals,
             subscript_spans,
-        } = build_surface_fragment_facts(self.file, &commands, &command_ids_by_span, self.source);
+        } = surface_fragments;
         let double_paren_grouping_spans = build_double_paren_grouping_spans(&commands, self.source);
         let arithmetic_for_update_operator_spans =
             build_arithmetic_for_update_operator_spans(&commands, self.source);
@@ -6448,12 +6451,63 @@ struct CollectedWordFacts<'a> {
     pattern_literal_spans: Vec<Span>,
     pattern_charclass_spans: Vec<Span>,
     arithmetic: ArithmeticFactSummary,
+    surface: SurfaceFragmentFacts,
+}
+
+fn extend_surface_fragment_facts(target: &mut SurfaceFragmentFacts, source: SurfaceFragmentFacts) {
+    target.single_quoted.extend(source.single_quoted);
+    target
+        .dollar_double_quoted
+        .extend(source.dollar_double_quoted);
+    target.open_double_quotes.extend(source.open_double_quotes);
+    target
+        .suspect_closing_quotes
+        .extend(source.suspect_closing_quotes);
+    target.backticks.extend(source.backticks);
+    target.legacy_arithmetic.extend(source.legacy_arithmetic);
+    target
+        .positional_parameters
+        .extend(source.positional_parameters);
+    target
+        .positional_parameter_operator_spans
+        .extend(source.positional_parameter_operator_spans);
+    target
+        .unicode_smart_quote_spans
+        .extend(source.unicode_smart_quote_spans);
+    target
+        .pattern_exactly_one_extglob_spans
+        .extend(source.pattern_exactly_one_extglob_spans);
+    target
+        .pattern_charclass_spans
+        .extend(source.pattern_charclass_spans);
+    target
+        .nested_pattern_charclass_spans
+        .extend(source.nested_pattern_charclass_spans);
+    target
+        .nested_parameter_expansions
+        .extend(source.nested_parameter_expansions);
+    target
+        .indirect_expansions
+        .extend(source.indirect_expansions);
+    target
+        .indexed_array_references
+        .extend(source.indexed_array_references);
+    target
+        .substring_expansions
+        .extend(source.substring_expansions);
+    target.case_modifications.extend(source.case_modifications);
+    target
+        .replacement_expansions
+        .extend(source.replacement_expansions);
+    target.star_glob_removals.extend(source.star_glob_removals);
+    target.subscript_spans.extend(source.subscript_spans);
 }
 
 struct WordFactCollector<'a> {
     source: &'a str,
     command_id: CommandId,
     nested_word_command: bool,
+    surface_command_name: Option<Box<str>>,
     command_zsh_options: Option<ZshOptionState>,
     facts: Vec<WordFact<'a>>,
     array_assignment_split_word_indices: Vec<usize>,
@@ -6462,6 +6516,7 @@ struct WordFactCollector<'a> {
     pattern_literal_spans: Vec<Span>,
     pattern_charclass_spans: Vec<Span>,
     arithmetic: ArithmeticFactSummary,
+    surface: SurfaceFragmentSink<'a>,
 }
 
 impl<'a> WordFactCollector<'a> {
@@ -6476,6 +6531,10 @@ impl<'a> WordFactCollector<'a> {
             source,
             command_id,
             nested_word_command,
+            surface_command_name: normalized
+                .effective_or_literal_name()
+                .map(str::to_owned)
+                .map(String::into_boxed_str),
             command_zsh_options: effective_command_zsh_options(
                 semantic,
                 normalized.body_span.start.offset,
@@ -6488,6 +6547,7 @@ impl<'a> WordFactCollector<'a> {
             pattern_literal_spans: Vec::new(),
             pattern_charclass_spans: Vec::new(),
             arithmetic: ArithmeticFactSummary::default(),
+            surface: SurfaceFragmentSink::new(source),
         }
     }
 
@@ -6499,6 +6559,7 @@ impl<'a> WordFactCollector<'a> {
             pattern_literal_spans: self.pattern_literal_spans,
             pattern_charclass_spans: self.pattern_charclass_spans,
             arithmetic: self.arithmetic,
+            surface: self.surface.finish(),
         }
     }
 
@@ -6506,11 +6567,15 @@ impl<'a> WordFactCollector<'a> {
         self.collect_command_name_context_word(command);
         self.collect_argument_context_words(command);
         self.collect_expansion_assignment_value_words(command);
+        let surface_command_name = self.surface_command_name.clone();
+        let surface_context =
+            SurfaceScanContext::new(surface_command_name.as_deref(), self.nested_word_command);
 
         if let Command::Compound(command) = command {
             match command {
                 CompoundCommand::For(command) => {
                     if let Some(words) = &command.words {
+                        self.surface.collect_words(words, surface_context);
                         for word in words {
                             self.push_word(
                                 word,
@@ -6521,6 +6586,7 @@ impl<'a> WordFactCollector<'a> {
                     }
                 }
                 CompoundCommand::Repeat(command) => {
+                    self.surface.collect_word(&command.count, surface_context);
                     self.push_word(
                         &command.count,
                         WordFactContext::Expansion(ExpansionContext::CommandArgument),
@@ -6528,6 +6594,7 @@ impl<'a> WordFactCollector<'a> {
                     );
                 }
                 CompoundCommand::Foreach(command) => {
+                    self.surface.collect_words(&command.words, surface_context);
                     for word in &command.words {
                         self.push_word(
                             word,
@@ -6537,6 +6604,7 @@ impl<'a> WordFactCollector<'a> {
                     }
                 }
                 CompoundCommand::Select(command) => {
+                    self.surface.collect_words(&command.words, surface_context);
                     for word in &command.words {
                         self.push_word(
                             word,
@@ -6546,6 +6614,7 @@ impl<'a> WordFactCollector<'a> {
                     }
                 }
                 CompoundCommand::Case(command) => {
+                    self.surface.collect_word(&command.word, surface_context);
                     self.push_word(
                         &command.word,
                         WordFactContext::CaseSubject,
@@ -6553,6 +6622,10 @@ impl<'a> WordFactCollector<'a> {
                     );
                     for case in &command.cases {
                         for pattern in &case.patterns {
+                            self.surface.collect_pattern(
+                                pattern,
+                                surface_context.with_pattern_charclass_scan(),
+                            );
                             self.collect_pattern_context_words(
                                 pattern,
                                 WordFactContext::Expansion(ExpansionContext::CasePattern),
@@ -6562,7 +6635,10 @@ impl<'a> WordFactCollector<'a> {
                     }
                 }
                 CompoundCommand::Conditional(command) => {
-                    self.collect_conditional_expansion_words(&command.expression);
+                    self.collect_conditional_expansion_words(
+                        &command.expression,
+                        SurfaceScanContext::new(None, self.nested_word_command),
+                    );
                 }
                 CompoundCommand::Arithmetic(command) => {
                     if let Some(expression) = &command.expr_ast {
@@ -6602,6 +6678,10 @@ impl<'a> WordFactCollector<'a> {
             }
         }
 
+        self.surface.collect_redirects(
+            redirects,
+            SurfaceScanContext::new(None, self.nested_word_command),
+        );
         for redirect in redirects {
             let Some(context) = ExpansionContext::from_redirect_kind(redirect.kind) else {
                 continue;
@@ -6626,8 +6706,12 @@ impl<'a> WordFactCollector<'a> {
     }
 
     fn collect_command_name_context_word(&mut self, command: &'a Command) {
+        let surface_command_name = self.surface_command_name.clone();
+        let surface_context =
+            SurfaceScanContext::new(surface_command_name.as_deref(), self.nested_word_command);
         match command {
             Command::Simple(command) => {
+                self.surface.collect_word(&command.name, surface_context);
                 if static_word_text(&command.name, self.source).is_none() {
                     self.push_word(
                         &command.name,
@@ -6638,6 +6722,7 @@ impl<'a> WordFactCollector<'a> {
             }
             Command::Function(function) => {
                 for entry in &function.header.entries {
+                    self.surface.collect_word(&entry.word, surface_context);
                     if static_word_text(&entry.word, self.source).is_none() {
                         self.push_word(
                             &entry.word,
@@ -6658,65 +6743,102 @@ impl<'a> WordFactCollector<'a> {
     fn collect_argument_context_words(&mut self, command: &'a Command) {
         match command {
             Command::Simple(command) => {
-                if static_word_text(&command.name, self.source).as_deref() == Some("trap") {
-                    return;
+                let surface_command_name = self.surface_command_name.clone();
+                let surface_context = SurfaceScanContext::new(
+                    surface_command_name.as_deref(),
+                    self.nested_word_command,
+                );
+                let trap_command =
+                    static_word_text(&command.name, self.source).as_deref() == Some("trap");
+                let variable_set_operand =
+                    surface::simple_command_variable_set_operand(command, self.source);
+                if surface_command_name.as_deref() == Some("unset") {
+                    for word in &command.args {
+                        self.surface.record_unset_array_target_word(word);
+                    }
                 }
                 for word in &command.args {
-                    self.push_word(
-                        word,
-                        WordFactContext::Expansion(ExpansionContext::CommandArgument),
-                        WordFactHostKind::Direct,
-                    );
-                }
-            }
-            Command::Builtin(command) => match command {
-                BuiltinCommand::Break(command) => {
-                    if let Some(word) = &command.depth {
+                    let surface_word_context = if variable_set_operand
+                        .is_some_and(|operand| std::ptr::eq(word, operand))
+                    {
+                        surface_context.variable_set_operand()
+                    } else {
+                        surface_context
+                    };
+                    self.surface.collect_word(word, surface_word_context);
+                    if !trap_command {
                         self.push_word(
                             word,
                             WordFactContext::Expansion(ExpansionContext::CommandArgument),
                             WordFactHostKind::Direct,
                         );
                     }
+                }
+            }
+            Command::Builtin(command) => match command {
+                BuiltinCommand::Break(command) => {
+                    let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
+                    if let Some(word) = &command.depth {
+                        self.surface.collect_word(word, surface_context);
+                        self.push_word(
+                            word,
+                            WordFactContext::Expansion(ExpansionContext::CommandArgument),
+                            WordFactHostKind::Direct,
+                        );
+                    }
+                    self.surface
+                        .collect_words(&command.extra_args, surface_context);
                     self.collect_words_with_context(
                         &command.extra_args,
                         WordFactContext::Expansion(ExpansionContext::CommandArgument),
                     );
                 }
                 BuiltinCommand::Continue(command) => {
+                    let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
                     if let Some(word) = &command.depth {
+                        self.surface.collect_word(word, surface_context);
                         self.push_word(
                             word,
                             WordFactContext::Expansion(ExpansionContext::CommandArgument),
                             WordFactHostKind::Direct,
                         );
                     }
+                    self.surface
+                        .collect_words(&command.extra_args, surface_context);
                     self.collect_words_with_context(
                         &command.extra_args,
                         WordFactContext::Expansion(ExpansionContext::CommandArgument),
                     );
                 }
                 BuiltinCommand::Return(command) => {
+                    let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
                     if let Some(word) = &command.code {
+                        self.surface.collect_word(word, surface_context);
                         self.push_word(
                             word,
                             WordFactContext::Expansion(ExpansionContext::CommandArgument),
                             WordFactHostKind::Direct,
                         );
                     }
+                    self.surface
+                        .collect_words(&command.extra_args, surface_context);
                     self.collect_words_with_context(
                         &command.extra_args,
                         WordFactContext::Expansion(ExpansionContext::CommandArgument),
                     );
                 }
                 BuiltinCommand::Exit(command) => {
+                    let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
                     if let Some(word) = &command.code {
+                        self.surface.collect_word(word, surface_context);
                         self.push_word(
                             word,
                             WordFactContext::Expansion(ExpansionContext::CommandArgument),
                             WordFactHostKind::Direct,
                         );
                     }
+                    self.surface
+                        .collect_words(&command.extra_args, surface_context);
                     self.collect_words_with_context(
                         &command.extra_args,
                         WordFactContext::Expansion(ExpansionContext::CommandArgument),
@@ -6724,18 +6846,28 @@ impl<'a> WordFactCollector<'a> {
                 }
             },
             Command::Decl(command) => {
+                let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
                 for operand in &command.operands {
-                    if let DeclOperand::Dynamic(word) = operand {
-                        self.push_word(
-                            word,
-                            WordFactContext::Expansion(ExpansionContext::CommandArgument),
-                            WordFactHostKind::Direct,
-                        );
+                    match operand {
+                        DeclOperand::Flag(word) => self.surface.collect_word(word, surface_context),
+                        DeclOperand::Dynamic(word) => {
+                            self.surface.collect_word(word, surface_context);
+                            self.push_word(
+                                word,
+                                WordFactContext::Expansion(ExpansionContext::CommandArgument),
+                                WordFactHostKind::Direct,
+                            );
+                        }
+                        DeclOperand::Name(_) | DeclOperand::Assignment(_) => {}
                     }
                 }
             }
             Command::Binary(_) | Command::Compound(_) | Command::Function(_) => {}
             Command::AnonymousFunction(function) => {
+                self.surface.collect_words(
+                    &function.args,
+                    SurfaceScanContext::new(None, self.nested_word_command),
+                );
                 self.collect_words_with_context(
                     &function.args,
                     WordFactContext::Expansion(ExpansionContext::CommandArgument),
@@ -6755,10 +6887,15 @@ impl<'a> WordFactCollector<'a> {
         for operand in query::declaration_operands(command) {
             match operand {
                 DeclOperand::Name(reference) => {
+                    self.surface.record_var_ref_subscript(reference);
                     query::visit_var_ref_subscript_words_with_source(
                         reference,
                         self.source,
                         &mut |word| {
+                            self.surface.collect_word(
+                                word,
+                                SurfaceScanContext::new(None, self.nested_word_command),
+                            );
                             self.push_owned_word(
                                 word.clone(),
                                 WordFactContext::Expansion(
@@ -6785,10 +6922,14 @@ impl<'a> WordFactCollector<'a> {
         assignment: &'a Assignment,
         context: WordFactContext,
     ) {
+        let surface_context = SurfaceScanContext::new(None, self.nested_word_command)
+            .with_assignment_target(assignment.target.name.as_str());
+        self.surface.record_var_ref_subscript(&assignment.target);
         query::visit_var_ref_subscript_words_with_source(
             &assignment.target,
             self.source,
             &mut |word| {
+                self.surface.collect_word(word, surface_context);
                 self.push_owned_word(
                     word.clone(),
                     context,
@@ -6799,12 +6940,14 @@ impl<'a> WordFactCollector<'a> {
 
         match &assignment.value {
             AssignmentValue::Scalar(word) => {
+                self.surface.collect_word(word, surface_context);
                 self.push_word(word, context, WordFactHostKind::Direct);
             }
             AssignmentValue::Compound(array) => {
                 for element in &array.elements {
                     match element {
                         ArrayElem::Sequential(word) => {
+                            self.surface.collect_word(word, surface_context);
                             self.compound_assignment_value_word_spans
                                 .insert(FactSpan::new(word.span));
                             if let Some(index) =
@@ -6814,13 +6957,16 @@ impl<'a> WordFactCollector<'a> {
                             }
                         }
                         ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
+                            self.surface.record_subscript(Some(key));
                             query::visit_subscript_words(Some(key), self.source, &mut |word| {
+                                self.surface.collect_word(word, surface_context);
                                 self.push_owned_word(
                                     word.clone(),
                                     context,
                                     WordFactHostKind::ArrayKeySubscript,
                                 );
                             });
+                            self.surface.collect_word(value, surface_context);
                             self.compound_assignment_value_word_spans
                                 .insert(FactSpan::new(value.span));
                             self.push_word(value, context, WordFactHostKind::Direct);
@@ -6880,17 +7026,29 @@ impl<'a> WordFactCollector<'a> {
         }
     }
 
-    fn collect_conditional_expansion_words(&mut self, expression: &'a ConditionalExpr) {
+    fn collect_conditional_expansion_words(
+        &mut self,
+        expression: &'a ConditionalExpr,
+        surface_context: SurfaceScanContext<'_>,
+    ) {
         match expression {
             ConditionalExpr::Binary(expr) => {
-                self.collect_conditional_expansion_words(&expr.left);
-                self.collect_conditional_expansion_words(&expr.right);
+                self.collect_conditional_expansion_words(&expr.left, surface_context);
+                self.collect_conditional_expansion_words(&expr.right, surface_context);
             }
-            ConditionalExpr::Unary(expr) => self.collect_conditional_expansion_words(&expr.expr),
+            ConditionalExpr::Unary(expr) => self.collect_conditional_expansion_words(
+                &expr.expr,
+                if expr.op == ConditionalUnaryOp::VariableSet {
+                    surface_context.variable_set_operand()
+                } else {
+                    surface_context
+                },
+            ),
             ConditionalExpr::Parenthesized(expr) => {
-                self.collect_conditional_expansion_words(&expr.expr)
+                self.collect_conditional_expansion_words(&expr.expr, surface_context)
             }
             ConditionalExpr::Word(word) => {
+                self.surface.collect_word(word, surface_context);
                 self.push_word(
                     word,
                     WordFactContext::Expansion(ExpansionContext::StringTestOperand),
@@ -6898,18 +7056,23 @@ impl<'a> WordFactCollector<'a> {
                 );
             }
             ConditionalExpr::Regex(word) => {
+                self.surface.collect_word(word, surface_context);
                 self.push_word(
                     word,
                     WordFactContext::Expansion(ExpansionContext::RegexOperand),
                     WordFactHostKind::Direct,
                 );
             }
-            ConditionalExpr::Pattern(_) => {}
+            ConditionalExpr::Pattern(pattern) => self
+                .surface
+                .collect_pattern(pattern, surface_context.with_pattern_charclass_scan()),
             ConditionalExpr::VarRef(reference) => {
+                self.surface.record_var_ref_subscript(reference);
                 query::visit_var_ref_subscript_words_with_source(
                     reference,
                     self.source,
                     &mut |word| {
+                        self.surface.collect_word(word, surface_context);
                         self.push_owned_word(
                             word.clone(),
                             WordFactContext::Expansion(
@@ -7059,7 +7222,6 @@ impl<'a> WordFactCollector<'a> {
             | WordFactContext::CaseSubject
             | WordFactContext::ArithmeticCommand => None,
         };
-
         let index = self.facts.len();
         self.facts.push(WordFact {
             key,
@@ -14147,6 +14309,55 @@ printf '%s\\n' $0 $1 $* $@
     }
 
     #[test]
+    fn builds_word_facts_for_quoted_all_elements_array_expansions() {
+        let source = "\
+#!/bin/bash
+eval \"${shims[@]}\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let fact = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source) == "\"${shims[@]}\"")
+                .expect("expected eval argument fact");
+
+            assert_eq!(
+                fact.all_elements_array_expansion_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${shims[@]}"],
+                "parts: {:?}",
+                fact.word().parts
+            );
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_for_mixed_quoted_all_elements_array_expansions() {
+        let source = "\
+#!/bin/bash
+shims=(a)
+eval \"conda_shim() { case \\\"\\${1##*/}\\\" in ${shims[@]} *) return 1;; esac }\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let fact = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source).contains("${shims[@]}"))
+                .expect("expected eval argument fact");
+
+            assert_eq!(
+                fact.all_elements_array_expansion_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${shims[@]}"]
+            );
+        });
+    }
+
+    #[test]
     fn builds_array_assignment_split_word_facts() {
         let source = "\
 #!/bin/bash
@@ -14233,6 +14444,31 @@ arr=(\"$(printf '%s\\n' \"$x\")\")
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["$x"]
+            );
+        });
+    }
+
+    #[test]
+    fn shared_command_traversal_collects_word_facts_and_surface_fragments() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' ${name%$suffix} `printf backtick`
+";
+
+        with_facts(source, None, |_, facts| {
+            let parameter_pattern = facts
+                .expansion_word_facts(ExpansionContext::ParameterPattern)
+                .find(|fact| fact.span().slice(source) == "$suffix")
+                .expect("expected parameter pattern fact");
+            assert_eq!(parameter_pattern.host_kind(), WordFactHostKind::Direct);
+
+            assert_eq!(
+                facts
+                    .backtick_fragments()
+                    .iter()
+                    .map(|fragment| fragment.span().slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["`printf backtick`"]
             );
         });
     }

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -26,7 +26,7 @@ pub(super) struct SurfaceFragmentFacts {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-struct SurfaceScanContext<'a> {
+pub(super) struct SurfaceScanContext<'a> {
     command_name: Option<&'a str>,
     assignment_target: Option<&'a str>,
     nested_word_command: bool,
@@ -36,22 +36,24 @@ struct SurfaceScanContext<'a> {
 }
 
 impl<'a> SurfaceScanContext<'a> {
-    fn new() -> Self {
+    pub(super) fn new(command_name: Option<&'a str>, nested_word_command: bool) -> Self {
         Self {
+            command_name,
+            nested_word_command,
             collect_open_double_quotes: true,
             collect_pattern_charclasses: false,
             ..Self::default()
         }
     }
 
-    fn with_assignment_target(self, assignment_target: &'a str) -> Self {
+    pub(super) fn with_assignment_target(self, assignment_target: &'a str) -> Self {
         Self {
             assignment_target: Some(assignment_target),
             ..self
         }
     }
 
-    fn variable_set_operand(self) -> Self {
+    pub(super) fn variable_set_operand(self) -> Self {
         Self {
             variable_set_operand: true,
             ..self
@@ -65,7 +67,7 @@ impl<'a> SurfaceScanContext<'a> {
         }
     }
 
-    fn with_pattern_charclass_scan(self) -> Self {
+    pub(super) fn with_pattern_charclass_scan(self) -> Self {
         Self {
             collect_pattern_charclasses: true,
             ..self
@@ -73,28 +75,20 @@ impl<'a> SurfaceScanContext<'a> {
     }
 }
 
-struct SurfaceFragmentCollector<'a> {
-    commands: &'a [CommandFact<'a>],
-    command_ids_by_span: &'a CommandLookupIndex,
+pub(super) struct SurfaceFragmentSink<'a> {
     source: &'a str,
     facts: SurfaceFragmentFacts,
 }
 
-impl<'a> SurfaceFragmentCollector<'a> {
-    fn new(
-        commands: &'a [CommandFact<'a>],
-        command_ids_by_span: &'a CommandLookupIndex,
-        source: &'a str,
-    ) -> Self {
+impl<'a> SurfaceFragmentSink<'a> {
+    pub(super) fn new(source: &'a str) -> Self {
         Self {
-            commands,
-            command_ids_by_span,
             source,
             facts: SurfaceFragmentFacts::default(),
         }
     }
 
-    fn finish(self) -> SurfaceFragmentFacts {
+    pub(super) fn finish(self) -> SurfaceFragmentFacts {
         self.facts
     }
 
@@ -172,254 +166,23 @@ impl<'a> SurfaceFragmentCollector<'a> {
             .push(StarGlobRemovalFragmentFact { span });
     }
 
-    fn collect_commands(&mut self, commands: &StmtSeq) {
-        for command in commands.iter() {
-            self.collect_command(command);
-        }
-    }
-
-    fn collect_command(&mut self, stmt: &Stmt) {
-        let command_name_storage = self
-            .command_fact_for_command(&stmt.command)
-            .and_then(CommandFact::effective_or_literal_name)
-            .map(str::to_owned)
-            .map(String::into_boxed_str);
-        let nested_word_command = self
-            .command_fact_for_command(&stmt.command)
-            .is_some_and(CommandFact::is_nested_word_command);
-        let context = SurfaceScanContext {
-            command_name: command_name_storage.as_deref(),
-            nested_word_command,
-            ..SurfaceScanContext::new()
-        };
-
-        match &stmt.command {
-            Command::Simple(command) => self.collect_simple_command(command, context),
-            Command::Builtin(command) => self.collect_builtin(command),
-            Command::Decl(command) => self.collect_decl_command(command),
-            Command::Binary(command) => {
-                self.collect_command(&command.left);
-                self.collect_command(&command.right);
-            }
-            Command::Compound(command) => self.collect_compound(command),
-            Command::Function(function) => {
-                for entry in &function.header.entries {
-                    self.collect_word(&entry.word, context);
-                }
-                self.collect_command(&function.body);
-            }
-            Command::AnonymousFunction(function) => {
-                for word in &function.args {
-                    self.collect_word(word, context);
-                }
-                self.collect_command(&function.body);
-            }
-        }
-
-        self.collect_redirects(
-            &stmt.redirects,
-            SurfaceScanContext {
-                nested_word_command,
-                ..SurfaceScanContext::new()
-            },
-        );
-    }
-
-    fn collect_simple_command(&mut self, command: &SimpleCommand, context: SurfaceScanContext<'_>) {
-        self.collect_assignments(&command.assignments, context);
-        self.collect_word(&command.name, context);
-
-        if context.command_name == Some("unset") {
-            for word in &command.args {
-                if word_looks_like_unset_array_target(word, self.source) {
-                    self.facts.subscript_spans.push(word.span);
-                }
-            }
-        }
-
-        let variable_set_operand = simple_command_variable_set_operand(command, self.source);
-        for word in &command.args {
-            let word_context =
-                if variable_set_operand.is_some_and(|operand| std::ptr::eq(word, operand)) {
-                    context.variable_set_operand()
-                } else {
-                    context
-                };
-            self.collect_word(word, word_context);
-        }
-    }
-
-    fn collect_builtin(&mut self, command: &BuiltinCommand) {
-        let context = SurfaceScanContext::new();
-        match command {
-            BuiltinCommand::Break(command) => {
-                self.collect_assignments(&command.assignments, context);
-                if let Some(word) = &command.depth {
-                    self.collect_word(word, context);
-                }
-                self.collect_words(&command.extra_args, context);
-            }
-            BuiltinCommand::Continue(command) => {
-                self.collect_assignments(&command.assignments, context);
-                if let Some(word) = &command.depth {
-                    self.collect_word(word, context);
-                }
-                self.collect_words(&command.extra_args, context);
-            }
-            BuiltinCommand::Return(command) => {
-                self.collect_assignments(&command.assignments, context);
-                if let Some(word) = &command.code {
-                    self.collect_word(word, context);
-                }
-                self.collect_words(&command.extra_args, context);
-            }
-            BuiltinCommand::Exit(command) => {
-                self.collect_assignments(&command.assignments, context);
-                if let Some(word) = &command.code {
-                    self.collect_word(word, context);
-                }
-                self.collect_words(&command.extra_args, context);
-            }
-        }
-    }
-
-    fn collect_decl_command(&mut self, command: &DeclClause) {
-        let context = SurfaceScanContext::new();
-        self.collect_assignments(&command.assignments, context);
-        for operand in &command.operands {
-            match operand {
-                DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                    self.collect_word(word, context);
-                }
-                DeclOperand::Name(reference) => {
-                    self.record_var_ref_subscript(reference);
-                    query::visit_var_ref_subscript_words_with_source(
-                        reference,
-                        self.source,
-                        &mut |word| self.collect_word(word, context),
-                    );
-                }
-                DeclOperand::Assignment(assignment) => self.collect_assignment(assignment, context),
-            }
-        }
-    }
-
-    fn collect_compound(&mut self, command: &CompoundCommand) {
-        match command {
-            CompoundCommand::If(command) => {
-                self.collect_commands(&command.condition);
-                self.collect_commands(&command.then_branch);
-                for (condition, body) in &command.elif_branches {
-                    self.collect_commands(condition);
-                    self.collect_commands(body);
-                }
-                if let Some(body) = &command.else_branch {
-                    self.collect_commands(body);
-                }
-            }
-            CompoundCommand::For(command) => {
-                if let Some(words) = &command.words {
-                    self.collect_words(words, SurfaceScanContext::new());
-                }
-                self.collect_commands(&command.body);
-            }
-            CompoundCommand::Repeat(command) => {
-                self.collect_word(&command.count, SurfaceScanContext::new());
-                self.collect_commands(&command.body);
-            }
-            CompoundCommand::Foreach(command) => {
-                self.collect_words(&command.words, SurfaceScanContext::new());
-                self.collect_commands(&command.body);
-            }
-            CompoundCommand::ArithmeticFor(command) => self.collect_commands(&command.body),
-            CompoundCommand::While(command) => {
-                self.collect_commands(&command.condition);
-                self.collect_commands(&command.body);
-            }
-            CompoundCommand::Until(command) => {
-                self.collect_commands(&command.condition);
-                self.collect_commands(&command.body);
-            }
-            CompoundCommand::Case(command) => {
-                self.collect_word(&command.word, SurfaceScanContext::new());
-                for case in &command.cases {
-                    self.collect_patterns(
-                        &case.patterns,
-                        SurfaceScanContext::new().with_pattern_charclass_scan(),
-                    );
-                    self.collect_commands(&case.body);
-                }
-            }
-            CompoundCommand::Select(command) => {
-                self.collect_words(&command.words, SurfaceScanContext::new());
-                self.collect_commands(&command.body);
-            }
-            CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
-                self.collect_commands(commands);
-            }
-            CompoundCommand::Always(command) => {
-                self.collect_commands(&command.body);
-                self.collect_commands(&command.always_body);
-            }
-            CompoundCommand::Arithmetic(_) => {}
-            CompoundCommand::Time(command) => {
-                if let Some(command) = &command.command {
-                    self.collect_command(command);
-                }
-            }
-            CompoundCommand::Conditional(command) => {
-                self.collect_conditional_expr(&command.expression, SurfaceScanContext::new());
-            }
-            CompoundCommand::Coproc(command) => self.collect_command(&command.body),
-        }
-    }
-
-    fn collect_assignments(&mut self, assignments: &[Assignment], context: SurfaceScanContext<'_>) {
-        for assignment in assignments {
-            self.collect_assignment(assignment, context);
-        }
-    }
-
-    fn collect_assignment(&mut self, assignment: &Assignment, context: SurfaceScanContext<'_>) {
-        let context = context.with_assignment_target(assignment.target.name.as_str());
-        self.record_var_ref_subscript(&assignment.target);
-        query::visit_var_ref_subscript_words_with_source(
-            &assignment.target,
-            self.source,
-            &mut |word| self.collect_word(word, context),
-        );
-        match &assignment.value {
-            AssignmentValue::Scalar(word) => self.collect_word(word, context),
-            AssignmentValue::Compound(array) => {
-                for element in &array.elements {
-                    match element {
-                        ArrayElem::Sequential(word) => self.collect_word(word, context),
-                        ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
-                            self.record_subscript(Some(key));
-                            query::visit_subscript_words(Some(key), self.source, &mut |word| {
-                                self.collect_word(word, context);
-                            });
-                            self.collect_word(value, context);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn collect_words(&mut self, words: &[Word], context: SurfaceScanContext<'_>) {
+    pub(super) fn collect_words(&mut self, words: &[Word], context: SurfaceScanContext<'_>) {
         for word in words {
             self.collect_word(word, context);
         }
     }
 
-    fn collect_patterns(&mut self, patterns: &[Pattern], context: SurfaceScanContext<'_>) {
+    pub(super) fn collect_patterns(
+        &mut self,
+        patterns: &[Pattern],
+        context: SurfaceScanContext<'_>,
+    ) {
         for pattern in patterns {
             self.collect_pattern(pattern, context);
         }
     }
 
-    fn collect_word(&mut self, word: &Word, context: SurfaceScanContext<'_>) {
+    pub(super) fn collect_word(&mut self, word: &Word, context: SurfaceScanContext<'_>) {
         collect_unicode_smart_quote_spans_in_word_parts(
             &word.parts,
             self.source,
@@ -433,6 +196,12 @@ impl<'a> SurfaceFragmentCollector<'a> {
         self.collect_raw_replacement_expansions_in_span(word.span);
         self.collect_raw_case_modifications_in_span(word.span);
         self.collect_word_parts(&word.parts, context);
+    }
+
+    pub(super) fn record_unset_array_target_word(&mut self, word: &Word) {
+        if word_looks_like_unset_array_target(word, self.source) {
+            self.facts.subscript_spans.push(word.span);
+        }
     }
 
     fn collect_open_double_quote_fragments(&mut self, word: &Word) {
@@ -560,16 +329,14 @@ impl<'a> SurfaceFragmentCollector<'a> {
                 }
                 WordPart::CommandSubstitution {
                     syntax: CommandSubstitutionSyntax::Backtick,
-                    body,
+                    body: _,
                     ..
                 } => {
                     self.facts
                         .backticks
                         .push(BacktickFragmentFact { span: part.span });
-                    self.collect_commands(body);
                 }
-                WordPart::CommandSubstitution { body, .. }
-                | WordPart::ProcessSubstitution { body, .. } => self.collect_commands(body),
+                WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
                 WordPart::Parameter(parameter) => {
                     if is_nested_parameter_expansion(parameter, self.source) {
                         self.facts
@@ -764,7 +531,7 @@ impl<'a> SurfaceFragmentCollector<'a> {
         }
     }
 
-    fn collect_pattern(&mut self, pattern: &Pattern, context: SurfaceScanContext<'_>) {
+    pub(super) fn collect_pattern(&mut self, pattern: &Pattern, context: SurfaceScanContext<'_>) {
         for (part, span) in pattern.parts_with_spans() {
             match part {
                 PatternPart::Group { kind, patterns } => {
@@ -886,7 +653,11 @@ impl<'a> SurfaceFragmentCollector<'a> {
         }
     }
 
-    fn collect_redirects(&mut self, redirects: &[Redirect], context: SurfaceScanContext<'_>) {
+    pub(super) fn collect_redirects(
+        &mut self,
+        redirects: &[Redirect],
+        context: SurfaceScanContext<'_>,
+    ) {
         for redirect in redirects {
             match redirect.word_target() {
                 Some(word) => self.collect_word(word, context),
@@ -899,44 +670,6 @@ impl<'a> SurfaceFragmentCollector<'a> {
                         self.collect_word(&heredoc.body, context.without_open_double_quote_scan());
                     }
                 }
-            }
-        }
-    }
-
-    fn collect_conditional_expr(
-        &mut self,
-        expression: &ConditionalExpr,
-        context: SurfaceScanContext<'_>,
-    ) {
-        match expression {
-            ConditionalExpr::Binary(expr) => {
-                self.collect_conditional_expr(&expr.left, context);
-                self.collect_conditional_expr(&expr.right, context);
-            }
-            ConditionalExpr::Unary(expr) => {
-                let context = if expr.op == ConditionalUnaryOp::VariableSet {
-                    context.variable_set_operand()
-                } else {
-                    context
-                };
-                self.collect_conditional_expr(&expr.expr, context);
-            }
-            ConditionalExpr::Parenthesized(expr) => {
-                self.collect_conditional_expr(&expr.expr, context);
-            }
-            ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-                self.collect_word(word, context)
-            }
-            ConditionalExpr::Pattern(pattern) => {
-                self.collect_pattern(pattern, context.with_pattern_charclass_scan())
-            }
-            ConditionalExpr::VarRef(reference) => {
-                self.record_var_ref_subscript(reference);
-                query::visit_var_ref_subscript_words_with_source(
-                    reference,
-                    self.source,
-                    &mut |word| self.collect_word(word, context),
-                );
             }
         }
     }
@@ -1011,11 +744,11 @@ impl<'a> SurfaceFragmentCollector<'a> {
         }
     }
 
-    fn record_var_ref_subscript(&mut self, reference: &VarRef) {
+    pub(super) fn record_var_ref_subscript(&mut self, reference: &VarRef) {
         self.record_subscript(reference.subscript.as_ref());
     }
 
-    fn record_subscript(&mut self, subscript: Option<&Subscript>) {
+    pub(super) fn record_subscript(&mut self, subscript: Option<&Subscript>) {
         let Some(subscript) = subscript else {
             return;
         };
@@ -1023,10 +756,6 @@ impl<'a> SurfaceFragmentCollector<'a> {
             return;
         }
         self.facts.subscript_spans.push(subscript.span());
-    }
-
-    fn command_fact_for_command(&self, command: &Command) -> Option<&CommandFact<'a>> {
-        command_fact_for_command(command, self.commands, self.command_ids_by_span)
     }
 }
 
@@ -1373,17 +1102,6 @@ fn next_parameter_expansion_candidate(text: &str, search_start: usize) -> Option
     None
 }
 
-pub(super) fn build_surface_fragment_facts<'a>(
-    file: &'a File,
-    commands: &'a [CommandFact<'a>],
-    command_ids_by_span: &'a CommandLookupIndex,
-    source: &'a str,
-) -> SurfaceFragmentFacts {
-    let mut collector = SurfaceFragmentCollector::new(commands, command_ids_by_span, source);
-    collector.collect_commands(&file.body);
-    collector.finish()
-}
-
 fn collect_positional_parameter_operator_spans_in_arithmetic(
     expansion_span: Span,
     expression: &SourceText,
@@ -1613,7 +1331,7 @@ fn is_nested_parameter_expansion(parameter: &shuck_ast::ParameterExpansion, sour
 fn contains_nested_parameter_marker(text: &str) -> bool {
     text.starts_with("${${") || text.starts_with("${#${") || text.starts_with("${!${")
 }
-fn simple_command_variable_set_operand<'a>(
+pub(super) fn simple_command_variable_set_operand<'a>(
     command: &'a SimpleCommand,
     source: &str,
 ) -> Option<&'a Word> {


### PR DESCRIPTION
## What changed
- added a `linter_facts` Criterion group in `crates/shuck-benchmark/benches/linter.rs` so `LinterFacts::build(...)` is measured directly alongside the existing end-to-end `linter` benchmark
- folded surface fragment collection into the same per-command traversal that already builds word facts, removing the extra post-pass tree walk
- added fact-level regression coverage to keep both word facts and surface fragments flowing from the shared traversal, including mixed quoted all-elements array expansions

## Why
`SurfaceFragmentCollector` was rewalking commands, assignments, words, redirects, and subscripts after the fact builder had already visited the same structures. The main win here is removing that duplicate traversal while keeping rule behavior unchanged.

## Impact
- facts building is now measured directly, which makes future perf work much easier to validate
- the current tree keeps the shared-traversal speedup and avoids the slower word-scan-summary experiment
- no production-facing API or diagnostic wording changed

## Validation
- `cargo test -p shuck-linter`
- `cargo bench -p shuck-benchmark --bench linter -- --baseline=before-linter-facts --noplot`

Key benchmark deltas vs `before-linter-facts` on this branch:
- `linter_facts/nvm`: about 33-35% faster
- `linter_facts/all`: about 31-32% faster
- `linter/nvm`: about 42-46% faster
- `linter/all`: about 58-67% faster
