### PR TITLE
Fix C151 with parser-owned array comma surface

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -9,7 +9,11 @@ use crate::{
     Name,
     span::{Position, Span, TextRange},
 };
-use std::{borrow::Cow, fmt};
+use std::{
+    borrow::Cow,
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
 /// Source-backed text for AST nodes that need stable spans but only occasionally
 /// need owned cooked text.
@@ -2353,21 +2357,85 @@ pub enum ArrayKind {
     Contextual,
 }
 
+/// A compound-array value word plus parser-owned surface metadata.
+#[derive(Debug, Clone)]
+pub struct ArrayValueWord {
+    pub word: Word,
+    pub has_top_level_unquoted_comma: bool,
+}
+
+impl ArrayValueWord {
+    pub fn new(word: Word, has_top_level_unquoted_comma: bool) -> Self {
+        Self {
+            word,
+            has_top_level_unquoted_comma,
+        }
+    }
+
+    pub fn has_top_level_unquoted_comma(&self) -> bool {
+        self.has_top_level_unquoted_comma
+    }
+
+    pub fn span(&self) -> Span {
+        self.word.span
+    }
+}
+
+impl From<Word> for ArrayValueWord {
+    fn from(word: Word) -> Self {
+        Self::new(word, false)
+    }
+}
+
+impl Deref for ArrayValueWord {
+    type Target = Word;
+
+    fn deref(&self) -> &Self::Target {
+        &self.word
+    }
+}
+
+impl DerefMut for ArrayValueWord {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.word
+    }
+}
+
 /// An element inside a compound array literal.
 #[derive(Debug, Clone)]
 pub enum ArrayElem {
-    Sequential(Word),
-    Keyed { key: Subscript, value: Word },
-    KeyedAppend { key: Subscript, value: Word },
+    Sequential(ArrayValueWord),
+    Keyed {
+        key: Subscript,
+        value: ArrayValueWord,
+    },
+    KeyedAppend {
+        key: Subscript,
+        value: ArrayValueWord,
+    },
 }
 
 impl ArrayElem {
     pub fn span(&self) -> Span {
         match self {
-            Self::Sequential(word) => word.span,
+            Self::Sequential(word) => word.span(),
             Self::Keyed { key, value } | Self::KeyedAppend { key, value } => {
-                key.span().merge(value.span)
+                key.span().merge(value.span())
             }
+        }
+    }
+
+    pub fn value(&self) -> &ArrayValueWord {
+        match self {
+            Self::Sequential(word) => word,
+            Self::Keyed { value, .. } | Self::KeyedAppend { value, .. } => value,
+        }
+    }
+
+    pub fn value_mut(&mut self) -> &mut ArrayValueWord {
+        match self {
+            Self::Sequential(word) => word,
+            Self::Keyed { value, .. } | Self::KeyedAppend { value, .. } => value,
         }
     }
 }
@@ -4265,9 +4333,9 @@ mod tests {
             AssignmentValue::Compound(ArrayExpr {
                 kind: ArrayKind::Indexed,
                 elements: vec![
-                    ArrayElem::Sequential(Word::literal("a")),
-                    ArrayElem::Sequential(Word::literal("b")),
-                    ArrayElem::Sequential(Word::literal("c")),
+                    ArrayElem::Sequential(Word::literal("a").into()),
+                    ArrayElem::Sequential(Word::literal("b").into()),
+                    ArrayElem::Sequential(Word::literal("c").into()),
                 ],
                 span: Span::new(),
             }),

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13691,6 +13691,26 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
     }
 
     #[test]
+    fn ignores_commas_inside_backticks_inside_parameter_expansions() {
+        let source = "#!/bin/bash\na=(${x/`echo }`/a,b})\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn summarizes_command_options_and_invokers() {
         let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -type d -name CVS | xargs -iX rm -rf X\nfind . -type d -name CVS | xargs --replace rm -rf {}\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13711,6 +13711,26 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
     }
 
     #[test]
+    fn ignores_commas_inside_process_substitutions_inside_parameter_expansions() {
+        let source = "#!/bin/bash\na=(${x/<(echo })/foo,bar})\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn summarizes_command_options_and_invokers() {
         let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -type d -name CVS | xargs -iX rm -rf X\nfind . -type d -name CVS | xargs --replace rm -rf {}\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12539,101 +12539,11 @@ fn comma_array_assignment_span(assignment: &Assignment, source: &str) -> Option<
 }
 
 fn array_value_has_unquoted_comma(array: &shuck_ast::ArrayExpr, source: &str) -> bool {
-    array.elements.iter().any(|element| match element {
-        ArrayElem::Sequential(word) => word_has_unquoted_array_comma(word, source),
-        ArrayElem::Keyed { value, .. } | ArrayElem::KeyedAppend { value, .. } => {
-            word_has_unquoted_array_comma(value, source)
-        }
-    })
-}
-
-fn word_has_unquoted_array_comma(word: &Word, source: &str) -> bool {
-    word.parts.iter().any(|part| {
-        let WordPart::Literal(text) = &part.kind else {
-            return false;
-        };
-        let text = text.as_str(source, part.span);
-
-        text.char_indices().any(|(index, ch)| {
-            if ch != ',' {
-                return false;
-            }
-
-            let prefix = &text[..index];
-            let comma = part.span.start.advanced_by(prefix);
-            let escaped = trailing_backslashes(prefix) % 2 == 1;
-            !comma_is_brace_separator(word, source, comma.offset, escaped)
-        })
-    })
-}
-
-fn comma_is_brace_separator(word: &Word, source: &str, offset: usize, escaped: bool) -> bool {
-    if escaped {
-        return false;
-    }
-
-    inside_active_brace_expansion(word, offset) || inside_unquoted_brace_group(word, source, offset)
-}
-
-fn inside_active_brace_expansion(word: &Word, offset: usize) -> bool {
-    word.brace_syntax()
+    let _ = source;
+    array
+        .elements
         .iter()
-        .copied()
-        .filter(|brace| brace.expands())
-        .any(|brace| brace.span.start.offset <= offset && offset < brace.span.end.offset)
-}
-
-fn inside_unquoted_brace_group(word: &Word, source: &str, target_offset: usize) -> bool {
-    let text = word.span.slice(source);
-    let mut in_single = false;
-    let mut in_double = false;
-    let mut escaped = false;
-    let mut brace_depth = 0usize;
-
-    for (index, ch) in text.char_indices() {
-        let absolute = word.span.start.offset + index;
-
-        if absolute == target_offset {
-            return brace_depth > 0;
-        }
-
-        if escaped {
-            escaped = false;
-            continue;
-        }
-
-        match ch {
-            '\\' if !in_single => {
-                escaped = true;
-                continue;
-            }
-            '\'' if !in_double => {
-                in_single = !in_single;
-                continue;
-            }
-            '"' if !in_single => {
-                in_double = !in_double;
-                continue;
-            }
-            _ => {}
-        }
-
-        if in_single || in_double {
-            continue;
-        }
-
-        match ch {
-            '{' if !text[..index].ends_with('$') => brace_depth += 1,
-            '}' if brace_depth > 0 => brace_depth -= 1,
-            _ => {}
-        }
-    }
-
-    false
-}
-
-fn trailing_backslashes(text: &str) -> usize {
-    text.chars().rev().take_while(|ch| *ch == '\\').count()
+        .any(|element| element.value().has_top_level_unquoted_comma())
 }
 
 fn compound_assignment_paren_span(assignment: &Assignment, source: &str) -> Option<Span> {
@@ -13358,6 +13268,425 @@ complex[$((i+=1))]+=x
                 "(x\\, y)",
                 "(foo,{x,y},bar)"
             ]
