### PR TITLE
Fix C010 large-corpus comparison target

### DIFF
--- a/crates/shuck/tests/testdata/corpus-metadata/c010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c010.yaml
@@ -1,3 +1,7 @@
+comparison_target_notes:
+  - current_shellcheck_code: "SC2015"
+    reason: "The nix-pinned ShellCheck build used by the large-corpus harness currently folds both all-condition shortcut chains and broader `A && B || C` fallthrough chains into SC2015. C010 is intentionally limited to the all-condition shape, while the broader live-oracle fallthrough behavior is compared through C079, so SC2015 is not a stable standalone corpus target for C010 in this oracle build."
+
 reviewed_divergences:
   - side: shuck-only
     reason: "C010 intentionally treats mixed `&&` / `||` fallback chains as a control-flow hazard even when they appear in helper scripts, project-closure code, directives, or test harnesses. ShellCheck does not emit SC2015 for the remaining corpus cases, and the survivors are all the same policy shape, so one broad reviewed divergence captures that stricter Shuck behavior without masking a separate implementation bug."

--- a/docs/bugs/C010.md
+++ b/docs/bugs/C010.md
@@ -1,4 +1,4 @@
-# C010: Close the SC2015 parity gap
+# C010: Re-scope large-corpus comparison for the SC2015 split
 
 ## Rule
 
@@ -11,69 +11,37 @@
 
 ## Delta Snapshot
 
-Sampled on 2026-04-05 using `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C010 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10 SHUCK_LARGE_CORPUS_KEEP_GOING=1`.
+Re-sampled on 2026-04-16 using `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C010 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10 SHUCK_LARGE_CORPUS_KEEP_GOING=1`.
 
-| Bucket | Locations | Scripts |
-|--------|-----------|---------|
-| ShellCheck-only | 0 | 0 |
-| Shuck-only | 123 | 52 |
-| Location-only | 20 | 7 |
-| Parse-error / environment noise | 11 | 11 |
+That run covered 682 fixtures, skipped 79 unsupported-shell fixtures, and reported only 2 blocking implementation diffs:
 
-The sample covered 3,602 fixtures and skipped 223 unsupported-shell fixtures.
+- `rvm__rvm__scripts__pkg:52`
+- `void-linux__void-packages__srcpkgs__inadyn__files__inadyn__run:5`
 
-## Delta Analysis
+## Current Analysis
 
-### Broad `&&` / `||` chain warnings `[shuck-fix]`
+Both remaining `shellcheck-only` hits are ordinary fallthrough chains, not the all-condition shortcut shape that `C010` is written to flag.
 
-**Bucket:** Shuck-only  
-**Impact:** 123 locations / 52 scripts
+- `rvm__rvm__scripts__pkg:52` uses `__rvm_rm_rf ... && rvm_log ... || rvm_error ...`
+- `void-linux__void-packages__srcpkgs__inadyn__files__inadyn__run:5` uses a longer `test && mkdir && chown || rm` chain
 
-This is the dominant divergence in the sample. Shuck reports `C010` on obvious short-circuit chains such as `[ ... ] && ... || ...`, `[[ ... ]] && ... || ...`, and `test ... && ... || ...`, while ShellCheck stays silent in these scripts. The sample includes a mix of standalone scripts and large helper files, so the checker is currently broader than the SC2015 parity target.
+Those patterns already belong to `C079` (`ShortCircuitFallthrough`). The pinned ShellCheck build used by the large-corpus harness currently emits both the narrow `C010` family and the broader `C079` family as `SC2015`, so a selected `C010` corpus run cannot isolate the intended all-condition subset.
 
-There are also 15 ShellCheck-only operator-token anchors in 10 scripts, but every one of them is mixed into a script that already has shuck-only hits. I treated those as part of the span-difference story instead of a standalone under-reporting bucket.
+This means the remaining failures are not evidence that `C010` itself should expand. Broadening `C010` here would collapse the authored split between:
 
-**Samples:**
-- `SlackBuildsOrg__slackbuilds__development__metakit__metakit.SlackBuild:106` - `A && B || C` chain with no ShellCheck warning
-- `SlackBuildsOrg__slackbuilds__network__netqmail__tests__makechroot:20` - top-level branch chain
-- `rvm__rvm__scripts__override_gem:16` - short-circuit chain used as branch control
-- `termux__termux-packages__scripts__build__termux_step_get_dependencies_python.sh:25` - long chain in a helper script
-- `juewuy__ShellCrash__scripts__libs__compare.sh:8` - compact `&&` / `||` fallback chain
+- `C010`: mixed `&&` / `||` chains where every branch is a condition-like check
+- `C079`: general fallthrough chains where later commands can fail and unexpectedly trigger the fallback
 
