### PR TITLE
Fix nested condition ancestry tracking

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2810,15 +2810,11 @@ impl<'a> LinterFactsBuilder<'a> {
                 id,
             });
 
-            match context.condition_kind {
-                Some(query::ConditionKind::If) => {
-                    if_condition_command_ids.insert(id);
-                }
-                Some(query::ConditionKind::Elif) => {
-                    if_condition_command_ids.insert(id);
-                    elif_condition_command_ids.insert(id);
-                }
-                Some(query::ConditionKind::While | query::ConditionKind::Until) | None => {}
+            if context.in_if_condition {
+                if_condition_command_ids.insert(id);
+            }
+            if context.in_elif_condition {
+                elif_condition_command_ids.insert(id);
             }
 
             collect_scalar_bindings(visit.command, &mut scalar_bindings);
@@ -13146,6 +13142,42 @@ done
                 .find(|fact| fact.span().slice(source) == "[[ -f elif_path ]]")
                 .expect("expected nested elif condition command");
             assert!(elif_nested.scope_read_source_words().is_empty());
+            assert!(facts.is_elif_condition_command(elif_nested.id()));
+        });
+    }
+
+    #[test]
+    fn tracks_nested_while_and_until_conditions_inside_if_and_elif_conditions() {
+        let source = "\
+#!/bin/bash
+if while [[ -f if_path ]]; do
+  :
+done; then
+  :
+elif until [[ -f elif_path ]]; do
+  :
+done; then
+  :
+fi
+";
+
+        with_facts(source, None, |_, facts| {
+            let if_nested = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "[[ -f if_path ]]")
+                .expect("expected nested while condition command");
+            assert!(if_nested.scope_read_source_words().is_empty());
+            assert!(facts.is_if_condition_command(if_nested.id()));
+            assert!(!facts.is_elif_condition_command(if_nested.id()));
+
+            let elif_nested = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "[[ -f elif_path ]]")
+                .expect("expected nested until condition command");
+            assert!(elif_nested.scope_read_source_words().is_empty());
+            assert!(facts.is_if_condition_command(elif_nested.id()));
             assert!(facts.is_elif_condition_command(elif_nested.id()));
         });
     }

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -24,6 +24,8 @@ pub(crate) struct CommandTraversalContext {
     pub(crate) walk: WalkContext,
     pub(crate) nested_word_command: bool,
     pub(crate) condition_kind: Option<ConditionKind>,
+    pub(crate) in_if_condition: bool,
+    pub(crate) in_elif_condition: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -367,8 +369,18 @@ fn condition_context(
     context: CommandTraversalContext,
     kind: ConditionKind,
 ) -> CommandTraversalContext {
+    let (in_if_condition, in_elif_condition) = match kind {
+        ConditionKind::If => (true, context.in_elif_condition),
+        ConditionKind::Elif => (true, true),
+        ConditionKind::While | ConditionKind::Until => {
+            (context.in_if_condition, context.in_elif_condition)
+        }
+    };
+
     CommandTraversalContext {
         condition_kind: Some(kind),
+        in_if_condition,
+        in_elif_condition,
         ..context
     }
 }
@@ -850,17 +862,41 @@ fi
                 if name == ":" {
                     return;
                 }
-                visits.push((name, context.nested_word_command, context.condition_kind));
+                visits.push((
+                    name,
+                    context.nested_word_command,
+                    context.condition_kind,
+                    context.in_if_condition,
+                    context.in_elif_condition,
+                ));
             },
         );
 
         assert_eq!(
             visits,
             vec![
-                ("foo".to_owned(), false, Some(ConditionKind::If)),
-                ("bar".to_owned(), true, Some(ConditionKind::If)),
-                ("baz".to_owned(), false, Some(ConditionKind::While)),
-                ("qux".to_owned(), true, Some(ConditionKind::While)),
+                (
+                    "foo".to_owned(),
+                    false,
+                    Some(ConditionKind::If),
+                    true,
+                    false
+                ),
+                ("bar".to_owned(), true, Some(ConditionKind::If), true, false),
+                (
+                    "baz".to_owned(),
+                    false,
+                    Some(ConditionKind::While),
+                    true,
+                    true
+                ),
+                (
+                    "qux".to_owned(),
+                    true,
+                    Some(ConditionKind::While),
+                    true,
+                    true
+                ),
             ]
         );
     }
@@ -890,17 +926,22 @@ done
                 if name == ":" {
                     return;
                 }
-                visits.push((name, context.condition_kind));
+                visits.push((
+                    name,
+                    context.condition_kind,
+                    context.in_if_condition,
+                    context.in_elif_condition,
+                ));
             },
         );
 
         assert_eq!(
             visits,
             vec![
-                ("foo".to_owned(), Some(ConditionKind::If)),
-                ("bar".to_owned(), Some(ConditionKind::While)),
-                ("baz".to_owned(), Some(ConditionKind::Elif)),
-                ("qux".to_owned(), Some(ConditionKind::While)),
+                ("foo".to_owned(), Some(ConditionKind::If), true, false),
+                ("bar".to_owned(), Some(ConditionKind::While), false, false),
+                ("baz".to_owned(), Some(ConditionKind::Elif), true, true),
+                ("qux".to_owned(), Some(ConditionKind::While), false, false),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- preserve outer if/elif condition ancestry while still reporting the innermost condition kind
- restore if/elif fact tagging for nested while/until conditions inside condition trees
- add regression coverage for nested if/elif and while/until condition combinations

## Validation
- cargo test -p shuck-linter

Follow-up to #128 to address post-merge review feedback.