### PR TITLE
Fix X071 ownership when X018 is enabled

### DIFF
--- a/crates/shuck-linter/src/rules/portability/array_keys_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/array_keys_in_sh.rs
@@ -17,11 +17,6 @@ pub fn array_keys_in_sh(checker: &mut Checker) {
         return;
     }
 
-    // X018 owns the broader indirect-expansion wording when both rules are enabled.
-    if checker.is_rule_enabled(Rule::IndirectExpansion) {
-        return;
-    }
-
     let spans = checker
         .facts()
         .indirect_expansion_fragments()
@@ -118,15 +113,26 @@ printf '%s\\n' \"${!arr[*]}\"
     }
 
     #[test]
-    fn defers_to_x018_when_both_indirect_expansion_rules_are_enabled() {
-        let source = "printf '%s\\n' \"${!arr[*]}\"\n";
+    fn owns_array_key_expansions_when_both_indirect_expansion_rules_are_enabled() {
+        let source = "printf '%s\\n' \"${!arr[*]}\" \"${!name}\"\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rules([Rule::ArrayKeysInSh, Rule::IndirectExpansion])
                 .with_shell(ShellDialect::Sh),
         );
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule, Rule::IndirectExpansion);
+        assert_eq!(diagnostics.len(), 2);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.slice(source) == "${!arr[*]}"
+                    && diagnostic.rule == Rule::ArrayKeysInSh)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.slice(source) == "${!name}"
+                    && diagnostic.rule == Rule::IndirectExpansion)
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/portability/indirect_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/indirect_expansion.rs
@@ -17,10 +17,13 @@ pub fn indirect_expansion(checker: &mut Checker) {
         return;
     }
 
+    let specific_array_keys_rule_enabled = checker.is_rule_enabled(Rule::ArrayKeysInSh);
+
     let spans = checker
         .facts()
         .indirect_expansion_fragments()
         .iter()
+        .filter(|fragment| !(specific_array_keys_rule_enabled && fragment.array_keys()))
         .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
 
@@ -63,5 +66,32 @@ printf '%s\n' \"${!name}\" \"${!name:-fallback}\" \"${!build_option_@}\" \"${!ar
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_array_key_expansions_to_x071_when_enabled() {
+        let source = "\
+#!/bin/sh
+printf '%s\n' \"${!name}\" \"${!arr[*]}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rules([Rule::IndirectExpansion, Rule::ArrayKeysInSh])
+                .with_shell(ShellDialect::Sh),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.slice(source) == "${!name}"
+                    && diagnostic.rule == Rule::IndirectExpansion)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.slice(source) == "${!arr[*]}"
+                    && diagnostic.rule == Rule::ArrayKeysInSh)
+        );
     }
 }


### PR DESCRIPTION
## What changed

This updates the X071/X018 interaction so array-key expansions like `${!arr[*]}` stay owned by `X071` even when `X018` is enabled in the same run.

## Why it changed

The large-corpus mapped run enables both rules. `X071` was returning early whenever `X018` was enabled, so full-corpus runs dropped the specific X071 finding even though isolated X071 runs passed.

## User impact

Full large-corpus compatibility runs now keep the specific `X071` portability diagnostic for array-key expansions while still letting `X018` report the remaining indirect expansions.

## Root cause

Rule ownership was implemented as a blanket early return in `array_keys_in_sh`, which worked in isolated rule runs but suppressed X071 entirely once the broader indirect-expansion rule was also active.

## Validation

- `cargo test -p shuck-linter array_keys_in_sh`
- `cargo test -p shuck-linter indirect_expansion`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=X071 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`