### PR TITLE
Fix C006 guarded parameter operands

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -2149,13 +2149,39 @@ printf '%s %s %s %s\\n' \
   \"${missing_assign:=value}\" \
   \"${missing_replace:+alt}\" \
   \"${missing_error:?missing}\"
-printf '%s %s\\n' \"$missing_assign\" \"$plain_missing\"
+printf '%s %s %s %s %s\\n' \
+  \"${missing_default:-$fallback_name}\" \
+  \"${missing_assign:=${seed_name:-value}}\" \
+  \"${missing_replace:+$replacement_name}\" \
+  \"${missing_error:?$hint_name}\" \
+  \"$missing_assign\"
+printf '%s\\n' \"$fallback_name\" \"$seed_name\" \"$replacement_name\" \"$hint_name\" \"$plain_missing\"
 ";
         let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
-        assert!(diagnostics[0].message.contains("plain_missing"));
+        assert_eq!(diagnostics.len(), 5);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| d.rule == Rule::UndefinedVariable)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("fallback_name"))
+        );
+        assert!(diagnostics.iter().any(|d| d.message.contains("seed_name")));
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("replacement_name"))
+        );
+        assert!(diagnostics.iter().any(|d| d.message.contains("hint_name")));
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("plain_missing"))
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -81,6 +81,7 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     deferred_functions: Vec<DeferredFunction>,
     scope_stack: Vec<ScopeId>,
     command_stack: Vec<Span>,
+    guarded_parameter_operand_depth: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -149,6 +150,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             deferred_functions: Vec::new(),
             scope_stack: vec![ScopeId(0)],
             command_stack: Vec::new(),
+            guarded_parameter_operand_depth: 0,
         };
         let file_commands = builder.visit_stmt_seq(&file.body, FlowState::default());
         builder.recorded_program.set_file_commands(file_commands);
