### PR TITLE
Reduce repeated command walks in linter facts

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2735,13 +2735,6 @@ struct ArithmeticFactSummary {
 }
 
 #[derive(Debug, Default)]
-struct FunctionStyleFactSummary<'a> {
-    function_headers: Vec<FunctionHeaderFact<'a>>,
-    function_body_without_braces_spans: Vec<Span>,
-    redundant_return_status_spans: Vec<Span>,
-}
-
-#[derive(Debug, Default)]
 struct HeredocFactSummary {
     unused_heredoc_spans: Vec<Span>,
     heredoc_missing_end_spans: Vec<Span>,
@@ -2770,17 +2763,11 @@ impl<'a> LinterFactsBuilder<'a> {
     }
 
     fn build(self) -> LinterFacts<'a> {
-        let structural_commands = query::iter_commands(
-            &self.file.body,
-            CommandWalkOptions {
-                descend_nested_word_commands: false,
-            },
-        )
-        .map(|visit| FactSpan::new(command_span(visit.command)))
-        .collect::<FxHashSet<_>>();
         let mut commands = Vec::new();
         let mut structural_command_ids = Vec::new();
         let mut command_ids_by_span = CommandLookupIndex::default();
+        let mut if_condition_command_ids = FxHashSet::default();
+        let mut elif_condition_command_ids = FxHashSet::default();
         let mut scalar_bindings = FxHashMap::default();
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
@@ -2792,13 +2779,21 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut pattern_charclass_spans = Vec::new();
         let mut arithmetic_summary = ArithmeticFactSummary::default();
         let mut surface_fragments = SurfaceFragmentFacts::default();
+        let mut functions = Vec::new();
+        let mut function_body_without_braces_spans = Vec::new();
+        let mut redundant_return_status_spans = Vec::new();
+        let mut getopts_cases = Vec::new();
+        let mut condition_status_capture_spans = Vec::new();
+        let mut condition_command_substitution_spans = Vec::new();
 
-        for visit in query::iter_commands(
+        for traversed in query::iter_commands_with_context(
             &self.file.body,
             CommandWalkOptions {
                 descend_nested_word_commands: true,
             },
         ) {
+            let visit = traversed.visit;
+            let context = traversed.context;
             let key = FactSpan::new(command_span(visit.command));
             let id = CommandId::new(commands.len());
             let lookup_kind = command_lookup_kind(visit.command);
@@ -2809,6 +2804,17 @@ impl<'a> LinterFactsBuilder<'a> {
                 kind: lookup_kind,
                 id,
             });
+
+            match context.condition_kind {
+                Some(query::ConditionKind::If) => {
+                    if_condition_command_ids.insert(id);
+                }
+                Some(query::ConditionKind::Elif) => {
+                    if_condition_command_ids.insert(id);
+                    elif_condition_command_ids.insert(id);
+                }
+                Some(query::ConditionKind::While | query::ConditionKind::Until) | None => {}
+            }
 
             collect_scalar_bindings(visit.command, &mut scalar_bindings);
             collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
@@ -2823,7 +2829,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 command_span(visit.command).start.offset,
                 &normalized,
             );
-            let nested_word_command = !structural_commands.contains(&key);
+            let nested_word_command = context.nested_word_command;
             if !nested_word_command {
                 structural_command_ids.push(id);
             }
@@ -2891,6 +2897,130 @@ impl<'a> LinterFactsBuilder<'a> {
                 simple_test,
                 conditional,
             });
+
+            if let Command::Function(function) = visit.command {
+                functions.push(function);
+                if let Some(span) = function_body_without_braces_span(function) {
+                    function_body_without_braces_spans.push(span);
+                }
+                collect_terminal_redundant_return_status_spans(
+                    function,
+                    &mut redundant_return_status_spans,
+                );
+            }
+
+            if !nested_word_command {
+                match visit.command {
+                    Command::Compound(CompoundCommand::If(command)) => {
+                        collect_condition_status_capture_from_body(
+                            &command.condition,
+                            &command.then_branch,
+                            self.source,
+                            &mut condition_status_capture_spans,
+                        );
+
+                        for (condition, branch) in &command.elif_branches {
+                            collect_condition_status_capture_from_body(
+                                condition,
+                                branch,
+                                self.source,
+                                &mut condition_status_capture_spans,
+                            );
+                        }
+
+                        if let Some(else_branch) = &command.else_branch {
+                            let fallback_condition = command
+                                .elif_branches
+                                .last()
+                                .map(|(condition, _)| condition)
+                                .unwrap_or(&command.condition);
+                            collect_condition_status_capture_from_body(
+                                fallback_condition,
+                                else_branch,
+                                self.source,
+                                &mut condition_status_capture_spans,
+                            );
+                        }
+                    }
+                    Command::Compound(CompoundCommand::While(command)) => {
+                        collect_condition_status_capture_from_body(
+                            &command.condition,
+                            &command.body,
+                            self.source,
+                            &mut condition_status_capture_spans,
+                        );
+                        if let Some(case) = build_getopts_case_fact_for_while(command, self.source)
+                        {
+                            getopts_cases.push(case);
+                        }
+                    }
+                    Command::Compound(CompoundCommand::Until(command)) => {
+                        collect_condition_status_capture_from_body(
+                            &command.condition,
+                            &command.body,
+                            self.source,
+                            &mut condition_status_capture_spans,
+                        );
+                    }
+                    Command::Binary(command)
+                        if matches!(command.op, BinaryOp::And | BinaryOp::Or) =>
+                    {
+                        if stmt_terminals_are_test_commands(&command.left, self.source) {
+                            collect_status_parameter_spans_in_stmt(
+                                &command.right,
+                                self.source,
+                                &mut condition_status_capture_spans,
+                            );
+                        }
+                    }
+                    Command::Simple(_)
+                    | Command::Builtin(_)
+                    | Command::Decl(_)
+                    | Command::Binary(_)
+                    | Command::Compound(_)
+                    | Command::Function(_)
+                    | Command::AnonymousFunction(_) => {}
+                }
+            }
+
+            match visit.command {
+                Command::Compound(CompoundCommand::If(command)) => {
+                    collect_condition_command_substitution_from_body(
+                        &command.condition,
+                        self.source,
+                        &mut condition_command_substitution_spans,
+                    );
+
+                    for (condition, _) in &command.elif_branches {
+                        collect_condition_command_substitution_from_body(
+                            condition,
+                            self.source,
+                            &mut condition_command_substitution_spans,
+                        );
+                    }
+                }
+                Command::Compound(CompoundCommand::While(command)) => {
+                    collect_condition_command_substitution_from_body(
+                        &command.condition,
+                        self.source,
+                        &mut condition_command_substitution_spans,
+                    );
+                }
+                Command::Compound(CompoundCommand::Until(command)) => {
+                    collect_condition_command_substitution_from_body(
+                        &command.condition,
+                        self.source,
+                        &mut condition_command_substitution_spans,
+                    );
+                }
+                Command::Simple(_)
+                | Command::Builtin(_)
+                | Command::Decl(_)
+                | Command::Binary(_)
+                | Command::Compound(_)
+                | Command::Function(_)
+                | Command::AnonymousFunction(_) => {}
+            }
         }
 
         let substitution_facts =
