### PR TITLE
Tighten C151 array comma detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12422,9 +12422,11 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
     let text = word.span.slice(source);
     let mut index = 0usize;
     let mut in_single = false;
+    let mut in_ansi_c_single = false;
     let mut in_double = false;
     let mut in_backtick = false;
     let mut escaped = false;
+    let mut ansi_c_quote_pending = false;
 
     while index < text.len() {
         let ch = text[index..]
@@ -12435,15 +12437,17 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
         let was_escaped = escaped;
         if ch == '\\' && !in_single {
             escaped = !escaped;
+            ansi_c_quote_pending = false;
             index = next_index;
             continue;
         }
         escaped = false;
 
-        if !in_single && !in_backtick && !was_escaped && ch == '$' {
+        if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped && ch == '$' {
             if text[next_index..].starts_with("((")
                 && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
             {
+                ansi_c_quote_pending = false;
                 index = next_index + 2 + consumed;
                 continue;
             }
@@ -12453,6 +12457,7 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
                 && let Some(consumed) =
                     scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])
             {
+                ansi_c_quote_pending = false;
                 index = next_index + '('.len_utf8() + consumed;
                 continue;
             }
@@ -12461,12 +12466,14 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
                 && let Some(consumed) =
                     scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])
             {
+                ansi_c_quote_pending = false;
                 index = next_index + '{'.len_utf8() + consumed;
                 continue;
             }
         }
 
         if !in_single
+            && !in_ansi_c_single
             && !in_double
             && !in_backtick
             && !was_escaped
@@ -12475,15 +12482,26 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
             && let Some(consumed) =
                 scan_array_process_substitution_len(&text[next_index + '('.len_utf8()..])
         {
+            ansi_c_quote_pending = false;
             index = next_index + '('.len_utf8() + consumed;
             continue;
         }
 
         match ch {
-            '\'' if !in_double && !was_escaped => in_single = !in_single,
-            '"' if !in_single && !was_escaped => in_double = !in_double,
-            '`' if !in_single && !in_double && !was_escaped => in_backtick = !in_backtick,
-            ',' if !in_single && !in_double && !in_backtick => {
+            '\'' if !in_double && !in_backtick && !was_escaped => {
+                if in_ansi_c_single {
+                    in_ansi_c_single = false;
+                } else if !in_single && ansi_c_quote_pending {
+                    in_ansi_c_single = true;
+                } else {
+                    in_single = !in_single;
+                }
+            }
+            '"' if !in_single && !in_ansi_c_single && !was_escaped => in_double = !in_double,
+            '`' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                in_backtick = !in_backtick
+            }
+            ',' if !in_single && !in_ansi_c_single && !in_double && !in_backtick => {
                 let comma_offset = word.span.start.offset + index;
                 if !comma_is_brace_separator(word, source, comma_offset, was_escaped) {
                     return true;
@@ -12492,6 +12510,12 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
             _ => {}
         }
 
+        ansi_c_quote_pending = ch == '$'
+            && !in_single
+            && !in_ansi_c_single
+            && !in_double
+            && !in_backtick
+            && !was_escaped;
         index = next_index;
     }
 
@@ -13570,6 +13594,26 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_after_even_backslashes_before_quote_regions() {
         let source = "#!/bin/bash\na=(x\\\\\",y\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_ansi_c_quoted_array_elements() {
+        let source = "#!/bin/bash\na=($'a\\'b,c')\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12503,25 +12503,60 @@ fn next_char_boundary(text: &str, index: usize) -> Option<(char, usize)> {
     Some((ch, index + ch.len_utf8()))
 }
 
-fn inside_unclosed_double_paren_on_line(text: &str, index: usize) -> bool {
-    let line_start = text[..index].rfind('\n').map_or(0, |found| found + 1);
-    let prefix = &text[line_start..index];
-    let mut chars = prefix.chars().peekable();
+fn line_has_unclosed_double_paren(prefix: &str) -> bool {
+    let mut index = 0usize;
     let mut depth = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_backtick = false;
+    let mut escaped = false;
 
-    while let Some(ch) = chars.next() {
-        if ch == '(' && chars.peek() == Some(&'(') {
-            chars.next();
-            depth += 1;
+    while let Some((ch, next_index)) = next_char_boundary(prefix, index) {
+        let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
             continue;
         }
-        if ch == ')' && chars.peek() == Some(&')') {
-            chars.next();
-            depth = depth.saturating_sub(1);
+        escaped = false;
+
+        match ch {
+            '\'' if !in_double && !in_backtick && !was_escaped => in_single = !in_single,
+            '"' if !in_single && !in_backtick && !was_escaped => in_double = !in_double,
+            '`' if !in_single && !in_double && !was_escaped => in_backtick = !in_backtick,
+            '(' if !in_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && prefix[next_index..].starts_with('(') =>
+            {
+                depth += 1;
+                index = next_index + '('.len_utf8();
+                continue;
+            }
+            ')' if !in_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && prefix[next_index..].starts_with(')') =>
+            {
+                depth = depth.saturating_sub(1);
+                index = next_index + ')'.len_utf8();
+                continue;
+            }
+            _ => {}
         }
+
+        index = next_index;
     }
 
     depth > 0
+}
+
+fn inside_unclosed_double_paren_on_line(text: &str, index: usize) -> bool {
+    let line_start = text[..index].rfind('\n').map_or(0, |found| found + 1);
+    let prefix = &text[line_start..index];
+    line_has_unclosed_double_paren(prefix)
 }
 
 fn hash_starts_comment(text: &str, index: usize) -> bool {
@@ -12768,6 +12803,11 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                     &mut pending_case_headers,
                     &mut case_clause_depth,
                 );
+                if inside_unclosed_double_paren_on_line(text, index) {
+                    index = next_index + '<'.len_utf8();
+                    continue;
+                }
+
                 if text[next_index + '('.len_utf8()..].starts_with('<') {
                     index = next_index + '<'.len_utf8() + '<'.len_utf8();
                     continue;
@@ -13712,6 +13752,46 @@ complex[$((i+=1))]+=x
     }
 
     #[test]
+    fn ignores_commas_inside_comments_after_quoted_double_parens() {
+        let source = "#!/bin/bash\na=($(printf '((' # comment with )\nprintf %s 1,2\n))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_arithmetic_shift_command_substitutions() {
+        let source = "#!/bin/bash\na=($( ((x<<2))\nprintf %s 1,2\n))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn hash_starts_comment_ignores_zsh_inline_glob_controls_after_left_paren() {
         let source = "[[ \"$buf\" == (#b)(*) ]]";
         let index = source.find('#').expect("expected hash");
@@ -13725,6 +13805,14 @@ complex[$((i+=1))]+=x
         let index = source.find('#').expect("expected hash");
 
         assert!(!super::hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn hash_starts_comment_respects_quoted_double_parens() {
+        let source = "printf '((' # comment";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(super::hash_starts_comment(source, index));
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12490,10 +12490,40 @@ fn next_char_boundary(text: &str, index: usize) -> Option<(char, usize)> {
     Some((ch, index + ch.len_utf8()))
 }
 
+fn inside_unclosed_double_paren_on_line(text: &str, index: usize) -> bool {
+    let line_start = text[..index].rfind('\n').map_or(0, |found| found + 1);
+    let prefix = &text[line_start..index];
+    let mut chars = prefix.chars().peekable();
+    let mut depth = 0usize;
+
+    while let Some(ch) = chars.next() {
+        if ch == '(' && chars.peek() == Some(&'(') {
+            chars.next();
+            depth += 1;
+            continue;
+        }
+        if ch == ')' && chars.peek() == Some(&')') {
+            chars.next();
+            depth = depth.saturating_sub(1);
+        }
+    }
+
+    depth > 0
+}
+
 fn hash_starts_comment(text: &str, index: usize) -> bool {
-    text[..index].chars().next_back().is_none_or(|prev| {
-        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | '(' | ')')
-    })
+    if inside_unclosed_double_paren_on_line(text, index) {
+        return false;
+    }
+
+    let next = text[index + '#'.len_utf8()..].chars().next();
+    text[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|prev| match prev {
+            '(' => next.is_none_or(char::is_whitespace),
+            _ => prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | ')'),
+        })
 }
 
 fn flush_array_command_subst_keyword(
@@ -13623,6 +13653,22 @@ complex[$((i+=1))]+=x
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn hash_starts_comment_ignores_zsh_inline_glob_controls_after_left_paren() {
+        let source = "[[ \"$buf\" == (#b)(*) ]]";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(!super::hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn hash_starts_comment_ignores_hash_inside_unclosed_double_parens() {
+        let source = "(( #c < 256 ))";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(!super::hash_starts_comment(source, index));
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12543,6 +12543,11 @@ fn scan_array_double_quoted_command_substitution_segment(
                     index = escaped_next;
                 }
             }
+            '$' if text[next_index..].starts_with('{') => {
+                let consumed =
+                    scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])?;
+                index = next_index + '{'.len_utf8() + consumed;
+            }
             '$' if text[next_index..].starts_with('(')
                 && !text[next_index + '('.len_utf8()..].starts_with('(') =>
             {
@@ -12748,6 +12753,16 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                         text, index, &delimiter, strip_tabs,
                     );
                 }
+            }
+            '$' if text[next_index..].starts_with('{') => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                let consumed =
+                    scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])?;
+                index = next_index + '{'.len_utf8() + consumed;
             }
             '$' if text[next_index..].starts_with('(')
                 && !text[next_index + '('.len_utf8()..].starts_with('(') =>
@@ -13553,6 +13568,26 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_piped_heredoc_command_substitution_array_elements() {
         let source = "#!/bin/bash\na=(\"$(cat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_parameter_expansions_with_right_parens_in_command_substitutions() {
+        let source = "#!/bin/bash\na=($(printf %s ${x//foo/)},1))\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12466,6 +12466,19 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
             }
         }
 
+        if !in_single
+            && !in_double
+            && !in_backtick
+            && !was_escaped
+            && matches!(ch, '<' | '>')
+            && text[next_index..].starts_with('(')
+            && let Some(consumed) =
+                scan_array_process_substitution_len(&text[next_index + '('.len_utf8()..])
+        {
+            index = next_index + '('.len_utf8() + consumed;
+            continue;
+        }
+
         match ch {
             '\'' if !in_double && !was_escaped => in_single = !in_single,
             '"' if !in_single && !was_escaped => in_double = !in_double,
@@ -12885,6 +12898,10 @@ fn scan_array_arithmetic_expansion_len(text: &str) -> Option<usize> {
     }
 
     None
+}
+
+fn scan_array_process_substitution_len(text: &str) -> Option<usize> {
+    scan_array_command_substitution_len(text)
 }
 
 fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
@@ -13638,6 +13655,26 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_case_pattern_comments_after_right_parens() {
         let source = "#!/bin/bash\na=($(case $kind in\na)# comment with esac )\nprintf %s 1,2 ;;\nesac\n))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_process_substitution_array_elements() {
+        let source = "#!/bin/bash\na=(<(printf %s 1,2))\nb=(>(printf %s 3,4))\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12433,9 +12433,14 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
             .expect("index is within bounds while scanning array comma candidates");
         let next_index = index + ch.len_utf8();
         let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
+            continue;
+        }
         escaped = false;
 