-### Span anchoring on chain operators `[location-only]`
+## Resolution
 
-**Bucket:** Location-only  
-**Impact:** 20 anchor mismatches across 7 scripts
-
-In the scripts where ShellCheck and shuck both agree that the chain is problematic, the reported spans differ. ShellCheck tends to point at the `&&` / `||` operator token, while shuck points at the larger surrounding command list or line range. That makes the diagnostic meaning correct but the location noisier than ShellCheck's.
-
-**Samples:**
-- `SlackBuildsOrg__slackbuilds__academic__ed-v6__ed-v6.SlackBuild:64` - ShellCheck anchors `&&` / `||`, shuck anchors the full chain
-- `SlackBuildsOrg__slackbuilds__system__mongodb__files__rc.mongodb:28` - ShellCheck points at the operator positions inside the branch chain
-- `alexanderepstein__Bash-Snippets__ytview__ytview:70` - ShellCheck and shuck agree on the warning, not the span
-- `moovweb__gvm__scripts__pkg:52` - ShellCheck anchors the inner operator token
-- `void-linux__void-packages__srcpkgs__inadyn__files__inadyn__run:5` - ShellCheck anchors the operator token rather than the whole stanza
-
-### Parse Errors And Shell Collapse `[environment]`
-
-**Bucket:** Environment noise  
-**Impact:** 11 fixtures / 11 scripts
-
-These fixtures are parser failures or shell-detection artifacts, so they are not actionable C010 parity work.
-
-**Samples:**
-- `GameServerManagers__LinuxGSM__lgsm__modules__alert_ifttt.sh` - shuck parse error
-- `GameServerManagers__LinuxGSM__lgsm__modules__alert_telegram.sh` - shuck parse error
-- `HariSekhon__DevOps-Bash-tools__git__git_diff_commit.sh` - shuck parse error
-- `google__oss-fuzz__infra__chronos__coverage_test_collection.py` - parse error
-- `oh-my-fish__oh-my-fish__tools__generate-authors.fish` - parse error
+Record a `comparison_target_notes` entry for `C010` so the large-corpus harness no longer treats the live `SC2015` bucket as a stable standalone comparison target for this rule. Keep the rule implementation unchanged and let `C079` own the broader live-oracle fallthrough parity in this ShellCheck build.
 
 ## Checklist
 
-- [ ] Tighten the `C010` trigger so the checker only reports the ShellCheck-equivalent short-circuit cases seen in the corpus sample.
-- [ ] Align the reported span with ShellCheck's operator-token anchoring for the scripts where both tools already agree on the diagnostic.
-- [ ] Re-run the 10% corpus sample and update this document.
+- [x] Confirm the remaining selected-run failures are broader fallthrough chains, not missed all-condition `C010` sites.
+- [x] Record the comparison-target note in `crates/shuck/tests/testdata/corpus-metadata/c010.yaml`.
+- [x] Re-run the 10% corpus sample and update this document.
 
 ## Notes
 
-No reviewed intentional divergences were identified in this sample, and I did not add any allowlist entries while writing this report.
+The existing broad `shuck-only` reviewed divergence in `c010.yaml` still documents the intentional stricter policy on helper-library and test-harness shortcut chains. This change only fixes the selected-rule comparison target so `C010` no longer gets judged against the broader live `SC2015` bucket that now also feeds `C079`.


### PR DESCRIPTION
## Summary
This updates the `C010` large-corpus metadata to treat the live `SC2015` bucket as an unstable comparison target for that rule and refreshes the bug write-up with the current sample results.

## Why
The nix-pinned ShellCheck build used by the large-corpus harness currently reports both narrow all-condition shortcut chains and broader fallthrough chains as `SC2015`. That made selected `C010` corpus runs pick up cases that actually belong to `C079`, which looked like a parity failure even though the authored rule split is still correct.

## Impact
`C010` selected-rule corpus runs now compare against the intended target shape again instead of being blocked by broader `C079` fallthrough sites.

## Root Cause
The live oracle bucket for `SC2015` is broader than the authored `C010` scope in this ShellCheck build.

## Validation
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C010 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10 SHUCK_LARGE_CORPUS_KEEP_GOING=1`