### PR TITLE
Fix fuzz-init script lint failures

### DIFF
--- a/scripts/fuzz-init.sh
+++ b/scripts/fuzz-init.sh
@@ -9,17 +9,6 @@ COMMON_CORPUS_DIR="${CORPUS_DIR}/common"
 FORMATTER_CORPUS_DIR="${CORPUS_DIR}/formatter"
 ARTIFACTS_DIR="${FUZZ_DIR}/artifacts"
 
-TARGETS=(
-  parser_fuzz
-  lexer_fuzz
-  arithmetic_fuzz
-  glob_fuzz
-  recovered_parser_fuzz
-  formatter_consistency_fuzz
-  formatter_validity_fuzz
-  linter_no_panic_fuzz
-)
-
 COMMON_TARGETS=(
   parser_fuzz
   lexer_fuzz
@@ -145,7 +134,7 @@ seed_from_directory() {
   [[ -d "${directory}" ]] || return 0
 
   while IFS= read -r file; do
-    local relative_path="${file#${ROOT_DIR}/}"
+    local relative_path="${file:$(( ${#ROOT_DIR} + 1 ))}"
     local sanitized_name="${relative_path//\//__}"
     cp "${file}" "${destination}/${sanitized_name}"
   done < <(


### PR DESCRIPTION
## Summary
- remove the unused `TARGETS` array from `scripts/fuzz-init.sh`
- replace pattern-based `${file#${ROOT_DIR}/}` trimming with a literal substring slice
- keep `make check` green for the scripts lint pass

## Why
`make check` failed because `scripts/fuzz-init.sh` triggered two shell lint findings:
- `C001` on a dead `TARGETS` assignment
- `C055` on variable expansion inside a parameter-pattern expression

The substring form preserves the intended relative-path behavior without relying on pattern matching semantics.

## Validation
- `cargo run -q -p shuck -- check --no-cache scripts/fuzz-init.sh`
- `make check`