+        );
+    }
+
+    #[test]
+    fn ignores_commas_after_even_backslashes_before_quote_regions() {
+        let source = "#!/bin/bash\na=(x\\\\\",y\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_ansi_c_quoted_array_elements() {
+        let source = "#!/bin/bash\na=($'a\\'b,c')\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_quoted_command_substitution_array_elements() {
+        let source = "#!/bin/bash\nf() {\n\tlocal -a graphql_request=(\n\t\t-X POST\n\t\t-d \"$(\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"\n\t)\n}\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_separator_started_command_substitution_comments() {
+        let source =
+            "#!/bin/bash\na=(\"$(printf '%s' x;# comment with ) and ,\nprintf '%s' y\n)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_grouped_command_substitution_comments() {
+        let source = "#!/bin/bash\na=(\"$( (# comment with )\nprintf %s 1,2\n) )\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_compact_grouped_command_substitution_comments() {
+        let source = "#!/bin/bash\na=(\"$( (#comment with )\nprintf %s 1,2\n) )\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_command_substitution_case_patterns() {
+        let source = "#!/bin/bash\na=(\"$(case $kind in\nalpha) printf %s 1,2 ;;\nesac)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_piped_heredoc_command_substitution_array_elements() {
+        let source = "#!/bin/bash\na=(\"$(cat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_parameter_expansions_with_right_parens_in_command_substitutions() {
+        let source = "#!/bin/bash\na=($(printf %s ${x//foo/)},1))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_parameter_expansions_with_literal_braces() {
+        let source = "#!/bin/bash\na=(${x/a,b/{})\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_parameter_expansions_with_ansi_c_single_quotes() {
+        let source = "#!/bin/bash\na=(${x/$'a\\'b'/c,d})\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_case_pattern_comments_after_right_parens() {
+        let source = "#!/bin/bash\na=($(case $kind in\na)# comment with esac )\nprintf %s 1,2 ;;\nesac\n))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_process_substitution_array_elements() {
+        let source = "#!/bin/bash\na=(<(printf %s 1,2))\nb=(>(printf %s 3,4))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_comments_after_quoted_double_parens() {
+        let source = "#!/bin/bash\na=($(printf '((' # comment with )\nprintf %s 1,2\n))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_arithmetic_shift_command_substitutions() {
+        let source = "#!/bin/bash\na=($( ((x<<2))\nprintf %s 1,2\n))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_multiline_command_substitution_scanner_edge_cases() {
+        let source = "\
+#!/bin/bash
+a=($(printf '((' # comment with )
+printf %s 1,2
+))
+b=($( ((x<<2))
+printf %s 3,4
+))
+c=($( (case $kind in
+a) printf %s 5,6 ;;
+esac
+) ))
+d=(\"$( (#comment with )
+printf %s 7,8
+) )\")
+e=($(printf %s 9,10; echo case in))
+f=($(printf %s $'a\\'b'; printf %s 11,12))
+g=($(printf %s `echo foo)`; printf %s 13,14))
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_nested_case_patterns_in_command_substitutions() {
+        let source = "#!/bin/bash\na=($( (case $kind in\na) printf %s 1,2 ;;\nesac\n) ))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_command_substitutions_with_plain_case_words() {
+        let source = "#!/bin/bash\na=($(printf %s 1,2; echo case in))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_command_substitutions_with_ansi_c_single_quotes() {
+        let source = "#!/bin/bash\na=($(printf %s $'a\\'b'; printf %s 1,2))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_command_substitutions_with_backticks() {
+        let source = "#!/bin/bash\na=($(printf %s `echo foo)`; printf %s 1,2))\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13731,6 +13731,47 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
     }
 
     #[test]
+    fn ignores_commas_after_backticks_inside_parameter_expansions_in_command_substitutions() {
+        let source = "#!/bin/bash\na=(\"$(printf %s ${x/`echo }`/foo)},1)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ignores_commas_after_process_substitutions_inside_parameter_expansions_in_command_substitutions()
+     {
+        let source = "#!/bin/bash\na=(\"$(printf %s ${x/<(echo })/foo)},1)\")\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(
+            facts.comma_array_assignment_spans().is_empty(),
+            "{:#?}",
+            facts
+                .comma_array_assignment_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn summarizes_command_options_and_invokers() {
         let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -type d -name CVS | xargs -iX rm -rf X\nfind . -type d -name CVS | xargs --replace rm -rf {}\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1288,22 +1288,7 @@ impl<'a> Lexer<'a> {
             .rfind('\n')
             .map_or(0, |index| index + 1);
         let prefix = &self.input[line_start..self.offset];
-        let mut chars = prefix.chars().peekable();
-        let mut depth = 0usize;
-
-        while let Some(ch) = chars.next() {
-            if ch == '(' && chars.peek() == Some(&'(') {
-                chars.next();
-                depth += 1;
-                continue;
-            }
-            if ch == ')' && chars.peek() == Some(&')') {
-                chars.next();
-                depth = depth.saturating_sub(1);
-            }
-        }
-
-        depth > 0
+        line_has_unclosed_double_paren(prefix)
     }
 
     /// Check if this is a file descriptor redirect (e.g., 2>, 2>>, 2>&1)
@@ -2404,23 +2389,122 @@ impl<'a> Lexer<'a> {
     fn flush_command_subst_keyword(
         current_word: &mut String,
         pending_case_headers: &mut usize,
-        case_clause_depth: &mut usize,
+        case_clause_depths: &mut Vec<usize>,
+        depth: usize,
+        word_started_at_command_start: &mut bool,
     ) {
         if current_word.is_empty() {
+            *word_started_at_command_start = false;
             return;
         }
 
         match current_word.as_str() {
-            "case" => *pending_case_headers += 1,
+            "case" if *word_started_at_command_start => *pending_case_headers += 1,
             "in" if *pending_case_headers > 0 => {
                 *pending_case_headers -= 1;
-                *case_clause_depth += 1;
+                case_clause_depths.push(depth);
             }
-            "esac" if *case_clause_depth > 0 => *case_clause_depth -= 1,
+            "esac" if *word_started_at_command_start => {
+                case_clause_depths.pop();
+            }
             _ => {}
         }
 
         current_word.clear();
+        *word_started_at_command_start = false;
+    }
+
+    fn read_command_subst_heredoc_delimiter_into(
+        &mut self,
+        content: &mut Option<String>,
+    ) -> Option<String> {
+        while let Some(ch) = self.peek_char() {
+            if !matches!(ch, ' ' | '\t') {
+                break;
+            }
+            Self::push_capture_char(content, ch);
+            self.advance();
+        }
+
+        let mut cooked = String::new();
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+        let mut saw_any = false;
+
+        while let Some(ch) = self.peek_char() {
+            if heredoc_delimiter_is_terminator(ch, in_single, in_double, escaped) {
+                break;
+            }
+
+            saw_any = true;
+            Self::push_capture_char(content, ch);
+            self.advance();
+
+            if escaped {
+                cooked.push(ch);
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' if !in_single => escaped = true,
+                '\'' if !in_double => in_single = !in_single,
+                '"' if !in_single => in_double = !in_double,
+                _ => cooked.push(ch),
+            }
+        }
+
+        saw_any.then_some(cooked)
+    }
+
+    fn read_command_subst_backtick_segment_into(&mut self, content: &mut Option<String>) {
+        Self::push_capture_char(content, '`');
+        self.advance();
+        while let Some(ch) = self.peek_char() {
+            Self::push_capture_char(content, ch);
+            self.advance();
+            if ch == '\\' {
+                if let Some(esc) = self.peek_char() {
+                    Self::push_capture_char(content, esc);
+                    self.advance();
+                }
+                continue;
+            }
+            if ch == '`' {
+                break;
+            }
+        }
+    }
+
+    fn read_command_subst_pending_heredoc_into(
+        &mut self,
+        content: &mut Option<String>,
+        delimiter: &str,
+        strip_tabs: bool,
+    ) -> bool {
+        loop {
+            let mut line = String::new();
+            let mut saw_newline = false;
+
+            while let Some(ch) = self.peek_char() {
+                self.advance();
+                if ch == '\n' {
+                    saw_newline = true;
+                    break;
+                }
+                line.push(ch);
+            }
+
+            Self::push_capture_str(content, &line);
+            if saw_newline {
+                Self::push_capture_char(content, '\n');
+            }
+
+            if heredoc_line_matches_delimiter(&line, delimiter, strip_tabs) || !saw_newline {
+                return true;
+            }
+        }
     }
 
     fn read_command_subst_into_depth(
@@ -2449,23 +2533,42 @@ impl<'a> Lexer<'a> {
         }
 
         let mut depth = 1;
+        let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
         let mut pending_case_headers = 0usize;
-        let mut case_clause_depth = 0usize;
+        let mut case_clause_depths = Vec::new();
         let mut current_word = String::with_capacity(16);
+        let mut at_command_start = true;
+        let mut expecting_redirection_target = false;
+        let mut current_word_started_at_command_start = false;
         while let Some(c) = self.peek_char() {
             match c {
                 '#' if !self.should_treat_hash_as_word_char() => {
+                    let had_word = !current_word.is_empty();
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
                     Self::push_capture_char(content, '#');
                     self.advance();
                     while let Some(comment_ch) = self.peek_char() {
                         Self::push_capture_char(content, comment_ch);
                         self.advance();
                         if comment_ch == '\n' {
+                            for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                                if !self.read_command_subst_pending_heredoc_into(
+                                    content, &delimiter, strip_tabs,
+                                ) {
+                                    return false;
+                                }
+                            }
+                            at_command_start = true;
+                            expecting_redirection_target = false;
                             break;
                         }
                     }
@@ -2474,21 +2577,32 @@ impl<'a> Lexer<'a> {
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
                     );
                     depth += 1;
                     Self::push_capture_char(content, c);
                     self.advance();
+                    at_command_start = true;
+                    expecting_redirection_target = false;
                 }
                 ')' => {
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
                     );
-                    if depth == 1 && case_clause_depth > 0 {
+                    if case_clause_depths
+                        .last()
+                        .is_some_and(|case_depth| *case_depth == depth)
+                    {
                         Self::push_capture_char(content, ')');
                         self.advance();
+                        at_command_start = true;
+                        expecting_redirection_target = false;
                         continue;
                     }
                     depth -= 1;
@@ -2498,13 +2612,21 @@ impl<'a> Lexer<'a> {
                         return true;
                     }
                     Self::push_capture_char(content, c);
+                    at_command_start = false;
+                    expecting_redirection_target = false;
                 }
                 '"' => {
+                    let had_word = !current_word.is_empty();
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
                     // Nested double-quoted string inside $()
                     Self::push_capture_char(content, '"');
                     self.advance();
@@ -2541,13 +2663,24 @@ impl<'a> Lexer<'a> {
                             }
                         }
                     }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
                 }
                 '\'' => {
+                    let had_word = !current_word.is_empty();
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
                     // Single-quoted string inside $()
                     Self::push_capture_char(content, '\'');
                     self.advance();
@@ -2558,29 +2691,206 @@ impl<'a> Lexer<'a> {
                             break;
                         }
                     }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
                 }
-                '\\' => {
+                '`' => {
+                    let had_word = !current_word.is_empty();
                     Self::flush_command_subst_keyword(
                         &mut current_word,
                         &mut pending_case_headers,
-                        &mut case_clause_depth,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
                     );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
+                    self.read_command_subst_backtick_segment_into(content);
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
+                }
+                '$' if self.second_char() == Some('\'') => {
+                    let had_word = !current_word.is_empty();
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
+                    Self::push_capture_char(content, '$');
+                    self.advance();
+                    Self::push_capture_char(content, '\'');
+                    self.advance();
+                    while let Some(qc) = self.peek_char() {
+                        Self::push_capture_char(content, qc);
+                        self.advance();
+                        if qc == '\\' {
+                            if let Some(esc) = self.peek_char() {
+                                Self::push_capture_char(content, esc);
+                                self.advance();
+                            }
+                            continue;
+                        }
+                        if qc == '\'' {
+                            break;
+                        }
+                    }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
+                }
+                '\\' => {
+                    let had_word = !current_word.is_empty();
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
                     Self::push_capture_char(content, '\\');
                     self.advance();
                     if let Some(esc) = self.peek_char() {
                         Self::push_capture_char(content, esc);
                         self.advance();
                     }
+                    if expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    } else {
+                        at_command_start = false;
+                    }
+                }
+                '<' if self.second_char() == Some('<') => {
+                    let word_was_redirection_fd = current_word_started_at_command_start
+                        && !current_word.is_empty()
+                        && current_word.chars().all(|current| current.is_ascii_digit());
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if word_was_redirection_fd {
+                        at_command_start = true;
+                    }
+
+                    Self::push_capture_char(content, '<');
+                    self.advance();
+                    Self::push_capture_char(content, '<');
+                    self.advance();
+
+                    if self.peek_char() == Some('<') {
+                        Self::push_capture_char(content, '<');
+                        self.advance();
+                        expecting_redirection_target = true;
+                        continue;
+                    }
+
+                    let strip_tabs = if self.peek_char() == Some('-') {
+                        Self::push_capture_char(content, '-');
+                        self.advance();
+                        true
+                    } else {
+                        false
+                    };
+
+                    if let Some(delimiter) = self.read_command_subst_heredoc_delimiter_into(content)
+                    {
+                        pending_heredocs.push((delimiter, strip_tabs));
+                        expecting_redirection_target = false;
+                    } else {
+                        expecting_redirection_target = true;
+                    }
+                }
+                '>' | '<' => {
+                    let word_was_redirection_fd = current_word_started_at_command_start
+                        && !current_word.is_empty()
+                        && current_word.chars().all(|current| current.is_ascii_digit());
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if word_was_redirection_fd {
+                        at_command_start = true;
+                    }
+                    Self::push_capture_char(content, c);
+                    self.advance();
+                    expecting_redirection_target = true;
+                }
+                '\n' => {
+                    Self::flush_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    Self::push_capture_char(content, '\n');
+                    self.advance();
+                    for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                        if !self.read_command_subst_pending_heredoc_into(
+                            content, &delimiter, strip_tabs,
+                        ) {
+                            return false;
+                        }
+                    }
+                    at_command_start = true;
+                    expecting_redirection_target = false;
                 }
                 _ => {
                     if c.is_ascii_alphanumeric() || c == '_' {
+                        if current_word.is_empty()
+                            && !expecting_redirection_target
+                            && at_command_start
+                        {
+                            current_word_started_at_command_start = true;
+                            at_command_start = false;
+                        }
                         current_word.push(c);
                     } else {
+                        let had_word = !current_word.is_empty();
                         Self::flush_command_subst_keyword(
                             &mut current_word,
                             &mut pending_case_headers,
-                            &mut case_clause_depth,
+                            &mut case_clause_depths,
+                            depth,
+                            &mut current_word_started_at_command_start,
                         );
+                        if had_word && expecting_redirection_target {
+                            expecting_redirection_target = false;
+                        }
+                        match c {
+                            ' ' | '\t' => {}
+                            ';' | '|' | '&' => {
+                                at_command_start = true;
+                                expecting_redirection_target = false;
+                            }
+                            _ => {
+                                if !expecting_redirection_target {
+                                    at_command_start = false;
+                                }
+                            }
+                        }
                     }
                     Self::push_capture_char(content, c);
                     self.advance();
@@ -3221,12 +3531,680 @@ fn heredoc_line_matches_delimiter(line: &str, delimiter: &str, strip_tabs: bool)
     }
 }
 
+fn next_char_boundary(input: &str, index: usize) -> Option<(char, usize)> {
+    let ch = input.get(index..)?.chars().next()?;
+    Some((ch, index + ch.len_utf8()))
+}
+
+fn line_has_unclosed_double_paren(prefix: &str) -> bool {
+    let mut index = 0usize;
+    let mut depth = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_backtick = false;
+    let mut escaped = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(prefix, index) {
+        let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
+            continue;
+        }
+        escaped = false;
+
+        match ch {
+            '\'' if !in_double && !in_backtick && !was_escaped => in_single = !in_single,
+            '"' if !in_single && !in_backtick && !was_escaped => in_double = !in_double,
+            '`' if !in_single && !in_double && !was_escaped => in_backtick = !in_backtick,
+            '(' if !in_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && prefix[next_index..].starts_with('(') =>
+            {
+                depth += 1;
+                index = next_index + '('.len_utf8();
+                continue;
+            }
+            ')' if !in_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && prefix[next_index..].starts_with(')') =>
+            {
+                depth = depth.saturating_sub(1);
+                index = next_index + ')'.len_utf8();
+                continue;
+            }
+            _ => {}
+        }
+
+        index = next_index;
+    }
+
+    depth > 0
+}
+
+fn inside_unclosed_double_paren_on_line(input: &str, index: usize) -> bool {
+    let line_start = input[..index].rfind('\n').map_or(0, |found| found + 1);
+    let prefix = &input[line_start..index];
+    line_has_unclosed_double_paren(prefix)
+}
+
+fn hash_starts_comment(input: &str, index: usize) -> bool {
+    if inside_unclosed_double_paren_on_line(input, index) {
+        return false;
+    }
+
+    let next = &input[index + '#'.len_utf8()..];
+    input[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|prev| match prev {
+            '(' => {
+                let whitespace_index = next.find(char::is_whitespace);
+                let close_index = next.find(')');
+
+                match (whitespace_index, close_index) {
+                    (Some(whitespace), Some(close)) => whitespace < close,
+                    (Some(_), None) | (None, None) => true,
+                    (None, Some(_)) => false,
+                }
+            }
+            _ => prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | ')'),
+        })
+}
+
+fn heredoc_delimiter_is_terminator(
+    ch: char,
+    in_single: bool,
+    in_double: bool,
+    escaped: bool,
+) -> bool {
+    !in_single
+        && !in_double
+        && !escaped
+        && (ch.is_whitespace() || matches!(ch, '|' | '&' | ';' | '<' | '>' | '(' | ')'))
+}
+
+fn scan_double_quoted_command_substitution_segment(
+    input: &str,
+    mut index: usize,
+    subst_depth: usize,
+) -> Option<usize> {
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        match ch {
+            '"' => return Some(next_index),
+            '\\' => {
+                index = next_index;
+                if let Some((_, escaped_next)) = next_char_boundary(input, index) {
+                    index = escaped_next;
+                }
+            }
+            '$' if input[next_index..].starts_with('{') => {
+                let consumed = scan_command_subst_parameter_expansion_len(
+                    &input[next_index + '{'.len_utf8()..],
+                    subst_depth,
+                )?;
+                index = next_index + '{'.len_utf8() + consumed;
+            }
+            '$' if input[next_index..].starts_with('(')
+                && !input[next_index + '('.len_utf8()..].starts_with('(') =>
+            {
+                let consumed = scan_command_substitution_body_len_inner(
+                    &input[next_index + '('.len_utf8()..],
+                    subst_depth + 1,
+                )?;
+                index = next_index + '('.len_utf8() + consumed;
+            }
+            _ => index = next_index,
+        }
+    }
+
+    None
+}
+
+fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -> Option<usize> {
+    let mut index = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
+            continue;
+        }
+        escaped = false;
+
+        if !in_single && !was_escaped && ch == '$' {
+            if input[next_index..].starts_with('{')
+                && let Some(consumed) = scan_command_subst_parameter_expansion_len(
+                    &input[next_index + '{'.len_utf8()..],
+                    subst_depth,
+                )
+            {
+                index = next_index + '{'.len_utf8() + consumed;
+                continue;
+            }
+
+            if input[next_index..].starts_with('(')
+                && !input[next_index + '('.len_utf8()..].starts_with('(')
+                && let Some(consumed) = scan_command_substitution_body_len_inner(
+                    &input[next_index + '('.len_utf8()..],
+                    subst_depth + 1,
+                )
+            {
+                index = next_index + '('.len_utf8() + consumed;
+                continue;
+            }
+        }
+
+        match ch {
+            '\'' if !in_double && !was_escaped => in_single = !in_single,
+            '"' if !in_single && !was_escaped => in_double = !in_double,
+            '}' if !in_single && !in_double && !was_escaped => return Some(next_index),
+            _ => {}
+        }
+
+        index = next_index;
+    }
+
+    None
+}
+
+fn scan_command_subst_heredoc_delimiter(input: &str, mut index: usize) -> Option<(usize, String)> {
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        if !matches!(ch, ' ' | '\t') {
+            break;
+        }
+        index = next_index;
+    }
+
+    let start = index;
+    let mut cooked = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        if heredoc_delimiter_is_terminator(ch, in_single, in_double, escaped) {
+            break;
+        }
+
+        index = next_index;
+        if escaped {
+            cooked.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if !in_single => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            _ => cooked.push(ch),
+        }
+    }
+
+    (index > start).then_some((index, cooked))
+}
+
+fn skip_command_subst_pending_heredoc(
+    input: &str,
+    mut index: usize,
+    delimiter: &str,
+    strip_tabs: bool,
+) -> usize {
+    while index <= input.len() {
+        let rest = &input[index..];
+        let line_len = rest.find('\n').unwrap_or(rest.len());
+        let line = &rest[..line_len];
+        let has_newline = line_len < rest.len();
+
+        index += line_len;
+        if has_newline {
+            index += '\n'.len_utf8();
+        }
+
+        if heredoc_line_matches_delimiter(line, delimiter, strip_tabs) || !has_newline {
+            return index;
+        }
+    }
+
+    index
+}
+
+fn scan_command_subst_ansi_c_single_quoted_segment(
+    input: &str,
+    quote_index: usize,
+) -> Option<usize> {
+    let mut index = quote_index + '\''.len_utf8();
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        index = next_index;
+        if ch == '\\' {
+            if let Some((_, escaped_next)) = next_char_boundary(input, index) {
+                index = escaped_next;
+            }
+            continue;
+        }
+
+        if ch == '\'' {
+            return Some(index);
+        }
+    }
+
+    None
+}
+
+fn scan_command_subst_backtick_segment(input: &str, start: usize) -> Option<usize> {
+    let mut index = start;
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        index = next_index;
+        if ch == '\\' {
+            if let Some((_, escaped_next)) = next_char_boundary(input, index) {
+                index = escaped_next;
+            }
+            continue;
+        }
+
+        if ch == '`' {
+            return Some(index);
+        }
+    }
+
+    None
+}
+
+fn flush_scanned_command_subst_keyword(
+    current_word: &mut String,
+    pending_case_headers: &mut usize,
+    case_clause_depths: &mut Vec<usize>,
+    depth: usize,
+    word_started_at_command_start: &mut bool,
+) {
+    if current_word.is_empty() {
+        *word_started_at_command_start = false;
+        return;
+    }
+
+    match current_word.as_str() {
+        "case" if *word_started_at_command_start => *pending_case_headers += 1,
+        "in" if *pending_case_headers > 0 => {
+            *pending_case_headers -= 1;
+            case_clause_depths.push(depth);
+        }
+        "esac" if *word_started_at_command_start => {
+            case_clause_depths.pop();
+        }
+        _ => {}
+    }
+
+    current_word.clear();
+    *word_started_at_command_start = false;
+}
+
+fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> Option<usize> {
+    if subst_depth >= DEFAULT_MAX_SUBST_DEPTH {
+        return None;
+    }
+
+    let mut index = 0usize;
+    let mut depth = 1;
+    let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+    let mut pending_case_headers = 0usize;
+    let mut case_clause_depths = Vec::new();
+    let mut current_word = String::with_capacity(16);
+    let mut at_command_start = true;
+    let mut expecting_redirection_target = false;
+    let mut current_word_started_at_command_start = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        match ch {
+            '#' if hash_starts_comment(input, index) => {
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = next_index;
+                while let Some((comment_ch, comment_next)) = next_char_boundary(input, index) {
+                    index = comment_next;
+                    if comment_ch == '\n' {
+                        for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                            index = skip_command_subst_pending_heredoc(
+                                input, index, &delimiter, strip_tabs,
+                            );
+                        }
+                        at_command_start = true;
+                        expecting_redirection_target = false;
+                        break;
+                    }
+                }
+            }
+            '(' => {
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                depth += 1;
+                index = next_index;
+                at_command_start = true;
+                expecting_redirection_target = false;
+            }
+            ')' => {
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if case_clause_depths
+                    .last()
+                    .is_some_and(|case_depth| *case_depth == depth)
+                {
+                    index = next_index;
+                    at_command_start = true;
+                    expecting_redirection_target = false;
+                    continue;
+                }
+                depth -= 1;
+                index = next_index;
+                if depth == 0 {
+                    return Some(index);
+                }
+                at_command_start = false;
+                expecting_redirection_target = false;
+            }
+            '"' => {
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = scan_double_quoted_command_substitution_segment(
+                    input,
+                    next_index,
+                    subst_depth,
+                )?;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '\'' => {
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = next_index;
+                while let Some((quoted_ch, quoted_next)) = next_char_boundary(input, index) {
+                    index = quoted_next;
+                    if quoted_ch == '\'' {
+                        break;
+                    }
+                }
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '`' => {
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = scan_command_subst_backtick_segment(input, next_index)?;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '$' if input[next_index..].starts_with('\'') => {
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = scan_command_subst_ansi_c_single_quoted_segment(input, next_index)?;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '\\' => {
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                index = next_index;
+                if let Some((_, escaped_next)) = next_char_boundary(input, index) {
+                    index = escaped_next;
+                }
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '>' => {
+                let word_was_redirection_fd = current_word_started_at_command_start
+                    && !current_word.is_empty()
+                    && current_word.chars().all(|current| current.is_ascii_digit());
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if word_was_redirection_fd {
+                    at_command_start = true;
+                }
+                index = next_index;
+                expecting_redirection_target = true;
+            }
+            '<' if input[next_index..].starts_with('<') => {
+                let word_was_redirection_fd = current_word_started_at_command_start
+                    && !current_word.is_empty()
+                    && current_word.chars().all(|current| current.is_ascii_digit());
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                if word_was_redirection_fd {
+                    at_command_start = true;
+                }
+                if inside_unclosed_double_paren_on_line(input, index) {
+                    index = next_index + '<'.len_utf8();
+                    continue;
+                }
+
+                if input[next_index + '<'.len_utf8()..].starts_with('<') {
+                    index = next_index + '<'.len_utf8() + '<'.len_utf8();
+                    expecting_redirection_target = true;
+                    continue;
+                }
+
+                let strip_tabs = input[next_index..].starts_with("<-");
+                let delimiter_start = next_index + if strip_tabs { 2 } else { 1 };
+                if let Some((delimiter_index, delimiter)) =
+                    scan_command_subst_heredoc_delimiter(input, delimiter_start)
+                {
+                    pending_heredocs.push((delimiter, strip_tabs));
+                    index = delimiter_index;
+                    expecting_redirection_target = false;
+                } else {
+                    index = next_index;
+                    expecting_redirection_target = true;
+                }
+            }
+            '\n' => {
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                index = next_index;
+                for (delimiter, strip_tabs) in pending_heredocs.drain(..) {
+                    index =
+                        skip_command_subst_pending_heredoc(input, index, &delimiter, strip_tabs);
+                }
+                at_command_start = true;
+                expecting_redirection_target = false;
+            }
+            '$' if input[next_index..].starts_with('{') => {
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                let consumed = scan_command_subst_parameter_expansion_len(
+                    &input[next_index + '{'.len_utf8()..],
+                    subst_depth,
+                )?;
+                index = next_index + '{'.len_utf8() + consumed;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            '$' if input[next_index..].starts_with('(')
+                && !input[next_index + '('.len_utf8()..].starts_with('(') =>
+            {
+                let had_word = !current_word.is_empty();
+                flush_scanned_command_subst_keyword(
+                    &mut current_word,
+                    &mut pending_case_headers,
+                    &mut case_clause_depths,
+                    depth,
+                    &mut current_word_started_at_command_start,
+                );
+                if had_word && expecting_redirection_target {
+                    expecting_redirection_target = false;
+                }
+                let consumed = scan_command_substitution_body_len_inner(
+                    &input[next_index + '('.len_utf8()..],
+                    subst_depth + 1,
+                )?;
+                index = next_index + '('.len_utf8() + consumed;
+                if expecting_redirection_target {
+                    expecting_redirection_target = false;
+                } else {
+                    at_command_start = false;
+                }
+            }
+            _ => {
+                if ch.is_ascii_alphanumeric() || ch == '_' {
+                    if current_word.is_empty() && !expecting_redirection_target && at_command_start
+                    {
+                        current_word_started_at_command_start = true;
+                        at_command_start = false;
+                    }
+                    current_word.push(ch);
+                } else {
+                    let had_word = !current_word.is_empty();
+                    flush_scanned_command_subst_keyword(
+                        &mut current_word,
+                        &mut pending_case_headers,
+                        &mut case_clause_depths,
+                        depth,
+                        &mut current_word_started_at_command_start,
+                    );
+                    if had_word && expecting_redirection_target {
+                        expecting_redirection_target = false;
+                    }
+                    match ch {
+                        ' ' | '\t' => {}
+                        ';' | '|' | '&' => {
+                            at_command_start = true;
+                            expecting_redirection_target = false;
+                        }
+                        _ => {
+                            if !expecting_redirection_target {
+                                at_command_start = false;
+                            }
+                        }
+                    }
+                }
+                index = next_index;
+            }
+        }
+    }
+
+    None
+}
+
 pub(super) fn scan_command_substitution_body_len(input: &str) -> Option<usize> {
-    let mut lexer = Lexer::new(input);
-    let mut content = Some(String::new());
-    lexer
-        .read_command_subst_into(&mut content)
-        .then_some(lexer.offset)
+    scan_command_substitution_body_len_inner(input, 0)
 }
 
 #[cfg(test)]
@@ -3360,6 +4338,233 @@ mod tests {
                 .slice(source),
             "foo"
         );
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_tabstripped_heredoc() {
+        let source = "\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("field, direction"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_separator_started_comment() {
+        let source = "printf '%s' x;# comment with ) and ,\nprintf '%s' y\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf '%s' y"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_grouping_comment_after_left_paren() {
+        let source = " (# comment with )\nprintf %s 1,2\n) )\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_piped_heredoc_delimiter_without_space() {
+        let source = "\ncat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("field, direction"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_parameter_expansion_with_right_paren() {
+        let source = "printf %s ${x//foo/)},1)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("${x//foo/)},1"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_case_pattern_comment_after_right_paren() {
+        let source = "case $kind in\na)# comment with esac )\nprintf %s 1,2 ;;\nesac\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_hash_starts_comment_ignores_zsh_inline_glob_controls_after_left_paren() {
+        let source = "[[ \"$buf\" == (#b)(*) ]]";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(!hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn test_hash_starts_comment_allows_grouped_comments_without_space_after_hash() {
+        let source = "(#comment with )";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn test_hash_starts_comment_ignores_hash_inside_unclosed_double_parens() {
+        let source = "(( #c < 256 ))";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(!hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn test_hash_starts_comment_respects_quoted_double_parens() {
+        let source = "printf '((' # comment";
+        let index = source.find('#').expect("expected hash");
+
+        assert!(hash_starts_comment(source, index));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_quoted_double_parens_before_comments() {
+        let source = "printf '((' # comment with )\nprintf %s 1,2\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_grouped_comments_without_space_after_hash() {
+        let source = " (#comment with )\nprintf %s 1,2\n) )\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_ignores_arithmetic_shift_for_heredoc_detection() {
+        let source = "((x<<2))\nprintf %s 1,2\n)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_nested_case_pattern_right_paren() {
+        let source = "(case $kind in\na) printf %s 1,2 ;;\nesac\n))\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with("))"));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_ignores_plain_case_words_in_commands() {
+        let source = "printf %s 1,2; echo case in)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("echo case in"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_ansi_c_quotes_with_escaped_single_quotes() {
+        let source = "printf %s $'a\\'b'; printf %s 1,2)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("$'a\\'b'"));
+        assert!(body.contains("printf %s 1,2"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_backticks_with_right_parens() {
+        let source = "printf %s `echo foo)`; printf %s ok)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("`echo foo)`"));
+        assert!(body.contains("printf %s ok"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_plain_case_words_at_eof() {
+        let source = "printf %s 1,2; echo case in)";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert_eq!(body, source);
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_ansi_c_quotes_at_eof() {
+        let source = "printf %s $'a\\'b'; printf %s 1,2)";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert_eq!(body, source);
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_backticks_with_right_parens_at_eof() {
+        let source = "printf %s `echo foo)`; printf %s ok)";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert_eq!(body, source);
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_tabstripped_heredoc_at_eof() {
+        let source = "\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert_eq!(body, source);
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_piped_heredoc_at_eof() {
+        let source = "cat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n)";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert_eq!(body, source);
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3669,18 +3669,22 @@ fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -
     let mut index = 0usize;
     let mut in_single = false;
     let mut in_double = false;
+    let mut in_ansi_c_single = false;
+    let mut in_backtick = false;
     let mut escaped = false;
+    let mut ansi_c_quote_pending = false;
 
     while let Some((ch, next_index)) = next_char_boundary(input, index) {
         let was_escaped = escaped;
         if ch == '\\' && !in_single {
             escaped = !escaped;
             index = next_index;
+            ansi_c_quote_pending = false;
             continue;
         }
         escaped = false;
 
-        if !in_single && !was_escaped && ch == '$' {
+        if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped && ch == '$' {
             if input[next_index..].starts_with('{')
                 && let Some(consumed) = scan_command_subst_parameter_expansion_len(
                     &input[next_index + '{'.len_utf8()..],
@@ -3688,6 +3692,7 @@ fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -
                 )
             {
                 index = next_index + '{'.len_utf8() + consumed;
+                ansi_c_quote_pending = false;
                 continue;
             }
 
@@ -3699,17 +3704,61 @@ fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -
                 )
             {
                 index = next_index + '('.len_utf8() + consumed;
+                ansi_c_quote_pending = false;
                 continue;
             }
         }
 
+        if !in_single
+            && !in_ansi_c_single
+            && !in_double
+            && !in_backtick
+            && !was_escaped
+            && matches!(ch, '<' | '>')
+            && input[next_index..].starts_with('(')
+            && let Some(consumed) = scan_command_substitution_body_len_inner(
+                &input[next_index + '('.len_utf8()..],
+                subst_depth + 1,
+            )
+        {
+            index = next_index + '('.len_utf8() + consumed;
+            ansi_c_quote_pending = false;
+            continue;
+        }
+
         match ch {
-            '\'' if !in_double && !was_escaped => in_single = !in_single,
-            '"' if !in_single && !was_escaped => in_double = !in_double,
-            '}' if !in_single && !in_double && !was_escaped => return Some(next_index),
+            '\'' if !in_double && !in_backtick && !was_escaped => {
+                if in_ansi_c_single {
+                    in_ansi_c_single = false;
+                } else if !in_single && ansi_c_quote_pending {
+                    in_ansi_c_single = true;
+                } else {
+                    in_single = !in_single;
+                }
+            }
+            '"' if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped => {
+                in_double = !in_double
+            }
+            '`' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                in_backtick = !in_backtick
+            }
+            '}' if !in_single
+                && !in_ansi_c_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped =>
+            {
+                return Some(next_index);
+            }
             _ => {}
         }
 
+        ansi_c_quote_pending = ch == '$'
+            && !in_single
+            && !in_ansi_c_single
+            && !in_double
+            && !in_backtick
+            && !was_escaped;
         index = next_index;
     }
 
@@ -4514,6 +4563,29 @@ mod tests {
 
         assert!(body.contains("`echo foo)`"));
         assert!(body.contains("printf %s ok"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_backticks_inside_parameter_expansions() {
+        let source = "printf %s ${x/`echo }`/foo)},1)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("${x/`echo }`/foo)},1"));
+        assert!(body.ends_with(')'));
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_process_substitutions_inside_parameter_expansions()
+     {
+        let source = "printf %s ${x/<(echo })/foo)},1)\"";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert!(body.contains("${x/<(echo })/foo)},1"));
         assert!(body.ends_with(')'));
     }
 

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -828,6 +828,7 @@ arr=(
   <(printf %s 1,2)
   >(printf %s 3,4)
   ${x/a,b/c}
+  ${x/`echo }`/a,b}
   $((1,2))
   foo,{x,y},bar
 )
@@ -841,7 +842,7 @@ arr=(
         panic!("expected compound array assignment");
     };
 
-    assert_eq!(array.elements.len(), 11, "{:#?}", array.elements);
+    assert_eq!(array.elements.len(), 12, "{:#?}", array.elements);
 
     let ArrayElem::Sequential(first) = &array.elements[0] else {
         panic!("expected first sequential element");
@@ -865,7 +866,8 @@ arr=(
         (6, "<(printf %s 1,2)"),
         (7, ">(printf %s 3,4)"),
         (8, "${x/a,b/c}"),
-        (9, "$((1,2))"),
+        (9, "${x/`echo }`/a,b}"),
+        (10, "$((1,2))"),
     ] {
         let ArrayElem::Sequential(value) = &array.elements[index] else {
             panic!("expected sequential element at index {index}");
@@ -878,7 +880,7 @@ arr=(
         );
     }
 
-    let ArrayElem::Sequential(last) = &array.elements[10] else {
+    let ArrayElem::Sequential(last) = &array.elements[11] else {
         panic!("expected trailing sequential element");
     };
     assert_eq!(last.span.slice(input), "foo,{x,y},bar");

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2926,6 +2926,102 @@ fn test_parse_declare_array_preserves_backticks_with_right_parens_in_command_sub
 }
 
 #[test]
+fn test_parse_declare_array_preserves_backticks_inside_parameter_expansions_in_command_substitution()
+ {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t\"$(printf %s ${x/`echo }`/foo)},1)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
+fn test_parse_declare_array_preserves_process_substitutions_inside_parameter_expansions_in_command_substitution()
+ {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t\"$(printf %s ${x/<(echo })/foo)},1)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
 fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
     let input = "printf '%s\\n' ${assoc[\"key\"]} ${assoc['k']}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1117,6 +1117,50 @@ fn test_escaped_backticks_inside_double_quotes_stay_literal() {
 }
 
 #[test]
+fn test_process_substitution_like_text_inside_double_quotes_stays_literal() {
+    let input = "echo \"<(printf hi)\" \" >(printf bye)\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+
+    for word in &command.args {
+        let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+            panic!("expected double-quoted word");
+        };
+        assert!(
+            !parts
+                .iter()
+                .any(|part| matches!(part.kind, WordPart::ProcessSubstitution { .. })),
+            "{:#?}",
+            parts
+        );
+    }
+}
+
+#[test]
+fn test_escaped_process_substitution_like_text_stays_literal() {
+    let input = "echo \\<(printf hi) \\>(printf bye)\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+
+    for word in &command.args {
+        assert!(
+            !word
+                .parts
+                .iter()
+                .any(|part| matches!(part.kind, WordPart::ProcessSubstitution { .. })),
+            "{:#?}",
+            word.parts
+        );
+    }
+}
+
+#[test]
 fn test_unquoted_backtick_substitution_can_contain_spaces() {
     let input = "commands=(`pyenv-commands --sh`)\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -829,6 +829,7 @@ arr=(
   >(printf %s 3,4)
   ${x/a,b/c}
   ${x/`echo }`/a,b}
+  ${x/<(echo })/foo,bar}
   $((1,2))
   foo,{x,y},bar
 )
@@ -842,7 +843,7 @@ arr=(
         panic!("expected compound array assignment");
     };
 
-    assert_eq!(array.elements.len(), 12, "{:#?}", array.elements);
+    assert_eq!(array.elements.len(), 13, "{:#?}", array.elements);
 
     let ArrayElem::Sequential(first) = &array.elements[0] else {
         panic!("expected first sequential element");
@@ -867,7 +868,8 @@ arr=(
         (7, ">(printf %s 3,4)"),
         (8, "${x/a,b/c}"),
         (9, "${x/`echo }`/a,b}"),
-        (10, "$((1,2))"),
+        (10, "${x/<(echo })/foo,bar}"),
+        (11, "$((1,2))"),
     ] {
         let ArrayElem::Sequential(value) = &array.elements[index] else {
             panic!("expected sequential element at index {index}");
@@ -880,7 +882,7 @@ arr=(
         );
     }
 
-    let ArrayElem::Sequential(last) = &array.elements[11] else {
+    let ArrayElem::Sequential(last) = &array.elements[12] else {
         panic!("expected trailing sequential element");
     };
     assert_eq!(last.span.slice(input), "foo,{x,y},bar");

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -816,6 +816,100 @@ fn test_assignment_target_mixed_subscript_and_compound_value_stay_structured() {
 }
 
 #[test]
+fn test_compound_array_value_words_track_top_level_unquoted_commas() {
+    let input = "\
+arr=(
+  alpha,beta
+  head,$tail
+  [k]=v,
+  \"alpha,beta\"
+  $'alpha,beta'
+  $(printf %s 1,2)
+  <(printf %s 1,2)
+  >(printf %s 3,4)
+  ${x/a,b/c}
+  $((1,2))
+  foo,{x,y},bar
+)
+";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Compound(array) = &command.assignments[0].value else {
+        panic!("expected compound array assignment");
+    };
+
+    assert_eq!(array.elements.len(), 11, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(first) = &array.elements[0] else {
+        panic!("expected first sequential element");
+    };
+    assert!(first.has_top_level_unquoted_comma());
+
+    let ArrayElem::Sequential(second) = &array.elements[1] else {
+        panic!("expected second sequential element");
+    };
+    assert!(second.has_top_level_unquoted_comma());
+
+    let ArrayElem::Keyed { value, .. } = &array.elements[2] else {
+        panic!("expected keyed element");
+    };
+    assert!(value.has_top_level_unquoted_comma());
+
+    for (index, expected_span) in [
+        (3usize, "\"alpha,beta\""),
+        (4, "$'alpha,beta'"),
+        (5, "$(printf %s 1,2)"),
+        (6, "<(printf %s 1,2)"),
+        (7, ">(printf %s 3,4)"),
+        (8, "${x/a,b/c}"),
+        (9, "$((1,2))"),
+    ] {
+        let ArrayElem::Sequential(value) = &array.elements[index] else {
+            panic!("expected sequential element at index {index}");
+        };
+        assert_eq!(value.span.slice(input), expected_span);
+        assert!(
+            !value.has_top_level_unquoted_comma(),
+            "unexpected comma flag for {}",
+            value.span.slice(input)
+        );
+    }
+
+    let ArrayElem::Sequential(last) = &array.elements[10] else {
+        panic!("expected trailing sequential element");
+    };
+    assert_eq!(last.span.slice(input), "foo,{x,y},bar");
+    assert!(last.has_top_level_unquoted_comma());
+}
+
+#[test]
+fn test_compound_array_process_substitution_stays_typed_for_comma_detection() {
+    let input = "arr=(<(printf %s 1,2) >(printf %s 3,4))\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Compound(array) = &command.assignments[0].value else {
+        panic!("expected compound array assignment");
+    };
+
+    for (index, is_input) in [(0usize, true), (1usize, false)] {
+        let ArrayElem::Sequential(value) = &array.elements[index] else {
+            panic!("expected sequential element at index {index}");
+        };
+        assert!(!value.has_top_level_unquoted_comma());
+        assert!(matches!(
+            &value.parts[0].kind,
+            WordPart::ProcessSubstitution { is_input: actual, .. } if *actual == is_input
+        ));
+    }
+}
+
+#[test]
 fn test_word_part_spans_track_mixed_expansions() {
     let input = "echo pre${name:-fallback}$(printf hi)$((1+2))post\n";
     let script = Parser::new(input).parse().unwrap().file;
@@ -2469,6 +2563,318 @@ fn test_parse_declare_a_threads_associative_kind_into_compound_array() {
     assert_eq!(key.interpretation, SubscriptInterpretation::Associative);
 
     assert!(matches!(array.elements[3], ArrayElem::Sequential(_)));
+}
+
+#[test]
+fn test_parse_declare_array_preserves_quoted_command_substitution_elements() {
+    let input = "f() {\n\tlocal -a graphql_request=(\n\t\t-X POST\n\t\t-d \"$(\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 4, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[3] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
+fn test_parse_declare_array_preserves_separator_comment_in_quoted_command_substitution() {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t\"$(printf '%s' x;# comment with ) and ,\n\t\tprintf '%s' y\n\t\t)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
+fn test_parse_declare_array_preserves_piped_heredoc_without_spacing_in_command_substitution() {
+    let input = "f() {\n\tlocal -a graphql_request=(\n\t\t\"$(\ncat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n\t\t)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
+fn test_parse_declare_array_preserves_parameter_expansion_with_right_paren_in_command_substitution()
+{
+    let input = "f() {\n\tlocal -a parts=(\n\t\t\"$(printf %s ${x//foo/)},1)\"\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| {
+            matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if parts.iter().any(|part| matches!(
+                        &part.kind,
+                        WordPart::CommandSubstitution {
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                            ..
+                        }
+                    ))
+            )
+        }),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
+fn test_parse_declare_array_preserves_plain_case_words_in_command_substitution() {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t$(printf %s 1,2; echo case in)\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| matches!(
+            &part.kind,
+            WordPart::CommandSubstitution {
+                syntax: CommandSubstitutionSyntax::DollarParen,
+                ..
+            }
+        )),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
+fn test_parse_declare_array_preserves_ansi_c_quotes_in_command_substitution() {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t$(printf %s $'a\\'b'; printf %s 1,2)\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| matches!(
+            &part.kind,
+            WordPart::CommandSubstitution {
+                syntax: CommandSubstitutionSyntax::DollarParen,
+                ..
+            }
+        )),
+        "{:#?}",
+        payload.parts
+    );
+}
+
+#[test]
+fn test_parse_declare_array_preserves_backticks_with_right_parens_in_command_substitution() {
+    let input = "f() {\n\tlocal -a parts=(\n\t\t$(printf %s `echo foo)`; printf %s ok)\n\t)\n}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Function(function) = &script.body[0].command else {
+        panic!("expected function");
+    };
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    let AstCommand::Decl(command) = &body[0].command else {
+        panic!("expected declaration, got {:#?}", body[0].command);
+    };
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand, got {:#?}", command.operands);
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    assert_eq!(array.elements.len(), 1, "{:#?}", array.elements);
+
+    let ArrayElem::Sequential(payload) = &array.elements[0] else {
+        panic!("expected payload element");
+    };
+    assert!(
+        payload.parts.iter().any(|part| matches!(
+            &part.kind,
+            WordPart::CommandSubstitution {
+                syntax: CommandSubstitutionSyntax::DollarParen,
+                ..
+            }
+        )),
+        "{:#?}",
+        payload.parts
+    );
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -38,11 +38,23 @@ struct ParsedWordTarget {
     boundary: WordTargetBoundary,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub(super) struct DecodeWordPartsOptions {
     preserve_quote_fragments: bool,
     parse_dollar_quotes: bool,
     preserve_escaped_expansion_literals: bool,
+    parse_process_substitutions: bool,
+}
+
+impl Default for DecodeWordPartsOptions {
+    fn default() -> Self {
+        Self {
+            preserve_quote_fragments: false,
+            parse_dollar_quotes: false,
+            preserve_escaped_expansion_literals: false,
+            parse_process_substitutions: true,
+        }
+    }
 }
 
 impl<'a> PatternParser<'a> {
@@ -2982,15 +2994,30 @@ impl<'a> Parser<'a> {
 
                 let inner_span = Span::from_positions(content_start, content_end);
                 let inner = if source_backed {
-                    self.decode_word_text(
+                    self.decode_word_text_with_options(
                         inner_span.slice(self.input),
                         inner_span,
                         content_start,
                         true,
+                        DecodeWordPartsOptions {
+                            parse_dollar_quotes: true,
+                            parse_process_substitutions: false,
+                            ..DecodeWordPartsOptions::default()
+                        },
                     )
                 } else {
                     let content = content.unwrap_or_default();
-                    self.decode_word_text(&content, inner_span, content_start, false)
+                    self.decode_word_text_with_options(
+                        &content,
+                        inner_span,
+                        content_start,
+                        false,
+                        DecodeWordPartsOptions {
+                            parse_dollar_quotes: true,
+                            parse_process_substitutions: false,
+                            ..DecodeWordPartsOptions::default()
+                        },
+                    )
                 };
 
                 Self::push_word_part(
@@ -3065,7 +3092,10 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if matches!(ch, '<' | '>') && chars.peek() == Some(&'(') {
+            if options.parse_process_substitutions
+                && matches!(ch, '<' | '>')
+                && chars.peek() == Some(&'(')
+            {
                 self.flush_literal_part(parts, &mut current, current_start, part_start);
 
                 let is_input = ch == '<';
@@ -3222,15 +3252,30 @@ impl<'a> Parser<'a> {
 
                 let inner_span = Span::from_positions(content_start, content_end);
                 let inner = if source_backed {
-                    self.decode_word_text(
+                    self.decode_word_text_with_options(
                         inner_span.slice(self.input),
                         inner_span,
                         content_start,
                         true,
+                        DecodeWordPartsOptions {
+                            parse_dollar_quotes: true,
+                            parse_process_substitutions: false,
+                            ..DecodeWordPartsOptions::default()
+                        },
                     )
                 } else {
                     let content = content.unwrap_or_default();
-                    self.decode_word_text(&content, inner_span, content_start, false)
+                    self.decode_word_text_with_options(
+                        &content,
+                        inner_span,
+                        content_start,
+                        false,
+                        DecodeWordPartsOptions {
+                            parse_dollar_quotes: true,
+                            parse_process_substitutions: false,
+                            ..DecodeWordPartsOptions::default()
+                        },
+                    )
                 };
 
                 Self::push_word_part(
@@ -4662,6 +4707,25 @@ impl<'a> Parser<'a> {
         self.word_with_parts(parts, span)
     }
 
+    fn decode_word_text_with_options(
+        &mut self,
+        s: &str,
+        span: Span,
+        base: Position,
+        source_backed: bool,
+        options: DecodeWordPartsOptions,
+    ) -> Word {
+        let mut parts = Vec::new();
+        self.decode_word_parts_into_with_quote_fragments(
+            s,
+            base,
+            source_backed,
+            options,
+            &mut parts,
+        );
+        self.word_with_parts(parts, span)
+    }
+
     pub(super) fn decode_fragment_word_text(
         &mut self,
         s: &str,
@@ -4697,6 +4761,7 @@ impl<'a> Parser<'a> {
             source_backed,
             DecodeWordPartsOptions {
                 preserve_escaped_expansion_literals: true,
+                parse_process_substitutions: false,
                 ..DecodeWordPartsOptions::default()
             },
             &mut parts,

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1215,6 +1215,21 @@ impl<'a> Parser<'a> {
                 }
             }
 
+            if !in_single
+                && !in_ansi_c_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && matches!(ch, '<' | '>')
+                && text[next_index..].starts_with('(')
+                && let Some(consumed) =
+                    lexer::scan_command_substitution_body_len(&text[next_index + '('.len_utf8()..])
+            {
+                index = next_index + '('.len_utf8() + consumed;
+                ansi_c_quote_pending = false;
+                continue;
+            }
+
             match ch {
                 '\'' if !in_double && !in_backtick && !was_escaped => {
                     if in_ansi_c_single {

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1,4 +1,5 @@
 use super::*;
+use shuck_ast::ArrayValueWord;
 #[derive(Debug, Clone, Copy)]
 struct PatternCursor {
     segment_index: usize,
@@ -843,6 +844,17 @@ impl<'a> Parser<'a> {
         self.parse_word_with_context(raw, span, span.start, self.source_matches(span, raw))
     }
 
+    pub(super) fn array_value_word_from_raw_text(
+        &mut self,
+        raw: &str,
+        span: Span,
+    ) -> ArrayValueWord {
+        let word = self.word_from_raw_text(raw, span);
+        let has_top_level_unquoted_comma =
+            self.raw_text_has_top_level_unquoted_array_comma(raw, &word);
+        ArrayValueWord::new(word, has_top_level_unquoted_comma)
+    }
+
     pub(super) fn split_compound_array_elements(&self, inner: &str) -> Vec<(usize, usize)> {
         let mut ranges = Vec::new();
         let mut start: Option<usize> = None;
@@ -964,6 +976,323 @@ impl<'a> Parser<'a> {
         Some(body_start + consumed)
     }
 
+    fn raw_text_has_top_level_unquoted_array_comma(&self, raw: &str, word: &Word) -> bool {
+        let mut index = 0usize;
+        let mut in_single = false;
+        let mut in_ansi_c_single = false;
+        let mut in_double = false;
+        let mut in_backtick = false;
+        let mut escaped = false;
+        let mut ansi_c_quote_pending = false;
+
+        while index < raw.len() {
+            let ch = raw[index..]
+                .chars()
+                .next()
+                .expect("index is within bounds while scanning parser-owned array surface");
+            let next_index = index + ch.len_utf8();
+            let was_escaped = escaped;
+            if ch == '\\' && !in_single {
+                escaped = !escaped;
+                ansi_c_quote_pending = false;
+                index = next_index;
+                continue;
+            }
+            escaped = false;
+
+            if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped && ch == '$' {
+                if raw[next_index..].starts_with("((")
+                    && let Some(consumed) =
+                        Self::scan_array_arithmetic_expansion_len(&raw[next_index + 2..])
+                {
+                    ansi_c_quote_pending = false;
+                    index = next_index + 2 + consumed;
+                    continue;
+                }
+
+                if raw[next_index..].starts_with('(')
+                    && !raw[next_index + '('.len_utf8()..].starts_with('(')
+                    && let Some(consumed) = lexer::scan_command_substitution_body_len(
+                        &raw[next_index + '('.len_utf8()..],
+                    )
+                {
+                    ansi_c_quote_pending = false;
+                    index = next_index + '('.len_utf8() + consumed;
+                    continue;
+                }
+
+                if raw[next_index..].starts_with('{')
+                    && let Some(consumed) = Self::scan_array_parameter_expansion_len(
+                        &raw[next_index + '{'.len_utf8()..],
+                    )
+                {
+                    ansi_c_quote_pending = false;
+                    index = next_index + '{'.len_utf8() + consumed;
+                    continue;
+                }
+            }
+
+            if !in_single
+                && !in_ansi_c_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && matches!(ch, '<' | '>')
+                && raw[next_index..].starts_with('(')
+                && let Some(consumed) =
+                    lexer::scan_command_substitution_body_len(&raw[next_index + '('.len_utf8()..])
+            {
+                ansi_c_quote_pending = false;
+                index = next_index + '('.len_utf8() + consumed;
+                continue;
+            }
+
+            match ch {
+                '\'' if !in_double && !in_backtick && !was_escaped => {
+                    if in_ansi_c_single {
+                        in_ansi_c_single = false;
+                    } else if !in_single && ansi_c_quote_pending {
+                        in_ansi_c_single = true;
+                    } else {
+                        in_single = !in_single;
+                    }
+                }
+                '"' if !in_single && !in_ansi_c_single && !was_escaped => in_double = !in_double,
+                '`' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                    in_backtick = !in_backtick
+                }
+                ',' if !in_single && !in_ansi_c_single && !in_double && !in_backtick => {
+                    let comma_offset = word.span.start.offset + index;
+                    if !self.comma_is_brace_separator(word, comma_offset, was_escaped) {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+
+            ansi_c_quote_pending = ch == '$'
+                && !in_single
+                && !in_ansi_c_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped;
+            index = next_index;
+        }
+
+        false
+    }
+
+    fn scan_array_arithmetic_expansion_len(text: &str) -> Option<usize> {
+        let mut index = 0usize;
+        let mut depth = 2usize;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+
+        while index < text.len() {
+            let ch = text[index..].chars().next()?;
+            let next_index = index + ch.len_utf8();
+            let was_escaped = escaped;
+            if ch == '\\' && !in_single {
+                escaped = !escaped;
+                index = next_index;
+                continue;
+            }
+            escaped = false;
+
+            if !in_single && !was_escaped && ch == '$' {
+                if text[next_index..].starts_with("((")
+                    && let Some(consumed) =
+                        Self::scan_array_arithmetic_expansion_len(&text[next_index + 2..])
+                {
+                    index = next_index + 2 + consumed;
+                    continue;
+                }
+
+                if text[next_index..].starts_with('(')
+                    && !text[next_index + '('.len_utf8()..].starts_with('(')
+                    && let Some(consumed) = lexer::scan_command_substitution_body_len(
+                        &text[next_index + '('.len_utf8()..],
+                    )
+                {
+                    index = next_index + '('.len_utf8() + consumed;
+                    continue;
+                }
+
+                if text[next_index..].starts_with('{')
+                    && let Some(consumed) = Self::scan_array_parameter_expansion_len(
+                        &text[next_index + '{'.len_utf8()..],
+                    )
+                {
+                    index = next_index + '{'.len_utf8() + consumed;
+                    continue;
+                }
+            }
+
+            match ch {
+                '\'' if !in_double && !was_escaped => in_single = !in_single,
+                '"' if !in_single && !was_escaped => in_double = !in_double,
+                '(' if !in_single && !in_double && !was_escaped => depth += 1,
+                ')' if !in_single && !in_double && !was_escaped => {
+                    depth -= 1;
+                    index = next_index;
+                    if depth == 0 {
+                        return Some(index);
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+
+            index = next_index;
+        }
+
+        None
+    }
+
+    fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
+        let mut index = 0usize;
+        let mut in_single = false;
+        let mut in_ansi_c_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+        let mut ansi_c_quote_pending = false;
+
+        while index < text.len() {
+            let ch = text[index..].chars().next()?;
+            let next_index = index + ch.len_utf8();
+            let was_escaped = escaped;
+            if ch == '\\' && !in_single {
+                escaped = !escaped;
+                index = next_index;
+                ansi_c_quote_pending = false;
+                continue;
+            }
+            escaped = false;
+
+            if !in_single && !in_ansi_c_single && !was_escaped && ch == '$' {
+                if text[next_index..].starts_with('{')
+                    && let Some(consumed) = Self::scan_array_parameter_expansion_len(
+                        &text[next_index + '{'.len_utf8()..],
+                    )
+                {
+                    index = next_index + '{'.len_utf8() + consumed;
+                    ansi_c_quote_pending = false;
+                    continue;
+                }
+
+                if text[next_index..].starts_with("((")
+                    && let Some(consumed) =
+                        Self::scan_array_arithmetic_expansion_len(&text[next_index + 2..])
+                {
+                    index = next_index + 2 + consumed;
+                    ansi_c_quote_pending = false;
+                    continue;
+                }
+
+                if text[next_index..].starts_with('(')
+                    && !text[next_index + '('.len_utf8()..].starts_with('(')
+                    && let Some(consumed) = lexer::scan_command_substitution_body_len(
+                        &text[next_index + '('.len_utf8()..],
+                    )
+                {
+                    index = next_index + '('.len_utf8() + consumed;
+                    ansi_c_quote_pending = false;
+                    continue;
+                }
+            }
+
+            match ch {
+                '\'' if !in_double && !was_escaped => {
+                    if in_ansi_c_single {
+                        in_ansi_c_single = false;
+                    } else if !in_single && ansi_c_quote_pending {
+                        in_ansi_c_single = true;
+                    } else {
+                        in_single = !in_single;
+                    }
+                }
+                '"' if !in_single && !in_ansi_c_single && !was_escaped => in_double = !in_double,
+                '}' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                    return Some(next_index);
+                }
+                _ => {}
+            }
+
+            ansi_c_quote_pending =
+                ch == '$' && !in_single && !in_ansi_c_single && !in_double && !was_escaped;
+            index = next_index;
+        }
+
+        None
+    }
+
+    fn comma_is_brace_separator(&self, word: &Word, offset: usize, escaped: bool) -> bool {
+        if escaped {
+            return false;
+        }
+
+        Self::inside_active_brace_expansion(word, offset)
+            || self.inside_unquoted_brace_group(word, offset)
+    }
+
+    fn inside_active_brace_expansion(word: &Word, offset: usize) -> bool {
+        word.brace_syntax()
+            .iter()
+            .copied()
+            .filter(|brace| brace.expands())
+            .any(|brace| brace.span.start.offset <= offset && offset < brace.span.end.offset)
+    }
+
+    fn inside_unquoted_brace_group(&self, word: &Word, target_offset: usize) -> bool {
+        let text = word.span.slice(self.input);
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+        let mut brace_depth = 0usize;
+
+        for (index, ch) in text.char_indices() {
+            let absolute = word.span.start.offset + index;
+
+            if absolute == target_offset {
+                return brace_depth > 0;
+            }
+
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' if !in_single => {
+                    escaped = true;
+                    continue;
+                }
+                '\'' if !in_double => {
+                    in_single = !in_single;
+                    continue;
+                }
+                '"' if !in_single => {
+                    in_double = !in_double;
+                    continue;
+                }
+                _ => {}
+            }
+
+            if in_single || in_double {
+                continue;
+            }
+
+            match ch {
+                '{' if !text[..index].ends_with('$') => brace_depth += 1,
+                '}' if brace_depth > 0 => brace_depth -= 1,
+                _ => {}
+            }
+        }
+
+        false
+    }
+
     fn raw_source_hash_starts_comment(source: &str, index: usize) -> bool {
         source[..index]
             .chars()
@@ -1054,7 +1383,7 @@ impl<'a> Parser<'a> {
                 .start
                 .advanced_by(&raw[..close_index + 1 + value_offset]);
             let value_span = Span::from_positions(value_start, span.end);
-            let value = self.word_from_raw_text(value_raw, value_span);
+            let value = self.array_value_word_from_raw_text(value_raw, value_span);
             return if append {
                 ArrayElem::KeyedAppend { key, value }
             } else {
@@ -1062,7 +1391,7 @@ impl<'a> Parser<'a> {
             };
         }
 
-        ArrayElem::Sequential(self.word_from_raw_text(raw, span))
+        ArrayElem::Sequential(self.array_value_word_from_raw_text(raw, span))
     }
 
     pub(super) fn parse_array_expr_from_text(
@@ -2714,6 +3043,75 @@ impl<'a> Parser<'a> {
                         body,
                         syntax: CommandSubstitutionSyntax::Backtick,
                     },
+                    part_start,
+                    cursor,
+                );
+                current_start = cursor;
+                continue;
+            }
+
+            if matches!(ch, '<' | '>') && chars.peek() == Some(&'(') {
+                self.flush_literal_part(parts, &mut current, current_start, part_start);
+
+                let is_input = ch == '<';
+                Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                let inner_start = cursor;
+                let body = if source_backed {
+                    let remaining_word_text = chars.clone().collect::<String>();
+                    let consumed = lexer::scan_command_substitution_body_len(&remaining_word_text);
+                    let inner_end = if let Some(consumed) = consumed {
+                        let consumed_text = &remaining_word_text[..consumed];
+                        for _ in consumed_text.chars() {
+                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                        }
+                        let inner_text = consumed_text.strip_suffix(')').unwrap_or_default();
+                        inner_start.advanced_by(inner_text)
+                    } else {
+                        let mut depth = 1;
+                        let mut inner_end = inner_start;
+                        while chars.peek().is_some() {
+                            let c = Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                            match c {
+                                '(' => {
+                                    depth += 1;
+                                    inner_end = cursor;
+                                }
+                                ')' => {
+                                    depth -= 1;
+                                    if depth == 0 {
+                                        break;
+                                    }
+                                    inner_end = cursor;
+                                }
+                                _ => inner_end = cursor,
+                            }
+                        }
+                        inner_end
+                    };
+                    self.nested_stmt_seq_from_current_input(inner_start, inner_end)
+                } else {
+                    let mut cmd_str = String::new();
+                    let mut depth = 1;
+                    while let Some(c) = Self::next_word_char(&mut chars, &mut cursor) {
+                        if c == '(' {
+                            depth += 1;
+                            cmd_str.push(c);
+                        } else if c == ')' {
+                            depth -= 1;
+                            if depth == 0 {
+                                break;
+                            }
+                            cmd_str.push(c);
+                        } else {
+                            cmd_str.push(c);
+                        }
+                    }
+                    self.nested_stmt_seq_from_source(&cmd_str, inner_start)
+                };
+
+                Self::push_word_part(
+                    parts,
+                    WordPart::ProcessSubstitution { body, is_input },
                     part_start,
                     cursor,
                 );

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1155,6 +1155,7 @@ impl<'a> Parser<'a> {
         let mut in_single = false;
         let mut in_ansi_c_single = false;
         let mut in_double = false;
+        let mut in_backtick = false;
         let mut escaped = false;
         let mut ansi_c_quote_pending = false;
 
@@ -1170,7 +1171,7 @@ impl<'a> Parser<'a> {
             }
             escaped = false;
 
-            if !in_single && !in_ansi_c_single && !was_escaped && ch == '$' {
+            if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped && ch == '$' {
                 if text[next_index..].starts_with('{')
                     && let Some(consumed) = Self::scan_array_parameter_expansion_len(
                         &text[next_index + '{'.len_utf8()..],
@@ -1203,7 +1204,7 @@ impl<'a> Parser<'a> {
             }
 
             match ch {
-                '\'' if !in_double && !was_escaped => {
+                '\'' if !in_double && !in_backtick && !was_escaped => {
                     if in_ansi_c_single {
                         in_ansi_c_single = false;
                     } else if !in_single && ansi_c_quote_pending {
@@ -1212,15 +1213,29 @@ impl<'a> Parser<'a> {
                         in_single = !in_single;
                     }
                 }
-                '"' if !in_single && !in_ansi_c_single && !was_escaped => in_double = !in_double,
-                '}' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                '"' if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped => {
+                    in_double = !in_double
+                }
+                '`' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                    in_backtick = !in_backtick
+                }
+                '}' if !in_single
+                    && !in_ansi_c_single
+                    && !in_double
+                    && !in_backtick
+                    && !was_escaped =>
+                {
                     return Some(next_index);
                 }
                 _ => {}
             }
 
-            ansi_c_quote_pending =
-                ch == '$' && !in_single && !in_ansi_c_single && !in_double && !was_escaped;
+            ansi_c_quote_pending = ch == '$'
+                && !in_single
+                && !in_ansi_c_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped;
             index = next_index;
         }
 


### PR DESCRIPTION
## Summary
Fix C151 by moving comma detection for compound-array elements into parser-owned structure instead of linter-side whole-word rescanning.

## What changed
- Added `ArrayValueWord` so compound-array elements carry parser-computed top-level comma metadata.
- Taught compound-array parsing to compute that metadata once from array-element surface structure while respecting shell quoting and nesting.
- Ported the command-substitution boundary fixes needed for compound-array parsing across comments, heredocs, case patterns, ANSI-C quotes, backticks, parameter expansions, arithmetic forms, and process substitutions.
- Simplified linter facts so C151 consumes the parser-owned signal directly instead of rescanning raw word source.
- Added parser, lexer, and linter regressions covering the PR #121 array/substitution edge cases and the new AST contract.

## Why
The previous correctness attempt fixed the false positives by rescanning compound-array element source in `facts.rs`, but it regressed `LinterFacts::build` too much. This version keeps the shell-aware decision in the parser, where quote and substitution boundaries are already known, and lets the linter read a cheap typed flag.

## Impact
- C151 still reports real top-level comma-separated array literals like `parts=(alpha,beta)` and mixed cases like `values=(head,$tail)`.
- C151 no longer treats commas inside nested syntax as top-level separators, including quoted strings, ANSI-C quotes, command/process substitutions, parameter expansions and operators, arithmetic expansions, heredocs inside substitutions, and related comment/case edge cases.
- The hot linter path avoids the abandoned raw-source rescanning approach.

## Validation
- `cargo test -p shuck-parser`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C151 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=120`
  - C151 comparison summary: `reviewed divergence=0`
- Criterion vs clean `main` baseline using a shared `CARGO_TARGET_DIR`
  - `linter_facts/all`: `24.611 ms .. 24.783 ms`, change `-15.35% .. -13.46%`
  - `linter/all`: `207.46 ms .. 211.06 ms`, change `-11.69% .. -6.28%`
  - `linter_facts/fzf-install` showed a small local regression (`+1.19% .. +2.89%`), but the aggregate `linter_facts/all` result improved.
