### PR TITLE
Fix C063 sourced helper overrides

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,4 +1,4 @@
-use shuck_semantic::{OverwrittenFunction as SemanticOverwrittenFunction, ScopeKind};
+use shuck_semantic::{BindingKind, OverwrittenFunction as SemanticOverwrittenFunction, ScopeKind};
 
 use crate::context::FileContextTag;
 use crate::{Checker, Rule, Violation};
@@ -81,6 +81,13 @@ fn should_suppress_overwrite(
                     checker,
                     first.span.end.offset,
                     second.span.start.offset,
+                ))
+            || (file_context.has_tag(FileContextTag::ProjectClosure)
+                && is_project_closure_imported_override(
+                    checker,
+                    overwritten,
+                    first.span.end.offset,
+                    second.span.start.offset,
                 )))
 }
 
@@ -141,9 +148,42 @@ fn has_only_indirect_call_sites_between(
     has_nested_call_site && !has_same_scope_call_between
 }
 
+fn is_project_closure_imported_override(
+    checker: &Checker<'_>,
+    overwritten: &SemanticOverwrittenFunction,
+    start_offset: usize,
+    end_offset: usize,
+) -> bool {
+    let first = checker.semantic().binding(overwritten.first);
+
+    matches!(first.kind, BindingKind::Imported)
+        && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
+}
+
+fn has_same_scope_call_site_between(
+    checker: &Checker<'_>,
+    overwritten: &SemanticOverwrittenFunction,
+    start_offset: usize,
+    end_offset: usize,
+) -> bool {
+    let first = checker.semantic().binding(overwritten.first);
+
+    checker.semantic().call_sites_for(&overwritten.name).iter().any(|site| {
+        site.scope == first.scope
+            && site.span.start.offset > start_offset
+            && site.span.start.offset < end_offset
+            && checker
+                .semantic()
+                .visible_binding(&overwritten.name, site.span)
+                .is_some_and(|binding| binding.id == overwritten.first)
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
 
     use crate::test::test_snippet_at_path;
     use crate::{LinterSettings, Rule};
@@ -359,5 +399,91 @@ helper() { printf '%s\\n' second; }
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn sourced_helper_overrides_in_helper_libraries_are_suppressed() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("libexec/bats-gather-tests");
+        let helper = temp.path().join("libexec/test_functions.bash");
+        let source = "\
+#!/usr/bin/env bash
+source ./test_functions.bash
+bats_test_function() { printf '%s\\n' local; }
+";
+
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::write(&main, source).unwrap();
+        fs::write(
+            &helper,
+            "bats_test_function() { printf '%s\\n' imported; }\n",
+        )
+        .unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_analyzed_paths([main.clone(), helper.clone()]),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn sourced_helper_overrides_in_nested_helper_scopes_are_suppressed() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("libexec/bats-exec-file");
+        let helper = temp.path().join("libexec/tracing.bash");
+        let source = "\
+#!/usr/bin/env bash
+runner() {
+  source ./tracing.bash
+  prepare_context
+  bats_setup_tracing() { printf '%s\\n' local; }
+}
+";
+
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::write(&main, source).unwrap();
+        fs::write(
+            &helper,
+            "bats_setup_tracing() { printf '%s\\n' imported; }\n",
+        )
+        .unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_analyzed_paths([main.clone(), helper.clone()]),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn sourced_helper_overrides_in_regular_scripts_still_report() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("helper.sh");
+        let source = "\
+#!/usr/bin/env bash
+source ./helper.sh
+helper() { printf '%s\\n' local; }
+";
+
+        fs::write(&main, source).unwrap();
+        fs::write(&helper, "helper() { printf '%s\\n' imported; }\n").unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_analyzed_paths([main.clone(), helper.clone()]),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -155,8 +155,10 @@ fn is_project_closure_imported_override(
     end_offset: usize,
 ) -> bool {
     let first = checker.semantic().binding(overwritten.first);
+    let second = checker.semantic().binding(overwritten.second);
 
     matches!(first.kind, BindingKind::Imported)
+        && matches!(second.kind, BindingKind::FunctionDefinition)
         && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
 }
 
@@ -485,6 +487,45 @@ helper() { printf '%s\\n' local; }
             source,
             &LinterSettings::for_rule(Rule::OverwrittenFunction)
                 .with_analyzed_paths([main.clone(), helper.clone()]),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+    }
+
+    #[test]
+    fn imported_helper_collisions_still_report() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("libexec/bats-gather-tests");
+        let first_helper = temp.path().join("libexec/first.bash");
+        let second_helper = temp.path().join("libexec/second.bash");
+        let source = "\
+#!/usr/bin/env bash
+source ./first.bash
+source ./second.bash
+";
+
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::write(&main, source).unwrap();
+        fs::write(
+            &first_helper,
+            "bats_test_function() { printf '%s\\n' first; }\n",
+        )
+        .unwrap();
+        fs::write(
+            &second_helper,
+            "bats_test_function() { printf '%s\\n' second; }\n",
+        )
+        .unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction).with_analyzed_paths([
+                main.clone(),
+                first_helper.clone(),
+                second_helper.clone(),
+            ]),
         );
 
         assert_eq!(diagnostics.len(), 1);

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -168,15 +168,19 @@ fn has_same_scope_call_site_between(
 ) -> bool {
     let first = checker.semantic().binding(overwritten.first);
 
-    checker.semantic().call_sites_for(&overwritten.name).iter().any(|site| {
-        site.scope == first.scope
-            && site.span.start.offset > start_offset
-            && site.span.start.offset < end_offset
-            && checker
-                .semantic()
-                .visible_binding(&overwritten.name, site.span)
-                .is_some_and(|binding| binding.id == overwritten.first)
-    })
+    checker
+        .semantic()
+        .call_sites_for(&overwritten.name)
+        .iter()
+        .any(|site| {
+            site.scope == first.scope
+                && site.span.start.offset > start_offset
+                && site.span.start.offset < end_offset
+                && checker
+                    .semantic()
+                    .visible_binding(&overwritten.name, site.span)
+                    .is_some_and(|binding| binding.id == overwritten.first)
+        })
 }
 
 #[cfg(test)]