@@ -2899,16 +3029,10 @@ impl<'a> LinterFactsBuilder<'a> {
             fact.substitution_facts = substitutions;
         }
 
-        let if_condition_command_ids =
-            build_if_condition_command_ids(&self.file.body, &command_ids_by_span);
-        let elif_condition_command_ids =
-            build_elif_condition_command_ids(&self.file.body, &command_ids_by_span);
         let presence_tested_names = build_presence_tested_names(&commands, self.source);
-        let FunctionStyleFactSummary {
-            function_headers,
-            function_body_without_braces_spans,
-            redundant_return_status_spans,
-        } = build_function_style_facts(&self.file.body, self.semantic);
+        let function_headers = build_function_header_facts(self.semantic, &functions);
+        sort_and_dedup_spans(&mut condition_status_capture_spans);
+        sort_and_dedup_spans(&mut condition_command_substitution_spans);
         let function_parameter_fallback_spans = build_function_parameter_fallback_spans(
             &commands,
             &structural_command_ids,
@@ -2921,7 +3045,6 @@ impl<'a> LinterFactsBuilder<'a> {
             build_select_header_facts(&commands, &command_ids_by_span, self.source);
         let case_items = build_case_item_facts(&commands);
         let case_pattern_shadows = build_case_pattern_shadow_facts(&commands, self.source);
-        let getopts_cases = build_getopts_case_facts(&self.file.body, self.source);
         let pipelines = build_pipeline_facts(&commands, &command_ids_by_span);
         let scope_read_source_words =
             build_scope_read_source_words(&commands, &pipelines, &if_condition_command_ids);
@@ -2940,10 +3063,6 @@ impl<'a> LinterFactsBuilder<'a> {
             build_commented_continuation_comment_spans(self.source, self._indexer);
         let trailing_directive_comment_spans =
             build_trailing_directive_comment_spans(self.source, self._indexer);
-        let condition_status_capture_spans =
-            build_condition_status_capture_spans(&self.file.body, self.source);
-        let condition_command_substitution_spans =
-            build_condition_command_substitution_spans(&self.file.body, self.source);
         let backtick_command_name_spans = build_backtick_command_name_spans(&commands);
         let dollar_question_after_command_spans = build_dollar_question_after_command_spans(
             &self.file.body,
@@ -3963,36 +4082,14 @@ fn collect_base_prefix_spans_in_text(span: Span, source: &str, spans: &mut Vec<S
     }
 }
 
-fn build_function_style_facts<'a>(
-    body: &'a StmtSeq,
+fn build_function_header_facts<'a>(
     semantic: &SemanticModel,
-) -> FunctionStyleFactSummary<'a> {
-    let mut summary = FunctionStyleFactSummary::default();
-    let mut functions = Vec::new();
-
-    for visit in query::iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
-        let Command::Function(function) = visit.command else {
-            continue;
-        };
-
-        functions.push(function);
-        if let Some(span) = function_body_without_braces_span(function) {
-            summary.function_body_without_braces_spans.push(span);
-        }
-        collect_terminal_redundant_return_status_spans(
-            function,
-            &mut summary.redundant_return_status_spans,
-        );
-    }
-
+    functions: &[&'a FunctionDef],
+) -> Vec<FunctionHeaderFact<'a>> {
     let call_arity_by_binding = build_function_call_arity_facts(semantic, &functions);
-    summary.function_headers = functions
-        .into_iter()
+    functions
+        .iter()
+        .copied()
         .map(|function| {
             let binding_id = function_header_binding_id(semantic, function);
             let scope_id = binding_id
@@ -4008,9 +4105,7 @@ fn build_function_style_facts<'a>(
                 call_arity,
             }
         })
