### PR TITLE
Honor shellcheck shell directives in shell inference

### DIFF
--- a/crates/shuck-linter/src/rules/portability/array_keys_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/array_keys_in_sh.rs
@@ -35,7 +35,9 @@ pub fn array_keys_in_sh(checker: &mut Checker) {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
+    use std::path::Path;
+
+    use crate::test::{test_snippet, test_snippet_at_path};
     use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
@@ -61,6 +63,55 @@ printf '%s\n' \"${!name}\" \"${!build_option_@}\" \"${!arr[*]}\" \"${!arr[@]}\"
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::ArrayKeysInSh).with_shell(ShellDialect::Bash),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn honors_shellcheck_shell_directive_in_plain_script() {
+        let source = "\
+# shellcheck shell=sh
+printf '%s\\n' \"${!arr[*]}\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/x071-plain-script"),
+            source,
+            &LinterSettings::for_rule(Rule::ArrayKeysInSh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "${!arr[*]}");
+    }
+
+    #[test]
+    fn shellcheck_shell_directive_overrides_shebang_for_x071() {
+        let source = "\
+#!/bin/bash
+# shellcheck shell=sh
+printf '%s\\n' \"${!arr[*]}\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/x071-shell-override"),
+            source,
+            &LinterSettings::for_rule(Rule::ArrayKeysInSh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "${!arr[*]}");
+    }
+
+    #[test]
+    fn shellcheck_shell_directive_can_suppress_x071_under_sh_shebang() {
+        let source = "\
+#!/bin/sh
+# shellcheck shell=bash
+printf '%s\\n' \"${!arr[*]}\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/x071-shell-override"),
+            source,
+            &LinterSettings::for_rule(Rule::ArrayKeysInSh),
         );
 
         assert!(diagnostics.is_empty());

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -26,24 +26,26 @@ impl ShellDialect {
     }
 
     pub fn infer(source: &str, path: Option<&Path>) -> Self {
-        Self::infer_from_shebang(source).unwrap_or_else(|| {
-            path.map_or(Self::Unknown, |path| {
-                match path
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .map(|ext| ext.to_ascii_lowercase())
-                    .as_deref()
-                {
-                    Some("sh") => Self::Sh,
-                    Some("bash") => Self::Bash,
-                    Some("dash") => Self::Dash,
-                    Some("ksh") => Self::Ksh,
-                    Some("mksh") => Self::Mksh,
-                    Some("zsh") => Self::Zsh,
-                    _ => Self::Unknown,
-                }
+        Self::infer_from_shellcheck_header(source)
+            .or_else(|| Self::infer_from_shebang(source))
+            .unwrap_or_else(|| {
+                path.map_or(Self::Unknown, |path| {
+                    match path
+                        .extension()
+                        .and_then(|ext| ext.to_str())
+                        .map(|ext| ext.to_ascii_lowercase())
+                        .as_deref()
+                    {
+                        Some("sh") => Self::Sh,
+                        Some("bash") => Self::Bash,
+                        Some("dash") => Self::Dash,
+                        Some("ksh") => Self::Ksh,
+                        Some("mksh") => Self::Mksh,
+                        Some("zsh") => Self::Zsh,
+                        _ => Self::Unknown,
+                    }
+                })
             })
-        })
     }
 
     fn infer_from_shebang(source: &str) -> Option<Self> {
@@ -59,6 +61,30 @@ impl ShellDialect {
         };
 
         Some(Self::from_name(interpreter))
+    }
+
+    fn infer_from_shellcheck_header(source: &str) -> Option<Self> {
+        for line in source.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.is_empty() || trimmed.starts_with("#!") {
+                continue;
+            }
+
+            let Some(comment) = trimmed.strip_prefix('#') else {
+                break;
+            };
+            let body = comment.trim_start().to_ascii_lowercase();
+            let Some(shell_name) = body.strip_prefix("shellcheck shell=") else {
+                continue;
+            };
+
+            let dialect = Self::from_name(shell_name.split_whitespace().next().unwrap_or_default());
+            if dialect != Self::Unknown {
+                return Some(dialect);
+            }
+        }
+
+        None
     }
 }
 
@@ -76,5 +102,23 @@ mod tests {
     fn infers_from_extension_when_shebang_is_missing() {
         let inferred = ShellDialect::infer("local foo=bar\n", Some(Path::new("/tmp/example.bash")));
         assert_eq!(inferred, ShellDialect::Bash);
+    }
+
+    #[test]
+    fn infers_from_shellcheck_shell_directive_without_shebang() {
+        let inferred = ShellDialect::infer(
+            "# shellcheck shell=sh\nprintf '%s\\n' \"${!arr[*]}\"\n",
+            Some(Path::new("/tmp/example")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn shellcheck_shell_directive_overrides_shebang() {
+        let inferred = ShellDialect::infer(
+            "#!/bin/bash\n# shellcheck shell=sh\nprintf '%s\\n' \"${!arr[*]}\"\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
     }
 }


### PR DESCRIPTION
## Summary
- honor `# shellcheck shell=...` headers when resolving the effective shell dialect for linting
- add `X071` regressions for plain scripts and directive/shebang override cases
- keep the fix at the shared shell-resolution layer instead of special-casing the rule

## Root Cause
Shell inference only looked at shebangs and file extensions. Files that relied on a ShellCheck shell header, or used one to override a conflicting shebang, could miss the `X071` portability warning even though ShellCheck treated them as `sh`.

## Impact
`X071` now follows the same header-driven shell selection that ShellCheck uses, so array-key portability diagnostics line up for plain scripts and directive-handling cases without weakening the rule overall.

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter array_keys_in_sh`
- `cargo test -p shuck-linter shell::tests`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=600 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=120 SHUCK_LARGE_CORPUS_RULES=X071 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`