### PR TITLE
Fix C063 helper library reimport false positives

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -183,11 +183,11 @@ fn is_nested_project_closure_import_reimport_from_same_origin(
         && matches!(first.kind, BindingKind::Imported)
         && matches!(second.kind, BindingKind::Imported)
         && !matches!(checker.semantic().scope_kind(first.scope), ScopeKind::File)
-        && imported_binding_origins_overlap(checker, overwritten.first, overwritten.second)
+        && imported_binding_origins_match_exactly(checker, overwritten.first, overwritten.second)
         && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
 }
 
-fn imported_binding_origins_overlap(
+fn imported_binding_origins_match_exactly(
     checker: &Checker<'_>,
     first: shuck_semantic::BindingId,
     second: shuck_semantic::BindingId,
@@ -196,9 +196,10 @@ fn imported_binding_origins_overlap(
     let second_origins = checker.semantic().import_origins_for_binding(second);
 
     !first_origins.is_empty()
+        && first_origins.len() == second_origins.len()
         && first_origins
             .iter()
-            .any(|origin| second_origins.contains(origin))
+            .all(|origin| second_origins.contains(origin))
 }
 
 fn has_same_scope_call_site_between(
@@ -599,6 +600,53 @@ runner
                 second_helper.clone(),
                 test_functions.clone(),
                 warnings.clone(),
+            ]),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+    }
+
+    #[test]
+    fn nested_helper_library_collisions_with_partial_origin_overlap_still_report() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("libexec/bats-exec-file");
+        let first_helper = temp.path().join("libexec/first.bash");
+        let second_helper = temp.path().join("libexec/second.bash");
+        let shared = temp.path().join("libexec/shared.bash");
+        let source = "\
+#!/usr/bin/env bash
+runner() {
+  # shellcheck source=./first.bash
+  source ./first.bash
+  # shellcheck source=./second.bash
+  source ./second.bash
+}
+runner
+";
+
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::write(&main, source).unwrap();
+        fs::write(
+            &first_helper,
+            "#!/usr/bin/env bash\nsource ./shared.bash\nbats_setup_tracing() { printf '%s\\n' first; }\n",
+        )
+        .unwrap();
+        fs::write(
+            &second_helper,
+            "#!/usr/bin/env bash\nsource ./shared.bash\nbats_setup_tracing() { printf '%s\\n' second; }\n",
+        )
+        .unwrap();
+        fs::write(&shared, "bats_setup_tracing() { printf '%s\\n' shared; }\n").unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction).with_analyzed_paths([
+                main.clone(),
+                first_helper.clone(),
+                second_helper.clone(),
+                shared.clone(),
             ]),
         );
 

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -88,6 +88,14 @@ fn should_suppress_overwrite(
                     overwritten,
                     first.span.end.offset,
                     second.span.start.offset,
+                ))
+            || (file_context.has_tag(FileContextTag::DirectiveHandling)
+                && file_context.has_tag(FileContextTag::ProjectClosure)
+                && is_nested_project_closure_import_reimport(
+                    checker,
+                    overwritten,
+                    first.span.end.offset,
+                    second.span.start.offset,
                 )))
 }
 
@@ -159,6 +167,22 @@ fn is_project_closure_imported_override(
 
     matches!(first.kind, BindingKind::Imported)
         && matches!(second.kind, BindingKind::FunctionDefinition)
+        && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
+}
+
+fn is_nested_project_closure_import_reimport(
+    checker: &Checker<'_>,
+    overwritten: &SemanticOverwrittenFunction,
+    start_offset: usize,
+    end_offset: usize,
+) -> bool {
+    let first = checker.semantic().binding(overwritten.first);
+    let second = checker.semantic().binding(overwritten.second);
+
+    first.scope == second.scope
+        && matches!(first.kind, BindingKind::Imported)
+        && matches!(second.kind, BindingKind::Imported)
+        && !matches!(checker.semantic().scope_kind(first.scope), ScopeKind::File)
         && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
 }
 
