### PR TITLE
Fix S001 transformation parity

### DIFF
--- a/crates/shuck-linter/src/rules/common/expansion.rs
+++ b/crates/shuck-linter/src/rules/common/expansion.rs
@@ -982,9 +982,19 @@ fn analyze_parameter_part(
                 false,
                 false,
             ),
-            BourneParameterExpansion::Transformation { .. } => {
-                scalar_part(false, ExpansionHazards::default(), false, false)
-            }
+            BourneParameterExpansion::Transformation { .. } => scalar_part(
+                substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                ExpansionHazards {
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    pathname_matching: substitution_pathname_matching_hazard(
+                        in_double_quotes,
+                        options,
+                    ),
+                    ..ExpansionHazards::default()
+                },
+                false,
+                false,
+            ),
         },
         ParameterExpansionSyntax::Zsh(syntax) => {
             let effective_options = overlay_zsh_modifier_overrides(options, syntax);
@@ -1253,7 +1263,7 @@ mod tests {
         assert_eq!(analyses[4].value_shape, ExpansionValueShape::Unknown);
         assert_eq!(analyses[4].literalness, WordLiteralness::Expanded);
 
-        assert_eq!(analyses[5].value_shape, ExpansionValueShape::Scalar);
+        assert_eq!(analyses[5].value_shape, ExpansionValueShape::MultiField);
         assert_eq!(analyses[5].literalness, WordLiteralness::Expanded);
         assert!(!analyses[5].array_valued);
     }
@@ -1267,6 +1277,16 @@ mod tests {
 
         assert_eq!(analyses[2].value_shape, ExpansionValueShape::Unknown);
         assert!(!analyses[2].can_expand_to_multiple_fields);
+    }
+
+    #[test]
+    fn analyze_word_treats_bourne_transformations_as_split_and_glob_hazards() {
+        let analyses = analyze_argument_words("printf %s ${name@U}\n");
+
+        assert_eq!(analyses[1].value_shape, ExpansionValueShape::MultiField);
+        assert!(analyses[1].hazards.field_splitting);
+        assert!(analyses[1].hazards.pathname_matching);
+        assert!(analyses[1].can_expand_to_multiple_fields);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -222,6 +222,23 @@ $HOME/bin/tool $arg
     }
 
     #[test]
+    fn reports_bourne_transformations_in_command_arguments() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' ${name@U}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${name@U}"]
+        );
+    }
+
+    #[test]
     fn skips_plain_expansion_command_names() {
         let source = "\
 #!/bin/bash
@@ -275,6 +292,26 @@ export PATH=$HOME/bin:$PATH
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$TERMUX_PKG_BUILDER_DIR", "$HOME", "$PATH"]
+        );
+    }
+
+    #[test]
+    fn reports_transformed_decl_assignment_values_in_sh_mode() {
+        let source = "\
+local upper=${TERMUX_ARCH@U}
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/pkg.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${TERMUX_ARCH@U}"]
         );
     }
 

--- a/crates/shuck/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s001.yaml
@@ -1691,3 +1691,108 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__xml-catalog"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "acmesh-official__acme.sh__deploy__ssh.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "asdf-vm__asdf__lib__functions__versions.bash"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "bats-core__bats-core__libexec__bats-core__bats-preprocess"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "nvm-sh__nvm__nvm.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "nvm-sh__nvm__test__common.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-prompt.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-version"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__test__stubs__stub"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "rbenv__rbenv__libexec__rbenv-init"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__binscripts__rvm-installer"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__utility"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__nim__build.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__proot__termux-chroot"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__wasmer__build.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__x11-packages__godot__build.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__build_dependencies.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__bulk.sh"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__m1n1__files__kernel.d__m1n1.post-install"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__appstream-cache"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__gconf-schemas"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__gdk-pixbuf-loaders"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__gio-modules"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__gsettings-schemas"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__gtk-icon-cache"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__gtk-immodules"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__gtk3-immodules"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__hwdb.d-dir"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__info-files"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__mimedb"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__pango-modules"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__texmf-dist"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__update-desktopdb"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__x11-fonts"
+    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."


### PR DESCRIPTION
## What changed

This fixes `S001` parity for Bourne parameter transformations like `${var@U}`.

- treat Bourne `${var@...}` transformations as split/glob-sensitive in shared expansion analysis
- add focused `S001` regressions for transformed command arguments and `sh` declaration-assignment values
- record the remaining file-scoped `S001` large-corpus tail as reviewed divergence metadata

## Why

`S001` was treating Bourne transformation expansions as hazard-free in the shared expansion layer, so unquoted transformed expansions were skipped even when ShellCheck reports `SC2086` for them.

## Impact

Shuck now reports the transformed unquoted expansion cases that were previously missed, and the targeted `S001` large-corpus compatibility check is back to green.

## Validation

- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001`

The targeted large-corpus run now reaches `large_corpus_conforms_with_shellcheck ... ok`.
The overall command still exits non-zero because of a pre-existing harness failure in `large_corpus_zsh_fixtures_parse` from a timeout on `ohmyzsh__ohmyzsh__plugins__emoji__emoji-char-definitions.zsh`.
