### PR TITLE
Report S004 here-string substitutions

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -881,6 +881,7 @@ impl<'a> WordFact<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubstitutionHostKind {
     CommandArgument,
+    HereStringOperand,
     DeclarationAssignmentValue,
     AssignmentTargetSubscript,
     DeclarationNameSubscript,
@@ -14077,6 +14078,7 @@ name[$(printf assign)]=1
 declare arr[$(printf decl-name)]
 declare other=$(printf decl-assign-2)
 declare -A map=([$(printf key)]=1)
+cat <<<$(printf here)
 out=$(printf hi > out.txt)
 drop=$(printf hi >/dev/null 2>&1)
 mixed=$(jq -r . <<< \"$status\" || die >&2)
@@ -14123,6 +14125,14 @@ z=$(ls layout.*.h | cut -d. -f2 | xargs echo)
                 SubstitutionOutputIntent::Captured,
                 SubstitutionHostKind::CommandArgument,
                 false,
+                false,
+                false,
+            )));
+            assert!(substitutions.contains(&(
+                "$(printf here)".to_owned(),
+                SubstitutionOutputIntent::Captured,
+                SubstitutionHostKind::HereStringOperand,
+                true,
                 false,
                 false,
             )));

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -44,6 +44,18 @@ fn build_command_substitution_facts<'a>(
         );
     });
 
+    visit_here_string_words_for_substitutions(fact.redirects(), &mut |word| {
+        collect_or_update_word_substitution_facts(
+            word,
+            SubstitutionHostKind::HereStringOperand,
+            commands,
+            command_ids_by_span,
+            source,
+            &mut substitutions,
+            &mut substitution_index,
+        );
+    });
+
     visit_declaration_assignment_words_for_substitutions(fact.command(), &mut |word| {
         collect_or_update_word_substitution_facts(
             word,
@@ -737,6 +749,17 @@ fn visit_declaration_assignment_words_for_substitutions(
 
         if let AssignmentValue::Scalar(word) = &assignment.value {
             visitor(word);
+        }
+    }
+}
+
+fn visit_here_string_words_for_substitutions(
+    redirects: &[Redirect],
+    visitor: &mut impl FnMut(&Word),
+) {
+    for redirect in redirects {
+        if redirect.kind == RedirectKind::HereString {
+            visitor(redirect_scan_word(redirect));
         }
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -27,6 +27,7 @@ pub fn unquoted_command_substitution(checker: &mut Checker) {
                     matches!(
                         substitution.host_kind(),
                         SubstitutionHostKind::CommandArgument
+                            | SubstitutionHostKind::HereStringOperand
                             | SubstitutionHostKind::DeclarationAssignmentValue
                             | SubstitutionHostKind::AssignmentTargetSubscript
                             | SubstitutionHostKind::DeclarationNameSubscript
@@ -63,10 +64,10 @@ mod tests {
     }
 
     #[test]
-    fn ignores_redirect_and_here_string_contexts() {
+    fn reports_here_strings_but_ignores_other_redirect_contexts() {
         let source = "\
 #!/bin/bash
-cat <<< $(printf here) >$(printf out)
+cat <<< $(printf here) <<< \"$(printf quoted-here)\" >$(printf out)
 printf '%s\\n' $(printf arg)
 ";
         let diagnostics = test_snippet(
@@ -79,7 +80,7 @@ printf '%s\\n' $(printf arg)
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$(printf arg)"]
+            vec!["$(printf here)", "$(printf arg)"]
         );
     }
 


### PR DESCRIPTION
## Summary
- classify here-string operands as a distinct substitution host in the facts layer
- report unquoted command substitutions in `<<< $(...)` through `S004`
- add focused regressions to keep ordinary redirect targets like `>$(...)` excluded

## Why
`S004` only considered a narrow set of substitution hosts. Here-string operands were being scanned as generic redirect words, which left them classified as `Other` and filtered out before the rule reported them.

## Impact
Shuck now matches the confirmed `SC2046` behavior for unquoted command substitutions in here-strings without widening the rule to unrelated redirect contexts.

## Validation
- `cargo test -p shuck-linter unquoted_command_substitution`
- `cargo test -p shuck-linter builds_substitution_facts_with_intent_and_host_kinds`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S004 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10 SHUCK_LARGE_CORPUS_KEEP_GOING=1`