### PR TITLE
Fix C156 RubyGems runtime variable false positives

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -161,6 +161,8 @@ fn is_known_runtime_name(name: &str) -> bool {
             | "OSTYPE"
             | "HISTCONTROL"
             | "HISTSIZE"
+            | "GEM_HOME"
+            | "GEM_PATH"
     ) || name.starts_with("LC_")
 }
 
@@ -242,6 +244,10 @@ echo \"$FOOBAR\"
 #!/bin/sh
 path=1
 echo \"$PATH\"
+gem_home=1
+gem_path=1
+echo \"$GEM_HOME\"
+echo \"$GEM_PATH\"
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck/tests/testdata/corpus-metadata/c156.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c156.yaml
@@ -49,13 +49,6 @@ reviewed_divergences:
       - project-closure
       - shell-collapse
     reason: "The trailing-underscore variant is a project-specific helper naming convention, and shuck intentionally avoids teaching C156 every collapsed helper suffix pattern."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__gemset"
-    line: 146
-    end_line: 146
-    column: 38
-    end_column: 47
-    reason: "GEM_HOME is a standard runtime variable in this Ruby tooling flow, so treating it as a misspelling of a lowercase helper binding is too aggressive."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__alpine__build.sh"
     line: 27


### PR DESCRIPTION
## Summary
- exempt `GEM_HOME` and `GEM_PATH` from `C156` misspelling reports as known runtime names
- extend the `C156` runtime-name regression test to cover RubyGems environment variables
- remove the obsolete reviewed divergence entry for the RVM corpus fixture

## Why
`C156` was treating RubyGems environment variables as likely misspellings of lowercase helper bindings, which produced a Shuck-only false positive in the large corpus on RVM's `functions/gemset` helper. Those names are standard runtime variables in Ruby tooling flows, so they should be excluded from this heuristic.

## Impact
This keeps `C156` focused on real case-mismatch typos and eliminates the remaining implementation diff for this rule in the ShellCheck compatibility corpus.

## Validation
- `cargo test -p shuck-linter possible_variable_misspelling`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_TIMEOUT_SECS=300 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30 SHUCK_LARGE_CORPUS_RULES=C156 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`
- `cargo test --workspace`