### PR TITLE
Fix S017 false positives for quoted heredoc substitutions

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -15741,6 +15741,104 @@ arr=(\"$(printf '%s\\n' \"$x\")\")
     }
 
     #[test]
+    fn array_assignment_split_facts_keep_heredoc_substitutions_as_single_words() {
+        let source = "\
+#!/bin/bash
+arr=(\"$(
+  cat <<-EOF
+    repository(owner: \\\"${project%/*}\\\", name: \\\"${project##*/}\\\")
+EOF
+)\")
+";
+
+        with_facts(source, None, |_, facts| {
+            let split_words = facts
+                .array_assignment_split_word_facts()
+                .map(|fact| fact.span().slice(source).to_owned())
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                split_words,
+                vec![
+                    "\"$(\n  cat <<-EOF\n    repository(owner: \\\"${project%/*}\\\", name: \\\"${project##*/}\\\")\nEOF\n)\""
+                ]
+            );
+        });
+    }
+
+    #[test]
+    fn array_assignment_split_facts_keep_pipelined_heredoc_substitutions_as_single_words() {
+        let source = "\
+#!/bin/bash
+arr=(\"$(
+  cat <<-EOF | tr '\\n' ' '
+    {
+      \\\"query\\\": \\\"query {
+        repository(owner: \\\"${project%/*}\\\", name: \\\"${project##*/}\\\") {
+          refs(refPrefix: \\\"refs/tags/\\\")
+        }
+      }\\\"
+    }
+EOF
+)\")
+";
+
+        with_facts(source, None, |_, facts| {
+            let split_words = facts
+                .array_assignment_split_word_facts()
+                .map(|fact| fact.span().slice(source).to_owned())
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                split_words,
+                vec![
+                    "\"$(\n  cat <<-EOF | tr '\\n' ' '\n    {\n      \\\"query\\\": \\\"query {\n        repository(owner: \\\"${project%/*}\\\", name: \\\"${project##*/}\\\") {\n          refs(refPrefix: \\\"refs/tags/\\\")\n        }\n      }\\\"\n    }\nEOF\n)\""
+                ]
+            );
+        });
+    }
+
+    #[test]
+    fn array_assignment_split_facts_track_realistic_pipelined_heredoc_substitutions() {
+        let source = r#"# shellcheck shell=bash
+project=owner/repo
+graphql_request=(
+  -X POST
+  -d "$(
+    cat <<-EOF | tr '\n' ' '
+      {
+        "query": "query {
+          repository(owner: \"${project%/*}\", name: \"${project##*/}\") {
+            refs(refPrefix: \"refs/tags/\")
+          }
+        }"
+      }
+EOF
+  )"
+)
+"#;
+
+        with_facts(source, None, |_, facts| {
+            let split_facts = facts
+                .array_assignment_split_word_facts()
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                split_facts
+                    .iter()
+                    .map(|fact| fact.span().slice(source))
+                    .collect::<Vec<_>>(),
+                vec![
+                    "-X",
+                    "POST",
+                    "-d",
+                    "\"$(\n    cat <<-EOF | tr '\\n' ' '\n      {\n        \"query\": \"query {\n          repository(owner: \\\"${project%/*}\\\", name: \\\"${project##*/}\\\") {\n            refs(refPrefix: \\\"refs/tags/\\\")\n          }\n        }\"\n      }\nEOF\n  )\"",
+                ]
+            );
+        });
+    }
+
+    #[test]
     fn shared_command_traversal_collects_word_facts_and_surface_fragments() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
@@ -141,6 +141,33 @@ arr=(\"$(printf '%s\\n' \"$x\")\")
     }
 
     #[test]
+    fn ignores_expansions_inside_quoted_pipelined_heredoc_substitutions() {
+        let source = r#"# shellcheck shell=bash
+project=owner/repo
+graphql_request=(
+  -X POST
+  -d "$(
+    cat <<-EOF | tr '\n' ' '
+      {
+        "query": "query {
+          repository(owner: \"${project%/*}\", name: \"${project##*/}\") {
+            refs(refPrefix: \"refs/tags/\")
+          }
+        }"
+      }
+EOF
+  )"
+)
+"#;
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedArraySplit));
+        let slices = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.span.slice(source))
+            .collect::<Vec<_>>();
+        assert_eq!(slices, Vec::<&str>::new());
+    }
+
+    #[test]
     fn ignores_safe_special_parameters() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1004,6 +1004,54 @@ fn test_unquoted_backtick_substitution_can_contain_spaces() {
 }
 
 #[test]
