### PR TITLE
Fix X023 false positives in single-quoted words

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -15468,6 +15468,7 @@ printf '%s\n' \"${arr[0]}\" \"${arr[@]}\" \"${arr[*]}\" \"${#arr[0]}\" \"${#arr[
 printf '%s\n' \"${name:2}\" \"${1:1}\" \"${name::2}\" \"${@:1}\" \"${*:1:2}\" \"${arr[@]:1}\" \"${arr[0]:1}\"
 printf '%s\n' \"${name^}\" \"${name^^pattern}\" \"${name,}\" \"${arr[0]^^}\" \"${arr[@],,}\" \"${!name^^}\" \"${name//x/y}\"
 printf '%s\n' \"${name/a/b}\" \"${name//a}\" \"${arr[0]//a/b}\" \"${arr[@]/a/b}\" \"${arr[*]//a}\" \"${!name//a/b}\"
+if [ \"$(dpkg-query -W -f '${db:Status-Status}\\n' package 2>/dev/null)\" != \"installed\" ]; then :; fi
 cat <<EOF
 Expected: '${expected_commit::7}'
 #define LAST_COMMIT_POSITION \"2311 ${GN_COMMIT:0:12}\"

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -215,9 +215,9 @@ impl<'a> SurfaceFragmentSink<'a> {
         if context.collect_open_double_quotes && context.assignment_target.is_none() {
             self.collect_open_double_quote_fragments(word);
         }
-        self.collect_raw_substring_expansions_in_span(word.span);
-        self.collect_raw_replacement_expansions_in_span(word.span);
-        self.collect_raw_case_modifications_in_span(word.span);
+        self.collect_raw_word_substring_expansions_in_span(word.span);
+        self.collect_raw_word_replacement_expansions_in_span(word.span);
+        self.collect_raw_word_case_modifications_in_span(word.span);
         self.collect_word_parts(&word.parts, context);
     }
 
@@ -595,9 +595,9 @@ impl<'a> SurfaceFragmentSink<'a> {
             return;
         }
 
-        self.collect_raw_substring_expansions_in_span(text.span());
-        self.collect_raw_case_modifications_in_span(text.span());
-        self.collect_raw_replacement_expansions_in_span(text.span());
+        self.collect_raw_word_substring_expansions_in_span(text.span());
+        self.collect_raw_word_case_modifications_in_span(text.span());
+        self.collect_raw_word_replacement_expansions_in_span(text.span());
         if let Some(word) = word {
             self.collect_word(word, context.without_open_double_quote_scan());
         } else {
@@ -606,16 +606,13 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    fn collect_raw_substring_expansions_in_span(&mut self, span: Span) {
+    fn collect_raw_word_substring_expansions_in_span(&mut self, span: Span) {
         let snippet = span.slice(self.source);
         let mut search_start = 0;
 
-        while let Some(relative_start) = snippet[search_start..].find("${") {
-            let start = search_start + relative_start;
-            let Some(relative_end) = snippet[start..].find('}') else {
-                break;
-            };
-            let end = start + relative_end + '}'.len_utf8();
+        while let Some((start, end)) =
+            next_word_parameter_expansion_candidate(snippet, search_start)
+        {
             let candidate = &snippet[start..end];
             if is_plain_substring_expansion_text(candidate) {
                 let span = Span::from_positions(
@@ -628,16 +625,30 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    fn collect_raw_case_modifications_in_span(&mut self, span: Span) {
+    fn collect_raw_substring_expansions_in_span(&mut self, span: Span) {
         let snippet = span.slice(self.source);
         let mut search_start = 0;
 
-        while let Some(relative_start) = snippet[search_start..].find("${") {
-            let start = search_start + relative_start;
-            let Some(relative_end) = snippet[start..].find('}') else {
-                break;
-            };
-            let end = start + relative_end + '}'.len_utf8();
+        while let Some((start, end)) = next_parameter_expansion_candidate(snippet, search_start) {
+            let candidate = &snippet[start..end];
+            if is_plain_substring_expansion_text(candidate) {
+                let span = Span::from_positions(
+                    span.start.advanced_by(&snippet[..start]),
+                    span.start.advanced_by(&snippet[..end]),
+                );
+                self.record_substring_expansion(span);
+            }
+            search_start = end;
+        }
+    }
+
+    fn collect_raw_word_case_modifications_in_span(&mut self, span: Span) {
+        let snippet = span.slice(self.source);
+        let mut search_start = 0;
+
+        while let Some((start, end)) =
+            next_word_parameter_expansion_candidate(snippet, search_start)
+        {
             let candidate = &snippet[start..end];
             if is_plain_case_modification_text(candidate) {
                 let span = Span::from_positions(
@@ -645,6 +656,42 @@ impl<'a> SurfaceFragmentSink<'a> {
                     span.start.advanced_by(&snippet[..end]),
                 );
                 self.record_case_modification(span);
+            }
+            search_start = end;
+        }
+    }
+
+    fn collect_raw_case_modifications_in_span(&mut self, span: Span) {
+        let snippet = span.slice(self.source);
+        let mut search_start = 0;
+
+        while let Some((start, end)) = next_parameter_expansion_candidate(snippet, search_start) {
+            let candidate = &snippet[start..end];
+            if is_plain_case_modification_text(candidate) {
+                let span = Span::from_positions(
+                    span.start.advanced_by(&snippet[..start]),
+                    span.start.advanced_by(&snippet[..end]),
+                );
+                self.record_case_modification(span);
+            }
+            search_start = end;
+        }
+    }
+
+    fn collect_raw_word_replacement_expansions_in_span(&mut self, span: Span) {
+        let snippet = span.slice(self.source);
+        let mut search_start = 0;
+
+        while let Some((start, end)) =
+            next_word_parameter_expansion_candidate(snippet, search_start)
+        {
+            let candidate = &snippet[start..end];
+            if is_plain_replacement_expansion_text(candidate) {
+                let span = Span::from_positions(
+                    span.start.advanced_by(&snippet[..start]),
+                    span.start.advanced_by(&snippet[..end]),
+                );
+                self.record_replacement_expansion(span);
             }
             search_start = end;
         }
@@ -1095,6 +1142,83 @@ fn next_parameter_expansion_candidate(text: &str, search_start: usize) -> Option
         match bytes[index] {
             b'\\' => {
                 index += 2;
+            }
+            b'$' if bytes[index + 1] == b'{' => {
+                let start = index;
+                index += 2;
+                let mut depth = 1;
+
+                while index < bytes.len() {
+                    match bytes[index] {
+                        b'\\' => {
+                            index += 2;
+                        }
+                        b'$' if index + 1 < bytes.len() && bytes[index + 1] == b'{' => {
+                            depth += 1;
+                            index += 2;
+                        }
+                        b'}' => {
+                            depth -= 1;
+                            index += 1;
+                            if depth == 0 {
+                                return Some((start, index));
+                            }
+                        }
+                        _ => {
+                            index += 1;
+                        }
+                    }
+                }
+
+                return None;
+            }
+            _ => {
+                index += 1;
+            }
+        }
+    }
+
+    None
+}
+
+fn next_word_parameter_expansion_candidate(
+    text: &str,
+    search_start: usize,
+) -> Option<(usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut index = search_start;
+
+    while index + 1 < bytes.len() {
+        match bytes[index] {
+            b'\\' => {
+                index += 2;
+            }
+            b'$' if bytes[index + 1] == b'\'' => {
+                index += 2;
+                while index < bytes.len() {
+                    match bytes[index] {
+                        b'\\' => {
+                            index += 2;
+                        }
+                        b'\'' => {
+                            index += 1;
+                            break;
+                        }
+                        _ => {
+                            index += 1;
+                        }
+                    }
+                }
+            }
+            b'\'' => {
+                index += 1;
+                while index < bytes.len() {
+                    if bytes[index] == b'\'' {
+                        index += 1;
+                        break;
+                    }
+                    index += 1;
+                }
             }
             b'$' if bytes[index + 1] == b'{' => {
                 let start = index;


### PR DESCRIPTION
## Summary
- teach the raw word-level portability scanners to skip single-quoted and `$'...'` regions when looking for `${...}` fragments
- keep the generic raw scan for heredoc bodies so real unquoted heredoc substring expansions still produce X023
- add regression coverage for the `dpkg-query -W -f '${db:Status-Status}\n'` pattern in the surface facts test

## Root cause
X023 was over-reporting because the surface fact builder scanned whole word spans for `${...}` text before it distinguished quoting context. That caused single-quoted literals used as command data, like `dpkg-query` format strings, to be treated as shell substring expansions.

## Validation
- `cargo test -p shuck-linter`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_RULES=X023 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`