### PR TITLE
Fix X018 file corpus comparison regressions

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -966,7 +966,7 @@ fn looks_like_plain_substring_target(name: &str) -> bool {
         return false;
     }
 
-    matches!(name, "@" | "*")
+    matches!(name, "@" | "*" | "?" | "-" | "$")
         || name.bytes().all(|byte| byte.is_ascii_digit())
         || is_shell_name(name)
 }

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -947,13 +947,9 @@ fn is_plain_substring_expansion_text(text: &str) -> bool {
         return false;
     };
     let name = &inner[..colon_index];
-    if name.is_empty() {
+    if !looks_like_plain_substring_target(name) {
         return false;
     }
-    if name.contains('[') || name.contains(']') {
-        return false;
-    }
-
     let suffix = &inner[colon_index + 1..];
     if suffix.is_empty() {
         return false;
@@ -963,6 +959,16 @@ fn is_plain_substring_expansion_text(text: &str) -> bool {
     }
 
     true
+}
+
+fn looks_like_plain_substring_target(name: &str) -> bool {
+    if name.is_empty() || name.contains('[') || name.contains(']') {
+        return false;
+    }
+
+    matches!(name, "@" | "*")
+        || name.bytes().all(|byte| byte.is_ascii_digit())
+        || is_shell_name(name)
 }
 
 fn plain_case_modification_span(span: Span, source: &str) -> Option<Span> {

--- a/crates/shuck-linter/src/rules/portability/array_keys_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/array_keys_in_sh.rs
@@ -113,7 +113,7 @@ printf '%s\\n' \"${!arr[*]}\"
     }
 
     #[test]
-    fn owns_array_key_expansions_when_both_indirect_expansion_rules_are_enabled() {
+    fn adds_specific_array_key_diagnostic_without_suppressing_x018() {
         let source = "printf '%s\\n' \"${!arr[*]}\" \"${!name}\"\n";
         let diagnostics = test_snippet(
             source,
@@ -121,12 +121,18 @@ printf '%s\\n' \"${!arr[*]}\"
                 .with_shell(ShellDialect::Sh),
         );
 
-        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics.len(), 3);
         assert!(
             diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.span.slice(source) == "${!arr[*]}"
                     && diagnostic.rule == Rule::ArrayKeysInSh)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.slice(source) == "${!arr[*]}"
+                    && diagnostic.rule == Rule::IndirectExpansion)
         );
         assert!(
             diagnostics

--- a/crates/shuck-linter/src/rules/portability/indirect_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/indirect_expansion.rs
@@ -17,13 +17,10 @@ pub fn indirect_expansion(checker: &mut Checker) {
         return;
     }
 
-    let specific_array_keys_rule_enabled = checker.is_rule_enabled(Rule::ArrayKeysInSh);
-
     let spans = checker
         .facts()
         .indirect_expansion_fragments()
         .iter()
-        .filter(|fragment| !(specific_array_keys_rule_enabled && fragment.array_keys()))
         .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
 
@@ -69,7 +66,7 @@ printf '%s\n' \"${!name}\" \"${!name:-fallback}\" \"${!build_option_@}\" \"${!ar
     }
 
     #[test]
-    fn leaves_array_key_expansions_to_x071_when_enabled() {
+    fn still_reports_broader_indirect_expansion_for_array_keys_when_x071_is_enabled() {
         let source = "\
 #!/bin/sh
 printf '%s\n' \"${!name}\" \"${!arr[*]}\"
@@ -80,11 +77,17 @@ printf '%s\n' \"${!name}\" \"${!arr[*]}\"
                 .with_shell(ShellDialect::Sh),
         );
 
-        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics.len(), 3);
         assert!(
             diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.span.slice(source) == "${!name}"
+                    && diagnostic.rule == Rule::IndirectExpansion)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.slice(source) == "${!arr[*]}"
                     && diagnostic.rule == Rule::IndirectExpansion)
         );
         assert!(

--- a/crates/shuck-linter/src/rules/portability/substring_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/substring_expansion.rs
@@ -36,7 +36,7 @@ mod tests {
     fn anchors_on_scalar_and_positional_substring_expansions() {
         let source = "\
 #!/bin/sh
-printf '%s\n' \"${1:1}\" \"${name:2}\" \"${name::2}\" \"${@:1}\" \"${*:1:2}\" \"${arr[@]:1}\" \"${arr[0]:1}\"\n\
+printf '%s\n' \"${1:1}\" \"${name:2}\" \"${name::2}\" \"${@:1}\" \"${*:1:2}\" \"${?:1}\" \"${-:1}\" \"${$:1}\" \"${arr[@]:1}\" \"${arr[0]:1}\"\n\
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubstringExpansion));
 
@@ -45,7 +45,16 @@ printf '%s\n' \"${1:1}\" \"${name:2}\" \"${name::2}\" \"${@:1}\" \"${*:1:2}\" \"
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["${1:1}", "${name:2}", "${name::2}", "${@:1}", "${*:1:2}"]
+            vec![
+                "${1:1}",
+                "${name:2}",
+                "${name::2}",
+                "${@:1}",
+                "${*:1:2}",
+                "${?:1}",
+                "${-:1}",
+                "${$:1}",
+            ]
         );
     }
 

--- a/crates/shuck-linter/src/rules/portability/substring_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/substring_expansion.rs
@@ -79,4 +79,15 @@ EOF
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_prefix_removal_operands_that_contain_colons() {
+        let source = "\
+#!/bin/sh
+printf '%s\n' \"${name#http://}\" \"${name%https://}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubstringExpansion));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }


### PR DESCRIPTION
## Summary

This fixes the file-scoped large corpus mismatch around `X018` and removes a related `X023` false positive.

## What changed

- keep `X018` diagnostics for indirect array-key expansions even when `X071` is enabled, so Shuck matches the pinned ShellCheck behavior that emits both `SC3053` and `SC3055` on `${!arr[@]}` and `${!arr[*]}`
- tighten the raw substring detector so prefix-removal forms like `${name#http://}` are no longer misclassified as `X023`
- add regression tests covering both behaviors

## Root cause

The file-level corpus fixture exposed two separate issues:

1. Shuck treated `X071` as owning array-key indirect expansions and suppressed the broader `X018` diagnostic, while the pinned ShellCheck oracle reports both portability warnings on the same span.
2. The fallback substring scanner treated any colon inside `${...}` as a substring marker, even when the expansion target was actually part of a prefix-removal pattern.

## Impact

Single-file large corpus comparisons now agree with ShellCheck for the `X018` fixture family, and Shuck no longer invents an unrelated `X023` diagnostic on URL-style prefix removals.

## Validation

- `cargo test -p shuck-linter indirect_expansion -- --nocapture`
- `cargo test -p shuck-linter array_keys_in_sh -- --nocapture`
- `cargo test -p shuck-linter substring_expansion -- --nocapture`
- single-file large corpus repro with `SHUCK_LARGE_CORPUS_RULES=X018`
- single-file large corpus repro with `SHUCK_LARGE_CORPUS_MAPPED_ONLY=1`
- `cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture` with `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_RULES=X018`
