### PR TITLE
Optimize SemanticModel scope_at lookups

### DIFF
--- a/crates/shuck-benchmark/benches/semantic.rs
+++ b/crates/shuck-benchmark/benches/semantic.rs
@@ -1,9 +1,15 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixture};
 use shuck_indexer::Indexer;
-use shuck_semantic::SemanticModel;
+use shuck_semantic::{ScopeKind, SemanticModel};
+use std::collections::HashSet;
 
 configure_benchmark_allocator!();
+
+struct PreparedScopeLookupInput {
+    semantic: SemanticModel,
+    offsets: Vec<usize>,
+}
 
 fn build_semantic(source: &str) -> usize {
     let output = parse_fixture(source);
@@ -11,6 +17,59 @@ fn build_semantic(source: &str) -> usize {
     let semantic = SemanticModel::build(&output.file, source, &indexer);
 
     black_box(semantic.bindings().len() + semantic.references().len() + semantic.scopes().len())
+}
+
+fn prepare_scope_lookup_input(source: &'static str) -> PreparedScopeLookupInput {
+    let output = parse_fixture(source);
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let mut seen = HashSet::new();
+    let mut offsets = Vec::new();
+
+    for offset in semantic
+        .scopes()
+        .iter()
+        .map(|scope| scope.span.start.offset)
+        .chain(
+            semantic
+                .bindings()
+                .iter()
+                .map(|binding| binding.span.start.offset),
+        )
+        .chain(
+            semantic
+                .references()
+                .iter()
+                .map(|reference| reference.span.start.offset),
+        )
+    {
+        if seen.insert(offset) {
+            offsets.push(offset);
+        }
+    }
+
+    if offsets.is_empty() {
+        offsets.push(0);
+    }
+
+    PreparedScopeLookupInput { semantic, offsets }
+}
+
+fn run_scope_lookups(input: &PreparedScopeLookupInput) -> usize {
+    let mut score = 0usize;
+
+    for &offset in &input.offsets {
+        let scope = input.semantic.scope_at(black_box(offset));
+        score += match input.semantic.scope_kind(scope) {
+            ScopeKind::File => 1,
+            ScopeKind::Function(_) => 3,
+            ScopeKind::Subshell => 5,
+            ScopeKind::CommandSubstitution => 7,
+            ScopeKind::Pipeline => 11,
+        };
+    }
+
+    black_box(score)
 }
 
 fn bench_semantic(c: &mut Criterion) {
@@ -34,5 +93,29 @@ fn bench_semantic(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_semantic);
+fn bench_semantic_scope_at(c: &mut Criterion) {
+    let mut group = c.benchmark_group("semantic_scope_at");
+
+    for case in benchmark_cases() {
+        let inputs = case
+            .files
+            .iter()
+            .map(|file| prepare_scope_lookup_input(file.source))
+            .collect::<Vec<_>>();
+        let total_lookups = inputs.iter().map(|input| input.offsets.len() as u64).sum();
+
+        group.sample_size(case.speed.sample_size());
+        group.throughput(Throughput::Elements(total_lookups));
+        group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter(|| {
+                let score: usize = inputs.iter().map(run_scope_lookups).sum();
+                black_box(score);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_semantic, bench_semantic_scope_at);
 criterion_main!(benches);

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -201,9 +201,79 @@ fn is_in_named_function_scope(scopes: &[Scope], scope: ScopeId, name: &Name) -> 
 }
 
 #[derive(Debug)]
+struct ScopeLookup {
+    children: Vec<Box<[ScopeId]>>,
+}
+
+impl ScopeLookup {
+    fn new(scopes: &[Scope]) -> Self {
+        let mut children = vec![Vec::new(); scopes.len()];
+
+        for scope in scopes {
+            if let Some(parent) = scope.parent {
+                children[parent.index()].push(scope.id);
+            }
+        }
+
+        for scope_ids in &mut children {
+            scope_ids.sort_by_key(|scope_id| {
+                let span = scopes[scope_id.index()].span;
+                (span.start.offset, span.end.offset)
+            });
+        }
+
+        Self {
+            children: children.into_iter().map(Vec::into_boxed_slice).collect(),
+        }
+    }
+
+    fn scope_at(&self, scopes: &[Scope], offset: usize) -> Option<ScopeId> {
+        let root = scopes.first()?;
+        if !contains_offset(root.span, offset) {
+            return None;
+        }
+
+        let mut scope = root.id;
+        while let Some(child) = self.child_scope_at(scopes, scope, offset) {
+            scope = child;
+        }
+
+        Some(scope)
+    }
+
+    fn child_scope_at(&self, scopes: &[Scope], parent: ScopeId, offset: usize) -> Option<ScopeId> {
+        let children = self.children.get(parent.index())?;
+        let cutoff = children
+            .partition_point(|scope_id| scopes[scope_id.index()].span.start.offset <= offset);
+        let mut best: Option<ScopeId> = None;
+        let mut index = cutoff;
+
+        while index > 0 {
+            index -= 1;
+            let scope_id = children[index];
+            let span = scopes[scope_id.index()].span;
+            if span.end.offset < offset {
+                break;
+            }
+            if contains_offset(span, offset) {
+                match best {
+                    Some(current)
+                        if scope_span_width(scopes[current.index()].span)
+                            <= scope_span_width(span) => {}
+                    _ => best = Some(scope_id),
+                }
+            }
+        }
+
+        best
+    }
+}
+
+#[derive(Debug)]
 pub struct SemanticModel {
     shell_profile: ShellProfile,
     scopes: Vec<Scope>,
+    scope_lookup: ScopeLookup,
     bindings: Vec<Binding>,
     references: Vec<Reference>,
     predefined_runtime_refs: FxHashSet<ReferenceId>,
@@ -271,9 +341,11 @@ impl SemanticModel {
             &built.bindings,
             &built.recorded_program,
         );
+        let scope_lookup = ScopeLookup::new(&built.scopes);
         Self {
             shell_profile: built.shell_profile,
             scopes: built.scopes,
+            scope_lookup,
             bindings: built.bindings,
             references: built.references,
             predefined_runtime_refs: built.predefined_runtime_refs,
@@ -457,11 +529,8 @@ impl SemanticModel {
     }
 
     pub fn scope_at(&self, offset: usize) -> ScopeId {
-        self.scopes
-            .iter()
-            .filter(|scope| contains_offset(scope.span, offset))
-            .min_by_key(|scope| scope.span.end.offset - scope.span.start.offset)
-            .map(|scope| scope.id)
+        self.scope_lookup
+            .scope_at(&self.scopes, offset)
             .unwrap_or(ScopeId(0))
     }
 
@@ -1107,12 +1176,26 @@ fn contains_offset(span: Span, offset: usize) -> bool {
     span.start.offset <= offset && offset <= span.end.offset
 }
 
+fn scope_span_width(span: Span) -> usize {
+    span.end.offset.saturating_sub(span.start.offset)
+}
+
 fn contains_span(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
 }
 
 fn ancestor_scopes(scopes: &[Scope], scope: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
     std::iter::successors(Some(scope), move |scope| scopes[scope.index()].parent)
+}
+
+#[cfg(test)]
+fn linear_scope_at(scopes: &[Scope], offset: usize) -> ScopeId {
+    scopes
+        .iter()
+        .filter(|scope| contains_offset(scope.span, offset))
+        .min_by_key(|scope| scope_span_width(scope.span))
+        .map(|scope| scope.id)
+        .unwrap_or(ScopeId(0))
 }
 
 fn build_indirect_targets_by_binding(
@@ -1721,6 +1804,31 @@ done
             .filter(|scope| matches!(scope.kind, ScopeKind::Pipeline))
             .count();
         assert_eq!(pipeline_scopes, 3);
+    }
+
+    #[test]
+    fn indexed_scope_lookup_matches_linear_scan_for_all_offsets() {
+        let source = "\
+outer() {
+  local current=1
+  (
+    printf '%s\\n' \"$(
+      printf '%s\\n' \"$current\" | tr a b
+    )\"
+  )
+  inner() { echo \"$current\"; }
+}
+outer
+";
+        let model = model(source);
+
+        for offset in 0..=source.len() {
+            assert_eq!(
+                model.scope_at(offset),
+                linear_scope_at(model.scopes(), offset),
+                "offset {offset}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a precomputed child-scope lookup to `SemanticModel` and route `scope_at` through indexed descent instead of a full linear scan
- add a correctness test that compares the indexed result against the old linear behavior across every byte offset in a nested fixture
- add a focused Criterion benchmark for repeated `scope_at` calls so the regression surface stays measurable

## Why
`SemanticModel::scope_at` was scanning every scope and choosing the smallest containing span on every query. Facts and several rules call it repeatedly, so the cost showed up across the lint pipeline.

## Validation
- `cargo test -p shuck-semantic`
- `cargo bench -p shuck-benchmark --bench semantic -- scope_at --save-baseline=scope-at-before --noplot`
- `cargo bench -p shuck-benchmark --bench semantic -- scope_at --baseline=scope-at-before --noplot`
- `cargo bench -p shuck-benchmark --bench linter -- linter_facts/all --save-baseline=main --noplot`
- `cargo bench -p shuck-benchmark --bench linter -- linter_facts/all --baseline=main --noplot`

## Benchmarks
- `semantic_scope_at/all`: `4.40 ms -> 0.240 ms` (`-94.6%`)
- `semantic_scope_at/nvm`: `3.14 ms -> 0.133 ms` (`-95.9%`)
- `linter_facts/all`: `73.16 ms -> 61.15 ms` (`-16.4%`)
