### PR TITLE
Refine X023 corpus metadata for Termux heredoc spans

### DIFF
--- a/crates/shuck/tests/testdata/corpus-metadata/x023.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x023.yaml
@@ -7,7 +7,32 @@ reviewed_divergences:
     reason: "This startup script is intentionally zsh-specific and already depends on zsh path modifiers, associative arrays, and glob qualifiers, so the remaining X023 hits are zsh substring forms exposed only after the corpus path collapses the file to POSIX sh."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__luajit__build.sh"
-    reason: "This Termux build recipe is already using bash-only `[[ ... ]]` tests and double-colon substring slicing on commit hashes, so the remaining SC3057 hits come from the comparison path collapsing a bash-oriented recipe to POSIX sh more aggressively than Shuck's dialect resolution."
+    line: 45
+    end_line: 45
+    column: 15
+    end_column: 36
+    reason: "This bash-oriented Termux recipe is already reviewed for shell-collapse. On this heredoc status line, the remaining X023 mismatch is only where the substring slice is anchored inside the quoted fragment."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__luajit__build.sh"
+    line: 45
+    end_line: 45
+    column: 18
+    end_column: 39
+    reason: "This bash-oriented Termux recipe is already reviewed for shell-collapse. On this heredoc status line, the remaining X023 mismatch is only where Shuck anchors the same substring slice inside the quoted fragment."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__luajit__build.sh"
+    line: 46
+    end_line: 46
+    column: 15
+    end_column: 34
+    reason: "This bash-oriented Termux recipe is already reviewed for shell-collapse. On this heredoc status line, the remaining X023 mismatch is only where the substring slice is anchored inside the quoted fragment."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__luajit__build.sh"
+    line: 46
+    end_line: 46
+    column: 21
+    end_column: 40
+    reason: "This bash-oriented Termux recipe is already reviewed for shell-collapse. On this heredoc status line, the remaining X023 mismatch is only where Shuck anchors the same substring slice inside the quoted fragment."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_gn.sh"
     reason: "This remaining mismatch is a span-only delta on the same reviewed substring expansion embedded in generated header text."


### PR DESCRIPTION
## Summary
This narrows the reviewed `X023` corpus divergence for the Termux `luajit` fixture to the exact heredoc lines and column ranges that still differ.

## Why
The remaining blocker was not a real rule bug in `X023`. Shuck and ShellCheck both report the same substring expansions, but they anchor the heredoc diagnostics at different columns inside the quoted fragment. The previous broad metadata entry was no longer precise enough once Shuck started surfacing its own location-only records for those lines.

## Impact
This keeps the `X023` large-corpus comparison green without suppressing unrelated findings elsewhere in the file.

## Validation
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X023`