### PR TITLE
Fix C020 heredoc span drift

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -15246,6 +15246,90 @@ for version ($versions); do :; done
     }
 
     #[test]
+    fn tab_stripped_heredoc_substitutions_after_earlier_heredocs_keep_command_spans_intact() {
+        let source = "\
+#!/bin/bash
+case \"${tag_type}\" in
+  newest-tag)
+\t:
+\t;;
+  latest-release-tag)
+\t:
+\t;;
+  latest-regex)
+\t:
+\t;;
+  *)
+\ttermux_error_exit <<-EndOfError
+\t\tERROR: Invalid TERMUX_PKG_UPDATE_TAG_TYPE: '${tag_type}'.
+\t\tAllowed values: 'newest-tag', 'latest-release-tag', 'latest-regex'.
+\tEndOfError
+\t;;
+esac
+
+case \"${http_code}\" in
+  404)
+\ttermux_error_exit <<-EndOfError
+\t\tNo '${tag_type}' found. (${api_url})
+\t\tHTTP code: ${http_code}
+\t\tTry using '$(
+\t\t\tif [[ \"${tag_type}\" == \"newest-tag\" ]]; then
+\t\t\t\techo \"latest-release-tag\"
+\t\t\telse
+\t\t\t\techo \"newest-tag\"
+\t\t\tfi
+\t\t)'.
+\tEndOfError
+\t;;
+esac
+";
+
+        with_facts(source, None, |_, facts| {
+            let conditional = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "[[ \"${tag_type}\" == \"newest-tag\" ]]")
+                .expect("expected nested heredoc conditional command");
+
+            let conditional_fact = conditional
+                .conditional()
+                .expect("expected conditional fact for nested heredoc command");
+
+            match conditional_fact.root() {
+                ConditionalNodeFact::Binary(binary) => {
+                    assert_eq!(
+                        binary.operator_family(),
+                        ConditionalOperatorFamily::StringBinary
+                    );
+                    assert_eq!(
+                        binary.left().word().map(|word| word.span.slice(source)),
+                        Some("\"${tag_type}\"")
+                    );
+                    assert_eq!(
+                        binary.right().word().map(|word| word.span.slice(source)),
+                        Some("\"newest-tag\"")
+                    );
+                }
+                other => panic!("expected binary root, got {other:?}"),
+            }
+
+            let latest_release = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "echo \"latest-release-tag\"\n")
+                .expect("expected latest-release echo command");
+            assert!(latest_release.simple_test().is_none());
+
+            let newest_tag = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.span().slice(source) == "echo \"newest-tag\"\n")
+                .expect("expected newest-tag echo command");
+            assert!(newest_tag.simple_test().is_none());
+        });
+    }
+
+    #[test]
     fn keeps_parenthesized_logical_groups_separate_for_mixed_operator_detection() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
@@ -113,4 +113,57 @@ test foo
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "\"\"");
     }
