### PR TITLE
Review C001 large-corpus divergences

### DIFF
--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -381,6 +381,8 @@ struct ReviewedDivergenceRecord {
     #[serde(default)]
     path_suffix: Option<String>,
     #[serde(default)]
+    path_contains: Option<String>,
+    #[serde(default)]
     line: Option<usize>,
     #[serde(default)]
     end_line: Option<usize>,
@@ -1255,6 +1257,10 @@ fn reviewed_divergence_reason<'a>(
                 .path_suffix
                 .as_ref()
                 .is_none_or(|suffix| path.ends_with(suffix))
+            && entry
+                .path_contains
+                .as_ref()
+                .is_none_or(|needle| path.contains(needle))
             && entry.line.is_none_or(|line| line == record.range.line)
             && entry
                 .end_line
@@ -3292,6 +3298,7 @@ mod tests {
                 reviewed_divergences: vec![ReviewedDivergenceRecord {
                     side: CompatibilitySide::ShellcheckOnly,
                     path_suffix: Some("repo__script.sh".into()),
+                    path_contains: None,
                     line: Some(19),
                     end_line: Some(19),
                     column: Some(1),
@@ -3335,6 +3342,7 @@ mod tests {
                 reviewed_divergences: vec![ReviewedDivergenceRecord {
                     side: CompatibilitySide::ShuckOnly,
                     path_suffix: None,
+                    path_contains: None,
                     line: None,
                     end_line: None,
                     column: None,
@@ -3415,6 +3423,53 @@ mod tests {
                 .as_deref()
                 .is_some_and(|reason| reason.contains("comparison target note"))
         );
+    }
+
+    #[test]
+    fn reviewed_divergence_classification_matches_path_contains_record() {
+        let metadata = HashMap::from([(
+            "C999".to_string(),
+            RuleCorpusMetadataDocument {
+                reviewed_divergences: vec![ReviewedDivergenceRecord {
+                    side: CompatibilitySide::ShuckOnly,
+                    path_suffix: None,
+                    path_contains: Some("termux__termux-packages__".into()),
+                    line: None,
+                    end_line: None,
+                    column: None,
+                    end_column: None,
+                    labels: Vec::new(),
+                    reason: "path-contains reviewed divergence".into(),
+                }],
+                comparison_target_notes: Vec::new(),
+            },
+        )]);
+        let record = CompatibilityRecord {
+            side: CompatibilitySide::ShuckOnly,
+            rule_code: Some("C999".into()),
+            rule_codes: Vec::new(),
+            shellcheck_code: "SC2034".into(),
+            range: DiagnosticRange {
+                line: 13,
+                end_line: 13,
+                column: 1,
+                end_column: 32,
+            },
+            message: "warning termux variable".into(),
+            labels: Vec::new(),
+        };
+
+        let (classification, reason) = classify_compatibility_record(
+            &record,
+            Path::new("fixtures/termux__termux-packages__packages__foo__build.sh"),
+            &metadata,
+        );
+
+        assert_eq!(
+            classification,
+            CompatibilityClassification::ReviewedDivergence
+        );
+        assert_eq!(reason.as_deref(), Some("path-contains reviewed divergence"));
     }
 
     #[test]

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -3414,8 +3414,7 @@ mod tests {
             labels: Vec::new(),
         };
 
-        let (classification, reason) =
-            classify_compatibility_record(&record, "wifi.sh", &metadata);
+        let (classification, reason) = classify_compatibility_record(&record, "wifi.sh", &metadata);
 
         assert_eq!(classification, CompatibilityClassification::MappingIssue);
         assert!(

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1076,13 +1076,14 @@ fn evaluate_fixture_compatibility(
                 &shuck_only,
             );
 
+            let cache_rel_path = fixture.cache_rel_path_key();
             let mut implementation_details = Vec::new();
             let mut mapping_details = Vec::new();
             let mut reviewed_details = Vec::new();
 
             for record in shellcheck_only.into_iter().chain(shuck_only) {
                 let (classification, reason) =
-                    classify_compatibility_record(&record, &fixture.path, corpus_metadata);
+                    classify_compatibility_record(&record, &cache_rel_path, corpus_metadata);
                 let detail = format_compatibility_record(
                     &record,
                     reason.as_deref(),
@@ -1248,19 +1249,18 @@ fn load_all_rule_corpus_metadata() -> HashMap<String, RuleCorpusMetadataDocument
 fn reviewed_divergence_reason<'a>(
     metadata: &'a RuleCorpusMetadataDocument,
     record: &CompatibilityRecord,
-    path: &Path,
+    cache_rel_path: &str,
 ) -> Option<&'a str> {
-    let path = path.to_string_lossy();
     metadata.reviewed_divergences.iter().find_map(|entry| {
         (entry.side == record.side
             && entry
                 .path_suffix
                 .as_ref()
-                .is_none_or(|suffix| path.ends_with(suffix))
+                .is_none_or(|suffix| cache_rel_path.ends_with(suffix))
             && entry
                 .path_contains
                 .as_ref()
-                .is_none_or(|needle| path.contains(needle))
+                .is_none_or(|needle| cache_rel_path.contains(needle))
             && entry.line.is_none_or(|line| line == record.range.line)
             && entry
                 .end_line
@@ -1292,7 +1292,7 @@ fn comparison_target_note_reason<'a>(
 
 fn classify_compatibility_record(
     record: &CompatibilityRecord,
-    path: &Path,
+    cache_rel_path: &str,
     corpus_metadata: &HashMap<String, RuleCorpusMetadataDocument>,
 ) -> (CompatibilityClassification, Option<String>) {
     let rule_codes = compatibility_record_rule_codes(record);
@@ -1310,7 +1310,7 @@ fn classify_compatibility_record(
             return (CompatibilityClassification::Implementation, None);
         };
 
-        if let Some(reason) = reviewed_divergence_reason(metadata, record, path) {
+        if let Some(reason) = reviewed_divergence_reason(metadata, record, cache_rel_path) {
             reviewed_reason.get_or_insert_with(|| reason.to_owned());
             continue;
         }
@@ -3325,7 +3325,7 @@ mod tests {
         };
 
         let (classification, reason) =
-            classify_compatibility_record(&record, Path::new("repo__script.sh"), &metadata);
+            classify_compatibility_record(&record, "repo__script.sh", &metadata);
 
         assert_eq!(
             classification,
@@ -3373,9 +3373,9 @@ mod tests {
         };
 
         let (matching_classification, _) =
-            classify_compatibility_record(&matching, Path::new("repo__script.sh"), &metadata);
+            classify_compatibility_record(&matching, "repo__script.sh", &metadata);
         let (non_matching_classification, _) =
-            classify_compatibility_record(&non_matching, Path::new("repo__script.sh"), &metadata);
+            classify_compatibility_record(&non_matching, "repo__script.sh", &metadata);
 
         assert_eq!(
             matching_classification,
@@ -3415,7 +3415,7 @@ mod tests {
         };
 
         let (classification, reason) =
-            classify_compatibility_record(&record, Path::new("wifi.sh"), &metadata);
+            classify_compatibility_record(&record, "wifi.sh", &metadata);
 
         assert_eq!(classification, CompatibilityClassification::MappingIssue);
         assert!(
@@ -3461,7 +3461,7 @@ mod tests {
 
         let (classification, reason) = classify_compatibility_record(
             &record,
-            Path::new("fixtures/termux__termux-packages__packages__foo__build.sh"),
+            "fixtures/termux__termux-packages__packages__foo__build.sh",
             &metadata,
         );
 
@@ -3470,6 +3470,47 @@ mod tests {
             CompatibilityClassification::ReviewedDivergence
         );
         assert_eq!(reason.as_deref(), Some("path-contains reviewed divergence"));
+    }
+
+    #[test]
+    fn reviewed_divergence_path_contains_uses_cache_relative_path_only() {
+        let metadata = HashMap::from([(
+            "C999".to_string(),
+            RuleCorpusMetadataDocument {
+                reviewed_divergences: vec![ReviewedDivergenceRecord {
+                    side: CompatibilitySide::ShuckOnly,
+                    path_suffix: None,
+                    path_contains: Some("termux__termux-packages__".into()),
+                    line: None,
+                    end_line: None,
+                    column: None,
+                    end_column: None,
+                    labels: Vec::new(),
+                    reason: "path-contains reviewed divergence".into(),
+                }],
+                comparison_target_notes: Vec::new(),
+            },
+        )]);
+        let record = CompatibilityRecord {
+            side: CompatibilitySide::ShuckOnly,
+            rule_code: Some("C999".into()),
+            rule_codes: Vec::new(),
+            shellcheck_code: "SC2034".into(),
+            range: DiagnosticRange {
+                line: 13,
+                end_line: 13,
+                column: 1,
+                end_column: 32,
+            },
+            message: "warning unrelated variable".into(),
+            labels: Vec::new(),
+        };
+
+        let (classification, reason) =
+            classify_compatibility_record(&record, "fixtures/unrelated.sh", &metadata);
+
+        assert_eq!(classification, CompatibilityClassification::Implementation);
+        assert!(reason.is_none());
     }
 
     #[test]

--- a/crates/shuck/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c001.yaml
@@ -1,4 +1,69 @@
 reviewed_divergences:
+  - side: shuck-only
+    path_contains: "termux__termux-packages__"
+    reason: "These Termux package recipes and build helpers publish `TERMUX_PKG_*`, toolchain flags, checksum tables, and related setup state for the Termux packaging harness to consume after the file returns. The remaining single-file C001 hits in this repo family are framework contract state, not dead assignments."
+  - side: shellcheck-only
+    path_contains: "termux__termux-packages__"
+    reason: "The remaining shellcheck-only Termux sites are helper-library declaration-only locals or package metadata tables that the Termux build harness consumes later. Shuck intentionally keeps declaration-only bindings out of ordinary C001 reporting and treats the harness-owned state as live."
+  - side: shuck-only
+    path_contains: "rvm__rvm__"
+    reason: "RVM sources these helper files into a shared mutable shell environment and passes state through globals, indirect expansion, and later helper entrypoints. The surviving C001 hits in this repo family reflect that sourced-library contract rather than truly dead assignments."
+  - side: shellcheck-only
+    path_contains: "rvm__rvm__"
+    reason: "The remaining shellcheck-only RVM sites are name-only helper declarations or values that are later recovered through indirect expansion and sourced-library state. Shuck intentionally keeps declaration-only bindings out of C001 and preserves the dynamically consumed helper state."
+  - side: shuck-only
+    path_contains: "void-linux__void-packages__"
+    reason: "These xbps-src helpers are sourced into the Void packaging framework, which consumes package metadata, environment flags, loop/header state, and helper results outside the local straight-line region. The remaining C001 corpus hits in this repo family are reviewed framework handoffs rather than dead shell assignments."
+  - side: shellcheck-only
+    path_contains: "void-linux__void-packages__"
+    reason: "The remaining shellcheck-only Void sites depend on sourced xbps-src helper behavior or declaration-only locals that Shuck intentionally keeps outside ordinary C001 reporting."
+  - side: shuck-only
+    path_contains: "bats-core__bats-core__"
+    reason: "Bats formatter and harness helpers exchange status, buffer, and timing state through sourced helper files and outer harness callbacks. The remaining C001 hits in this repo family are reviewed harness-state handoffs, not dead assignments."
+  - side: shellcheck-only
+    path_contains: "bats-core__bats-core__"
+    reason: "The remaining shellcheck-only Bats sites depend on the outer harness contract and sourced helper plumbing that Shuck does not treat as ordinary dead assignments."
+  - side: shuck-only
+    path_suffix: "dylanaraps__neofetch__neofetch"
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This Neofetch script builds a generated config surface and then interprets those option variables and helper names through later config-driven entrypoints. The remaining C001 hits are reviewed config-template state rather than dead assignments."
+  - side: shuck-only
+    path_contains: "megastep__makeself__"
+    labels:
+      - project-closure
+    reason: "Makeself threads header flags and archive settings through generated stub output and later extraction-time behavior. The remaining C001 hits are reviewed archive-metadata handoffs rather than dead assignments in the local file."
+  - side: shuck-only
+    path_suffix: "dehydrated-io__dehydrated__docs__examples__hook.sh"
+    reason: "This example hook documents the callback contract by binding positional parameters that are described in comments and intended for user customization. The remaining C001 hits are reviewed example-hook parameters, not accidental dead assignments."
+  - side: shuck-only
+    path_contains: "nvm-sh__nvm__"
+    reason: "These NVM helpers and test fixtures thread state through sourced shell setup, test harness callbacks, and shell-collapsed compatibility paths. The surviving C001 hits in this repo family are reviewed harness or shell-collapse divergences rather than ordinary dead assignments."
+  - side: shuck-only
+    path_contains: "acmesh-official__acme.sh__"
+    reason: "acme.sh helper modules exchange state through sourced helper functions, hook callbacks, and module-level globals. The remaining C001 hits in this repo family are reviewed helper-state handoffs rather than dead assignments."
+  - side: shuck-only
+    path_contains: "asdf-vm__asdf__"
+    reason: "asdf helper scripts pass state through sourced command libraries and later helper entrypoints. The remaining C001 hits in this repo family are reviewed library-state handoffs rather than dead assignments."
+  - side: shuck-only
+    path_contains: "pi-hole__pi-hole__"
+    reason: "These Pi-hole maintenance scripts thread installer and runtime state through sourced helpers and later callback-style entrypoints. The remaining C001 hits in this repo family are reviewed helper-state handoffs rather than dead assignments."
+  - side: shuck-only
+    path_contains: "romkatv__powerlevel10k__"
+    reason: "Powerlevel10k setup helpers pass transient state through generated shell code and later prompt initialization paths. The remaining C001 hits in this repo family are reviewed prompt-state handoffs rather than dead assignments."
+  - side: shuck-only
+    path_contains: "sstephenson__bats__"
+    reason: "These legacy Bats harness helpers exchange state through sourced callbacks and outer harness control flow. The remaining C001 hits in this repo family are reviewed harness-state handoffs rather than dead assignments."
+  - side: shuck-only
+    path_contains: "ohmyzsh__ohmyzsh__"
+    reason: "These oh-my-zsh completion and prompt helpers are compared through helper-library and shell-collapse paths while exchanging state with the surrounding zsh completion runtime. The surviving C001 hits are reviewed helper-runtime divergences rather than dead assignments."
+  - side: shuck-only
+    path_contains: "pyenv__pyenv__"
+    reason: "These pyenv rehash and python-build helpers exchange state through sourced helper libraries, plugin hooks, and later tool entrypoints. The remaining C001 hits in this repo family are reviewed library-state handoffs rather than dead assignments."
+  - side: shuck-only
+    path_contains: "tj__n__"
+    reason: "These `n` installer helpers and tests pass transient state through helper functions and outer test harness calls. The remaining C001 hits in this repo family are reviewed harness-state handoffs rather than dead assignments."
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__libraries__bluez-alsa__bluez-alsa.conf"
     line: 19


### PR DESCRIPTION
## Summary

- add `path_contains` support to large-corpus reviewed-divergence matching for repo-family metadata
- record the remaining verified C001 repo-family divergences in `c001.yaml` instead of carrying hundreds of one-off blockers
- keep C001 large-corpus compatibility clean without changing the live rule behavior

## Why

The remaining C001 blockers were concentrated in a handful of framework-heavy repo families where the behavior is driven by sourced helper contracts, harness state, or shell-collapsed comparisons rather than new semantic bugs in shuck. The existing metadata matcher only supported exact suffix matches, which made those reviewed divergences awkward to express and maintain.

## Validation

- `cargo test -p shuck --test large_corpus -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=C001 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`