@@ -1678,7 +1680,6 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 if let Some(operation) = &syntax.operation {
                     match operation {
                         ZshExpansionOperation::PatternOperation { operand, .. }
-                        | ZshExpansionOperation::Defaulting { operand, .. }
                         | ZshExpansionOperation::TrimOperation { operand, .. } => self
                             .visit_fragment_word(
                                 operation.operand_word_ast(),
@@ -1687,6 +1688,17 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                                 flow,
                                 nested_regions,
                             ),
+                        ZshExpansionOperation::Defaulting { operand, .. } => {
+                            self.guarded_parameter_operand_depth += 1;
+                            self.visit_fragment_word(
+                                operation.operand_word_ast(),
+                                Some(operand),
+                                kind,
+                                flow,
+                                nested_regions,
+                            );
+                            self.guarded_parameter_operand_depth -= 1;
+                        }
                         ZshExpansionOperation::ReplacementOperation {
                             pattern,
                             replacement,
@@ -1794,7 +1806,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             | ParameterOp::AssignDefault
             | ParameterOp::UseReplacement
             | ParameterOp::Error => {
+                self.guarded_parameter_operand_depth += 1;
                 self.visit_fragment_word(operand_word_ast, operand, kind, flow, nested_regions);
+                self.guarded_parameter_operand_depth -= 1;
             }
             ParameterOp::UpperFirst
             | ParameterOp::UpperAll
@@ -2278,6 +2292,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             scope,
             span,
         });
+        if self.guarded_parameter_operand_depth > 0 {
+            self.guarded_parameter_refs.insert(id);
+        }
         if let Some(command) = self.command_stack.last().copied() {
             self.command_references
                 .entry(SpanKey::new(command))

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3213,6 +3213,39 @@ printf '%s\\n' \
     }
 
     #[test]
+    fn guarded_parameter_operands_are_not_marked_uninitialized() {
+        let source = "\
+printf '%s\\n' \
+  \"${missing_default:-$fallback_name}\" \
+  \"${missing_assign:=${seed_name:-value}}\" \
+  \"${missing_replace:+$replacement_name}\" \
+  \"${missing_error:?$hint_name}\"
+";
+        let model = model(source);
+        let unresolved = unresolved_names(&model);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_present(
+            &[
+                "fallback_name",
+                "seed_name",
+                "replacement_name",
+                "hint_name",
+            ],
+            &unresolved,
+        );
+        assert_names_absent(
+            &[
+                "fallback_name",
+                "seed_name",
+                "replacement_name",
+                "hint_name",
+            ],
+            &uninitialized,
+        );
+    }
+
+    #[test]
     fn assign_default_parameter_expansion_initializes_later_reads() {
         let source = "\
 printf '%s\\n' \"${config_path:=/tmp/default}\"

--- a/crates/shuck/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c006.yaml
@@ -23,6 +23,24 @@ reviewed_divergences:
       - project-closure
     reason: "This oh-my-zsh helper relies on completion/runtime state provided by surrounding functions, so the remaining Shuck-side read is reviewed narrowly."
   - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "This oh-my-zsh entrypoint uses zsh-only loop bindings and `${name:h:t}`-style modifiers inside a shell-collapse/project-closure context, so we review these Shuck-only reads narrowly instead of widening C006 around non-native zsh syntax."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    labels:
+      - helper-library
+      - test-harness
+    reason: "This zunit test harness populates `lines` as framework-managed result state, and ShellCheck does not compare that helper-owned array as a live undefined-variable read here."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
+    labels:
+      - helper-library
+      - shell-collapse
+    reason: "This completion helper reaches into zsh's special `parameters` table inside a shell-collapse helper context, and ShellCheck stays quiet on that zsh-specific runtime surface in the corpus run."
+  - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
     labels:
       - helper-library
@@ -114,6 +132,27 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__ree"
     reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__manage__ree"
+    line: 84
+    end_line: 84
+    column: 32
+    end_column: 54
+    reason: "This RVM helper relies on `__rvm_db` to populate `db_configure_flags` through a by-name helper side effect, and we keep the remaining file-local read reviewed narrowly instead of modeling that contract."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__manage__rubinius"
+    line: 125
+    end_line: 125
+    column: 30
+    end_column: 51
+    reason: "This RVM helper relies on `__rvm_db` to populate `db_configure_flags` through a by-name helper side effect, and the remaining comparison difference is just the file-local anchor around that helper-managed read."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__manage__rubinius"
+    line: 124
+    end_line: 124
+    column: 30
+    end_column: 52
+    reason: "This RVM helper relies on `__rvm_db` to populate `db_configure_flags` through a by-name helper side effect, and the remaining comparison difference is just the file-local anchor around that helper-managed read."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__ruby"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."

--- a/docs/bugs/C006.md
+++ b/docs/bugs/C006.md
@@ -1,4 +1,4 @@
-# C006: Parser and semantic parity fixes are in; the remaining corpus tail is reviewed closure/collapse context
+# C006: Guarded parameter-operand parity is fixed; the remaining compatibility tail is reviewed closure/collapse context
 
 ## Rule
 
@@ -11,21 +11,28 @@
 
 ## Final status
 
-Refreshed on 2026-04-08 from:
+Refreshed on 2026-04-16 from:
 
 ```bash
-make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006 SHUCK_LARGE_CORPUS_KEEP_GOING=1
+SHUCK_TEST_LARGE_CORPUS=1 \
+  SHUCK_LARGE_CORPUS_RULES=C006 \
+  SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 \
+  SHUCK_LARGE_CORPUS_KEEP_GOING=1 \
+  nix --extra-experimental-features 'nix-command flakes' develop --command \
+  cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture
 ```
 
-The targeted large-corpus comparison now passes.
+The targeted `C006` compatibility comparison now passes.
 
 Final non-blocking summary from the passing run:
 
-- `reviewed divergence=72`
-- `corpus noise=11`
-- `unsupported-shell=709`
+- `reviewed divergence=68`
+- `corpus noise=1`
+- `unsupported-shell=710`
 
-There are no remaining blocking `C006` implementation diffs in the targeted corpus run.
+There are no remaining blocking `C006` implementation diffs in the targeted compatibility run.
+
+The broader `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006` command still fails one unrelated harness check: `large_corpus_zsh_fixtures_parse` times out on `ohmyzsh__ohmyzsh__plugins__emoji__emoji-char-definitions.zsh`. That timeout is outside the `C006` rule logic.
 
 ## What changed
 
@@ -35,6 +42,7 @@ The rule now handles the main parser/semantic parity gaps that were still produc
 
 - `${#}` and `${$}` are treated as real special-parameter reads instead of empty-name references.
 - indirect expansions preserve the real carrier reference instead of synthesizing names like `!tools[$target]` or `var//...`.
+- names that appear only inside the operand word of guarded parameter expansions such as `${var:-$fallback}`, `${var:+$alt}`, `${var:=$seed}`, and `${var:?$hint}` are now treated as guarded too, matching the pinned ShellCheck oracle.
 - zsh-style modifier forms that do not name a real variable stop producing empty-name `C006` reports.
 - expanding heredoc bodies are decoded line-locally, which restores live `$name` reads in large mixed-content generator bodies such as `makeself-header.sh`.
 
@@ -45,7 +53,7 @@ The residual corpus cases are now captured in `crates/shuck/tests/testdata/corpu
 The reviewed families are:
 
 - `void-packages` helper/build-style files in `shell-collapse` or `project-closure` contexts
-- `rvm` helper files where the remaining disagreement is still project-local state selection or location anchoring, without adding repo-specific ambient contracts
+- `rvm` helper files where the remaining disagreement is still project-local state selection, helper side effects, or location anchoring, without adding repo-specific ambient contracts
 - a small set of isolated helper and harness fixtures such as `ohmyzsh`, `nvm`, `acme.sh`, and `termux`
 
 ## Notes on the final tail
@@ -65,4 +73,4 @@ Those were useful during investigation, but the actionable closure for `C006` is
 
 1. the parser/semantic fixes above,
 2. reviewed divergence metadata for the residual closure/collapse tail,
-3. a passing targeted corpus run.
+3. a passing targeted compatibility run, with the remaining full-target failure tracked as an unrelated zsh parse-timeout harness issue.


### PR DESCRIPTION
## Summary

This fixes the remaining `C006` compatibility gap around guarded parameter-expansion operands and refreshes the reviewed corpus metadata for the residual file-local divergences.

## What changed

- mark names referenced only inside guarded parameter-expansion operands as guarded in the semantic model
- add semantic and linter regression coverage for guarded operand cases like `${var:-$fallback}` and `${var:=${seed:-value}}`
- narrow the remaining `C006` corpus tail with explicit reviewed-divergence entries for the surviving `ohmyzsh` and `rvm` fixtures
- update the `C006` bug note to reflect the current compatibility status

## Root cause

Shuck treated names appearing inside the operand word of guarded parameter expansions as ordinary live reads, which made `C006` report undefined-variable diagnostics that the pinned ShellCheck oracle does not emit for those guarded forms.

## Validation

- `cargo test -p shuck-semantic guarded_parameter`
- `cargo test -p shuck-linter undefined_variable_ignores_guarded_parameter_expansions`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_RULES=C006 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`

## Notes

- The targeted `large_corpus_conforms_with_shellcheck` coverage for `C006` now passes.
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006 SHUCK_LARGE_CORPUS_KEEP_GOING=1` still hits the pre-existing `large_corpus_zsh_fixtures_parse` timeout on `ohmyzsh__ohmyzsh__plugins__emoji__emoji-char-definitions.zsh`, which is unrelated to the `C006` rule changes.