@@ -463,6 +487,48 @@ runner() {
             source,
             &LinterSettings::for_rule(Rule::OverwrittenFunction)
                 .with_analyzed_paths([main.clone(), helper.clone()]),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn nested_helper_library_reimports_are_suppressed() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("libexec/bats-exec-file");
+        let tracing = temp.path().join("lib/bats-core/tracing.bash");
+        let test_functions = temp.path().join("lib/bats-core/test_functions.bash");
+        let warnings = temp.path().join("lib/bats-core/warnings.bash");
+        let source = "\
+#!/usr/bin/env bash
+runner() {
+  # shellcheck source=lib/bats-core/tracing.bash
+  source ../lib/bats-core/tracing.bash
+  # shellcheck source=lib/bats-core/test_functions.bash
+  source ../lib/bats-core/test_functions.bash
+}
+";
+
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::create_dir_all(tracing.parent().unwrap()).unwrap();
+        fs::write(&main, source).unwrap();
+        fs::write(&tracing, "bats_setup_tracing() { :; }\n").unwrap();
+        fs::write(
+            &test_functions,
+            "#!/usr/bin/env bash\nsource ./warnings.bash\n",
+        )
+        .unwrap();
+        fs::write(&warnings, "#!/usr/bin/env bash\nsource ./tracing.bash\n").unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction).with_analyzed_paths([
+                main.clone(),
+                tracing.clone(),
+                test_functions.clone(),
+                warnings.clone(),
+            ]),
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -91,7 +91,7 @@ fn should_suppress_overwrite(
                 ))
             || (file_context.has_tag(FileContextTag::DirectiveHandling)
                 && file_context.has_tag(FileContextTag::ProjectClosure)
-                && is_nested_project_closure_import_reimport(
+                && is_nested_project_closure_import_reimport_from_same_origin(
                     checker,
                     overwritten,
                     first.span.end.offset,
@@ -170,7 +170,7 @@ fn is_project_closure_imported_override(
         && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
 }
 
-fn is_nested_project_closure_import_reimport(
+fn is_nested_project_closure_import_reimport_from_same_origin(
     checker: &Checker<'_>,
     overwritten: &SemanticOverwrittenFunction,
     start_offset: usize,
@@ -183,7 +183,22 @@ fn is_nested_project_closure_import_reimport(
         && matches!(first.kind, BindingKind::Imported)
         && matches!(second.kind, BindingKind::Imported)
         && !matches!(checker.semantic().scope_kind(first.scope), ScopeKind::File)
+        && imported_binding_origins_overlap(checker, overwritten.first, overwritten.second)
         && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
+}
+
+fn imported_binding_origins_overlap(
+    checker: &Checker<'_>,
+    first: shuck_semantic::BindingId,
+    second: shuck_semantic::BindingId,
+) -> bool {
+    let first_origins = checker.semantic().import_origins_for_binding(first);
+    let second_origins = checker.semantic().import_origins_for_binding(second);
+
+    !first_origins.is_empty()
+        && first_origins
+            .iter()
+            .any(|origin| second_origins.contains(origin))
 }
 
 fn has_same_scope_call_site_between(
@@ -472,6 +487,7 @@ runner() {
   prepare_context
   bats_setup_tracing() { printf '%s\\n' local; }
 }
+runner
 ";
 
         fs::create_dir_all(main.parent().unwrap()).unwrap();
@@ -496,17 +512,18 @@ runner() {
     fn nested_helper_library_reimports_are_suppressed() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("libexec/bats-exec-file");
-        let tracing = temp.path().join("lib/bats-core/tracing.bash");
-        let test_functions = temp.path().join("lib/bats-core/test_functions.bash");
-        let warnings = temp.path().join("lib/bats-core/warnings.bash");
+        let tracing = temp.path().join("libexec/tracing.bash");
+        let test_functions = temp.path().join("libexec/test_functions.bash");
+        let warnings = temp.path().join("libexec/warnings.bash");
         let source = "\
 #!/usr/bin/env bash
 runner() {
-  # shellcheck source=lib/bats-core/tracing.bash
-  source ../lib/bats-core/tracing.bash
-  # shellcheck source=lib/bats-core/test_functions.bash
-  source ../lib/bats-core/test_functions.bash
+  # shellcheck source=./tracing.bash
+  source ./tracing.bash
+  # shellcheck source=./test_functions.bash
+  source ./test_functions.bash
 }
+runner
 ";
 
         fs::create_dir_all(main.parent().unwrap()).unwrap();
@@ -532,6 +549,61 @@ runner() {
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn nested_helper_library_collisions_from_different_origins_still_report() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("libexec/bats-exec-file");
+        let first_helper = temp.path().join("libexec/first.bash");
+        let second_helper = temp.path().join("libexec/second.bash");
+        let test_functions = temp.path().join("libexec/test_functions.bash");
+        let warnings = temp.path().join("libexec/warnings.bash");
+        let source = "\
+#!/usr/bin/env bash
+runner() {
+  # shellcheck source=./first.bash
+  source ./first.bash
+  # shellcheck source=./test_functions.bash
+  source ./test_functions.bash
+}
+runner
+";
+
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::create_dir_all(first_helper.parent().unwrap()).unwrap();
+        fs::write(&main, source).unwrap();
+        fs::write(
+            &first_helper,
+            "bats_setup_tracing() { printf '%s\\n' first; }\n",
+        )
+        .unwrap();
+        fs::write(
+            &test_functions,
+            "#!/usr/bin/env bash\nsource ./warnings.bash\n",
+        )
+        .unwrap();
+        fs::write(&warnings, "#!/usr/bin/env bash\nsource ./second.bash\n").unwrap();
+        fs::write(
+            &second_helper,
+            "bats_setup_tracing() { printf '%s\\n' second; }\n",
+        )
+        .unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction).with_analyzed_paths([
+                main.clone(),
+                first_helper.clone(),
+                second_helper.clone(),
+                test_functions.clone(),
+                warnings.clone(),
+            ]),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
     }
 
     #[test]

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -48,6 +48,7 @@ pub struct FunctionContract {
     pub name: Name,
     pub required_reads: Vec<Name>,
     pub provided_bindings: Vec<ProvidedBinding>,
+    pub origin_paths: Vec<PathBuf>,
 }
 
 impl FunctionContract {
@@ -56,6 +57,7 @@ impl FunctionContract {
             name,
             required_reads: Vec::new(),
             provided_bindings: Vec::new(),
+            origin_paths: Vec::new(),
         }
     }
 
@@ -80,6 +82,12 @@ impl FunctionContract {
         }
     }
 
+    pub fn add_origin_path(&mut self, path: PathBuf) {
+        if !self.origin_paths.contains(&path) {
+            self.origin_paths.push(path);
+        }
+    }
+
     pub(crate) fn merge_candidate_contracts(contracts: &[Self]) -> Option<Self> {
         let first = contracts.first()?;
         let mut merged = Self::new(first.name.clone());
@@ -97,6 +105,9 @@ impl FunctionContract {
                     .or_insert((0, true));
                 entry.0 += 1;
                 entry.1 &= binding.certainty == ContractCertainty::Definite;
+            }
+            for path in &contract.origin_paths {
+                merged.add_origin_path(path.clone());
             }
         }
 
@@ -151,6 +162,9 @@ impl FileContract {
                 }
                 for binding in &function.provided_bindings {
                     existing.add_provided_binding(binding.clone());
+                }
+                for path in &function.origin_paths {
+                    existing.add_origin_path(path.clone());
                 }
                 merged = true;
                 break;

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -39,6 +39,7 @@ use crate::builder::SemanticModelBuilder;
 use crate::cfg::{RecordedProgram, build_control_flow_graph};
 use crate::dataflow::{DataflowContext, DataflowResult, ExactVariableDataflow};
 use crate::runtime::RuntimePrelude;
+use crate::source_closure::ImportedBindingContractSite;
 use crate::zsh_options::ZshOptionAnalysis;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -295,6 +296,7 @@ pub struct SemanticModel {
     recorded_program: RecordedProgram,
     command_bindings: FxHashMap<SpanKey, Vec<BindingId>>,
     command_references: FxHashMap<SpanKey, Vec<ReferenceId>>,
+    import_origins_by_binding: FxHashMap<BindingId, Vec<PathBuf>>,
     heuristic_unused_assignments: Vec<BindingId>,
     zsh_option_analysis: Option<ZshOptionAnalysis>,
 }
@@ -367,6 +369,7 @@ impl SemanticModel {
             recorded_program: built.recorded_program,
             command_bindings: built.command_bindings,
             command_references: built.command_references,
+            import_origins_by_binding: FxHashMap::default(),
             heuristic_unused_assignments: built.heuristic_unused_assignments,
             zsh_option_analysis,
         }
@@ -560,6 +563,7 @@ impl SemanticModel {
         scope: ScopeId,
         span: Span,
         command_span: Option<Span>,
+        origin_paths: Vec<PathBuf>,
     ) -> BindingId {
         let mut attributes = BindingAttributes::empty();
         if provided.certainty == ContractCertainty::Possible {
@@ -600,6 +604,9 @@ impl SemanticModel {
                 .or_default()
                 .push(id);
         }
+        if !origin_paths.is_empty() {
+            self.import_origins_by_binding.insert(id, origin_paths);
+        }
         id
     }
 
@@ -622,6 +629,11 @@ impl SemanticModel {
 
         let entry_span = Span::from_positions(file.span.start, file.span.start);
         let mut entry_bindings = self.entry_bindings.clone();
+        let function_origin_paths = contract
+            .provided_functions
+            .iter()
+            .map(|function| (function.name.clone(), function.origin_paths.clone()))
+            .collect::<FxHashMap<_, _>>();
         let mut provided_bindings = contract.provided_bindings;
         for function in contract.provided_functions {
             if !provided_bindings.iter().any(|binding| {
@@ -635,7 +647,11 @@ impl SemanticModel {
             }
         }
         for binding in &provided_bindings {
-            let id = self.add_imported_binding(binding, ScopeId(0), entry_span, None);
+            let origin_paths = function_origin_paths
+                .get(&binding.name)
+                .cloned()
+                .unwrap_or_default();
+            let id = self.add_imported_binding(binding, ScopeId(0), entry_span, None, origin_paths);
             entry_bindings.push(id);
         }
 
@@ -653,7 +669,7 @@ impl SemanticModel {
     pub(crate) fn apply_source_contracts(
         &mut self,
         synthetic_reads: Vec<SyntheticRead>,
-        imported_bindings: Vec<(ScopeId, Span, ProvidedBinding)>,
+        imported_bindings: Vec<ImportedBindingContractSite>,
         source_ref_resolutions: Vec<SourceRefResolution>,
         source_ref_explicitness: Vec<bool>,
     ) {
@@ -690,8 +706,14 @@ impl SemanticModel {
             }
         }
 
-        for (scope, span, binding) in imported_bindings {
-            self.add_imported_binding(&binding, scope, span, Some(span));
+        for site in imported_bindings {
+            self.add_imported_binding(
+                &site.binding,
+                site.scope,
+                site.span,
+                Some(site.span),
+                site.origin_paths,
+            );
         }
         self.resolve_unresolved_references();
         self.call_graph = build_call_graph(
@@ -752,6 +774,13 @@ impl SemanticModel {
 
     pub fn source_refs(&self) -> &[SourceRef] {
         &self.source_refs
+    }
+
+    pub fn import_origins_for_binding(&self, id: BindingId) -> &[PathBuf] {
+        self.import_origins_by_binding
+            .get(&id)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 
     pub(crate) fn recorded_program(&self) -> &RecordedProgram {

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Debug, Clone)]
 struct SourceClosureContracts {
     synthetic_reads: Vec<SyntheticRead>,
-    imported_bindings: Vec<(ScopeId, Span, ProvidedBinding)>,
+    imported_bindings: Vec<ImportedBindingContractSite>,
     imported_functions: Vec<ImportedFunctionContractSite>,
     source_ref_resolutions: Vec<SourceRefResolution>,
     source_ref_explicitness: Vec<bool>,
@@ -28,7 +28,7 @@ struct SourceClosureContracts {
 
 type SourceClosureContractResult = (
     Vec<SyntheticRead>,
-    Vec<(ScopeId, Span, ProvidedBinding)>,
+    Vec<ImportedBindingContractSite>,
     Vec<SourceRefResolution>,
     Vec<bool>,
 );
@@ -37,6 +37,14 @@ type SourceClosureContractResult = (
 struct SourceClosureLookupContext<'a> {
     source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
     analyzed_paths: Option<&'a FxHashSet<PathBuf>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ImportedBindingContractSite {
+    pub(crate) scope: ScopeId,
+    pub(crate) span: Span,
+    pub(crate) binding: ProvidedBinding,
+    pub(crate) origin_paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -109,7 +117,12 @@ fn collect_source_closure_contracts_with_cache(
         source_ref_resolutions.push(classify_source_ref_resolution(&source_ref.kind, resolved));
         source_ref_explicitness.push(explicit);
         for provided in contract.provided_bindings.iter().cloned() {
-            imported_bindings.push((scope, source_ref.span, provided));
+            imported_bindings.push(ImportedBindingContractSite {
+                scope,
+                span: source_ref.span,
+                origin_paths: binding_origin_paths(&contract, &provided),
+                binding: provided,
+            });
         }
         imported_functions.extend(imported_function_sites_for_contract(
             scope,
@@ -141,11 +154,12 @@ fn collect_source_closure_contracts_with_cache(
                 });
             }
             for binding in &function_site.contract.provided_bindings {
-                imported_bindings.push((
-                    call.scope,
-                    call.span,
-                    binding_for_imported_function_call(binding, function_site.certainty),
-                ));
+                imported_bindings.push(ImportedBindingContractSite {
+                    scope: call.scope,
+                    span: call.span,
+                    binding: binding_for_imported_function_call(binding, function_site.certainty),
+                    origin_paths: Vec::new(),
+                });
             }
         }
 
@@ -236,20 +250,42 @@ fn dedup_synthetic_reads(reads: Vec<SyntheticRead>) -> Vec<SyntheticRead> {
 }
 
 fn dedup_imported_bindings(
-    bindings: Vec<(ScopeId, Span, ProvidedBinding)>,
-) -> Vec<(ScopeId, Span, ProvidedBinding)> {
+    bindings: Vec<ImportedBindingContractSite>,
+) -> Vec<ImportedBindingContractSite> {
     let mut merged = FxHashMap::default();
-    for (scope, span, binding) in bindings {
+    for site in bindings {
+        let ImportedBindingContractSite {
+            scope,
+            span,
+            binding,
+            origin_paths,
+        } = site;
         let key = (scope, span.start.offset, binding.name.clone(), binding.kind);
-        let entry = merged.entry(key).or_insert((span, binding.certainty));
+        let entry = merged
+            .entry(key)
+            .or_insert((span, binding.certainty, Vec::<PathBuf>::new()));
         entry.1 = entry.1.merge_same_site(binding.certainty);
+        merge_origin_paths(&mut entry.2, &origin_paths);
     }
 
     let mut deduped = Vec::new();
-    for ((scope, _, name, kind), (span, certainty)) in merged {
-        deduped.push((scope, span, ProvidedBinding::new(name, kind, certainty)));
+    for ((scope, _, name, kind), (span, certainty, origin_paths)) in merged {
+        deduped.push(ImportedBindingContractSite {
+            scope,
+            span,
+            binding: ProvidedBinding::new(name, kind, certainty),
+            origin_paths,
+        });
     }
     deduped
+}
+
+fn merge_origin_paths(dest: &mut Vec<PathBuf>, origins: &[PathBuf]) {
+    for origin in origins {
+        if !dest.contains(origin) {
+            dest.push(origin.clone());
+        }
+    }
 }
 
 fn imported_function_sites_for_contract(
@@ -277,6 +313,19 @@ fn function_contract_certainty(contract: &FileContract, name: &Name) -> Contract
         .find(|binding| binding.kind == ProvidedBindingKind::Function && binding.name == *name)
         .map(|binding| binding.certainty)
         .unwrap_or(ContractCertainty::Definite)
+}
+
+fn binding_origin_paths(contract: &FileContract, binding: &ProvidedBinding) -> Vec<PathBuf> {
+    if binding.kind != ProvidedBindingKind::Function {
+        return Vec::new();
+    }
+
+    contract
+        .provided_functions
+        .iter()
+        .find(|function| function.name == binding.name)
+        .map(|function| function.origin_paths.clone())
+        .unwrap_or_default()
 }
 
 fn binding_for_imported_function_call(
@@ -1121,6 +1170,7 @@ fn summarize_helper_uncached(
         contract.add_provided_binding(binding.clone());
     }
     for function in build_scope_function_contracts(
+        path,
         &semantic,
         &analysis,
         ScopeId(0),
@@ -1159,6 +1209,7 @@ fn summarize_scope_body_contract(
 }
 
 fn build_scope_function_contracts(
+    origin_path: &Path,
     semantic: &SemanticModel,
     analysis: &crate::SemanticAnalysis<'_>,
     scope: ScopeId,
@@ -1193,6 +1244,7 @@ fn build_scope_function_contracts(
             .clone();
         for name in names {
             let mut function_contract = FunctionContract::new(name.clone());
+            function_contract.add_origin_path(origin_path.to_path_buf());
             for read in &body_contract.required_reads {
                 function_contract.add_required_read(read.clone());
             }

--- a/docs/bugs/C063.md
+++ b/docs/bugs/C063.md
@@ -11,7 +11,7 @@
 
 ## Delta snapshot
 
-Re-checked on 2026-04-15 with:
+Re-checked on 2026-04-16 with:
 
 ```bash
 cargo test -p shuck-linter overwritten_function -- --nocapture
@@ -27,16 +27,9 @@ nix --extra-experimental-features 'nix-command flakes' develop --command \
 ```
 
 The compatibility target covered 6,449 fixtures and skipped 710
-unsupported-shell fixtures.
-
-| Bucket | Locations | Scripts |
-|--------|-----------|---------|
-| ShellCheck-only | 0 | 0 |
-| Shuck-only | 1 reviewed divergence | 1 |
-| Location-only | 0 | 0 |
-
-The remaining non-`C063` blockers are still the existing corpus-noise fixtures
-and the separate zsh parse harness timeouts.
+unsupported-shell fixtures. The focused `large_corpus_conforms_with_shellcheck`
+run finished with 0 blocking `C063` diffs; its non-blocking summary was
+`reviewed divergence=8` and `corpus noise=3`.
 
 ## What changed
 
@@ -51,6 +44,9 @@ and the separate zsh parse harness timeouts.
   are now suppressed in helper-library and test-harness contexts when local
   code immediately replaces them without same-scope evidence that the imported
   version is the one meant to be dead.
+- Nested helper-library setup functions also suppress directive-tracked
+  project-closure reimports when one sourced helper immediately pulls the same
+  helper stack back into the same non-file scope.
 - File-context classification now treats escaped source commands such as
   `\. ./helpers.sh` as project-closure markers so those test-harness
   suppressions match real fixtures.
@@ -61,15 +57,13 @@ and the separate zsh parse harness timeouts.
   factories and test doubles from true "overwritten before call" bugs.
 - [x] Re-run the large-corpus comparison and refresh this document.
 
-## Allowlisted divergences
+## Reviewed divergences
 
-- `ohmyzsh__ohmyzsh__oh-my-zsh.sh` line 3: `omz_f` is conditionally replaced
-  with a no-op only on the non-terminal branch, so the original formatter still
-  survives to the later calls on the terminal-output path.
+Reviewed non-blocking corpus differences for `C063` are tracked in
+`crates/shuck/tests/testdata/corpus-metadata/c063.yaml`.
 
 ## Notes
 
-The full compatibility comparison is clean for `C063` after the new imported
-helper-override suppression, aside from the reviewed Oh My Zsh shell-collapse
-divergence above. The remaining large-corpus blockers are still outside this
-rule.
+The focused compatibility comparison is clean for `C063` after the nested
+helper-library reimport suppression. Remaining large-corpus blockers are still
+outside this rule.

--- a/docs/bugs/C063.md
+++ b/docs/bugs/C063.md
@@ -45,8 +45,8 @@ run finished with 0 blocking `C063` diffs; its non-blocking summary was
   code immediately replaces them without same-scope evidence that the imported
   version is the one meant to be dead.
 - Nested helper-library setup functions also suppress directive-tracked
-  project-closure reimports when one sourced helper immediately pulls the same
-  helper stack back into the same non-file scope.
+  project-closure reimports only when the later import resolves back to the
+  same helper origin in the same non-file scope.
 - File-context classification now treats escaped source commands such as
   `\. ./helpers.sh` as project-closure markers so those test-harness
   suppressions match real fixtures.


### PR DESCRIPTION
## Summary
- suppress `C063` for directive-tracked project-closure helper reimports within the same non-file scope
- add a regression test that mirrors the nested Bats helper-library source chain
- refresh the `C063` closeout note with the April 16, 2026 verification results

## Root cause
`bats-exec-file` sources `tracing.bash` and then sources `test_functions.bash`, which pulls `warnings.bash` and reimports `tracing.bash` into the same helper scope. Shuck treated that imported-on-imported reimport as an overwritten function before call, even though it is an intentional helper stack setup pattern rather than a dead definition.

## Impact
This removes the remaining blocking `C063` implementation diff in the focused large-corpus compatibility run without weakening the existing cases that should still report real imported helper collisions.

## Validation
- `cargo test -p shuck-linter overwritten_function -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=C063 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`

## Notes
I did not rerun the full `make test-large-corpus` because that target still includes the separate known zsh harness timeout outside `C063`.