### PR TITLE
Record remaining S029 corpus divergences

### DIFF
--- a/crates/shuck/tests/testdata/corpus-metadata/s029.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s029.yaml
@@ -1,5 +1,19 @@
 reviewed_divergences:
   - side: shellcheck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 3
+    end_line: 3
+    column: 8
+    end_column: 8
+    reason: "This zunit test harness uses `@setup {` as a framework block opener, so the remaining SC1083 hit is fallout from non-shell harness syntax rather than a brace-expansion ambiguity Shuck should model as S029."
+  - side: shellcheck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
+    line: 1029
+    end_line: 1029
+    column: 4
+    end_column: 4
+    reason: "This completion helper uses `{)` as a literal case-pattern arm while the corpus has already collapsed the file away from its authored shell context, so the surviving SC1083 report is treated as an oracle-specific helper-library mismatch instead of an S029 bug."
+  - side: shellcheck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_gir.sh"
     line: 105
     end_line: 105


### PR DESCRIPTION
## Summary
- record the remaining `S029` / `SC1083` large-corpus mismatches as reviewed divergences in `crates/shuck/tests/testdata/corpus-metadata/s029.yaml`
- cover the `zunit` `@setup {` harness opener and the literal `{)` case-pattern arm in `git-completion.bash`

## Why
The remaining `SC1083` hits were showing up in helper-library corpus fixtures, but both cases are oracle-specific shapes rather than actionable `S029` bugs in Shuck.

## Impact
This keeps the large-corpus comparison from treating those two `SC1083` reports as blocking implementation diffs for `S029`, while preserving narrow fixture-specific documentation for future investigators.

## Root Cause
- `ohmyzsh` alias-finder test uses framework syntax (`@setup {`) that ShellCheck still surfaces as `SC1083`
- `git-completion.bash` uses a literal `{)` case-pattern arm in a shell-collapsed helper fixture, which the oracle still reports as `SC1083`

## Validation
- ran a focused two-fixture `large_corpus_conforms_with_shellcheck` repro using the `ohmyzsh` alias-finder and gitfast fixtures
- confirmed both `shellcheck-only S029/SC1083` records moved from `Implementation Diffs` to `Reviewed Divergence`
- the focused repro still reports unrelated blocking diffs in those fixtures (`C006`, `C010`, and others)
