### PR TITLE
Review X043 large-corpus divergences

### DIFF
--- a/crates/shuck/tests/testdata/corpus-metadata/x043.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x043.yaml
@@ -1,4 +1,43 @@
 reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
+    line: 326
+    end_line: 326
+    labels:
+      - helper-library
+      - shell-collapse
+    reason: "This completion helper reaches the nested `${(M)${(k)...}}` form only inside a guarded `ZSH_VERSION` branch. Shuck keeps that compound expansion on X044 and does not duplicate separate X043 modifier hits for the inner and outer flag groups in this shell-collapsed helper."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__build"
+    labels:
+      - project-closure
+    reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__installer"
+    labels:
+      - project-closure
+    reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__manage__base_install"
+    labels:
+      - project-closure
+    reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__manage__ree"
+    reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path, so the remaining X043 hit is reviewed for this helper."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__manage__rubinius"
+    labels:
+      - project-closure
+    reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__utility"
+    labels:
+      - project-closure
+    reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__utility_package"
+    reason: "This Bash helper only uses the `${=...}` split form inside explicit `ZSH_VERSION` branches before falling back to the Bash form. The pinned ShellCheck run stays quiet on those guarded zsh paths, so the remaining X043 hits are reviewed for this helper."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
     line: 22


### PR DESCRIPTION
## Summary

- add reviewed `X043` large-corpus divergences for the current `SC2296` mismatch cluster
- cover the guarded nested `gitfast` helper case plus the guarded `${=...}` RVM helper paths
- preserve the existing reviewed `wd` divergence while keeping the rule implementation unchanged

## Why

The remaining `X043` large-corpus failures came from guarded zsh-only branches and nested substitution ownership, not from a clean matcher bug in the rule itself. Recording these as reviewed divergences keeps the comparison signal accurate without weakening `X043` for direct cases.

## Validation

- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=X043 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`
