### PR TITLE
Document current C061 comparison target

### DIFF
--- a/crates/shuck/tests/testdata/corpus-metadata/c061.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c061.yaml
@@ -1,3 +1,7 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2262"
+    reason: "The nix-pinned ShellCheck oracle used by the large-corpus harness reports double-brace command-name placeholder findings as SC2288, so C061 compares against that live bucket instead of the older authored compatibility code."
+
 reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__openssl__add-trusted-certificate"


### PR DESCRIPTION
## Summary
- add a C061 comparison target note documenting that the nix-pinned ShellCheck oracle reports this family as SC2288
- keep the existing reviewed divergence entry unchanged

## Testing
- not run (metadata-only change)