### PR TITLE
Split heredoc bodies into dedicated AST nodes

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1907,7 +1907,7 @@ pub enum HeredocBodyPart {
         expression_ast: Option<ArithmeticExprNode>,
         syntax: ArithmeticExpansionSyntax,
     },
-    Parameter(ParameterExpansion),
+    Parameter(Box<ParameterExpansion>),
 }
 
 /// A parsed heredoc body with its expansion mode.
@@ -4237,7 +4237,8 @@ mod tests {
             span: Span::new(),
             target: RedirectTarget::Heredoc(Heredoc {
                 delimiter,
-                body: Word::quoted_literal("body"),
+                body: HeredocBody::literal_with_span("body", Span::new())
+                    .with_mode(HeredocBodyMode::Literal),
             }),
         };
 

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1867,6 +1867,151 @@ impl fmt::Display for Word {
     }
 }
 
+/// Whether a heredoc body expands shell syntax.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeredocBodyMode {
+    Literal,
+    Expanding,
+}
+
+impl HeredocBodyMode {
+    pub const fn expands(self) -> bool {
+        matches!(self, Self::Expanding)
+    }
+}
+
+/// A heredoc body part paired with its source span.
+#[derive(Debug, Clone)]
+pub struct HeredocBodyPartNode {
+    pub kind: HeredocBodyPart,
+    pub span: Span,
+}
+
+impl HeredocBodyPartNode {
+    pub fn new(kind: HeredocBodyPart, span: Span) -> Self {
+        Self { kind, span }
+    }
+}
+
+/// Parts of a heredoc body.
+#[derive(Debug, Clone)]
+pub enum HeredocBodyPart {
+    Literal(LiteralText),
+    Variable(Name),
+    CommandSubstitution {
+        body: StmtSeq,
+        syntax: CommandSubstitutionSyntax,
+    },
+    ArithmeticExpansion {
+        expression: SourceText,
+        expression_ast: Option<ArithmeticExprNode>,
+        syntax: ArithmeticExpansionSyntax,
+    },
+    Parameter(ParameterExpansion),
+}
+
+/// A parsed heredoc body with its expansion mode.
+#[derive(Debug, Clone)]
+pub struct HeredocBody {
+    pub mode: HeredocBodyMode,
+    pub source_backed: bool,
+    pub parts: Vec<HeredocBodyPartNode>,
+    pub span: Span,
+}
+
+impl HeredocBody {
+    pub fn literal_with_span(s: impl Into<String>, span: Span) -> Self {
+        Self {
+            mode: HeredocBodyMode::Literal,
+            source_backed: true,
+            parts: vec![HeredocBodyPartNode::new(
+                HeredocBodyPart::Literal(LiteralText::owned(s.into())),
+                span,
+            )],
+            span,
+        }
+    }
+
+    pub fn source_literal_with_spans(span: Span, part_span: Span) -> Self {
+        Self {
+            mode: HeredocBodyMode::Literal,
+            source_backed: true,
+            parts: vec![HeredocBodyPartNode::new(
+                HeredocBodyPart::Literal(LiteralText::source()),
+                part_span,
+            )],
+            span,
+        }
+    }
+
+    pub fn with_mode(mut self, mode: HeredocBodyMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn with_source_backed(mut self, source_backed: bool) -> Self {
+        self.source_backed = source_backed;
+        self
+    }
+
+    pub fn part_span(&self, index: usize) -> Option<Span> {
+        self.parts.get(index).map(|part| part.span)
+    }
+
+    pub fn part(&self, index: usize) -> Option<&HeredocBodyPart> {
+        self.parts.get(index).map(|part| &part.kind)
+    }
+
+    pub fn parts_with_spans(&self) -> impl Iterator<Item = (&HeredocBodyPart, Span)> + '_ {
+        self.parts.iter().map(|part| (&part.kind, part.span))
+    }
+
+    pub fn render(&self, source: &str) -> String {
+        let mut rendered = String::new();
+        self.render_to_buf(source, &mut rendered);
+        rendered
+    }
+
+    pub fn render_syntax(&self, source: &str) -> String {
+        let mut rendered = String::new();
+        self.render_syntax_to_buf(source, &mut rendered);
+        rendered
+    }
+
+    pub fn render_to_buf(&self, source: &str, rendered: &mut String) {
+        self.fmt_with_source(rendered, Some(source))
+            .expect("writing into a String should not fail");
+    }
+
+    pub fn render_syntax_to_buf(&self, source: &str, rendered: &mut String) {
+        self.fmt_with_source(rendered, Some(source))
+            .expect("writing into a String should not fail");
+    }
+
+    fn fmt_with_source(&self, f: &mut impl fmt::Write, source: Option<&str>) -> fmt::Result {
+        let source = source.filter(|_| self.source_backed);
+        if let Some(source) = source
+            && heredoc_body_prefers_whole_source_slice(self)
+            && let Some(slice) = syntax_source_slice(self.span, source)
+        {
+            f.write_str(slice)?;
+            return Ok(());
+        }
+
+        for (part, span) in self.parts_with_spans() {
+            fmt_heredoc_body_part_with_source(f, part, span, source)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for HeredocBody {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_with_source(f, None)
+    }
+}
+
 /// A shell pattern in a pattern-sensitive context such as `case`, `[[ ... == ... ]]`,
 /// or parameter pattern operators.
 #[derive(Debug, Clone)]
@@ -2041,6 +2186,14 @@ fn pattern_prefers_whole_source_slice_in_syntax(pattern: &Pattern) -> bool {
             .parts
             .iter()
             .all(|part| top_level_pattern_part_prefers_source_slice_in_syntax(&part.kind))
+}
+
+fn heredoc_body_prefers_whole_source_slice(body: &HeredocBody) -> bool {
+    !body.parts.is_empty()
+        && body
+            .parts
+            .iter()
+            .all(|part| heredoc_body_part_is_source_backed(&part.kind))
 }
 
 fn top_level_pattern_part_prefers_source_slice_in_syntax(part: &PatternPart) -> bool {
@@ -2651,6 +2804,49 @@ fn fmt_word_part_with_source_mode(
     Ok(())
 }
 
+fn fmt_heredoc_body_part_with_source(
+    f: &mut impl fmt::Write,
+    part: &HeredocBodyPart,
+    span: Span,
+    source: Option<&str>,
+) -> fmt::Result {
+    if let Some(source) = source
+        && heredoc_body_part_is_source_backed(part)
+        && span.end.offset <= source.len()
+    {
+        f.write_str(span.slice(source))?;
+        return Ok(());
+    }
+
+    match part {
+        HeredocBodyPart::Literal(text) => fmt_literal_text(f, text, span, source)?,
+        HeredocBodyPart::Variable(name) => write!(f, "${}", name)?,
+        HeredocBodyPart::CommandSubstitution { body, syntax } => match syntax {
+            CommandSubstitutionSyntax::DollarParen => write!(f, "$({:?})", body)?,
+            CommandSubstitutionSyntax::Backtick => write!(f, "`{:?}`", body)?,
+        },
+        HeredocBodyPart::ArithmeticExpansion {
+            expression, syntax, ..
+        } => match syntax {
+            ArithmeticExpansionSyntax::DollarParenParen => {
+                write!(f, "$(({}))", display_source_text(Some(expression), source))?
+            }
+            ArithmeticExpansionSyntax::LegacyBracket => {
+                write!(f, "$[{}]", display_source_text(Some(expression), source))?
+            }
+        },
+        HeredocBodyPart::Parameter(parameter) => {
+            write!(
+                f,
+                "${{{}}}",
+                display_source_text(Some(&parameter.raw_body), source)
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
 fn part_prefers_source_slice_in_syntax(part: &WordPart) -> bool {
     matches!(
         part,
@@ -2747,6 +2943,15 @@ fn part_is_source_backed(part: &WordPart) -> bool {
         | WordPart::Variable(_)
         | WordPart::PrefixMatch { .. }
         | WordPart::ProcessSubstitution { .. } => true,
+    }
+}
+
+fn heredoc_body_part_is_source_backed(part: &HeredocBodyPart) -> bool {
+    match part {
+        HeredocBodyPart::Literal(text) => text.is_source_backed(),
+        HeredocBodyPart::Variable(_) | HeredocBodyPart::CommandSubstitution { .. } => true,
+        HeredocBodyPart::ArithmeticExpansion { expression, .. } => expression.is_source_backed(),
+        HeredocBodyPart::Parameter(parameter) => parameter.raw_body.is_source_backed(),
     }
 }
 
@@ -3009,7 +3214,7 @@ pub enum RedirectTarget {
 #[derive(Debug, Clone)]
 pub struct Heredoc {
     pub delimiter: HeredocDelimiter,
-    pub body: Word,
+    pub body: HeredocBody,
 }
 
 /// Parsed heredoc delimiter metadata.

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod ast_format;
 mod command;
 mod comments;

--- a/crates/shuck-formatter/src/simplify.rs
+++ b/crates/shuck-formatter/src/simplify.rs
@@ -539,29 +539,28 @@ fn rewrite_compound_words(
 ) -> usize {
     match command {
         CompoundCommand::If(command) => {
-            rewrite_stmt_seq_words(&mut command.condition, source, visitor)
-                + rewrite_stmt_seq_words(&mut command.then_branch, source, visitor)
-                + command
-                    .elif_branches
-                    .iter_mut()
-                    .map(|(condition, body)| {
-                        rewrite_stmt_seq_words(condition, source, visitor)
-                            + rewrite_stmt_seq_words(body, source, visitor)
-                    })
-                    .sum::<usize>()
-                + command
-                    .else_branch
-                    .as_mut()
-                    .map_or(0, |body| rewrite_stmt_seq_words(body, source, visitor))
+            let mut count = rewrite_stmt_seq_words(&mut command.condition, source, visitor)
+                + rewrite_stmt_seq_words(&mut command.then_branch, source, visitor);
+
+            for (condition, body) in &mut command.elif_branches {
+                count += rewrite_stmt_seq_words(condition, source, visitor);
+                count += rewrite_stmt_seq_words(body, source, visitor);
+            }
+
+            if let Some(body) = &mut command.else_branch {
+                count += rewrite_stmt_seq_words(body, source, visitor);
+            }
+
+            count
         }
         CompoundCommand::For(command) => {
-            command
-                .words
-                .iter_mut()
-                .flat_map(|words| words.iter_mut())
-                .map(|word| walk_word(word, source, &mut |word| visitor(word, source)))
-                .sum::<usize>()
-                + rewrite_stmt_seq_words(&mut command.body, source, visitor)
+            let mut count = 0;
+            if let Some(words) = &mut command.words {
+                for word in words {
+                    count += walk_word(word, source, &mut |word| visitor(word, source));
+                }
+            }
+            count + rewrite_stmt_seq_words(&mut command.body, source, visitor)
         }
         CompoundCommand::Repeat(command) => {
             walk_word(&mut command.count, source, &mut |word| {
@@ -569,12 +568,11 @@ fn rewrite_compound_words(
             }) + rewrite_stmt_seq_words(&mut command.body, source, visitor)
         }
         CompoundCommand::Foreach(command) => {
-            command
-                .words
-                .iter_mut()
-                .map(|word| walk_word(word, source, &mut |word| visitor(word, source)))
-                .sum::<usize>()
-                + rewrite_stmt_seq_words(&mut command.body, source, visitor)
+            let mut count = 0;
+            for word in &mut command.words {
+                count += walk_word(word, source, &mut |word| visitor(word, source));
+            }
+            count + rewrite_stmt_seq_words(&mut command.body, source, visitor)
         }
         CompoundCommand::ArithmeticFor(command) => {
             rewrite_stmt_seq_words(&mut command.body, source, visitor)
@@ -588,28 +586,21 @@ fn rewrite_compound_words(
                 + rewrite_stmt_seq_words(&mut command.body, source, visitor)
         }
         CompoundCommand::Case(command) => {
-            walk_word(&mut command.word, source, &mut |word| visitor(word, source))
-                + command
-                    .cases
-                    .iter_mut()
-                    .map(|item| {
-                        item.patterns
-                            .iter_mut()
-                            .map(|pattern| {
-                                walk_pattern(pattern, source, &mut |word| visitor(word, source))
-                            })
-                            .sum::<usize>()
-                            + rewrite_stmt_seq_words(&mut item.body, source, visitor)
-                    })
-                    .sum::<usize>()
+            let mut count = walk_word(&mut command.word, source, &mut |word| visitor(word, source));
+            for item in &mut command.cases {
+                for pattern in &mut item.patterns {
+                    count += walk_pattern(pattern, source, &mut |word| visitor(word, source));
+                }
+                count += rewrite_stmt_seq_words(&mut item.body, source, visitor);
+            }
+            count
         }
         CompoundCommand::Select(command) => {
-            command
-                .words
-                .iter_mut()
-                .map(|word| walk_word(word, source, &mut |word| visitor(word, source)))
-                .sum::<usize>()
-                + rewrite_stmt_seq_words(&mut command.body, source, visitor)
+            let mut count = 0;
+            for word in &mut command.words {
+                count += walk_word(word, source, &mut |word| visitor(word, source));
+            }
+            count + rewrite_stmt_seq_words(&mut command.body, source, visitor)
         }
         CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
             rewrite_stmt_seq_words(commands, source, visitor)
@@ -639,10 +630,11 @@ fn rewrite_stmt_seq_words(
     source: &str,
     visitor: &mut impl FnMut(&mut Word, &str) -> usize,
 ) -> usize {
-    commands
-        .iter_mut()
-        .map(|command| rewrite_stmt_words(command, source, visitor))
-        .sum()
+    let mut count = 0;
+    for command in commands.iter_mut() {
+        count += rewrite_stmt_words(command, source, visitor);
+    }
+    count
 }
 
 fn rewrite_assignment_words(
@@ -652,17 +644,19 @@ fn rewrite_assignment_words(
 ) -> usize {
     match &mut assignment.value {
         AssignmentValue::Scalar(word) => walk_word(word, source, &mut |word| visitor(word, source)),
-        AssignmentValue::Compound(array) => array
-            .elements
-            .iter_mut()
-            .map(|element| match element {
-                ArrayElem::Sequential(word)
-                | ArrayElem::Keyed { value: word, .. }
-                | ArrayElem::KeyedAppend { value: word, .. } => {
-                    walk_word(word, source, &mut |word| visitor(word, source))
-                }
-            })
-            .sum(),
+        AssignmentValue::Compound(array) => {
+            let mut count = 0;
+            for element in &mut array.elements {
+                count += match element {
+                    ArrayElem::Sequential(word)
+                    | ArrayElem::Keyed { value: word, .. }
+                    | ArrayElem::KeyedAppend { value: word, .. } => {
+                        walk_word(word, source, &mut |word| visitor(word, source))
+                    }
+                };
+            }
+            count
+        }
     }
 }
 
@@ -734,11 +728,27 @@ fn walk_word(
 }
 
 fn walk_heredoc_body(
-    _body: &mut HeredocBody,
-    _source: &str,
-    _visitor: &mut impl FnMut(&mut Word) -> usize,
+    body: &mut HeredocBody,
+    source: &str,
+    visitor: &mut dyn FnMut(&mut Word) -> usize,
 ) -> usize {
-    0
+    let mut count = 0;
+
+    for part in &mut body.parts {
+        if let HeredocBodyPart::CommandSubstitution {
+            body: command_body, ..
+        } = &mut part.kind
+        {
+            count +=
+                rewrite_stmt_seq_words(command_body, source, &mut |word, _source| visitor(word));
+        }
+    }
+
+    if count > 0 {
+        body.source_backed = false;
+    }
+
+    count
 }
 
 fn walk_word_part(part: &mut WordPartNode) -> usize {
@@ -761,21 +771,26 @@ fn walk_pattern(
     source: &str,
     visitor: &mut impl FnMut(&mut Word) -> usize,
 ) -> usize {
-    pattern
-        .parts
-        .iter_mut()
-        .map(|part| match &mut part.kind {
-            PatternPart::Group { patterns, .. } => patterns
-                .iter_mut()
-                .map(|pattern| walk_pattern(pattern, source, visitor))
-                .sum(),
+    let mut count = 0;
+
+    for part in &mut pattern.parts {
+        count += match &mut part.kind {
+            PatternPart::Group { patterns, .. } => {
+                let mut inner = 0;
+                for pattern in patterns {
+                    inner += walk_pattern(pattern, source, visitor);
+                }
+                inner
+            }
             PatternPart::Word(word) => walk_word(word, source, visitor),
             PatternPart::Literal(_)
             | PatternPart::AnyString
             | PatternPart::AnyChar
             | PatternPart::CharClass(_) => 0,
-        })
-        .sum()
+        };
+    }
+
+    count
 }
 
 fn walk_conditional_words(
@@ -1155,10 +1170,17 @@ fn rewrite_heredoc_body_source_texts(
     source: &str,
     visitor: &mut impl FnMut(&mut SourceText, &str) -> usize,
 ) -> usize {
-    body.parts
+    let count: usize = body
+        .parts
         .iter_mut()
         .map(|part| rewrite_heredoc_body_part_source_texts(part, source, visitor))
-        .sum()
+        .sum();
+
+    if count > 0 {
+        body.source_backed = false;
+    }
+
+    count
 }
 
 fn rewrite_word_part_source_texts(
@@ -2086,6 +2108,22 @@ mod tests {
         assert_eq!(
             format_with_simplify("echo \"$foo bar\"\n"),
             "echo \"$foo bar\"\n"
+        );
+    }
+
+    #[test]
+    fn quote_tightening_rewrites_command_substitutions_inside_heredoc_bodies() {
+        assert_eq!(
+            format_with_simplify("cat <<EOF\n$(printf \"%s\" \"fo\\$o\")\nEOF\n"),
+            "cat <<EOF\n$(printf '%s' 'fo$o')\nEOF\n"
+        );
+    }
+
+    #[test]
+    fn arithmetic_var_rewrite_updates_expanding_heredoc_bodies() {
+        assert_eq!(
+            format_with_simplify("cat <<EOF\n$(( $a + ${b} ))\nEOF\n"),
+            "cat <<EOF\n$((a + b))\nEOF\n"
         );
     }
 

--- a/crates/shuck-formatter/src/simplify.rs
+++ b/crates/shuck-formatter/src/simplify.rs
@@ -2,9 +2,10 @@ use shuck_ast::{
     ArrayElem, Assignment, AssignmentValue, BourneParameterExpansion, BuiltinCommand, Command,
     CompoundCommand, ConditionalBinaryExpr, ConditionalBinaryOp, ConditionalCommand,
     ConditionalExpr, ConditionalParenExpr, ConditionalUnaryExpr, ConditionalUnaryOp, DeclClause,
-    DeclOperand, File, FunctionDef, ParameterExpansion, ParameterExpansionSyntax, ParameterOp,
-    Pattern, PatternPart, Redirect, RedirectTarget, SourceText, Stmt, StmtSeq, VarRef, Word,
-    WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget,
+    DeclOperand, File, FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode,
+    ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Redirect,
+    RedirectTarget, SourceText, Stmt, StmtSeq, VarRef, Word, WordPart, WordPartNode,
+    ZshExpansionOperation, ZshExpansionTarget,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -415,7 +416,7 @@ fn walk_redirect(
         RedirectTarget::Word(word) => walk_word(word, source, word_visitor),
         RedirectTarget::Heredoc(heredoc) => {
             walk_word(&mut heredoc.delimiter.raw, source, word_visitor)
-                + walk_word(&mut heredoc.body, source, word_visitor)
+                + walk_heredoc_body(&mut heredoc.body, source, word_visitor)
         }
     }
 }
@@ -675,7 +676,7 @@ fn rewrite_redirect_words(
         RedirectTarget::Heredoc(heredoc) => {
             walk_word(&mut heredoc.delimiter.raw, source, &mut |word| {
                 visitor(word, source)
-            }) + walk_word(&mut heredoc.body, source, &mut |word| visitor(word, source))
+            }) + walk_heredoc_body(&mut heredoc.body, source, &mut |word| visitor(word, source))
         }
     }
 }
@@ -730,6 +731,14 @@ fn walk_word(
         count += walk_word_part(part);
     }
     count
+}
+
+fn walk_heredoc_body(
+    _body: &mut HeredocBody,
+    _source: &str,
+    _visitor: &mut impl FnMut(&mut Word) -> usize,
+) -> usize {
+    0
 }
 
 fn walk_word_part(part: &mut WordPartNode) -> usize {
@@ -1118,7 +1127,7 @@ fn rewrite_redirect_source_texts(
         RedirectTarget::Word(word) => rewrite_word_source_texts(word, source, visitor),
         RedirectTarget::Heredoc(heredoc) => {
             rewrite_word_source_texts(&mut heredoc.delimiter.raw, source, visitor)
-                + rewrite_word_source_texts(&mut heredoc.body, source, visitor)
+                + rewrite_heredoc_body_source_texts(&mut heredoc.body, source, visitor)
         }
     }
 }
@@ -1139,6 +1148,17 @@ fn rewrite_word_source_texts(
         };
     }
     count
+}
+
+fn rewrite_heredoc_body_source_texts(
+    body: &mut HeredocBody,
+    source: &str,
+    visitor: &mut impl FnMut(&mut SourceText, &str) -> usize,
+) -> usize {
+    body.parts
+        .iter_mut()
+        .map(|part| rewrite_heredoc_body_part_source_texts(part, source, visitor))
+        .sum()
 }
 
 fn rewrite_word_part_source_texts(
@@ -1217,6 +1237,21 @@ fn rewrite_word_part_source_texts(
                 })
         }
         WordPart::PrefixMatch { .. } => 0,
+    }
+}
+
+fn rewrite_heredoc_body_part_source_texts(
+    part: &mut HeredocBodyPartNode,
+    source: &str,
+    visitor: &mut impl FnMut(&mut SourceText, &str) -> usize,
+) -> usize {
+    match &mut part.kind {
+        HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => 0,
+        HeredocBodyPart::CommandSubstitution { .. } => 0,
+        HeredocBodyPart::ArithmeticExpansion { expression, .. } => visitor(expression, source),
+        HeredocBodyPart::Parameter(parameter) => {
+            rewrite_parameter_source_texts(parameter, source, visitor)
+        }
     }
 }
 

--- a/crates/shuck-formatter/src/streaming.rs
+++ b/crates/shuck-formatter/src/streaming.rs
@@ -22,7 +22,9 @@ use crate::command::{
 use crate::comments::{SourceComment, SourceMap};
 use crate::facts::FormatterFacts;
 use crate::options::ResolvedShellFormatOptions;
-use crate::word::{render_pattern_syntax_to_buf, render_word_syntax_with_facts_to_buf};
+use crate::word::{
+    render_heredoc_body_to_buf, render_pattern_syntax_to_buf, render_word_syntax_with_facts_to_buf,
+};
 
 enum StreamOutput<'source> {
     Buffer(String),
@@ -182,7 +184,7 @@ pub(crate) fn format_stmt_sequence_streaming_to_buf(
 
 #[derive(Debug, Clone)]
 struct PendingHeredoc {
-    body_span: Span,
+    body: String,
     delimiter: String,
 }
 
@@ -425,7 +427,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         for heredoc in pending {
             self.push_output_str(self.line_ending());
             self.line_start = true;
-            self.write_verbatim(heredoc.body_span.slice(self.source));
+            self.write_verbatim(&heredoc.body);
             self.write_verbatim(&heredoc.delimiter);
         }
     }
@@ -1690,15 +1692,26 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             let Some(heredoc) = redirect.heredoc() else {
                 continue;
             };
+            let body = if heredoc.body.source_backed {
+                heredoc.body.span.slice(source).to_owned()
+            } else {
+                let mut rendered = String::new();
+                render_heredoc_body_to_buf(
+                    &heredoc.body,
+                    source,
+                    &self.options,
+                    self.facts,
+                    &mut rendered,
+                );
+                rendered
+            };
             let mut delimiter = String::new();
             heredoc
                 .delimiter
                 .raw
                 .render_syntax_to_buf(source, &mut delimiter);
-            self.pending_heredocs.push(PendingHeredoc {
-                body_span: heredoc.body.span,
-                delimiter,
-            });
+            self.pending_heredocs
+                .push(PendingHeredoc { body, delimiter });
         }
     }
 

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -3,8 +3,9 @@ use std::fmt::Write as _;
 use shuck_ast::{
     ArithmeticAssignOp, ArithmeticBinaryOp, ArithmeticExpansionSyntax, ArithmeticExpr,
     ArithmeticExprNode, ArithmeticLvalue, ArithmeticPostfixOp, ArithmeticUnaryOp,
-    BourneParameterExpansion, Command, CommandSubstitutionSyntax, CompoundCommand, ParameterOp,
-    Pattern, Stmt, StmtSeq, SubscriptSelector, VarRef, Word, WordPart,
+    BourneParameterExpansion, Command, CommandSubstitutionSyntax, CompoundCommand, HeredocBody,
+    HeredocBodyPart, ParameterOp, Pattern, Stmt, StmtSeq, SubscriptSelector, VarRef, Word,
+    WordPart,
 };
 use shuck_format::IndentStyle;
 use shuck_format::{FormatResult, text, write};
@@ -66,6 +67,19 @@ pub(crate) fn render_word_syntax_with_facts_to_buf(
         Some(facts),
         rendered,
     );
+}
+
+pub(crate) fn render_heredoc_body_to_buf(
+    body: &HeredocBody,
+    source: &str,
+    options: &ResolvedShellFormatOptions,
+    _facts: &FormatterFacts<'_>,
+    rendered: &mut String,
+) {
+    for part in &body.parts {
+        render_heredoc_body_part(rendered, &part.kind, part.span, source, options, _facts)
+            .expect("writing into a String should not fail");
+    }
 }
 
 fn render_word_syntax_internal(
@@ -161,6 +175,106 @@ fn render_word_parts(
             rendered, &part.kind, part.span, source, options, source_map, facts,
         )?;
     }
+    Ok(())
+}
+
+fn render_heredoc_body_part(
+    rendered: &mut String,
+    part: &HeredocBodyPart,
+    span: shuck_ast::Span,
+    source: &str,
+    options: &ResolvedShellFormatOptions,
+    _facts: &FormatterFacts<'_>,
+) -> Result<(), std::fmt::Error> {
+    match part {
+        HeredocBodyPart::Literal(text) => rendered.push_str(text.as_str(source, span)),
+        HeredocBodyPart::Variable(name) => {
+            std::write!(rendered, "${name}")?;
+        }
+        HeredocBodyPart::CommandSubstitution { body, syntax } => {
+            let raw = raw_source_slice(span, source);
+            let multiline = raw.is_some_and(|raw| raw.contains('\n'))
+                || raw.is_none() && *syntax == CommandSubstitutionSyntax::DollarParen;
+
+            if render_command_substitution(
+                rendered,
+                body,
+                span.end.offset,
+                source,
+                options,
+                multiline,
+                None,
+                None,
+            )
+            .is_none()
+            {
+                if let Some(raw) = raw {
+                    rendered.push_str(raw);
+                } else {
+                    std::write!(rendered, "$({body:?})")?;
+                }
+            }
+        }
+        HeredocBodyPart::ArithmeticExpansion {
+            expression,
+            expression_ast,
+            syntax,
+        } => {
+            if matches!(syntax, ArithmeticExpansionSyntax::LegacyBracket) {
+                push_trimmed_arithmetic_expansion_source(
+                    rendered,
+                    expression.slice(source),
+                    *syntax,
+                );
+            } else if let Some(expression_ast) = expression_ast {
+                if !expression.is_source_backed() {
+                    push_trimmed_arithmetic_expansion_source(
+                        rendered,
+                        expression.slice(source),
+                        *syntax,
+                    );
+                } else {
+                    match syntax {
+                        ArithmeticExpansionSyntax::DollarParenParen => {
+                            rendered.push_str("$((");
+                            push_arithmetic_expr(
+                                rendered,
+                                expression_ast,
+                                ArithmeticContext::TopLevel,
+                                source,
+                                options,
+                            );
+                            rendered.push_str("))");
+                        }
+                        ArithmeticExpansionSyntax::LegacyBracket => {
+                            rendered.push_str("$[");
+                            push_arithmetic_expr(
+                                rendered,
+                                expression_ast,
+                                ArithmeticContext::TopLevel,
+                                source,
+                                options,
+                            );
+                            rendered.push(']');
+                        }
+                    }
+                }
+            } else {
+                match syntax {
+                    ArithmeticExpansionSyntax::DollarParenParen => {
+                        std::write!(rendered, "$(({}))", expression.slice(source))?;
+                    }
+                    ArithmeticExpansionSyntax::LegacyBracket => {
+                        std::write!(rendered, "$[{}]", expression.slice(source))?;
+                    }
+                }
+            }
+        }
+        HeredocBodyPart::Parameter(parameter) => {
+            push_parameter_word(rendered, parameter, source, options)?;
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/shuck-indexer/src/comment_index.rs
+++ b/crates/shuck-indexer/src/comment_index.rs
@@ -2,8 +2,9 @@ use std::ops::Range;
 
 use shuck_ast::{
     ArrayElem, Assignment, AssignmentValue, BuiltinCommand, Command, Comment, CompoundCommand,
-    ConditionalExpr, DeclOperand, File, Pattern, PatternPart, Redirect, Stmt, StmtSeq, TextRange,
-    TextSize, Word, WordPart, WordPartNode, ZshGlobSegment,
+    ConditionalExpr, DeclOperand, File, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, Pattern,
+    PatternPart, Redirect, Stmt, StmtSeq, TextRange, TextSize, Word, WordPart, WordPartNode,
+    ZshGlobSegment,
 };
 
 use crate::LineIndex;
@@ -352,7 +353,7 @@ fn collect_redirect_comments(redirects: &[Redirect], comments: &mut Vec<Comment>
             collect_word_comments(word, comments);
         }
         if let Some(heredoc) = redirect.heredoc() {
-            collect_word_comments(&heredoc.body, comments);
+            collect_heredoc_body_comments(&heredoc.body, comments);
         }
     }
 }
@@ -430,6 +431,10 @@ fn collect_word_comments(word: &Word, comments: &mut Vec<Comment>) {
     collect_word_part_comments(&word.parts, comments);
 }
 
+fn collect_heredoc_body_comments(body: &HeredocBody, comments: &mut Vec<Comment>) {
+    collect_heredoc_body_part_comments(&body.parts, comments);
+}
+
 fn collect_word_part_comments(parts: &[WordPartNode], comments: &mut Vec<Comment>) {
     for part in parts {
         match &part.kind {
@@ -464,6 +469,24 @@ fn collect_word_part_comments(parts: &[WordPartNode], comments: &mut Vec<Comment
             | WordPart::IndirectExpansion { .. }
             | WordPart::PrefixMatch { .. }
             | WordPart::Transformation { .. } => {}
+        }
+    }
+}
+
+fn collect_heredoc_body_part_comments(parts: &[HeredocBodyPartNode], comments: &mut Vec<Comment>) {
+    for part in parts {
+        match &part.kind {
+            HeredocBodyPart::CommandSubstitution { body, .. } => {
+                collect_stmt_seq_comments(body, comments)
+            }
+            HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
+                if let Some(expression) = expression_ast {
+                    collect_arithmetic_expr_comments(expression, comments);
+                }
+            }
+            HeredocBodyPart::Literal(_)
+            | HeredocBodyPart::Variable(_)
+            | HeredocBodyPart::Parameter(_) => {}
         }
     }
 }

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -1,8 +1,8 @@
 use shuck_ast::{
     ArithmeticForCommand, Assignment, AssignmentValue, BuiltinCommand, Command, CompoundCommand,
-    ConditionalExpr, DeclClause, DeclOperand, File, FunctionDef, Pattern, PatternPart,
-    PatternPartNode, Redirect, RedirectKind, Stmt, StmtSeq, Subscript, TextRange, TextSize, VarRef,
-    Word, WordPart, WordPartNode, ZshGlobSegment,
+    ConditionalExpr, DeclClause, DeclOperand, File, FunctionDef, HeredocBody, HeredocBodyPart,
+    HeredocBodyPartNode, Pattern, PatternPart, PatternPartNode, Redirect, RedirectKind, Stmt,
+    StmtSeq, Subscript, TextRange, TextSize, VarRef, Word, WordPart, WordPartNode, ZshGlobSegment,
 };
 use shuck_parser::parser::Parser;
 
@@ -427,7 +427,7 @@ impl<'a> RegionCollector<'a> {
                 if heredoc.delimiter.quoted {
                     push_range(&mut self.quoted_heredocs, range);
                 }
-                self.visit_word_parts(&heredoc.body.parts);
+                self.visit_heredoc_body(&heredoc.body);
             }
             _ => self.visit_word(
                 redirect
@@ -458,6 +458,10 @@ impl<'a> RegionCollector<'a> {
 
     fn visit_word(&mut self, word: &Word) {
         self.visit_word_parts(&word.parts);
+    }
+
+    fn visit_heredoc_body(&mut self, body: &HeredocBody) {
+        self.visit_heredoc_body_parts(&body.parts);
     }
 
     fn visit_pattern(&mut self, pattern: &Pattern) {
@@ -520,6 +524,24 @@ impl<'a> RegionCollector<'a> {
                 | WordPart::IndirectExpansion { .. }
                 | WordPart::PrefixMatch { .. }
                 | WordPart::Transformation { .. } => {}
+            }
+        }
+    }
+
+    fn visit_heredoc_body_parts(&mut self, parts: &[HeredocBodyPartNode]) {
+        for part in parts {
+            let range = part.span.to_range();
+            match &part.kind {
+                HeredocBodyPart::CommandSubstitution { body, .. } => {
+                    push_range(&mut self.command_substitutions, range);
+                    self.visit_stmt_seq(body);
+                }
+                HeredocBodyPart::ArithmeticExpansion { .. } => {
+                    push_range(&mut self.arithmetic, range);
+                }
+                HeredocBodyPart::Literal(_)
+                | HeredocBodyPart::Variable(_)
+                | HeredocBodyPart::Parameter(_) => {}
             }
         }
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -16211,6 +16211,44 @@ EOF
     }
 
     #[test]
+    fn surface_facts_track_parameter_operations_in_expanding_heredocs() {
+        let source = "\
+cat <<EOF
+${name:2}
+${arr[0]//x/y}
+${name^^pattern}
+EOF
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .substring_expansion_fragments()
+                    .iter()
+                    .map(|fragment| fragment.span().slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${name:2}"]
+            );
+            assert_eq!(
+                facts
+                    .replacement_expansion_fragments()
+                    .iter()
+                    .map(|fragment| fragment.span().slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${arr[0]//x/y}"]
+            );
+            assert_eq!(
+                facts
+                    .case_modification_fragments()
+                    .iter()
+                    .map(|fragment| fragment.span().slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${name^^pattern}"]
+            );
+        });
+    }
+
+    #[test]
     fn shared_command_traversal_collects_word_facts_and_surface_fragments() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -32,6 +32,18 @@ fn build_command_substitution_facts<'a>(
         );
     });
 
+    visit_heredoc_bodies_for_substitutions(fact.redirects(), &mut |body| {
+        collect_or_update_heredoc_body_substitution_facts(
+            body,
+            SubstitutionHostKind::Other,
+            commands,
+            command_ids_by_span,
+            source,
+            &mut substitutions,
+            &mut substitution_index,
+        );
+    });
+
     visit_command_argument_words_for_substitutions(fact.command(), source, &mut |word| {
         collect_or_update_word_substitution_facts(
             word,
@@ -94,11 +106,55 @@ fn collect_or_update_word_substitution_facts<'a>(
 ) {
     let mut occurrences = Vec::new();
     collect_word_substitution_occurrences(&word.parts, false, &mut occurrences);
+    collect_or_update_substitution_facts_from_occurrences(
+        word.span,
+        host_kind,
+        occurrences,
+        commands,
+        command_ids_by_span,
+        source,
+        substitutions,
+        substitution_index,
+    );
+}
 
+fn collect_or_update_heredoc_body_substitution_facts<'a>(
+    body: &shuck_ast::HeredocBody,
+    host_kind: SubstitutionHostKind,
+    commands: &[CommandFact<'a>],
+    command_ids_by_span: &CommandLookupIndex,
+    source: &str,
+    substitutions: &mut Vec<SubstitutionFact>,
+    substitution_index: &mut FxHashMap<FactSpan, usize>,
+) {
+    let mut occurrences = Vec::new();
+    collect_heredoc_body_substitution_occurrences(&body.parts, &mut occurrences);
+    collect_or_update_substitution_facts_from_occurrences(
+        body.span,
+        host_kind,
+        occurrences,
+        commands,
+        command_ids_by_span,
+        source,
+        substitutions,
+        substitution_index,
+    );
+}
+
+fn collect_or_update_substitution_facts_from_occurrences<'a>(
+    host_span: Span,
+    host_kind: SubstitutionHostKind,
+    occurrences: Vec<SubstitutionOccurrence<'a>>,
+    commands: &[CommandFact<'a>],
+    command_ids_by_span: &CommandLookupIndex,
+    source: &str,
+    substitutions: &mut Vec<SubstitutionFact>,
+    substitution_index: &mut FxHashMap<FactSpan, usize>,
+) {
     for occurrence in occurrences {
         let key = FactSpan::new(occurrence.span);
         if let Some(&index) = substitution_index.get(&key) {
-            substitutions[index].host_word_span = word.span;
+            substitutions[index].host_word_span = host_span;
             substitutions[index].host_kind = host_kind;
             substitutions[index].unquoted_in_host = occurrence.unquoted_in_host;
             continue;
@@ -117,7 +173,7 @@ fn collect_or_update_word_substitution_facts<'a>(
             body_contains_echo: body_facts.body_contains_echo,
             body_contains_grep: body_facts.body_contains_grep,
             bash_file_slurp: body_facts.bash_file_slurp,
-            host_word_span: word.span,
+            host_word_span: host_span,
             host_kind,
             unquoted_in_host: occurrence.unquoted_in_host,
         });
@@ -183,6 +239,31 @@ fn collect_word_substitution_occurrences<'a>(
             | WordPart::PrefixMatch { .. }
             | WordPart::Transformation { .. }
             | WordPart::ZshQualifiedGlob(_) => {}
+        }
+    }
+}
+
+fn collect_heredoc_body_substitution_occurrences<'a>(
+    parts: &'a [shuck_ast::HeredocBodyPartNode],
+    occurrences: &mut Vec<SubstitutionOccurrence<'a>>,
+) {
+    for part in parts {
+        match &part.kind {
+            shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
+                visit_arithmetic_words_in_expression(expression_ast.as_ref(), false, occurrences);
+            }
+            shuck_ast::HeredocBodyPart::CommandSubstitution { body, syntax } => {
+                occurrences.push(SubstitutionOccurrence {
+                    body,
+                    span: part.span,
+                    kind: CommandSubstitutionKind::Command,
+                    command_syntax: Some(*syntax),
+                    unquoted_in_host: true,
+                });
+            }
+            shuck_ast::HeredocBodyPart::Literal(_)
+            | shuck_ast::HeredocBodyPart::Variable(_)
+            | shuck_ast::HeredocBodyPart::Parameter(_) => {}
         }
     }
 }
@@ -652,7 +733,9 @@ fn visit_command_words_for_substitutions(
     }
 
     for redirect in redirects {
-        visitor(redirect_scan_word(redirect));
+        if let Some(word) = redirect.word_target() {
+            visitor(word);
+        }
     }
 }
 
@@ -759,7 +842,24 @@ fn visit_here_string_words_for_substitutions(
 ) {
     for redirect in redirects {
         if redirect.kind == RedirectKind::HereString {
-            visitor(redirect_scan_word(redirect));
+            let word = redirect
+                .word_target()
+                .expect("expected non-heredoc here-string target");
+            visitor(word);
+        }
+    }
+}
+
+fn visit_heredoc_bodies_for_substitutions(
+    redirects: &[Redirect],
+    visitor: &mut impl FnMut(&shuck_ast::HeredocBody),
+) {
+    for redirect in redirects {
+        let Some(heredoc) = redirect.heredoc() else {
+            continue;
+        };
+        if heredoc.delimiter.expands_body {
+            visitor(&heredoc.body);
         }
     }
 }
@@ -947,13 +1047,6 @@ fn visit_conditional_words_for_substitutions(
         ConditionalExpr::VarRef(reference) => {
             query::visit_var_ref_subscript_words_with_source(reference, source, visitor);
         }
-    }
-}
-
-fn redirect_scan_word(redirect: &Redirect) -> &Word {
-    match redirect.word_target() {
-        Some(word) => word,
-        None => &redirect.heredoc().expect("expected heredoc redirect").body,
     }
 }
 

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -19,14 +19,17 @@ fn build_command_substitution_facts<'a>(
 ) -> Box<[SubstitutionFact]> {
     let mut substitutions = Vec::new();
     let mut substitution_index = FxHashMap::default();
+    let context = SubstitutionFactBuildContext {
+        commands,
+        command_ids_by_span,
+        source,
+    };
 
     visit_command_words_for_substitutions(fact.command(), fact.redirects(), source, &mut |word| {
         collect_or_update_word_substitution_facts(
             word,
             SubstitutionHostKind::Other,
-            commands,
-            command_ids_by_span,
-            source,
+            context,
             &mut substitutions,
             &mut substitution_index,
         );
@@ -36,9 +39,7 @@ fn build_command_substitution_facts<'a>(
         collect_or_update_heredoc_body_substitution_facts(
             body,
             SubstitutionHostKind::Other,
-            commands,
-            command_ids_by_span,
-            source,
+            context,
             &mut substitutions,
             &mut substitution_index,
         );
@@ -48,9 +49,7 @@ fn build_command_substitution_facts<'a>(
         collect_or_update_word_substitution_facts(
             word,
             SubstitutionHostKind::CommandArgument,
-            commands,
-            command_ids_by_span,
-            source,
+            context,
             &mut substitutions,
             &mut substitution_index,
         );
@@ -60,9 +59,7 @@ fn build_command_substitution_facts<'a>(
         collect_or_update_word_substitution_facts(
             word,
             SubstitutionHostKind::HereStringOperand,
-            commands,
-            command_ids_by_span,
-            source,
+            context,
             &mut substitutions,
             &mut substitution_index,
         );
@@ -72,9 +69,7 @@ fn build_command_substitution_facts<'a>(
         collect_or_update_word_substitution_facts(
             word,
             SubstitutionHostKind::DeclarationAssignmentValue,
-            commands,
-            command_ids_by_span,
-            source,
+            context,
             &mut substitutions,
             &mut substitution_index,
         );
@@ -84,9 +79,7 @@ fn build_command_substitution_facts<'a>(
         collect_or_update_word_substitution_facts(
             word,
             kind,
-            commands,
-            command_ids_by_span,
-            source,
+            context,
             &mut substitutions,
             &mut substitution_index,
         );
@@ -98,9 +91,7 @@ fn build_command_substitution_facts<'a>(
 fn collect_or_update_word_substitution_facts<'a>(
     word: &Word,
     host_kind: SubstitutionHostKind,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-    source: &str,
+    context: SubstitutionFactBuildContext<'a, '_>,
     substitutions: &mut Vec<SubstitutionFact>,
     substitution_index: &mut FxHashMap<FactSpan, usize>,
 ) {
@@ -110,9 +101,7 @@ fn collect_or_update_word_substitution_facts<'a>(
         word.span,
         host_kind,
         occurrences,
-        commands,
-        command_ids_by_span,
-        source,
+        context,
         substitutions,
         substitution_index,
     );
@@ -121,9 +110,7 @@ fn collect_or_update_word_substitution_facts<'a>(
 fn collect_or_update_heredoc_body_substitution_facts<'a>(
     body: &shuck_ast::HeredocBody,
     host_kind: SubstitutionHostKind,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-    source: &str,
+    context: SubstitutionFactBuildContext<'a, '_>,
     substitutions: &mut Vec<SubstitutionFact>,
     substitution_index: &mut FxHashMap<FactSpan, usize>,
 ) {
@@ -133,21 +120,24 @@ fn collect_or_update_heredoc_body_substitution_facts<'a>(
         body.span,
         host_kind,
         occurrences,
-        commands,
-        command_ids_by_span,
-        source,
+        context,
         substitutions,
         substitution_index,
     );
+}
+
+#[derive(Clone, Copy)]
+struct SubstitutionFactBuildContext<'a, 'b> {
+    commands: &'b [CommandFact<'a>],
+    command_ids_by_span: &'b CommandLookupIndex,
+    source: &'b str,
 }
 
 fn collect_or_update_substitution_facts_from_occurrences<'a>(
     host_span: Span,
     host_kind: SubstitutionHostKind,
     occurrences: Vec<SubstitutionOccurrence<'a>>,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-    source: &str,
