### PR TITLE
Fix C062 zsh nested expansion false positives

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1317,19 +1317,22 @@ fn closing_double_quote_span(span: Span, source: &str) -> Option<Span> {
 }
 
 fn is_nested_parameter_expansion(parameter: &shuck_ast::ParameterExpansion, source: &str) -> bool {
-    match &parameter.syntax {
-        ParameterExpansionSyntax::Zsh(syntax) => {
-            matches!(syntax.target, ZshExpansionTarget::Nested(_))
-        }
-        ParameterExpansionSyntax::Bourne(_) => {
-            let body = parameter.raw_body.slice(source).trim_start();
-            contains_nested_parameter_marker(body)
-        }
-    }
+    matches!(&parameter.syntax, ParameterExpansionSyntax::Bourne(_))
+        && contains_nested_parameter_marker(parameter.raw_body.slice(source).trim_start())
 }
 
 fn contains_nested_parameter_marker(text: &str) -> bool {
-    text.starts_with("${${") || text.starts_with("${#${") || text.starts_with("${!${")
+    let inner = text
+        .strip_prefix("${${")
+        .or_else(|| text.strip_prefix("${#${"))
+        .or_else(|| text.strip_prefix("${!${"));
+    inner
+        .and_then(|inner| inner.chars().next())
+        .is_some_and(is_bourne_nested_parameter_start)
+}
+
+fn is_bourne_nested_parameter_start(char: char) -> bool {
+    matches!(char, '_' | '@' | '*' | '#' | '?' | '$' | '!' | '-') || char.is_ascii_alphanumeric()
 }
 pub(super) fn simple_command_variable_set_operand<'a>(
     command: &'a SimpleCommand,

--- a/crates/shuck-linter/src/rules/correctness/nested_parameter_expansion.rs
+++ b/crates/shuck-linter/src/rules/correctness/nested_parameter_expansion.rs
@@ -57,4 +57,30 @@ echo '${${ignored}:-value}'
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_zsh_nested_expansions() {
+        let source = "\
+#!/bin/zsh
+[[ -n \"$ZSH\" ]] || export ZSH=\"${${(%):-%x}:a:h}\"
+unset ${(M)${(k)parameters[@]}:#__gitcomp_builtin_*} 2>/dev/null
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::NestedParameterExpansion),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_zsh_style_nested_expansions_in_non_zsh_shells() {
+        let source = "#!/bin/sh\nx=${${(M)path:#/*}:-$PWD/$path}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::NestedParameterExpansion),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- narrow `C062` fact collection so it only reports Bourne-style nested parameter expansions
- stop treating zsh nested-target syntax as a `C062` correctness issue
- add regression coverage for the zsh forms that showed up in the large corpus

## Why
`C062` was over-reporting on zsh nested expansion syntax like `${${(%):-%x}:a:h}` and `${(M)${(k)parameters[@]}:#...}`. Those forms belong to the zsh portability rules, not the Bourne nested-parameter rule, so the corpus comparison was showing false positives.

## Validation
- `cargo test -p shuck-linter nested_parameter_expansion`
- `cargo test -p shuck-linter rule_nestedparameterexpansion_path_new_c062_sh_expects`
- `SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=60 make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C062`