-        .collect();
-
-    summary
+        .collect()
 }
 
 fn build_function_parameter_fallback_spans(
@@ -5566,201 +5661,6 @@ fn has_header_shellcheck_shell_directive(source: &str) -> bool {
     }
 
     false
-}
-
-fn build_elif_condition_command_ids(
-    commands: &StmtSeq,
-    command_ids_by_span: &CommandLookupIndex,
-) -> FxHashSet<CommandId> {
-    let mut ids = FxHashSet::default();
-
-    for visit in query::iter_commands(
-        commands,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
-        let Command::Compound(CompoundCommand::If(command)) = visit.command else {
-            continue;
-        };
-
-        for (condition, _) in &command.elif_branches {
-            for condition_visit in query::iter_commands(
-                condition,
-                CommandWalkOptions {
-                    descend_nested_word_commands: true,
-                },
-            ) {
-                if let Some(id) =
-                    command_id_for_command(condition_visit.command, command_ids_by_span)
-                {
-                    ids.insert(id);
-                }
-            }
-        }
-    }
-
-    ids
-}
-
-fn build_if_condition_command_ids(
-    commands: &StmtSeq,
-    command_ids_by_span: &CommandLookupIndex,
-) -> FxHashSet<CommandId> {
-    let mut ids = FxHashSet::default();
-
-    for visit in query::iter_commands(
-        commands,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
-        let Command::Compound(CompoundCommand::If(command)) = visit.command else {
-            continue;
-        };
-
-        for condition_visit in query::iter_commands(
-            &command.condition,
-            CommandWalkOptions {
-                descend_nested_word_commands: true,
-            },
-        ) {
-            if let Some(id) = command_id_for_command(condition_visit.command, command_ids_by_span) {
-                ids.insert(id);
-            }
-        }
-
-        for (condition, _) in &command.elif_branches {
-            for condition_visit in query::iter_commands(
-                condition,
-                CommandWalkOptions {
-                    descend_nested_word_commands: true,
-                },
-            ) {
-                if let Some(id) =
-                    command_id_for_command(condition_visit.command, command_ids_by_span)
-                {
-                    ids.insert(id);
-                }
-            }
-        }
-    }
-
-    ids
-}
-
-fn build_condition_status_capture_spans(commands: &StmtSeq, source: &str) -> Vec<Span> {
-    let mut spans = Vec::new();
-
-    for visit in query::iter_commands(
-        commands,
-        CommandWalkOptions {
-            descend_nested_word_commands: false,
-        },
-    ) {
-        match visit.command {
-            Command::Compound(CompoundCommand::If(command)) => {
-                collect_condition_status_capture_from_body(
-                    &command.condition,
-                    &command.then_branch,
-                    source,
-                    &mut spans,
-                );
-
-                for (condition, branch) in &command.elif_branches {
-                    collect_condition_status_capture_from_body(
-                        condition, branch, source, &mut spans,
-                    );
-                }
-
-                if let Some(else_branch) = &command.else_branch {
-                    let fallback_condition = command
-                        .elif_branches
-                        .last()
-                        .map(|(condition, _)| condition)
-                        .unwrap_or(&command.condition);
-                    collect_condition_status_capture_from_body(
-                        fallback_condition,
-                        else_branch,
-                        source,
-                        &mut spans,
-                    );
-                }
-            }
-            Command::Compound(CompoundCommand::While(command)) => {
-                collect_condition_status_capture_from_body(
-                    &command.condition,
-                    &command.body,
-                    source,
-                    &mut spans,
-                );
-            }
-            Command::Compound(CompoundCommand::Until(command)) => {
-                collect_condition_status_capture_from_body(
-                    &command.condition,
-                    &command.body,
-                    source,
-                    &mut spans,
-                );
-            }
-            Command::Binary(command) if matches!(command.op, BinaryOp::And | BinaryOp::Or) => {
-                if stmt_terminals_are_test_commands(&command.left, source) {
-                    collect_status_parameter_spans_in_stmt(&command.right, source, &mut spans);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    let mut seen = FxHashSet::default();
-    spans.retain(|span| seen.insert(FactSpan::new(*span)));
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
-    spans
-}
-
-fn build_condition_command_substitution_spans(commands: &StmtSeq, source: &str) -> Vec<Span> {
-    let mut spans = Vec::new();
-
-    for visit in query::iter_commands(
-        commands,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
-        match visit.command {
-            Command::Compound(CompoundCommand::If(command)) => {
-                collect_condition_command_substitution_from_body(
-                    &command.condition,
-                    source,
-                    &mut spans,
-                );
-
-                for (condition, _) in &command.elif_branches {
-                    collect_condition_command_substitution_from_body(condition, source, &mut spans);
-                }
-            }
-            Command::Compound(CompoundCommand::While(command)) => {
-                collect_condition_command_substitution_from_body(
-                    &command.condition,
-                    source,
-                    &mut spans,
-                );
-            }
-            Command::Compound(CompoundCommand::Until(command)) => {
-                collect_condition_command_substitution_from_body(
-                    &command.condition,
-                    source,
-                    &mut spans,
-                );
-            }
-            _ => {}
-        }
-    }
-
-    let mut seen = FxHashSet::default();
-    spans.retain(|span| seen.insert(FactSpan::new(*span)));
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
-    spans
 }
 
 fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
@@ -8379,23 +8279,6 @@ struct GetoptsCaseMatch {
     invalid_case_pattern_spans: Vec<Span>,
     has_fallback_pattern: bool,
     has_unknown_coverage: bool,
-}
-
-fn build_getopts_case_facts(commands: &StmtSeq, source: &str) -> Vec<GetoptsCaseFact> {
-    query::iter_commands(
-        commands,
-        CommandWalkOptions {
-            descend_nested_word_commands: false,
-        },
-    )
-    .filter_map(|visit| {
-        let Command::Compound(CompoundCommand::While(command)) = visit.command else {
-            return None;
-        };
-
-        build_getopts_case_fact_for_while(command, source)
-    })
-    .collect()
 }
 
 fn build_getopts_case_fact_for_while(
@@ -12741,6 +12624,12 @@ fn command_fact<'a>(commands: &'a [CommandFact<'a>], id: CommandId) -> &'a Comma
     &commands[id.index()]
 }
 
+fn sort_and_dedup_spans(spans: &mut Vec<Span>) {
+    let mut seen = FxHashSet::default();
+    spans.retain(|span| seen.insert(FactSpan::new(*span)));
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+}
+
 fn trim_trailing_whitespace_span(span: Span, source: &str) -> Span {
     let text = span.slice(source);
     let trimmed = text.trim_end_matches(char::is_whitespace);
@@ -13033,6 +12922,112 @@ o() {
             facts.command_id_for_command(&output.file.body[0].command),
             Some(echo_id)
         );
+    }
+
+    #[test]
+    fn tracks_nested_commands_inside_if_and_elif_conditions() {
+        let source = "\
+#!/bin/bash
+if \"$( [[ -f if_path ]] )\"; then
+  :
+elif \"$( [[ -f elif_path ]] )\"; then
+  :
+fi
+";
+
+        with_facts(source, None, |_, facts| {
+            let if_nested = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "[[ -f if_path ]]")
+                .expect("expected nested if condition command");
+            assert!(if_nested.scope_read_source_words().is_empty());
+            assert!(!facts.is_elif_condition_command(if_nested.id()));
+
+            let elif_nested = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "[[ -f elif_path ]]")
+                .expect("expected nested elif condition command");
+            assert!(elif_nested.scope_read_source_words().is_empty());
+            assert!(facts.is_elif_condition_command(elif_nested.id()));
+        });
+    }
+
+    #[test]
+    fn preserves_condition_related_span_outputs() {
+        let source = "\
+#!/bin/bash
+if [[ -f foo ]]; then
+  echo $?
+elif [[ -f bar ]]; then
+  echo $?
+fi
+while test -f baz; do
+  echo $?
+done
+if $(printf one); then
+  :
+fi
+while $(printf two); do
+  :
+done
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .condition_command_substitution_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["$(printf one)", "$(printf two)"]
+            );
+            assert_eq!(
+                facts
+                    .condition_status_capture_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["$?", "$?", "$?"]
+            );
+        });
+    }
+
+    #[test]
+    fn keeps_getopts_case_facts_when_loop_body_has_nested_command_content() {
+        let source = "\
+#!/bin/bash
+while getopts 'ab' opt; do
+  echo \"$(printf warmup)\"
+  case \"$opt\" in
+    a)
+      ;;
+    b)
+      echo \"$(printf body)\"
+      ;;
+  esac
+done
+";
+
+        with_facts(source, None, |_, facts| {
+            let [case] = facts.getopts_cases() else {
+                panic!("expected one getopts case fact");
+            };
+
+            assert_eq!(
+                case.case_span().slice(source).trim_end(),
+                "case \"$opt\" in\n    a)\n      ;;\n    b)\n      echo \"$(printf body)\"\n      ;;\n  esac"
+            );
+            assert_eq!(
+                case.handled_case_labels()
+                    .iter()
+                    .map(|label| label.label())
+                    .collect::<Vec<_>>(),
+                vec!['a', 'b']
+            );
+            assert!(case.missing_options().is_empty());
+        });
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2212,6 +2212,7 @@ pub struct LinterFacts<'a> {
     structural_command_ids: Vec<CommandId>,
     #[cfg_attr(not(test), allow(dead_code))]
     command_ids_by_span: CommandLookupIndex,