-        if !in_single && !in_backtick && ch == '$' {
+        if !in_single && !in_backtick && !was_escaped && ch == '$' {
             if text[next_index..].starts_with("((")
                 && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
             {
@@ -12462,7 +12467,6 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
         }
 
         match ch {
-            '\\' if !in_single => escaped = true,
             '\'' if !in_double && !was_escaped => in_single = !in_single,
             '"' if !in_single && !was_escaped => in_double = !in_double,
             '`' if !in_single && !in_double && !was_escaped => in_backtick = !in_backtick,
@@ -12784,9 +12788,14 @@ fn scan_array_arithmetic_expansion_len(text: &str) -> Option<usize> {
 
     while let Some((ch, next_index)) = next_char_boundary(text, index) {
         let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
+            continue;
+        }
         escaped = false;
 
-        if !in_single && ch == '$' {
+        if !in_single && !was_escaped && ch == '$' {
             if text[next_index..].starts_with("((")
                 && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
             {
@@ -12813,7 +12822,6 @@ fn scan_array_arithmetic_expansion_len(text: &str) -> Option<usize> {
         }
 
         match ch {
-            '\\' if !in_single => escaped = true,
             '\'' if !in_double && !was_escaped => in_single = !in_single,
             '"' if !in_single && !was_escaped => in_double = !in_double,
             '(' if !in_single && !in_double && !was_escaped => depth += 1,
@@ -12843,9 +12851,14 @@ fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
 
     while let Some((ch, next_index)) = next_char_boundary(text, index) {
         let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
+            continue;
+        }
         escaped = false;
 
-        if !in_single && ch == '$' {
+        if !in_single && !was_escaped && ch == '$' {
             if text[next_index..].starts_with("((")
                 && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
             {
@@ -12864,7 +12877,6 @@ fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
         }
 
         match ch {
-            '\\' if !in_single => escaped = true,
             '\'' if !in_double && !was_escaped => in_single = !in_single,
             '"' if !in_single && !was_escaped => in_double = !in_double,
             '{' if !in_single && !in_double && !was_escaped => depth += 1,
@@ -12915,16 +12927,19 @@ fn inside_unquoted_brace_group(word: &Word, source: &str, target_offset: usize) 
             return brace_depth > 0;
         }
 
-        if escaped {
+        let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            continue;
+        }
+        escaped = false;
+
+        if was_escaped {
             escaped = false;
             continue;
         }
 
         match ch {
-            '\\' if !in_single => {
-                escaped = true;
-                continue;
-            }
             '\'' if !in_double => {
                 in_single = !in_single;
                 continue;
@@ -13410,7 +13425,7 @@ complex[$((i+=1))]+=x
 
     #[test]
     fn collects_comma_array_assignment_spans_from_compound_values() {
-        let source = "#!/bin/bash\na=(alpha,beta)\nb=(\"alpha,beta\")\nc=({x,y})\nd=([k]=v, [q]=w)\ne=(x,$y)\nf=(x\\, y)\ng=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)\nh=(foo,{x,y},bar)\n";
+        let source = "#!/bin/bash\na=(alpha,beta)\nb=(\"alpha,beta\")\nc=({x,y})\nd=([k]=v, [q]=w)\ne=(x,$y)\nf=(x\\, y)\ng=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)\nh=(foo,{x,y},bar)\ni=(\\$((1,2)))\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -13428,8 +13443,29 @@ complex[$((i+=1))]+=x
                 "([k]=v, [q]=w)",
                 "(x,$y)",
                 "(x\\, y)",
-                "(foo,{x,y},bar)"
+                "(foo,{x,y},bar)",
+                "(\\$((1,2)))"
             ]
+        );
+    }
+
+    #[test]
+    fn ignores_commas_after_even_backslashes_before_quote_regions() {
+        let source = "#!/bin/bash\na=(x\\\\\",y\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12906,7 +12906,6 @@ fn scan_array_process_substitution_len(text: &str) -> Option<usize> {
 
 fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
     let mut index = 0usize;
-    let mut depth = 1usize;
     let mut in_single = false;
     let mut in_double = false;
     let mut escaped = false;
@@ -12921,6 +12920,14 @@ fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
         escaped = false;
 
         if !in_single && !was_escaped && ch == '$' {
+            if text[next_index..].starts_with('{')
+                && let Some(consumed) =
+                    scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])
+            {
+                index = next_index + '{'.len_utf8() + consumed;
+                continue;
+            }
+
             if text[next_index..].starts_with("((")
                 && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
             {
@@ -12941,15 +12948,7 @@ fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
         match ch {
             '\'' if !in_double && !was_escaped => in_single = !in_single,
             '"' if !in_single && !was_escaped => in_double = !in_double,
-            '{' if !in_single && !in_double && !was_escaped => depth += 1,
-            '}' if !in_single && !in_double && !was_escaped => {
-                depth -= 1;
-                index = next_index;
-                if depth == 0 {
-                    return Some(index);
-                }
-                continue;
-            }
+            '}' if !in_single && !in_double && !was_escaped => return Some(next_index),
             _ => {}
         }
 
@@ -13635,6 +13634,26 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_parameter_expansions_with_right_parens_in_command_substitutions() {
         let source = "#!/bin/bash\na=($(printf %s ${x//foo/)},1))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_parameter_expansions_with_literal_braces() {
+        let source = "#!/bin/bash\na=(${x/a,b/{})\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12612,24 +12612,27 @@ fn flush_array_command_subst_keyword(
     pending_case_headers: &mut usize,
     case_clause_depths: &mut Vec<usize>,
     depth: usize,
+    word_started_at_command_start: &mut bool,
 ) {
     if current_word.is_empty() {
+        *word_started_at_command_start = false;
         return;
     }
 
     match current_word.as_str() {
-        "case" => *pending_case_headers += 1,
+        "case" if *word_started_at_command_start => *pending_case_headers += 1,
         "in" if *pending_case_headers > 0 => {
             *pending_case_headers -= 1;
             case_clause_depths.push(depth);
         }
-        "esac" => {
+        "esac" if *word_started_at_command_start => {
             case_clause_depths.pop();
         }
         _ => {}
     }
 
     current_word.clear();
+    *word_started_at_command_start = false;
 }
 
 fn heredoc_delimiter_is_terminator(
@@ -12716,6 +12719,29 @@ fn scan_array_command_subst_heredoc_delimiter(
     (index > start).then_some((index, cooked))
 }
 
+fn scan_array_ansi_c_single_quoted_command_substitution_segment(
+    text: &str,
+    quote_index: usize,
+) -> Option<usize> {
+    let mut index = quote_index + '\''.len_utf8();
+
+    while let Some((ch, next_index)) = next_char_boundary(text, index) {
+        index = next_index;
+        if ch == '\\' {
+            if let Some((_, escaped_next)) = next_char_boundary(text, index) {
+                index = escaped_next;
+            }
+            continue;
+        }
+
+        if ch == '\'' {
+            return Some(index);
+        }
+    }
+
+    None
+}
+
 fn skip_array_command_subst_pending_heredoc(
     text: &str,
     mut index: usize,
@@ -12753,16 +12779,24 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
     let mut pending_case_headers = 0usize;
     let mut case_clause_depths = Vec::new();
     let mut current_word = String::with_capacity(16);
+    let mut at_command_start = true;
+    let mut expecting_redirection_target = false;
+    let mut current_word_started_at_command_start = false;
 
     while let Some((ch, next_index)) = next_char_boundary(text, index) {
         match ch {
             '#' if hash_starts_comment(text, index) => {
+                let had_word = !current_word.is_empty();
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 index = next_index;
                 while let Some((comment_ch, comment_next)) = next_char_boundary(text, index) {
                     index = comment_next;
@@ -12772,6 +12806,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                                 text, index, &delimiter, strip_tabs,
                             );
                         }
+                        at_command_start = true;
+                        expecting_redirection_target = false;
                         break;
                     }
                 }
@@ -12782,9 +12818,12 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
                 depth += 1;
                 index = next_index;
+                at_command_start = true;
+                expecting_redirection_target = false;
             }
             ')' => {
                 flush_array_command_subst_keyword(
@@ -12792,12 +12831,15 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
                 if case_clause_depths
                     .last()
                     .is_some_and(|case_depth| *case_depth == depth)
                 {
                     index = next_index;
+                    at_command_start = true;
+                    expecting_redirection_target = false;
                     continue;
                 }
                 depth -= 1;
@@ -12805,23 +12847,40 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 if depth == 0 {
                     return Some(index);
                 }
+                at_command_start = false;
+                expecting_redirection_target = false;
             }
             '"' => {
+                let had_word = !current_word.is_empty();
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 index = scan_array_double_quoted_command_substitution_segment(text, next_index)?;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
             '\'' => {
+                let had_word = !current_word.is_empty();
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 index = next_index;
                 while let Some((quoted_ch, quoted_next)) = next_char_boundary(text, index) {
                     index = quoted_next;
@@ -12829,26 +12888,69 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                         break;
                     }
                 }
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
             '\\' => {
+                let had_word = !current_word.is_empty();
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 index = next_index;
                 if let Some((_, escaped_next)) = next_char_boundary(text, index) {
                     index = escaped_next;
                 }
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
-            '<' if text[next_index..].starts_with('<') => {
+            '>' => {
+                let word_was_redirection_fd = current_word_started_at_command_start
+                    && !current_word.is_empty()
+                    && current_word.chars().all(|current| current.is_ascii_digit());
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if word_was_redirection_fd {
+                    at_command_start = true;
+                }
+                index = next_index;
+                expecting_redirection_target = true;
+            }
+            '<' if text[next_index..].starts_with('<') => {
+                let word_was_redirection_fd = current_word_started_at_command_start
+                    && !current_word.is_empty()
+                    && current_word.chars().all(|current| current.is_ascii_digit());
+                let had_word = !current_word.is_empty();
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                if word_was_redirection_fd {
+                    at_command_start = true;
+                }
                 if inside_unclosed_double_paren_on_line(text, index) {
                     index = next_index + '<'.len_utf8();
                     continue;
@@ -12856,6 +12958,7 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
 
                 if text[next_index + '('.len_utf8()..].starts_with('<') {
                     index = next_index + '<'.len_utf8() + '<'.len_utf8();
+                    expecting_redirection_target = true;
                     continue;
                 }
 
@@ -12866,8 +12969,10 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 {
                     pending_heredocs.push((delimiter, strip_tabs));
                     index = delimiter_index;
+                    expecting_redirection_target = false;
                 } else {
                     index = next_index;
+                    expecting_redirection_target = true;
                 }
             }
             '\n' => {
@@ -12876,6 +12981,7 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
                 index = next_index;
                 for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
@@ -12883,41 +12989,105 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                         text, index, &delimiter, strip_tabs,
                     );
                 }
+                at_command_start = true;
+                expecting_redirection_target = false;
             }
-            '$' if text[next_index..].starts_with('{') => {
+            '$' if text[next_index..].starts_with('\'') => {
+                let had_word = !current_word.is_empty();
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index =
+                    scan_array_ansi_c_single_quoted_command_substitution_segment(text, next_index)?;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '$' if text[next_index..].starts_with('{') => {
+                let had_word = !current_word.is_empty();
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 let consumed =
                     scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])?;
                 index = next_index + '{'.len_utf8() + consumed;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
             '$' if text[next_index..].starts_with('(')
                 && !text[next_index + '('.len_utf8()..].starts_with('(') =>
             {
+                let had_word = !current_word.is_empty();
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 let consumed =
                     scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])?;
                 index = next_index + '('.len_utf8() + consumed;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
             _ => {
                 if ch.is_ascii_alphanumeric() || ch == '_' {
+                    if current_word.is_empty() && !expecting_redirection_target && at_command_start
+                    {
+                        current_word_started_at_command_start = true;
+                        at_command_start = false;
+                    }
                     current_word.push(ch);
                 } else {
+                    let had_word = !current_word.is_empty();
                     flush_array_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
                         &mut case_clause_depths,
                         depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
+                    match ch {
+                        ' ' | '\t' => {}
+                        ';' | '|' | '&' => {
+                            at_command_start = true;
+                            expecting_redirection_target = false;
+                        }
+                        _ => {
+                            if !expecting_redirection_target {
+                                at_command_start = false;
+                            }
+                        }
+                    }
                 }
                 index = next_index;
             }
@@ -13884,6 +14054,46 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_nested_case_patterns_in_command_substitutions() {
         let source = "#!/bin/bash\na=($( (case $kind in\na) printf %s 1,2 ;;\nesac\n) ))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_command_substitutions_with_plain_case_words() {
+        let source = "#!/bin/bash\na=($(printf %s 1,2; echo case in))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_command_substitutions_with_ansi_c_single_quotes() {
+        let source = "#!/bin/bash\na=($(printf %s $'a\\'b'; printf %s 1,2))\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12419,23 +12419,313 @@ fn array_value_has_unquoted_comma(array: &shuck_ast::ArrayExpr, source: &str) ->
 }
 
 fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
-    word.parts.iter().any(|part| {
-        let WordPart::Literal(text) = &part.kind else {
-            return false;
-        };
-        let text = text.as_str(source, part.span);
+    let text = word.span.slice(source);
+    let mut index = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_backtick = false;
+    let mut escaped = false;
 
-        text.char_indices().any(|(index, ch)| {
-            if ch != ',' {
-                return false;
+    while index < text.len() {
+        let ch = text[index..]
+            .chars()
+            .next()
+            .expect("index is within bounds while scanning array comma candidates");
+        let next_index = index + ch.len_utf8();
+        let was_escaped = escaped;
+        escaped = false;
+
+        if !in_single
+            && !in_backtick
+            && ch == '$'
+        {
+            if text[next_index..].starts_with('(')
+                && !text[next_index + '('.len_utf8()..].starts_with('(')
+                && let Some(consumed) = scan_array_command_substitution_len(
+                    &text[next_index + '('.len_utf8()..],
+                )
+            {
+                index = next_index + '('.len_utf8() + consumed;
+                continue;
             }
 
-            let prefix = &text[..index];
-            let comma = part.span.start.advanced_by(prefix);
-            let escaped = trailing_backslashes(prefix) % 2 == 1;
-            !comma_is_brace_separator(word, source, comma.offset, escaped)
-        })
-    })
+            if text[next_index..].starts_with('{')
+                && let Some(consumed) =
+                    scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])
+            {
+                index = next_index + '{'.len_utf8() + consumed;
+                continue;
+            }
+        }
+
+        match ch {
+            '\\' if !in_single => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '`' if !in_single && !in_double => in_backtick = !in_backtick,
+            ',' if !in_single && !in_double && !in_backtick => {
+                let comma_offset = word.span.start.offset + index;
+                if !comma_is_brace_separator(word, source, comma_offset, was_escaped) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+
+        index = next_index;
+    }
+
+    false
+}
+
+fn next_char_boundary(text: &str, index: usize) -> Option<(char, usize)> {
+    let ch = text.get(index..)?.chars().next()?;
+    Some((ch, index + ch.len_utf8()))
+}
+
+fn hash_starts_comment(text: &str, index: usize) -> bool {
+    text[..index]
+        .chars()
+        .next_back()
+        .is_none_or(char::is_whitespace)
+}
+
+fn scan_array_double_quoted_command_substitution_segment(
+    text: &str,
+    mut index: usize,
+) -> Option<usize> {
+    while let Some((ch, next_index)) = next_char_boundary(text, index) {
+        match ch {
+            '"' => return Some(next_index),
+            '\\' => {
+                index = next_index;
+                if let Some((_, escaped_next)) = next_char_boundary(text, index) {
+                    index = escaped_next;
+                }
+            }
+            '$'
+                if text[next_index..].starts_with('(')
+                    && !text[next_index + '('.len_utf8()..].starts_with('(') =>
+            {
+                let consumed =
+                    scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])?;
+                index = next_index + '('.len_utf8() + consumed;
+            }
+            _ => index = next_index,
+        }
+    }
+
+    None
+}
+
+fn scan_array_command_subst_heredoc_delimiter(
+    text: &str,
+    mut index: usize,
+) -> Option<(usize, String)> {
+    while let Some((ch, next_index)) = next_char_boundary(text, index) {
+        if !matches!(ch, ' ' | '\t') {
+            break;
+        }
+        index = next_index;
+    }
+
+    let start = index;
+    let mut cooked = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(text, index) {
+        if !in_single && !in_double && !escaped && ch.is_whitespace() {
+            break;
+        }
+
+        index = next_index;
+        if escaped {
+            cooked.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if !in_single => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            _ => cooked.push(ch),
+        }
+    }
+
+    (index > start).then_some((index, cooked))
+}
+
+fn skip_array_command_subst_pending_heredoc(
+    text: &str,
+    mut index: usize,
+    delimiter: &str,
+    strip_tabs: bool,
+) -> usize {
+    while index <= text.len() {
+        let rest = &text[index..];
+        let line_len = rest.find('\n').unwrap_or(rest.len());
+        let line = &rest[..line_len];
+        let has_newline = line_len < rest.len();
+
+        index += line_len;
+        if has_newline {
+            index += '\n'.len_utf8();
+        }
+
+        let matches_delimiter = if strip_tabs {
+            line.trim_start_matches('\t') == delimiter
+        } else {
+            line == delimiter
+        };
+        if matches_delimiter || !has_newline {
+            return index;
+        }
+    }
+
+    index
+}
+
+fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
+    let mut index = 0usize;
+    let mut depth = 1;
+    let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+
+    while let Some((ch, next_index)) = next_char_boundary(text, index) {
+        match ch {
+            '#' if hash_starts_comment(text, index) => {
+                index = next_index;
+                while let Some((comment_ch, comment_next)) = next_char_boundary(text, index) {
+                    index = comment_next;
+                    if comment_ch == '\n' {
+                        for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                            index = skip_array_command_subst_pending_heredoc(
+                                text,
+                                index,
+                                &delimiter,
+                                strip_tabs,
+                            );
+                        }
+                        break;
+                    }
+                }
+            }
+            '(' => {
+                depth += 1;
+                index = next_index;
+            }
+            ')' => {
+                depth -= 1;
+                index = next_index;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            '"' => {
+                index = scan_array_double_quoted_command_substitution_segment(text, next_index)?;
+            }
+            '\'' => {
+                index = next_index;
+                while let Some((quoted_ch, quoted_next)) = next_char_boundary(text, index) {
+                    index = quoted_next;
+                    if quoted_ch == '\'' {
+                        break;
+                    }
+                }
+            }
+            '\\' => {
+                index = next_index;
+                if let Some((_, escaped_next)) = next_char_boundary(text, index) {
+                    index = escaped_next;
+                }
+            }
+            '<' if text[next_index..].starts_with('<') => {
+                if text[next_index + '('.len_utf8()..].starts_with('<') {
+                    index = next_index + '<'.len_utf8() + '<'.len_utf8();
+                    continue;
+                }
+
+                let strip_tabs = text[next_index..].starts_with("<-");
+                let delimiter_start = next_index + if strip_tabs { 2 } else { 1 };
+                if let Some((delimiter_index, delimiter)) =
+                    scan_array_command_subst_heredoc_delimiter(text, delimiter_start)
+                {
+                    pending_heredocs.push((delimiter, strip_tabs));
+                    index = delimiter_index;
+                } else {
+                    index = next_index;
+                }
+            }
+            '\n' => {
+                index = next_index;
+                for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                    index = skip_array_command_subst_pending_heredoc(
+                        text,
+                        index,
+                        &delimiter,
+                        strip_tabs,
+                    );
+                }
+            }
+            '$'
+                if text[next_index..].starts_with('(')
+                    && !text[next_index + '('.len_utf8()..].starts_with('(') =>
+            {
+                let consumed =
+                    scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])?;
+                index = next_index + '('.len_utf8() + consumed;
+            }
+            _ => index = next_index,
+        }
+    }
+
+    None
+}
+
+fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
+    let mut index = 0usize;
+    let mut depth = 1usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(text, index) {
+        let was_escaped = escaped;
+        escaped = false;
+
+        if !in_single
+            && ch == '$'
+            && text[next_index..].starts_with('(')
+            && !text[next_index + '('.len_utf8()..].starts_with('(')
+            && let Some(consumed) =
+                scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])
+        {
+            index = next_index + '('.len_utf8() + consumed;
+            continue;
+        }
+
+        match ch {
+            '\\' if !in_single => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '{' if !in_single && !in_double && !was_escaped => depth += 1,
+            '}' if !in_single && !in_double && !was_escaped => {
+                depth -= 1;
+                index = next_index;
+                if depth == 0 {
+                    return Some(index);
+                }
+                continue;
+            }
+            _ => {}
+        }
+
+        index = next_index;
+    }
+
+    None
 }
 
 fn comma_is_brace_separator(word: &Word, source: &str, offset: usize, escaped: bool) -> bool {
@@ -12501,10 +12791,6 @@ fn inside_unquoted_brace_group(word: &Word, source: &str, target_offset: usize) 
     }
 
     false
-}
-
-fn trailing_backslashes(text: &str) -> usize {
-    text.chars().rev().take_while(|ch| *ch == '\\').count()
 }
 
 fn compound_assignment_paren_span(assignment: &Assignment, source: &str) -> Option<Span> {
@@ -12987,6 +13273,26 @@ complex[$((i+=1))]+=x
                 "(x\\, y)",
                 "(foo,{x,y},bar)"
             ]
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_quoted_command_substitution_array_elements() {
+        let source = "#!/bin/bash\nf() {\n\tlocal -a graphql_request=(\n\t\t-X POST\n\t\t-d \"$(\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"\n\t)\n}\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12435,15 +12435,11 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
         let was_escaped = escaped;
         escaped = false;
 
-        if !in_single
-            && !in_backtick
-            && ch == '$'
-        {
+        if !in_single && !in_backtick && ch == '$' {
             if text[next_index..].starts_with('(')
                 && !text[next_index + '('.len_utf8()..].starts_with('(')
-                && let Some(consumed) = scan_array_command_substitution_len(
-                    &text[next_index + '('.len_utf8()..],
-                )
+                && let Some(consumed) =
+                    scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])
             {
                 index = next_index + '('.len_utf8() + consumed;
                 continue;
@@ -12460,9 +12456,9 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
 
         match ch {
             '\\' if !in_single => escaped = true,
-            '\'' if !in_double => in_single = !in_single,
-            '"' if !in_single => in_double = !in_double,
-            '`' if !in_single && !in_double => in_backtick = !in_backtick,
+            '\'' if !in_double && !was_escaped => in_single = !in_single,
+            '"' if !in_single && !was_escaped => in_double = !in_double,
+            '`' if !in_single && !in_double && !was_escaped => in_backtick = !in_backtick,
             ',' if !in_single && !in_double && !in_backtick => {
                 let comma_offset = word.span.start.offset + index;
                 if !comma_is_brace_separator(word, source, comma_offset, was_escaped) {
@@ -12487,7 +12483,7 @@ fn hash_starts_comment(text: &str, index: usize) -> bool {
     text[..index]
         .chars()
         .next_back()
-        .is_none_or(char::is_whitespace)
+        .is_none_or(|prev| prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>'))
 }
 
 fn scan_array_double_quoted_command_substitution_segment(
@@ -12503,9 +12499,8 @@ fn scan_array_double_quoted_command_substitution_segment(
                     index = escaped_next;
                 }
             }
-            '$'
-                if text[next_index..].starts_with('(')
-                    && !text[next_index + '('.len_utf8()..].starts_with('(') =>
+            '$' if text[next_index..].starts_with('(')
+                && !text[next_index + '('.len_utf8()..].starts_with('(') =>
             {
                 let consumed =
                     scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])?;
@@ -12602,10 +12597,7 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                     if comment_ch == '\n' {
                         for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
                             index = skip_array_command_subst_pending_heredoc(
-                                text,
-                                index,
-                                &delimiter,
-                                strip_tabs,
+                                text, index, &delimiter, strip_tabs,
                             );
                         }
                         break;
@@ -12662,16 +12654,12 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 index = next_index;
                 for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
                     index = skip_array_command_subst_pending_heredoc(
-                        text,
-                        index,
-                        &delimiter,
-                        strip_tabs,
+                        text, index, &delimiter, strip_tabs,
                     );
                 }
             }
-            '$'
-                if text[next_index..].starts_with('(')
-                    && !text[next_index + '('.len_utf8()..].starts_with('(') =>
+            '$' if text[next_index..].starts_with('(')
+                && !text[next_index + '('.len_utf8()..].starts_with('(') =>
             {
                 let consumed =
                     scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])?;
@@ -13279,6 +13267,27 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_quoted_command_substitution_array_elements() {
         let source = "#!/bin/bash\nf() {\n\tlocal -a graphql_request=(\n\t\t-X POST\n\t\t-d \"$(\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"\n\t)\n}\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_separator_started_command_substitution_comments() {
+        let source =
+            "#!/bin/bash\na=(\"$(printf '%s' x;# comment with ) and ,\nprintf '%s' y\n)\")\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12742,6 +12742,10 @@ fn scan_array_ansi_c_single_quoted_command_substitution_segment(
     None
 }
 
+fn scan_array_backtick_command_substitution_segment(text: &str, start: usize) -> Option<usize> {
+    skip_backticks(text.as_bytes(), start)
+}
+
 fn skip_array_command_subst_pending_heredoc(
     text: &str,
     mut index: usize,
@@ -12888,6 +12892,25 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                         break;
                     }
                 }
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '`' => {
+                let had_word = !current_word.is_empty();
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = scan_array_backtick_command_substitution_segment(text, next_index)?;
                 if expecting_redirection_target {
                     expecting_redirection_target = false;
                 } else {
@@ -14094,6 +14117,26 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_command_substitutions_with_ansi_c_single_quotes() {
         let source = "#!/bin/bash\na=($(printf %s $'a\\'b'; printf %s 1,2))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_command_substitutions_with_backticks() {
+        let source = "#!/bin/bash\na=($(printf %s `echo foo)`; printf %s 1,2))\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12492,7 +12492,7 @@ fn next_char_boundary(text: &str, index: usize) -> Option<(char, usize)> {
 
 fn hash_starts_comment(text: &str, index: usize) -> bool {
     text[..index].chars().next_back().is_none_or(|prev| {
-        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | '(')
+        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | '(' | ')')
     })
 }
 
@@ -13588,6 +13588,26 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_parameter_expansions_with_right_parens_in_command_substitutions() {
         let source = "#!/bin/bash\na=($(printf %s ${x//foo/)},1))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_case_pattern_comments_after_right_parens() {
+        let source = "#!/bin/bash\na=($(case $kind in\na)# comment with esac )\nprintf %s 1,2 ;;\nesac\n))\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12487,10 +12487,9 @@ fn next_char_boundary(text: &str, index: usize) -> Option<(char, usize)> {
 }
 
 fn hash_starts_comment(text: &str, index: usize) -> bool {
-    text[..index]
-        .chars()
-        .next_back()
-        .is_none_or(|prev| prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>'))
+    text[..index].chars().next_back().is_none_or(|prev| {
+        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | '(')
+    })
 }
 
 fn flush_array_command_subst_keyword(
@@ -12866,8 +12865,8 @@ fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
 
         match ch {
             '\\' if !in_single => escaped = true,
-            '\'' if !in_double => in_single = !in_single,
-            '"' if !in_single => in_double = !in_double,
+            '\'' if !in_double && !was_escaped => in_single = !in_single,
+            '"' if !in_single && !was_escaped => in_double = !in_double,
             '{' if !in_single && !in_double && !was_escaped => depth += 1,
             '}' if !in_single && !in_double && !was_escaped => {
                 depth -= 1;
@@ -13458,6 +13457,26 @@ complex[$((i+=1))]+=x
     fn ignores_commas_inside_separator_started_command_substitution_comments() {
         let source =
             "#!/bin/bash\na=(\"$(printf '%s' x;# comment with ) and ,\nprintf '%s' y\n)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_grouped_command_substitution_comments() {
+        let source = "#!/bin/bash\na=(\"$( (# comment with )\nprintf %s 1,2\n) )\")\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12436,6 +12436,13 @@ fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
         escaped = false;
 
         if !in_single && !in_backtick && ch == '$' {
+            if text[next_index..].starts_with("((")
+                && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
+            {
+                index = next_index + 2 + consumed;
+                continue;
+            }
+
             if text[next_index..].starts_with('(')
                 && !text[next_index + '('.len_utf8()..].starts_with('(')
                 && let Some(consumed) =
@@ -12486,6 +12493,40 @@ fn hash_starts_comment(text: &str, index: usize) -> bool {
         .is_none_or(|prev| prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>'))
 }
 
+fn flush_array_command_subst_keyword(
+    current_word: &mut String,
+    pending_case_headers: &mut usize,
+    case_clause_depth: &mut usize,
+) {
+    if current_word.is_empty() {
+        return;
+    }
+
+    match current_word.as_str() {
+        "case" => *pending_case_headers += 1,
+        "in" if *pending_case_headers > 0 => {
+            *pending_case_headers -= 1;
+            *case_clause_depth += 1;
+        }
+        "esac" if *case_clause_depth > 0 => *case_clause_depth -= 1,
+        _ => {}
+    }
+
+    current_word.clear();
+}
+
+fn heredoc_delimiter_is_terminator(
+    ch: char,
+    in_single: bool,
+    in_double: bool,
+    escaped: bool,
+) -> bool {
+    !in_single
+        && !in_double
+        && !escaped
+        && (ch.is_whitespace() || matches!(ch, '|' | '&' | ';' | '<' | '>' | '(' | ')'))
+}
+
 fn scan_array_double_quoted_command_substitution_segment(
     text: &str,
     mut index: usize,
@@ -12531,7 +12572,7 @@ fn scan_array_command_subst_heredoc_delimiter(
     let mut escaped = false;
 
     while let Some((ch, next_index)) = next_char_boundary(text, index) {
-        if !in_single && !in_double && !escaped && ch.is_whitespace() {
+        if heredoc_delimiter_is_terminator(ch, in_single, in_double, escaped) {
             break;
         }
 
@@ -12587,10 +12628,18 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
     let mut index = 0usize;
     let mut depth = 1;
     let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+    let mut pending_case_headers = 0usize;
+    let mut case_clause_depth = 0usize;
+    let mut current_word = String::with_capacity(16);
 
     while let Some((ch, next_index)) = next_char_boundary(text, index) {
         match ch {
             '#' if hash_starts_comment(text, index) => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
                 index = next_index;
                 while let Some((comment_ch, comment_next)) = next_char_boundary(text, index) {
                     index = comment_next;
@@ -12605,10 +12654,24 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 }
             }
             '(' => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
                 depth += 1;
                 index = next_index;
             }
             ')' => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                if depth == 1 && case_clause_depth > 0 {
+                    index = next_index;
+                    continue;
+                }
                 depth -= 1;
                 index = next_index;
                 if depth == 0 {
@@ -12616,9 +12679,19 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 }
             }
             '"' => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
                 index = scan_array_double_quoted_command_substitution_segment(text, next_index)?;
             }
             '\'' => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
                 index = next_index;
                 while let Some((quoted_ch, quoted_next)) = next_char_boundary(text, index) {
                     index = quoted_next;
@@ -12628,12 +12701,22 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 }
             }
             '\\' => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
                 index = next_index;
                 if let Some((_, escaped_next)) = next_char_boundary(text, index) {
                     index = escaped_next;
                 }
             }
             '<' if text[next_index..].starts_with('<') => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
                 if text[next_index + '('.len_utf8()..].starts_with('<') {
                     index = next_index + '<'.len_utf8() + '<'.len_utf8();
                     continue;
@@ -12651,6 +12734,11 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 }
             }
             '\n' => {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
                 index = next_index;
                 for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
                     index = skip_array_command_subst_pending_heredoc(
@@ -12661,12 +12749,87 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
             '$' if text[next_index..].starts_with('(')
                 && !text[next_index + '('.len_utf8()..].starts_with('(') =>
             {
+                flush_array_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
                 let consumed =
                     scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])?;
                 index = next_index + '('.len_utf8() + consumed;
             }
-            _ => index = next_index,
+            _ => {
+                if ch.is_ascii_alphanumeric() || ch == '_' {
+                    current_word.push(ch);
+                } else {
+                    flush_array_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depth,
+                    );
+                }
+                index = next_index;
+            }
         }
+    }
+
+    None
+}
+
+fn scan_array_arithmetic_expansion_len(text: &str) -> Option<usize> {
+    let mut index = 0usize;
+    let mut depth = 2usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(text, index) {
+        let was_escaped = escaped;
+        escaped = false;
+
+        if !in_single && ch == '$' {
+            if text[next_index..].starts_with("((")
+                && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
+            {
+                index = next_index + 2 + consumed;
+                continue;
+            }
+
+            if text[next_index..].starts_with('(')
+                && !text[next_index + '('.len_utf8()..].starts_with('(')
+                && let Some(consumed) =
+                    scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])
+            {
+                index = next_index + '('.len_utf8() + consumed;
+                continue;
+            }
+
+            if text[next_index..].starts_with('{')
+                && let Some(consumed) =
+                    scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])
+            {
+                index = next_index + '{'.len_utf8() + consumed;
+                continue;
+            }
+        }
+
+        match ch {
+            '\\' if !in_single => escaped = true,
+            '\'' if !in_double && !was_escaped => in_single = !in_single,
+            '"' if !in_single && !was_escaped => in_double = !in_double,
+            '(' if !in_single && !in_double && !was_escaped => depth += 1,
+            ')' if !in_single && !in_double && !was_escaped => {
+                depth -= 1;
+                index = next_index;
+                if depth == 0 {
+                    return Some(index);
+                }
+                continue;
+            }
+            _ => {}
+        }
+
+        index = next_index;
     }
 
     None
@@ -12683,15 +12846,22 @@ fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
         let was_escaped = escaped;
         escaped = false;
 
-        if !in_single
-            && ch == '$'
-            && text[next_index..].starts_with('(')
-            && !text[next_index + '('.len_utf8()..].starts_with('(')
-            && let Some(consumed) =
-                scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])
-        {
-            index = next_index + '('.len_utf8() + consumed;
-            continue;
+        if !in_single && ch == '$' {
+            if text[next_index..].starts_with("((")
+                && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
+            {
+                index = next_index + 2 + consumed;
+                continue;
+            }
+
+            if text[next_index..].starts_with('(')
+                && !text[next_index + '('.len_utf8()..].starts_with('(')
+                && let Some(consumed) =
+                    scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])
+            {
+                index = next_index + '('.len_utf8() + consumed;
+                continue;
+            }
         }
 
         match ch {
@@ -13288,6 +13458,46 @@ complex[$((i+=1))]+=x
     fn ignores_commas_inside_separator_started_command_substitution_comments() {
         let source =
             "#!/bin/bash\na=(\"$(printf '%s' x;# comment with ) and ,\nprintf '%s' y\n)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_command_substitution_case_patterns() {
+        let source = "#!/bin/bash\na=(\"$(case $kind in\nalpha) printf %s 1,2 ;;\nesac)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_piped_heredoc_command_substitution_array_elements() {
+        let source = "#!/bin/bash\na=(\"$(cat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n)\")\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13190,24 +13190,28 @@ fn scan_array_process_substitution_len(text: &str) -> Option<usize> {
 fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
     let mut index = 0usize;
     let mut in_single = false;
+    let mut in_ansi_c_single = false;
     let mut in_double = false;
     let mut escaped = false;
+    let mut ansi_c_quote_pending = false;
 
     while let Some((ch, next_index)) = next_char_boundary(text, index) {
         let was_escaped = escaped;
         if ch == '\\' && !in_single {
             escaped = !escaped;
             index = next_index;
+            ansi_c_quote_pending = false;
             continue;
         }
         escaped = false;
 
-        if !in_single && !was_escaped && ch == '$' {
+        if !in_single && !in_ansi_c_single && !was_escaped && ch == '$' {
             if text[next_index..].starts_with('{')
                 && let Some(consumed) =
                     scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])
             {
                 index = next_index + '{'.len_utf8() + consumed;
+                ansi_c_quote_pending = false;
                 continue;
             }
 
@@ -13215,6 +13219,7 @@ fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
                 && let Some(consumed) = scan_array_arithmetic_expansion_len(&text[next_index + 2..])
             {
                 index = next_index + 2 + consumed;
+                ansi_c_quote_pending = false;
                 continue;
             }
 
@@ -13224,17 +13229,30 @@ fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
                     scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])
             {
                 index = next_index + '('.len_utf8() + consumed;
+                ansi_c_quote_pending = false;
                 continue;
             }
         }
 
         match ch {
-            '\'' if !in_double && !was_escaped => in_single = !in_single,
-            '"' if !in_single && !was_escaped => in_double = !in_double,
-            '}' if !in_single && !in_double && !was_escaped => return Some(next_index),
+            '\'' if !in_double && !was_escaped => {
+                if in_ansi_c_single {
+                    in_ansi_c_single = false;
+                } else if !in_single && ansi_c_quote_pending {
+                    in_ansi_c_single = true;
+                } else {
+                    in_single = !in_single;
+                }
+            }
+            '"' if !in_single && !in_ansi_c_single && !was_escaped => in_double = !in_double,
+            '}' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                return Some(next_index);
+            }
             _ => {}
         }
 
