### PR TITLE
Move C108 unset operand parsing into facts

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1507,6 +1507,7 @@ pub struct PrintfCommandFacts<'a> {
 pub struct UnsetCommandFacts<'a> {
     pub function_mode: bool,
     operand_words: Box<[&'a Word]>,
+    operand_facts: Box<[UnsetOperandFact<'a>]>,
     prefix_match_operand_spans: Box<[Span]>,
     options_parseable: bool,
 }
@@ -1518,6 +1519,10 @@ impl<'a> UnsetCommandFacts<'a> {
 
     pub fn prefix_match_operand_spans(&self) -> &[Span] {
         &self.prefix_match_operand_spans
+    }
+
+    pub(crate) fn operand_facts(&self) -> &[UnsetOperandFact<'a>] {
+        &self.operand_facts
     }
 
     pub fn targets_function_name(&self, source: &str, target_name: &str) -> bool {
@@ -1536,6 +1541,38 @@ impl<'a> UnsetCommandFacts<'a> {
         }
 
         false
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UnsetOperandFact<'a> {
+    word: &'a Word,
+    array_subscript: Option<UnsetArraySubscriptFact>,
+}
+
+impl<'a> UnsetOperandFact<'a> {
+    pub(crate) fn word(&self) -> &'a Word {
+        self.word
+    }
+
+    pub(crate) fn array_subscript(&self) -> Option<&UnsetArraySubscriptFact> {
+        self.array_subscript.as_ref()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UnsetArraySubscriptFact {
+    name: Name,
+    key_contains_quote: bool,
+}
+
+impl UnsetArraySubscriptFact {
+    pub(crate) fn name(&self) -> &Name {
+        &self.name
+    }
+
+    pub(crate) fn key_contains_quote(&self) -> bool {
+        self.key_contains_quote
     }
 }
 
@@ -10849,6 +10886,7 @@ fn parse_unset_command<'a>(args: &[&'a Word], source: &str) -> UnsetCommandFacts
     let mut parsing_options = true;
     let mut options_parseable = true;
     let mut operands = Vec::new();
+    let mut operand_facts = Vec::new();
     let mut prefix_match_operand_spans = Vec::new();
 
     for word in args {
@@ -10860,6 +10898,7 @@ fn parse_unset_command<'a>(args: &[&'a Word], source: &str) -> UnsetCommandFacts
 
             collect_word_prefix_match_spans(word, &mut prefix_match_operand_spans);
             operands.push(*word);
+            operand_facts.push(parse_unset_operand_fact(word, source));
             continue;
         };
 
@@ -10881,14 +10920,32 @@ fn parse_unset_command<'a>(args: &[&'a Word], source: &str) -> UnsetCommandFacts
 
         collect_word_prefix_match_spans(word, &mut prefix_match_operand_spans);
         operands.push(*word);
+        operand_facts.push(parse_unset_operand_fact(word, source));
     }
 
     UnsetCommandFacts {
         function_mode,
         operand_words: operands.into_boxed_slice(),
+        operand_facts: operand_facts.into_boxed_slice(),
         prefix_match_operand_spans: prefix_match_operand_spans.into_boxed_slice(),
         options_parseable,
     }