--- a/crates/shuck/tests/testdata/corpus-metadata/c063.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c063.yaml
@@ -20,6 +20,13 @@ reviewed_divergences:
     line: 12
     reason: "This fixture sources nvm.sh and then replaces the version-check helper with a mock implementation to generate test data."
   - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
+    line: 3
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "This formatter helper is replaced with a no-op only on the non-terminal branch, while terminal output still uses the original definition later in the file."
+  - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__requirements__openindiana"
     line: 68
     reason: "This platform-specific helper is part of RVM's override chain, so the overwrite is intentional rather than a real dead-definition bug."

--- a/docs/bugs/C063.md
+++ b/docs/bugs/C063.md
@@ -11,19 +11,32 @@
 
 ## Delta snapshot
 
-Sampled on 2026-04-07 using `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C063 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10 SHUCK_LARGE_CORPUS_KEEP_GOING=1`.
+Re-checked on 2026-04-15 with:
 
-The sample covered 683 fixtures and skipped 79 unsupported-shell fixtures.
+```bash
+cargo test -p shuck-linter overwritten_function -- --nocapture
+SHUCK_TEST_LARGE_CORPUS=1 \
+SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 \
+SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 \
+SHUCK_LARGE_CORPUS_RULES=C063 \
+SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 \
+SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 \
+SHUCK_LARGE_CORPUS_KEEP_GOING=1 \
+nix --extra-experimental-features 'nix-command flakes' develop --command \
+  cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture
+```
+
+The compatibility target covered 6,449 fixtures and skipped 710
+unsupported-shell fixtures.
 
 | Bucket | Locations | Scripts |
 |--------|-----------|---------|
 | ShellCheck-only | 0 | 0 |
-| Shuck-only | 0 | 0 |
+| Shuck-only | 1 reviewed divergence | 1 |
 | Location-only | 0 | 0 |
 
-The compatibility run still reported one patch corpus-noise fixture, and the
-separate zsh large-corpus parse harness still reports 10 blocking fixtures
-across 79 zsh inputs. Those parser gaps are outside `C063`.
+The remaining non-`C063` blockers are still the existing corpus-noise fixtures
+and the separate zsh parse harness timeouts.
 
 ## What changed
 
@@ -34,6 +47,10 @@ across 79 zsh inputs. Those parser gaps are outside `C063`.
   suppresses sourced project-closure test-double swaps with intervening
   executable commands when the helper is only consumed indirectly or remains
   opaque to the local semantic model.
+- Imported helper definitions that arrive through sourced project-closure files
+  are now suppressed in helper-library and test-harness contexts when local
+  code immediately replaces them without same-scope evidence that the imported
+  version is the one meant to be dead.
 - File-context classification now treats escaped source commands such as
   `\. ./helpers.sh` as project-closure markers so those test-harness
   suppressions match real fixtures.
@@ -46,10 +63,13 @@ across 79 zsh inputs. Those parser gaps are outside `C063`.
 
 ## Allowlisted divergences
 
-None were added in this run.
+- `ohmyzsh__ohmyzsh__oh-my-zsh.sh` line 3: `omz_f` is conditionally replaced
+  with a no-op only on the non-terminal branch, so the original formatter still
+  survives to the later calls on the terminal-output path.
 
 ## Notes
 
-The sampled `C063` comparison is clean again. The remaining large-corpus
-blockers on April 7, 2026 are the existing zsh parse harness failures and one
-patch corpus-noise fixture, not `C063` mismatches.
+The full compatibility comparison is clean for `C063` after the new imported
+helper-override suppression, aside from the reviewed Oh My Zsh shell-collapse
+divergence above. The remaining large-corpus blockers are still outside this
+rule.


### PR DESCRIPTION
## Summary
- suppress `C063` when imported helper definitions from sourced project-closure files are intentionally replaced in helper-library and test-harness contexts
- add focused regression tests for sourced helper overrides at both file scope and nested scope while preserving ordinary overwrite reports
- record the remaining Oh My Zsh shell-collapse case as a reviewed divergence and refresh the `C063` bug note

## Root cause
`C063` treated imported function definitions from sourced helper files as if they were local dead definitions. In helper-library and test-harness flows, that produced false positives when local code intentionally overrode sourced helper entrypoints before later execution paths.

## Validation
- `cargo test -p shuck-linter`
- `cargo test -p shuck-linter overwritten_function -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=C063 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`