+    if_condition_command_ids: FxHashSet<CommandId>,
     elif_condition_command_ids: FxHashSet<CommandId>,
     scalar_bindings: FxHashMap<FactSpan, &'a Word>,
     broken_assoc_key_spans: Vec<Span>,
@@ -2385,6 +2386,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn comma_array_assignment_spans(&self) -> &[Span] {
         &self.comma_array_assignment_spans
+    }
+
+    pub fn is_if_condition_command(&self, id: CommandId) -> bool {
+        self.if_condition_command_ids.contains(&id)
     }
 
     pub fn is_elif_condition_command(&self, id: CommandId) -> bool {
@@ -3143,6 +3148,7 @@ impl<'a> LinterFactsBuilder<'a> {
             commands,
             structural_command_ids,
             command_ids_by_span,
+            if_condition_command_ids,
             elif_condition_command_ids,
             scalar_bindings,
             broken_assoc_key_spans,
@@ -4086,7 +4092,7 @@ fn build_function_header_facts<'a>(
     semantic: &SemanticModel,
     functions: &[&'a FunctionDef],
 ) -> Vec<FunctionHeaderFact<'a>> {
-    let call_arity_by_binding = build_function_call_arity_facts(semantic, &functions);
+    let call_arity_by_binding = build_function_call_arity_facts(semantic, functions);
     functions
         .iter()
         .copied()
@@ -12942,6 +12948,40 @@ fi
                 .find(|fact| fact.span().slice(source) == "[[ -f if_path ]]")
                 .expect("expected nested if condition command");
             assert!(if_nested.scope_read_source_words().is_empty());
+            assert!(facts.is_if_condition_command(if_nested.id()));
+            assert!(!facts.is_elif_condition_command(if_nested.id()));
+
+            let elif_nested = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "[[ -f elif_path ]]")
+                .expect("expected nested elif condition command");
+            assert!(elif_nested.scope_read_source_words().is_empty());
+            assert!(facts.is_elif_condition_command(elif_nested.id()));
+        });
+    }
+
+    #[test]
+    fn tracks_nested_if_and_elif_conditions_inside_while_conditions() {
+        let source = "\
+#!/bin/bash
+while if \"$( [[ -f if_path ]] )\"; then
+  :
+elif \"$( [[ -f elif_path ]] )\"; then
+  :
+fi; do
+  :
+done
+";
+
+        with_facts(source, None, |_, facts| {
+            let if_nested = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "[[ -f if_path ]]")
+                .expect("expected nested if condition command");
+            assert!(if_nested.scope_read_source_words().is_empty());
+            assert!(facts.is_if_condition_command(if_nested.id()));
             assert!(!facts.is_elif_condition_command(if_nested.id()));
 
             let elif_nested = facts

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -11,6 +11,21 @@ pub(crate) struct WalkContext {
     pub(crate) loop_depth: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConditionKind {
+    If,
+    Elif,
+    While,
+    Until,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CommandTraversalContext {
+    pub(crate) walk: WalkContext,
+    pub(crate) nested_word_command: bool,
+    pub(crate) condition_kind: Option<ConditionKind>,
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct CommandWalkOptions {
     pub(crate) descend_nested_word_commands: bool,
@@ -23,6 +38,12 @@ pub(crate) struct CommandVisit<'a> {
     pub(crate) redirects: &'a [Redirect],
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TraversedCommandVisit<'a> {
+    pub(crate) visit: CommandVisit<'a>,
+    pub(crate) context: CommandTraversalContext,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandSubstitutionKind {
     Command,
@@ -32,14 +53,39 @@ pub enum CommandSubstitutionKind {
 
 // Structural traversal helpers stay crate-visible so `facts.rs` owns repeated
 // AST walks. Rule implementations should consume `Checker::facts()` instead of
-// calling these walkers directly.
+// calling these walkers directly, while `facts.rs` can opt into the streaming
+// walker when it needs traversal context without a second whole-file pass.
+pub(crate) fn walk_commands<'a, F>(
+    commands: &'a StmtSeq,
+    options: CommandWalkOptions,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
+    collect_command_visits(
+        commands,
+        options,
+        CommandTraversalContext::default(),
+        visitor,
+    );
+}
+
+pub(crate) fn iter_commands_with_context<'a>(
+    commands: &'a StmtSeq,
+    options: CommandWalkOptions,
+) -> impl Iterator<Item = TraversedCommandVisit<'a>> {
+    let mut visits = Vec::new();
+    walk_commands(commands, options, &mut |visit, context| {
+        visits.push(TraversedCommandVisit { visit, context });
+    });
+    visits.into_iter()
+}
+
 pub(crate) fn iter_commands<'a>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
 ) -> impl Iterator<Item = CommandVisit<'a>> {
-    let mut visits = Vec::new();
-    collect_command_visits(commands, options, WalkContext::default(), &mut visits);
-    visits.into_iter()
+    iter_commands_with_context(commands, options).map(|visit| visit.visit)
 }
 
 pub(crate) fn pipeline_segments(command: &Command) -> Option<Vec<&Stmt>> {
@@ -244,70 +290,107 @@ fn visit_arithmetic_lvalue_words(target: &ArithmeticLvalue, visitor: &mut impl F
     }
 }
 
-fn collect_command_visits<'a>(
+fn collect_command_visits<'a, F>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     for stmt in commands.iter() {
-        collect_command_visit(stmt, options, context, visits);
+        collect_command_visit(stmt, options, context, visitor);
     }
 }
 
-fn collect_command_visit<'a>(
+fn collect_command_visit<'a, F>(
     stmt: &'a Stmt,
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
-    visits.push(CommandVisit {
-        stmt,
-        command: &stmt.command,
-        redirects: &stmt.redirects,
-    });
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
+    visitor(
+        CommandVisit {
+            stmt,
+            command: &stmt.command,
+            redirects: &stmt.redirects,
+        },
+        context,
+    );
 
     match &stmt.command {
         Command::Simple(command) => {
-            collect_assignment_visits(&command.assignments, options, context, visits);
-            collect_word_visits(&command.name, options, context, visits);
-            collect_word_slice_visits(&command.args, options, context, visits);
+            collect_assignment_visits(&command.assignments, options, context, visitor);
+            collect_word_visits(&command.name, options, context, visitor);
+            collect_word_slice_visits(&command.args, options, context, visitor);
         }
-        Command::Builtin(command) => collect_builtin_visits(command, options, context, visits),
+        Command::Builtin(command) => collect_builtin_visits(command, options, context, visitor),
         Command::Decl(command) => {
-            collect_assignment_visits(&command.assignments, options, context, visits);
+            collect_assignment_visits(&command.assignments, options, context, visitor);
             for operand in &command.operands {
                 match operand {
                     DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                        collect_word_visits(word, options, context, visits);
+                        collect_word_visits(word, options, context, visitor);
                     }
                     DeclOperand::Name(_) => {}
                     DeclOperand::Assignment(assignment) => {
-                        collect_assignment_visit(assignment, options, context, visits);
+                        collect_assignment_visit(assignment, options, context, visitor);
                     }
                 }
             }
         }
         Command::Binary(command) => {
-            collect_command_visit(&command.left, options, context, visits);
-            collect_command_visit(&command.right, options, context, visits);
+            collect_command_visit(&command.left, options, context, visitor);
+            collect_command_visit(&command.right, options, context, visitor);
         }
         Command::Compound(command) => {
-            collect_compound_visits(command, options, context, visits);
+            collect_compound_visits(command, options, context, visitor);
         }
         Command::Function(FunctionDef { header, body, .. }) => {
             for entry in &header.entries {
-                collect_word_visits(&entry.word, options, context, visits);
+                collect_word_visits(&entry.word, options, context, visitor);
             }
-            collect_command_visit(body, options, context, visits);
+            collect_command_visit(body, options, context, visitor);
         }
         Command::AnonymousFunction(function) => {
-            collect_word_slice_visits(&function.args, options, context, visits);
-            collect_command_visit(&function.body, options, context, visits);
+            collect_word_slice_visits(&function.args, options, context, visitor);
+            collect_command_visit(&function.body, options, context, visitor);
         }
     }
 