+    context: SubstitutionFactBuildContext<'a, '_>,
     substitutions: &mut Vec<SubstitutionFact>,
     substitution_index: &mut FxHashMap<FactSpan, usize>,
 ) {
@@ -160,8 +150,12 @@ fn collect_or_update_substitution_facts_from_occurrences<'a>(
             continue;
         }
 
-        let body_facts =
-            classify_substitution_body(occurrence.body, commands, command_ids_by_span, source);
+        let body_facts = classify_substitution_body(
+            occurrence.body,
+            context.commands,
+            context.command_ids_by_span,
+            context.source,
+        );
         substitution_index.insert(key, substitutions.len());
         substitutions.push(SubstitutionFact {
             span: occurrence.span,

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -286,36 +286,49 @@ impl<'a> SurfaceFragmentSink<'a> {
         let mut open_quote = None;
 
         for part in parts {
-            let HeredocBodyPart::Literal(text) = &part.kind else {
-                continue;
-            };
-            let text = text.as_str(self.source, part.span);
-            let mut quote_scan_offset = 0usize;
+            match &part.kind {
+                HeredocBodyPart::Literal(text) => {
+                    let text = text.as_str(self.source, part.span);
 
-            while let Some(relative_quote_offset) = text[quote_scan_offset..].find('\'') {
-                let quote_offset = quote_scan_offset + relative_quote_offset;
-                let quote_start = part.span.start.advanced_by(&text[..quote_offset]);
-                let quote_end = quote_start.advanced_by("'");
+                    for (quote_offset, ch) in text.char_indices() {
+                        match ch {
+                            '\n' => open_quote = None,
+                            '\'' => {
+                                let quote_start =
+                                    part.span.start.advanced_by(&text[..quote_offset]);
+                                if heredoc_single_quote_is_escaped(self.source, quote_start.offset)
+                                {
+                                    continue;
+                                }
+                                let quote_end = quote_start.advanced_by("'");
 
-                if let Some(open_start) = open_quote.take() {
-                    self.facts.single_quoted.push(SingleQuotedFragmentFact {
-                        span: Span::from_positions(open_start, quote_end),
-                        dollar_quoted: false,
-                        command_name: context
-                            .command_name
-                            .map(str::to_owned)
-                            .map(String::into_boxed_str),
-                        assignment_target: context
-                            .assignment_target
-                            .map(str::to_owned)
-                            .map(String::into_boxed_str),
-                        variable_set_operand: context.variable_set_operand,
-                    });
-                } else {
-                    open_quote = Some(quote_start);
+                                if let Some(open_start) = open_quote.take() {
+                                    self.facts.single_quoted.push(SingleQuotedFragmentFact {
+                                        span: Span::from_positions(open_start, quote_end),
+                                        dollar_quoted: false,
+                                        command_name: context
+                                            .command_name
+                                            .map(str::to_owned)
+                                            .map(String::into_boxed_str),
+                                        assignment_target: context
+                                            .assignment_target
+                                            .map(str::to_owned)
+                                            .map(String::into_boxed_str),
+                                        variable_set_operand: context.variable_set_operand,
+                                    });
+                                } else {
+                                    open_quote = Some(quote_start);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
                 }
-
-                quote_scan_offset = quote_offset + '\''.len_utf8();
+                _ => {
+                    if part.span.slice(self.source).contains('\n') {
+                        open_quote = None;
+                    }
+                }
             }
         }
     }
@@ -861,6 +874,27 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
         self.facts.subscript_spans.push(subscript.span());
     }
+}
+
+fn heredoc_single_quote_is_escaped(source: &str, offset: usize) -> bool {
+    if source.as_bytes().get(offset) != Some(&b'\'') {
+        return false;
+    }
+
+    let mut backslash_count = 0usize;
+    let mut cursor = offset;
+    while cursor > 0 {
+        match source.as_bytes()[cursor - 1] {
+            b'\\' => {
+                backslash_count += 1;
+                cursor -= 1;
+            }
+            b'\n' => break,
+            _ => break,
+        }
+    }
+
+    !backslash_count.is_multiple_of(2)
 }
 
 fn parameter_has_array_reference(parameter: &shuck_ast::ParameterExpansion) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -296,8 +296,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                             '\'' => {
                                 let quote_start =
                                     part.span.start.advanced_by(&text[..quote_offset]);
-                                if heredoc_single_quote_is_escaped(self.source, quote_start.offset)
-                                {
+                                if heredoc_single_quote_is_escaped(text, quote_offset) {
                                     continue;
                                 }
                                 let quote_end = quote_start.advanced_by("'");
@@ -325,7 +324,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     }
                 }
                 _ => {
-                    if part.span.slice(self.source).contains('\n') {
+                    if part.span.start.line != part.span.end.line {
                         open_quote = None;
                     }
                 }
@@ -876,15 +875,11 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 }
 
-fn heredoc_single_quote_is_escaped(source: &str, offset: usize) -> bool {
-    if source.as_bytes().get(offset) != Some(&b'\'') {
-        return false;
-    }
-
+fn heredoc_single_quote_is_escaped(text: &str, quote_offset: usize) -> bool {
     let mut backslash_count = 0usize;
-    let mut cursor = offset;
+    let mut cursor = quote_offset;
     while cursor > 0 {
-        match source.as_bytes()[cursor - 1] {
+        match text.as_bytes()[cursor - 1] {
             b'\\' => {
                 backslash_count += 1;
                 cursor -= 1;

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1,5 +1,5 @@
 use super::*;
-use shuck_ast::PatternGroupKind;
+use shuck_ast::{HeredocBody, HeredocBodyPart, HeredocBodyPartNode, PatternGroupKind};
 
 #[derive(Debug, Default)]
 pub(super) struct SurfaceFragmentFacts {
@@ -215,10 +215,21 @@ impl<'a> SurfaceFragmentSink<'a> {
         if context.collect_open_double_quotes && context.assignment_target.is_none() {
             self.collect_open_double_quote_fragments(word);
         }
-        self.collect_raw_word_substring_expansions_in_span(word.span);
-        self.collect_raw_word_replacement_expansions_in_span(word.span);
-        self.collect_raw_word_case_modifications_in_span(word.span);
         self.collect_word_parts(&word.parts, context);
+    }
+
+    pub(super) fn collect_heredoc_body(
+        &mut self,
+        body: &HeredocBody,
+        context: SurfaceScanContext<'_>,
+    ) {
+        self.collect_single_quoted_fragments_in_heredoc_body_parts(&body.parts, context);
+        collect_unicode_smart_quote_spans_in_heredoc_body_parts(
+            &body.parts,
+            self.source,
+            &mut self.facts.unicode_smart_quote_spans,
+        );
+        self.collect_heredoc_body_parts(&body.parts, context);
     }
 
     pub(super) fn record_unset_array_target_word(&mut self, word: &Word) {
@@ -263,6 +274,48 @@ impl<'a> SurfaceFragmentSink<'a> {
                 self.facts
                     .suspect_closing_quotes
                     .push(SuspectClosingQuoteFragmentFact { span });
+            }
+        }
+    }
+
+    fn collect_single_quoted_fragments_in_heredoc_body_parts(
+        &mut self,
+        parts: &[HeredocBodyPartNode],
+        context: SurfaceScanContext<'_>,
+    ) {
+        let mut open_quote = None;
+
+        for part in parts {
+            let HeredocBodyPart::Literal(text) = &part.kind else {
+                continue;
+            };
+            let text = text.as_str(self.source, part.span);
+            let mut quote_scan_offset = 0usize;
+
+            while let Some(relative_quote_offset) = text[quote_scan_offset..].find('\'') {
+                let quote_offset = quote_scan_offset + relative_quote_offset;
+                let quote_start = part.span.start.advanced_by(&text[..quote_offset]);
+                let quote_end = quote_start.advanced_by("'");
+
+                if let Some(open_start) = open_quote.take() {
+                    self.facts.single_quoted.push(SingleQuotedFragmentFact {
+                        span: Span::from_positions(open_start, quote_end),
+                        dollar_quoted: false,
+                        command_name: context
+                            .command_name
+                            .map(str::to_owned)
+                            .map(String::into_boxed_str),
+                        assignment_target: context
+                            .assignment_target
+                            .map(str::to_owned)
+                            .map(String::into_boxed_str),
+                        variable_set_operand: context.variable_set_operand,
+                    });
+                } else {
+                    open_quote = Some(quote_start);
+                }
+
+                quote_scan_offset = quote_offset + '\''.len_utf8();
             }
         }
     }
@@ -364,73 +417,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 }
                 WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
                 WordPart::Parameter(parameter) => {
-                    if is_nested_parameter_expansion(parameter, self.source) {
-                        self.facts
-                            .nested_parameter_expansions
-                            .push(NestedParameterExpansionFragmentFact { span: part.span });
-                    }
-                    if parameter_has_array_reference(parameter) {
-                        self.record_array_reference(part.span);
-                    }
-                    if parameter_has_substring_expansion(parameter) {
-                        self.record_substring_expansion(parameter.span);
-                    }
-                    if parameter_has_case_modification(parameter) {
-                        self.record_case_modification(parameter.span);
-                    }
-                    if parameter_has_replacement_expansion(parameter) {
-                        self.record_replacement_expansion(parameter.span);
-                    }
-                    if parameter_has_star_glob_removal(parameter) {
-                        self.record_star_glob_removal(parameter.span);
-                    }
-                    self.record_parameter_subscripts(parameter);
-                    if let ParameterExpansionSyntax::Bourne(syntax) = &parameter.syntax {
-                        if matches!(
-                            syntax,
-                            BourneParameterExpansion::Indirect { .. }
-                                | BourneParameterExpansion::PrefixMatch { .. }
-                                | BourneParameterExpansion::Indices { .. }
-                        ) {
-                            self.facts
-                                .indirect_expansions
-                                .push(IndirectExpansionFragmentFact {
-                                    span: part.span,
-                                    array_keys: matches!(
-                                        syntax,
-                                        BourneParameterExpansion::Indices { .. }
-                                    ),
-                                });
-                        }
-                        match syntax {
-                            BourneParameterExpansion::Operation {
-                                operator,
-                                operand,
-                                operand_word_ast,
-                                ..
-                            }
-                            | BourneParameterExpansion::Indirect {
-                                operator: Some(operator),
-                                operand,
-                                operand_word_ast,
-                                ..
-                            } => {
-                                self.collect_parameter_operator_patterns(
-                                    operator,
-                                    operand.as_ref(),
-                                    operand_word_ast.as_ref(),
-                                    context,
-                                );
-                            }
-                            BourneParameterExpansion::Access { .. }
-                            | BourneParameterExpansion::Length { .. }
-                            | BourneParameterExpansion::Indices { .. }
-                            | BourneParameterExpansion::Indirect { operator: None, .. }
-                            | BourneParameterExpansion::PrefixMatch { .. }
-                            | BourneParameterExpansion::Slice { .. }
-                            | BourneParameterExpansion::Transformation { .. } => {}
-                        }
-                    }
+                    self.collect_parameter_expansion(parameter, part.span, context);
                 }
                 WordPart::Variable(name)
                     if name.as_str() == "$"
@@ -557,6 +544,89 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
+    fn collect_heredoc_body_parts(
+        &mut self,
+        parts: &[HeredocBodyPartNode],
+        context: SurfaceScanContext<'_>,
+    ) {
+        for (index, part) in parts.iter().enumerate() {
+            if let HeredocBodyPart::Variable(name) = &part.kind
+                && matches!(
+                    name.as_str(),
+                    "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+                )
+                && let Some(next_part) = parts.get(index + 1)
+                && let HeredocBodyPart::Literal(text) = &next_part.kind
+                && text
+                    .as_str(self.source, next_part.span)
+                    .starts_with(|char: char| char.is_ascii_digit())
+            {
+                self.facts
+                    .positional_parameters
+                    .push(PositionalParameterFragmentFact {
+                        span: part.span.merge(next_part.span),
+                    });
+            }
+
+            match &part.kind {
+                HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
+                HeredocBodyPart::CommandSubstitution {
+                    syntax: CommandSubstitutionSyntax::Backtick,
+                    ..
+                } => {
+                    if self.opening_backtick_is_escaped(part.span) {
+                        continue;
+                    }
+                    self.facts
+                        .backticks
+                        .push(BacktickFragmentFact { span: part.span });
+                }
+                HeredocBodyPart::CommandSubstitution { .. } => {}
+                HeredocBodyPart::ArithmeticExpansion {
+                    expression,
+                    syntax: ArithmeticExpansionSyntax::LegacyBracket,
+                    expression_ast,
+                    ..
+                } => {
+                    self.facts
+                        .legacy_arithmetic
+                        .push(LegacyArithmeticFragmentFact { span: part.span });
+                    collect_positional_parameter_operator_spans_in_arithmetic(
+                        part.span,
+                        expression,
+                        self.source,
+                        &mut self.facts.positional_parameter_operator_spans,
+                    );
+                    if let Some(expression_ast) = expression_ast.as_ref() {
+                        query::visit_arithmetic_words(expression_ast, &mut |word| {
+                            self.collect_word(word, context);
+                        });
+                    }
+                }
+                HeredocBodyPart::ArithmeticExpansion {
+                    expression,
+                    expression_ast,
+                    ..
+                } => {
+                    collect_positional_parameter_operator_spans_in_arithmetic(
+                        part.span,
+                        expression,
+                        self.source,
+                        &mut self.facts.positional_parameter_operator_spans,
+                    );
+                    if let Some(expression_ast) = expression_ast.as_ref() {
+                        query::visit_arithmetic_words(expression_ast, &mut |word| {
+                            self.collect_word(word, context);
+                        });
+                    }
+                }
+                HeredocBodyPart::Parameter(parameter) => {
+                    self.collect_parameter_expansion(parameter, part.span, context);
+                }
+            }
+        }
+    }
+
     pub(super) fn collect_pattern(&mut self, pattern: &Pattern, context: SurfaceScanContext<'_>) {
         for (part, span) in pattern.parts_with_spans() {
             match part {
@@ -595,122 +665,11 @@ impl<'a> SurfaceFragmentSink<'a> {
             return;
         }
 
-        self.collect_raw_word_substring_expansions_in_span(text.span());
-        self.collect_raw_word_case_modifications_in_span(text.span());
-        self.collect_raw_word_replacement_expansions_in_span(text.span());
         if let Some(word) = word {
             self.collect_word(word, context.without_open_double_quote_scan());
         } else {
             let word = Parser::parse_word_fragment(self.source, snippet, text.span());
             self.collect_word(&word, context.without_open_double_quote_scan());
-        }
-    }
-
-    fn collect_raw_word_substring_expansions_in_span(&mut self, span: Span) {
-        let snippet = span.slice(self.source);
-        let mut search_start = 0;
-
-        while let Some((start, end)) =
-            next_word_parameter_expansion_candidate(snippet, search_start)
-        {
-            let candidate = &snippet[start..end];
-            if is_plain_substring_expansion_text(candidate) {
-                let span = Span::from_positions(
-                    span.start.advanced_by(&snippet[..start]),
-                    span.start.advanced_by(&snippet[..end]),
-                );
-                self.record_substring_expansion(span);
-            }
-            search_start = end;
-        }
-    }
-
-    fn collect_raw_substring_expansions_in_span(&mut self, span: Span) {
-        let snippet = span.slice(self.source);
-        let mut search_start = 0;
-
-        while let Some((start, end)) = next_parameter_expansion_candidate(snippet, search_start) {
-            let candidate = &snippet[start..end];
-            if is_plain_substring_expansion_text(candidate) {
-                let span = Span::from_positions(
-                    span.start.advanced_by(&snippet[..start]),
-                    span.start.advanced_by(&snippet[..end]),
-                );
-                self.record_substring_expansion(span);
-            }
-            search_start = end;
-        }
-    }
-
-    fn collect_raw_word_case_modifications_in_span(&mut self, span: Span) {
-        let snippet = span.slice(self.source);
-        let mut search_start = 0;
-
-        while let Some((start, end)) =
-            next_word_parameter_expansion_candidate(snippet, search_start)
-        {
-            let candidate = &snippet[start..end];
-            if is_plain_case_modification_text(candidate) {
-                let span = Span::from_positions(
-                    span.start.advanced_by(&snippet[..start]),
-                    span.start.advanced_by(&snippet[..end]),
-                );
-                self.record_case_modification(span);
-            }
-            search_start = end;
-        }
-    }
-
-    fn collect_raw_case_modifications_in_span(&mut self, span: Span) {
-        let snippet = span.slice(self.source);
-        let mut search_start = 0;
-
-        while let Some((start, end)) = next_parameter_expansion_candidate(snippet, search_start) {
-            let candidate = &snippet[start..end];
-            if is_plain_case_modification_text(candidate) {
-                let span = Span::from_positions(
-                    span.start.advanced_by(&snippet[..start]),
-                    span.start.advanced_by(&snippet[..end]),
-                );
-                self.record_case_modification(span);
-            }
-            search_start = end;
-        }
-    }
-
-    fn collect_raw_word_replacement_expansions_in_span(&mut self, span: Span) {
-        let snippet = span.slice(self.source);
-        let mut search_start = 0;
-
-        while let Some((start, end)) =
-            next_word_parameter_expansion_candidate(snippet, search_start)
-        {
-            let candidate = &snippet[start..end];
-            if is_plain_replacement_expansion_text(candidate) {
-                let span = Span::from_positions(
-                    span.start.advanced_by(&snippet[..start]),
-                    span.start.advanced_by(&snippet[..end]),
-                );
-                self.record_replacement_expansion(span);
-            }
-            search_start = end;
-        }
-    }
-
-    fn collect_raw_replacement_expansions_in_span(&mut self, span: Span) {
-        let snippet = span.slice(self.source);
-        let mut search_start = 0;
-
-        while let Some((start, end)) = next_parameter_expansion_candidate(snippet, search_start) {
-            let candidate = &snippet[start..end];
-            if is_plain_replacement_expansion_text(candidate) {
-                let span = Span::from_positions(
-                    span.start.advanced_by(&snippet[..start]),
-                    span.start.advanced_by(&snippet[..end]),
-                );
-                self.record_replacement_expansion(span);
-            }
-            search_start = end;
         }
     }
 
@@ -737,12 +696,84 @@ impl<'a> SurfaceFragmentSink<'a> {
                 None => {
                     let heredoc = redirect.heredoc().expect("expected heredoc redirect");
                     if heredoc.delimiter.expands_body {
-                        self.collect_raw_substring_expansions_in_span(heredoc.body.span);
-                        self.collect_raw_case_modifications_in_span(heredoc.body.span);
-                        self.collect_raw_replacement_expansions_in_span(heredoc.body.span);
-                        self.collect_word(&heredoc.body, context.without_open_double_quote_scan());
+                        self.collect_heredoc_body(
+                            &heredoc.body,
+                            context.without_open_double_quote_scan(),
+                        );
                     }
                 }
+            }
+        }
+    }
+
+    fn collect_parameter_expansion(
+        &mut self,
+        parameter: &shuck_ast::ParameterExpansion,
+        span: Span,
+        context: SurfaceScanContext<'_>,
+    ) {
+        if is_nested_parameter_expansion(parameter, self.source) {
+            self.facts
+                .nested_parameter_expansions
+                .push(NestedParameterExpansionFragmentFact { span });
+        }
+        if parameter_has_array_reference(parameter) {
+            self.record_array_reference(span);
+        }
+        if parameter_has_substring_expansion(parameter) {
+            self.record_substring_expansion(parameter.span);
+        }
+        if parameter_has_case_modification(parameter) {
+            self.record_case_modification(parameter.span);
+        }
+        if parameter_has_replacement_expansion(parameter) {
+            self.record_replacement_expansion(parameter.span);
+        }
+        if parameter_has_star_glob_removal(parameter) {
+            self.record_star_glob_removal(parameter.span);
+        }
+        self.record_parameter_subscripts(parameter);
+        if let ParameterExpansionSyntax::Bourne(syntax) = &parameter.syntax {
+            if matches!(
+                syntax,
+                BourneParameterExpansion::Indirect { .. }
+                    | BourneParameterExpansion::PrefixMatch { .. }
+                    | BourneParameterExpansion::Indices { .. }
+            ) {
+                self.facts
+                    .indirect_expansions
+                    .push(IndirectExpansionFragmentFact {
+                        span,
+                        array_keys: matches!(syntax, BourneParameterExpansion::Indices { .. }),
+                    });
+            }
+            match syntax {
+                BourneParameterExpansion::Operation {
+                    operator,
+                    operand,
+                    operand_word_ast,
+                    ..
+                }
+                | BourneParameterExpansion::Indirect {
+                    operator: Some(operator),
+                    operand,
+                    operand_word_ast,
+                    ..
+                } => {
+                    self.collect_parameter_operator_patterns(
+                        operator,
+                        operand.as_ref(),
+                        operand_word_ast.as_ref(),
+                        context,
+                    );
+                }
+                BourneParameterExpansion::Access { .. }
+                | BourneParameterExpansion::Length { .. }
+                | BourneParameterExpansion::Indices { .. }
+                | BourneParameterExpansion::Indirect { operator: None, .. }
+                | BourneParameterExpansion::PrefixMatch { .. }
+                | BourneParameterExpansion::Slice { .. }
+                | BourneParameterExpansion::Transformation { .. } => {}
             }
         }
     }
@@ -1181,83 +1212,6 @@ fn next_parameter_expansion_candidate(text: &str, search_start: usize) -> Option
     None
 }
 
-fn next_word_parameter_expansion_candidate(
-    text: &str,
-    search_start: usize,
-) -> Option<(usize, usize)> {
-    let bytes = text.as_bytes();
-    let mut index = search_start;
-
-    while index + 1 < bytes.len() {
-        match bytes[index] {
-            b'\\' => {
-                index += 2;
-            }
-            b'$' if bytes[index + 1] == b'\'' => {
-                index += 2;
-                while index < bytes.len() {
-                    match bytes[index] {
-                        b'\\' => {
-                            index += 2;
-                        }
-                        b'\'' => {
-                            index += 1;
-                            break;
-                        }
-                        _ => {
-                            index += 1;
-                        }
-                    }
-                }
-            }
-            b'\'' => {
-                index += 1;
-                while index < bytes.len() {
-                    if bytes[index] == b'\'' {
-                        index += 1;
-                        break;
-                    }
-                    index += 1;
-                }
-            }
-            b'$' if bytes[index + 1] == b'{' => {
-                let start = index;
-                index += 2;
-                let mut depth = 1;
-
-                while index < bytes.len() {
-                    match bytes[index] {
-                        b'\\' => {
-                            index += 2;
-                        }
-                        b'$' if index + 1 < bytes.len() && bytes[index + 1] == b'{' => {
-                            depth += 1;
-                            index += 2;
-                        }
-                        b'}' => {
-                            depth -= 1;
-                            index += 1;
-                            if depth == 0 {
-                                return Some((start, index));
-                            }
-                        }
-                        _ => {
-                            index += 1;
-                        }
-                    }
-                }
-
-                return None;
-            }
-            _ => {
-                index += 1;
-            }
-        }
-    }
-
-    None
-}
-
 fn collect_positional_parameter_operator_spans_in_arithmetic(
     expansion_span: Span,
     expression: &SourceText,
@@ -1522,6 +1476,26 @@ fn collect_unicode_smart_quote_spans_in_word_parts(
                 collect_unicode_smart_quote_spans_in_word_parts(parts, source, true, spans)
             }
             _ => {}
+        }
+    }
+}
+
+fn collect_unicode_smart_quote_spans_in_heredoc_body_parts(
+    parts: &[HeredocBodyPartNode],
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for part in parts {
+        if let HeredocBodyPart::Literal(text) = &part.kind {
+            let literal = text.as_str(source, part.span);
+            for (offset, char) in literal.char_indices() {
+                if !is_unicode_smart_quote(char) {
+                    continue;
+                }
+                let start = part.span.start.advanced_by(&literal[..offset]);
+                let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
+                spans.push(Span::from_positions(start, end));
+            }
         }
     }
 }

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -1,8 +1,8 @@
 use shuck_ast::{
     ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
     BinaryCommand, BinaryOp, BuiltinCommand, Command, CompoundCommand, ConditionalExpr,
-    DeclOperand, FunctionDef, Pattern, PatternPart, Redirect, Stmt, StmtSeq, Subscript, VarRef,
-    Word, WordPart, WordPartNode, ZshGlobSegment,
+    DeclOperand, FunctionDef, HeredocBodyPartNode, Pattern, PatternPart, Redirect, Stmt, StmtSeq,
+    Subscript, VarRef, Word, WordPart, WordPartNode, ZshGlobSegment,
 };
 use shuck_parser::parser::Parser;
 
@@ -716,7 +716,13 @@ fn collect_redirect_visits<'a, F>(
     F: FnMut(CommandVisit<'a>, CommandTraversalContext),
 {
     for redirect in redirects {
-        collect_word_visits(redirect_walk_word(redirect), options, context, visitor);
+        if let Some(word) = redirect.word_target() {
+            collect_word_visits(word, options, context, visitor);
+        } else if let Some(heredoc) = redirect.heredoc()
+            && heredoc.delimiter.expands_body
+        {
+            collect_heredoc_body_part_visits(&heredoc.body.parts, options, context, visitor);
+        }
     }
 }
 
@@ -764,10 +770,36 @@ fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
     }
 }
 
-fn redirect_walk_word(redirect: &Redirect) -> &Word {
-    match redirect.word_target() {
-        Some(word) => word,
-        None => &redirect.heredoc().expect("expected heredoc redirect").body,
+fn collect_heredoc_body_part_visits<'a, F>(
+    parts: &'a [HeredocBodyPartNode],
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
+    if !options.descend_nested_word_commands {
+        return;
+    }
+
+    for part in parts {
+        match &part.kind {
+            shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
+                if let Some(expression_ast) = expression_ast.as_ref() {
+                    let mut arithmetic_words = Vec::new();
+                    collect_optional_arithmetic_words(Some(expression_ast), &mut arithmetic_words);
+                    for word in arithmetic_words {
+                        collect_word_visits(word, options, context, visitor);
+                    }
+                }
+            }
+            shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
+                collect_command_visits(body, options, context, visitor);
+            }
+            shuck_ast::HeredocBodyPart::Literal(_)
+            | shuck_ast::HeredocBodyPart::Variable(_)
+            | shuck_ast::HeredocBodyPart::Parameter(_) => {}
+        }
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -338,6 +338,11 @@ mod tests {
     }
 
     #[test]
+    fn ignores_escaped_single_quotes_inside_tab_stripped_heredoc_bodies() {
+        assert_eq!(c005("cat <<-EOF\n\t\\'$HOME\\'\nEOF\n"), 0);
+    }
+
+    #[test]
     fn ignores_single_quotes_paired_across_heredoc_newlines() {
         assert_eq!(c005("cat <<EOF\n'$HOME\nstill here'\nEOF\n"), 0);
     }

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -333,6 +333,16 @@ mod tests {
     }
 
     #[test]
+    fn ignores_escaped_single_quotes_inside_heredoc_bodies() {
+        assert_eq!(c005("cat <<EOF\n\\'$HOME\\'\nEOF\n"), 0);
+    }
+
+    #[test]
+    fn ignores_single_quotes_paired_across_heredoc_newlines() {
+        assert_eq!(c005("cat <<EOF\n'$HOME\nstill here'\nEOF\n"), 0);
+    }
+
+    #[test]
     fn ignores_single_quoted_sequences_inside_quoted_heredoc_bodies() {
         assert_eq!(c005("cat <<'EOF'\n'$HOME'\nEOF\n"), 0);
     }

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -1,8 +1,8 @@
 use rustc_hash::FxHashMap;
 use shuck_ast::{
     ArrayElem, Assignment, AssignmentValue, BuiltinCommand, Command, CompoundCommand,
-    ConditionalExpr, DeclOperand, File, FunctionDef, Pattern, PatternPart, Redirect, Span, Stmt,
-    StmtSeq, TextSize, Word, WordPart, WordPartNode,
+    ConditionalExpr, DeclOperand, File, FunctionDef, HeredocBodyPartNode, Pattern, PatternPart,
+    Redirect, Span, Stmt, StmtSeq, TextSize, Word, WordPart, WordPartNode,
 };
 
 use crate::Rule;
@@ -434,11 +434,36 @@ where
     F: FnMut(Span),
 {
     for redirect in redirects {
-        let word = match redirect.word_target() {
-            Some(word) => word,
-            None => &redirect.heredoc().expect("expected heredoc redirect").body,
-        };
-        walk_word(word, visit);
+        if let Some(word) = redirect.word_target() {
+            walk_word(word, visit);
+        } else if let Some(heredoc) = redirect.heredoc()
+            && heredoc.delimiter.expands_body
+        {
+            walk_heredoc_body_parts(&heredoc.body.parts, visit);
+        }
+    }
+}
+
+fn walk_heredoc_body_parts<F>(parts: &[HeredocBodyPartNode], visit: &mut F)
+where
+    F: FnMut(Span),
+{
+    for part in parts {
+        match &part.kind {
+            shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
+                if let Some(expression_ast) = expression_ast.as_ref() {
+                    query::visit_arithmetic_words(expression_ast, &mut |word| {
+                        walk_word(word, visit);
+                    });
+                }
+            }
+            shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
+                walk_commands(body, visit)
+            }
+            shuck_ast::HeredocBodyPart::Literal(_)
+            | shuck_ast::HeredocBodyPart::Variable(_)
+            | shuck_ast::HeredocBodyPart::Parameter(_) => {}
+        }
     }
 }
 

--- a/crates/shuck-parser/src/parser/heredocs.rs
+++ b/crates/shuck-parser/src/parser/heredocs.rs
@@ -69,7 +69,7 @@ impl<'a> Parser<'a> {
         };
 
         let body = if quoted {
-            Word::quoted_literal_with_span(content, content_span)
+            HeredocBody::literal_with_span(content, content_span).with_source_backed(!strip_tabs)
         } else {
             self.decode_heredoc_body_text(&content, content_span, !strip_tabs)
         };

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2042,7 +2042,7 @@ impl<'a> Parser<'a> {
                 expression_ast,
                 syntax,
             },
-            WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(parameter),
+            WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(Box::new(parameter)),
             other => panic!("unsupported heredoc body part: {other:?}"),
         };
 

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -36,17 +36,17 @@ use shuck_ast::{
     ConditionalParenExpr, ConditionalUnaryExpr, ConditionalUnaryOp,
     ContinueCommand as AstContinueCommand, CoprocCommand, DeclClause as AstDeclClause, DeclOperand,
     ExitCommand as AstExitCommand, File, ForCommand, ForSyntax, ForTarget, ForeachCommand,
-    ForeachSyntax, FunctionDef, FunctionHeader, FunctionHeaderEntry, Heredoc, HeredocDelimiter,
-    IfCommand, IfSyntax, LiteralText, Name, ParameterExpansion, ParameterExpansionSyntax,
-    ParameterOp, Pattern, PatternGroupKind, PatternPart, PatternPartNode, Position,
-    PrefixMatchKind, Redirect, RedirectKind, RedirectTarget, RepeatCommand, RepeatSyntax,
-    ReturnCommand as AstReturnCommand, SelectCommand, SimpleCommand as AstSimpleCommand,
-    SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript, SubscriptInterpretation,
-    SubscriptKind, SubscriptSelector, TextSize, TimeCommand, TokenKind, UntilCommand, VarRef,
-    WhileCommand, Word, WordPart, WordPartNode, ZshDefaultingOp, ZshExpansionOperation,
-    ZshExpansionTarget, ZshGlobQualifier, ZshGlobQualifierGroup, ZshGlobQualifierKind,
-    ZshGlobSegment, ZshInlineGlobControl, ZshModifier, ZshParameterExpansion, ZshPatternOp,
-    ZshQualifiedGlob, ZshReplacementOp, ZshTrimOp,
+    ForeachSyntax, FunctionDef, FunctionHeader, FunctionHeaderEntry, Heredoc, HeredocBody,
+    HeredocBodyMode, HeredocBodyPart, HeredocBodyPartNode, HeredocDelimiter, IfCommand, IfSyntax,
+    LiteralText, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
+    PatternGroupKind, PatternPart, PatternPartNode, Position, PrefixMatchKind, Redirect,
+    RedirectKind, RedirectTarget, RepeatCommand, RepeatSyntax, ReturnCommand as AstReturnCommand,
+    SelectCommand, SimpleCommand as AstSimpleCommand, SourceText, Span, Stmt, StmtSeq,
+    StmtTerminator, Subscript, SubscriptInterpretation, SubscriptKind, SubscriptSelector, TextSize,
+    TimeCommand, TokenKind, UntilCommand, VarRef, WhileCommand, Word, WordPart, WordPartNode,
+    ZshDefaultingOp, ZshExpansionOperation, ZshExpansionTarget, ZshGlobQualifier,
+    ZshGlobQualifierGroup, ZshGlobQualifierKind, ZshGlobSegment, ZshInlineGlobControl, ZshModifier,
+    ZshParameterExpansion, ZshPatternOp, ZshQualifiedGlob, ZshReplacementOp, ZshTrimOp,
 };
 
 use crate::error::{Error, Result};
@@ -2011,6 +2011,44 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn heredoc_body_with_parts(
+        &self,
+        parts: Vec<HeredocBodyPartNode>,
+        span: Span,
+        mode: HeredocBodyMode,
+        source_backed: bool,
+    ) -> HeredocBody {
+        HeredocBody {
+            mode,
+            source_backed,
+            parts,
+            span,
+        }
+    }
+
+    fn heredoc_body_part_from_word_part_node(part: WordPartNode) -> HeredocBodyPartNode {
+        let kind = match part.kind {
+            WordPart::Literal(text) => HeredocBodyPart::Literal(text),
+            WordPart::Variable(name) => HeredocBodyPart::Variable(name),
+            WordPart::CommandSubstitution { body, syntax } => {
+                HeredocBodyPart::CommandSubstitution { body, syntax }
+            }
+            WordPart::ArithmeticExpansion {
+                expression,
+                expression_ast,
+                syntax,
+            } => HeredocBodyPart::ArithmeticExpansion {
+                expression,
+                expression_ast,
+                syntax,
+            },
+            WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(parameter),
+            other => panic!("unsupported heredoc body part: {other:?}"),
+        };
+
+        HeredocBodyPartNode::new(kind, part.span)
+    }
+
     fn brace_syntax_from_parts(&self, parts: &[WordPartNode], offset: usize) -> Vec<BraceSyntax> {
         if !self.brace_syntax_enabled_at(offset) {
             return Vec::new();
@@ -3718,6 +3756,13 @@ impl<'a> Parser<'a> {
         Self::rebase_word_parts(&mut word.parts, base);
     }
 
+    fn rebase_heredoc_body(body: &mut HeredocBody, base: Position) {
+        body.span = body.span.rebased(base);
+        for part in &mut body.parts {
+            Self::rebase_heredoc_body_part(part, base);
+        }
+    }
+
     fn rebase_pattern(pattern: &mut Pattern, base: Position) {
         pattern.span = pattern.span.rebased(base);
         Self::rebase_pattern_parts(&mut pattern.parts, base);
@@ -3737,6 +3782,29 @@ impl<'a> Parser<'a> {
                 PatternPart::Group { patterns, .. } => Self::rebase_patterns(patterns, base),
                 PatternPart::Word(word) => Self::rebase_word(word, base),
                 PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => {}
+            }
+        }
+    }
+
+    fn rebase_heredoc_body_part(part: &mut HeredocBodyPartNode, base: Position) {
+        part.span = part.span.rebased(base);
+        match &mut part.kind {
+            HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
+            HeredocBodyPart::CommandSubstitution { body, .. } => Self::rebase_stmt_seq(body, base),
+            HeredocBodyPart::ArithmeticExpansion {
+                expression,
+                expression_ast,
+                ..
+            } => {
+                expression.rebased(base);
+                if let Some(expr) = expression_ast {
+                    Self::rebase_arithmetic_expr(expr, base);
+                }
+            }
+            HeredocBodyPart::Parameter(parameter) => {
+                parameter.span = parameter.span.rebased(base);
+                parameter.raw_body.rebased(base);
+                Self::rebase_parameter_expansion_syntax(&mut parameter.syntax, base);
             }
         }
     }
@@ -5350,7 +5418,7 @@ impl<'a> Parser<'a> {
                 RedirectTarget::Heredoc(heredoc) => {
                     heredoc.delimiter.span = heredoc.delimiter.span.rebased(base);
                     Self::rebase_word(&mut heredoc.delimiter.raw, base);
-                    Self::rebase_word(&mut heredoc.body, base);
+                    Self::rebase_heredoc_body(&mut heredoc.body, base);
                 }
             }
         }

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -204,7 +204,7 @@ fn test_heredoc_target_preserves_body_span() {
     let redirect = &stmt.redirects[0];
     let heredoc = redirect_heredoc(redirect);
     assert_eq!(heredoc.body.span.slice(input), "hello $name\n");
-    assert!(is_fully_quoted(&heredoc.body));
+    assert!(heredoc_body_is_literal(&heredoc.body));
 }
 
 #[test]
@@ -272,7 +272,10 @@ fn test_backslash_escaped_heredoc_delimiter_is_treated_as_quoted_static_text() {
         assert!(heredoc.delimiter.quoted, "dialect: {dialect:?}");
         assert!(!heredoc.delimiter.expands_body, "dialect: {dialect:?}");
         assert!(!heredoc.delimiter.strip_tabs, "dialect: {dialect:?}");
-        assert!(is_fully_quoted(&heredoc.body), "dialect: {dialect:?}");
+        assert!(
+            heredoc_body_is_literal(&heredoc.body),
+            "dialect: {dialect:?}"
+        );
         assert_eq!(heredoc.body.render(input), "hello $name\n");
     }
 }
@@ -319,7 +322,7 @@ EOF
 
     assert!(heredoc.delimiter.quoted);
     assert!(!heredoc.delimiter.expands_body);
-    assert!(is_fully_quoted(&heredoc.body));
+    assert!(heredoc_body_is_literal(&heredoc.body));
 }
 
 #[test]
@@ -399,7 +402,7 @@ END
     let heredoc = redirect_heredoc(&body[0].redirects[0]);
     assert!(heredoc.delimiter.quoted);
     assert!(!heredoc.delimiter.expands_body);
-    assert!(is_fully_quoted(&heredoc.body));
+    assert!(heredoc_body_is_literal(&heredoc.body));
 }
 
 #[test]
@@ -481,7 +484,7 @@ END
     let heredoc = redirect_heredoc(&body[0].redirects[0]);
     assert!(heredoc.delimiter.quoted);
     assert!(!heredoc.delimiter.expands_body);
-    assert!(is_fully_quoted(&heredoc.body));
+    assert!(heredoc_body_is_literal(&heredoc.body));
 }
 
 #[test]
@@ -506,21 +509,21 @@ fn test_heredoc_targets_preserve_quoted_and_unquoted_decode_behavior() {
     let script = Parser::new(input).parse().unwrap().file;
 
     let unquoted_target = &redirect_heredoc(&script.body[0].redirects[0]).body;
-    assert!(!is_fully_quoted(unquoted_target));
+    assert!(!heredoc_body_is_literal(unquoted_target));
     assert_eq!(unquoted_target.render(input), "hello $name\n");
-    let unquoted_slices = top_level_part_slices(unquoted_target, input);
+    let unquoted_slices = heredoc_top_level_part_slices(unquoted_target, input);
     assert_eq!(unquoted_slices, vec!["hello ", "$name", "\n"]);
     assert!(matches!(
         unquoted_target.parts[1].kind,
-        WordPart::Variable(_)
+        shuck_ast::HeredocBodyPart::Variable(_)
     ));
 
     let quoted_target = &redirect_heredoc(&script.body[1].redirects[0]).body;
-    assert!(is_fully_quoted(quoted_target));
+    assert!(heredoc_body_is_literal(quoted_target));
     assert_eq!(quoted_target.render(input), "hello $name\n");
     assert!(matches!(
         quoted_target.parts.as_slice(),
-        [part] if matches!(&part.kind, WordPart::SingleQuoted { .. })
+        [part] if matches!(&part.kind, shuck_ast::HeredocBodyPart::Literal(_))
     ));
 }
 
@@ -531,13 +534,44 @@ fn test_unquoted_heredoc_body_preserves_multiple_quoted_fragments() {
 
     let body = &redirect_heredoc(&script.body[0].redirects[0]).body;
 
-    assert!(!is_fully_quoted(body));
+    assert!(!heredoc_body_is_literal(body));
     assert_eq!(
-        top_level_part_slices(body, input),
-        vec!["before ", "'$HOME'", " and ", "\"$USER\"", "\n"]
+        heredoc_top_level_part_slices(body, input),
+        vec!["before '", "$HOME", "' and \"", "$USER", "\"\n"]
     );
-    assert!(matches!(body.parts[1].kind, WordPart::SingleQuoted { .. }));
-    assert!(matches!(body.parts[3].kind, WordPart::DoubleQuoted { .. }));
+    assert!(matches!(
+        body.parts[1].kind,
+        shuck_ast::HeredocBodyPart::Variable(_)
+    ));
+    assert!(matches!(
+        body.parts[3].kind,
+        shuck_ast::HeredocBodyPart::Variable(_)
+    ));
+}
+
+#[test]
+fn test_unquoted_heredoc_body_keeps_dollar_quoted_forms_literal() {
+    let input = "cat <<EOF\n$'line\\n' $\"hello\" ${name}\nEOF\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let body = &redirect_heredoc(&script.body[0].redirects[0]).body;
+
+    assert_eq!(
+        heredoc_top_level_part_slices(body, input),
+        vec!["$'line\\n' ", "$\"hello\" ", "${name}", "\n"]
+    );
+    assert!(matches!(
+        body.parts[0].kind,
+        shuck_ast::HeredocBodyPart::Literal(_)
+    ));
+    assert!(matches!(
+        body.parts[1].kind,
+        shuck_ast::HeredocBodyPart::Literal(_)
+    ));
+    assert!(matches!(
+        body.parts[2].kind,
+        shuck_ast::HeredocBodyPart::Parameter(_)
+    ));
 }
 
 #[test]
@@ -557,15 +591,25 @@ EOF
     let script = Parser::new(input).parse().unwrap().file;
 
     let body = &redirect_heredoc(&script.body[0].redirects[0]).body;
-    let slices = top_level_part_slices(body, input);
+    let slices = heredoc_top_level_part_slices(body, input);
 
     assert!(
-        slices.contains(&"\"$CRCsum\""),
-        "expected heredoc body to keep $CRCsum inside a live fragment: {slices:?}"
+        body.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                shuck_ast::HeredocBodyPart::Variable(name) if name.as_str() == "CRCsum"
+            )
+        }),
+        "expected heredoc body to keep $CRCsum live: {slices:?}"
     );
     assert!(
-        slices.contains(&"\"$archdirname\""),
-        "expected heredoc body to keep $archdirname inside a live fragment: {slices:?}"
+        body.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                shuck_ast::HeredocBodyPart::Variable(name) if name.as_str() == "archdirname"
+            )
+        }),
+        "expected heredoc body to keep $archdirname live: {slices:?}"
     );
 }
 