+        ansi_c_quote_pending =
+            ch == '$' && !in_single && !in_ansi_c_single && !in_double && !was_escaped;
         index = next_index;
     }
 
@@ -13977,6 +13995,26 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_parameter_expansions_with_literal_braces() {
         let source = "#!/bin/bash\na=(${x/a,b/{})\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_parameter_expansions_with_ansi_c_single_quotes() {
+        let source = "#!/bin/bash\na=(${x/$'a\\'b'/c,d})\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12577,7 +12577,8 @@ fn hash_starts_comment(text: &str, index: usize) -> bool {
 fn flush_array_command_subst_keyword(
     current_word: &mut String,
     pending_case_headers: &mut usize,
-    case_clause_depth: &mut usize,
+    case_clause_depths: &mut Vec<usize>,
+    depth: usize,
 ) {
     if current_word.is_empty() {
         return;
@@ -12587,9 +12588,11 @@ fn flush_array_command_subst_keyword(
         "case" => *pending_case_headers += 1,
         "in" if *pending_case_headers > 0 => {
             *pending_case_headers -= 1;
-            *case_clause_depth += 1;
+            case_clause_depths.push(depth);
         }
-        "esac" if *case_clause_depth > 0 => *case_clause_depth -= 1,
+        "esac" => {
+            case_clause_depths.pop();
+        }
         _ => {}
     }
 
@@ -12715,7 +12718,7 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
     let mut depth = 1;
     let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
     let mut pending_case_headers = 0usize;
-    let mut case_clause_depth = 0usize;
+    let mut case_clause_depths = Vec::new();
     let mut current_word = String::with_capacity(16);
 
     while let Some((ch, next_index)) = next_char_boundary(text, index) {
@@ -12724,7 +12727,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = next_index;
                 while let Some((comment_ch, comment_next)) = next_char_boundary(text, index) {
@@ -12743,7 +12747,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 depth += 1;
                 index = next_index;
@@ -12752,9 +12757,13 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
-                if depth == 1 && case_clause_depth > 0 {
+                if case_clause_depths
+                    .last()
+                    .is_some_and(|case_depth| *case_depth == depth)
+                {
                     index = next_index;
                     continue;
                 }
@@ -12768,7 +12777,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = scan_array_double_quoted_command_substitution_segment(text, next_index)?;
             }
@@ -12776,7 +12786,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = next_index;
                 while let Some((quoted_ch, quoted_next)) = next_char_boundary(text, index) {
@@ -12790,7 +12801,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = next_index;
                 if let Some((_, escaped_next)) = next_char_boundary(text, index) {
@@ -12801,7 +12813,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 if inside_unclosed_double_paren_on_line(text, index) {
                     index = next_index + '<'.len_utf8();
@@ -12828,7 +12841,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = next_index;
                 for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
@@ -12841,7 +12855,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 let consumed =
                     scan_array_parameter_expansion_len(&text[next_index + '{'.len_utf8()..])?;
@@ -12853,7 +12868,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                 flush_array_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 let consumed =
                     scan_array_command_substitution_len(&text[next_index + '('.len_utf8()..])?;
@@ -12866,7 +12882,8 @@ fn scan_array_command_substitution_len(text: &str) -> Option<usize> {
                     flush_array_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
                     );
                 }
                 index = next_index;
@@ -13774,6 +13791,26 @@ complex[$((i+=1))]+=x
     #[test]
     fn ignores_commas_inside_arithmetic_shift_command_substitutions() {
         let source = "#!/bin/bash\na=($( ((x<<2))\nprintf %s 1,2\n))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_nested_case_patterns_in_command_substitutions() {
+        let source = "#!/bin/bash\na=($( (case $kind in\na) printf %s 1,2 ;;\nesac\n) ))\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12588,12 +12588,21 @@ fn hash_starts_comment(text: &str, index: usize) -> bool {
         return false;
     }
 
-    let next = text[index + '#'.len_utf8()..].chars().next();
+    let next = &text[index + '#'.len_utf8()..];
     text[..index]
         .chars()
         .next_back()
         .is_none_or(|prev| match prev {
-            '(' => next.is_none_or(char::is_whitespace),
+            '(' => {
+                let whitespace_index = next.find(char::is_whitespace);
+                let close_index = next.find(')');
+
+                match (whitespace_index, close_index) {
+                    (Some(whitespace), Some(close)) => whitespace < close,
+                    (Some(_), None) | (None, None) => true,
+                    (None, Some(_)) => false,
+                }
+            }
             _ => prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | ')'),
         })
 }
@@ -13693,6 +13702,26 @@ complex[$((i+=1))]+=x
     }
 
     #[test]
+    fn ignores_commas_inside_compact_grouped_command_substitution_comments() {
+        let source = "#!/bin/bash\na=(\"$( (#comment with )\nprintf %s 1,2\n) )\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn ignores_commas_inside_command_substitution_case_patterns() {
         let source = "#!/bin/bash\na=(\"$(case $kind in\nalpha) printf %s 1,2 ;;\nesac)\")\n";
         let output = Parser::new(source).parse().unwrap();
@@ -13878,6 +13907,14 @@ complex[$((i+=1))]+=x
         let index = source.find('#').expect("expected hash");
 
         assert!(!super::hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn hash_starts_comment_allows_grouped_comments_without_space_after_hash() {
+        let source = "(#comment with )";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(super::hash_starts_comment(source, index));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -71,6 +71,7 @@ k=(x\\\\\",y\")
 l=($(printf %s ${x//foo/)},1))
 m=(<(printf %s 1,2))
 n=(>(printf %s 3,4))
+o=(${x/a,b/{})
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -98,6 +98,7 @@ printf %s 7,8
 ) )\")
 e=($(printf %s 9,10; echo case in))
 f=($(printf %s $'a\\'b'; printf %s 11,12))
+g=($(printf %s `echo foo)`; printf %s 13,14))
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -68,6 +68,7 @@ h=(\"x\\\",y\")
 i=($((1,2)))
 j=(${x/\\\"/a,b})
 k=(x\\\\\",y\")
+l=($(printf %s ${x//foo/)},1))
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -77,4 +77,20 @@ o=(${x/a,b/{})
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
+
+    #[test]
+    fn ignores_multiline_command_substitution_scanner_edge_cases() {
+        let source = "\
+#!/bin/bash
+a=($(printf '((' # comment with )
+printf %s 1,2
+))
+b=($( ((x<<2))
+printf %s 3,4
+))
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -63,6 +63,7 @@ e=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)
 f=(${versions/,/ })
 g=(${token//,/ })
 h=(\"x\\\",y\")
+i=($((1,2)))
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -62,6 +62,7 @@ d=($(printf 'x,y'))
 e=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)
 f=(${versions/,/ })
 g=(${token//,/ })
+h=(\"x\\\",y\")
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -88,6 +88,10 @@ printf %s 1,2
 b=($( ((x<<2))
 printf %s 3,4
 ))
+c=($( (case $kind in
+a) printf %s 5,6 ;;
+esac
+) ))
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -73,6 +73,7 @@ m=(<(printf %s 1,2))
 n=(>(printf %s 3,4))
 o=(${x/a,b/{})
 p=($'a\\'b,c')
+q=(${x/$'a\\'b'/c,d})
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -72,6 +72,7 @@ l=($(printf %s ${x//foo/)},1))
 m=(<(printf %s 1,2))
 n=(>(printf %s 3,4))
 o=(${x/a,b/{})
+p=($'a\\'b,c')
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -64,6 +64,7 @@ f=(${versions/,/ })
 g=(${token//,/ })
 h=(\"x\\\",y\")
 i=($((1,2)))
+j=(${x/\\\"/a,b})
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -33,6 +33,7 @@ b=(alpha, beta)
 c=([k]=v, [q]=w)
 d+=(x,y)
 e=(foo,{x,y},bar)
+f=(\\$((1,2)))
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 
@@ -46,7 +47,8 @@ e=(foo,{x,y},bar)
                 "(alpha, beta)",
                 "([k]=v, [q]=w)",
                 "(x,y)",
-                "(foo,{x,y},bar)"
+                "(foo,{x,y},bar)",
+                "(\\$((1,2)))"
             ]
         );
     }
@@ -65,6 +67,7 @@ g=(${token//,/ })
 h=(\"x\\\",y\")
 i=($((1,2)))
 j=(${x/\\\"/a,b})
+k=(x\\\\\",y\")
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -93,6 +93,9 @@ c=($( (case $kind in
 a) printf %s 5,6 ;;
 esac
 ) ))
+d=(\"$( (#comment with )
+printf %s 7,8
+) )\")
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -96,6 +96,8 @@ esac
 d=(\"$( (#comment with )
 printf %s 7,8
 ) )\")
+e=($(printf %s 9,10; echo case in))
+f=($(printf %s $'a\\'b'; printf %s 11,12))
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -60,6 +60,8 @@ b=('alpha,beta')
 c=({x,y})
 d=($(printf 'x,y'))
 e=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)
+f=(${versions/,/ })
+g=(${token//,/ })
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -69,6 +69,8 @@ i=($((1,2)))
 j=(${x/\\\"/a,b})
 k=(x\\\\\",y\")
 l=($(printf %s ${x//foo/)},1))
+m=(<(printf %s 1,2))
+n=(>(printf %s 3,4))
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3228,7 +3228,7 @@ fn next_char_boundary(input: &str, index: usize) -> Option<(char, usize)> {
 
 fn hash_starts_comment(input: &str, index: usize) -> bool {
     input[..index].chars().next_back().is_none_or(|prev| {
-        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | '(')
+        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | '(' | ')')
     })
 }
 
@@ -3757,6 +3757,17 @@ mod tests {
         let body = &source[..consumed];
 
         assert!(body.contains("${x//foo/)},1"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_case_pattern_comment_after_right_paren() {
+        let source = "case $kind in\na)# comment with esac )\nprintf %s 1,2 ;;\nesac\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
         assert!(body.ends_with(')'));
     }
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3285,12 +3285,21 @@ fn hash_starts_comment(input: &str, index: usize) -> bool {
         return false;
     }
 
-    let next = input[index + '#'.len_utf8()..].chars().next();
+    let next = &input[index + '#'.len_utf8()..];
     input[..index]
         .chars()
         .next_back()
         .is_none_or(|prev| match prev {
-            '(' => next.is_none_or(char::is_whitespace),
+            '(' => {
+                let whitespace_index = next.find(char::is_whitespace);
+                let close_index = next.find(')');
+
+                match (whitespace_index, close_index) {
+                    (Some(whitespace), Some(close)) => whitespace < close,
+                    (Some(_), None) | (None, None) => true,
+                    (None, Some(_)) => false,
+                }
+            }
             _ => prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | ')'),
         })
 }
@@ -3862,6 +3871,14 @@ mod tests {
     }
 
     #[test]
+    fn test_hash_starts_comment_allows_grouped_comments_without_space_after_hash() {
+        let source = "(#comment with )";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(hash_starts_comment(source, index));
+    }
+
+    #[test]
     fn test_hash_starts_comment_ignores_hash_inside_unclosed_double_parens() {
         let source = "(( #c < 256 ))";
         let index = source.find('#').expect("expected hash");
@@ -3880,6 +3897,17 @@ mod tests {
     #[test]
     fn test_scan_command_substitution_body_len_handles_quoted_double_parens_before_comments() {
         let source = "printf '((' # comment with )\nprintf %s 1,2\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_grouped_comments_without_space_after_hash() {
+        let source = " (#comment with )\nprintf %s 1,2\n) )\"";
 
         let consumed = scan_command_substitution_body_len(source).expect("expected match");
         let body = &source[..consumed];

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3230,7 +3230,7 @@ fn hash_starts_comment(input: &str, index: usize) -> bool {
     input[..index]
         .chars()
         .next_back()
-        .is_none_or(char::is_whitespace)
+        .is_none_or(|prev| prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>'))
 }
 
 fn scan_double_quoted_command_substitution_segment(
@@ -3247,9 +3247,8 @@ fn scan_double_quoted_command_substitution_segment(
                     index = escaped_next;
                 }
             }
-            '$'
-                if input[next_index..].starts_with('(')
-                    && !input[next_index + '('.len_utf8()..].starts_with('(') =>
+            '$' if input[next_index..].starts_with('(')
+                && !input[next_index + '('.len_utf8()..].starts_with('(') =>
             {
                 let consumed = scan_command_substitution_body_len_inner(
                     &input[next_index + '('.len_utf8()..],
@@ -3352,10 +3351,7 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                     if comment_ch == '\n' {
                         for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
                             index = skip_command_subst_pending_heredoc(
-                                input,
-                                index,
-                                &delimiter,
-                                strip_tabs,
+                                input, index, &delimiter, strip_tabs,
                             );
                         }
                         break;
@@ -3393,8 +3389,11 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                     &mut pending_case_headers,
                     &mut case_clause_depth,
                 );
-                index =
-                    scan_double_quoted_command_substitution_segment(input, next_index, subst_depth)?;
+                index = scan_double_quoted_command_substitution_segment(
+                    input,
+                    next_index,
+                    subst_depth,
+                )?;
             }
             '\'' => {
                 Lexer::flush_command_subst_keyword(
@@ -3456,9 +3455,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                         skip_command_subst_pending_heredoc(input, index, &delimiter, strip_tabs);
                 }
             }
-            '$'
-                if input[next_index..].starts_with('(')
-                    && !input[next_index + '('.len_utf8()..].starts_with('(') =>
+            '$' if input[next_index..].starts_with('(')
+                && !input[next_index + '('.len_utf8()..].starts_with('(') =>
             {
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
@@ -3628,13 +3626,23 @@ mod tests {
 
     #[test]
     fn test_scan_command_substitution_body_len_handles_tabstripped_heredoc() {
-        let source =
-            "\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"";
+        let source = "\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"";
 
         let consumed = scan_command_substitution_body_len(source).expect("expected match");
         let body = &source[..consumed];
 
         assert!(body.contains("field, direction"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_separator_started_comment() {
+        let source = "printf '%s' x;# comment with ) and ,\nprintf '%s' y\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf '%s' y"));
         assert!(body.ends_with(')'));
     }
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3227,10 +3227,9 @@ fn next_char_boundary(input: &str, index: usize) -> Option<(char, usize)> {
 }
 
 fn hash_starts_comment(input: &str, index: usize) -> bool {
-    input[..index]
-        .chars()
-        .next_back()
-        .is_none_or(|prev| prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>'))
+    input[..index].chars().next_back().is_none_or(|prev| {
+        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | '(')
+    })
 }
 
 fn heredoc_delimiter_is_terminator(
@@ -3655,6 +3654,17 @@ mod tests {
         let body = &source[..consumed];
 
         assert!(body.contains("printf '%s' y"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_grouping_comment_after_left_paren() {
+        let source = " (# comment with )\nprintf %s 1,2\n) )\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
         assert!(body.ends_with(')'));
     }
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -2391,24 +2391,101 @@ impl<'a> Lexer<'a> {
         pending_case_headers: &mut usize,
         case_clause_depths: &mut Vec<usize>,
         depth: usize,
+        word_started_at_command_start: &mut bool,
     ) {
         if current_word.is_empty() {
+            *word_started_at_command_start = false;
             return;
         }
 
         match current_word.as_str() {
-            "case" => *pending_case_headers += 1,
+            "case" if *word_started_at_command_start => *pending_case_headers += 1,
             "in" if *pending_case_headers > 0 => {
                 *pending_case_headers -= 1;
                 case_clause_depths.push(depth);
             }
-            "esac" => {
+            "esac" if *word_started_at_command_start => {
                 case_clause_depths.pop();
             }
             _ => {}
         }
 
         current_word.clear();
+        *word_started_at_command_start = false;
+    }
+
+    fn read_command_subst_heredoc_delimiter_into(
+        &mut self,
+        content: &mut Option<String>,
+    ) -> Option<String> {
+        while let Some(ch) = self.peek_char() {
+            if !matches!(ch, ' ' | '\t') {
+                break;
+            }
+            Self::push_capture_char(content, ch);
+            self.advance();
+        }
+
+        let mut cooked = String::new();
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+        let mut saw_any = false;
+
+        while let Some(ch) = self.peek_char() {
+            if heredoc_delimiter_is_terminator(ch, in_single, in_double, escaped) {
+                break;
+            }
+
+            saw_any = true;
+            Self::push_capture_char(content, ch);
+            self.advance();
+
+            if escaped {
+                cooked.push(ch);
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' if !in_single => escaped = true,
+                '\'' if !in_double => in_single = !in_single,
+                '"' if !in_single => in_double = !in_double,
+                _ => cooked.push(ch),
+            }
+        }
+
+        saw_any.then_some(cooked)
+    }
+
+    fn read_command_subst_pending_heredoc_into(
+        &mut self,
+        content: &mut Option<String>,
+        delimiter: &str,
+        strip_tabs: bool,
+    ) -> bool {
+        loop {
+            let mut line = String::new();
+            let mut saw_newline = false;
+
+            while let Some(ch) = self.peek_char() {
+                self.advance();
+                if ch == '\n' {
+                    saw_newline = true;
+                    break;
+                }
+                line.push(ch);
+            }
+
+            Self::push_capture_str(content, &line);
+            if saw_newline {
+                Self::push_capture_char(content, '\n');
+            }
+
+            if heredoc_line_matches_delimiter(&line, delimiter, strip_tabs) || !saw_newline {
+                return true;
+            }
+        }
     }
 
     fn read_command_subst_into_depth(
@@ -2437,24 +2514,42 @@ impl<'a> Lexer<'a> {
         }
 
         let mut depth = 1;
+        let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
         let mut pending_case_headers = 0usize;
         let mut case_clause_depths = Vec::new();
         let mut current_word = String::with_capacity(16);
+        let mut at_command_start = true;
+        let mut expecting_redirection_target = false;
+        let mut current_word_started_at_command_start = false;
         while let Some(c) = self.peek_char() {
             match c {
                 '#' if !self.should_treat_hash_as_word_char() => {
+                    let had_word = !current_word.is_empty();
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
                         &mut case_clause_depths,
                         depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
                     Self::push_capture_char(content, '#');
                     self.advance();
                     while let Some(comment_ch) = self.peek_char() {
                         Self::push_capture_char(content, comment_ch);
                         self.advance();
                         if comment_ch == '\n' {
+                            for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                                if !self.read_command_subst_pending_heredoc_into(
+                                    content, &delimiter, strip_tabs,
+                                ) {
+                                    return false;
+                                }
+                            }
+                            at_command_start = true;
+                            expecting_redirection_target = false;
                             break;
                         }
                     }
@@ -2465,10 +2560,13 @@ impl<'a> Lexer<'a> {
                         &mut pending_case_headers,
                         &mut case_clause_depths,
                         depth,
+                        &mut current_word_started_at_command_start,
                     );
                     depth += 1;
                     Self::push_capture_char(content, c);
                     self.advance();
+                    at_command_start = true;
+                    expecting_redirection_target = false;
                 }
                 ')' => {
                     Self::flush_command_subst_keyword(
@@ -2476,6 +2574,7 @@ impl<'a> Lexer<'a> {
                         &mut pending_case_headers,
                         &mut case_clause_depths,
                         depth,
+                        &mut current_word_started_at_command_start,
                     );
                     if case_clause_depths
                         .last()
@@ -2483,6 +2582,8 @@ impl<'a> Lexer<'a> {
                     {
                         Self::push_capture_char(content, ')');
                         self.advance();
+                        at_command_start = true;
+                        expecting_redirection_target = false;
                         continue;
                     }
                     depth -= 1;
@@ -2492,14 +2593,21 @@ impl<'a> Lexer<'a> {
                         return true;
                     }
                     Self::push_capture_char(content, c);
+                    at_command_start = false;
+                    expecting_redirection_target = false;
                 }
                 '"' => {
+                    let had_word = !current_word.is_empty();
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
                         &mut case_clause_depths,
                         depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
                     // Nested double-quoted string inside $()
                     Self::push_capture_char(content, '"');
                     self.advance();
@@ -2536,14 +2644,24 @@ impl<'a> Lexer<'a> {
                             }
                         }
                     }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
                 }
                 '\'' => {
+                    let had_word = !current_word.is_empty();
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
                         &mut case_clause_depths,
                         depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
                     // Single-quoted string inside $()
                     Self::push_capture_char(content, '\'');
                     self.advance();
@@ -2554,31 +2672,187 @@ impl<'a> Lexer<'a> {
                             break;
                         }
                     }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
                 }
-                '\\' => {
+                '$' if self.second_char() == Some('\'') => {
+                    let had_word = !current_word.is_empty();
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
                         &mut case_clause_depths,
                         depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
+                    Self::push_capture_char(content, '$');
+                    self.advance();
+                    Self::push_capture_char(content, '\'');
+                    self.advance();
+                    while let Some(qc) = self.peek_char() {
+                        Self::push_capture_char(content, qc);
+                        self.advance();
+                        if qc == '\\' {
+                            if let Some(esc) = self.peek_char() {
+                                Self::push_capture_char(content, esc);
+                                self.advance();
+                            }
+                            continue;
+                        }
+                        if qc == '\'' {
+                            break;
+                        }
+                    }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
+                }
+                '\\' => {
+                    let had_word = !current_word.is_empty();
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
                     Self::push_capture_char(content, '\\');
                     self.advance();
                     if let Some(esc) = self.peek_char() {
                         Self::push_capture_char(content, esc);
                         self.advance();
                     }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
+                }
+                '<' if self.second_char() == Some('<') => {
+                    let word_was_redirection_fd = current_word_started_at_command_start
+                        && !current_word.is_empty()
+                        && current_word.chars().all(|current| current.is_ascii_digit());
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if word_was_redirection_fd {
+                        at_command_start = true;
+                    }
+
+                    Self::push_capture_char(content, '<');
+                    self.advance();
+                    Self::push_capture_char(content, '<');
+                    self.advance();
+
+                    if self.peek_char() == Some('<') {
+                        Self::push_capture_char(content, '<');
+                        self.advance();
+                        expecting_redirection_target = true;
+                        continue;
+                    }
+
+                    let strip_tabs = if self.peek_char() == Some('-') {
+                        Self::push_capture_char(content, '-');
+                        self.advance();
+                        true
+                    } else {
+                        false
+                    };
+
+                    if let Some(delimiter) = self.read_command_subst_heredoc_delimiter_into(content)
+                    {
+                        pending_heredocs.push((delimiter, strip_tabs));
+                        expecting_redirection_target = false;
+                    } else {
+                        expecting_redirection_target = true;
+                    }
+                }
+                '>' | '<' => {
+                    let word_was_redirection_fd = current_word_started_at_command_start
+                        && !current_word.is_empty()
+                        && current_word.chars().all(|current| current.is_ascii_digit());
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if word_was_redirection_fd {
+                        at_command_start = true;
+                    }
+                    Self::push_capture_char(content, c);
+                    self.advance();
+                    expecting_redirection_target = true;
+                }
+                '\n' => {
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    Self::push_capture_char(content, '\n');
+                    self.advance();
+                    for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                        if !self.read_command_subst_pending_heredoc_into(
+                            content, &delimiter, strip_tabs,
+                        ) {
+                            return false;
+                        }
+                    }
+                    at_command_start = true;
+                    expecting_redirection_target = false;
                 }
                 _ => {
                     if c.is_ascii_alphanumeric() || c == '_' {
+                        if current_word.is_empty()
+                            && !expecting_redirection_target
+                            && at_command_start
+                        {
+                            current_word_started_at_command_start = true;
+                            at_command_start = false;
+                        }
                         current_word.push(c);
                     } else {
+                        let had_word = !current_word.is_empty();
                         Self::flush_command_subst_keyword(
                             &mut current_word,
                             &mut pending_case_headers,
                             &mut case_clause_depths,
                             depth,
+                            &mut current_word_started_at_command_start,
                         );
+                        if had_word && expecting_redirection_target {
+                            expecting_redirection_target = false;
+                        }
+                        match c {
+                            ' ' | '\t' => {}
+                            ';' | '|' | '&' => {
+                                at_command_start = true;
+                                expecting_redirection_target = false;
+                            }
+                            _ => {
+                                if !expecting_redirection_target {
+                                    at_command_start = false;
+                                }
+                            }
+                        }
                     }
                     Self::push_capture_char(content, c);
                     self.advance();
@@ -3466,6 +3740,29 @@ fn skip_command_subst_pending_heredoc(
     index
 }
 
+fn scan_command_subst_ansi_c_single_quoted_segment(
+    input: &str,
+    quote_index: usize,
+) -> Option<usize> {
+    let mut index = quote_index + '\''.len_utf8();
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        index = next_index;
+        if ch == '\\' {
+            if let Some((_, escaped_next)) = next_char_boundary(input, index) {
+                index = escaped_next;
+            }
+            continue;
+        }
+
+        if ch == '\'' {
+            return Some(index);
+        }
+    }
+
+    None
+}
+
 fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> Option<usize> {
     if subst_depth >= DEFAULT_MAX_SUBST_DEPTH {
         return None;
@@ -3477,16 +3774,24 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
     let mut pending_case_headers = 0usize;
     let mut case_clause_depths = Vec::new();
     let mut current_word = String::with_capacity(16);
+    let mut at_command_start = true;
+    let mut expecting_redirection_target = false;
+    let mut current_word_started_at_command_start = false;
 
     while let Some((ch, next_index)) = next_char_boundary(input, index) {
         match ch {
             '#' if hash_starts_comment(input, index) => {
+                let had_word = !current_word.is_empty();
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 index = next_index;
                 while let Some((comment_ch, comment_next)) = next_char_boundary(input, index) {
                     index = comment_next;
@@ -3496,6 +3801,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                                 input, index, &delimiter, strip_tabs,
                             );
                         }
+                        at_command_start = true;
+                        expecting_redirection_target = false;
                         break;
                     }
                 }
@@ -3506,9 +3813,12 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
                 depth += 1;
                 index = next_index;
+                at_command_start = true;
+                expecting_redirection_target = false;
             }
             ')' => {
                 Lexer::flush_command_subst_keyword(
@@ -3516,12 +3826,15 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
                 if case_clause_depths
                     .last()
                     .is_some_and(|case_depth| *case_depth == depth)
                 {
                     index = next_index;
+                    at_command_start = true;
+                    expecting_redirection_target = false;
                     continue;
                 }
                 depth -= 1;
@@ -3529,27 +3842,44 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 if depth == 0 {
                     return Some(index);
                 }
+                at_command_start = false;
+                expecting_redirection_target = false;
             }
             '"' => {
+                let had_word = !current_word.is_empty();
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 index = scan_double_quoted_command_substitution_segment(
                     input,
                     next_index,
                     subst_depth,
                 )?;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
             '\'' => {
+                let had_word = !current_word.is_empty();
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 index = next_index;
                 while let Some((quoted_ch, quoted_next)) = next_char_boundary(input, index) {
                     index = quoted_next;
@@ -3557,26 +3887,88 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                         break;
                     }
                 }
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
-            '\\' => {
+            '$' if input[next_index..].starts_with('\'') => {
+                let had_word = !current_word.is_empty();
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = scan_command_subst_ansi_c_single_quoted_segment(input, next_index)?;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '\\' => {
+                let had_word = !current_word.is_empty();
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 index = next_index;
                 if let Some((_, escaped_next)) = next_char_boundary(input, index) {
                     index = escaped_next;
                 }
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
-            '<' if input[next_index..].starts_with('<') => {
+            '>' => {
+                let word_was_redirection_fd = current_word_started_at_command_start
+                    && !current_word.is_empty()
+                    && current_word.chars().all(|current| current.is_ascii_digit());
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if word_was_redirection_fd {
+                    at_command_start = true;
+                }
+                index = next_index;
+                expecting_redirection_target = true;
+            }
+            '<' if input[next_index..].starts_with('<') => {
+                let word_was_redirection_fd = current_word_started_at_command_start
+                    && !current_word.is_empty()
+                    && current_word.chars().all(|current| current.is_ascii_digit());
+                let had_word = !current_word.is_empty();
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                if word_was_redirection_fd {
+                    at_command_start = true;
+                }
                 if inside_unclosed_double_paren_on_line(input, index) {
                     index = next_index + '<'.len_utf8();
                     continue;
@@ -3585,6 +3977,7 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 // Here string (`<<<`) does not queue a heredoc body.
                 if input[next_index + '<'.len_utf8()..].starts_with('<') {
                     index = next_index + '<'.len_utf8() + '<'.len_utf8();
+                    expecting_redirection_target = true;
                     continue;
                 }
 
@@ -3595,8 +3988,10 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 {
                     pending_heredocs.push((delimiter, strip_tabs));
                     index = delimiter_index;
+                    expecting_redirection_target = false;
                 } else {
                     index = next_index;
+                    expecting_redirection_target = true;
                 }
             }
             '\n' => {
@@ -3605,51 +4000,96 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
                 index = next_index;
                 for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
                     index =
                         skip_command_subst_pending_heredoc(input, index, &delimiter, strip_tabs);
                 }
+                at_command_start = true;
+                expecting_redirection_target = false;
             }
             '$' if input[next_index..].starts_with('{') => {
+                let had_word = !current_word.is_empty();
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 let consumed = scan_command_subst_parameter_expansion_len(
                     &input[next_index + '{'.len_utf8()..],
                     subst_depth,
                 )?;
                 index = next_index + '{'.len_utf8() + consumed;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
             '$' if input[next_index..].starts_with('(')
                 && !input[next_index + '('.len_utf8()..].starts_with('(') =>
             {
+                let had_word = !current_word.is_empty();
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
                     &mut case_clause_depths,
                     depth,
+                    &mut current_word_started_at_command_start,
                 );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
                 let consumed = scan_command_substitution_body_len_inner(
                     &input[next_index + '('.len_utf8()..],
                     subst_depth + 1,
                 )?;
                 index = next_index + '('.len_utf8() + consumed;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
             }
             _ => {
                 if ch.is_ascii_alphanumeric() || ch == '_' {
+                    if current_word.is_empty() && !expecting_redirection_target && at_command_start
+                    {
+                        current_word_started_at_command_start = true;
+                        at_command_start = false;
+                    }
                     current_word.push(ch);
                 } else {
+                    let had_word = !current_word.is_empty();
                     Lexer::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
                         &mut case_clause_depths,
                         depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
+                    match ch {
+                        ' ' | '\t' => {}
+                        ';' | '|' | '&' => {
+                            at_command_start = true;
+                            expecting_redirection_target = false;
+                        }
+                        _ => {
+                            if !expecting_redirection_target {
+                                at_command_start = false;
+                            }
+                        }
+                    }
                 }
                 index = next_index;
             }
@@ -3936,6 +4376,29 @@ mod tests {
 
         assert!(body.contains("printf %s 1,2"));
         assert!(body.ends_with("))"));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_ignores_plain_case_words_in_commands() {
+        let source = "printf %s 1,2; echo case in)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("echo case in"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_ansi_c_quotes_with_escaped_single_quotes() {
+        let source = "printf %s $'a\\'b'; printf %s 1,2)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("$'a\\'b'"));
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -2458,6 +2458,25 @@ impl<'a> Lexer<'a> {
         saw_any.then_some(cooked)
     }
 
+    fn read_command_subst_backtick_segment_into(&mut self, content: &mut Option<String>) {
+        Self::push_capture_char(content, '`');
+        self.advance();
+        while let Some(ch) = self.peek_char() {
+            Self::push_capture_char(content, ch);
+            self.advance();
+            if ch == '\\' {
+                if let Some(esc) = self.peek_char() {
+                    Self::push_capture_char(content, esc);
+                    self.advance();
+                }
+                continue;
+            }
+            if ch == '`' {
+                break;
+            }
+        }
+    }
+
     fn read_command_subst_pending_heredoc_into(
         &mut self,
         content: &mut Option<String>,
@@ -2672,6 +2691,25 @@ impl<'a> Lexer<'a> {
                             break;
                         }
                     }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
+                }
+                '`' => {
+                    let had_word = !current_word.is_empty();
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
+                    self.read_command_subst_backtick_segment_into(content);
                     if expecting_redirection_target {
                         expecting_redirection_target = false;
                     } else {
@@ -3763,6 +3801,26 @@ fn scan_command_subst_ansi_c_single_quoted_segment(
     None
 }
 
+fn scan_command_subst_backtick_segment(input: &str, start: usize) -> Option<usize> {
+    let mut index = start;
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        index = next_index;
+        if ch == '\\' {
+            if let Some((_, escaped_next)) = next_char_boundary(input, index) {
+                index = escaped_next;
+            }
+            continue;
+        }
+
+        if ch == '`' {
+            return Some(index);
+        }
+    }
+
+    None
+}
+
 fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> Option<usize> {
     if subst_depth >= DEFAULT_MAX_SUBST_DEPTH {
         return None;
@@ -3887,6 +3945,25 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                         break;
                     }
                 }
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '`' => {
+                let had_word = !current_word.is_empty();
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = scan_command_subst_backtick_segment(input, next_index)?;
                 if expecting_redirection_target {
                     expecting_redirection_target = false;
                 } else {
@@ -4398,6 +4475,18 @@ mod tests {
 
         assert!(body.contains("$'a\\'b'"));
         assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_backticks_with_right_parens() {
+        let source = "printf %s `echo foo)`; printf %s ok)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("`echo foo)`"));
+        assert!(body.contains("printf %s ok"));
         assert!(body.ends_with(')'));
     }
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3233,6 +3233,18 @@ fn hash_starts_comment(input: &str, index: usize) -> bool {
         .is_none_or(|prev| prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>'))
 }
 
+fn heredoc_delimiter_is_terminator(
+    ch: char,
+    in_single: bool,
+    in_double: bool,
+    escaped: bool,
+) -> bool {
+    !in_single
+        && !in_double
+        && !escaped
+        && (ch.is_whitespace() || matches!(ch, '|' | '&' | ';' | '<' | '>' | '(' | ')'))
+}
+
 fn scan_double_quoted_command_substitution_segment(
     input: &str,
     mut index: usize,
@@ -3278,7 +3290,7 @@ fn scan_command_subst_heredoc_delimiter(input: &str, mut index: usize) -> Option
     let mut escaped = false;
 
     while let Some((ch, next_index)) = next_char_boundary(input, index) {
-        if !in_single && !in_double && !escaped && ch.is_whitespace() {
+        if heredoc_delimiter_is_terminator(ch, in_single, in_double, escaped) {
             break;
         }
 
@@ -3643,6 +3655,17 @@ mod tests {
         let body = &source[..consumed];
 
         assert!(body.contains("printf '%s' y"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_piped_heredoc_delimiter_without_space() {
+        let source = "\ncat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("field, direction"));
         assert!(body.ends_with(')'));
     }
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3221,12 +3221,276 @@ fn heredoc_line_matches_delimiter(line: &str, delimiter: &str, strip_tabs: bool)
     }
 }
 
+fn next_char_boundary(input: &str, index: usize) -> Option<(char, usize)> {
+    let ch = input.get(index..)?.chars().next()?;
+    Some((ch, index + ch.len_utf8()))
+}
+
+fn hash_starts_comment(input: &str, index: usize) -> bool {
+    input[..index]
+        .chars()
+        .next_back()
+        .is_none_or(char::is_whitespace)
+}
+
+fn scan_double_quoted_command_substitution_segment(
+    input: &str,
+    mut index: usize,
+    subst_depth: usize,
+) -> Option<usize> {
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        match ch {
+            '"' => return Some(next_index),
+            '\\' => {
+                index = next_index;
+                if let Some((_, escaped_next)) = next_char_boundary(input, index) {
+                    index = escaped_next;
+                }
+            }
+            '$'
+                if input[next_index..].starts_with('(')
+                    && !input[next_index + '('.len_utf8()..].starts_with('(') =>
+            {
+                let consumed = scan_command_substitution_body_len_inner(
+                    &input[next_index + '('.len_utf8()..],
+                    subst_depth + 1,
+                )?;
+                index = next_index + '('.len_utf8() + consumed;
+            }
+            _ => index = next_index,
+        }
+    }
+
+    None
+}
+
+fn scan_command_subst_heredoc_delimiter(input: &str, mut index: usize) -> Option<(usize, String)> {
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        if !matches!(ch, ' ' | '\t') {
+            break;
+        }
+        index = next_index;
+    }
+
+    let start = index;
+    let mut cooked = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        if !in_single && !in_double && !escaped && ch.is_whitespace() {
+            break;
+        }
+
+        index = next_index;
+        if escaped {
+            cooked.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if !in_single => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            _ => cooked.push(ch),
+        }
+    }
+
+    (index > start).then_some((index, cooked))
+}
+
+fn skip_command_subst_pending_heredoc(
+    input: &str,
+    mut index: usize,
+    delimiter: &str,
+    strip_tabs: bool,
+) -> usize {
+    while index <= input.len() {
+        let rest = &input[index..];
+        let line_len = rest.find('\n').unwrap_or(rest.len());
+        let line = &rest[..line_len];
+        let has_newline = line_len < rest.len();
+
+        index += line_len;
+        if has_newline {
+            index += '\n'.len_utf8();
+        }
+
+        if heredoc_line_matches_delimiter(line, delimiter, strip_tabs) || !has_newline {
+            return index;
+        }
+    }
+
+    index
+}
+
+fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> Option<usize> {
+    if subst_depth >= DEFAULT_MAX_SUBST_DEPTH {
+        return None;
+    }
+
+    let mut index = 0usize;
+    let mut depth = 1;
+    let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+    let mut pending_case_headers = 0usize;
+    let mut case_clause_depth = 0usize;
+    let mut current_word = String::with_capacity(16);
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        match ch {
+            '#' if hash_starts_comment(input, index) => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                index = next_index;
+                while let Some((comment_ch, comment_next)) = next_char_boundary(input, index) {
+                    index = comment_next;
+                    if comment_ch == '\n' {
+                        for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                            index = skip_command_subst_pending_heredoc(
+                                input,
+                                index,
+                                &delimiter,
+                                strip_tabs,
+                            );
+                        }
+                        break;
+                    }
+                }
+            }
+            '(' => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                depth += 1;
+                index = next_index;
+            }
+            ')' => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                if depth == 1 && case_clause_depth > 0 {
+                    index = next_index;
+                    continue;
+                }
+                depth -= 1;
+                index = next_index;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            '"' => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                index =
+                    scan_double_quoted_command_substitution_segment(input, next_index, subst_depth)?;
+            }
+            '\'' => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                index = next_index;
+                while let Some((quoted_ch, quoted_next)) = next_char_boundary(input, index) {
+                    index = quoted_next;
+                    if quoted_ch == '\'' {
+                        break;
+                    }
+                }
+            }
+            '\\' => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                index = next_index;
+                if let Some((_, escaped_next)) = next_char_boundary(input, index) {
+                    index = escaped_next;
+                }
+            }
+            '<' if input[next_index..].starts_with('<') => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                // Here string (`<<<`) does not queue a heredoc body.
+                if input[next_index + '<'.len_utf8()..].starts_with('<') {
+                    index = next_index + '<'.len_utf8() + '<'.len_utf8();
+                    continue;
+                }
+
+                let strip_tabs = input[next_index..].starts_with("<-");
+                let delimiter_start = next_index + if strip_tabs { 2 } else { 1 };
+                if let Some((delimiter_index, delimiter)) =
+                    scan_command_subst_heredoc_delimiter(input, delimiter_start)
+                {
+                    pending_heredocs.push((delimiter, strip_tabs));
+                    index = delimiter_index;
+                } else {
+                    index = next_index;
+                }
+            }
+            '\n' => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                index = next_index;
+                for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                    index =
+                        skip_command_subst_pending_heredoc(input, index, &delimiter, strip_tabs);
+                }
+            }
+            '$'
+                if input[next_index..].starts_with('(')
+                    && !input[next_index + '('.len_utf8()..].starts_with('(') =>
+            {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                let consumed = scan_command_substitution_body_len_inner(
+                    &input[next_index + '('.len_utf8()..],
+                    subst_depth + 1,
+                )?;
+                index = next_index + '('.len_utf8() + consumed;
+            }
+            _ => {
+                if ch.is_ascii_alphanumeric() || ch == '_' {
+                    current_word.push(ch);
+                } else {
+                    Lexer::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depth,
+                    );
+                }
+                index = next_index;
+            }
+        }
+    }
+
+    None
+}
+
 pub(super) fn scan_command_substitution_body_len(input: &str) -> Option<usize> {
-    let mut lexer = Lexer::new(input);
-    let mut content = Some(String::new());
-    lexer
-        .read_command_subst_into(&mut content)
-        .then_some(lexer.offset)
+    scan_command_substitution_body_len_inner(input, 0)
 }
 
 #[cfg(test)]
@@ -3360,6 +3624,18 @@ mod tests {
                 .slice(source),
             "foo"
         );
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_tabstripped_heredoc() {
+        let source =
+            "\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("field, direction"));
+        assert!(body.ends_with(')'));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3226,10 +3226,40 @@ fn next_char_boundary(input: &str, index: usize) -> Option<(char, usize)> {
     Some((ch, index + ch.len_utf8()))
 }
 
+fn inside_unclosed_double_paren_on_line(input: &str, index: usize) -> bool {
+    let line_start = input[..index].rfind('\n').map_or(0, |found| found + 1);
+    let prefix = &input[line_start..index];
+    let mut chars = prefix.chars().peekable();
+    let mut depth = 0usize;
+
+    while let Some(ch) = chars.next() {
+        if ch == '(' && chars.peek() == Some(&'(') {
+            chars.next();
+            depth += 1;
+            continue;
+        }
+        if ch == ')' && chars.peek() == Some(&')') {
+            chars.next();
+            depth = depth.saturating_sub(1);
+        }
+    }
+
+    depth > 0
+}
+
 fn hash_starts_comment(input: &str, index: usize) -> bool {
-    input[..index].chars().next_back().is_none_or(|prev| {
-        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | '(' | ')')
-    })
+    if inside_unclosed_double_paren_on_line(input, index) {
+        return false;
+    }
+
+    let next = input[index + '#'.len_utf8()..].chars().next();
+    input[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|prev| match prev {
+            '(' => next.is_none_or(char::is_whitespace),
+            _ => prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | ')'),
+        })
 }
 
 fn heredoc_delimiter_is_terminator(
@@ -3769,6 +3799,22 @@ mod tests {
 
         assert!(body.contains("printf %s 1,2"));
         assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_hash_starts_comment_ignores_zsh_inline_glob_controls_after_left_paren() {
+        let source = "[[ \"$buf\" == (#b)(*) ]]";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(!hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn test_hash_starts_comment_ignores_hash_inside_unclosed_double_parens() {
+        let source = "(( #c < 256 ))";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(!hash_starts_comment(source, index));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1288,22 +1288,7 @@ impl<'a> Lexer<'a> {
             .rfind('\n')
             .map_or(0, |index| index + 1);
         let prefix = &self.input[line_start..self.offset];
-        let mut chars = prefix.chars().peekable();
-        let mut depth = 0usize;
-
-        while let Some(ch) = chars.next() {
-            if ch == '(' && chars.peek() == Some(&'(') {
-                chars.next();
-                depth += 1;
-                continue;
-            }
-            if ch == ')' && chars.peek() == Some(&')') {
-                chars.next();
-                depth = depth.saturating_sub(1);
-            }
-        }
-
-        depth > 0
+        line_has_unclosed_double_paren(prefix)
     }
 
     /// Check if this is a file descriptor redirect (e.g., 2>, 2>>, 2>&1)
@@ -3226,25 +3211,60 @@ fn next_char_boundary(input: &str, index: usize) -> Option<(char, usize)> {
     Some((ch, index + ch.len_utf8()))
 }
 
-fn inside_unclosed_double_paren_on_line(input: &str, index: usize) -> bool {
-    let line_start = input[..index].rfind('\n').map_or(0, |found| found + 1);
-    let prefix = &input[line_start..index];
-    let mut chars = prefix.chars().peekable();
+fn line_has_unclosed_double_paren(prefix: &str) -> bool {
+    let mut index = 0usize;
     let mut depth = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_backtick = false;
+    let mut escaped = false;
 
-    while let Some(ch) = chars.next() {
-        if ch == '(' && chars.peek() == Some(&'(') {
-            chars.next();
-            depth += 1;
+    while let Some((ch, next_index)) = next_char_boundary(prefix, index) {
+        let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
             continue;
         }
-        if ch == ')' && chars.peek() == Some(&')') {
-            chars.next();
-            depth = depth.saturating_sub(1);
+        escaped = false;
+
+        match ch {
+            '\'' if !in_double && !in_backtick && !was_escaped => in_single = !in_single,
+            '"' if !in_single && !in_backtick && !was_escaped => in_double = !in_double,
+            '`' if !in_single && !in_double && !was_escaped => in_backtick = !in_backtick,
+            '(' if !in_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && prefix[next_index..].starts_with('(') =>
+            {
+                depth += 1;
+                index = next_index + '('.len_utf8();
+                continue;
+            }
+            ')' if !in_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && prefix[next_index..].starts_with(')') =>
+            {
+                depth = depth.saturating_sub(1);
+                index = next_index + ')'.len_utf8();
+                continue;
+            }
+            _ => {}
         }
+
+        index = next_index;
     }
 
     depth > 0
+}
+
+fn inside_unclosed_double_paren_on_line(input: &str, index: usize) -> bool {
+    let line_start = input[..index].rfind('\n').map_or(0, |found| found + 1);
+    let prefix = &input[line_start..index];
+    line_has_unclosed_double_paren(prefix)
 }
 
 fn hash_starts_comment(input: &str, index: usize) -> bool {
@@ -3525,6 +3545,11 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                     &mut pending_case_headers,
                     &mut case_clause_depth,
                 );
+                if inside_unclosed_double_paren_on_line(input, index) {
+                    index = next_index + '<'.len_utf8();
+                    continue;
+                }
+
                 // Here string (`<<<`) does not queue a heredoc body.
                 if input[next_index + '<'.len_utf8()..].starts_with('<') {
                     index = next_index + '<'.len_utf8() + '<'.len_utf8();
@@ -3815,6 +3840,36 @@ mod tests {
         let index = source.find('#').expect("expected hash");
 
         assert!(!hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn test_hash_starts_comment_respects_quoted_double_parens() {
+        let source = "printf '((' # comment";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_quoted_double_parens_before_comments() {
+        let source = "printf '((' # comment with )\nprintf %s 1,2\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_ignores_arithmetic_shift_for_heredoc_detection() {
+        let source = "((x<<2))\nprintf %s 1,2\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -2389,7 +2389,8 @@ impl<'a> Lexer<'a> {
     fn flush_command_subst_keyword(
         current_word: &mut String,
         pending_case_headers: &mut usize,
-        case_clause_depth: &mut usize,
+        case_clause_depths: &mut Vec<usize>,
+        depth: usize,
     ) {
         if current_word.is_empty() {
             return;
@@ -2399,9 +2400,11 @@ impl<'a> Lexer<'a> {
             "case" => *pending_case_headers += 1,
             "in" if *pending_case_headers > 0 => {
                 *pending_case_headers -= 1;
-                *case_clause_depth += 1;
+                case_clause_depths.push(depth);
             }
-            "esac" if *case_clause_depth > 0 => *case_clause_depth -= 1,
+            "esac" => {
+                case_clause_depths.pop();
+            }
             _ => {}
         }
 
@@ -2435,7 +2438,7 @@ impl<'a> Lexer<'a> {
 
         let mut depth = 1;
         let mut pending_case_headers = 0usize;
-        let mut case_clause_depth = 0usize;
+        let mut case_clause_depths = Vec::new();
         let mut current_word = String::with_capacity(16);
         while let Some(c) = self.peek_char() {
             match c {
@@ -2443,7 +2446,8 @@ impl<'a> Lexer<'a> {
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
                     );
                     Self::push_capture_char(content, '#');
                     self.advance();
@@ -2459,7 +2463,8 @@ impl<'a> Lexer<'a> {
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
                     );
                     depth += 1;
                     Self::push_capture_char(content, c);
@@ -2469,9 +2474,13 @@ impl<'a> Lexer<'a> {
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
                     );
-                    if depth == 1 && case_clause_depth > 0 {
+                    if case_clause_depths
+                        .last()
+                        .is_some_and(|case_depth| *case_depth == depth)
+                    {
                         Self::push_capture_char(content, ')');
                         self.advance();
                         continue;
@@ -2488,7 +2497,8 @@ impl<'a> Lexer<'a> {
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
                     );
                     // Nested double-quoted string inside $()
                     Self::push_capture_char(content, '"');
@@ -2531,7 +2541,8 @@ impl<'a> Lexer<'a> {
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
                     );
                     // Single-quoted string inside $()
                     Self::push_capture_char(content, '\'');
@@ -2548,7 +2559,8 @@ impl<'a> Lexer<'a> {
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
                     );
                     Self::push_capture_char(content, '\\');
                     self.advance();
@@ -2564,7 +2576,8 @@ impl<'a> Lexer<'a> {
                         Self::flush_command_subst_keyword(
                             &mut current_word,
                             &mut pending_case_headers,
-                            &mut case_clause_depth,
+                            &mut case_clause_depths,
+                            depth,
                         );
                     }
                     Self::push_capture_char(content, c);
@@ -3453,7 +3466,7 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
     let mut depth = 1;
     let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
     let mut pending_case_headers = 0usize;
-    let mut case_clause_depth = 0usize;
+    let mut case_clause_depths = Vec::new();
     let mut current_word = String::with_capacity(16);
 
     while let Some((ch, next_index)) = next_char_boundary(input, index) {
@@ -3462,7 +3475,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = next_index;
                 while let Some((comment_ch, comment_next)) = next_char_boundary(input, index) {
@@ -3481,7 +3495,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 depth += 1;
                 index = next_index;
@@ -3490,9 +3505,13 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
-                if depth == 1 && case_clause_depth > 0 {
+                if case_clause_depths
+                    .last()
+                    .is_some_and(|case_depth| *case_depth == depth)
+                {
                     index = next_index;
                     continue;
                 }
@@ -3506,7 +3525,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = scan_double_quoted_command_substitution_segment(
                     input,
@@ -3518,7 +3538,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = next_index;
                 while let Some((quoted_ch, quoted_next)) = next_char_boundary(input, index) {
@@ -3532,7 +3553,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = next_index;
                 if let Some((_, escaped_next)) = next_char_boundary(input, index) {
@@ -3543,7 +3565,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 if inside_unclosed_double_paren_on_line(input, index) {
                     index = next_index + '<'.len_utf8();
@@ -3571,7 +3594,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 index = next_index;
                 for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
@@ -3583,7 +3607,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 let consumed = scan_command_subst_parameter_expansion_len(
                     &input[next_index + '{'.len_utf8()..],
@@ -3597,7 +3622,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                 Lexer::flush_command_subst_keyword(
                     &mut current_word,
                     &mut pending_case_headers,
-                    &mut case_clause_depth,
+                    &mut case_clause_depths,
+                    depth,
                 );
                 let consumed = scan_command_substitution_body_len_inner(
                     &input[next_index + '('.len_utf8()..],
@@ -3612,7 +3638,8 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                     Lexer::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
                     );
                 }
                 index = next_index;
@@ -3870,6 +3897,17 @@ mod tests {
 
         assert!(body.contains("printf %s 1,2"));
         assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_nested_case_pattern_right_paren() {
+        let source = "(case $kind in\na) printf %s 1,2 ;;\nesac\n))\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with("))"));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3258,6 +3258,13 @@ fn scan_double_quoted_command_substitution_segment(
                     index = escaped_next;
                 }
             }
+            '$' if input[next_index..].starts_with('{') => {
+                let consumed = scan_command_subst_parameter_expansion_len(
+                    &input[next_index + '{'.len_utf8()..],
+                    subst_depth,
+                )?;
+                index = next_index + '{'.len_utf8() + consumed;
+            }
             '$' if input[next_index..].starts_with('(')
                 && !input[next_index + '('.len_utf8()..].starts_with('(') =>
             {
@@ -3269,6 +3276,57 @@ fn scan_double_quoted_command_substitution_segment(
             }
             _ => index = next_index,
         }
+    }
+
+    None
+}
+
+fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -> Option<usize> {
+    let mut index = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
+            continue;
+        }
+        escaped = false;
+
+        if !in_single && !was_escaped && ch == '$' {
+            if input[next_index..].starts_with('{')
+                && let Some(consumed) = scan_command_subst_parameter_expansion_len(
+                    &input[next_index + '{'.len_utf8()..],
+                    subst_depth,
+                )
+            {
+                index = next_index + '{'.len_utf8() + consumed;
+                continue;
+            }
+
+            if input[next_index..].starts_with('(')
+                && !input[next_index + '('.len_utf8()..].starts_with('(')
+                && let Some(consumed) = scan_command_substitution_body_len_inner(
+                    &input[next_index + '('.len_utf8()..],
+                    subst_depth + 1,
+                )
+            {
+                index = next_index + '('.len_utf8() + consumed;
+                continue;
+            }
+        }
+
+        match ch {
+            '\'' if !in_double && !was_escaped => in_single = !in_single,
+            '"' if !in_single && !was_escaped => in_double = !in_double,
+            '}' if !in_single && !in_double && !was_escaped => return Some(next_index),
+            _ => {}
+        }
+
+        index = next_index;
     }
 
     None
@@ -3465,6 +3523,18 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
                     index =
                         skip_command_subst_pending_heredoc(input, index, &delimiter, strip_tabs);
                 }
+            }
+            '$' if input[next_index..].starts_with('{') => {
+                Lexer::flush_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depth,
+                );
+                let consumed = scan_command_subst_parameter_expansion_len(
+                    &input[next_index + '{'.len_utf8()..],
+                    subst_depth,
+                )?;
+                index = next_index + '{'.len_utf8() + consumed;
             }
             '$' if input[next_index..].starts_with('(')
                 && !input[next_index + '('.len_utf8()..].starts_with('(') =>
@@ -3676,6 +3746,17 @@ mod tests {
         let body = &source[..consumed];
 
         assert!(body.contains("field, direction"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_parameter_expansion_with_right_paren() {
+        let source = "printf %s ${x//foo/)},1)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("${x//foo/)},1"));
         assert!(body.ends_with(')'));
     }
 

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2506,6 +2506,54 @@ fn test_parse_declare_array_preserves_piped_heredoc_without_spacing_in_command_s
 }
 
 #[test]
+fn test_parse_declare_array_preserves_parameter_expansion_with_right_paren_in_command_substitution()
+{
+    let input = "f() {\n\tlocal -a parts=(\n\t\t\"$(printf %s ${x//foo/)},1)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
 fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
     let input = "printf '%s\\n' ${assoc[\"key\"]} ${assoc['k']}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2365,6 +2365,53 @@ fn test_parse_declare_a_threads_associative_kind_into_compound_array() {
 }
 
 #[test]
+fn test_parse_declare_array_preserves_quoted_command_substitution_elements() {
+    let input = "f() {\n\tlocal -a graphql_request=(\n\t\t-X POST\n\t\t-d \"$(\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 4, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[3] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
 fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
     let input = "printf '%s\\n' ${assoc[\"key\"]} ${assoc['k']}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2636,6 +2636,47 @@ fn test_parse_declare_array_preserves_ansi_c_quotes_in_command_substitution() {
 }
 
 #[test]
+fn test_parse_declare_array_preserves_backticks_with_right_parens_in_command_substitution() {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t$(printf %s `echo foo)`; printf %s ok)\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| matches!(
+            &part.kind,
+            WordPart::CommandSubstitution {
+                syntax: CommandSubstitutionSyntax::DollarParen,
+                ..
+            }
+        )),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
 fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
     let input = "printf '%s\\n' ${assoc[\"key\"]} ${assoc['k']}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2554,6 +2554,88 @@ fn test_parse_declare_array_preserves_parameter_expansion_with_right_paren_in_co
 }
 
 #[test]
+fn test_parse_declare_array_preserves_plain_case_words_in_command_substitution() {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t$(printf %s 1,2; echo case in)\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| matches!(
+            &part.kind,
+            WordPart::CommandSubstitution {
+                syntax: CommandSubstitutionSyntax::DollarParen,
+                ..
+            }
+        )),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
+fn test_parse_declare_array_preserves_ansi_c_quotes_in_command_substitution() {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t$(printf %s $'a\\'b'; printf %s 1,2)\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| matches!(
+            &part.kind,
+            WordPart::CommandSubstitution {
+                syntax: CommandSubstitutionSyntax::DollarParen,
+                ..
+            }
+        )),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
 fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
     let input = "printf '%s\\n' ${assoc[\"key\"]} ${assoc['k']}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2412,6 +2412,53 @@ fn test_parse_declare_array_preserves_quoted_command_substitution_elements() {
 }
 
 #[test]
+fn test_parse_declare_array_preserves_separator_comment_in_quoted_command_substitution() {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t\"$(printf '%s' x;# comment with ) and ,\n\t\tprintf '%s' y\n\t\t)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
 fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
     let input = "printf '%s\\n' ${assoc[\"key\"]} ${assoc['k']}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2459,6 +2459,53 @@ fn test_parse_declare_array_preserves_separator_comment_in_quoted_command_substi
 }
 
 #[test]
+fn test_parse_declare_array_preserves_piped_heredoc_without_spacing_in_command_substitution() {
+    let input = "f() {\n\tlocal -a graphql_request=(\n\t\t\"$(\ncat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n\t\t)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
 fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
     let input = "printf '%s\\n' ${assoc[\"key\"]} ${assoc['k']}\n";
     let script = Parser::new(input).parse().unwrap().file;


### PR DESCRIPTION
## Summary
- narrow C151 comma scanning so it ignores commas inside `$(...)` command substitutions and `${...}` parameter expansions
- harden compound-array parsing around quoted command substitutions with tab-stripped heredocs
- add focused regressions for the parser, lexer helper, facts layer, and C151 rule behavior

## Why
C151 was treating commas embedded in heredoc-backed command substitutions and parameter-expansion operators as if they were top-level array separators. That produced false positives in real corpus fixtures even though true comma-separated array literals should still be reported.

## Impact
This keeps legitimate `parts=(alpha,beta)` style findings, removes the false positives seen in Termux and RVM fixtures, and preserves the parser/linter contract around quoted command-substitution array elements.

## Validation
- `cargo test -p shuck-parser test_scan_command_substitution_body_len_handles_tabstripped_heredoc -- --nocapture`
- `cargo test -p shuck-parser test_parse_declare_array_preserves_quoted_command_substitution_elements -- --nocapture`
- `cargo test -p shuck-linter reports_comma_separated_array_literals -- --nocapture`
- `cargo test -p shuck-linter ignores_quoted_and_brace_expansion_commas -- --nocapture`
- `cargo test -p shuck-linter ignores_commas_inside_quoted_command_substitution_array_elements -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=C151 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`