-    collect_redirect_visits(&stmt.redirects, options, context, visits);
+    collect_redirect_visits(&stmt.redirects, options, context, visitor);
+}
+
+fn condition_context(
+    context: CommandTraversalContext,
+    kind: ConditionKind,
+) -> CommandTraversalContext {
+    if context.condition_kind.is_some() {
+        context
+    } else {
+        CommandTraversalContext {
+            condition_kind: Some(kind),
+            ..context
+        }
+    }
+}
+
+fn loop_context(context: CommandTraversalContext) -> CommandTraversalContext {
+    CommandTraversalContext {
+        walk: WalkContext {
+            loop_depth: context.walk.loop_depth + 1,
+        },
+        ..context
+    }
+}
+
+fn nested_word_context(context: CommandTraversalContext) -> CommandTraversalContext {
+    CommandTraversalContext {
+        nested_word_command: true,
+        ..context
+    }
 }
 
 fn collect_pipeline_segments<'a>(command: &'a BinaryCommand, segments: &mut Vec<&'a Stmt>) {
@@ -326,186 +409,177 @@ fn collect_pipeline_segments<'a>(command: &'a BinaryCommand, segments: &mut Vec<
     }
 }
 
-fn collect_builtin_visits<'a>(
+fn collect_builtin_visits<'a, F>(
     command: &'a BuiltinCommand,
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     match command {
         BuiltinCommand::Break(command) => {
-            collect_assignment_visits(&command.assignments, options, context, visits);
+            collect_assignment_visits(&command.assignments, options, context, visitor);
             if let Some(word) = &command.depth {
-                collect_word_visits(word, options, context, visits);
+                collect_word_visits(word, options, context, visitor);
             }
-            collect_word_slice_visits(&command.extra_args, options, context, visits);
+            collect_word_slice_visits(&command.extra_args, options, context, visitor);
         }
         BuiltinCommand::Continue(command) => {
-            collect_assignment_visits(&command.assignments, options, context, visits);
+            collect_assignment_visits(&command.assignments, options, context, visitor);
             if let Some(word) = &command.depth {
-                collect_word_visits(word, options, context, visits);
+                collect_word_visits(word, options, context, visitor);
             }
-            collect_word_slice_visits(&command.extra_args, options, context, visits);
+            collect_word_slice_visits(&command.extra_args, options, context, visitor);
         }
         BuiltinCommand::Return(command) => {
-            collect_assignment_visits(&command.assignments, options, context, visits);
+            collect_assignment_visits(&command.assignments, options, context, visitor);
             if let Some(word) = &command.code {
-                collect_word_visits(word, options, context, visits);
+                collect_word_visits(word, options, context, visitor);
             }
-            collect_word_slice_visits(&command.extra_args, options, context, visits);
+            collect_word_slice_visits(&command.extra_args, options, context, visitor);
         }
         BuiltinCommand::Exit(command) => {
-            collect_assignment_visits(&command.assignments, options, context, visits);
+            collect_assignment_visits(&command.assignments, options, context, visitor);
             if let Some(word) = &command.code {
-                collect_word_visits(word, options, context, visits);
+                collect_word_visits(word, options, context, visitor);
             }
-            collect_word_slice_visits(&command.extra_args, options, context, visits);
+            collect_word_slice_visits(&command.extra_args, options, context, visitor);
         }
     }
 }
 
