### PR TITLE
Speed up source closure and scale large corpus timeouts

### DIFF
--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -22,6 +22,7 @@ use crate::cfg::{
 use crate::declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 use crate::reference::{Reference, ReferenceKind};
 use crate::runtime::RuntimePrelude;
+use crate::source_closure::source_path_template;
 use crate::source_ref::{SourceRef, SourceRefKind, SourceRefResolution};
 use crate::{
     BindingId, FunctionScopeKind, IndirectTargetHint, ReferenceId, Scope, ScopeId, ScopeKind,
@@ -253,7 +254,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.recorded_program.command_mut(recorded).span = span;
         self.recorded_program.command_infos.insert(
             SpanKey::new(span),
-            recorded_command_info(&stmt.command, self.source),
+            recorded_command_info(&stmt.command, self.source, self.runtime.bash_enabled()),
         );
 
         self.command_stack.pop();
@@ -2903,9 +2904,15 @@ fn static_word_text(word: &Word, source: &str) -> Option<String> {
     collect_static_word_text(&word.parts, source, &mut result).then_some(result)
 }
 
-fn recorded_command_info(command: &Command, source: &str) -> RecordedCommandInfo {
+fn recorded_command_info(
+    command: &Command,
+    source: &str,
+    bash_runtime_vars_enabled: bool,
+) -> RecordedCommandInfo {
     match command {
-        Command::Simple(command) => recorded_simple_command_info(command, source),
+        Command::Simple(command) => {
+            recorded_simple_command_info(command, source, bash_runtime_vars_enabled)
+        }
         Command::Builtin(_)
         | Command::Decl(_)
         | Command::Binary(_)
@@ -2918,11 +2925,23 @@ fn recorded_command_info(command: &Command, source: &str) -> RecordedCommandInfo
 fn recorded_simple_command_info(
     command: &shuck_ast::SimpleCommand,
     source: &str,
+    bash_runtime_vars_enabled: bool,
 ) -> RecordedCommandInfo {
     let words = std::iter::once(&command.name)
         .chain(command.args.iter())
         .collect::<Vec<_>>();
     let mut static_callee = static_word_text(&command.name, source);
+    let static_args = command
+        .args
+        .iter()
+        .map(|word| static_word_text(word, source))
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
+    let source_path_template = static_callee
+        .as_deref()
+        .filter(|name| matches!(*name, "source" | "."))
+        .and_then(|_| command.args.first())
+        .and_then(|word| source_path_template(word, source, bash_runtime_vars_enabled));
 
     if static_callee.as_deref() == Some("noglob") {
         static_callee = words.get(1).and_then(|word| static_word_text(word, source));
@@ -2930,6 +2949,8 @@ fn recorded_simple_command_info(
 
     let mut info = RecordedCommandInfo {
         static_callee,
+        static_args,
+        source_path_template,
         zsh_effects: Vec::new(),
     };
     let Some((effect_callee, effect_index)) = normalize_recorded_zsh_effect_command(&words, source)

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -3,6 +3,7 @@ use shuck_ast::{CaseTerminator, Span};
 use shuck_parser::ZshEmulationMode;
 use std::marker::PhantomData;
 
+use crate::source_closure::SourcePathTemplate;
 use crate::{BindingId, ReferenceId, ScopeId, SpanKey};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -270,6 +271,8 @@ pub(crate) struct RecordedElifBranch {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RecordedCommandInfo {
     pub(crate) static_callee: Option<String>,
+    pub(crate) static_args: Box<[Option<String>]>,
+    pub(crate) source_path_template: Option<SourcePathTemplate>,
     pub(crate) zsh_effects: Vec<RecordedZshCommandEffect>,
 }
 

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -331,6 +331,10 @@ impl RecordedProgram {
         &mut self.commands[id.index()]
     }
 
+    pub(crate) fn commands(&self) -> &[RecordedCommand] {
+        &self.commands
+    }
+
     pub(crate) fn commands_in(&self, range: RecordedCommandRange) -> &[RecordedCommandId] {
         range.slice(&self.command_sequence_items)
     }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -685,8 +685,8 @@ impl SemanticModel {
         &self.source_refs
     }
 
-    pub(crate) fn bash_runtime_vars_enabled(&self) -> bool {
-        self.runtime.bash_enabled()
+    pub(crate) fn recorded_program(&self) -> &RecordedProgram {
+        &self.recorded_program
     }
 
     pub(crate) fn set_synthetic_reads(&mut self, synthetic_reads: Vec<SyntheticRead>) {

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -3,11 +3,9 @@ use std::path::{Path, PathBuf};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
-    ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
-    BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand, ConditionalExpr,
-    DeclOperand, File, FunctionDef, Name, ParameterExpansion, ParameterExpansionSyntax, Pattern,
-    PatternPart, PatternPartNode, Redirect, SourceText, Span, Stmt, StmtSeq, VarRef, Word,
-    WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
+    ArithmeticExpr, ArithmeticExprNode, BourneParameterExpansion, Command, File, Name,
+    ParameterExpansion, ParameterExpansionSyntax, Span, StmtSeq, VarRef, Word, WordPart,
+    WordPartNode,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
@@ -17,6 +15,7 @@ use crate::{
     FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel,
     SourcePathResolver, SourceRefKind, SourceRefResolution, SpanKey, SyntheticRead,
     build_semantic_model_base,
+    cfg::{RecordedCommandId, RecordedCommandKind, RecordedCommandRange, RecordedProgram},
 };
 
 #[derive(Debug, Clone)]
@@ -82,14 +81,14 @@ pub(crate) fn collect_source_closure_contracts(
 
 fn collect_source_closure_contracts_with_cache(
     model: &SemanticModel,
-    file: &File,
-    source: &str,
+    _file: &File,
+    _source: &str,
     source_path: &Path,
     summaries: &mut FxHashMap<PathBuf, FileContract>,
     active: &mut FxHashSet<PathBuf>,
     context: SourceClosureLookupContext<'_>,
 ) -> SourceClosureContracts {
-    let facts = collect_ast_facts(file, model, source);
+    let facts = collect_ast_facts(model);
     let call_args_by_scope = resolve_literal_call_args_by_scope(model, &facts.calls);
     let mut synthetic_reads = Vec::new();
     let mut imported_bindings = Vec::new();
@@ -395,701 +394,122 @@ struct CallInfo {
 }
 
 #[derive(Debug, Clone)]
-enum SourcePathTemplate {
+pub(crate) enum SourcePathTemplate {
     Interpolated(Vec<TemplatePart>),
 }
 
 #[derive(Debug, Clone)]
-enum TemplatePart {
+pub(crate) enum TemplatePart {
     Literal(String),
     Arg(usize),
     SourceDir,
     SourceFile,
 }
 
-fn collect_ast_facts(file: &File, model: &SemanticModel, source: &str) -> AstFacts {
+fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
     let mut facts = AstFacts {
         source_templates: FxHashMap::default(),
         calls: Vec::new(),
     };
-    walk_stmt_seq(&file.body, model, source, &mut facts);
+    let program = model.recorded_program();
+    collect_commands_in_range(model, program, program.file_commands(), &mut facts);
     facts
 }
 
-fn walk_stmt_seq(commands: &StmtSeq, model: &SemanticModel, source: &str, facts: &mut AstFacts) {
-    for stmt in commands.iter() {
-        walk_stmt(stmt, model, source, facts);
-    }
-}
-
-fn walk_stmt(stmt: &Stmt, model: &SemanticModel, source: &str, facts: &mut AstFacts) {
-    walk_redirects(&stmt.redirects, model, source, facts);
-    walk_command(&stmt.command, model, source, facts);
-}
-
-fn walk_command(command: &Command, model: &SemanticModel, source: &str, facts: &mut AstFacts) {
-    match command {
-        Command::Simple(command) => {
-            if let Some(name) = static_word_text(&command.name, source)
-                && !name.is_empty()
-            {
-                facts.calls.push(CallInfo {
-                    name: Name::from(name.as_str()),
-                    scope: model.scope_at(command.span.start.offset),
-                    span: command.span,
-                    args: command
-                        .args
-                        .iter()
-                        .map(|word| static_word_text(word, source))
-                        .collect(),
-                });
-
-                if matches!(name.as_str(), "source" | ".")
-                    && let Some(argument) = command.args.first()
-                    && let Some(template) =
-                        source_path_template(argument, source, model.bash_runtime_vars_enabled())
-                {
-                    facts
-                        .source_templates
-                        .insert(SpanKey::new(command.span), template);
-                }
-            }
-
-            walk_assignments(&command.assignments, model, source, facts);
-            walk_word(&command.name, model, source, facts);
-            walk_words(&command.args, model, source, facts);
-        }
-        Command::Builtin(BuiltinCommand::Break(command)) => {
-            walk_assignments(&command.assignments, model, source, facts);
-            if let Some(word) = &command.depth {
-                walk_word(word, model, source, facts);
-            }
-            walk_words(&command.extra_args, model, source, facts);
-        }
-        Command::Builtin(BuiltinCommand::Continue(command)) => {
-            walk_assignments(&command.assignments, model, source, facts);
-            if let Some(word) = &command.depth {
-                walk_word(word, model, source, facts);
-            }
-            walk_words(&command.extra_args, model, source, facts);
-        }
-        Command::Builtin(BuiltinCommand::Return(command)) => {
-            walk_assignments(&command.assignments, model, source, facts);
-            if let Some(word) = &command.code {
-                walk_word(word, model, source, facts);
-            }
-            walk_words(&command.extra_args, model, source, facts);
-        }
-        Command::Builtin(BuiltinCommand::Exit(command)) => {
-            walk_assignments(&command.assignments, model, source, facts);
-            if let Some(word) = &command.code {
-                walk_word(word, model, source, facts);
-            }
-            walk_words(&command.extra_args, model, source, facts);
-        }
-        Command::Decl(command) => {
-            walk_assignments(&command.assignments, model, source, facts);
-            for operand in &command.operands {
-                match operand {
-                    DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                        walk_word(word, model, source, facts);
-                    }
-                    DeclOperand::Name(name) => walk_var_ref_subscript(name, model, source, facts),
-                    DeclOperand::Assignment(assignment) => {
-                        walk_assignment(assignment, model, source, facts);
-                    }
-                }
-            }
-        }
-        Command::Binary(command) => {
-            walk_stmt(&command.left, model, source, facts);
-            walk_stmt(&command.right, model, source, facts);
-        }
-        Command::Compound(command) => {
-            walk_compound(command, model, source, facts);
-        }
-        Command::Function(FunctionDef { header, body, .. }) => {
-            for entry in &header.entries {
-                walk_word(&entry.word, model, source, facts);
-            }
-            walk_stmt(body, model, source, facts);
-        }
-        Command::AnonymousFunction(function) => {
-            walk_words(&function.args, model, source, facts);
-            walk_stmt(&function.body, model, source, facts);
-        }
-    }
-}
-
-fn walk_compound(
-    command: &CompoundCommand,
+fn collect_commands_in_range(
     model: &SemanticModel,
-    source: &str,
+    program: &RecordedProgram,
+    range: RecordedCommandRange,
     facts: &mut AstFacts,
 ) {
-    match command {
-        CompoundCommand::If(command) => {
-            walk_stmt_seq(&command.condition, model, source, facts);
-            walk_stmt_seq(&command.then_branch, model, source, facts);
-            for (condition, body) in &command.elif_branches {
-                walk_stmt_seq(condition, model, source, facts);
-                walk_stmt_seq(body, model, source, facts);
-            }
-            if let Some(body) = &command.else_branch {
-                walk_stmt_seq(body, model, source, facts);
-            }
-        }
-        CompoundCommand::For(command) => {
-            if let Some(words) = &command.words {
-                walk_words(words, model, source, facts);
-            }
-            walk_stmt_seq(&command.body, model, source, facts);
-        }
-        CompoundCommand::Repeat(command) => {
-            walk_word(&command.count, model, source, facts);
-            walk_stmt_seq(&command.body, model, source, facts);
-        }
-        CompoundCommand::Foreach(command) => {
-            walk_words(&command.words, model, source, facts);
-            walk_stmt_seq(&command.body, model, source, facts);
-        }
-        CompoundCommand::ArithmeticFor(command) => {
-            if let Some(expr) = &command.init_ast {
-                walk_arithmetic_expr(expr, model, source, facts);
-            }
-            if let Some(expr) = &command.condition_ast {
-                walk_arithmetic_expr(expr, model, source, facts);
-            }
-            if let Some(expr) = &command.step_ast {
-                walk_arithmetic_expr(expr, model, source, facts);
-            }
-            walk_stmt_seq(&command.body, model, source, facts)
-        }
-        CompoundCommand::While(command) => {
-            walk_stmt_seq(&command.condition, model, source, facts);
-            walk_stmt_seq(&command.body, model, source, facts);
-        }
-        CompoundCommand::Until(command) => {
-            walk_stmt_seq(&command.condition, model, source, facts);
-            walk_stmt_seq(&command.body, model, source, facts);
-        }
-        CompoundCommand::Case(command) => {
-            walk_word(&command.word, model, source, facts);
-            for case in &command.cases {
-                walk_patterns(&case.patterns, model, source, facts);
-                walk_stmt_seq(&case.body, model, source, facts);
-            }
-        }
-        CompoundCommand::Select(command) => {
-            walk_words(&command.words, model, source, facts);
-            walk_stmt_seq(&command.body, model, source, facts);
-        }
-        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
-            walk_stmt_seq(commands, model, source, facts);
-        }
-        CompoundCommand::Always(command) => {
-            walk_stmt_seq(&command.body, model, source, facts);
-            walk_stmt_seq(&command.always_body, model, source, facts);
-        }
-        CompoundCommand::Arithmetic(command) => {
-            if let Some(expr) = &command.expr_ast {
-                walk_arithmetic_expr(expr, model, source, facts);
-            }
-        }
-        CompoundCommand::Time(command) => {
-            if let Some(command) = &command.command {
-                walk_stmt(command, model, source, facts);
-            }
-        }
-        CompoundCommand::Conditional(command) => {
-            walk_conditional_expr(&command.expression, model, source, facts)
-        }
-        CompoundCommand::Coproc(command) => walk_stmt(&command.body, model, source, facts),
+    for &command in program.commands_in(range) {
+        collect_command(model, program, command, facts);
     }
 }
 
-fn walk_assignments(
-    assignments: &[Assignment],
+fn collect_command(
     model: &SemanticModel,
-    source: &str,
+    program: &RecordedProgram,
+    command_id: RecordedCommandId,
     facts: &mut AstFacts,
 ) {
-    for assignment in assignments {
-        walk_assignment(assignment, model, source, facts);
-    }
-}
+    let command = program.command(command_id);
+    if let Some(info) = program.command_infos.get(&SpanKey::new(command.span))
+        && let Some(name) = info.static_callee.as_deref()
+        && !name.is_empty()
+    {
+        facts.calls.push(CallInfo {
+            name: Name::from(name),
+            scope: model.scope_at(command.span.start.offset),
+            span: command.span,
+            args: info.static_args.iter().cloned().collect(),
+        });
 
-fn walk_assignment(
-    assignment: &Assignment,
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    walk_var_ref_subscript(&assignment.target, model, source, facts);
-    match &assignment.value {
-        AssignmentValue::Scalar(word) => walk_word(word, model, source, facts),
-        AssignmentValue::Compound(array) => {
-            for element in &array.elements {
-                match element {
-                    ArrayElem::Sequential(word) => walk_word(word, model, source, facts),
-                    ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
-                        walk_subscript(Some(key), model, source, facts);
-                        walk_word(value, model, source, facts);
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn walk_words(words: &[Word], model: &SemanticModel, source: &str, facts: &mut AstFacts) {
-    for word in words {
-        walk_word(word, model, source, facts);
-    }
-}
-
-fn walk_patterns(patterns: &[Pattern], model: &SemanticModel, source: &str, facts: &mut AstFacts) {
-    for pattern in patterns {
-        walk_pattern(pattern, model, source, facts);
-    }
-}
-
-fn walk_word(word: &Word, model: &SemanticModel, source: &str, facts: &mut AstFacts) {
-    walk_word_parts(&word.parts, model, source, facts);
-}
-
-fn walk_pattern(pattern: &Pattern, model: &SemanticModel, source: &str, facts: &mut AstFacts) {
-    walk_pattern_parts(&pattern.parts, model, source, facts);
-}
-
-fn walk_word_parts(
-    parts: &[WordPartNode],
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    for part in parts {
-        if word_part_starts_with_shell_expansion(&part.kind)
-            && span_is_backslash_escaped(source, &part.kind, part.span)
+        if matches!(name, "source" | ".")
+            && let Some(template) = info.source_path_template.clone()
         {
-            continue;
-        }
-        match &part.kind {
-            WordPart::ZshQualifiedGlob(glob) => {
-                for segment in &glob.segments {
-                    if let ZshGlobSegment::Pattern(pattern) = segment {
-                        walk_pattern(pattern, model, source, facts);
-                    }
-                }
-            }
-            WordPart::SingleQuoted { .. } => {}
-            WordPart::DoubleQuoted { parts, .. } => walk_word_parts(parts, model, source, facts),
-            WordPart::CommandSubstitution { body, .. }
-            | WordPart::ProcessSubstitution { body, .. } => {
-                walk_stmt_seq(body, model, source, facts)
-            }
-            WordPart::ArithmeticExpansion { expression_ast, .. } => {
-                if let Some(expr) = expression_ast {
-                    walk_arithmetic_expr(expr, model, source, facts);
-                }
-            }
-            WordPart::Parameter(parameter) => {
-                walk_parameter_expansion(parameter, model, source, facts);
-            }
-            WordPart::ParameterExpansion {
-                reference,
-                operator,
-                operand,
-                ..
-            } => {
-                walk_var_ref_subscript(reference, model, source, facts);
-                walk_fragment_word(None, operand.as_ref(), model, source, facts);
-                match operator {
-                    shuck_ast::ParameterOp::RemovePrefixShort { pattern }
-                    | shuck_ast::ParameterOp::RemovePrefixLong { pattern }
-                    | shuck_ast::ParameterOp::RemoveSuffixShort { pattern }
-                    | shuck_ast::ParameterOp::RemoveSuffixLong { pattern }
-                    | shuck_ast::ParameterOp::ReplaceFirst { pattern, .. }
-                    | shuck_ast::ParameterOp::ReplaceAll { pattern, .. } => {
-                        walk_pattern(pattern, model, source, facts);
-                    }
-                    shuck_ast::ParameterOp::UseDefault
-                    | shuck_ast::ParameterOp::AssignDefault
-                    | shuck_ast::ParameterOp::UseReplacement
-                    | shuck_ast::ParameterOp::Error
-                    | shuck_ast::ParameterOp::UpperFirst
-                    | shuck_ast::ParameterOp::UpperAll
-                    | shuck_ast::ParameterOp::LowerFirst
-                    | shuck_ast::ParameterOp::LowerAll => {}
-                }
-            }
-            WordPart::Substring {
-                reference,
-                offset_ast,
-                length_ast,
-                ..
-            }
-            | WordPart::ArraySlice {
-                reference,
-                offset_ast,
-                length_ast,
-                ..
-            } => {
-                walk_var_ref_subscript(reference, model, source, facts);
-                if let Some(offset_ast) = offset_ast {
-                    walk_arithmetic_expr(offset_ast, model, source, facts);
-                }
-                if let Some(length_ast) = length_ast {
-                    walk_arithmetic_expr(length_ast, model, source, facts);
-                }
-            }
-            WordPart::ArrayAccess(reference) => {
-                walk_var_ref_subscript(reference, model, source, facts);
-            }
-            WordPart::IndirectExpansion {
-                reference, operand, ..
-            } => {
-                walk_var_ref_subscript(reference, model, source, facts);
-                walk_fragment_word(None, operand.as_ref(), model, source, facts);
-            }
-            WordPart::Transformation { reference, .. }
-            | WordPart::Length(reference)
-            | WordPart::ArrayLength(reference)
-            | WordPart::ArrayIndices(reference) => {
-                walk_var_ref_subscript(reference, model, source, facts);
-            }
-            WordPart::Literal(_) | WordPart::Variable(_) | WordPart::PrefixMatch { .. } => {}
+            facts
+                .source_templates
+                .insert(SpanKey::new(command.span), template);
         }
     }
-}
 
-fn walk_parameter_expansion(
-    parameter: &ParameterExpansion,
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
-            BourneParameterExpansion::Access { reference }
-            | BourneParameterExpansion::Length { reference }
-            | BourneParameterExpansion::Indices { reference }
-            | BourneParameterExpansion::Transformation { reference, .. } => {
-                walk_var_ref_subscript(reference, model, source, facts);
-            }
-            BourneParameterExpansion::Indirect {
-                reference,
-                operand,
-                operand_word_ast,
-                ..
-            } => {
-                walk_var_ref_subscript(reference, model, source, facts);
-                walk_fragment_word(
-                    operand_word_ast.as_ref(),
-                    operand.as_ref(),
-                    model,
-                    source,
-                    facts,
-                );
-            }
-            BourneParameterExpansion::PrefixMatch { .. } => {}
-            BourneParameterExpansion::Slice {
-                reference,
-                offset_ast,
-                length_ast,
-                ..
-            } => {
-                walk_var_ref_subscript(reference, model, source, facts);
-                if let Some(offset_ast) = offset_ast {
-                    walk_arithmetic_expr(offset_ast, model, source, facts);
-                }
-                if let Some(length_ast) = length_ast {
-                    walk_arithmetic_expr(length_ast, model, source, facts);
-                }
-            }
-            BourneParameterExpansion::Operation {
-                reference,
-                operator,
-                operand,
-                operand_word_ast,
-                ..
-            } => {
-                walk_var_ref_subscript(reference, model, source, facts);
-                walk_fragment_word(
-                    operand_word_ast.as_ref(),
-                    operand.as_ref(),
-                    model,
-                    source,
-                    facts,
-                );
-                match operator {
-                    shuck_ast::ParameterOp::RemovePrefixShort { pattern }
-                    | shuck_ast::ParameterOp::RemovePrefixLong { pattern }
-                    | shuck_ast::ParameterOp::RemoveSuffixShort { pattern }
-                    | shuck_ast::ParameterOp::RemoveSuffixLong { pattern }
-                    | shuck_ast::ParameterOp::ReplaceFirst { pattern, .. }
-                    | shuck_ast::ParameterOp::ReplaceAll { pattern, .. } => {
-                        walk_pattern(pattern, model, source, facts);
-                    }
-                    shuck_ast::ParameterOp::UseDefault
-                    | shuck_ast::ParameterOp::AssignDefault
-                    | shuck_ast::ParameterOp::UseReplacement
-                    | shuck_ast::ParameterOp::Error
-                    | shuck_ast::ParameterOp::UpperFirst
-                    | shuck_ast::ParameterOp::UpperAll
-                    | shuck_ast::ParameterOp::LowerFirst
-                    | shuck_ast::ParameterOp::LowerAll => {}
-                }
-            }
-        },
-        ParameterExpansionSyntax::Zsh(syntax) => {
-            match &syntax.target {
-                ZshExpansionTarget::Reference(reference) => {
-                    walk_var_ref_subscript(reference, model, source, facts);
-                }
-                ZshExpansionTarget::Word(word) => {
-                    walk_word(word, model, source, facts);
-                }
-                ZshExpansionTarget::Nested(parameter) => {
-                    walk_parameter_expansion(parameter, model, source, facts);
-                }
-                ZshExpansionTarget::Empty => {}
-            }
-
-            for modifier in &syntax.modifiers {
-                walk_fragment_word(
-                    modifier.argument_word_ast(),
-                    modifier.argument.as_ref(),
-                    model,
-                    source,
-                    facts,
-                );
-            }
-
-            if let Some(operation) = &syntax.operation {
-                match operation {
-                    ZshExpansionOperation::PatternOperation { operand, .. }
-                    | ZshExpansionOperation::Defaulting { operand, .. }
-                    | ZshExpansionOperation::TrimOperation { operand, .. } => walk_fragment_word(
-                        operation.operand_word_ast(),
-                        Some(operand),
-                        model,
-                        source,
-                        facts,
-                    ),
-                    ZshExpansionOperation::ReplacementOperation {
-                        pattern,
-                        replacement,
-                        ..
-                    } => {
-                        walk_fragment_word(
-                            operation.pattern_word_ast(),
-                            Some(pattern),
-                            model,
-                            source,
-                            facts,
-                        );
-                        walk_fragment_word(
-                            operation.replacement_word_ast(),
-                            replacement.as_ref(),
-                            model,
-                            source,
-                            facts,
-                        );
-                    }
-                    ZshExpansionOperation::Slice { offset, length, .. } => {
-                        walk_fragment_word(
-                            operation.offset_word_ast(),
-                            Some(offset),
-                            model,
-                            source,
-                            facts,
-                        );
-                        walk_fragment_word(
-                            operation.length_word_ast(),
-                            length.as_ref(),
-                            model,
-                            source,
-                            facts,
-                        );
-                    }
-                    ZshExpansionOperation::Unknown { text, .. } => walk_fragment_word(
-                        operation.operand_word_ast(),
-                        Some(text),
-                        model,
-                        source,
-                        facts,
-                    ),
-                }
-            }
-        }
+    for region in program.nested_regions(command.nested_regions) {
+        collect_commands_in_range(model, program, region.commands, facts);
     }
-}
 
-fn walk_arithmetic_expr(
-    expr: &ArithmeticExprNode,
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    match &expr.kind {
-        ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
-        ArithmeticExpr::Indexed { index, .. } => walk_arithmetic_expr(index, model, source, facts),
-        ArithmeticExpr::ShellWord(word) => walk_word(word, model, source, facts),
-        ArithmeticExpr::Parenthesized { expression } => {
-            walk_arithmetic_expr(expression, model, source, facts)
+    match command.kind {
+        RecordedCommandKind::Linear
+        | RecordedCommandKind::Break { .. }
+        | RecordedCommandKind::Continue { .. }
+        | RecordedCommandKind::Return
+        | RecordedCommandKind::Exit => {}
+        RecordedCommandKind::List { first, rest } => {
+            collect_command(model, program, first, facts);
+            for item in program.list_items(rest) {
+                collect_command(model, program, item.command, facts);
+            }
         }
-        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
-            walk_arithmetic_expr(expr, model, source, facts)
-        }
-        ArithmeticExpr::Binary { left, right, .. } => {
-            walk_arithmetic_expr(left, model, source, facts);
-            walk_arithmetic_expr(right, model, source, facts);
-        }
-        ArithmeticExpr::Conditional {
+        RecordedCommandKind::If {
             condition,
-            then_expr,
-            else_expr,
+            then_branch,
+            elif_branches,
+            else_branch,
         } => {
-            walk_arithmetic_expr(condition, model, source, facts);
-            walk_arithmetic_expr(then_expr, model, source, facts);
-            walk_arithmetic_expr(else_expr, model, source, facts);
+            collect_commands_in_range(model, program, condition, facts);
+            collect_commands_in_range(model, program, then_branch, facts);
+            for branch in program.elif_branches(elif_branches) {
+                collect_commands_in_range(model, program, branch.condition, facts);
+                collect_commands_in_range(model, program, branch.body, facts);
+            }
+            collect_commands_in_range(model, program, else_branch, facts);
         }
-        ArithmeticExpr::Assignment { target, value, .. } => {
-            walk_arithmetic_lvalue(target, model, source, facts);
-            walk_arithmetic_expr(value, model, source, facts);
+        RecordedCommandKind::While { condition, body }
+        | RecordedCommandKind::Until { condition, body } => {
+            collect_commands_in_range(model, program, condition, facts);
+            collect_commands_in_range(model, program, body, facts);
         }
-    }
-}
-
-fn walk_arithmetic_lvalue(
-    target: &ArithmeticLvalue,
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    match target {
-        ArithmeticLvalue::Variable(_) => {}
-        ArithmeticLvalue::Indexed { index, .. } => {
-            walk_arithmetic_expr(index, model, source, facts)
+        RecordedCommandKind::For { body }
+        | RecordedCommandKind::Select { body }
+        | RecordedCommandKind::ArithmeticFor { body }
+        | RecordedCommandKind::BraceGroup { body }
+        | RecordedCommandKind::Subshell { body } => {
+            collect_commands_in_range(model, program, body, facts);
         }
-    }
-}
-
-fn walk_pattern_parts(
-    parts: &[PatternPartNode],
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    for part in parts {
-        match &part.kind {
-            PatternPart::Group { patterns, .. } => walk_patterns(patterns, model, source, facts),
-            PatternPart::Word(word) => walk_word(word, model, source, facts),
-            PatternPart::Literal(_)
-            | PatternPart::AnyString
-            | PatternPart::AnyChar
-            | PatternPart::CharClass(_) => {}
+        RecordedCommandKind::Case { arms } => {
+            for arm in program.case_arms(arms) {
+                collect_commands_in_range(model, program, arm.commands, facts);
+            }
         }
-    }
-}
-
-fn walk_fragment_word(
-    word: Option<&Word>,
-    text: Option<&SourceText>,
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    if let Some(word) = word {
-        walk_word(word, model, source, facts);
-        return;
-    }
-    let Some(text) = text else {
-        return;
-    };
-    let word = Parser::parse_word_fragment(source, text.slice(source), text.span());
-    walk_word(&word, model, source, facts);
-}
-
-fn walk_redirects(
-    redirects: &[Redirect],
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    for redirect in redirects {
-        match redirect.word_target() {
-            Some(word) => walk_word(word, model, source, facts),
-            None => {
-                let heredoc = redirect.heredoc().expect("expected heredoc redirect");
-                if heredoc.delimiter.expands_body {
-                    walk_word(&heredoc.body, model, source, facts);
-                }
+        RecordedCommandKind::Pipeline { segments } => {
+            for segment in program.pipeline_segments(segments) {
+                collect_command(model, program, segment.command, facts);
             }
         }
     }
 }
 
-fn walk_conditional_expr(
-    expression: &ConditionalExpr,
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    match expression {
-        ConditionalExpr::Binary(expr) => {
-            walk_conditional_expr(&expr.left, model, source, facts);
-            walk_conditional_expr(&expr.right, model, source, facts);
-        }
-        ConditionalExpr::Unary(expr) => walk_conditional_expr(&expr.expr, model, source, facts),
-        ConditionalExpr::Parenthesized(expr) => {
-            walk_conditional_expr(&expr.expr, model, source, facts)
-        }
-        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-            walk_word(word, model, source, facts)
-        }
-        ConditionalExpr::Pattern(pattern) => walk_pattern(pattern, model, source, facts),
-        ConditionalExpr::VarRef(var_ref) => walk_var_ref_subscript(var_ref, model, source, facts),
-    }
-}
-
-fn walk_var_ref_subscript(
-    reference: &VarRef,
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    walk_subscript(reference.subscript.as_ref(), model, source, facts);
-}
-
-fn walk_subscript(
-    subscript: Option<&shuck_ast::Subscript>,
-    model: &SemanticModel,
-    source: &str,
-    facts: &mut AstFacts,
-) {
-    let Some(subscript) = subscript else {
-        return;
-    };
-    if subscript.selector().is_some() {
-        return;
-    }
-    if let Some(expr) = subscript.arithmetic_ast.as_ref() {
-        walk_arithmetic_expr(expr, model, source, facts);
-        return;
-    }
-
-    walk_fragment_word(
-        subscript.word_ast(),
-        Some(subscript.syntax_source_text()),
-        model,
-        source,
-        facts,
-    );
-}
-
-fn source_path_template(
+pub(crate) fn source_path_template(
     word: &Word,
     source: &str,
     bash_runtime_vars_enabled: bool,
@@ -1929,7 +1349,7 @@ mod tests {
             .unwrap();
         let indexer = Indexer::new(source, &output);
         let model = SemanticModel::build(&output.file, source, &indexer);
-        let facts = collect_ast_facts(&output.file, &model, source);
+        let facts = collect_ast_facts(&model);
         let call_names = facts
             .calls
             .iter()

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -15,7 +15,6 @@ use crate::{
     FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel,
     SourcePathResolver, SourceRefKind, SourceRefResolution, SpanKey, SyntheticRead,
     build_semantic_model_base,
-    cfg::{RecordedCommandId, RecordedCommandKind, RecordedCommandRange, RecordedProgram},
 };
 
 #[derive(Debug, Clone)]
@@ -412,37 +411,25 @@ fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
         calls: Vec::new(),
     };
     let program = model.recorded_program();
-    collect_commands_in_range(model, program, program.file_commands(), &mut facts);
-    facts
-}
+    let mut commands = program.commands().iter().collect::<Vec<_>>();
+    commands.sort_by_key(|command| (command.span.start.offset, command.span.end.offset));
 
-fn collect_commands_in_range(
-    model: &SemanticModel,
-    program: &RecordedProgram,
-    range: RecordedCommandRange,
-    facts: &mut AstFacts,
-) {
-    for &command in program.commands_in(range) {
-        collect_command(model, program, command, facts);
-    }
-}
+    for command in commands {
+        let Some(info) = program.command_infos.get(&SpanKey::new(command.span)) else {
+            continue;
+        };
+        let Some(name) = info.static_callee.as_deref() else {
+            continue;
+        };
+        if name.is_empty() {
+            continue;
+        }
 
-fn collect_command(
-    model: &SemanticModel,
-    program: &RecordedProgram,
-    command_id: RecordedCommandId,
-    facts: &mut AstFacts,
-) {
-    let command = program.command(command_id);
-    if let Some(info) = program.command_infos.get(&SpanKey::new(command.span))
-        && let Some(name) = info.static_callee.as_deref()
-        && !name.is_empty()
-    {
         facts.calls.push(CallInfo {
             name: Name::from(name),
             scope: model.scope_at(command.span.start.offset),
             span: command.span,
-            args: info.static_args.iter().cloned().collect(),
+            args: info.static_args.to_vec(),
         });
 
         if matches!(name, "source" | ".")
@@ -453,60 +440,7 @@ fn collect_command(
                 .insert(SpanKey::new(command.span), template);
         }
     }
-
-    for region in program.nested_regions(command.nested_regions) {
-        collect_commands_in_range(model, program, region.commands, facts);
-    }
-
-    match command.kind {
-        RecordedCommandKind::Linear
-        | RecordedCommandKind::Break { .. }
-        | RecordedCommandKind::Continue { .. }
-        | RecordedCommandKind::Return
-        | RecordedCommandKind::Exit => {}
-        RecordedCommandKind::List { first, rest } => {
-            collect_command(model, program, first, facts);
-            for item in program.list_items(rest) {
-                collect_command(model, program, item.command, facts);
-            }
-        }
-        RecordedCommandKind::If {
-            condition,
-            then_branch,
-            elif_branches,
-            else_branch,
-        } => {
-            collect_commands_in_range(model, program, condition, facts);
-            collect_commands_in_range(model, program, then_branch, facts);
-            for branch in program.elif_branches(elif_branches) {
-                collect_commands_in_range(model, program, branch.condition, facts);
-                collect_commands_in_range(model, program, branch.body, facts);
-            }
-            collect_commands_in_range(model, program, else_branch, facts);
-        }
-        RecordedCommandKind::While { condition, body }
-        | RecordedCommandKind::Until { condition, body } => {
-            collect_commands_in_range(model, program, condition, facts);
-            collect_commands_in_range(model, program, body, facts);
-        }
-        RecordedCommandKind::For { body }
-        | RecordedCommandKind::Select { body }
-        | RecordedCommandKind::ArithmeticFor { body }
-        | RecordedCommandKind::BraceGroup { body }
-        | RecordedCommandKind::Subshell { body } => {
-            collect_commands_in_range(model, program, body, facts);
-        }
-        RecordedCommandKind::Case { arms } => {
-            for arm in program.case_arms(arms) {
-                collect_commands_in_range(model, program, arm.commands, facts);
-            }
-        }
-        RecordedCommandKind::Pipeline { segments } => {
-            for segment in program.pipeline_segments(segments) {
-                collect_command(model, program, segment.command, facts);
-            }
-        }
-    }
+    facts
 }
 
 pub(crate) fn source_path_template(
@@ -1360,6 +1294,30 @@ mod tests {
         assert!(call_names.iter().any(|name| name == "dirname"));
         assert!(call_names.iter().any(|name| name == "source"));
     }
+
+    #[test]
+    fn wrapper_commands_keep_inner_call_and_source_template_facts() {
+        let source = "\
+#!/bin/bash
+time . \"$1\"
+coproc loader { . \"$2\"; }
+";
+        let output = Parser::with_dialect(source, ShellDialect::Bash)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        let facts = collect_ast_facts(&model);
+        let source_call_count = facts
+            .calls
+            .iter()
+            .filter(|call| call.name.as_str() == ".")
+            .count();
+
+        assert_eq!(source_call_count, 2);
+        assert_eq!(facts.source_templates.len(), 2);
+    }
+
     #[cfg(windows)]
     #[test]
     fn source_dir_templates_render_windows_paths_with_shell_separators() {

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -35,6 +35,9 @@ const LARGE_CORPUS_KEEP_GOING_ENV: &str = "SHUCK_LARGE_CORPUS_KEEP_GOING";
 
 const LARGE_CORPUS_DEFAULT_SHELLCHECK_TIMEOUT: Duration = Duration::from_secs(300);
 const LARGE_CORPUS_DEFAULT_SHUCK_TIMEOUT: Duration = Duration::from_secs(30);
+const LARGE_CORPUS_AUTOSCALED_SHUCK_TIMEOUT_BUFFER: Duration = Duration::from_secs(15);
+const LARGE_CORPUS_MAX_AUTOSCALED_SHUCK_TIMEOUT: Duration = Duration::from_secs(150);
+const LARGE_CORPUS_AUTOSCALED_SHUCK_LINES_PER_SEC: usize = 175;
 const LARGE_CORPUS_CACHE_DIR_NAME: &str = ".cache/large-corpus";
 const LARGE_CORPUS_WORKER_COUNT: usize = 4;
 const LARGE_CORPUS_TIMEOUT_FAILURE_CAP: usize = 5;
@@ -268,6 +271,35 @@ fn fixture_progress_label(fixture: &LargeCorpusFixture) -> String {
 
 fn log_large_corpus_timeout(fixture: &LargeCorpusFixture) {
     log_large_corpus_progress(&format!("timeout {}", fixture_progress_label(fixture)));
+}
+
+fn source_line_count(source: &[u8]) -> usize {
+    if source.is_empty() {
+        return 0;
+    }
+
+    let newline_count = source.iter().filter(|&&byte| byte == b'\n').count();
+    if source.last() == Some(&b'\n') {
+        newline_count
+    } else {
+        newline_count + 1
+    }
+}
+
+fn effective_shuck_timeout(source: &[u8], base_timeout: Duration) -> Duration {
+    if env::var_os(LARGE_CORPUS_SHUCK_TIMEOUT_ENV).is_some() {
+        return base_timeout;
+    }
+
+    let line_count = source_line_count(source);
+    let scaled_timeout_secs = line_count.div_ceil(LARGE_CORPUS_AUTOSCALED_SHUCK_LINES_PER_SEC);
+    if scaled_timeout_secs <= base_timeout.as_secs() as usize {
+        return base_timeout;
+    }
+
+    let scaled_timeout = Duration::from_secs(scaled_timeout_secs as u64)
+        + LARGE_CORPUS_AUTOSCALED_SHUCK_TIMEOUT_BUFFER;
+    scaled_timeout.min(LARGE_CORPUS_MAX_AUTOSCALED_SHUCK_TIMEOUT)
 }
 
 fn progress_bucket(total: usize, completed: usize) -> usize {
@@ -1009,6 +1041,7 @@ fn evaluate_fixture_compatibility(
 ) -> FixtureEvaluation {
     let mut evaluation = FixtureEvaluation::default();
     let src = fs::read(&fixture.path).unwrap_or_default();
+    let shuck_timeout = effective_shuck_timeout(&src, shuck_timeout);
 
     let shuck_run = match run_shuck_with_timeout(
         fixture,
@@ -2191,9 +2224,12 @@ fn parse_fixture_for_effective_large_corpus_shell_with_timeout(
     timeout: Duration,
 ) -> Result<Result<(), String>, String> {
     let fixture = fixture.clone();
+    let source = match fs::read_to_string(&fixture.path) {
+        Ok(source) => source,
+        Err(err) => return Ok(Err(format!("read error: {err}"))),
+    };
+    let timeout = effective_shuck_timeout(source.as_bytes(), timeout);
     run_with_timeout("shuck", timeout, move || {
-        let source =
-            fs::read_to_string(&fixture.path).map_err(|err| format!("read error: {err}"))?;
         let shell = effective_large_corpus_shell(&fixture);
         let shell_profile = shell_profile_for_large_corpus_shell(shell);
         let parsed =


### PR DESCRIPTION
## Summary
- reuse the semantic builder's recorded commands for source-closure call/template discovery instead of re-walking large ASTs
- record static args and source path templates in `RecordedCommandInfo` so source closure can consume them directly
- autoscale the large-corpus shuck timeout for giant fixtures when `SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS` is not set explicitly

## Testing
- `cargo test -p shuck --test large_corpus --no-run`
- targeted ignored large-corpus repro for the `airgeddon` fixture only; completed in `116.91s` without a shuck timeout
- targeted ignored large-corpus repro for the original top-5 timeout fixtures; completed in `123.24s` without a shuck timeout