+}
+
+fn parse_unset_operand_fact<'a>(word: &'a Word, source: &str) -> UnsetOperandFact<'a> {
+    UnsetOperandFact {
+        word,
+        array_subscript: parse_unset_array_subscript(word.span.slice(source)),
+    }
+}
+
+fn parse_unset_array_subscript(text: &str) -> Option<UnsetArraySubscriptFact> {
+    let (name, key_with_bracket) = text.split_once('[')?;
+    let key = key_with_bracket.strip_suffix(']')?;
+    is_shell_variable_name(name).then(|| UnsetArraySubscriptFact {
+        name: Name::from(name),
+        key_contains_quote: key.chars().any(|ch| ch == '\'' || ch == '"'),
+    })
 }
 
 fn collect_word_prefix_match_spans(word: &Word, spans: &mut Vec<Span>) {
@@ -12849,6 +12906,54 @@ unset parts[\"$key\"] extra
                 .map(|word| word.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["parts[\"$key\"]", "extra"]
+        );
+    }
+
+    #[test]
+    fn records_unset_array_subscript_details_in_operand_facts() {
+        let source = "\
+#!/bin/bash
+declare -A parts
+declare -a nums
+key=one
+unset parts[\"$key\"] plain \"parts[safe]\" 'parts[also_safe]' nums[1]
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let unset = facts
+            .commands()
+            .iter()
+            .find(|fact| fact.effective_name_is("unset"))
+            .and_then(|fact| fact.options().unset())
+            .expect("expected unset facts");
+
+        let operand_subscripts = unset
+            .operand_facts()
+            .iter()
+            .map(|operand| {
+                operand.array_subscript().map(|subscript| {
+                    (
+                        operand.word().span.slice(source),
+                        subscript.name().as_str().to_owned(),
+                        subscript.key_contains_quote(),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            operand_subscripts,
+            vec![
+                Some(("parts[\"$key\"]", "parts".to_owned(), true)),
+                None,
+                None,
+                None,
+                Some(("nums[1]", "nums".to_owned(), false)),
+            ]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
+++ b/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
@@ -1,4 +1,3 @@
-use shuck_ast::Name;
 use shuck_semantic::BindingAttributes;
 
 use crate::{Checker, Rule, Violation};
@@ -16,7 +15,6 @@ impl Violation for UnsetAssociativeArrayElement {
 }
 
 pub fn unset_associative_array_element(checker: &mut Checker) {
-    let source = checker.source();
     let semantic = checker.semantic();
     let mut spans = Vec::new();
 
@@ -29,44 +27,26 @@ pub fn unset_associative_array_element(checker: &mut Checker) {
             continue;
         };
 
-        for operand in unset.operand_words() {
-            let Some((name, key_text)) = parse_array_operand(operand.span.slice(source)) else {
+        for operand in unset.operand_facts() {
+            let Some(array_subscript) = operand.array_subscript() else {
                 continue;
             };
-            if !key_contains_quote(key_text) {
+            if !array_subscript.key_contains_quote() {
                 continue;
             }
 
-            let Some(visible) = semantic.visible_binding(&Name::from(name), operand.span) else {
+            let Some(visible) =
+                semantic.visible_binding(array_subscript.name(), operand.word().span)
+            else {
                 continue;
             };
             if visible.attributes.contains(BindingAttributes::ASSOC) {
-                spans.push(operand.span);
+                spans.push(operand.word().span);
             }
         }
     }
 
     checker.report_all_dedup(spans, || UnsetAssociativeArrayElement);
-}
-
-fn parse_array_operand(text: &str) -> Option<(&str, &str)> {
-    let (name, key_with_bracket) = text.split_once('[')?;
-    let key = key_with_bracket.strip_suffix(']')?;
-    is_shell_name(name).then_some((name, key))
-}
-
-fn is_shell_name(text: &str) -> bool {
-    let mut chars = text.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-
-    (first == '_' || first.is_ascii_alphabetic())
-        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-}
-
-fn key_contains_quote(text: &str) -> bool {
-    text.chars().any(|ch| ch == '\'' || ch == '"')
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- move unset array operand parsing into shared `UnsetCommandFacts` operand data
- have `C108` consume structured unset operand facts instead of reparsing raw `name[key]` text
- add fact-level coverage for quoted subscript keys and non-reporting cases

## Testing
- cargo fmt --all
- cargo test -p shuck-linter records_unset_array_subscript_details_in_operand_facts -- --nocapture
- cargo test -p shuck-linter reports_quoted_associative_unset_keys -- --nocapture
- cargo test -p shuck-linter ignores_indexed_or_safely_quoted_unset_operands -- --nocapture
- cargo test -p shuck-linter collects_prefix_match_spans_from_unset_operands -- --nocapture
- cargo test -p shuck-linter preserves_dynamic_unset_operands_after_option_parsing_stops -- --nocapture