-fn collect_compound_visits<'a>(
+fn collect_compound_visits<'a, F>(
     command: &'a CompoundCommand,
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     match command {
         CompoundCommand::If(command) => {
-            collect_command_visits(&command.condition, options, context, visits);
-            collect_command_visits(&command.then_branch, options, context, visits);
+            collect_command_visits(
+                &command.condition,
+                options,
+                condition_context(context, ConditionKind::If),
+                visitor,
+            );
+            collect_command_visits(&command.then_branch, options, context, visitor);
             for (condition, body) in &command.elif_branches {
-                collect_command_visits(condition, options, context, visits);
-                collect_command_visits(body, options, context, visits);
+                collect_command_visits(
+                    condition,
+                    options,
+                    condition_context(context, ConditionKind::Elif),
+                    visitor,
+                );
+                collect_command_visits(body, options, context, visitor);
             }
             if let Some(body) = &command.else_branch {
-                collect_command_visits(body, options, context, visits);
+                collect_command_visits(body, options, context, visitor);
             }
         }
         CompoundCommand::For(command) => {
             if let Some(words) = &command.words {
-                collect_word_slice_visits(words, options, context, visits);
+                collect_word_slice_visits(words, options, context, visitor);
             }
-            collect_command_visits(
-                &command.body,
-                options,
-                WalkContext {
-                    loop_depth: context.loop_depth + 1,
-                },
-                visits,
-            );
+            collect_command_visits(&command.body, options, loop_context(context), visitor);
         }
         CompoundCommand::Repeat(command) => {
-            collect_word_visits(&command.count, options, context, visits);
-            collect_command_visits(
-                &command.body,
-                options,
-                WalkContext {
-                    loop_depth: context.loop_depth + 1,
-                },
-                visits,
-            );
+            collect_word_visits(&command.count, options, context, visitor);
+            collect_command_visits(&command.body, options, loop_context(context), visitor);
         }
         CompoundCommand::Foreach(command) => {
-            collect_word_slice_visits(&command.words, options, context, visits);
-            collect_command_visits(
-                &command.body,
-                options,
-                WalkContext {
-                    loop_depth: context.loop_depth + 1,
-                },
-                visits,
-            );
+            collect_word_slice_visits(&command.words, options, context, visitor);
+            collect_command_visits(&command.body, options, loop_context(context), visitor);
         }
-        CompoundCommand::ArithmeticFor(command) => collect_command_visits(
-            &command.body,
-            options,
-            WalkContext {
-                loop_depth: context.loop_depth + 1,
-            },
-            visits,
-        ),
+        CompoundCommand::ArithmeticFor(command) => {
+            collect_command_visits(&command.body, options, loop_context(context), visitor);
+        }
         CompoundCommand::While(command) => {
-            let loop_context = WalkContext {
-                loop_depth: context.loop_depth + 1,
-            };
-            collect_command_visits(&command.condition, options, loop_context, visits);
-            collect_command_visits(&command.body, options, loop_context, visits);
+            let loop_context = loop_context(context);
+            collect_command_visits(
+                &command.condition,
+                options,
+                condition_context(loop_context, ConditionKind::While),
+                visitor,
+            );
+            collect_command_visits(&command.body, options, loop_context, visitor);
         }
         CompoundCommand::Until(command) => {
-            let loop_context = WalkContext {
-                loop_depth: context.loop_depth + 1,
-            };
-            collect_command_visits(&command.condition, options, loop_context, visits);
-            collect_command_visits(&command.body, options, loop_context, visits);
+            let loop_context = loop_context(context);
+            collect_command_visits(
+                &command.condition,
+                options,
+                condition_context(loop_context, ConditionKind::Until),
+                visitor,
+            );
+            collect_command_visits(&command.body, options, loop_context, visitor);
         }
         CompoundCommand::Case(command) => {
-            collect_word_visits(&command.word, options, context, visits);
+            collect_word_visits(&command.word, options, context, visitor);
             for case in &command.cases {
-                collect_pattern_slice_visits(&case.patterns, options, context, visits);
-                collect_command_visits(&case.body, options, context, visits);
+                collect_pattern_slice_visits(&case.patterns, options, context, visitor);
+                collect_command_visits(&case.body, options, context, visitor);
             }
         }
         CompoundCommand::Select(command) => {
-            collect_word_slice_visits(&command.words, options, context, visits);
-            collect_command_visits(
-                &command.body,
-                options,
-                WalkContext {
-                    loop_depth: context.loop_depth + 1,
-                },
-                visits,
-            );
+            collect_word_slice_visits(&command.words, options, context, visitor);
+            collect_command_visits(&command.body, options, loop_context(context), visitor);
         }
         CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
-            collect_command_visits(commands, options, context, visits);
+            collect_command_visits(commands, options, context, visitor);
         }
         CompoundCommand::Always(command) => {
-            collect_command_visits(&command.body, options, context, visits);
-            collect_command_visits(&command.always_body, options, context, visits);
+            collect_command_visits(&command.body, options, context, visitor);
+            collect_command_visits(&command.always_body, options, context, visitor);
         }
         CompoundCommand::Arithmetic(_) => {}
         CompoundCommand::Time(command) => {
             if let Some(command) = &command.command {
-                collect_command_visit(command, options, context, visits);
+                collect_command_visit(command, options, context, visitor);
             }
         }
         CompoundCommand::Conditional(command) => {
-            collect_conditional_visits(&command.expression, options, context, visits);
+            collect_conditional_visits(&command.expression, options, context, visitor);
         }
         CompoundCommand::Coproc(command) => {
-            collect_command_visit(&command.body, options, context, visits);
+            collect_command_visit(&command.body, options, context, visitor);
         }
     }
 }
 
-fn collect_assignment_visits<'a>(
+fn collect_assignment_visits<'a, F>(
     assignments: &'a [Assignment],
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     for assignment in assignments {
-        collect_assignment_visit(assignment, options, context, visits);
+        collect_assignment_visit(assignment, options, context, visitor);
     }
 }
 