+
+    #[test]
+    fn ignores_tab_stripped_heredoc_substitutions_after_earlier_heredocs() {
+        let source = "\
+#!/bin/bash
+case \"${tag_type}\" in
+  newest-tag)
+\t:
+\t;;
+  latest-release-tag)
+\t:
+\t;;
+  latest-regex)
+\t:
+\t;;
+  *)
+\ttermux_error_exit <<-EndOfError
+\t\tERROR: Invalid TERMUX_PKG_UPDATE_TAG_TYPE: '${tag_type}'.
+\t\tAllowed values: 'newest-tag', 'latest-release-tag', 'latest-regex'.
+\tEndOfError
+\t;;
+esac
+
+case \"${http_code}\" in
+  404)
+\ttermux_error_exit <<-EndOfError
+\t\tNo '${tag_type}' found. (${api_url})
+\t\tHTTP code: ${http_code}
+\t\tTry using '$(
+\t\t\tif [[ \"${tag_type}\" == \"newest-tag\" ]]; then
+\t\t\t\techo \"latest-release-tag\"
+\t\t\telse
+\t\t\t\techo \"newest-tag\"
+\t\t\tfi
+\t\t)'.
+\tEndOfError
+\t;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TruthyLiteralTest));
+
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics: {:?}",
+            diagnostics
+                .iter()
+                .map(|diagnostic| (
+                    diagnostic.span.start.line,
+                    diagnostic.span.slice(source).to_owned(),
+                ))
+                .collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/shuck-parser/src/parser/heredocs.rs
+++ b/crates/shuck-parser/src/parser/heredocs.rs
@@ -62,16 +62,19 @@ impl<'a> Parser<'a> {
 
         let heredoc = self.lexer.read_heredoc(&delimiter_text, strip_tabs);
         let content_span = heredoc.content_span;
-        let content = if strip_tabs {
-            Self::strip_heredoc_tabs(heredoc.content)
-        } else {
-            heredoc.content
-        };
+        let raw_content = heredoc.content;
+        let stripped_content = strip_tabs.then(|| Self::strip_heredoc_tabs(raw_content.clone()));
 
         let body = if quoted {
-            HeredocBody::literal_with_span(content, content_span).with_source_backed(!strip_tabs)
+            HeredocBody::literal_with_span(stripped_content.unwrap_or(raw_content), content_span)
+                .with_source_backed(!strip_tabs)
         } else {
-            self.decode_heredoc_body_text(&content, content_span, !strip_tabs)
+            let mut body = self.decode_heredoc_body_text(&raw_content, content_span, true);
+            if strip_tabs {
+                self.strip_tab_indentation_from_heredoc_body(&mut body);
+                body.source_backed = false;
+            }
+            body
         };
 
         redirects.push(Redirect {
@@ -97,6 +100,30 @@ impl<'a> Parser<'a> {
         Ok(true)
     }
 
+    fn strip_tab_indentation_from_heredoc_body(&self, body: &mut HeredocBody) {
+        let mut at_line_start = true;
+        let mut parts = Vec::with_capacity(body.parts.len());
+
+        for mut part in body.parts.drain(..) {
+            match &mut part.kind {
+                HeredocBodyPart::Literal(text) => {
+                    let original = text.as_str(self.input, part.span);
+                    let stripped = strip_heredoc_literal_indentation(original, &mut at_line_start);
+                    if stripped.is_empty() {
+                        continue;
+                    }
+                    *text = LiteralText::owned(stripped);
+                }
+                _ => {
+                    update_line_start_state(part.span.slice(self.input), &mut at_line_start);
+                }
+            }
+            parts.push(part);
+        }
+
+        body.parts = parts;
+    }
+
     /// Parse redirections that follow a compound command (>, >>, 2>, etc.)
     pub(super) fn parse_heredoc_redirect(
         &mut self,
@@ -116,5 +143,26 @@ impl<'a> Parser<'a> {
     ) -> Result<()> {
         while self.consume_non_heredoc_redirect(redirects, None, None, false)? {}
         Ok(())
+    }
+}
+
+fn strip_heredoc_literal_indentation(text: &str, at_line_start: &mut bool) -> String {
+    let mut stripped = String::with_capacity(text.len());
+
+    for ch in text.chars() {
+        if *at_line_start && ch == '\t' {
+            continue;
+        }
+
+        stripped.push(ch);
+        *at_line_start = ch == '\n';
+    }
+
+    stripped
+}
+
+fn update_line_start_state(text: &str, at_line_start: &mut bool) {
+    for ch in text.chars() {
+        *at_line_start = ch == '\n';
     }
 }

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -654,6 +654,82 @@ fn test_strip_tabs_heredoc_body_preserves_single_quoted_fragments() {
 }
 
 #[test]
+fn test_strip_tabs_heredoc_command_substitution_keeps_nested_command_spans() {
+    let input = "\
+case \"${tag_type}\" in
+\t*)
+\t\ttermux_error_exit <<-EndOfError
+\t\t\tERROR: Invalid TERMUX_PKG_UPDATE_TAG_TYPE: '${tag_type}'.
+\t\t\tAllowed values: 'newest-tag', 'latest-release-tag', 'latest-regex'.
+\t\tEndOfError
+\t;;
+esac
+
+case \"${http_code}\" in
+\t404)
+\t\ttermux_error_exit <<-EndOfError
+\t\t\tNo '${tag_type}' found. (${api_url})
+\t\t\tHTTP code: ${http_code}
+\t\t\tTry using '$(
+\t\t\t\tif [[ \"${tag_type}\" == \"newest-tag\" ]]; then
+\t\t\t\t\techo \"latest-release-tag\"
+\t\t\t\telse
+\t\t\t\t\techo \"newest-tag\"
+\t\t\t\tfi
+\t\t\t)'.
+\t\tEndOfError
+\t;;
+esac
+";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let (compound, _) = expect_compound(&script.body[1]);
+    let AstCompoundCommand::Case(case) = compound else {
+        panic!("expected case command");
+    };
+    let command = expect_simple(&case.cases[0].body[0]);
+    let heredoc = redirect_heredoc(&case.cases[0].body[0].redirects[0]);
+
+    assert_eq!(command.name.render(input), "termux_error_exit");
+
+    let command_substitution = heredoc
+        .body
+        .parts
+        .iter()
+        .find_map(|part| match &part.kind {
+            shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => Some(body),
+            _ => None,
+        })
+        .expect("expected command substitution inside heredoc");
+
+    let (if_compound, _) = expect_compound(&command_substitution[0]);
+    let AstCompoundCommand::If(if_command) = if_compound else {
+        panic!("expected if command inside command substitution");
+    };
+
+    let AstCommand::Compound(AstCompoundCommand::Conditional(conditional)) =
+        &if_command.condition[0].command
+    else {
+        panic!("expected conditional command in if header");
+    };
+
+    assert_eq!(
+        conditional.span.slice(input),
+        "[[ \"${tag_type}\" == \"newest-tag\" ]]"
+    );
+    assert_eq!(
+        expect_simple(&if_command.then_branch[0]).span.slice(input),
+        "echo \"latest-release-tag\"\n"
+    );
+    assert_eq!(
+        expect_simple(&if_command.else_branch.as_ref().unwrap()[0])
+            .span
+            .slice(input),
+        "echo \"newest-tag\"\n"
+    );
+}
+
+#[test]
 fn test_comment_ranges_heredoc_no_false_comments() {
     // Lines with # inside a heredoc must NOT produce Comment entries
     let source = "cat <<EOF\n# not a comment\nline two\nEOF\n# real\n";

--- a/docs/bugs/C020.md
+++ b/docs/bugs/C020.md
@@ -1,63 +1,53 @@
-# C020: Review the SC2159 fixed-literal test gap
+# C020: Fix tab-stripped heredoc span drift
 
 ## Rule
 
 | Field | Value |
 |-------|-------|
 | Shuck code | C020 |
-| ShellCheck code | SC2159 |
+| ShellCheck comparison target | SC2078 |
 | Category | Correctness |
 | Rule file | `crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs` |
 
 ## Delta snapshot
 
-Sampled on 2026-04-05 using `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C020 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10 SHUCK_LARGE_CORPUS_KEEP_GOING=1`.
+Verified on 2026-04-16 with:
 
-The sample covered 3,379 fixtures and skipped 223 unsupported-shell fixtures.
+```bash
+make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C020 SHUCK_LARGE_CORPUS_KEEP_GOING=1
+```
+
+The run covered 6,449 fixtures and skipped 710 unsupported-shell fixtures.
 
 | Bucket | Locations | Scripts |
 |--------|-----------|---------|
 | ShellCheck-only | 0 | 0 |
-| Shuck-only | 2 | 2 |
+| Shuck-only | 0 | 0 |
 | Location-only | 0 | 0 |
 
-The run also produced 11 parser-abort fixtures. Those are environment noise and are not counted in the compatibility buckets above.
+The run still reported 4 corpus-noise fixtures (`parse-abort` / `shell-collapse`), but none were blocking `C020`.
 
-## Delta analysis
+## Root cause
 
-### Fixed literal tests are still over-reported `[shuck-fix]`
+The remaining `C020` failures were not rule-policy mistakes. They came from parser span drift inside expanding `<<-` heredocs.
 
-**Bucket:** Shuck-only
-**Impact:** 1 location / 1 script
+When Shuck decoded a tab-stripped heredoc body, it first removed the leading tabs from each line and then parsed the stripped text against the original heredoc span. Nested command substitutions in the body therefore inherited offsets from the stripped text instead of the real file. In the Termux fixtures, that shifted the nested `if [[ "${tag_type}" == "newest-tag" ]]` command far enough left that later `echo` lines were sliced as bogus `test` commands, which made `C020` fire on text that was never a truthy test.
 
-The SlackBuilds sample is a plain fixed-literal test. Shuck still reports it even though the condition is predetermined, which is exactly the kind of literal-only check this rule is meant to catch. The corpus comparison did not show a ShellCheck-side hit for the mapped SC2159 comparison, so this is a direct parity gap.
+## Fix
 
-**Samples:**
-- `SlackBuildsOrg__slackbuilds__multimedia__droidcam__doinst.sh:22` - `[ "lsmod | grep v4l2loopback_dc" ]`
+- Parse expanding `<<-` heredoc bodies from the original source-backed text so nested command and conditional spans stay aligned with the file.
+- Strip the tab-indentation only from the top-level literal heredoc fragments after parsing, instead of shifting the parsed coordinate system up front.
+- Add regressions that cover the Termux-style pattern with an earlier tab-stripped heredoc plus a later heredoc command substitution carrying `[[ ... == ... ]]`.
 
-### Literal payload inside a heredoc is also being traversed `[shuck-fix]`
+## Verification
 
-**Bucket:** Shuck-only
-**Impact:** 1 location / 1 script
-
-The Termux helper embeds a quoted message body inside a heredoc. ShellCheck treats that payload as literal text, but Shuck still emits `C020` from inside the embedded block. That suggests the rule is reaching literal heredoc content that should not be treated like live shell code.
-
-**Samples:**
-- `termux__termux-packages__scripts__updates__api__termux_gitlab_api_get_tag.sh:85` - heredoc payload inside a literal error message block
-
-## Checklist
-
-- [ ] Keep the rule focused on actual shell tests, not literal text embedded in heredoc payloads.
-  - Start in `crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs`.
-  - Review the command traversal path so heredoc bodies do not produce `C020` hits.
-- [ ] Re-run the large-corpus comparison and refresh this document.
+- `cargo test -p shuck-linter ignores_tab_stripped_heredoc_substitutions_after_earlier_heredocs -- --nocapture`
+- `cargo test -p shuck-linter tab_stripped_heredoc_substitutions_after_earlier_heredocs_keep_command_spans_intact -- --nocapture`
+- `cargo test -p shuck-parser heredoc_strip_tabs -- --nocapture`
+- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C020 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
+- `make test`
+- `cargo test --workspace`
 
 ## Allowlisted divergences
 
-None were added in this run.
-
-## Notes
-
-Update on 2026-04-06: `C020` now uses the shared fixed-literal operand classifier for simple tests and `[[ ... ]]` conditionals.
-
-This rule is small in sample size but still looks like a real shuck-fix. The only non-noise mismatches were two Shuck-only locations, and the heredoc case is a good sign that the traversal boundary needs to be tightened rather than the warning wording changed.
+No corpus-metadata entries were added for `C020`.


### PR DESCRIPTION
## Summary
- parse expanding <<- heredocs from source-backed text before stripping indentation so nested command spans stay aligned
- add parser and linter regressions for tab-stripped heredoc substitutions after earlier heredocs
- refresh the C020 bug note now that the large corpus run is clean

## Testing
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C020 SHUCK_LARGE_CORPUS_KEEP_GOING=1
- make test
- cargo test --workspace