### PR TITLE
Fix S004 declaration assignment shell handling

### DIFF
--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -1,5 +1,5 @@
 use crate::SubstitutionHostKind;
-use crate::{Checker, CommandSubstitutionKind, Rule, Violation};
+use crate::{Checker, CommandSubstitutionKind, Rule, ShellDialect, Violation};
 
 pub struct UnquotedCommandSubstitution;
 
@@ -28,11 +28,12 @@ pub fn unquoted_command_substitution(checker: &mut Checker) {
                         substitution.host_kind(),
                         SubstitutionHostKind::CommandArgument
                             | SubstitutionHostKind::HereStringOperand
-                            | SubstitutionHostKind::DeclarationAssignmentValue
                             | SubstitutionHostKind::AssignmentTargetSubscript
                             | SubstitutionHostKind::DeclarationNameSubscript
                             | SubstitutionHostKind::ArrayKeySubscript
-                    )
+                    ) || (substitution.host_kind()
+                        == SubstitutionHostKind::DeclarationAssignmentValue
+                        && checker.shell() == ShellDialect::Sh)
                 })
                 .map(|substitution| substitution.span())
         })
@@ -44,7 +45,7 @@ pub fn unquoted_command_substitution(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_inner_command_substitution_spans() {
@@ -125,14 +126,36 @@ declare -A map=([$(printf key)]=1)
     }
 
     #[test]
-    fn reports_declaration_assignment_value_substitutions() {
+    fn ignores_declaration_assignment_value_substitutions() {
+        let source = "\
+local name=$(printf local)
+declare other=$(printf declare)
+printf '%s\\n' $(printf arg)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(printf arg)"]
+        );
+    }
+
+    #[test]
+    fn reports_declaration_assignment_value_substitutions_in_sh() {
         let source = "\
 local name=$(printf local)
 declare other=$(printf declare)
 ";
         let diagnostics = test_snippet(
             source,
-            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution)
+                .with_shell(ShellDialect::Sh),
         );
 
         assert_eq!(


### PR DESCRIPTION
## Summary
- make `S004` treat declaration-assignment command substitutions as shell-sensitive instead of always warning
- keep `SC2046` parity for `sh` files while suppressing the false positive in bash-like files such as `git-completion.bash`
- add focused regressions for both the bash-like and `sh` behaviors

## Why
The remaining full-corpus `S004` implementation diff came from a bash completion script using `local expansion=$(__git_aliased_command "$command")`. Shuck was still reporting that as an unquoted argument split hazard, but ShellCheck only reports this declaration-assignment pattern in `sh`-style files.

## Impact
This narrows `S004` to the shell boundary the oracle expects: bash-like declaration assignments stop producing false positives, while `sh` declaration assignments continue to warn.

## Validation
- `cargo test -p shuck-linter unquoted_command_substitution -- --nocapture`
- `cargo fmt --all --check`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=S004 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`