-fn collect_assignment_visit<'a>(
+fn collect_assignment_visit<'a, F>(
     assignment: &'a Assignment,
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     match &assignment.value {
-        AssignmentValue::Scalar(word) => collect_word_visits(word, options, context, visits),
+        AssignmentValue::Scalar(word) => collect_word_visits(word, options, context, visitor),
         AssignmentValue::Compound(array) => {
             for element in &array.elements {
                 match element {
                     ArrayElem::Sequential(word) => {
-                        collect_word_visits(word, options, context, visits);
+                        collect_word_visits(word, options, context, visitor);
                     }
                     ArrayElem::Keyed { value, .. } | ArrayElem::KeyedAppend { value, .. } => {
-                        collect_word_visits(value, options, context, visits);
+                        collect_word_visits(value, options, context, visitor);
                     }
                 }
             }
@@ -513,69 +587,77 @@ fn collect_assignment_visit<'a>(
     }
 }
 
-fn collect_word_slice_visits<'a>(
+fn collect_word_slice_visits<'a, F>(
     words: &'a [Word],
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     for word in words {
-        collect_word_visits(word, options, context, visits);
+        collect_word_visits(word, options, context, visitor);
     }
 }
 
-fn collect_pattern_slice_visits<'a>(
+fn collect_pattern_slice_visits<'a, F>(
     patterns: &'a [Pattern],
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     for pattern in patterns {
-        collect_pattern_visits(pattern, options, context, visits);
+        collect_pattern_visits(pattern, options, context, visitor);
     }
 }
 
-fn collect_word_visits<'a>(
+fn collect_word_visits<'a, F>(
     word: &'a Word,
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     if !options.descend_nested_word_commands {
         return;
     }
 
-    collect_word_part_visits(&word.parts, options, context, visits);
+    collect_word_part_visits(&word.parts, options, nested_word_context(context), visitor);
 }
 
-fn collect_word_part_visits<'a>(
+fn collect_word_part_visits<'a, F>(
     parts: &'a [WordPartNode],
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     for part in parts {
         match &part.kind {
             WordPart::ZshQualifiedGlob(glob) => {
                 for pattern in zsh_glob_patterns(glob) {
-                    collect_pattern_visits(pattern, options, context, visits);
+                    collect_pattern_visits(pattern, options, context, visitor);
                 }
             }
             WordPart::DoubleQuoted { parts, .. } => {
-                collect_word_part_visits(parts, options, context, visits);
+                collect_word_part_visits(parts, options, context, visitor);
             }
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
                 if let Some(expression_ast) = expression_ast.as_ref() {
                     let mut arithmetic_words = Vec::new();
                     collect_optional_arithmetic_words(Some(expression_ast), &mut arithmetic_words);
                     for word in arithmetic_words {
-                        collect_word_visits(word, options, context, visits);
+                        collect_word_visits(word, options, context, visitor);
                     }
                 }
             }
             WordPart::CommandSubstitution { body, .. }
             | WordPart::ProcessSubstitution { body, .. } => {
-                collect_command_visits(body, options, context, visits);
+                collect_command_visits(body, options, context, visitor);
             }
             WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
@@ -595,18 +677,20 @@ fn collect_word_part_visits<'a>(
     }
 }
 
-fn collect_pattern_visits<'a>(
+fn collect_pattern_visits<'a, F>(
     pattern: &'a Pattern,
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     for (part, _) in pattern.parts_with_spans() {
         match part {
             PatternPart::Group { patterns, .. } => {
-                collect_pattern_slice_visits(patterns, options, context, visits);
+                collect_pattern_slice_visits(patterns, options, context, visitor);
             }
-            PatternPart::Word(word) => collect_word_visits(word, options, context, visits),
+            PatternPart::Word(word) => collect_word_visits(word, options, context, visitor),
             PatternPart::Literal(_)
             | PatternPart::AnyString
             | PatternPart::AnyChar
@@ -615,45 +699,49 @@ fn collect_pattern_visits<'a>(
     }
 }
 
-fn collect_redirect_visits<'a>(
+fn collect_redirect_visits<'a, F>(
     redirects: &'a [Redirect],
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     for redirect in redirects {
-        collect_word_visits(redirect_walk_word(redirect), options, context, visits);
+        collect_word_visits(redirect_walk_word(redirect), options, context, visitor);
     }
 }
 
-fn collect_conditional_visits<'a>(
+fn collect_conditional_visits<'a, F>(
     expression: &'a ConditionalExpr,
     options: CommandWalkOptions,
-    context: WalkContext,
-    visits: &mut Vec<CommandVisit<'a>>,
-) {
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
     match expression {
         ConditionalExpr::Binary(expr) => {
-            collect_conditional_visits(&expr.left, options, context, visits);
-            collect_conditional_visits(&expr.right, options, context, visits);
+            collect_conditional_visits(&expr.left, options, context, visitor);
+            collect_conditional_visits(&expr.right, options, context, visitor);
         }
         ConditionalExpr::Unary(expr) => {
-            collect_conditional_visits(&expr.expr, options, context, visits)
+            collect_conditional_visits(&expr.expr, options, context, visitor)
         }
         ConditionalExpr::Parenthesized(expr) => {
-            collect_conditional_visits(&expr.expr, options, context, visits);
+            collect_conditional_visits(&expr.expr, options, context, visitor);
         }
         ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-            collect_word_visits(word, options, context, visits)
+            collect_word_visits(word, options, context, visitor)
         }
         ConditionalExpr::Pattern(pattern) => {
-            collect_pattern_visits(pattern, options, context, visits)
+            collect_pattern_visits(pattern, options, context, visitor)
         }
         ConditionalExpr::VarRef(reference) => {
             let mut subscript_words = Vec::new();
             collect_var_ref_subscript_words(reference, &mut subscript_words);
             for word in subscript_words {
-                collect_word_visits(word, options, context, visits);
+                collect_word_visits(word, options, context, visitor);
             }
         }
     }