@@ -580,7 +624,7 @@ fn test_unquoted_heredoc_body_leaves_unmatched_single_quote_literal() {
         !body
             .parts
             .iter()
-            .any(|part| matches!(part.kind, WordPart::SingleQuoted { .. }))
+            .any(|part| matches!(part.kind, shuck_ast::HeredocBodyPart::Parameter(_)))
     );
     assert_eq!(body.render_syntax(input), "'$HOME\n");
 }
@@ -593,9 +637,18 @@ fn test_strip_tabs_heredoc_body_preserves_single_quoted_fragments() {
     let heredoc = redirect_heredoc(&script.body[0].redirects[0]);
 
     assert!(heredoc.delimiter.strip_tabs);
+    assert_eq!(heredoc.body.parts.len(), 3);
     assert!(matches!(
         heredoc.body.parts[0].kind,
-        WordPart::SingleQuoted { .. }
+        shuck_ast::HeredocBodyPart::Literal(_)
+    ));
+    assert!(matches!(
+        heredoc.body.parts[1].kind,
+        shuck_ast::HeredocBodyPart::Variable(_)
+    ));
+    assert!(matches!(
+        heredoc.body.parts[2].kind,
+        shuck_ast::HeredocBodyPart::Literal(_)
     ));
     assert_eq!(heredoc.body.render_syntax(input), "'$HOME'\n");
 }

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -4,13 +4,18 @@ use shuck_ast::{
     ArithmeticBinaryOp, ArithmeticPostfixOp, ArithmeticUnaryOp, BackgroundOperator, BinaryCommand,
     BourneParameterExpansion, BuiltinCommand as AstBuiltinCommand, Command as AstCommand,
     CompoundCommand as AstCompoundCommand, ForSyntax, ForeachSyntax, FunctionDef as AstFunctionDef,
-    IfSyntax, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, PrefixMatchKind,
-    RepeatSyntax, SimpleCommand as AstSimpleCommand, SourceText, StmtTerminator, ZshDefaultingOp,
-    ZshExpansionOperation, ZshExpansionTarget, ZshPatternOp, ZshReplacementOp, ZshTrimOp,
+    HeredocBody, HeredocBodyMode, IfSyntax, Name, ParameterExpansion, ParameterExpansionSyntax,
+    ParameterOp, PrefixMatchKind, RepeatSyntax, SimpleCommand as AstSimpleCommand, SourceText,
+    StmtTerminator, ZshDefaultingOp, ZshExpansionOperation, ZshExpansionTarget, ZshPatternOp,
+    ZshReplacementOp, ZshTrimOp,
 };
 
 fn is_fully_quoted(word: &Word) -> bool {
     word.is_fully_quoted()
+}
+
+fn heredoc_body_is_literal(body: &HeredocBody) -> bool {
+    body.mode == HeredocBodyMode::Literal
 }
 
 fn pattern_part_slices<'a>(pattern: &'a Pattern, input: &'a str) -> Vec<&'a str> {
@@ -23,6 +28,13 @@ fn pattern_part_slices<'a>(pattern: &'a Pattern, input: &'a str) -> Vec<&'a str>
 
 fn top_level_part_slices<'a>(word: &'a Word, input: &'a str) -> Vec<&'a str> {
     word.parts
+        .iter()
+        .map(|part| part.span.slice(input))
+        .collect()
+}
+
+fn heredoc_top_level_part_slices<'a>(body: &'a HeredocBody, input: &'a str) -> Vec<&'a str> {
+    body.parts
         .iter()
         .map(|part| part.span.slice(input))
         .collect()

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1421,6 +1421,36 @@ fn test_array_target_parameter_operations_normalize_to_bourne_operations() {
 }
 
 #[test]
+fn test_case_modification_operands_consume_nested_parameter_expansions() {
+    let input = "echo ${name^^${pat}} ${arr[1],,${pat}}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+
+    let (_, upper_operator, upper_operand) =
+        expect_parameter_operation_part(&command.args[0].parts[0].kind);
+    assert!(matches!(upper_operator, ParameterOp::UpperAll));
+    assert_eq!(
+        upper_operand
+            .expect("expected upper case-modification operand")
+            .slice(input),
+        "${pat}"
+    );
+
+    let (lower_reference, lower_operator, lower_operand) =
+        expect_parameter_operation_part(&command.args[1].parts[0].kind);
+    expect_subscript(lower_reference, input, "1");
+    assert!(matches!(lower_operator, ParameterOp::LowerAll));
+    assert_eq!(
+        lower_operand
+            .expect("expected lower case-modification operand")
+            .slice(input),
+        "${pat}"
+    );
+}
+
+#[test]
 fn test_parameter_expansion_trim_operand_accepts_literal_left_brace_after_multiline_quote() {
     let input = "dns_servercow_info='ServerCow.de\nSite: ServerCow.de\n'\n\nf(){\n  if true; then\n    txtvalue_old=${response#*{\\\"name\\\":\\\"\"$_sub_domain\"\\\",\\\"ttl\\\":20,\\\"type\\\":\\\"TXT\\\",\\\"content\\\":\\\"}\n  fi\n}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1390,6 +1390,37 @@ fn test_parameter_expansion_operand_stays_source_backed() {
 }
 
 #[test]
+fn test_array_target_parameter_operations_normalize_to_bourne_operations() {
+    let input = "echo ${arr[0]//x/y} ${arr[@],,} ${arr[1]^^pattern}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+
+    let (replace_reference, replace_operator, _) =
+        expect_parameter_operation_part(&command.args[0].parts[0].kind);
+    expect_subscript(replace_reference, input, "0");
+    assert!(matches!(replace_operator, ParameterOp::ReplaceAll { .. }));
+
+    let (lower_reference, lower_operator, lower_operand) =
+        expect_parameter_operation_part(&command.args[1].parts[0].kind);
+    expect_subscript(lower_reference, input, "@");
+    assert!(matches!(lower_operator, ParameterOp::LowerAll));
+    assert!(lower_operand.is_none());
+
+    let (upper_reference, upper_operator, upper_operand) =
+        expect_parameter_operation_part(&command.args[2].parts[0].kind);
+    expect_subscript(upper_reference, input, "1");
+    assert!(matches!(upper_operator, ParameterOp::UpperAll));
+    assert_eq!(
+        upper_operand
+            .expect("expected case-modification operand")
+            .slice(input),
+        "pattern"
+    );
+}
+
+#[test]
 fn test_parameter_expansion_trim_operand_accepts_literal_left_brace_after_multiline_quote() {
     let input = "dns_servercow_info='ServerCow.de\nSite: ServerCow.de\n'\n\nf(){\n  if true; then\n    txtvalue_old=${response#*{\\\"name\\\":\\\"\"$_sub_domain\"\\\",\\\"ttl\\\":20,\\\"type\\\":\\\"TXT\\\",\\\"content\\\":\\\"}\n  fi\n}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -530,6 +530,8 @@ impl<'a> Parser<'a> {
             span.start,
             text.is_source_backed(),
             true,
+            true,
+            false,
             &mut parts,
         );
         PatternParser::from_word_parts(self.input, &parts, span).parse()
@@ -2448,7 +2450,15 @@ impl<'a> Parser<'a> {
         source_backed: bool,
         parts: &mut Vec<WordPartNode>,
     ) {
-        self.decode_word_parts_into_with_quote_fragments(s, base, source_backed, false, parts);
+        self.decode_word_parts_into_with_quote_fragments(
+            s,
+            base,
+            source_backed,
+            false,
+            true,
+            false,
+            parts,
+        );
     }
 
     pub(super) fn decode_word_parts_into_with_quote_fragments(
@@ -2457,6 +2467,8 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
         preserve_quote_fragments: bool,
+        parse_dollar_quotes: bool,
+        preserve_escaped_expansion_literals: bool,
         parts: &mut Vec<WordPartNode>,
     ) {
         let mut chars = s.chars().peekable();
@@ -2481,6 +2493,18 @@ impl<'a> Parser<'a> {
             if preserve_quote_fragments
                 && ch == '\\'
                 && matches!(chars.peek().copied(), Some('\'' | '"'))
+            {
+                if current.is_empty() {
+                    current_start = part_start;
+                }
+                current.push(ch);
+                current.push(Self::next_word_char_unwrap(&mut chars, &mut cursor));
+                continue;
+            }
+
+            if preserve_escaped_expansion_literals
+                && ch == '\\'
+                && matches!(chars.peek().copied(), Some('$' | '`' | '\\'))
             {
                 if current.is_empty() {
                     current_start = part_start;
@@ -2699,7 +2723,7 @@ impl<'a> Parser<'a> {
 
             self.flush_literal_part(parts, &mut current, current_start, part_start);
 
-            if chars.peek() == Some(&'\'') {
+            if parse_dollar_quotes && chars.peek() == Some(&'\'') {
                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
                 let mut ansi = String::new();
                 while let Some(c) = Self::next_word_char(&mut chars, &mut cursor) {
@@ -2740,7 +2764,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if chars.peek() == Some(&'"') {
+            if parse_dollar_quotes && chars.peek() == Some(&'"') {
                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
                 let content_start = cursor;
                 let mut content = (!source_backed).then(String::new);
@@ -3500,6 +3524,167 @@ impl<'a> Parser<'a> {
                                 operand: Some(operand),
                                 colon_variant: false,
                             }
+                        } else if next_c == '#' {
+                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                            let longest = Self::consume_word_char_if(&mut chars, &mut cursor, '#');
+                            let operand_text =
+                                self.read_brace_operand(&mut chars, &mut cursor, source_backed);
+                            let pattern = self.pattern_from_source_text(&operand_text);
+                            let operator = if longest {
+                                ParameterOp::RemovePrefixLong { pattern }
+                            } else {
+                                ParameterOp::RemovePrefixShort { pattern }
+                            };
+                            WordPart::ParameterExpansion {
+                                reference: self.parameter_var_ref(
+                                    part_start,
+                                    "${",
+                                    &var_name,
+                                    Some(subscript),
+                                    cursor,
+                                ),
+                                operator,
+                                operand: None,
+                                colon_variant: false,
+                            }
+                        } else if next_c == '%' {
+                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                            let longest = Self::consume_word_char_if(&mut chars, &mut cursor, '%');
+                            let operand_text =
+                                self.read_brace_operand(&mut chars, &mut cursor, source_backed);
+                            let pattern = self.pattern_from_source_text(&operand_text);
+                            let operator = if longest {
+                                ParameterOp::RemoveSuffixLong { pattern }
+                            } else {
+                                ParameterOp::RemoveSuffixShort { pattern }
+                            };
+                            WordPart::ParameterExpansion {
+                                reference: self.parameter_var_ref(
+                                    part_start,
+                                    "${",
+                                    &var_name,
+                                    Some(subscript),
+                                    cursor,
+                                ),
+                                operator,
+                                operand: None,
+                                colon_variant: false,
+                            }
+                        } else if next_c == '/' {
+                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                            let replace_all =
+                                Self::consume_word_char_if(&mut chars, &mut cursor, '/');
+                            let pattern_text = self.read_replacement_pattern(
+                                &mut chars,
+                                &mut cursor,
+                                source_backed,
+                            );
+                            let pattern = self.pattern_from_source_text(&pattern_text);
+                            let replacement =
+                                if Self::consume_word_char_if(&mut chars, &mut cursor, '/') {
+                                    self.read_source_text_while(
+                                        &mut chars,
+                                        &mut cursor,
+                                        |ch| ch != '}',
+                                        source_backed,
+                                    )
+                                } else {
+                                    self.empty_source_text(cursor)
+                                };
+                            Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                            let operator = if replace_all {
+                                ParameterOp::ReplaceAll {
+                                    pattern,
+                                    replacement_word_ast: self
+                                        .parse_source_text_as_word(&replacement),
+                                    replacement,
+                                }
+                            } else {
+                                ParameterOp::ReplaceFirst {
+                                    pattern,
+                                    replacement_word_ast: self
+                                        .parse_source_text_as_word(&replacement),
+                                    replacement,
+                                }
+                            };
+                            WordPart::ParameterExpansion {
+                                reference: self.parameter_var_ref(
+                                    part_start,
+                                    "${",
+                                    &var_name,
+                                    Some(subscript),
+                                    cursor,
+                                ),
+                                operator,
+                                operand: None,
+                                colon_variant: false,
+                            }
+                        } else if next_c == '^' {
+                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                            let operator =
+                                if Self::consume_word_char_if(&mut chars, &mut cursor, '^') {
+                                    ParameterOp::UpperAll
+                                } else {
+                                    ParameterOp::UpperFirst
+                                };
+                            let operand =
+                                if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
+                                    None
+                                } else {
+                                    let operand = self.read_source_text_while(
+                                        &mut chars,
+                                        &mut cursor,
+                                        |ch| ch != '}',
+                                        source_backed,
+                                    );
+                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                                    Some(operand)
+                                };
+                            WordPart::ParameterExpansion {
+                                reference: self.parameter_var_ref(
+                                    part_start,
+                                    "${",
+                                    &var_name,
+                                    Some(subscript),
+                                    cursor,
+                                ),
+                                operator,
+                                operand,
+                                colon_variant: false,
+                            }
+                        } else if next_c == ',' {
+                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                            let operator =
+                                if Self::consume_word_char_if(&mut chars, &mut cursor, ',') {
+                                    ParameterOp::LowerAll
+                                } else {
+                                    ParameterOp::LowerFirst
+                                };
+                            let operand =
+                                if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
+                                    None
+                                } else {
+                                    let operand = self.read_source_text_while(
+                                        &mut chars,
+                                        &mut cursor,
+                                        |ch| ch != '}',
+                                        source_backed,
+                                    );
+                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                                    Some(operand)
+                                };
+                            WordPart::ParameterExpansion {
+                                reference: self.parameter_var_ref(
+                                    part_start,
+                                    "${",
+                                    &var_name,
+                                    Some(subscript),
+                                    cursor,
+                                ),
+                                operator,
+                                operand,
+                                colon_variant: false,
+                            }
                         } else if next_c == '@' {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             if chars.peek().is_some() {
@@ -3748,12 +3933,24 @@ impl<'a> Parser<'a> {
                                 } else {
                                     ParameterOp::UpperFirst
                                 };
-                            Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                            let operand =
+                                if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
+                                    None
+                                } else {
+                                    let operand = self.read_source_text_while(
+                                        &mut chars,
+                                        &mut cursor,
+                                        |ch| ch != '}',
+                                        source_backed,
+                                    );
+                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                                    Some(operand)
+                                };
                             WordPart::ParameterExpansion {
                                 reference: self
                                     .parameter_var_ref(part_start, "${", &var_name, None, cursor),
                                 operator,
-                                operand: None,
+                                operand,
                                 colon_variant: false,
                             }
                         }
@@ -3765,12 +3962,24 @@ impl<'a> Parser<'a> {
                                 } else {
                                     ParameterOp::LowerFirst
                                 };
-                            Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                            let operand =
+                                if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
+                                    None
+                                } else {
+                                    let operand = self.read_source_text_while(
+                                        &mut chars,
+                                        &mut cursor,
+                                        |ch| ch != '}',
+                                        source_backed,
+                                    );
+                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                                    Some(operand)
+                                };
                             WordPart::ParameterExpansion {
                                 reference: self
                                     .parameter_var_ref(part_start, "${", &var_name, None, cursor),
                                 operator,
-                                operand: None,
+                                operand,
                                 colon_variant: false,
                             }
                         }
@@ -3937,9 +4146,10 @@ impl<'a> Parser<'a> {
         if source_backed {
             let mut end = *cursor;
             let mut has_escaped_slash = false;
+            let mut nested_parameter_depth = 0usize;
 
             while let Some(&ch) = chars.peek() {
-                if ch == '/' || ch == '}' {
+                if nested_parameter_depth == 0 && (ch == '/' || ch == '}') {
                     end = *cursor;
                     break;
                 }
@@ -3952,6 +4162,25 @@ impl<'a> Parser<'a> {
                         has_escaped_slash = true;
                         Self::next_word_char_unwrap(chars, cursor);
                     }
+                    end = *cursor;
+                    continue;
+                }
+
+                if ch == '$' {
+                    let mut lookahead = chars.clone();
+                    lookahead.next();
+                    if lookahead.peek() == Some(&'{') {
+                        Self::next_word_char_unwrap(chars, cursor);
+                        Self::next_word_char_unwrap(chars, cursor);
+                        nested_parameter_depth += 1;
+                        end = *cursor;
+                        continue;
+                    }
+                }
+
+                if ch == '}' && nested_parameter_depth > 0 {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    nested_parameter_depth -= 1;
                     end = *cursor;
                     continue;
                 }
@@ -3969,8 +4198,9 @@ impl<'a> Parser<'a> {
         } else {
             let mut pattern = String::new();
             let mut end = *cursor;
+            let mut nested_parameter_depth = 0usize;
             while let Some(&ch) = chars.peek() {
-                if ch == '/' || ch == '}' {
+                if nested_parameter_depth == 0 && (ch == '/' || ch == '}') {
                     end = *cursor;
                     break;
                 }
@@ -3984,6 +4214,23 @@ impl<'a> Parser<'a> {
                         continue;
                     }
                     pattern.push('\\');
+                    end = *cursor;
+                    continue;
+                }
+                if ch == '$' {
+                    let mut lookahead = chars.clone();
+                    lookahead.next();
+                    if lookahead.peek() == Some(&'{') {
+                        pattern.push(Self::next_word_char_unwrap(chars, cursor));
+                        pattern.push(Self::next_word_char_unwrap(chars, cursor));
+                        nested_parameter_depth += 1;
+                        end = *cursor;
+                        continue;
+                    }
+                }
+                if ch == '}' && nested_parameter_depth > 0 {
+                    pattern.push(Self::next_word_char_unwrap(chars, cursor));
+                    nested_parameter_depth -= 1;
                     end = *cursor;
                     continue;
                 }
@@ -4014,7 +4261,15 @@ impl<'a> Parser<'a> {
         source_backed: bool,
     ) -> Word {
         let mut parts = Vec::new();
-        self.decode_word_parts_into_with_quote_fragments(s, base, source_backed, true, &mut parts);
+        self.decode_word_parts_into_with_quote_fragments(
+            s,
+            base,
+            source_backed,
+            true,
+            true,
+            false,
+            &mut parts,
+        );
         self.word_with_parts(parts, span)
     }
 
@@ -4023,24 +4278,22 @@ impl<'a> Parser<'a> {
         s: &str,
         span: Span,
         source_backed: bool,
-    ) -> Word {
+    ) -> HeredocBody {
         let mut parts = Vec::new();
-        let mut line_start = span.start;
-
-        for line in s.split_inclusive('\n') {
-            let line_end = line_start.advanced_by(line);
-            let line_span = Span::from_positions(line_start, line_end);
-            let line_word = self.decode_word_text_preserving_quotes_if_needed(
-                line,
-                line_span,
-                line_start,
-                source_backed,
-            );
-            parts.extend(line_word.parts);
-            line_start = line_end;
-        }
-
-        self.word_with_parts(parts, span)
+        self.decode_word_parts_into_with_quote_fragments(
+            s,
+            span.start,
+            source_backed,
+            false,
+            false,
+            true,
+            &mut parts,
+        );
+        let parts = parts
+            .into_iter()
+            .map(Self::heredoc_body_part_from_word_part_node)
+            .collect();
+        self.heredoc_body_with_parts(parts, span, HeredocBodyMode::Expanding, source_backed)
     }
 
     pub(super) fn parse_word_with_context(

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3639,14 +3639,11 @@ impl<'a> Parser<'a> {
                                 if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
                                     None
                                 } else {
-                                    let operand = self.read_source_text_while(
+                                    Some(self.read_brace_operand(
                                         &mut chars,
                                         &mut cursor,
-                                        |ch| ch != '}',
                                         source_backed,
-                                    );
-                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                    Some(operand)
+                                    ))
                                 };
                             WordPart::ParameterExpansion {
                                 reference: self.parameter_var_ref(
@@ -3672,14 +3669,11 @@ impl<'a> Parser<'a> {
                                 if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
                                     None
                                 } else {
-                                    let operand = self.read_source_text_while(
+                                    Some(self.read_brace_operand(
                                         &mut chars,
                                         &mut cursor,
-                                        |ch| ch != '}',
                                         source_backed,
-                                    );
-                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                    Some(operand)
+                                    ))
                                 };
                             WordPart::ParameterExpansion {
                                 reference: self.parameter_var_ref(
@@ -3945,14 +3939,11 @@ impl<'a> Parser<'a> {
                                 if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
                                     None
                                 } else {
-                                    let operand = self.read_source_text_while(
+                                    Some(self.read_brace_operand(
                                         &mut chars,
                                         &mut cursor,
-                                        |ch| ch != '}',
                                         source_backed,
-                                    );
-                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                    Some(operand)
+                                    ))
                                 };
                             WordPart::ParameterExpansion {
                                 reference: self
@@ -3974,14 +3965,11 @@ impl<'a> Parser<'a> {
                                 if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
                                     None
                                 } else {
-                                    let operand = self.read_source_text_while(
+                                    Some(self.read_brace_operand(
                                         &mut chars,
                                         &mut cursor,
-                                        |ch| ch != '}',
                                         source_backed,
-                                    );
-                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                    Some(operand)
+                                    ))
                                 };
                             WordPart::ParameterExpansion {
                                 reference: self

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -37,6 +37,13 @@ struct ParsedWordTarget {
     boundary: WordTargetBoundary,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct DecodeWordPartsOptions {
+    preserve_quote_fragments: bool,
+    parse_dollar_quotes: bool,
+    preserve_escaped_expansion_literals: bool,
+}
+
 impl<'a> PatternParser<'a> {
     fn new(input: &'a str, word: &'a Word) -> Self {
         Self::from_word_parts_with_mode(input, &word.parts, word.span, PatternParseMode::Standard)
@@ -529,9 +536,11 @@ impl<'a> Parser<'a> {
             text.slice(self.input),
             span.start,
             text.is_source_backed(),
-            true,
-            true,
-            false,
+            DecodeWordPartsOptions {
+                preserve_quote_fragments: true,
+                parse_dollar_quotes: true,
+                ..DecodeWordPartsOptions::default()
+            },
             &mut parts,
         );
         PatternParser::from_word_parts(self.input, &parts, span).parse()
@@ -2454,9 +2463,10 @@ impl<'a> Parser<'a> {
             s,
             base,
             source_backed,
-            false,
-            true,
-            false,
+            DecodeWordPartsOptions {
+                parse_dollar_quotes: true,
+                ..DecodeWordPartsOptions::default()
+            },
             parts,
         );
     }
@@ -2466,9 +2476,7 @@ impl<'a> Parser<'a> {
         s: &str,
         base: Position,
         source_backed: bool,
-        preserve_quote_fragments: bool,
-        parse_dollar_quotes: bool,
-        preserve_escaped_expansion_literals: bool,
+        options: DecodeWordPartsOptions,
         parts: &mut Vec<WordPartNode>,
     ) {
         let mut chars = s.chars().peekable();
@@ -2490,7 +2498,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if preserve_quote_fragments
+            if options.preserve_quote_fragments
                 && ch == '\\'
                 && matches!(chars.peek().copied(), Some('\'' | '"'))
             {
@@ -2502,7 +2510,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if preserve_escaped_expansion_literals
+            if options.preserve_escaped_expansion_literals
                 && ch == '\\'
                 && matches!(chars.peek().copied(), Some('$' | '`' | '\\'))
             {
@@ -2514,7 +2522,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if preserve_quote_fragments && ch == '\'' {
+            if options.preserve_quote_fragments && ch == '\'' {
                 self.flush_literal_part(parts, &mut current, current_start, part_start);
 
                 let content_start = cursor;
@@ -2571,7 +2579,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if preserve_quote_fragments && ch == '"' {
+            if options.preserve_quote_fragments && ch == '"' {
                 self.flush_literal_part(parts, &mut current, current_start, part_start);
 
                 let content_start = cursor;
@@ -2723,7 +2731,7 @@ impl<'a> Parser<'a> {
 
             self.flush_literal_part(parts, &mut current, current_start, part_start);
 
-            if parse_dollar_quotes && chars.peek() == Some(&'\'') {
+            if options.parse_dollar_quotes && chars.peek() == Some(&'\'') {
                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
                 let mut ansi = String::new();
                 while let Some(c) = Self::next_word_char(&mut chars, &mut cursor) {
@@ -2764,7 +2772,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if parse_dollar_quotes && chars.peek() == Some(&'"') {
+            if options.parse_dollar_quotes && chars.peek() == Some(&'"') {
                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
                 let content_start = cursor;
                 let mut content = (!source_backed).then(String::new);
@@ -4265,9 +4273,11 @@ impl<'a> Parser<'a> {
             s,
             base,
             source_backed,
-            true,
-            true,
-            false,
+            DecodeWordPartsOptions {
+                preserve_quote_fragments: true,
+                parse_dollar_quotes: true,
+                ..DecodeWordPartsOptions::default()
+            },
             &mut parts,
         );
         self.word_with_parts(parts, span)
@@ -4284,9 +4294,10 @@ impl<'a> Parser<'a> {
             s,
             span.start,
             source_backed,
-            false,
-            false,
-            true,
+            DecodeWordPartsOptions {
+                preserve_escaped_expansion_literals: true,
+                ..DecodeWordPartsOptions::default()
+            },
             &mut parts,
         );
         let parts = parts

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -3,10 +3,10 @@ use shuck_ast::{
     AnonymousFunctionCommand, ArithmeticAssignOp, ArithmeticExpr, ArithmeticExprNode,
     ArithmeticLvalue, ArithmeticUnaryOp, ArrayElem, ArrayExpr, ArrayKind, Assignment,
     AssignmentValue, BinaryCommand, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command,
-    CompoundCommand, ConditionalExpr, DeclOperand, File, FunctionDef, Name, ParameterExpansion,
-    ParameterExpansionSyntax, ParameterOp, Pattern, PatternGroupKind, PatternPart, PatternPartNode,
-    Span, Stmt, StmtSeq, Subscript, VarRef, Word, WordPart, WordPartNode, ZshExpansionOperation,
-    ZshExpansionTarget, ZshGlobSegment,
+    CompoundCommand, ConditionalExpr, DeclOperand, File, FunctionDef, HeredocBody, HeredocBodyPart,
+    HeredocBodyPartNode, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
+    PatternGroupKind, PatternPart, PatternPartNode, Span, Stmt, StmtSeq, Subscript, VarRef, Word,
+    WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::{ShellProfile, ZshEmulationMode, parser::Parser};
@@ -1109,7 +1109,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 None => {
                     let heredoc = redirect.heredoc().expect("expected heredoc redirect");
                     if heredoc.delimiter.expands_body {
-                        self.visit_word_into(
+                        self.visit_heredoc_body_into(
                             &heredoc.body,
                             WordVisitKind::Expansion,
                             flow,
@@ -1143,6 +1143,19 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             return;
         }
         self.visit_word_part_nodes(&word.parts, kind, flow, nested_regions);
+    }
+
+    fn visit_heredoc_body_into(
+        &mut self,
+        body: &HeredocBody,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        if !body.mode.expands() || heredoc_body_is_semantically_inert(body) {
+            return;
+        }
+        self.visit_heredoc_body_part_nodes(&body.parts, kind, flow, nested_regions);
     }
 
     fn visit_pattern_into(
@@ -1179,6 +1192,18 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     ) {
         for part in parts {
             self.visit_pattern_part(&part.kind, kind, flow, nested_regions);
+        }
+    }
+
+    fn visit_heredoc_body_part_nodes(
+        &mut self,
+        parts: &[HeredocBodyPartNode],
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        for part in parts {
+            self.visit_heredoc_body_part(&part.kind, part.span, kind, flow, nested_regions);
         }
     }
 
@@ -1472,6 +1497,59 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     nested_regions,
                     span,
                 );
+            }
+        }
+    }
+
+    fn visit_heredoc_body_part(
+        &mut self,
+        part: &HeredocBodyPart,
+        span: Span,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match part {
+            HeredocBodyPart::Literal(_) => {}
+            HeredocBodyPart::Variable(name) => {
+                self.add_reference(
+                    name,
+                    if matches!(kind, WordVisitKind::Conditional) {
+                        ReferenceKind::ConditionalOperand
+                    } else {
+                        ReferenceKind::Expansion
+                    },
+                    span,
+                );
+            }
+            HeredocBodyPart::CommandSubstitution { body, .. } => {
+                let scope =
+                    self.push_scope(ScopeKind::CommandSubstitution, self.current_scope(), span);
+                let mut commands = Vec::with_capacity(body.len());
+                self.visit_stmt_seq_into(
+                    body,
+                    FlowState {
+                        in_subshell: true,
+                        ..flow
+                    },
+                    &mut commands,
+                );
+                self.pop_scope(scope);
+                self.mark_scope_completed(scope);
+                nested_regions.push(IsolatedRegion {
+                    scope,
+                    commands: self.recorded_program.push_command_ids(commands),
+                });
+            }
+            HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
+                self.visit_optional_arithmetic_expr_into(
+                    expression_ast.as_ref(),
+                    flow,
+                    nested_regions,
+                );
+            }
+            HeredocBodyPart::Parameter(parameter) => {
+                self.visit_parameter_expansion(parameter, kind, flow, nested_regions, span);
             }
         }
     }
@@ -3463,6 +3541,12 @@ fn word_is_semantically_inert(word: &Word) -> bool {
         .all(|part| word_part_is_semantically_inert(&part.kind))
 }
 
+fn heredoc_body_is_semantically_inert(body: &HeredocBody) -> bool {
+    body.parts
+        .iter()
+        .all(|part| heredoc_body_part_is_semantically_inert(&part.kind))
+}
+
 fn word_part_is_semantically_inert(part: &WordPart) -> bool {
     match part {
         WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
@@ -3485,6 +3569,16 @@ fn word_part_is_semantically_inert(part: &WordPart) -> bool {
         | WordPart::PrefixMatch { .. }
         | WordPart::ProcessSubstitution { .. }
         | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn heredoc_body_part_is_semantically_inert(part: &HeredocBodyPart) -> bool {
+    match part {
+        HeredocBodyPart::Literal(_) => true,
+        HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => expression_ast.is_none(),
+        HeredocBodyPart::Variable(_)
+        | HeredocBodyPart::CommandSubstitution { .. }
+        | HeredocBodyPart::Parameter(_) => false,
     }
 }
 


### PR DESCRIPTION
This stacks on #146.

## What changed

This replaces `Heredoc.body: Word` with a dedicated heredoc body AST and threads that model through the parser, semantic layer, indexer, formatter, suppression walker, and linter facts.

For expanding heredocs, the parser now keeps quote characters as literal text while still producing typed nodes for live expansions. I also extended parameter-expansion normalization so substring, case-modification, and replacement facts come from typed AST data instead of the old raw `${...}` surface scanners.

## Why

The previous `Word`-based heredoc representation conflated ordinary word quoting semantics with unquoted heredoc body semantics. That forced the linter to recover meaning with low-level raw scanning and made it easy to get incorrect behavior around quoted text, escaped dollars, and parameter-operation detection.

## Impact

The new model makes heredoc semantics explicit in the AST, removes the raw `${...}` fallback scanners from the linter surface-fact pipeline, preserves the existing single-quoted-literal rule behavior for expanding heredocs, and fixes escaped-placeholder handling so generated heredoc text does not produce false undefined-variable reads.

## Validation

- `cargo test -p shuck-parser`
- `cargo test -p shuck-linter`
- `cargo test -p shuck`
- `cargo bench -p shuck-benchmark --bench linter -- --save-baseline=heredoc-body-before`
- `cargo bench -p shuck-benchmark --bench linter -- --baseline=heredoc-body-before`

Criterion summary versus `heredoc-body-before`:
- `linter_facts/all`: no statistically significant change
- `linter/all`: aggregate improvement of about 4.5%
