### PR TITLE
Unify parser and linter around a single parse result

### DIFF
--- a/crates/shuck-benchmark/benches/formatter.rs
+++ b/crates/shuck-benchmark/benches/formatter.rs
@@ -17,7 +17,7 @@ fn format_source_bytes(source: &str, options: &ShellFormatOptions) -> usize {
 
 fn format_file_ast_bytes(
     source: &str,
-    parsed: shuck_parser::parser::ParseOutput,
+    parsed: shuck_parser::parser::ParseResult,
     options: &ShellFormatOptions,
 ) -> usize {
     let formatted = format_file_ast(black_box(source), black_box(parsed.file), None, options)
@@ -26,7 +26,7 @@ fn format_file_ast_bytes(
     output_bytes(source, formatted)
 }
 
-fn formatter_fact_items(source: &str, parsed: &shuck_parser::parser::ParseOutput) -> usize {
+fn formatter_fact_items(source: &str, parsed: &shuck_parser::parser::ParseResult) -> usize {
     black_box(build_formatter_facts(
         black_box(source),
         black_box(&parsed.file),

--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -7,14 +7,14 @@ use shuck_linter::{
     LinterFacts, LinterSettings, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
     classify_file_context, first_statement_line, lint_file, parse_directives,
 };
-use shuck_parser::parser::ParseOutput;
+use shuck_parser::parser::ParseResult;
 use shuck_semantic::SemanticModel;
 
 configure_benchmark_allocator!();
 
 struct PreparedFactsInput {
     source: &'static str,
-    output: ParseOutput,
+    output: ParseResult,
     indexer: Indexer,
     semantic: SemanticModel,
     file_context: shuck_linter::FileContext,

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+use shuck_parser::parser::{ParseResult, Parser};
 #[cfg(feature = "parser-benchmarking")]
-use shuck_parser::parser::ParserBenchmarkCounters;
-use shuck_parser::parser::{ParseOutput, Parser};
+use shuck_parser::parser::{ParseStatus, ParserBenchmarkCounters};
 
 /// Categorize fixtures by expected runtime so Criterion can spend
 /// more time where it is useful without making the slowest cases drag.
@@ -112,32 +112,14 @@ pub fn resources_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("resources")
 }
 
-fn parse_fixture_with<T, E>(
-    source: &str,
-    parse: impl FnOnce(Parser<'_>) -> std::result::Result<T, E>,
-    recover: impl FnOnce(Parser<'_>) -> T,
-) -> (T, bool) {
-    match parse(Parser::new(source)) {
-        Ok(output) => (output, false),
-        Err(_) => (recover(Parser::new(source)), true),
-    }
-}
-
-pub fn parse_fixture(source: &str) -> ParseOutput {
-    parse_fixture_with(
-        source,
-        |parser| parser.parse(),
-        |parser| ParseOutput {
-            file: parser.parse_recovered().file,
-        },
-    )
-    .0
+pub fn parse_fixture(source: &str) -> ParseResult {
+    Parser::new(source).parse()
 }
 
 #[cfg(feature = "parser-benchmarking")]
 #[doc(hidden)]
 pub struct CountedParseFixtureOutput {
-    pub output: ParseOutput,
+    pub output: ParseResult,
     pub counters: ParserBenchmarkCounters,
     pub recovered: bool,
 }
@@ -145,24 +127,12 @@ pub struct CountedParseFixtureOutput {
 #[cfg(feature = "parser-benchmarking")]
 #[doc(hidden)]
 pub fn parse_fixture_with_benchmark_counters(source: &str) -> CountedParseFixtureOutput {
-    let ((output, counters), recovered) = parse_fixture_with(
-        source,
-        |parser| parser.parse_with_benchmark_counters(),
-        |parser| {
-            let (recovered, counters) = parser.parse_recovered_with_benchmark_counters();
-            (
-                ParseOutput {
-                    file: recovered.file,
-                },
-                counters,
-            )
-        },
-    );
+    let (output, counters) = Parser::new(source).parse_with_benchmark_counters();
 
     CountedParseFixtureOutput {
+        recovered: output.status != ParseStatus::Clean,
         output,
         counters,
-        recovered,
     }
 }
 

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -90,9 +90,10 @@ pub fn format_source(
     options: &ShellFormatOptions,
 ) -> Result<FormattedSource> {
     let dialect = options.resolve(source, path).dialect();
-    let parsed = Parser::with_dialect(source, dialect)
-        .parse()
-        .map_err(map_parse_error)?;
+    let parsed = Parser::with_dialect(source, dialect).parse();
+    if parsed.is_err() {
+        return Err(map_parse_error(parsed.strict_error()));
+    }
 
     format_file_ast(source, parsed.file, path, options)
 }
@@ -104,9 +105,10 @@ pub fn source_is_formatted(
     options: &ShellFormatOptions,
 ) -> Result<bool> {
     let dialect = options.resolve(source, path).dialect();
-    let parsed = Parser::with_dialect(source, dialect)
-        .parse()
-        .map_err(map_parse_error)?;
+    let parsed = Parser::with_dialect(source, dialect).parse();
+    if parsed.is_err() {
+        return Err(map_parse_error(parsed.strict_error()));
+    }
 
     let resolved = options.resolve(source, path);
     check_file(source, parsed.file, resolved)
@@ -202,7 +204,7 @@ mod tests {
         source: &str,
         path: Option<&Path>,
         options: &ShellFormatOptions,
-    ) -> shuck_parser::parser::ParseOutput {
+    ) -> shuck_parser::parser::ParseResult {
         let dialect = options.resolve(source, path).dialect();
         Parser::with_dialect(source, dialect).parse().unwrap()
     }

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -7,7 +7,7 @@ pub use line_index::LineIndex;
 pub use region_index::{RegionIndex, RegionKind};
 
 use shuck_ast::TextSize;
-use shuck_parser::parser::ParseOutput;
+use shuck_parser::parser::ParseResult;
 
 /// Pre-computed positional and structural index over a parsed shell script.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,7 +20,7 @@ pub struct Indexer {
 
 impl Indexer {
     /// Build an index from parser output and the original source text.
-    pub fn new(source: &str, output: &ParseOutput) -> Self {
+    pub fn new(source: &str, output: &ParseResult) -> Self {
         let line_index = LineIndex::new(source);
         let comment_index = CommentIndex::new(source, &line_index, &output.file);
         let region_index = RegionIndex::new(source, &output.file);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12669,7 +12669,7 @@ mod tests {
         path: Option<&Path>,
         parse_dialect: ParseShellDialect,
         shell: ShellDialect,
-        visit: impl FnOnce(&shuck_parser::parser::ParseOutput, &LinterFacts<'_>),
+        visit: impl FnOnce(&shuck_parser::parser::ParseResult, &LinterFacts<'_>),
     ) {
         let output = Parser::with_dialect(source, parse_dialect).parse().unwrap();
         let indexer = Indexer::new(source, &output);
@@ -12682,7 +12682,7 @@ mod tests {
     fn with_facts(
         source: &str,
         path: Option<&Path>,
-        visit: impl FnOnce(&shuck_parser::parser::ParseOutput, &LinterFacts<'_>),
+        visit: impl FnOnce(&shuck_parser::parser::ParseResult, &LinterFacts<'_>),
     ) {
         with_facts_dialect(
             source,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -79,7 +79,7 @@ pub use violation::Violation;
 use rustc_hash::FxHashSet;
 use shuck_ast::{File, TextSize};
 use shuck_indexer::Indexer;
-use shuck_parser::parser::ParseResult;
+use shuck_parser::parser::{ParseResult, Parser};
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
 use shuck_semantic::{
     SemanticBuildOptions, SemanticModel, SourcePathResolver, TraversalObserver,
@@ -143,11 +143,7 @@ pub fn analyze_file_at_path_with_resolver(
     source_path: Option<&Path>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> AnalysisResult {
-    let shell = if settings.shell == ShellDialect::Unknown {
-        ShellDialect::infer(source, source_path)
-    } else {
-        settings.shell
-    };
+    let shell = resolve_shell(settings, source, source_path);
     let file_context = classify_file_context(source, source_path, shell);
     let file_entry_contract =
         ambient_contracts::file_entry_contract(source, source_path, shell, &file_context);
@@ -202,6 +198,18 @@ pub fn analyze_file_at_path_with_resolver(
     }
 }
 
+fn resolve_shell(
+    settings: &LinterSettings,
+    source: &str,
+    source_path: Option<&Path>,
+) -> ShellDialect {
+    if settings.shell == ShellDialect::Unknown {
+        ShellDialect::infer(source, source_path)
+    } else {
+        settings.shell
+    }
+}
+
 fn inferred_shell_profile(shell: ShellDialect) -> ShellProfile {
     let dialect = match shell {
         ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => ParseShellDialect::Posix,
@@ -210,6 +218,10 @@ fn inferred_shell_profile(shell: ShellDialect) -> ShellProfile {
         ShellDialect::Unknown | ShellDialect::Bash => ParseShellDialect::Bash,
     };
     ShellProfile::native(dialect)
+}
+
+fn parse_for_lint(source: &str, shell: ShellDialect) -> ParseResult {
+    Parser::with_profile(source, inferred_shell_profile(shell)).parse()
 }
 
 pub fn lint_file(
@@ -250,11 +262,8 @@ pub fn lint_file_at_path_with_resolver(
     source_path: Option<&Path>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> Vec<Diagnostic> {
-    let shell = if settings.shell == ShellDialect::Unknown {
-        ShellDialect::infer(source, source_path)
-    } else {
-        settings.shell
-    };
+    let shell = resolve_shell(settings, source, source_path);
+    let parse_result = parse_for_lint(source, shell);
 
     let mut diagnostics = analyze_file_at_path_with_resolver(
         file,
@@ -268,9 +277,9 @@ pub fn lint_file_at_path_with_resolver(
     .diagnostics;
 
     diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
-        file,
+        &parse_result.file,
         source,
-        None,
+        Some(&parse_result),
         &settings.rules,
         shell,
     ));
@@ -301,11 +310,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
     source_path: Option<&Path>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> Vec<Diagnostic> {
-    let shell = if settings.shell == ShellDialect::Unknown {
-        ShellDialect::infer(source, source_path)
-    } else {
-        settings.shell
-    };
+    let shell = resolve_shell(settings, source, source_path);
 
     let mut diagnostics = analyze_file_at_path_with_resolver(
         &parse_result.file,
@@ -435,6 +440,24 @@ mod tests {
     fn default_settings_run_without_emitting_noop_diagnostics() {
         let diagnostics = lint("#!/bin/bash\necho ok\n", &LinterSettings::default());
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn legacy_lint_entrypoints_preserve_parse_rule_diagnostics() {
+        let source = "#!/bin/sh\n{ :; } always { :; }\n";
+        let parse_result = Parser::new(source).parse();
+        let indexer = Indexer::new(source, &parse_result);
+        let diagnostics = lint_file(
+            &parse_result.file,
+            source,
+            &indexer,
+            &LinterSettings::for_rule(Rule::ZshAlwaysBlock),
+            None,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::ZshAlwaysBlock);
+        assert_eq!(diagnostics[0].span.slice(source), "always");
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -79,6 +79,7 @@ pub use violation::Violation;
 use rustc_hash::FxHashSet;
 use shuck_ast::{File, TextSize};
 use shuck_indexer::Indexer;
+use shuck_parser::parser::ParseResult;
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
 use shuck_semantic::{
     SemanticBuildOptions, SemanticModel, SourcePathResolver, TraversalObserver,
@@ -249,50 +250,6 @@ pub fn lint_file_at_path_with_resolver(
     source_path: Option<&Path>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> Vec<Diagnostic> {
-    lint_file_at_path_with_resolver_and_parse_diagnostics(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        source_path_resolver,
-        &[],
-    )
-}
-
-pub fn lint_file_at_path_with_parse_diagnostics(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-    parse_diagnostics: &[shuck_parser::parser::ParseDiagnostic],
-) -> Vec<Diagnostic> {
-    lint_file_at_path_with_resolver_and_parse_diagnostics(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        None,
-        parse_diagnostics,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn lint_file_at_path_with_resolver_and_parse_diagnostics(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    parse_diagnostics: &[shuck_parser::parser::ParseDiagnostic],
-) -> Vec<Diagnostic> {
     let shell = if settings.shell == ShellDialect::Unknown {
         ShellDialect::infer(source, source_path)
     } else {
@@ -313,7 +270,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_diagnostics(
     diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
         file,
         source,
-        parse_diagnostics,
+        None,
         &settings.rules,
         shell,
     ));
@@ -332,6 +289,76 @@ pub fn lint_file_at_path_with_resolver_and_parse_diagnostics(
         .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
 
     diagnostics
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn lint_file_at_path_with_resolver_and_parse_result(
+    parse_result: &ParseResult,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+) -> Vec<Diagnostic> {
+    let shell = if settings.shell == ShellDialect::Unknown {
+        ShellDialect::infer(source, source_path)
+    } else {
+        settings.shell
+    };
+
+    let mut diagnostics = analyze_file_at_path_with_resolver(
+        &parse_result.file,
+        source,
+        indexer,
+        settings,
+        None,
+        source_path,
+        source_path_resolver,
+    )
+    .diagnostics;
+
+    diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
+        &parse_result.file,
+        source,
+        Some(parse_result),
+        &settings.rules,
+        shell,
+    ));
+
+    for diagnostic in &mut diagnostics {
+        if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
+            diagnostic.severity = severity;
+        }
+    }
+
+    if let Some(suppression_index) = suppression_index {
+        filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
+    }
+
+    diagnostics
+        .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
+
+    diagnostics
+}
+
+pub fn lint_file_at_path_with_parse_result(
+    parse_result: &ParseResult,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
+) -> Vec<Diagnostic> {
+    lint_file_at_path_with_resolver_and_parse_result(
+        parse_result,
+        source,
+        indexer,
+        settings,
+        suppression_index,
+        source_path,
+        None,
+    )
 }
 
 fn filter_suppressed_diagnostics(

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -1,7 +1,5 @@
-use shuck_ast::{
-    Command, CompoundCommand, File, IfSyntax, PatternGroupKind, PatternPart, Position, Span,
-};
-use shuck_parser::parser::{ParseDiagnostic, Parser, ShellDialect as ParseShellDialect};
+use shuck_ast::{Command, CompoundCommand, File, Position, Span};
+use shuck_parser::parser::{ParseDiagnostic, ParseResult};
 
 use crate::rules::common::query::{self, CommandWalkOptions};
 use crate::rules::correctness::c_prototype_fragment::CPrototypeFragment;
@@ -45,18 +43,14 @@ impl Violation for ExtglobInCasePattern {
 pub(crate) fn collect_parse_rule_diagnostics(
     file: &File,
     source: &str,
-    parse_diagnostics: &[ParseDiagnostic],
+    parse_result: Option<&ParseResult>,
     enabled_rules: &RuleSet,
     shell: ShellDialect,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
-    let needs_zsh_recovered = (enabled_rules.contains(crate::Rule::ZshBraceIf)
-        || enabled_rules.contains(crate::Rule::ZshAlwaysBlock))
-        && targets_non_zsh_shell(shell)
-        || enabled_rules.contains(crate::Rule::ExtglobCase) && is_x037_shell(shell)
-        || enabled_rules.contains(crate::Rule::ExtglobInCasePattern) && is_x048_shell(shell);
-    let zsh_recovered = needs_zsh_recovered
-        .then(|| Parser::with_dialect(source, ParseShellDialect::Zsh).parse_recovered());
+    let parse_diagnostics = parse_result
+        .map(|result| result.diagnostics.as_slice())
+        .unwrap_or(&[]);
     let missing_done_loop_kind = (enabled_rules.contains(crate::Rule::LoopWithoutEnd)
         || enabled_rules.contains(crate::Rule::MissingDoneInForLoop))
     .then(|| missing_done_loop_kind(file, source, parse_diagnostics))
@@ -127,23 +121,39 @@ pub(crate) fn collect_parse_rule_diagnostics(
     }
 
     if enabled_rules.contains(crate::Rule::ZshBraceIf) && targets_non_zsh_shell(shell) {
-        for span in zsh_brace_if_spans(&zsh_recovered.as_ref().unwrap().file) {
-            diagnostics.push(Diagnostic::new(ZshBraceIf, span));
+        for span in parse_result
+            .map(|result| result.syntax_facts.zsh_brace_if_spans.as_slice())
+            .unwrap_or(&[])
+        {
+            diagnostics.push(Diagnostic::new(ZshBraceIf, *span));
         }
     }
     if enabled_rules.contains(crate::Rule::ZshAlwaysBlock) && targets_non_zsh_shell(shell) {
-        for span in zsh_always_block_spans(&zsh_recovered.as_ref().unwrap().file, source) {
-            diagnostics.push(Diagnostic::new(ZshAlwaysBlock, span));
+        for span in parse_result
+            .map(|result| result.syntax_facts.zsh_always_spans.as_slice())
+            .unwrap_or(&[])
+        {
+            diagnostics.push(Diagnostic::new(ZshAlwaysBlock, *span));
         }
     }
     if enabled_rules.contains(crate::Rule::ExtglobCase) && is_x037_shell(shell) {
-        for span in zsh_case_leading_group_spans(&zsh_recovered.as_ref().unwrap().file, source) {
-            diagnostics.push(Diagnostic::new(ExtglobCase, span));
+        for part in parse_result
+            .map(|result| result.syntax_facts.zsh_case_group_parts.as_slice())
+            .unwrap_or(&[])
+        {
+            if part.pattern_part_index == 0 {
+                diagnostics.push(Diagnostic::new(ExtglobCase, part.span));
+            }
         }
     }
     if enabled_rules.contains(crate::Rule::ExtglobInCasePattern) && is_x048_shell(shell) {
-        for span in zsh_case_embedded_group_spans(&zsh_recovered.as_ref().unwrap().file, source) {
-            diagnostics.push(Diagnostic::new(ExtglobInCasePattern, span));
+        for part in parse_result
+            .map(|result| result.syntax_facts.zsh_case_group_parts.as_slice())
+            .unwrap_or(&[])
+        {
+            if part.pattern_part_index > 0 {
+                diagnostics.push(Diagnostic::new(ExtglobInCasePattern, part.span));
+            }
         }
     }
 
@@ -800,107 +810,6 @@ fn c_prototype_fragment_span(diagnostic: &ParseDiagnostic, source: &str) -> Opti
     Some(Span::from_positions(point, point))
 }
 
-fn zsh_brace_if_spans(file: &File) -> Vec<Span> {
-    query::iter_commands(&file.body, CommandWalkOptions::default())
-        .filter_map(|visit| {
-            let Command::Compound(CompoundCommand::If(command)) = visit.command else {
-                return None;
-            };
-            let IfSyntax::Brace {
-                left_brace_span, ..
-            } = command.syntax
-            else {
-                return None;
-            };
-            Some(left_brace_span)
-        })
-        .collect()
-}
-
-fn zsh_always_block_spans(file: &File, source: &str) -> Vec<Span> {
-    query::iter_commands(&file.body, CommandWalkOptions::default())
-        .filter_map(|visit| {
-            let Command::Compound(CompoundCommand::Always(command)) = visit.command else {
-                return None;
-            };
-            always_keyword_span(
-                source,
-                command.body.span.end.offset,
-                command.always_body.span.start.offset,
-            )
-            .or(Some(visit.stmt.span))
-        })
-        .collect()
-}
-
-fn zsh_case_group_spans(file: &File, source: &str) -> Vec<(usize, Span)> {
-    query::iter_commands(&file.body, CommandWalkOptions::default())
-        .flat_map(|visit| {
-            let Command::Compound(CompoundCommand::Case(command)) = visit.command else {
-                return Vec::new();
-            };
-
-            command
-                .cases
-                .iter()
-                .flat_map(|case| {
-                    case.patterns.iter().flat_map(|pattern| {
-                        pattern
-                            .parts
-                            .iter()
-                            .enumerate()
-                            .filter_map(|(index, part)| match &part.kind {
-                                PatternPart::Group {
-                                    kind: PatternGroupKind::ExactlyOne,
-                                    ..
-                                } if part.span.slice(source).starts_with('(') => {
-                                    Some((index, part.span))
-                                }
-                                PatternPart::Word(_)
-                                | PatternPart::Literal(_)
-                                | PatternPart::AnyString
-                                | PatternPart::AnyChar
-                                | PatternPart::CharClass(_)
-                                | PatternPart::Group { .. } => None,
-                            })
-                    })
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect()
-}
-
-fn zsh_case_leading_group_spans(file: &File, source: &str) -> Vec<Span> {
-    zsh_case_group_spans(file, source)
-        .into_iter()
-        .filter_map(|(index, span)| (index == 0).then_some(span))
-        .collect()
-}
-
-fn zsh_case_embedded_group_spans(file: &File, source: &str) -> Vec<Span> {
-    zsh_case_group_spans(file, source)
-        .into_iter()
-        .filter_map(|(index, span)| (index > 0).then_some(span))
-        .collect()
-}
-
-fn always_keyword_span(source: &str, search_start: usize, search_end: usize) -> Option<Span> {
-    let search_start = search_start.min(source.len());
-    let search_end = search_end.min(source.len());
-    if search_start >= search_end {
-        return None;
-    }
-
-    let text = &source[search_start..search_end];
-    let relative = text.find("always")?;
-    let start_offset = search_start + relative;
-    let end_offset = start_offset + "always".len();
-
-    let start = position_at_offset(source, start_offset)?;
-    let end = position_at_offset(source, end_offset)?;
-    Some(Span::from_positions(start, end))
-}
-
 fn position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
     if target_offset > source.len() {
         return None;
@@ -976,12 +885,12 @@ mod tests {
     #[test]
     fn maps_missing_fi_parse_error_to_c035_at_end_of_file() {
         let source = "#!/bin/sh\nif true; then\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::MissingFi);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -995,12 +904,12 @@ mod tests {
     #[test]
     fn maps_function_parameter_parse_error_to_x035() {
         let source = "#!/bin/sh\nfunction g(y) { :; }\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::FunctionParamsInSh);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1013,12 +922,12 @@ mod tests {
     #[test]
     fn maps_function_parameter_parse_error_to_the_paren_near_reported_position() {
         let source = "#!/bin/sh\necho \"$(x)\"; function f(y) { :; }\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::FunctionParamsInSh);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1033,12 +942,12 @@ mod tests {
     #[test]
     fn ignores_missing_fi_parse_error_when_rule_is_not_enabled() {
         let source = "#!/bin/sh\nif true; then\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::UnusedAssignment);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1049,12 +958,12 @@ mod tests {
     #[test]
     fn maps_loop_without_end_parse_error_to_c141_at_end_of_file() {
         let source = "#!/bin/sh\nwhile true; do\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::LoopWithoutEnd);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1068,12 +977,12 @@ mod tests {
     #[test]
     fn ignores_loop_without_end_parse_error_when_rule_is_not_enabled() {
         let source = "#!/bin/sh\nwhile true; do\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::UnusedAssignment);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1084,12 +993,12 @@ mod tests {
     #[test]
     fn ignores_balanced_while_loop_for_c141() {
         let source = "#!/bin/sh\nwhile true; do\n  :\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::LoopWithoutEnd);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1100,12 +1009,12 @@ mod tests {
     #[test]
     fn ignores_balanced_until_loop_for_c141() {
         let source = "#!/bin/sh\nuntil false; do\n  :\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::LoopWithoutEnd);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1116,12 +1025,12 @@ mod tests {
     #[test]
     fn ignores_nested_for_loop_missing_done_for_c141() {
         let source = "#!/bin/sh\nwhile true; do\n  for x in a; do\n    :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::LoopWithoutEnd);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1132,12 +1041,12 @@ mod tests {
     #[test]
     fn ignores_balanced_nested_loops_for_c141() {
         let source = "#!/bin/sh\nwhile true; do\n  until false; do\n    :\n  done\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::LoopWithoutEnd);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1148,12 +1057,12 @@ mod tests {
     #[test]
     fn ignores_for_loop_missing_done_for_c141() {
         let source = "#!/bin/sh\nfor x in a; do\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::LoopWithoutEnd);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1164,12 +1073,12 @@ mod tests {
     #[test]
     fn maps_for_loop_missing_done_parse_error_to_c142() {
         let source = "#!/bin/sh\nfor x in a; do\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::MissingDoneInForLoop);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1193,12 +1102,12 @@ mod tests {
     #[test]
     fn ignores_inline_then_before_later_expected_command_for_c064() {
         let source = "#!/bin/sh\nif true; then :; fi\n&&\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfMissingThen);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1215,12 +1124,12 @@ mod tests {
     #[test]
     fn reports_missing_then_even_when_later_lines_expand_then_identifiers() {
         let source = "#!/bin/sh\nif true\n  echo ${then}\nfi\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfMissingThen);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1234,12 +1143,12 @@ mod tests {
     #[test]
     fn ignores_then_with_trailing_comment_before_later_expected_command_for_c064() {
         let source = "#!/bin/sh\nif true; then # keep body valid\n  :\nfi\n&&\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfMissingThen);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1256,12 +1165,12 @@ mod tests {
     #[test]
     fn maps_for_loop_missing_done_with_line_continuation_and_heredoc_to_c142() {
         let source = "#!/bin/sh\nfor name in \\\n  alpha beta; do\n  cat <<EOF\n$name\nEOF\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::MissingDoneInForLoop);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1273,12 +1182,12 @@ mod tests {
     #[test]
     fn ignores_for_loop_with_heredoc_and_trailing_done_for_c142() {
         let source = "#!/bin/sh\nfor name in \\\n  alpha beta; do\n  cat <<EOF\n$name\nEOF\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::MissingDoneInForLoop);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1289,12 +1198,12 @@ mod tests {
     #[test]
     fn ignores_while_loop_missing_done_for_c142() {
         let source = "#!/bin/sh\nwhile true; do\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::MissingDoneInForLoop);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1305,12 +1214,12 @@ mod tests {
     #[test]
     fn maps_dangling_else_parse_error_to_c143() {
         let source = "#!/bin/sh\nif true; then echo yes; else fi\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::DanglingElse);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1322,12 +1231,12 @@ mod tests {
     #[test]
     fn maps_nested_empty_else_parse_error_to_c143() {
         let source = "#!/bin/sh\nif true; then\n  if false; then\n    :\n  else\n  fi\nfi\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::DanglingElse);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1339,12 +1248,12 @@ mod tests {
     #[test]
     fn ignores_non_empty_nested_else_with_other_parse_recovery_noise_for_c143() {
         let source = "#!/bin/sh\nif true; then\n  :\nelse\n  if false; then\n    :\n  fi\nfi\nfi\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::DanglingElse);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1355,12 +1264,12 @@ mod tests {
     #[test]
     fn ignores_dangling_else_parse_error_when_rule_is_not_enabled() {
         let source = "#!/bin/sh\nif true; then echo yes; else fi\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::UnusedAssignment);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1371,12 +1280,12 @@ mod tests {
     #[test]
     fn maps_until_missing_do_parse_error_to_c146() {
         let source = "#!/bin/sh\nuntil :\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::UntilMissingDo);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1388,12 +1297,12 @@ mod tests {
     #[test]
     fn maps_multiline_until_header_missing_do_parse_error_to_c146() {
         let source = "#!/bin/sh\nuntil\n  false\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::UntilMissingDo);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1405,12 +1314,12 @@ mod tests {
     #[test]
     fn ignores_non_until_expected_command_parse_errors_for_c146() {
         let source = "#!/bin/sh\nwhile :\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::UntilMissingDo);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1421,12 +1330,12 @@ mod tests {
     #[test]
     fn ignores_until_with_do_after_comments_and_blank_lines_for_c146() {
         let source = "#!/bin/sh\nuntil false\n  # keep checking\n\ndo\n  :\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::UntilMissingDo);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1437,12 +1346,12 @@ mod tests {
     #[test]
     fn ignores_plain_until_word_before_done_for_c146() {
         let source = "#!/bin/sh\necho until\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::UntilMissingDo);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1453,12 +1362,12 @@ mod tests {
     #[test]
     fn maps_if_bracket_glued_parse_error_to_c157() {
         let source = "#!/bin/sh\nif[ \"${1:-}\" = ok ]; then\n  :\nfi\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfBracketGlued);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1479,12 +1388,12 @@ fi
 ;;
 esac
 ";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfBracketGlued);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1519,12 +1428,12 @@ esac
     #[test]
     fn ignores_non_if_bracket_expected_command_parse_errors_for_c157() {
         let source = "#!/bin/sh\nuntil :\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfBracketGlued);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1544,12 +1453,12 @@ if  [ \"$1\" = ok ]; then
   :
 fi
 ";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfBracketGlued);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1560,12 +1469,12 @@ fi
     #[test]
     fn ignores_quoted_if_bracket_text_on_expected_command_lines_for_c157() {
         let source = "#!/bin/sh\ntrue\n&& printf '%s\\n' \"if[\"\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfBracketGlued);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1576,12 +1485,12 @@ fi
     #[test]
     fn ignores_parameter_expansion_text_containing_if_bracket_on_expected_command_lines_for_c157() {
         let source = "#!/bin/sh\ntrue\n&& echo ${x#if[}\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfBracketGlued);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1592,12 +1501,12 @@ fi
     #[test]
     fn ignores_spaced_parameter_expansion_patterns_containing_if_bracket_for_c157() {
         let source = "#!/bin/sh\ntrue\n&& echo ${x# if[}\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfBracketGlued);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1608,12 +1517,12 @@ fi
     #[test]
     fn ignores_if_bracket_text_inside_comments_after_redirection_operators_for_c157() {
         let source = "#!/bin/sh\ntrue\n&& ># if[\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::IfBracketGlued);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1624,12 +1533,12 @@ fi
     #[test]
     fn maps_linebreak_before_and_parse_error_to_s072() {
         let source = "#!/bin/bash\ntrue\n&& echo x\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::LinebreakBeforeAnd);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Bash,
         );
@@ -1642,12 +1551,12 @@ fi
     #[test]
     fn ignores_non_and_expected_command_parse_errors_for_s072() {
         let source = "#!/bin/sh\nuntil :\ndone\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::LinebreakBeforeAnd);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1658,12 +1567,12 @@ fi
     #[test]
     fn maps_c_prototype_fragment_parse_recovery_to_c042() {
         let source = "#!/bin/sh\nX &NextItem ();\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::CPrototypeFragment);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1677,12 +1586,12 @@ fi
     #[test]
     fn maps_zsh_brace_if_recovery_to_x038() {
         let source = "#!/bin/sh\nif [[ -n \"$x\" ]] {\n  :\n}\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshBraceIf);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1695,12 +1604,12 @@ fi
     #[test]
     fn ignores_missing_then_without_zsh_brace_syntax() {
         let source = "#!/bin/sh\nif [[ -n \"$x\" ]]\n  :\nfi\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshBraceIf);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1711,12 +1620,12 @@ fi
     #[test]
     fn ignores_zsh_brace_if_when_target_shell_is_zsh() {
         let source = "#!/bin/zsh\nif [[ -n \"$x\" ]] {\n  :\n}\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshBraceIf);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Zsh,
         );
@@ -1727,12 +1636,12 @@ fi
     #[test]
     fn maps_zsh_brace_if_recovery_even_with_later_parse_errors() {
         let source = "#!/bin/sh\nif [[ -n \"$x\" ]] {\n  :\n}\nif true; then\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshBraceIf);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1745,12 +1654,12 @@ fi
     #[test]
     fn maps_zsh_brace_if_for_mksh_targets() {
         let source = "#!/bin/mksh\nif [[ -n \"$x\" ]] {\n  :\n}\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshBraceIf);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Mksh,
         );
@@ -1763,12 +1672,12 @@ fi
     #[test]
     fn maps_zsh_always_block_to_x039() {
         let source = "#!/bin/sh\n{ :; } always { :; }\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshAlwaysBlock);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1786,12 +1695,12 @@ fi
             "  (darwin|freebsd)*) print ok ;;\n",
             "esac\n",
         );
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ExtglobCase);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1809,14 +1718,14 @@ fi
             "  (darwin|freebsd)*) print ok ;;\n",
             "esac\n",
         );
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ExtglobCase);
 
         for shell in [ShellDialect::Bash, ShellDialect::Ksh] {
             let diagnostics = collect_parse_rule_diagnostics(
                 &recovered.file,
                 source,
-                &recovered.diagnostics,
+                Some(&recovered),
                 &settings.rules,
                 shell,
             );
@@ -1839,12 +1748,12 @@ fi
             "  foo_(a|b)_*) echo match ;;\n",
             "esac\n",
         );
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ExtglobInCasePattern);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1864,10 +1773,12 @@ fi
             "{ :; } always { :; }\n",
             "case \"$x\" in\n",
             "  (a|b)*) echo lead ;;\n",
+            "esac\n",
+            "case \"$x\" in\n",
             "  foo_(c|d)_*) echo embedded ;;\n",
             "esac\n",
         );
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rules([
             Rule::ZshBraceIf,
             Rule::ZshAlwaysBlock,
@@ -1877,13 +1788,13 @@ fi
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
         let rules: std::collections::HashSet<_> = diagnostics.iter().map(|d| d.rule).collect();
 
-        assert_eq!(diagnostics.len(), 4);
+        assert_eq!(rules.len(), 4);
         assert!(rules.contains(&Rule::ZshBraceIf));
         assert!(rules.contains(&Rule::ZshAlwaysBlock));
         assert!(rules.contains(&Rule::ExtglobCase));
@@ -1893,12 +1804,12 @@ fi
     #[test]
     fn ignores_non_always_brace_groups_for_x039() {
         let source = "#!/bin/sh\n{ :; }\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshAlwaysBlock);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );
@@ -1909,12 +1820,12 @@ fi
     #[test]
     fn ignores_zsh_always_block_when_target_shell_is_zsh() {
         let source = "#!/bin/zsh\n{ :; } always { :; }\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshAlwaysBlock);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Zsh,
         );
@@ -1925,12 +1836,12 @@ fi
     #[test]
     fn maps_zsh_always_block_even_with_later_parse_errors() {
         let source = "#!/bin/sh\n{ :; } always { :; }\nif true; then\n  :\n";
-        let recovered = Parser::new(source).parse_recovered();
+        let recovered = Parser::new(source).parse();
         let settings = LinterSettings::for_rule(Rule::ZshAlwaysBlock);
         let diagnostics = collect_parse_rule_diagnostics(
             &recovered.file,
             source,
-            &recovered.diagnostics,
+            Some(&recovered),
             &settings.rules,
             ShellDialect::Sh,
         );

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -1618,6 +1618,22 @@ fi
     }
 
     #[test]
+    fn ignores_condition_brace_groups_for_zsh_brace_if() {
+        let source = "#!/bin/sh\nif true\n{ echo ok; }\nthen\n  :\nfi\n";
+        let recovered = Parser::new(source).parse();
+        let settings = LinterSettings::for_rule(Rule::ZshBraceIf);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            Some(&recovered),
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_zsh_brace_if_when_target_shell_is_zsh() {
         let source = "#!/bin/zsh\nif [[ -n \"$x\" ]] {\n  :\n}\n";
         let recovered = Parser::new(source).parse();

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -1634,6 +1634,22 @@ fi
     }
 
     #[test]
+    fn ignores_later_then_after_brace_group_conditions_for_zsh_brace_if() {
+        let source = "#!/bin/sh\nif true; { echo ok; }; echo more; then\n  :\nfi\n";
+        let recovered = Parser::new(source).parse();
+        let settings = LinterSettings::for_rule(Rule::ZshBraceIf);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            Some(&recovered),
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_zsh_brace_if_when_target_shell_is_zsh() {
         let source = "#!/bin/zsh\nif [[ -n \"$x\" ]] {\n  :\n}\n";
         let recovered = Parser::new(source).parse();

--- a/crates/shuck-linter/src/rules/common/word.rs
+++ b/crates/shuck-linter/src/rules/common/word.rs
@@ -82,9 +82,10 @@ pub fn text_looks_like_nontrivial_arithmetic_expression(text: &str) -> bool {
     }
 
     let source = format!("(( {text} ))");
-    let Ok(file) = Parser::new(&source).parse() else {
+    let file = Parser::new(&source).parse();
+    if file.is_err() {
         return false;
-    };
+    }
 
     let Some(statement) = file.file.body.first() else {
         return false;

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -78,29 +78,25 @@ mod tests {
     use std::path::Path;
 
     use shuck_indexer::Indexer;
-    use shuck_parser::parser::{ParseOutput, Parser, ShellDialect as ParseDialect};
+    use shuck_parser::parser::{Parser, ShellDialect as ParseDialect};
 
     use crate::test::test_snippet;
     use crate::{
-        Diagnostic, LinterSettings, Rule, ShellDialect, lint_file_at_path_with_parse_diagnostics,
+        Diagnostic, LinterSettings, Rule, ShellDialect, lint_file_at_path_with_parse_result,
     };
 
     fn test_posix_snippet_at_path(path: &Path, source: &str) -> Vec<Diagnostic> {
-        let recovered = Parser::with_dialect(source, ParseDialect::Posix).parse_recovered();
-        let output = ParseOutput {
-            file: recovered.file,
-        };
-        let indexer = Indexer::new(source, &output);
+        let parse_result = Parser::with_dialect(source, ParseDialect::Posix).parse();
+        let indexer = Indexer::new(source, &parse_result);
         let settings =
             LinterSettings::for_rule(Rule::EscapedUnderscore).with_shell(ShellDialect::Sh);
-        lint_file_at_path_with_parse_diagnostics(
-            &output.file,
+        lint_file_at_path_with_parse_result(
+            &parse_result,
             source,
             &indexer,
             &settings,
             None,
             Some(path),
-            &recovered.diagnostics,
         )
     }
 

--- a/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore_literal.rs
@@ -45,29 +45,25 @@ mod tests {
     use std::path::Path;
 
     use shuck_indexer::Indexer;
-    use shuck_parser::parser::{ParseOutput, Parser, ShellDialect as ParseDialect};
+    use shuck_parser::parser::{Parser, ShellDialect as ParseDialect};
 
     use crate::test::test_snippet;
     use crate::{
-        Diagnostic, LinterSettings, Rule, ShellDialect, lint_file_at_path_with_parse_diagnostics,
+        Diagnostic, LinterSettings, Rule, ShellDialect, lint_file_at_path_with_parse_result,
     };
 
     fn test_posix_snippet_at_path(path: &Path, source: &str) -> Vec<Diagnostic> {
-        let recovered = Parser::with_dialect(source, ParseDialect::Posix).parse_recovered();
-        let output = ParseOutput {
-            file: recovered.file,
-        };
-        let indexer = Indexer::new(source, &output);
+        let parse_result = Parser::with_dialect(source, ParseDialect::Posix).parse();
+        let indexer = Indexer::new(source, &parse_result);
         let settings =
             LinterSettings::for_rule(Rule::EscapedUnderscoreLiteral).with_shell(ShellDialect::Sh);
-        lint_file_at_path_with_parse_diagnostics(
-            &output.file,
+        lint_file_at_path_with_parse_result(
+            &parse_result,
             source,
             &indexer,
             &settings,
             None,
             Some(path),
-            &recovered.diagnostics,
         )
     }
 

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -4,11 +4,9 @@ use std::path::Path;
 
 use shuck_indexer::Indexer;
 use shuck_parser::ShellProfile;
-use shuck_parser::parser::{
-    ParseDiagnostic, ParseOutput, Parser, ShellDialect as ParseShellDialect,
-};
+use shuck_parser::parser::{ParseResult, Parser, ShellDialect as ParseShellDialect};
 
-use crate::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_diagnostics};
+use crate::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_result};
 
 fn inferred_shell_profile(
     source: &str,
@@ -32,34 +30,15 @@ fn inferred_shell_profile(
     ShellProfile::native(dialect)
 }
 
-fn parse_for_lint(
-    source: &str,
-    settings: &LinterSettings,
-    path: Option<&Path>,
-) -> (ParseOutput, Vec<ParseDiagnostic>) {
-    let recovered = Parser::with_profile(source, inferred_shell_profile(source, settings, path))
-        .parse_recovered();
-    (
-        ParseOutput {
-            file: recovered.file,
-        },
-        recovered.diagnostics,
-    )
+fn parse_for_lint(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ParseResult {
+    Parser::with_profile(source, inferred_shell_profile(source, settings, path)).parse()
 }
 
 /// Lint a source string directly (no file needed).
 pub fn test_snippet(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
-    let (output, parse_diagnostics) = parse_for_lint(source, settings, None);
-    let indexer = Indexer::new(source, &output);
-    lint_file_at_path_with_parse_diagnostics(
-        &output.file,
-        source,
-        &indexer,
-        settings,
-        None,
-        None,
-        &parse_diagnostics,
-    )
+    let parse_result = parse_for_lint(source, settings, None);
+    let indexer = Indexer::new(source, &parse_result);
+    lint_file_at_path_with_parse_result(&parse_result, source, &indexer, settings, None, None)
 }
 
 /// Lint a source string while preserving an explicit path for path-sensitive rules.
@@ -68,17 +47,9 @@ pub fn test_snippet_at_path(
     source: &str,
     settings: &LinterSettings,
 ) -> Vec<Diagnostic> {
-    let (output, parse_diagnostics) = parse_for_lint(source, settings, Some(path));
-    let indexer = Indexer::new(source, &output);
-    lint_file_at_path_with_parse_diagnostics(
-        &output.file,
-        source,
-        &indexer,
-        settings,
-        None,
-        Some(path),
-        &parse_diagnostics,
-    )
+    let parse_result = parse_for_lint(source, settings, Some(path));
+    let indexer = Indexer::new(source, &parse_result);
+    lint_file_at_path_with_parse_result(&parse_result, source, &indexer, settings, None, Some(path))
 }
 
 /// Lint a fixture file relative to `resources/test/fixtures/`.

--- a/crates/shuck-parser/src/error.rs
+++ b/crates/shuck-parser/src/error.rs
@@ -4,7 +4,7 @@
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Shuck error types.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Error {
     /// Parse error occurred while parsing the script.
     ///

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -2684,19 +2684,23 @@ impl<'a> Parser<'a> {
         }
 
         let checkpoint = self.checkpoint();
-        let followed_by_then = self
-            .parse_brace_group(BraceBodyContext::Ordinary)
-            .and_then(|_| {
-                if self.at(TokenKind::Semicolon) {
-                    self.advance();
-                }
-                self.skip_newlines()?;
-                Ok(self.is_keyword(Keyword::Then))
-            })
-            .unwrap_or(false);
+        let reaches_then = loop {
+            if self.skip_newlines().is_err() {
+                break false;
+            }
+            if self.is_keyword(Keyword::Then) {
+                break true;
+            }
+            if self.current_token.is_none() {
+                break false;
+            }
+            if self.parse_command_list_required().is_err() {
+                break false;
+            }
+        };
         self.restore(checkpoint);
 
-        !followed_by_then
+        !reaches_then
     }
 
     fn peek_zsh_always_span(&mut self) -> Option<Span> {

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -186,59 +186,36 @@ impl<'a> Parser<'a> {
         advanced
     }
 
-    fn parse_impl(&mut self) -> Result<ParseOutput> {
-        // Check if the very first token is an error
-        self.check_error_token()?;
-
-        let file_span =
-            Span::from_positions(Position::new(), Position::new().advanced_by(self.input));
-        let mut stmts = Vec::new();
-
-        while self.current_token.is_some() {
-            self.tick()?;
-            self.skip_newlines()?;
-            self.check_error_token()?;
-            if self.current_token.is_none() {
-                break;
-            }
-            let command_stmts = self.parse_command_list_required()?;
-            self.apply_stmt_list_effects(&command_stmts);
-            stmts.extend(command_stmts);
-        }
-
-        let mut file = File {
-            body: Self::stmt_seq_with_span(file_span, stmts),
-            span: file_span,
-        };
-        self.attach_comments_to_file(&mut file);
-        Ok(ParseOutput { file })
-    }
-
-    /// Parse the input and return the AST with collected comments.
-    pub fn parse(mut self) -> Result<ParseOutput> {
-        self.parse_impl()
-    }
-
-    fn parse_recovered_impl(&mut self) -> RecoveredParse {
+    fn parse_impl(&mut self) -> ParseResult {
         let file_span =
             Span::from_positions(Position::new(), Position::new().advanced_by(self.input));
         let mut stmts = Vec::new();
         let mut diagnostics = Vec::new();
+        let mut terminal_error = None;
 
         while self.current_token.is_some() {
             let checkpoint = self.current_span.start.offset;
 
             if let Err(error) = self.tick() {
-                diagnostics.push(self.parse_diagnostic_from_error(error));
+                diagnostics.push(self.parse_diagnostic_from_error(error.clone()));
+                terminal_error.get_or_insert(error);
                 break;
             }
             if let Err(error) = self.skip_newlines() {
-                diagnostics.push(self.parse_diagnostic_from_error(error));
+                diagnostics.push(self.parse_diagnostic_from_error(error.clone()));
+                terminal_error.get_or_insert(error);
                 break;
             }
             if let Err(error) = self.check_error_token() {
-                diagnostics.push(self.parse_diagnostic_from_error(error));
-                if !self.recover_to_command_boundary(checkpoint) {
+                diagnostics.push(self.parse_diagnostic_from_error(error.clone()));
+                let recovered = self.recover_to_command_boundary(checkpoint);
+                if recovered
+                    || (self.current_token.is_some()
+                        && self.current_span.start.offset < self.input.len())
+                {
+                    terminal_error.get_or_insert(error);
+                }
+                if !recovered && terminal_error.is_some() {
                     break;
                 }
                 continue;
@@ -254,8 +231,15 @@ impl<'a> Parser<'a> {
                     stmts.extend(command_stmts);
                 }
                 Err(error) => {
-                    diagnostics.push(self.parse_diagnostic_from_error(error));
-                    if !self.recover_to_command_boundary(command_start) {
+                    diagnostics.push(self.parse_diagnostic_from_error(error.clone()));
+                    let recovered = self.recover_to_command_boundary(command_start);
+                    if recovered
+                        || (self.current_token.is_some()
+                            && self.current_span.start.offset < self.input.len())
+                    {
+                        terminal_error.get_or_insert(error);
+                    }
+                    if !recovered && terminal_error.is_some() {
                         break;
                     }
                 }
@@ -267,29 +251,34 @@ impl<'a> Parser<'a> {
             span: file_span,
         };
         self.attach_comments_to_file(&mut file);
-        RecoveredParse { file, diagnostics }
+
+        let status = if terminal_error.is_some() {
+            ParseStatus::Fatal
+        } else if diagnostics.is_empty() {
+            ParseStatus::Clean
+        } else {
+            ParseStatus::Recovered
+        };
+
+        ParseResult {
+            file,
+            diagnostics,
+            status,
+            terminal_error,
+            syntax_facts: std::mem::take(&mut self.syntax_facts),
+        }
     }
 
-    /// Parse the input while recovering at top-level command boundaries.
-    pub fn parse_recovered(mut self) -> RecoveredParse {
-        self.parse_recovered_impl()
+    /// Parse the input and return the AST, recovery diagnostics, and syntax facts.
+    pub fn parse(mut self) -> ParseResult {
+        self.parse_impl()
     }
 
     #[cfg(feature = "benchmarking")]
     #[doc(hidden)]
-    pub fn parse_with_benchmark_counters(self) -> Result<(ParseOutput, ParserBenchmarkCounters)> {
+    pub fn parse_with_benchmark_counters(self) -> (ParseResult, ParserBenchmarkCounters) {
         let mut parser = self.rebuild_with_benchmark_counters();
-        let output = parser.parse_impl()?;
-        Ok((output, parser.finish_benchmark_counters()))
-    }
-
-    #[cfg(feature = "benchmarking")]
-    #[doc(hidden)]
-    pub fn parse_recovered_with_benchmark_counters(
-        self,
-    ) -> (RecoveredParse, ParserBenchmarkCounters) {
-        let mut parser = self.rebuild_with_benchmark_counters();
-        let output = parser.parse_recovered_impl();
+        let output = parser.parse_impl();
         (output, parser.finish_benchmark_counters())
     }
 
@@ -858,6 +847,7 @@ impl<'a> Parser<'a> {
                         "syntax error: empty then clause",
                         BraceBodyContext::IfClause,
                     )?;
+                self.record_zsh_brace_if_span(left_brace_span);
                 (
                     IfSyntax::Brace {
                         left_brace_span,
@@ -1989,10 +1979,33 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_case_patterns(&mut self) -> Result<Vec<Pattern>> {
+        self.record_zsh_case_group_parts_from_current_case_header();
         if self.dialect == ShellDialect::Zsh {
             self.parse_zsh_case_patterns()
         } else {
             self.parse_posix_case_patterns()
+        }
+    }
+
+    fn record_zsh_case_group_parts_from_current_case_header(&mut self) {
+        let Ok((pattern_spans, _)) = self.scan_zsh_case_pattern_spans() else {
+            return;
+        };
+
+        for span in pattern_spans {
+            let pattern = self.pattern_from_zsh_case_span(span);
+            for (index, part) in pattern.parts.iter().enumerate() {
+                if matches!(
+                    &part.kind,
+                    PatternPart::Group {
+                        kind: PatternGroupKind::ExactlyOne,
+                        ..
+                    }
+                ) && part.span.slice(self.input).starts_with('(')
+                {
+                    self.record_zsh_case_group_part(index, part.span);
+                }
+            }
         }
     }
 
@@ -2527,7 +2540,13 @@ impl<'a> Parser<'a> {
         let (body, left_brace_span, right_brace_span) =
             self.parse_brace_enclosed_stmt_seq("syntax error: empty brace group", context)?;
 
+        let always_span = self.peek_zsh_always_span();
+        if let Some(span) = always_span {
+            self.record_zsh_always_span(span);
+        }
+
         let compound = if self.dialect.features().zsh_always && self.is_keyword(Keyword::Always) {
+            self.record_zsh_always_span(self.current_span);
             self.advance();
             self.skip_newlines()?;
             if !self.at(TokenKind::LeftBrace) {
@@ -2609,6 +2628,10 @@ impl<'a> Parser<'a> {
         loop {
             self.skip_newlines()?;
 
+            if !allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace) {
+                self.record_zsh_brace_if_span(self.current_span);
+            }
+
             if self.at(TokenKind::Semicolon) {
                 let checkpoint = self.checkpoint();
                 self.advance();
@@ -2616,12 +2639,21 @@ impl<'a> Parser<'a> {
                     self.restore(checkpoint);
                     return Err(error);
                 }
+                let brace_if_span =
+                    (!allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace))
+                        .then_some(self.current_span);
                 if self.is_keyword(Keyword::Then)
                     || (allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace))
                 {
+                    if let Some(span) = brace_if_span {
+                        self.record_zsh_brace_if_span(span);
+                    }
                     break;
                 }
                 self.restore(checkpoint);
+                if let Some(span) = brace_if_span {
+                    self.record_zsh_brace_if_span(span);
+                }
             }
 
             if self.is_keyword(Keyword::Then)
@@ -2640,6 +2672,23 @@ impl<'a> Parser<'a> {
         }
 
         Ok(stmts)
+    }
+
+    fn peek_zsh_always_span(&mut self) -> Option<Span> {
+        if !self.is_keyword(Keyword::Always) {
+            return None;
+        }
+
+        let always_span = self.current_span;
+        let checkpoint = self.checkpoint();
+        self.advance();
+        let result = match self.skip_newlines() {
+            Ok(()) if self.at(TokenKind::LeftBrace) => Some(always_span),
+            Ok(()) => None,
+            Err(_) => None,
+        };
+        self.restore(checkpoint);
+        result
     }
 
     fn has_recorded_comment_between(&self, start_offset: usize, end_offset: usize) -> bool {
@@ -2712,9 +2761,10 @@ impl<'a> Parser<'a> {
         nested.expand_next_word = self.expand_next_word;
 
         let inner_start = self.current_span.start.advanced_by("{");
-        let mut output = nested
-            .parse()
-            .map_err(|error| self.rebase_nested_parse_error(error, inner_start))?;
+        let mut output = nested.parse();
+        if output.is_err() {
+            return Err(self.rebase_nested_parse_error(output.strict_error(), inner_start));
+        }
         Self::rebase_stmt_seq(&mut output.file.body, inner_start);
         self.advance();
         Ok(Some(CompoundCommand::BraceGroup(output.file.body)))

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -2628,7 +2628,10 @@ impl<'a> Parser<'a> {
         loop {
             self.skip_newlines()?;
 
-            if !allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace) {
+            if !allow_brace_body
+                && !stmts.is_empty()
+                && self.current_brace_starts_zsh_if_body_fact()
+            {
                 self.record_zsh_brace_if_span(self.current_span);
             }
 
@@ -2639,9 +2642,10 @@ impl<'a> Parser<'a> {
                     self.restore(checkpoint);
                     return Err(error);
                 }
-                let brace_if_span =
-                    (!allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace))
-                        .then_some(self.current_span);
+                let brace_if_span = (!allow_brace_body
+                    && !stmts.is_empty()
+                    && self.current_brace_starts_zsh_if_body_fact())
+                .then_some(self.current_span);
                 if self.is_keyword(Keyword::Then)
                     || (allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace))
                 {
@@ -2672,6 +2676,27 @@ impl<'a> Parser<'a> {
         }
 
         Ok(stmts)
+    }
+
+    fn current_brace_starts_zsh_if_body_fact(&mut self) -> bool {
+        if !self.at(TokenKind::LeftBrace) {
+            return false;
+        }
+
+        let checkpoint = self.checkpoint();
+        let followed_by_then = self
+            .parse_brace_group(BraceBodyContext::Ordinary)
+            .and_then(|_| {
+                if self.at(TokenKind::Semicolon) {
+                    self.advance();
+                }
+                self.skip_newlines()?;
+                Ok(self.is_keyword(Keyword::Then))
+            })
+            .unwrap_or(false);
+        self.restore(checkpoint);
+
+        !followed_by_then
     }
 
     fn peek_zsh_always_span(&mut self) -> Option<Span> {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -68,10 +68,94 @@ const HARD_MAX_AST_DEPTH: usize = 100;
 /// Default maximum parser operations (matches ExecutionLimits default)
 const DEFAULT_MAX_PARSER_OPERATIONS: usize = 100_000;
 
-/// The result of a successful parse: a script plus collected comments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseStatus {
+    Clean,
+    Recovered,
+    Fatal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZshCaseGroupPart {
+    pub pattern_part_index: usize,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SyntaxFacts {
+    pub zsh_brace_if_spans: Vec<Span>,
+    pub zsh_always_spans: Vec<Span>,
+    pub zsh_case_group_parts: Vec<ZshCaseGroupPart>,
+}
+
+/// The result of parsing a script, including any recovery diagnostics and
+/// syntax facts collected along the way.
 #[derive(Debug, Clone)]
-pub struct ParseOutput {
+pub struct ParseResult {
     pub file: File,
+    pub diagnostics: Vec<ParseDiagnostic>,
+    pub status: ParseStatus,
+    pub terminal_error: Option<Error>,
+    pub syntax_facts: SyntaxFacts,
+}
+
+impl ParseResult {
+    pub fn is_ok(&self) -> bool {
+        self.status == ParseStatus::Clean
+    }
+
+    pub fn is_err(&self) -> bool {
+        !self.is_ok()
+    }
+
+    pub fn strict_error(&self) -> Error {
+        self.terminal_error.clone().unwrap_or_else(|| {
+            let diagnostic = self
+                .diagnostics
+                .first()
+                .expect("non-clean parse result should include a diagnostic or terminal error");
+            Error::parse_at(
+                diagnostic.message.clone(),
+                diagnostic.span.start.line,
+                diagnostic.span.start.column,
+            )
+        })
+    }
+
+    pub fn unwrap(self) -> Self {
+        if self.is_ok() {
+            self
+        } else {
+            panic!(
+                "called `ParseResult::unwrap()` on a non-clean parse: {}",
+                self.strict_error()
+            )
+        }
+    }
+
+    pub fn expect(self, message: &str) -> Self {
+        if self.is_ok() {
+            self
+        } else {
+            panic!("{message}: {}", self.strict_error())
+        }
+    }
+
+    pub fn unwrap_err(self) -> Error {
+        if self.is_err() {
+            self.strict_error()
+        } else {
+            panic!("called `ParseResult::unwrap_err()` on a clean parse")
+        }
+    }
+
+    pub fn expect_err(self, message: &str) -> Error {
+        if self.is_err() {
+            self.strict_error()
+        } else {
+            panic!("{message}")
+        }
+    }
 }
 
 #[cfg(feature = "benchmarking")]
@@ -1379,6 +1463,7 @@ pub struct Parser<'a> {
     /// Active brace-body parsing contexts, used to distinguish compact zsh
     /// closers from literal `}` arguments.
     brace_body_stack: Vec<BraceBodyContext>,
+    syntax_facts: SyntaxFacts,
     shell_profile: ShellProfile,
     zsh_timeline: Option<Arc<ZshOptionTimeline>>,
     dialect: ShellDialect,
@@ -1403,6 +1488,7 @@ struct ParserCheckpoint<'a> {
     expand_next_word: bool,
     brace_group_depth: usize,
     brace_body_stack: Vec<BraceBodyContext>,
+    syntax_facts: SyntaxFacts,
     #[cfg(feature = "benchmarking")]
     benchmark_counters: Option<ParserBenchmarkCounters>,
 }
@@ -1412,13 +1498,6 @@ struct ParserCheckpoint<'a> {
 pub struct ParseDiagnostic {
     pub message: String,
     pub span: Span,
-}
-
-/// The result of a recovered parse: a partial script plus parse diagnostics.
-#[derive(Debug, Clone)]
-pub struct RecoveredParse {
-    pub file: File,
-    pub diagnostics: Vec<ParseDiagnostic>,
 }
 
 #[derive(Debug, Clone)]
@@ -1748,6 +1827,7 @@ impl<'a> Parser<'a> {
             expand_next_word: false,
             brace_group_depth: 0,
             brace_body_stack: Vec::new(),
+            syntax_facts: SyntaxFacts::default(),
             dialect: shell_profile.dialect,
             shell_profile,
             zsh_timeline,
@@ -1887,6 +1967,34 @@ impl<'a> Parser<'a> {
             self.comments.push(Comment {
                 range: token.span.to_range(),
             });
+        }
+    }
+
+    fn record_zsh_brace_if_span(&mut self, span: Span) {
+        if !self.syntax_facts.zsh_brace_if_spans.contains(&span) {
+            self.syntax_facts.zsh_brace_if_spans.push(span);
+        }
+    }
+
+    fn record_zsh_always_span(&mut self, span: Span) {
+        if !self.syntax_facts.zsh_always_spans.contains(&span) {
+            self.syntax_facts.zsh_always_spans.push(span);
+        }
+    }
+
+    fn record_zsh_case_group_part(&mut self, pattern_part_index: usize, span: Span) {
+        if !self
+            .syntax_facts
+            .zsh_case_group_parts
+            .iter()
+            .any(|fact| fact.pattern_part_index == pattern_part_index && fact.span == span)
+        {
+            self.syntax_facts
+                .zsh_case_group_parts
+                .push(ZshCaseGroupPart {
+                    pattern_part_index,
+                    span,
+                });
         }
     }
 
@@ -3109,17 +3217,17 @@ impl<'a> Parser<'a> {
             .unwrap_or_else(|| self.shell_profile.clone());
         let inner_parser =
             Parser::with_limits_and_profile(source, remaining_depth, self.fuel, nested_profile);
-        match inner_parser.parse() {
-            Ok(mut output) => {
-                Self::rebase_file(&mut output.file, base);
-                output.file.body
-            }
-            Err(_) => StmtSeq {
+        let mut output = inner_parser.parse();
+        if output.is_ok() {
+            Self::rebase_file(&mut output.file, base);
+            output.file.body
+        } else {
+            StmtSeq {
                 leading_comments: Vec::new(),
                 stmts: Vec::new(),
                 trailing_comments: Vec::new(),
                 span: Span::from_positions(base, base),
-            },
+            }
         }
     }
 
@@ -5039,6 +5147,7 @@ impl<'a> Parser<'a> {
             expand_next_word: self.expand_next_word,
             brace_group_depth: self.brace_group_depth,
             brace_body_stack: self.brace_body_stack.clone(),
+            syntax_facts: self.syntax_facts.clone(),
             #[cfg(feature = "benchmarking")]
             benchmark_counters: self.benchmark_counters,
         }
@@ -5060,6 +5169,7 @@ impl<'a> Parser<'a> {
         self.expand_next_word = checkpoint.expand_next_word;
         self.brace_group_depth = checkpoint.brace_group_depth;
         self.brace_body_stack = checkpoint.brace_body_stack;
+        self.syntax_facts = checkpoint.syntax_facts;
         #[cfg(feature = "benchmarking")]
         {
             self.benchmark_counters = checkpoint.benchmark_counters;

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -4,7 +4,11 @@ use super::*;
 fn test_parse_simple_command() {
     let input = "echo hello";
     let parser = Parser::new(input);
-    let script = parser.parse().unwrap().file;
+    let parsed = parser.parse().unwrap();
+    assert_eq!(parsed.status, ParseStatus::Clean);
+    assert!(parsed.diagnostics.is_empty());
+    assert!(parsed.terminal_error.is_none());
+    let script = parsed.file;
 
     assert_eq!(script.body.len(), 1);
 
@@ -78,7 +82,10 @@ fn test_parse_multiple_args() {
 
 #[test]
 fn test_unexpected_top_level_token_errors_in_strict_mode() {
-    let error = Parser::new("echo ok\n)\necho later\n").parse().unwrap_err();
+    let parsed = Parser::new("echo ok\n)\necho later\n").parse();
+    assert_eq!(parsed.status, ParseStatus::Fatal);
+    assert!(parsed.terminal_error.is_some());
+    let error = parsed.unwrap_err();
 
     let Error::Parse {
         message,
@@ -93,8 +100,9 @@ fn test_unexpected_top_level_token_errors_in_strict_mode() {
 #[test]
 fn test_parse_recovered_skips_invalid_command_and_continues() {
     let input = "echo one\ncat >\necho two\n";
-    let recovered = Parser::new(input).parse_recovered();
+    let recovered = Parser::new(input).parse();
 
+    assert_eq!(recovered.status, ParseStatus::Fatal);
     assert_eq!(recovered.file.body.len(), 2);
     assert_eq!(recovered.diagnostics.len(), 1);
     assert_eq!(recovered.diagnostics[0].message, "expected word");
@@ -107,6 +115,56 @@ fn test_parse_recovered_skips_invalid_command_and_continues() {
     let second = expect_simple(&recovered.file.body[1]);
     assert_eq!(second.name.render(input), "echo");
     assert_eq!(second.args[0].render(input), "two");
+}
+
+#[test]
+fn test_parse_reports_eof_only_missing_fi_as_recovered() {
+    let input = "if true; then\n  :\n";
+    let parsed = Parser::new(input).parse();
+
+    assert_eq!(parsed.status, ParseStatus::Recovered);
+    assert!(parsed.terminal_error.is_none());
+    assert_eq!(parsed.diagnostics.len(), 1);
+    assert_eq!(parsed.diagnostics[0].message, "expected 'fi'");
+}
+
+#[test]
+fn test_parse_collects_zsh_brace_if_fact_in_bash_mode() {
+    let input = "if [[ -n $x ]] {\n  :\n}\n";
+    let parsed = Parser::new(input).parse();
+
+    assert_eq!(parsed.syntax_facts.zsh_brace_if_spans.len(), 1);
+    assert_eq!(parsed.syntax_facts.zsh_brace_if_spans[0].slice(input), "{");
+}
+
+#[test]
+fn test_parse_collects_zsh_always_fact_in_posix_mode() {
+    let input = "{ :; } always { :; }\n";
+    let parsed = Parser::with_dialect(input, ShellDialect::Posix).parse();
+
+    assert_eq!(parsed.syntax_facts.zsh_always_spans.len(), 1);
+    assert_eq!(
+        parsed.syntax_facts.zsh_always_spans[0].slice(input),
+        "always"
+    );
+}
+
+#[test]
+fn test_parse_collects_zsh_case_group_facts_in_posix_mode() {
+    let input = "case $x in\n  foo_(a|b)_*) echo ok ;;\nesac\n";
+    let parsed = Parser::with_dialect(input, ShellDialect::Posix).parse();
+
+    assert_eq!(parsed.syntax_facts.zsh_case_group_parts.len(), 1);
+    assert_eq!(
+        parsed.syntax_facts.zsh_case_group_parts[0].pattern_part_index,
+        1
+    );
+    assert_eq!(
+        parsed.syntax_facts.zsh_case_group_parts[0]
+            .span
+            .slice(input),
+        "(a|b)"
+    );
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -208,8 +208,10 @@ fn test_disabled_foreach_probe_restores_checkpoint_when_newline_skip_errors() {
 fn test_parse_with_benchmark_counters_is_repeatable() {
     let input = "echo hello\nprintf '%s' \"$x\"\n";
 
-    let (first, first_counters) = Parser::new(input).parse_with_benchmark_counters().unwrap();
-    let (second, second_counters) = Parser::new(input).parse_with_benchmark_counters().unwrap();
+    let (first, first_counters) = Parser::new(input).parse_with_benchmark_counters();
+    let (second, second_counters) = Parser::new(input).parse_with_benchmark_counters();
+    let first = first.unwrap();
+    let second = second.unwrap();
 
     assert_eq!(first.file.body.len(), second.file.body.len());
     assert_eq!(first.file.span, second.file.span);

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -138,6 +138,14 @@ fn test_parse_collects_zsh_brace_if_fact_in_bash_mode() {
 }
 
 #[test]
+fn test_parse_does_not_collect_zsh_brace_if_fact_for_condition_brace_group() {
+    let input = "if true\n{ echo ok; }\nthen\n  :\nfi\n";
+    let parsed = Parser::new(input).parse().unwrap();
+
+    assert!(parsed.syntax_facts.zsh_brace_if_spans.is_empty());
+}
+
+#[test]
 fn test_parse_collects_zsh_always_fact_in_posix_mode() {
     let input = "{ :; } always { :; }\n";
     let parsed = Parser::with_dialect(input, ShellDialect::Posix).parse();

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -146,6 +146,14 @@ fn test_parse_does_not_collect_zsh_brace_if_fact_for_condition_brace_group() {
 }
 
 #[test]
+fn test_parse_does_not_collect_zsh_brace_if_fact_for_later_then_after_brace_group_condition() {
+    let input = "if true; { echo ok; }; echo more; then\n  :\nfi\n";
+    let parsed = Parser::new(input).parse().unwrap();
+
+    assert!(parsed.syntax_facts.zsh_brace_if_spans.is_empty());
+}
+
+#[test]
 fn test_parse_collects_zsh_always_fact_in_posix_mode() {
     let input = "{ :; } always { :; }\n";
     let parsed = Parser::with_dialect(input, ShellDialect::Posix).parse();

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -135,7 +135,7 @@ fn collect_compound_comments(command: &AstCompoundCommand, comments: &mut Vec<Co
     }
 }
 
-fn assert_comment_ranges_valid(source: &str, output: &ParseOutput) {
+fn assert_comment_ranges_valid(source: &str, output: &ParseResult) {
     let comments = collect_file_comments(&output.file);
     for (i, comment) in comments.iter().enumerate() {
         let start = usize::from(comment.range.start());

--- a/crates/shuck-parser/tests/oils_parse.rs
+++ b/crates/shuck-parser/tests/oils_parse.rs
@@ -65,12 +65,13 @@ fn oils_corpus_matches_parser_expectations() {
             let outcome =
                 panic::catch_unwind(AssertUnwindSafe(|| Parser::new(&spec_case.script).parse()));
             match (expectation, outcome) {
-                (Expectation::ParseOk, Ok(Ok(_))) => {}
-                (Expectation::ParseErr, Ok(Err(_))) => {}
-                (Expectation::ParseOk, Ok(Err(err))) => {
-                    failures.push(format!("{case_key}: unexpected parse error: {err}"))
-                }
-                (Expectation::ParseErr, Ok(Ok(_))) => {
+                (Expectation::ParseOk, Ok(result)) if result.is_ok() => {}
+                (Expectation::ParseErr, Ok(result)) if result.is_err() => {}
+                (Expectation::ParseOk, Ok(result)) => failures.push(format!(
+                    "{case_key}: unexpected parse error: {}",
+                    result.strict_error()
+                )),
+                (Expectation::ParseErr, Ok(_)) => {
                     failures.push(format!("{case_key}: unexpected parse success"))
                 }
                 (_, Err(_)) => failures.push(format!("{case_key}: parser panic")),
@@ -115,12 +116,13 @@ fn zsh_fixture_cases_match_parser_expectations_in_zsh_mode() {
                 Parser::with_dialect(&spec_case.script, ShellDialect::Zsh).parse()
             }));
             match (expectation, outcome) {
-                (Expectation::ParseOk, Ok(Ok(_))) => {}
-                (Expectation::ParseErr, Ok(Err(_))) => {}
-                (Expectation::ParseOk, Ok(Err(err))) => {
-                    failures.push(format!("{case_key}: unexpected parse error: {err}"))
-                }
-                (Expectation::ParseErr, Ok(Ok(_))) => {
+                (Expectation::ParseOk, Ok(result)) if result.is_ok() => {}
+                (Expectation::ParseErr, Ok(result)) if result.is_err() => {}
+                (Expectation::ParseOk, Ok(result)) => failures.push(format!(
+                    "{case_key}: unexpected parse error: {}",
+                    result.strict_error()
+                )),
+                (Expectation::ParseErr, Ok(_)) => {
                     failures.push(format!("{case_key}: unexpected parse success"))
                 }
                 (_, Err(_)) => failures.push(format!("{case_key}: parser panic")),
@@ -186,10 +188,10 @@ fn zsh_idioms_fixture_cases_parse_in_zsh_mode() {
         .cases
         .iter()
         .filter_map(|spec_case| {
-            match Parser::with_dialect(&spec_case.script, ShellDialect::Zsh).parse() {
-                Ok(_) => None,
-                Err(err) => Some(format!("{}: {err}", spec_case.name)),
-            }
+            let result = Parser::with_dialect(&spec_case.script, ShellDialect::Zsh).parse();
+            result
+                .is_err()
+                .then(|| format!("{}: {}", spec_case.name, result.strict_error()))
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1726,9 +1726,10 @@ fn summarize_helper_uncached(
     let Ok(source) = fs::read_to_string(path) else {
         return FileContract::default();
     };
-    let Ok(output) = Parser::new(&source).parse() else {
+    let output = Parser::new(&source).parse();
+    if output.is_err() {
         return FileContract::default();
-    };
+    }
     let indexer = Indexer::new(&source, &output);
     let mut observer = crate::NoopTraversalObserver;
     let mut semantic = build_semantic_model_base(

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -14,7 +14,7 @@ use shuck_linter::{
 };
 use shuck_parser::{
     Error as ParseError,
-    parser::{ParseDiagnostic, ParseResult, ParseStatus, Parser},
+    parser::{ParseResult, Parser},
 };
 
 use crate::ExitStatus;
@@ -267,14 +267,7 @@ fn analyze_file(
         shellcheck_map,
         include_source,
     );
-    let handled_parse_diagnostic = linter_settings
-        .rules
-        .contains(shuck_linter::Rule::MissingFi)
-        && parse_diagnostics_include_missing_fi(&parse_result.diagnostics);
-    let (cache_data, diagnostics) = if parse_result.status == ParseStatus::Fatal
-        && lint_result.1.is_empty()
-        && !handled_parse_diagnostic
-    {
+    let (cache_data, diagnostics) = if parse_result.is_err() && lint_result.1.is_empty() {
         let ParseError::Parse {
             message,
             line,
@@ -360,12 +353,6 @@ fn lint_parsed_output(
     )
 }
 
-fn parse_diagnostics_include_missing_fi(parse_diagnostics: &[ParseDiagnostic]) -> bool {
-    parse_diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.message.starts_with("expected 'fi'"))
-}
-
 fn push_cached_lint_diagnostics(
     report: &mut CheckReport,
     path: &Path,
@@ -402,6 +389,21 @@ mod tests {
 
     use super::*;
     use crate::args::CheckOutputFormatArg;
+
+    fn pending_project_file(path: &Path, project_root: &Path) -> PendingProjectFile {
+        PendingProjectFile {
+            file: crate::discover::DiscoveredFile {
+                display_path: path.strip_prefix(project_root).unwrap().to_path_buf(),
+                absolute_path: path.to_path_buf(),
+                relative_path: path.strip_prefix(project_root).unwrap().to_path_buf(),
+                project_root: crate::discover::ProjectRoot {
+                    storage_root: project_root.to_path_buf(),
+                    canonical_root: fs::canonicalize(project_root).unwrap(),
+                },
+            },
+            file_key: shuck_cache::FileCacheKey::from_path(path).unwrap(),
+        }
+    }
 
     fn cache_root(cwd: &Path) -> PathBuf {
         cwd.join("cache")
@@ -466,6 +468,30 @@ mod tests {
             DisplayedDiagnosticKind::Lint { code, .. } => assert_eq!(code, "C035"),
             other => panic!("expected lint diagnostic, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn reports_missing_fi_as_parse_error_when_parse_rule_is_disabled() {
+        let tempdir = tempdir().unwrap();
+        let broken_path = tempdir.path().join("broken.sh");
+        fs::write(&broken_path, "#!/bin/sh\nif true; then\n  :\n").unwrap();
+
+        let result = analyze_file(
+            pending_project_file(&broken_path, tempdir.path()),
+            &LinterSettings::for_rule(shuck_linter::Rule::UnusedAssignment)
+                .with_analyzed_paths([broken_path.clone()]),
+            &ShellCheckCodeMap::default(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.diagnostics.len(), 1);
+        assert!(matches!(result.cache_data, CheckCacheData::ParseError(_)));
+        match &result.diagnostics[0].kind {
+            DisplayedDiagnosticKind::ParseError => {}
+            other => panic!("expected parse error, got {other:?}"),
+        }
+        assert!(result.diagnostics[0].message.contains("expected 'fi'"));
     }
 
     #[test]

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -14,7 +14,7 @@ use shuck_linter::{
 };
 use shuck_parser::{
     Error as ParseError,
-    parser::{ParseDiagnostic, ParseOutput, Parser},
+    parser::{ParseDiagnostic, ParseResult, ParseStatus, Parser},
 };
 
 use crate::ExitStatus;
@@ -258,58 +258,44 @@ fn analyze_file(
     };
 
     let linter_settings = base_linter_settings.clone().with_shell(inferred_shell);
-    let (cache_data, diagnostics) = match Parser::with_dialect(&source, parse_dialect).parse() {
-        Ok(output) => lint_parsed_output(
-            &pending,
-            &source,
-            output,
-            &[],
-            &linter_settings,
-            shellcheck_map,
-            include_source,
-        ),
-        Err(ParseError::Parse {
+    let parse_result = Parser::with_dialect(&source, parse_dialect).parse();
+    let lint_result = lint_parsed_output(
+        &pending,
+        &source,
+        &parse_result,
+        &linter_settings,
+        shellcheck_map,
+        include_source,
+    );
+    let handled_parse_diagnostic = linter_settings
+        .rules
+        .contains(shuck_linter::Rule::MissingFi)
+        && parse_diagnostics_include_missing_fi(&parse_result.diagnostics);
+    let (cache_data, diagnostics) = if parse_result.status == ParseStatus::Fatal
+        && lint_result.1.is_empty()
+        && !handled_parse_diagnostic
+    {
+        let ParseError::Parse {
             message,
             line,
             column,
-        }) => {
-            let recovered = Parser::with_dialect(&source, parse_dialect).parse_recovered();
-            let output = ParseOutput {
-                file: recovered.file,
-            };
-            let recovered_result = lint_parsed_output(
-                &pending,
-                &source,
-                output,
-                &recovered.diagnostics,
-                &linter_settings,
-                shellcheck_map,
-                include_source,
-            );
-            let handled_parse_diagnostic = linter_settings
-                .rules
-                .contains(shuck_linter::Rule::MissingFi)
-                && parse_diagnostics_include_missing_fi(&recovered.diagnostics);
-
-            if !recovered_result.1.is_empty() || handled_parse_diagnostic {
-                recovered_result
-            } else {
-                (
-                    CheckCacheData::ParseError(ParseCacheFailure {
-                        message: message.clone(),
-                        line,
-                        column,
-                    }),
-                    vec![DisplayedDiagnostic {
-                        path: pending.file.display_path.clone(),
-                        span: DisplaySpan::point(line, column),
-                        message,
-                        kind: DisplayedDiagnosticKind::ParseError,
-                        source: include_source.then_some(source.clone()),
-                    }],
-                )
-            }
-        }
+        } = parse_result.strict_error();
+        (
+            CheckCacheData::ParseError(ParseCacheFailure {
+                message: message.clone(),
+                line,
+                column,
+            }),
+            vec![DisplayedDiagnostic {
+                path: pending.file.display_path.clone(),
+                span: DisplaySpan::point(line, column),
+                message,
+                kind: DisplayedDiagnosticKind::ParseError,
+                source: include_source.then_some(source.clone()),
+            }],
+        )
+    } else {
+        lint_result
     };
 
     Ok(FileCheckResult {
@@ -323,29 +309,27 @@ fn analyze_file(
 fn lint_parsed_output(
     pending: &PendingProjectFile,
     source: &str,
-    output: ParseOutput,
-    parse_diagnostics: &[ParseDiagnostic],
+    parse_result: &ParseResult,
     linter_settings: &LinterSettings,
     shellcheck_map: &ShellCheckCodeMap,
     include_source: bool,
 ) -> (CheckCacheData, Vec<DisplayedDiagnostic>) {
-    let indexer = Indexer::new(source, &output);
+    let indexer = Indexer::new(source, parse_result);
     let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
     let suppression_index = (!directives.is_empty()).then(|| {
         SuppressionIndex::new(
             &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
+            &parse_result.file,
+            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
         )
     });
-    let diagnostics = shuck_linter::lint_file_at_path_with_parse_diagnostics(
-        &output.file,
+    let diagnostics = shuck_linter::lint_file_at_path_with_parse_result(
+        parse_result,
         source,
         &indexer,
         linter_settings,
         suppression_index.as_ref(),
         Some(&pending.file.absolute_path),
-        parse_diagnostics,
     );
     let diagnostic_source =
         (!diagnostics.is_empty() && include_source).then(|| Arc::<str>::from(source));

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -2102,48 +2102,28 @@ fn run_shuck_with_parse_dialect(
         .clone()
         .with_shell(shuck_linter::ShellDialect::from_name(shell))
         .with_analyzed_paths([fixture.path.clone()]);
-    let parsed = match shuck_parser::parser::Parser::with_dialect(&source, parse_dialect).parse() {
-        Ok(parsed) => parsed,
-        Err(error) => {
-            let recovered = shuck_parser::parser::Parser::with_dialect(&source, parse_dialect)
-                .parse_recovered();
-            let output = shuck_parser::parser::ParseOutput {
-                file: recovered.file,
-            };
-            let diagnostics = lint_large_corpus_output(
-                fixture,
-                &source,
-                &output,
-                &recovered.diagnostics,
-                &linter_settings,
-                source_path_resolver,
-            );
-            let handled_parse_diagnostic = linter_settings
-                .rules
-                .contains(shuck_linter::Rule::MissingFi)
-                && parse_diagnostics_include_missing_fi(&recovered.diagnostics);
-
-            if !diagnostics.is_empty() || handled_parse_diagnostic {
-                return ShuckRun {
-                    diagnostics,
-                    parse_error: None,
-                };
-            }
-
-            return ShuckRun {
-                diagnostics: Vec::new(),
-                parse_error: Some(error.to_string()),
-            };
-        }
-    };
+    let parsed = shuck_parser::parser::Parser::with_dialect(&source, parse_dialect).parse();
     let diagnostics = lint_large_corpus_output(
         fixture,
         &source,
         &parsed,
-        &[],
         &linter_settings,
         source_path_resolver,
     );
+    let handled_parse_diagnostic = linter_settings
+        .rules
+        .contains(shuck_linter::Rule::MissingFi)
+        && parse_diagnostics_include_missing_fi(&parsed.diagnostics);
+
+    if parsed.status == shuck_parser::parser::ParseStatus::Fatal
+        && diagnostics.is_empty()
+        && !handled_parse_diagnostic
+    {
+        return ShuckRun {
+            diagnostics: Vec::new(),
+            parse_error: Some(parsed.strict_error().to_string()),
+        };
+    }
 
     ShuckRun {
         diagnostics,
@@ -2154,32 +2134,30 @@ fn run_shuck_with_parse_dialect(
 fn lint_large_corpus_output(
     fixture: &LargeCorpusFixture,
     source: &str,
-    output: &shuck_parser::parser::ParseOutput,
-    parse_diagnostics: &[shuck_parser::parser::ParseDiagnostic],
+    parse_result: &shuck_parser::parser::ParseResult,
     linter_settings: &shuck_linter::LinterSettings,
     source_path_resolver: Option<&(dyn shuck_semantic::SourcePathResolver + Send + Sync)>,
 ) -> Vec<shuck_linter::Diagnostic> {
-    let indexer = shuck_indexer::Indexer::new(source, output);
+    let indexer = shuck_indexer::Indexer::new(source, parse_result);
     let shellcheck_map = shuck_linter::ShellCheckCodeMap::default();
     let directives =
         shuck_linter::parse_directives(source, indexer.comment_index(), &shellcheck_map);
     let suppression_index = (!directives.is_empty()).then(|| {
         shuck_linter::SuppressionIndex::new(
             &directives,
-            &output.file,
-            shuck_linter::first_statement_line(&output.file).unwrap_or(u32::MAX),
+            &parse_result.file,
+            shuck_linter::first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
         )
     });
 
-    shuck_linter::lint_file_at_path_with_resolver_and_parse_diagnostics(
-        &output.file,
+    shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
+        parse_result,
         source,
         &indexer,
         linter_settings,
         suppression_index.as_ref(),
         Some(&fixture.path),
         source_path_resolver,
-        parse_diagnostics,
     )
 }
 
@@ -2234,9 +2212,11 @@ fn parse_fixture_for_effective_large_corpus_shell_with_timeout(
             fs::read_to_string(&fixture.path).map_err(|err| format!("read error: {err}"))?;
         let shell = effective_large_corpus_shell(&fixture);
         let shell_profile = shell_profile_for_large_corpus_shell(shell);
-        let parsed = shuck_parser::parser::Parser::with_profile(&source, shell_profile.clone())
-            .parse()
-            .map_err(|err| err.to_string())?;
+        let parsed =
+            shuck_parser::parser::Parser::with_profile(&source, shell_profile.clone()).parse();
+        if parsed.is_err() {
+            return Err(parsed.strict_error().to_string());
+        }
 
         if shell == "zsh" {
             extract_large_corpus_zsh_option_state(&fixture.path, &source, &parsed, shell_profile)?;
@@ -2249,7 +2229,7 @@ fn parse_fixture_for_effective_large_corpus_shell_with_timeout(
 fn extract_large_corpus_zsh_option_state(
     path: &Path,
     source: &str,
-    output: &shuck_parser::parser::ParseOutput,
+    output: &shuck_parser::parser::ParseResult,
     shell_profile: shuck_parser::ShellProfile,
 ) -> Result<(), String> {
     let indexer = shuck_indexer::Indexer::new(source, output);

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -2110,15 +2110,7 @@ fn run_shuck_with_parse_dialect(
         &linter_settings,
         source_path_resolver,
     );
-    let handled_parse_diagnostic = linter_settings
-        .rules
-        .contains(shuck_linter::Rule::MissingFi)
-        && parse_diagnostics_include_missing_fi(&parsed.diagnostics);
-
-    if parsed.status == shuck_parser::parser::ParseStatus::Fatal
-        && diagnostics.is_empty()
-        && !handled_parse_diagnostic
-    {
+    if parsed.is_err() && diagnostics.is_empty() {
         return ShuckRun {
             diagnostics: Vec::new(),
             parse_error: Some(parsed.strict_error().to_string()),
@@ -2159,14 +2151,6 @@ fn lint_large_corpus_output(
         Some(&fixture.path),
         source_path_resolver,
     )
-}
-
-fn parse_diagnostics_include_missing_fi(
-    parse_diagnostics: &[shuck_parser::parser::ParseDiagnostic],
-) -> bool {
-    parse_diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.message.starts_with("expected 'fi'"))
 }
 
 fn run_shuck(
@@ -3873,6 +3857,29 @@ mod tests {
             shell: "sh".into(),
             source_hash: "source-hash".into(),
         }
+    }
+
+    #[test]
+    fn run_shuck_reports_parse_error_when_parse_rule_is_disabled() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let fixture_path = tempdir.path().join("broken.sh");
+        fs::write(&fixture_path, "#!/bin/sh\nif true; then\n  :\n").unwrap();
+        let fixture = fixture_at(&fixture_path, Path::new("broken.sh"));
+
+        let run = run_shuck_with_parse_dialect(
+            &fixture,
+            &shuck_linter::LinterSettings::for_rule(shuck_linter::Rule::UnusedAssignment),
+            None,
+            shuck_parser::ShellDialect::Posix,
+            "sh",
+        );
+
+        assert!(run.diagnostics.is_empty());
+        assert!(
+            run.parse_error
+                .as_deref()
+                .is_some_and(|error| error.contains("expected 'fi'"))
+        );
     }
 
     fn probe(version_text: &str) -> ShellCheckProbe {

--- a/crates/shuck/tests/zsh_option_state.rs
+++ b/crates/shuck/tests/zsh_option_state.rs
@@ -128,9 +128,10 @@ fn load_fixture(path: &Path) -> Result<Fixture> {
 fn run_fixture(fixture: &Fixture) -> Result<()> {
     let observed = run_fixture_in_zsh(fixture)?;
     let profile = ShellProfile::native(ParseShellDialect::Zsh);
-    let parsed = Parser::with_profile(&fixture.source, profile.clone())
-        .parse()
-        .map_err(|err| anyhow::anyhow!("parse error: {err}"))?;
+    let parsed = Parser::with_profile(&fixture.source, profile.clone()).parse();
+    if parsed.is_err() {
+        return Err(anyhow::anyhow!("parse error: {}", parsed.strict_error()));
+    }
     let indexer = Indexer::new(&fixture.source, &parsed);
     let semantic = SemanticModel::build_with_options(
         &parsed.file,

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -10,11 +10,8 @@ use shuck_formatter::{
     format_source, source_is_formatted,
 };
 use shuck_indexer::Indexer;
-use shuck_linter::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_diagnostics};
-use shuck_parser::{
-    ShellDialect as ParseDialect,
-    parser::{ParseOutput, Parser, RecoveredParse},
-};
+use shuck_linter::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_result};
+use shuck_parser::{ShellDialect as ParseDialect, parser::{ParseResult, Parser}};
 
 const MAX_FUZZ_INPUT_BYTES: usize = 16 * 1024;
 const MAX_FUZZ_NESTING: i32 = 64;
@@ -103,13 +100,10 @@ pub(crate) fn assert_span_valid(span: Span, source: &str) {
 pub(crate) fn recovered_parse_and_index(
     source: &str,
     dialect: ParseDialect,
-) -> (RecoveredParse, Indexer) {
-    let recovered = Parser::with_dialect(source, dialect).parse_recovered();
-    let output = ParseOutput {
-        file: recovered.file.clone(),
-    };
-    let indexer = Indexer::new(source, &output);
-    (recovered, indexer)
+) -> (ParseResult, Indexer) {
+    let parse_result = Parser::with_dialect(source, dialect).parse();
+    let indexer = Indexer::new(source, &parse_result);
+    (parse_result, indexer)
 }
 
 pub(crate) fn format_result_to_string(result: FormattedSource, source: &str) -> String {
@@ -124,23 +118,19 @@ pub(crate) fn lint_source_with_recovery(
     path: Option<&Path>,
     dialect: ParseDialect,
 ) -> Vec<Diagnostic> {
-    let recovered = Parser::with_dialect(source, dialect).parse_recovered();
-    let output = ParseOutput {
-        file: recovered.file,
-    };
-    let indexer = Indexer::new(source, &output);
+    let parse_result = Parser::with_dialect(source, dialect).parse();
+    let indexer = Indexer::new(source, &parse_result);
     let settings = match path {
         Some(path) => LinterSettings::default().with_analyzed_paths([path.to_path_buf()]),
         None => LinterSettings::default(),
     };
-    lint_file_at_path_with_parse_diagnostics(
-        &output.file,
+    lint_file_at_path_with_parse_result(
+        &parse_result,
         source,
         &indexer,
         &settings,
         None,
         path,
-        &recovered.diagnostics,
     )
 }
 
@@ -149,19 +139,23 @@ pub(crate) fn lint_source_strict(
     path: &Path,
     dialect: ParseDialect,
 ) -> Vec<Diagnostic> {
-    let output = Parser::with_dialect(source, dialect)
-        .parse()
-        .unwrap_or_else(|err| panic!("strict parse failed for {}: {err}", path.display()));
-    let indexer = Indexer::new(source, &output);
+    let parse_result = Parser::with_dialect(source, dialect).parse();
+    if parse_result.is_err() {
+        panic!(
+            "strict parse failed for {}: {}",
+            path.display(),
+            parse_result.strict_error()
+        );
+    }
+    let indexer = Indexer::new(source, &parse_result);
     let settings = LinterSettings::default().with_analyzed_paths([path.to_path_buf()]);
-    lint_file_at_path_with_parse_diagnostics(
-        &output.file,
+    lint_file_at_path_with_parse_result(
+        &parse_result,
         source,
         &indexer,
         &settings,
         None,
         Some(path),
-        &[],
     )
 }
 
@@ -181,13 +175,16 @@ pub(crate) fn compare_formatting_invariants(source: &str, case: FormatCase) {
     };
 
     let parsed = Parser::with_dialect(source, case.parse_dialect())
-        .parse()
-        .unwrap_or_else(|err| {
-            panic!(
-                "formatter accepted source but strict parsing failed for {}: {err}",
-                case.path().display()
-            )
-        });
+        .parse();
+    let parsed = if parsed.is_err() {
+        panic!(
+            "formatter accepted source but strict parsing failed for {}: {}",
+            case.path().display(),
+            parsed.strict_error()
+        )
+    } else {
+        parsed
+    };
     let from_ast = format_file_ast(source, parsed.file, path, &options).unwrap_or_else(|err| {
         panic!(
             "format_file_ast failed for {}: {err}",

--- a/fuzz/fuzz_targets/recovered_parser_fuzz.rs
+++ b/fuzz/fuzz_targets/recovered_parser_fuzz.rs
@@ -6,6 +6,7 @@ mod common;
 
 use libfuzzer_sys::{Corpus, fuzz_target};
 use shuck_ast::Span;
+use shuck_parser::parser::{ParseResult, ParseStatus};
 
 fuzz_target!(|data: &[u8]| -> Corpus {
     let input = match common::filtered_input(data) {
@@ -21,15 +22,17 @@ fuzz_target!(|data: &[u8]| -> Corpus {
     Corpus::Keep
 });
 
-fn validate_recovered_parse(source: &str, recovered: &shuck_parser::parser::RecoveredParse) {
-    common::assert_span_valid(recovered.file.span, source);
-    assert_eq!(
-        recovered.file.span.end.offset,
-        source.len(),
-        "recovered parse should cover the full source"
-    );
+fn validate_recovered_parse(source: &str, parse_result: &ParseResult) {
+    common::assert_span_valid(parse_result.file.span, source);
+    if parse_result.status != ParseStatus::Fatal {
+        assert_eq!(
+            parse_result.file.span.end.offset,
+            source.len(),
+            "non-fatal parse should cover the full source"
+        );
+    }
 
-    for diagnostic in &recovered.diagnostics {
+    for diagnostic in &parse_result.diagnostics {
         common::assert_span_valid(diagnostic.span, source);
         assert!(
             !diagnostic.message.trim().is_empty(),
@@ -37,7 +40,48 @@ fn validate_recovered_parse(source: &str, recovered: &shuck_parser::parser::Reco
         );
     }
 
-    validate_non_overlapping_root_span(recovered.file.span, source);
+    for span in &parse_result.syntax_facts.zsh_brace_if_spans {
+        common::assert_span_valid(*span, source);
+    }
+
+    for span in &parse_result.syntax_facts.zsh_always_spans {
+        common::assert_span_valid(*span, source);
+    }
+
+    for part in &parse_result.syntax_facts.zsh_case_group_parts {
+        common::assert_span_valid(part.span, source);
+    }
+
+    match parse_result.status {
+        ParseStatus::Clean => {
+            assert!(
+                parse_result.diagnostics.is_empty(),
+                "clean parses should not emit recovery diagnostics"
+            );
+            assert!(
+                parse_result.terminal_error.is_none(),
+                "clean parses should not carry a terminal error"
+            );
+        }
+        ParseStatus::Recovered => {
+            assert!(
+                !parse_result.diagnostics.is_empty(),
+                "recovered parses should include diagnostics"
+            );
+            assert!(
+                parse_result.terminal_error.is_none(),
+                "recovered parses should not carry a terminal error"
+            );
+        }
+        ParseStatus::Fatal => {
+            assert!(
+                parse_result.terminal_error.is_some(),
+                "fatal parses should carry a terminal error"
+            );
+        }
+    }
+
+    validate_non_overlapping_root_span(parse_result.file.span, source);
 }
 
 fn validate_non_overlapping_root_span(span: Span, source: &str) {


### PR DESCRIPTION
## Summary

- replace the split strict/recovered parser API with a single recovery-capable `ParseResult` contract
- teach the parser to collect targeted Zsh syntax facts during the main parse so portability rules no longer need cross-dialect reparses
- update the linter, CLI, large-corpus harness, benchmarks, formatter, semantic helpers, and fuzz targets to consume the single parse result

## Why

This removes the two remaining parse-again paths in the workspace: the check command fallback from strict to recovered parsing, and the parse-diagnostic portability checks that reparsed as Zsh to detect specific constructs. The parser now returns the AST, recovery diagnostics, parse status, terminal error, and syntax facts in one pass.

## Validation

- cargo test -p shuck-parser
- cargo test -p shuck-linter
- cargo test -p shuck --lib
- cargo test -p shuck-formatter -p shuck-semantic
- cargo check -p shuck-benchmark --benches
- cargo check --manifest-path fuzz/Cargo.toml --bins
