### PR TITLE
Fix X016 declare command spans

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1632,16 +1632,10 @@ f
 
     #[test]
     fn multiline_declare_command_is_clipped_to_opening_line() {
-        let source = "\
-#!/bin/sh
-declare -a values=(
-  one
-  two
-)
-";
+        let source = "#!/bin/sh\ndeclare -a values=(\n  one\n  two\n)\n";
         let diagnostics = lint(source, &LinterSettings::for_rule(Rule::DeclareCommand));
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "declare -a values=(");
+        assert_eq!(diagnostics[0].span.slice(source), "declare -a values");
         assert_eq!(diagnostics[0].span.end.line, 2);
     }
 

--- a/crates/shuck-linter/src/rules/portability/declare_command.rs
+++ b/crates/shuck-linter/src/rules/portability/declare_command.rs
@@ -50,10 +50,10 @@ fn command_anchor_end(fact: &crate::CommandFact<'_>, source: &str) -> shuck_ast:
         |redirect| redirect.span.end,
     );
 
-    if let Some(terminator_span) = fact.stmt().terminator_span {
-        if terminator_span.start.offset < end.offset {
-            end = terminator_span.start;
-        }
+    if let Some(terminator_span) = fact.stmt().terminator_span
+        && terminator_span.start.offset < end.offset
+    {
+        end = terminator_span.start;
     }
 
     end

--- a/crates/shuck-linter/src/rules/portability/declare_command.rs
+++ b/crates/shuck-linter/src/rules/portability/declare_command.rs
@@ -32,11 +32,7 @@ pub fn declare_command(checker: &mut Checker) {
 
 fn declare_anchor_span(fact: &crate::CommandFact<'_>, source: &str) -> Span {
     if let Some(declaration) = fact.declaration() {
-        let end = if fact.redirects().is_empty() {
-            declaration.head_span.end
-        } else {
-            command_anchor_end(fact, source)
-        };
+        let end = declaration_anchor_end(fact, declaration.head_span.end, source);
 
         return Span::from_positions(fact.span().start, end);
     }
@@ -44,12 +40,29 @@ fn declare_anchor_span(fact: &crate::CommandFact<'_>, source: &str) -> Span {
     Span::from_positions(fact.span().start, command_anchor_end(fact, source))
 }
 
-fn command_anchor_end(fact: &crate::CommandFact<'_>, source: &str) -> shuck_ast::Position {
-    let mut end = fact.redirects().last().map_or_else(
-        || fact.span_in_source(source).end,
-        |redirect| redirect.span.end,
-    );
+fn declaration_anchor_end(
+    fact: &crate::CommandFact<'_>,
+    mut end: shuck_ast::Position,
+    source: &str,
+) -> shuck_ast::Position {
+    for redirect in fact.redirects() {
+        if redirect.span.end.offset > end.offset {
+            end = redirect.span.end;
+        }
+    }
 
+    clip_terminator(fact, end, source)
+}
+
+fn command_anchor_end(fact: &crate::CommandFact<'_>, source: &str) -> shuck_ast::Position {
+    clip_terminator(fact, fact.span_in_source(source).end, source)
+}
+
+fn clip_terminator(
+    fact: &crate::CommandFact<'_>,
+    mut end: shuck_ast::Position,
+    _source: &str,
+) -> shuck_ast::Position {
     if let Some(terminator_span) = fact.stmt().terminator_span
         && terminator_span.start.offset < end.offset
     {
@@ -95,5 +108,14 @@ mod tests {
             diagnostics[0].span.slice(source),
             "command declare wrapped=value"
         );
+    }
+
+    #[test]
+    fn keeps_declaration_operands_after_interleaved_redirects() {
+        let source = "#!/bin/sh\ndeclare >/tmp/out foo=bar\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DeclareCommand));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "declare >/tmp/out foo");
     }
 }

--- a/crates/shuck-linter/src/rules/portability/declare_command.rs
+++ b/crates/shuck-linter/src/rules/portability/declare_command.rs
@@ -24,22 +24,76 @@ pub fn declare_command(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("declare"))
-        .map(|fact| {
-            fact.declaration().map_or(fact.body_span(), |declaration| {
-                declare_anchor_span(declaration.span, checker.source())
-            })
-        })
+        .map(|fact| declare_anchor_span(fact, checker.source()))
         .collect::<Vec<_>>();
 
     checker.report_all(spans, || DeclareCommand);
 }
 
-fn declare_anchor_span(span: Span, source: &str) -> Span {
-    let text = span.slice(source);
-    let Some(line_end) = text.find('\n') else {
-        return span;
-    };
+fn declare_anchor_span(fact: &crate::CommandFact<'_>, source: &str) -> Span {
+    if let Some(declaration) = fact.declaration() {
+        let end = if fact.redirects().is_empty() {
+            declaration.head_span.end
+        } else {
+            command_anchor_end(fact, source)
+        };
 
-    let first_line = text[..line_end].trim_end_matches('\r');
-    Span::from_positions(span.start, span.start.advanced_by(first_line))
+        return Span::from_positions(fact.span().start, end);
+    }
+
+    Span::from_positions(fact.span().start, command_anchor_end(fact, source))
+}
+
+fn command_anchor_end(fact: &crate::CommandFact<'_>, source: &str) -> shuck_ast::Position {
+    let mut end = fact.redirects().last().map_or_else(
+        || fact.span_in_source(source).end,
+        |redirect| redirect.span.end,
+    );
+
+    if let Some(terminator_span) = fact.stmt().terminator_span {
+        if terminator_span.start.offset < end.offset {
+            end = terminator_span.start;
+        }
+    }
+
+    end
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn excludes_assignment_values_for_direct_declarations() {
+        let source = "#!/bin/sh\nFOO=1 declare bar=baz\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DeclareCommand));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "FOO=1 declare bar");
+    }
+
+    #[test]
+    fn includes_attached_redirects_without_statement_terminators() {
+        let source = "#!/bin/sh\nif declare -f pre_step >/dev/null; then :; fi\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DeclareCommand));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "declare -f pre_step >/dev/null"
+        );
+    }
+
+    #[test]
+    fn anchors_wrapped_declare_on_the_full_command() {
+        let source = "#!/bin/sh\ncommand declare wrapped=value\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DeclareCommand));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "command declare wrapped=value"
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X016_X016.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X016_X016.sh.snap
@@ -8,7 +8,7 @@ X016 `declare` is not portable in `sh` scripts
   |
 
 X016 `declare` is not portable in `sh` scripts
- --> <source>:8:9
+ --> <source>:8:1
   |
 8 | command declare wrapped=value
   |


### PR DESCRIPTION
## Summary
- align X016 span anchoring with ShellCheck for direct `declare` clauses, attached redirects, and wrapped `declare` invocations
- add focused regression tests for assignment, redirect, and wrapper anchoring cases
- update the existing multiline expectation and the X016 portability snapshot to match the new spans

## Why
The rule was anchoring `declare` diagnostics too broadly or from the wrong start position in some forms, which produced location-only compatibility diffs in the large corpus.

## Impact
This keeps X016's reporting behavior closer to the ShellCheck oracle without changing the rule's detection scope.

## Validation
- `cargo test -p shuck-linter declare_command -- --nocapture`
- `cargo test -p shuck-linter rule_declarecommand_path_new_x016_sh_expects -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=X016 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`
- `cargo test --workspace`
