### PR TITLE
Fix escaped literal backticks in S005

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -92,6 +92,29 @@ impl<'a> SurfaceFragmentSink<'a> {
         self.facts
     }
 
+    fn opening_backtick_is_escaped(&self, span: Span) -> bool {
+        let source = self.source.as_bytes();
+        let start = span.start.offset;
+        let Some(fragment) = self.source.get(start..span.end.offset) else {
+            return false;
+        };
+        let Some(first_backtick) = fragment.find('`') else {
+            return true;
+        };
+        if !fragment[..first_backtick].bytes().all(|byte| byte == b'\\') {
+            return false;
+        }
+
+        let mut backslashes = first_backtick;
+        let mut cursor = start;
+        while cursor > 0 && source[cursor - 1] == b'\\' {
+            backslashes += 1;
+            cursor -= 1;
+        }
+
+        backslashes % 2 == 1
+    }
+
     fn record_array_reference(&mut self, span: Span) {
         let Some(span) = plain_array_reference_span(span, self.source) else {
             return;
@@ -332,6 +355,9 @@ impl<'a> SurfaceFragmentSink<'a> {
                     body: _,
                     ..
                 } => {
+                    if self.opening_backtick_is_escaped(part.span) {
+                        continue;
+                    }
                     self.facts
                         .backticks
                         .push(BacktickFragmentFact { span: part.span });

--- a/crates/shuck-linter/src/rules/style/legacy_backticks.rs
+++ b/crates/shuck-linter/src/rules/style/legacy_backticks.rs
@@ -65,4 +65,28 @@ mod tests {
             vec!["`pyenv-commands --sh`"]
         );
     }
+
+    #[test]
+    fn ignores_escaped_backticks_in_case_patterns() {
+        let source = "\
+case \"$ch\" in
+  \\`)
+    printf '%s\\n' literal
+    ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LegacyBackticks));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_escaped_backticks_after_nested_expansions_in_double_quotes() {
+        let source = "\
+echo \"::error ::Failed to reuse PR #${PR:-} ${WORKFLOW_ID:+\"(workflow run ${WORKFLOW_ID})\"} build artifacts, see \\`Gathering build summary\\` step logs.\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LegacyBackticks));
+
+        assert!(diagnostics.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Ignore escaped literal backticks when collecting `S005` backtick fragments so literal `\`` text no longer reports as legacy command substitution.
- Add regression coverage for escaped backticks in `case` patterns and double-quoted strings after nested expansions.

## Root Cause

The `S005` rule relies on surface backtick fragments. Escaped literal backticks could still be surfaced as backtick fragments in a few parser edge cases, which produced false positives during full large-corpus comparison.

## Validation

- `cargo test -p shuck-linter`
- `cargo test -p shuck-linter legacy_backticks -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=S005 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`
