### PR TITLE
Fix S076 reviewed divergence path matching

### DIFF
--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1284,16 +1284,19 @@ fn reviewed_divergence_reason<'a>(
     record: &CompatibilityRecord,
     cache_rel_path: &str,
 ) -> Option<&'a str> {
+    let cache_rel_path_variants = cache_rel_path_match_variants(cache_rel_path);
     metadata.reviewed_divergences.iter().find_map(|entry| {
         (entry.side == record.side
-            && entry
-                .path_suffix
-                .as_ref()
-                .is_none_or(|suffix| cache_rel_path.ends_with(suffix))
-            && entry
-                .path_contains
-                .as_ref()
-                .is_none_or(|needle| cache_rel_path.contains(needle))
+            && entry.path_suffix.as_ref().is_none_or(|suffix| {
+                cache_rel_path_variants
+                    .iter()
+                    .any(|candidate| candidate.ends_with(suffix))
+            })
+            && entry.path_contains.as_ref().is_none_or(|needle| {
+                cache_rel_path_variants
+                    .iter()
+                    .any(|candidate| candidate.contains(needle))
+            })
             && entry.line.is_none_or(|line| line == record.range.line)
             && entry
                 .end_line
@@ -1312,6 +1315,14 @@ fn reviewed_divergence_reason<'a>(
             }))
         .then_some(entry.reason.as_str())
     })
+}
+
+fn cache_rel_path_match_variants(cache_rel_path: &str) -> [String; 3] {
+    [
+        cache_rel_path.to_owned(),
+        format!("scripts/{cache_rel_path}"),
+        format!("corpus/scripts/{cache_rel_path}"),
+    ]
 }
 
 fn comparison_target_note_reason<'a>(
@@ -3368,6 +3379,53 @@ mod tests {
             CompatibilityClassification::ReviewedDivergence
         );
         assert_eq!(reason.as_deref(), Some("exact-match reviewed divergence"));
+    }
+
+    #[test]
+    fn reviewed_divergence_classification_matches_scripts_prefixed_path_suffix_record() {
+        let metadata = HashMap::from([(
+            "C999".to_string(),
+            RuleCorpusMetadataDocument {
+                reviewed_divergences: vec![ReviewedDivergenceRecord {
+                    side: CompatibilitySide::ShuckOnly,
+                    path_suffix: Some("scripts/repo__script.sh".into()),
+                    path_contains: None,
+                    line: Some(19),
+                    end_line: Some(19),
+                    column: Some(1),
+                    end_column: Some(14),
+                    labels: Vec::new(),
+                    reason: "scripts-prefixed reviewed divergence".into(),
+                }],
+                comparison_target_notes: Vec::new(),
+            },
+        )]);
+        let record = CompatibilityRecord {
+            side: CompatibilitySide::ShuckOnly,
+            rule_code: Some("C999".into()),
+            rule_codes: Vec::new(),
+            shellcheck_code: "SC2034".into(),
+            range: DiagnosticRange {
+                line: 19,
+                end_line: 19,
+                column: 1,
+                end_column: 14,
+            },
+            message: "warning reviewed divergence".into(),
+            labels: Vec::new(),
+        };
+
+        let (classification, reason) =
+            classify_compatibility_record(&record, "repo__script.sh", &metadata);
+
+        assert_eq!(
+            classification,
+            CompatibilityClassification::ReviewedDivergence
+        );
+        assert_eq!(
+            reason.as_deref(),
+            Some("scripts-prefixed reviewed divergence")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- teach reviewed divergence matching to accept bare cache-relative paths alongside legacy `scripts/` and `corpus/scripts/` prefixes
- add a regression test covering the legacy `scripts/...` metadata form

## Why
`S076` already had reviewed divergence metadata for the remaining large-corpus mismatches, but the harness now compares against cache-relative paths without the `scripts/` prefix. That left the existing metadata unmatched and turned reviewed sites back into blocking implementation diffs.

## Impact
The targeted `S076` large-corpus compatibility run now classifies those known cases as reviewed divergences instead of failures, without changing the lint rule itself.

## Validation
- `cargo fmt --all --check`
- `cargo test -p shuck --test large_corpus reviewed_divergence_classification_matches_scripts_prefixed_path_suffix_record`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=S076 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`