### PR TITLE
Fix S040 ShellCheck mapping

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3058,6 +3058,35 @@ function f { :; }
     }
 
     #[test]
+    fn backslash_before_command_suppressed_by_shellcheck_directive() {
+        let source = "\
+#!/bin/sh
+# shellcheck disable=SC2268
+\\command printf '%s\\n' hi
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let directives = parse_directives(
+            source,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        let suppressions = SuppressionIndex::new(
+            &directives,
+            &output.file,
+            first_statement_line(&output.file).unwrap_or(u32::MAX),
+        );
+        let diagnostics = lint_file(
+            &output.file,
+            source,
+            &indexer,
+            &LinterSettings::for_rule(Rule::BackslashBeforeCommand),
+            Some(&suppressions),
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn let_command_suppressed_by_shellcheck_directive() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -174,6 +174,9 @@ impl Default for ShellCheckCodeMap {
             (2360, Rule::ExprSubstrInTest),
             (2170, Rule::StringComparedWithEq),
             (2268, Rule::XPrefixInTest),
+            // Current ShellCheck releases no longer emit a matching backslash-before-command
+            // warning, but authored S040 metadata and SC2268 suppressions should still map here.
+            (2268, Rule::BackslashBeforeCommand),
             // Current ShellCheck releases report the x-prefix comparison family as SC2268.
             // Keep SC2351 as a suppression alias for the authored S065 metadata.
             (2331, Rule::AFlagInDoubleBracket),
@@ -566,7 +569,6 @@ impl Default for ShellCheckCodeMap {
             (1004, Rule::LiteralBackslash),
             (1049, Rule::IfMissingThen),
             (1036, Rule::ExtglobInTest),
-            (1012, Rule::BackslashBeforeCommand),
             (1074, Rule::ExtglobCase),
             (1058, Rule::MultiVarForLoop),
             (1070, Rule::ZshRedirPipe),
@@ -925,6 +927,9 @@ impl Default for ShellCheckCodeMap {
                 (3058, Rule::StarGlobRemovalInSh),
                 (3024, Rule::PlusEqualsInSh),
                 (2351, Rule::XPrefixInTest),
+                // Current ShellCheck releases no longer emit a matching backslash-before-command
+                // warning, but authored S040 metadata and SC2268 suppressions should still map here.
+                (2268, Rule::BackslashBeforeCommand),
                 // ShellCheck 0.11.0 reports redirect collisions as SC2094.
                 // Keep SC2094 available as the live comparison alias for SC2317.
                 (2094, Rule::RedirectClobbersInput),
@@ -1631,7 +1636,10 @@ mod tests {
         assert_eq!(map.resolve("SC2238"), Some(Rule::RedirectToCommandName));
         assert_eq!(map.resolve("SC2268"), Some(Rule::XPrefixInTest));
         assert_eq!(map.resolve("SC2351"), Some(Rule::XPrefixInTest));
-        assert_eq!(map.resolve_all("SC2268"), vec![Rule::XPrefixInTest]);
+        assert_eq!(
+            map.resolve_all("SC2268"),
+            vec![Rule::XPrefixInTest, Rule::BackslashBeforeCommand]
+        );
         assert_eq!(map.resolve("SC2239"), Some(Rule::NonAbsoluteShebang));
         assert_eq!(map.resolve("SC2260"), Some(Rule::RedirectToCommandName));
         assert_eq!(map.resolve("SC2358"), Some(Rule::RedirectBeforePipe));
@@ -2128,6 +2136,7 @@ mod tests {
             (3055, Rule::PlusEqualsAppend),
             (3055, Rule::ArrayKeysInSh),
             (2268, Rule::XPrefixInTest),
+            (2268, Rule::BackslashBeforeCommand),
             (2351, Rule::XPrefixInTest),
             (2357, Rule::MalformedArithmeticInCondition),
             (2361, Rule::StringComparedWithEq),
@@ -2184,7 +2193,6 @@ mod tests {
             Rule::ArraySubscriptTest,
             Rule::ArraySubscriptCondition,
             Rule::ExtglobInTest,
-            Rule::BackslashBeforeCommand,
             Rule::ShebangNotOnFirstLine,
         ]);
 
@@ -2406,7 +2414,6 @@ mod tests {
             (1004, Rule::LiteralBackslash),
             (1049, Rule::IfMissingThen),
             (1036, Rule::ExtglobInTest),
-            (1012, Rule::BackslashBeforeCommand),
             (1074, Rule::ExtglobCase),
             (1058, Rule::MultiVarForLoop),
             (1070, Rule::ZshRedirPipe),

--- a/crates/shuck/tests/testdata/corpus-metadata/s040.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s040.yaml
@@ -1,0 +1,7 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2268"
+    reason: "Current ShellCheck 0.11.0 does not surface a matching backslash-before-command warning in corpus runs, so S040 treats the legacy SC2268 mapping as reviewed context instead of an active oracle."
+
+reviewed_divergences:
+  - side: shuck-only
+    reason: "S040 intentionally flags leading `\\command` wrappers used to dodge alias expansion in command position. The current ShellCheck oracle no longer reports that guidance, so these corpus hits are reviewed divergence noise rather than an implementation bug."


### PR DESCRIPTION
## Summary
- fix the `S040` ShellCheck suppression mapping so `SC2268` disables `BackslashBeforeCommand`
- remove the incorrect `SC1012` large-corpus comparison alias that was conflating `S040` with literal-backslash warnings
- record the current ShellCheck corpus behavior for `S040` in rule metadata and add regression coverage for the suppression path

## Root Cause
`S040` was wired inconsistently in the compatibility layer: the rule metadata advertised `SC2268`, but the suppression map did not resolve `SC2268` to `BackslashBeforeCommand`, while the large-corpus comparison aliases incorrectly compared `S040` against `SC1012`. That made targeted corpus runs report unrelated `\\r` and `\\t` escape warnings as `S040` deltas.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S040`
- `make test`
- `cargo test --workspace`

## Notes
- The targeted `S040` large-corpus compatibility check now passes.
- The `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S040` command still surfaces the existing unrelated zsh harness timeout for `ohmyzsh__ohmyzsh__plugins__emoji__emoji-char-definitions.zsh`.