+fn test_compound_array_keeps_quoted_pipelined_heredoc_substitution_as_one_element() {
+    let input = r#"# shellcheck shell=bash
+project=owner/repo
+graphql_request=(
+  -X POST
+  -d "$(
+    cat <<-EOF | tr '\n' ' '
+      {
+        "query": "query {
+          repository(owner: \"${project%/*}\", name: \"${project##*/}\") {
+            refs(refPrefix: \"refs/tags/\")
+          }
+        }"
+      }
+EOF
+  )"
+)
+"#;
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[1].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Compound(array) = &command.assignments[0].value else {
+        panic!("expected compound assignment");
+    };
+
+    assert_eq!(array.elements.len(), 4);
+    let rendered = array
+        .elements
+        .iter()
+        .map(|element| match element {
+            ArrayElem::Sequential(word) => word.span.slice(input).to_owned(),
+            _ => panic!("expected sequential array element"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        rendered,
+        vec![
+            "-X",
+            "POST",
+            "-d",
+            "\"$(\n    cat <<-EOF | tr '\\n' ' '\n      {\n        \"query\": \"query {\n          repository(owner: \\\"${project%/*}\\\", name: \\\"${project##*/}\\\") {\n            refs(refPrefix: \\\"refs/tags/\\\")\n          }\n        }\"\n      }\nEOF\n  )\"",
+        ]
+    );
+}
+
+#[test]
 fn test_brace_syntax_marks_unquoted_expansion_candidates() {
     let list_input = "{a,b}";
     let list = Parser::parse_word_string(list_input);

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -877,6 +877,14 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
+            if ch == '$'
+                && !in_single
+                && let Some(end) = Self::scan_raw_dollar_paren_substitution_end(inner, index)
+            {
+                index = end;
+                continue;
+            }
+
             match ch {
                 '\\' if !in_single => escaped = true,
                 '\'' if !in_double => in_single = !in_single,
@@ -932,6 +940,17 @@ impl<'a> Parser<'a> {
         }
 
         ranges
+    }
+
+    fn scan_raw_dollar_paren_substitution_end(raw: &str, start: usize) -> Option<usize> {
+        let tail = raw.get(start..)?;
+        if !tail.starts_with("$(") || tail[2..].starts_with('(') {
+            return None;
+        }
+
+        let body_start = start + 2;
+        let consumed = lexer::scan_command_substitution_body_len(&raw[body_start..])?;
+        Some(body_start + consumed)
     }
 
     fn raw_source_hash_starts_comment(source: &str, index: usize) -> bool {
@@ -1094,6 +1113,15 @@ impl<'a> Parser<'a> {
 
             if escaped {
                 escaped = false;
+                continue;
+            }
+
+            if ch == '$'
+                && !in_single
+                && let Some(end) =
+                    Self::scan_raw_dollar_paren_substitution_end(self.input, ch_start.offset)
+            {
+                cursor = ch_start.advanced_by(&self.input[ch_start.offset..end]);
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- fix the compound-array parser so `$()` command substitutions are treated as opaque while raw array elements are split
- stop `S017` from flagging quoted pipelined heredoc substitutions inside array assignments
- add parser, facts, and rule regressions covering the Termux-shaped reproducer

## Root Cause
The raw compound-array element scanner was tracking quote state through heredoc body text inside a `$(...)` substitution. In the failing `-d "$()"` GraphQL payload shape, the heredoc line containing `"query {` flipped the outer quote state and caused one logical array element to be split into multiple faux elements, which then surfaced as `S017` false positives.

## Impact
This fixes the live `S017` compatibility diff for `termux_github_api_get_tag.sh` without changing the intended warnings for genuinely unquoted array-splitting cases.

## Testing
- `cargo fmt`
- `cargo test -p shuck-parser test_compound_array_keeps_quoted_pipelined_heredoc_substitution_as_one_element -- --nocapture`
- `cargo test -p shuck-linter unquoted_array_split -- --nocapture`
- `cargo test -p shuck-linter array_assignment_split_facts_track_realistic_pipelined_heredoc_substitutions -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S017`

`make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S017` now reports `large_corpus_conforms_with_shellcheck ... ok` for `S017`. The overall target still exits non-zero because of pre-existing unrelated zsh parse-timeout harness failures in `ohmyzsh__ohmyzsh__plugins__emoji__emoji-char-definitions.zsh` and `romkatv__powerlevel10k__internal__p10k.zsh`.