@@ -680,7 +768,9 @@ mod tests {
     use shuck_ast::{Command, StmtSeq, Word, WordPart};
     use shuck_parser::parser::Parser;
 
-    use super::{CommandWalkOptions, iter_commands, pipeline_segments};
+    use super::{
+        CommandWalkOptions, ConditionKind, iter_commands, pipeline_segments, walk_commands,
+    };
 
     fn parse_commands(source: &str) -> StmtSeq {
         let output = Parser::new(source).parse().unwrap();
@@ -735,6 +825,48 @@ mod tests {
 
         assert_eq!(structural, vec!["echo"]);
         assert_eq!(nested, vec!["echo", "printf"]);
+    }
+
+    #[test]
+    fn walk_commands_tracks_nested_word_and_condition_context() {
+        let source = "\
+if foo \"$(bar)\"; then
+  :
+elif while baz \"$(qux)\"; do :; done; then
+  :
+fi
+";
+        let commands = parse_commands(source);
+        let mut visits = Vec::new();
+
+        walk_commands(
+            &commands,
+            CommandWalkOptions {
+                descend_nested_word_commands: true,
+            },
+            &mut |visit, context| {
+                let Command::Simple(command) = visit.command else {
+                    return;
+                };
+                let Some(name) = static_word_text(&command.name, source) else {
+                    return;
+                };
+                if name == ":" {
+                    return;
+                }
+                visits.push((name, context.nested_word_command, context.condition_kind));
+            },
+        );
+
+        assert_eq!(
+            visits,
+            vec![
+                ("foo".to_owned(), false, Some(ConditionKind::If)),
+                ("bar".to_owned(), true, Some(ConditionKind::If)),
+                ("baz".to_owned(), false, Some(ConditionKind::Elif)),
+                ("qux".to_owned(), true, Some(ConditionKind::Elif)),
+            ]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -367,13 +367,9 @@ fn condition_context(
     context: CommandTraversalContext,
     kind: ConditionKind,
 ) -> CommandTraversalContext {
-    if context.condition_kind.is_some() {
-        context
-    } else {
-        CommandTraversalContext {
-            condition_kind: Some(kind),
-            ..context
-        }
+    CommandTraversalContext {
+        condition_kind: Some(kind),
+        ..context
     }
 }
 
@@ -863,8 +859,48 @@ fi
             vec![
                 ("foo".to_owned(), false, Some(ConditionKind::If)),
                 ("bar".to_owned(), true, Some(ConditionKind::If)),
-                ("baz".to_owned(), false, Some(ConditionKind::Elif)),
-                ("qux".to_owned(), true, Some(ConditionKind::Elif)),
+                ("baz".to_owned(), false, Some(ConditionKind::While)),
+                ("qux".to_owned(), true, Some(ConditionKind::While)),
+            ]
+        );
+    }
+
+    #[test]
+    fn walk_commands_prefers_nested_if_and_elif_condition_kinds_inside_loops() {
+        let source = "\
+while if foo; then bar; elif baz; then qux; fi; do
+  :
+done
+";
+        let commands = parse_commands(source);
+        let mut visits = Vec::new();
+
+        walk_commands(
+            &commands,
+            CommandWalkOptions {
+                descend_nested_word_commands: true,
+            },
+            &mut |visit, context| {
+                let Command::Simple(command) = visit.command else {
+                    return;
+                };
+                let Some(name) = static_word_text(&command.name, source) else {
+                    return;
+                };
+                if name == ":" {
+                    return;
+                }
+                visits.push((name, context.condition_kind));
+            },
+        );
+
+        assert_eq!(
+            visits,
+            vec![
+                ("foo".to_owned(), Some(ConditionKind::If)),
+                ("bar".to_owned(), Some(ConditionKind::While)),
+                ("baz".to_owned(), Some(ConditionKind::Elif)),
+                ("qux".to_owned(), Some(ConditionKind::While)),
             ]
         );
     }

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -748,7 +748,11 @@ fn collect_all_elements_array_expansion_spans(
                     spans.push(span);
                 }
             }
-            WordPart::Parameter(_parameter) => {
+            WordPart::Parameter(parameter)
+                if parameter_might_use_all_elements_array_expansion(
+                    parameter, part.span, source,
+                ) =>
+            {
                 if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
                     spans.push(span);
                 }
@@ -812,6 +816,12 @@ fn collect_quoted_unindexed_bash_source_spans(
 
 fn normalize_all_elements_array_expansion_span(span: Span, source: &str) -> Option<Span> {
     let text = span.slice(source);
+    if !span_is_escaped(span, source)
+        && (text == "$@" || candidate_is_all_elements_array_expansion(text))
+    {
+        return Some(span);
+    }
+
     let base_offset = span.start.offset;
     let mut search_from = 0usize;
 
@@ -1980,6 +1990,27 @@ fn parameter_is_array_like(parameter: &ParameterExpansion) -> bool {
             _ => false,
         },
         ParameterExpansionSyntax::Zsh(_) => false,
+    }
+}
+
+fn parameter_might_use_all_elements_array_expansion(
+    parameter: &ParameterExpansion,
+    span: Span,
+    source: &str,
+) -> bool {
+    if !span.slice(source).contains('@') {
+        return false;
+    }
+
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => !matches!(
+            syntax,
+            BourneParameterExpansion::Length { .. }
+                | BourneParameterExpansion::Indices { .. }
+                | BourneParameterExpansion::Indirect { .. }
+                | BourneParameterExpansion::PrefixMatch { .. }
+        ),
+        ParameterExpansionSyntax::Zsh(_) => true,
     }
 }
 


### PR DESCRIPTION
## Summary

This refactor removes repeated whole-file command walks from `LinterFacts::build` and replaces them with a shared contextual command traversal.

It keeps `iter_commands(...)` as a compatibility helper, but moves the fact builder itself onto a single pass that now collects:
- command ids and structural command ids
- `if` / `elif` condition command ids
- function-style facts
- condition status-capture and command-substitution spans
- `getopts` case facts

The remaining non-command follow-up scans, including base-prefix arithmetic and `$?`-after-command analysis, stay on their existing paths for now.

## Why

`facts.rs` was doing two full `query::iter_commands` traversals up front, and `iter_commands` itself is a recursive AST walk. This change collapses those duplicated command-oriented traversals into one shared walk and sets up the next round of fact-builder optimization more cleanly.

## Benchmark Notes

Before/after comparison was run with:
- `cargo bench -p shuck-benchmark --bench linter -- --save-baseline=command-walk-pre`
- `cargo bench -p shuck-benchmark --bench linter -- --baseline=command-walk-pre`

Observed results:
- `linter_facts/all`: Criterion reported no change in performance detected
- `linter/all`: improved materially
- per-fixture `linter_facts` results were mixed, with some larger fixtures improving and others regressing

I also profiled focused `linter_facts` runs afterward. The current hotspot is no longer the command traversal; most sampled time is now going into word/span lookup work, especially `position_at_offset`, `innermost_command_span_containing_offset`, and `SemanticModel::scope_at`.

## Validation

- `cargo test -p shuck-linter`
