### PR TITLE
Fix S029 literal brace false positives

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4864,15 +4864,99 @@ fn is_xargs_inline_replace_option(
         return false;
     }
 
-    let text = fact.span().slice(source);
-    let inline_replace = text
-        .strip_prefix("-I")
-        .or_else(|| text.strip_prefix("-i"))
-        .is_some_and(|replacement| !replacement.is_empty());
+    xargs_replacement_spans(command.body_args(), source)
+        .into_iter()
+        .any(|span| {
+            span.start.offset <= brace_span.start.offset && span.end.offset >= brace_span.end.offset
+        })
+}
 
-    inline_replace
-        && fact.span().start.offset <= brace_span.start.offset
-        && fact.span().end.offset >= brace_span.end.offset
+fn xargs_replacement_spans(args: &[&Word], source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+
+        if text == "--" {
+            break;
+        }
+
+        if let Some(long) = text.strip_prefix("--") {
+            if let Some(replacement) = long.strip_prefix("replace=") {
+                if !replacement.is_empty() {
+                    spans.push(word.span);
+                }
+                index += 1;
+                continue;
+            }
+
+            if long == "replace" {
+                let Some(next_word) = args.get(index + 1) else {
+                    break;
+                };
+                spans.push(next_word.span);
+                index += 2;
+                continue;
+            }
+
+            let consume_next_argument = xargs_long_option_requires_separate_argument(long);
+            index += 1;
+            if consume_next_argument {
+                index += 1;
+            }
+            continue;
+        }
+
+        if !text.starts_with('-') || text == "-" {
+            break;
+        }
+
+        let mut chars = text[1..].chars().peekable();
+        let mut consume_next_argument = false;
+
+        while let Some(flag) = chars.next() {
+            match flag {
+                'i' => {
+                    if chars.peek().is_some() {
+                        spans.push(word.span);
+                    }
+                    break;
+                }
+                'I' => {
+                    if chars.peek().is_some() {
+                        spans.push(word.span);
+                    } else {
+                        let Some(next_word) = args.get(index + 1) else {
+                            return spans;
+                        };
+                        spans.push(next_word.span);
+                        consume_next_argument = true;
+                    }
+                    break;
+                }
+                _ => match xargs_short_option_argument_style(flag) {
+                    XargsShortOptionArgumentStyle::None => {}
+                    XargsShortOptionArgumentStyle::OptionalInlineOnly => break,
+                    XargsShortOptionArgumentStyle::Required => {
+                        if chars.peek().is_none() {
+                            consume_next_argument = true;
+                        }
+                        break;
+                    }
+                },
+            }
+        }
+
+        index += 1;
+        if consume_next_argument {
+            index += 1;
+        }
+    }
+
+    spans
 }
 
 fn shellish_words(text: &str) -> Vec<&str> {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4737,7 +4737,10 @@ fn build_literal_brace_spans(
                     brace.kind == BraceSyntaxKind::Literal
                         && brace.quote_context == BraceQuoteContext::Unquoted
                 })
-                .filter(|brace| !is_find_exec_placeholder(commands, fact, brace.span, source))
+                .filter(|brace| {
+                    !is_find_exec_placeholder(commands, fact, brace.span, source)
+                        && !is_xargs_inline_replace_option(commands, fact, brace.span, source)
+                })
                 .flat_map(|brace| brace_literal_edge_spans(brace.span, source)),
         );
 
@@ -4764,6 +4767,10 @@ fn is_find_exec_placeholder(
     }
 
     let command = &commands[fact.command_id().index()];
+    if command.has_wrapper(WrapperKind::FindExec) || command.has_wrapper(WrapperKind::FindExecDir) {
+        return true;
+    }
+
     if command
         .body_name_word()
         .is_some_and(|name_word| name_word.span == fact.span())
@@ -4842,6 +4849,32 @@ fn line_has_find_exec_placeholder_context(source: &str, brace_span: Span) -> boo
         && has_exec_terminator_after
 }
 
+fn is_xargs_inline_replace_option(
+    commands: &[CommandFact<'_>],
+    fact: &WordFact<'_>,
+    brace_span: Span,
+    source: &str,
+) -> bool {
+    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
+        return false;
+    }
+
+    let command = &commands[fact.command_id().index()];
+    if !command.effective_name_is("xargs") {
+        return false;
+    }
+
+    let text = fact.span().slice(source);
+    let inline_replace = text
+        .strip_prefix("-I")
+        .or_else(|| text.strip_prefix("-i"))
+        .is_some_and(|replacement| !replacement.is_empty());
+
+    inline_replace
+        && fact.span().start.offset <= brace_span.start.offset
+        && fact.span().end.offset >= brace_span.end.offset
+}
+
 fn shellish_words(text: &str) -> Vec<&str> {
     let mut words = Vec::new();
     let mut start = None;
@@ -4887,6 +4920,7 @@ struct LiteralBraceCandidate {
     open_offset: usize,
     after_escaped_dollar: bool,
     has_runtime_shell_sigil_inside: bool,
+    has_brace_expansion_delimiter: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4988,11 +5022,24 @@ fn escaped_parameter_expansion_brace_edge_spans(word: &Word, source: &str) -> Ve
                 open_offset: index,
                 after_escaped_dollar: previous_char == Some('$') && previous_char_escaped,
                 has_runtime_shell_sigil_inside: false,
+                has_brace_expansion_delimiter: false,
             });
