### PR TITLE
Skip patch files in large corpus

### DIFF
--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1540,8 +1540,7 @@ fn classify_fixture_noise(
 }
 
 fn fixture_looks_like_patch(fixture: &LargeCorpusFixture) -> bool {
-    let path = fixture.path.to_string_lossy().to_lowercase();
-    path.ends_with(".patch") || path.ends_with(".diff") || path.ends_with(".dpatch")
+    path_is_patch_file(&fixture.path)
 }
 
 fn fixture_looks_like_fish(fixture: &LargeCorpusFixture, src: &[u8]) -> bool {
@@ -1669,6 +1668,7 @@ fn fixture_supported_for_large_corpus(
 ) -> bool {
     if path_is_sample_file(&fixture.path)
         || path_is_fish_file(&fixture.path)
+        || path_is_patch_file(&fixture.path)
         || fixture_is_repo_git_entry(fixture)
     {
         return false;
@@ -1683,6 +1683,7 @@ fn fixture_supported_for_large_corpus(
 fn fixture_selected_for_large_corpus_zsh_parse(fixture: &LargeCorpusFixture) -> bool {
     if path_is_sample_file(&fixture.path)
         || path_is_fish_file(&fixture.path)
+        || path_is_patch_file(&fixture.path)
         || fixture_is_repo_git_entry(fixture)
     {
         return false;
@@ -1724,6 +1725,11 @@ fn path_is_sample_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.ends_with(".sample"))
+}
+
+fn path_is_patch_file(path: &Path) -> bool {
+    let path = path.to_string_lossy().to_lowercase();
+    path.ends_with(".patch") || path.ends_with(".diff") || path.ends_with(".dpatch")
 }
 
 fn path_is_fish_file(path: &Path) -> bool {
@@ -1948,7 +1954,7 @@ fn collect_fixtures(corpus_dir: &Path) -> Vec<LargeCorpusFixture> {
         }
 
         let path = entry.path().to_path_buf();
-        if path_is_sample_file(&path) || path_is_fish_file(&path) {
+        if path_is_sample_file(&path) || path_is_fish_file(&path) || path_is_patch_file(&path) {
             continue;
         }
         let cache_rel_path = path
@@ -3191,6 +3197,20 @@ mod tests {
     }
 
     #[test]
+    fn patch_files_are_skipped_for_large_corpus() {
+        let fixture = LargeCorpusFixture {
+            path: PathBuf::from("patches/fixup.patch"),
+            cache_rel_path: PathBuf::from("patches/fixup.patch"),
+            shell: "sh".into(),
+            source_hash: String::new(),
+        };
+
+        assert!(path_is_patch_file(&fixture.path));
+        assert!(!fixture_supported_for_large_corpus(&fixture, None));
+        assert!(!fixture_selected_for_large_corpus_zsh_parse(&fixture));
+    }
+
+    #[test]
     fn shellcheck_parse_abort_classification() {
         let aborted = vec![
             ShellCheckDiagnostic {
@@ -3835,7 +3855,7 @@ mod tests {
     }
 
     #[test]
-    fn collect_fixtures_skips_sample_and_fish_files() {
+    fn collect_fixtures_skips_sample_fish_and_patch_files() {
         let tempdir = tempfile::tempdir().unwrap();
         let scripts_dir = tempdir.path().join("scripts");
         let nested_dir = scripts_dir.join("nested");
@@ -3848,12 +3868,14 @@ mod tests {
         )
         .unwrap();
         fs::write(scripts_dir.join("config.fish"), "echo skip\n").unwrap();
+        fs::write(scripts_dir.join("fixup.patch"), "--- a/file\n+++ b/file\n").unwrap();
         fs::write(
             nested_dir.join("post-checkout.sample"),
             "#!/bin/sh\necho skip\n",
         )
         .unwrap();
         fs::write(nested_dir.join("prompt.fish"), "echo skip\n").unwrap();
+        fs::write(nested_dir.join("fixup.diff"), "--- a/file\n+++ b/file\n").unwrap();
 
         let fixtures = collect_fixtures(tempdir.path());
         let collected_paths: Vec<_> = fixtures


### PR DESCRIPTION
## Summary
- skip `.patch`, `.diff`, and `.dpatch` fixtures when collecting large-corpus inputs
- apply the same patch-file exclusion in both the main large-corpus selection path and the zsh parse selection path
- add regression tests for fixture selection and fixture collection

## Why
Patch files were still entering the large-corpus harness and only being labeled as `patch-file` later. That let them show up in compatibility reporting even though they should have been excluded from the run entirely.

## Validation
- cargo test -p shuck --test large_corpus patch_files_are_skipped_for_large_corpus -- --nocapture
- cargo test -p shuck --test large_corpus collect_fixtures_skips_sample_fish_and_patch_files -- --nocapture
- cargo fmt --all --check
