### PR TITLE
Fix S024 replacement quote parsing

### DIFF
--- a/crates/shuck-linter/src/rules/style/single_quote_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/single_quote_backslash.rs
@@ -63,4 +63,18 @@ printf '%s\\n' \"foo\\\\bar\"
             vec![""]
         );
     }
+
+    #[test]
+    fn ignores_escaped_single_quotes_inside_replacement_expansions() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"${dest_dir//\\'/\\'\\\\\\'\\'}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SingleQuoteBackslash),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1589,6 +1589,32 @@ fn test_parameter_replacement_pattern_cooks_escaped_slash() {
 }
 
 #[test]
+fn test_parameter_replacement_word_keeps_escaped_single_quotes_literal() {
+    let input = r#"echo ${dest_dir//\'/\'\\\'\'}"#;
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    let (_, operator, _) = expect_parameter_operation_part(&word.parts[0].kind);
+    let ParameterOp::ReplaceAll {
+        replacement: _,
+        replacement_word_ast,
+        ..
+    } = operator
+    else {
+        panic!("expected replace-all operator");
+    };
+
+    assert!(!replacement_word_ast.parts.iter().any(|part| {
+        matches!(part.kind, WordPart::SingleQuoted { .. })
+            && part.span.slice(input).ends_with("\\'")
+    }));
+}
+
+#[test]
 fn test_parse_arithmetic_command_with_command_substitution() {
     let input = "(($(date -u) > DATE))\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1615,6 +1615,23 @@ fn test_parameter_replacement_word_keeps_escaped_single_quotes_literal() {
 }
 
 #[test]
+fn test_decode_cooked_word_keeps_variable_after_literal_backslash() {
+    let cooked = r#"\$HOME"#;
+    let span = Span::from_positions(Position::new(), Position::new().advanced_by(cooked));
+    let word = Parser::new("").decode_word_text(cooked, span, span.start, false);
+
+    assert_eq!(word.parts.len(), 2);
+    let WordPart::Literal(text) = &word.parts[0].kind else {
+        panic!("expected literal backslash prefix");
+    };
+    assert_eq!(text.as_str("", word.parts[0].span), "\\");
+    assert!(matches!(
+        &word.parts[1].kind,
+        WordPart::Variable(name) if name.as_str() == "HOME"
+    ));
+}
+
+#[test]
 fn test_parse_arithmetic_command_with_command_substitution() {
     let input = "(($(date -u) > DATE))\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2435,6 +2435,7 @@ impl<'a> Parser<'a> {
         let mut current = String::new();
         let mut current_start = base;
         let mut cursor = base;
+        let mut escaped = false;
 
         while chars.peek().is_some() {
             let part_start = cursor;
@@ -2447,6 +2448,24 @@ impl<'a> Parser<'a> {
                 if let Some(literal_ch) = Self::next_word_char(&mut chars, &mut cursor) {
                     current.push(literal_ch);
                 }
+                continue;
+            }
+
+            if escaped {
+                if current.is_empty() {
+                    current_start = part_start;
+                }
+                current.push(ch);
+                escaped = false;
+                continue;
+            }
+
+            if ch == '\\' {
+                if current.is_empty() {
+                    current_start = part_start;
+                }
+                current.push(ch);
+                escaped = true;
                 continue;
             }
 

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2435,7 +2435,6 @@ impl<'a> Parser<'a> {
         let mut current = String::new();
         let mut current_start = base;
         let mut cursor = base;
-        let mut escaped = false;
 
         while chars.peek().is_some() {
             let part_start = cursor;
@@ -2451,21 +2450,15 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if escaped {
+            if preserve_quote_fragments
+                && ch == '\\'
+                && matches!(chars.peek().copied(), Some('\'' | '"'))
+            {
                 if current.is_empty() {
                     current_start = part_start;
                 }
                 current.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            if ch == '\\' {
-                if current.is_empty() {
-                    current_start = part_start;
-                }
-                current.push(ch);
-                escaped = true;
+                current.push(Self::next_word_char_unwrap(&mut chars, &mut cursor));
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- fix quote-preserving parser decoding so escaped quotes in replacement words stay literal
- add parser and linter regressions for the S024 replacement-expansion case

## Why
S024 could report a false positive inside parameter replacement expansions because the quote-preserving fragment decoder treated an escaped single quote as the start of a quoted fragment.

## Impact
- removes the large-corpus S024 mismatch on real-world replacement escaping idioms
- keeps the existing warning for actual trailing backslashes in single-quoted strings

## Validation
- `cargo test -p shuck-parser test_parameter_replacement_word_keeps_escaped_single_quotes_literal -- --nocapture`
- `cargo test -p shuck-linter single_quote_backslash -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=S024 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`