+        } else if ch == ','
+            && let Some(candidate) = literal_stack.last_mut()
+        {
+            candidate.has_brace_expansion_delimiter = true;
+        } else if ch == '.'
+            && previous_char == Some('.')
+            && !previous_char_escaped
+            && let Some(candidate) = literal_stack.last_mut()
+        {
+            candidate.has_brace_expansion_delimiter = true;
         } else if ch == '}'
             && let Some(candidate) = literal_stack.pop()
             && index > candidate.open_offset + 1
             && (candidate.after_escaped_dollar || candidate.has_runtime_shell_sigil_inside)
+            && !candidate.has_brace_expansion_delimiter
+            && !brace_pair_matches_nonliteral_syntax(word, candidate.open_offset, index)
         {
             let open = span.start.advanced_by(&text[..candidate.open_offset]);
             let close = span.start.advanced_by(&text[..index]);
@@ -5119,7 +5166,9 @@ fn raw_escaped_parameter_brace_edge_spans(word: &Word, source: &str) -> Vec<Span
         } else if ch == '}' {
             if parameter_depth > 0 {
                 parameter_depth -= 1;
-            } else if let Some(open_offset) = escaped_parameter_stack.pop() {
+            } else if let Some(open_offset) = escaped_parameter_stack.pop()
+                && !brace_pair_matches_nonliteral_syntax(word, open_offset, index)
+            {
                 let open = span.start.advanced_by(&text[..open_offset]);
                 let close = span.start.advanced_by(&text[..index]);
                 spans.push(Span::from_positions(open, open));
@@ -5133,6 +5182,21 @@ fn raw_escaped_parameter_brace_edge_spans(word: &Word, source: &str) -> Vec<Span
     }
 
     spans
+}
+
+fn brace_pair_matches_nonliteral_syntax(
+    word: &Word,
+    open_offset: usize,
+    close_offset: usize,
+) -> bool {
+    let absolute_open_offset = word.span.start.offset + open_offset;
+    let absolute_close_offset = word.span.start.offset + close_offset + '}'.len_utf8();
+
+    word.brace_syntax().iter().any(|brace| {
+        brace.kind != BraceSyntaxKind::Literal
+            && brace.span.start.offset == absolute_open_offset
+            && brace.span.end.offset == absolute_close_offset
+    })
 }
 
 fn collect_raw_escaped_parameter_exclusions(

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -56,6 +56,46 @@ fi
     }
 
     #[test]
+    fn ignores_wrapped_and_multiline_find_exec_placeholders() {
+        let source = "\
+#!/bin/bash
+if ! find \"$output_dir\" -mindepth 1 -exec false {} + 2>/dev/null; then
+  exit 1
+fi
+find \"$TERMUX_PREFIX\"/share/doc/\"$TERMUX_PKG_NAME\" \\
+  -type f -execdir sed -i -e 's/\\r$//g' {} +
+find . \\
+  -exec sh -c 'is_empty \"$0\"' {} \\;
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_dynamic_brace_expansions() {
+        let source = "\
+#!/bin/bash
+ln -sf \"${TERMUX_PREFIX}/lib/\"{libjanet.so.${TERMUX_PKG_VERSION},libjanet.so.${TERMUX_PKG_VERSION%.*}}
+ln -sfr $TERMUX_PREFIX/lib/libaircrack-${m}{-$_LT_VER,}.so
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_xargs_inline_replace_options() {
+        let source = "\
+#!/bin/bash
+xargs -I{} basename \"{}\" | xargs echo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_literal_braces_for_non_find_exec_forms() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -88,11 +88,24 @@ ln -sfr $TERMUX_PREFIX/lib/libaircrack-${m}{-$_LT_VER,}.so
     fn ignores_xargs_inline_replace_options() {
         let source = "\
 #!/bin/bash
-xargs -I{} basename \"{}\" | xargs echo
+xargs -I{} basename \"{}\"
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_xargs_like_literals_after_option_parsing_stops() {
+        let source = "\
+#!/bin/bash
+xargs printf -I{}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.column, 16);
+        assert_eq!(diagnostics[1].span.start.column, 17);
     }
 
     #[test]

--- a/crates/shuck/tests/testdata/corpus-metadata/s029.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s029.yaml
@@ -1,6 +1,4 @@
 reviewed_divergences:
-  - side: shuck-only
-    reason: "Shuck keeps literal-brace findings for escaped template and eval string patterns that the ShellCheck oracle frequently suppresses in large helper-script and project-closure contexts."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_gir.sh"
     line: 105


### PR DESCRIPTION
## What changed
- tightened `S029` fact generation so literal-brace warnings skip `find -exec` and `-execdir` placeholders
- stopped the dynamic brace detector from flagging real brace expansions with embedded shell syntax
- ignored `xargs -I{}` inline replacement options
- added focused regression tests for the `find`, dynamic brace-expansion, and `xargs` cases
- removed the stale broad `S029` shuck-only corpus divergence entry

## Why
`S029` was over-reporting several brace-shaped forms that are intentionally interpreted by shell tooling instead of being risky literal braces. That left the rule depending on broad corpus metadata instead of matching the real shell surface more precisely.

## Impact
The rule now reports fewer false positives and the targeted large-corpus compatibility run passes for `S029` without reviewed divergences.

## Root cause
The literal-brace fact builder treated wrapped `find` placeholders, dynamic brace expansions, and `xargs` inline replace syntax as generic literal braces.

## Validation
- `cargo test -p shuck-linter literal_braces`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=120 SHUCK_LARGE_CORPUS_RULES=S029 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`
