### PR TITLE
Fix formatter idempotency for escaped backtick in redirect target

### DIFF
--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -752,6 +752,12 @@ mod tests {
     }
 
     #[test]
+    fn backtick_in_redirect_is_idempotent() {
+        let source = "declare -x foo=1<\\`OF\nhi\nEF\n";
+        assert_idempotent(source, None, &ShellFormatOptions::default());
+    }
+
+    #[test]
     fn preserves_backslash_continued_simple_commands_from_fzf_install() {
         let source = "create_file \"$bind_file\" \\\n  'function fish_user_key_bindings' \\\n  '  fzf --fish | source' \\\n  'end'\n";
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -76,6 +76,13 @@ fn render_word_syntax_internal(
     facts: Option<&FormatterFacts<'_>>,
     rendered: &mut String,
 ) {
+    if word_has_escaped_backtick_substitution(word, source)
+        && let Some(raw) = raw_word_source_slice(word, source)
+    {
+        rendered.push_str(raw);
+        return;
+    }
+
     if word_needs_special_rendering(word) {
         render_word_parts(
             word.parts.as_slice(),
@@ -104,6 +111,22 @@ fn render_word_syntax_internal(
     }
 
     word.render_syntax_to_buf(source, rendered);
+}
+
+/// Returns `true` when a word contains a backtick command-substitution node
+/// whose raw source starts with `\`, indicating the parser misinterpreted an
+/// escaped literal backtick (`\``) as a command-substitution delimiter.
+/// In that case the word's raw source must be preserved verbatim.
+fn word_has_escaped_backtick_substitution(word: &Word, source: &str) -> bool {
+    word.parts.iter().any(|part| {
+        matches!(
+            part.kind,
+            WordPart::CommandSubstitution {
+                syntax: CommandSubstitutionSyntax::Backtick,
+                ..
+            }
+        ) && raw_source_slice(part.span, source).is_some_and(|raw| raw.starts_with('\\'))
+    })
 }
 
 fn word_needs_special_rendering(word: &Word) -> bool {


### PR DESCRIPTION
## Summary

- Fixes a nightly fuzz failure (`formatter_consistency_fuzz`) where `declare -x foo=1<\`OF` was not formatted idempotently — the escaped backtick was misrendered as `$(`O)`, losing content on each successive format pass.
- Detects escaped-backtick command-substitution nodes (raw source starts with `\`) at the word level and preserves the entire raw word verbatim, bypassing part-by-part rendering that drops uncovered span gaps.
- Adds a regression test reproducing the exact fuzz input.

## Test plan

- [x] New `backtick_in_redirect_is_idempotent` test passes
- [x] All 108 formatter tests pass
- [x] Full `make test` suite passes (2,449 tests, 0 failures)
- [x] `cargo clippy --all-targets -- -D warnings` clean