### PR TITLE
Fix X025 replacement expansion coverage

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -230,7 +230,6 @@ impl<'a> SurfaceFragmentSink<'a> {
             &mut self.facts.unicode_smart_quote_spans,
         );
         self.collect_heredoc_body_parts(&body.parts, context);
-        self.collect_parameter_operation_fragments_in_text_span(body.span);
     }
 
     pub(super) fn record_unset_array_target_word(&mut self, word: &Word) {
@@ -330,26 +329,6 @@ impl<'a> SurfaceFragmentSink<'a> {
                     }
                 }
             }
-        }
-    }
-
-    fn collect_parameter_operation_fragments_in_text_span(&mut self, span: Span) {
-        let text = span.slice(self.source);
-        let mut search_start = 0;
-
-        while let Some((relative_start, relative_end)) =
-            next_parameter_expansion_candidate(text, search_start)
-        {
-            let candidate_span = Span::from_positions(
-                span.start.advanced_by(&text[..relative_start]),
-                span.start.advanced_by(&text[..relative_end]),
-            );
-
-            self.record_substring_expansion(candidate_span);
-            self.record_case_modification(candidate_span);
-            self.record_replacement_expansion(candidate_span);
-
-            search_start = relative_end;
         }
     }
 

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -230,6 +230,7 @@ impl<'a> SurfaceFragmentSink<'a> {
             &mut self.facts.unicode_smart_quote_spans,
         );
         self.collect_heredoc_body_parts(&body.parts, context);
+        self.collect_parameter_operation_fragments_in_text_span(body.span);
     }
 
     pub(super) fn record_unset_array_target_word(&mut self, word: &Word) {
@@ -329,6 +330,26 @@ impl<'a> SurfaceFragmentSink<'a> {
                     }
                 }
             }
+        }
+    }
+
+    fn collect_parameter_operation_fragments_in_text_span(&mut self, span: Span) {
+        let text = span.slice(self.source);
+        let mut search_start = 0;
+
+        while let Some((relative_start, relative_end)) =
+            next_parameter_expansion_candidate(text, search_start)
+        {
+            let candidate_span = Span::from_positions(
+                span.start.advanced_by(&text[..relative_start]),
+                span.start.advanced_by(&text[..relative_end]),
+            );
+
+            self.record_substring_expansion(candidate_span);
+            self.record_case_modification(candidate_span);
+            self.record_replacement_expansion(candidate_span);
+
+            search_start = relative_end;
         }
     }
 
@@ -733,16 +754,16 @@ impl<'a> SurfaceFragmentSink<'a> {
             self.record_array_reference(span);
         }
         if parameter_has_substring_expansion(parameter) {
-            self.record_substring_expansion(parameter.span);
+            self.record_substring_expansion(span);
         }
         if parameter_has_case_modification(parameter) {
-            self.record_case_modification(parameter.span);
+            self.record_case_modification(span);
         }
         if parameter_has_replacement_expansion(parameter) {
-            self.record_replacement_expansion(parameter.span);
+            self.record_replacement_expansion(span);
         }
         if parameter_has_star_glob_removal(parameter) {
-            self.record_star_glob_removal(parameter.span);
+            self.record_star_glob_removal(span);
         }
         self.record_parameter_subscripts(parameter);
         if let ParameterExpansionSyntax::Bourne(syntax) = &parameter.syntax {
@@ -1535,7 +1556,7 @@ fn is_unicode_smart_quote(char: char) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::SubscriptSpanIndex;
+    use super::{SubscriptSpanIndex, plain_replacement_expansion_span};
     use shuck_ast::{Position, Span};
 
     fn span(start: usize, end: usize) -> Span {
@@ -1562,5 +1583,23 @@ mod tests {
         assert!(index.contains(span(99, 100)));
         assert!(!index.contains(span(100, 101)));
         assert!(!index.contains(span(110, 115)));
+    }
+
+    #[test]
+    fn plain_replacement_expansion_span_handles_complex_replacements() {
+        for text in [
+            r#"${dest_dir//\'/\'\\\'\'}"#,
+            r#"${TERMUX_PKG_VERSION//-/.}"#,
+            r#"${TERMUX_PKG_VERSION_EDITED//${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}/${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}}"#,
+            r#"${GITHUB_GRAPHQL_QUERIES[$BATCH * $BATCH_SIZE]//\\/}"#,
+            r#"${run_depends/${i}/${dep}}"#,
+        ] {
+            assert_eq!(
+                plain_replacement_expansion_span(span(0, text.len()), text)
+                    .expect("expected replacement expansion span")
+                    .slice(text),
+                text
+            );
+        }
     }
 }

--- a/crates/shuck-linter/src/rules/portability/replacement_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/replacement_expansion.rs
@@ -85,6 +85,125 @@ EOF
     }
 
     #[test]
+    fn anchors_on_complex_replacement_expansions_inside_unquoted_heredocs() {
+        let source = "\
+#!/bin/sh
+cat <<EOF
+Expected: 'npx create-next-app@v${TERMUX_PKG_VERSION//\\~/-}'
+EOF
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ReplacementExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${TERMUX_PKG_VERSION//\\~/-}"]
+        );
+    }
+
+    #[test]
+    fn anchors_on_complex_replacement_expansions_inside_tab_stripped_heredocs() {
+        let source = "#!/bin/sh\ncat <<-EOF\n\tExpected: 'npx create-next-app@v${TERMUX_PKG_VERSION//\\~/-}'\nEOF\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ReplacementExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${TERMUX_PKG_VERSION//\\~/-}"]
+        );
+    }
+
+    #[test]
+    fn anchors_on_complex_replacement_expansions_in_termux_style_heredocs() {
+        let source = "\
+#!/bin/sh
+cat > ./postinst <<-EOF
+\t#!$TERMUX_PREFIX/bin/sh
+\techo \"You must explicitly use 'npx create-next-app@v${TERMUX_PKG_VERSION//\\~/-}' to avoid the error of Missing field 'isPersistentCachingEnabled'\"
+EOF
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ReplacementExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${TERMUX_PKG_VERSION//\\~/-}"]
+        );
+    }
+
+    #[test]
+    fn anchors_on_replacement_expansions_with_escaped_and_nested_operands() {
+        let source = "\
+#!/bin/sh
+TERMUX_PKG_SRCURL=https://github.com/vercel/next.js/archive/refs/tags/v${TERMUX_PKG_VERSION//\\~/-}.tar.gz
+printf '%s\n' \"${dest_dir//\\'/\\'\\\\\\'\\'}\"
+local TERMUX_PKG_VERSION_EDITED=${TERMUX_PKG_VERSION//-/.}
+local TERMUX_PKG_VERSION_EDITED=${TERMUX_PKG_VERSION_EDITED//${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}/${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}}
+echo \"Starting batch $BATCH at: ${GITHUB_GRAPHQL_QUERIES[$BATCH * $BATCH_SIZE]//\\\\/}\"
+run_depends=\"${run_depends/${i}/${dep}}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ReplacementExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "${TERMUX_PKG_VERSION//\\~/-}",
+                "${dest_dir//\\'/\\'\\\\\\'\\'}",
+                "${TERMUX_PKG_VERSION//-/.}",
+                "${TERMUX_PKG_VERSION_EDITED//${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}/${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}}",
+                "${GITHUB_GRAPHQL_QUERIES[$BATCH * $BATCH_SIZE]//\\\\/}",
+                "${run_depends/${i}/${dep}}",
+            ]
+        );
+    }
+
+    #[test]
+    fn anchors_on_replacement_expansions_with_complex_operator_bodies() {
+        let source = "\
+#!/bin/sh
+printf '%s\n' \"${dest_dir//\\'/\\'\\\\\\'\\'}\" \"${TERMUX_PKG_VERSION_EDITED//${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}/${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}}\" \"${GITHUB_GRAPHQL_QUERIES[$BATCH * $BATCH_SIZE]//\\\\/}\" \"${run_depends/${i}/${dep}}\"\n\
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ReplacementExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "${dest_dir//\\'/\\'\\\\\\'\\'}",
+                "${TERMUX_PKG_VERSION_EDITED//${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}/${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}}",
+                "${GITHUB_GRAPHQL_QUERIES[$BATCH * $BATCH_SIZE]//\\\\/}",
+                "${run_depends/${i}/${dep}}",
+            ]
+        );
+    }
+
+    #[test]
     fn ignores_replacement_expansion_in_bash() {
         let source = "printf '%s\n' \"${name//x/y}\"\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/replacement_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/replacement_expansion.rs
@@ -147,6 +147,22 @@ EOF
     }
 
     #[test]
+    fn ignores_literal_replacement_expansions_in_nested_heredoc_shell_contexts() {
+        let source = "\
+#!/bin/sh
+cat <<EOF
+$(printf '%s' '${commit//old/new}')
+EOF
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ReplacementExpansion),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn anchors_on_replacement_expansions_with_escaped_and_nested_operands() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-parser/src/parser/heredocs.rs
+++ b/crates/shuck-parser/src/parser/heredocs.rs
@@ -123,7 +123,6 @@ impl<'a> Parser<'a> {
 
         body.parts = parts;
     }
-
     /// Parse redirections that follow a compound command (>, >>, 2>, etc.)
     pub(super) fn parse_heredoc_redirect(
         &mut self,

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -745,6 +745,25 @@ esac
 }
 
 #[test]
+fn test_strip_tabs_heredoc_body_keeps_parameter_part_source_spans() {
+    let input = "cat <<-EOF\n\tExpected: ${TERMUX_PKG_VERSION//\\~/-}\nEOF\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let heredoc = redirect_heredoc(&script.body[0].redirects[0]);
+    let parameter = heredoc
+        .body
+        .parts
+        .iter()
+        .find(|part| matches!(part.kind, shuck_ast::HeredocBodyPart::Parameter(_)))
+        .expect("expected parameter part");
+
+    assert_eq!(
+        parameter.span.slice(input).trim_end_matches('\n'),
+        "${TERMUX_PKG_VERSION//\\~/-}"
+    );
+}
+
+#[test]
 fn test_comment_ranges_heredoc_no_false_comments() {
     // Lines with # inside a heredoc must NOT produce Comment entries
     let source = "cat <<EOF\n# not a comment\nline two\nEOF\n# real\n";

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -532,7 +532,12 @@ fn test_unquoted_heredoc_body_preserves_multiple_quoted_fragments() {
     let input = "cat <<EOF\nbefore '$HOME' and \"$USER\"\nEOF\n";
     let script = Parser::new(input).parse().unwrap().file;
 
-    let body = &redirect_heredoc(&script.body[0].redirects[0]).body;
+    let body = &script.body[0]
+        .redirects
+        .iter()
+        .find_map(|redirect| redirect.heredoc())
+        .expect("expected heredoc redirect")
+        .body;
 
     assert!(!heredoc_body_is_literal(body));
     assert_eq!(
@@ -554,7 +559,12 @@ fn test_unquoted_heredoc_body_keeps_dollar_quoted_forms_literal() {
     let input = "cat <<EOF\n$'line\\n' $\"hello\" ${name}\nEOF\n";
     let script = Parser::new(input).parse().unwrap().file;
 
-    let body = &redirect_heredoc(&script.body[0].redirects[0]).body;
+    let body = &script.body[0]
+        .redirects
+        .iter()
+        .find_map(|redirect| redirect.heredoc())
+        .expect("expected heredoc redirect")
+        .body;
 
     assert_eq!(
         heredoc_top_level_part_slices(body, input),
@@ -590,7 +600,12 @@ EOF
 ";
     let script = Parser::new(input).parse().unwrap().file;
 
-    let body = &redirect_heredoc(&script.body[0].redirects[0]).body;
+    let body = &script.body[0]
+        .redirects
+        .iter()
+        .find_map(|redirect| redirect.heredoc())
+        .expect("expected heredoc redirect")
+        .body;
     let slices = heredoc_top_level_part_slices(body, input);
 
     assert!(

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1912,6 +1912,77 @@ fn test_parameter_replacement_word_keeps_escaped_single_quotes_literal() {
 }
 
 #[test]
+fn test_parameter_replacement_spans_cover_complex_pattern_and_replacement_bodies() {
+    let input = "\
+echo ${dest_dir//\\'/\\'\\\\\\'\\'} ${TERMUX_PKG_VERSION_EDITED//${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}/${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}} ${GITHUB_GRAPHQL_QUERIES[$BATCH * $BATCH_SIZE]//\\\\/} ${run_depends/${i}/${dep}}\n\
+";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+
+    assert_eq!(
+        command.args[0]
+            .parts
+            .iter()
+            .map(|part| part.span.slice(input))
+            .collect::<Vec<_>>(),
+        vec![r#"${dest_dir//\'/\'\\\'\'}"#]
+    );
+
+    let spans = command
+        .args
+        .iter()
+        .map(|word| word.parts[0].span.slice(input))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        spans,
+        vec![
+            "${dest_dir//\\'/\\'\\\\\\'\\'}",
+            "${TERMUX_PKG_VERSION_EDITED//${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}/${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}}",
+            "${GITHUB_GRAPHQL_QUERIES[$BATCH * $BATCH_SIZE]//\\\\/}",
+            "${run_depends/${i}/${dep}}",
+        ]
+    );
+
+    let (_, operator, _) = expect_parameter_operation_part(&command.args[1].parts[0].kind);
+    let ParameterOp::ReplaceAll {
+        pattern,
+        replacement,
+        replacement_word_ast,
+    } = operator
+    else {
+        panic!("expected replace-all operator");
+    };
+    assert_eq!(
+        pattern.render(input),
+        "${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}"
+    );
+    assert_eq!(
+        replacement.slice(input),
+        "${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}"
+    );
+    assert_eq!(
+        replacement_word_ast.render(input),
+        "${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}"
+    );
+
+    let (_, operator, _) = expect_parameter_operation_part(&command.args[3].parts[0].kind);
+    let ParameterOp::ReplaceFirst {
+        pattern,
+        replacement,
+        replacement_word_ast,
+    } = operator
+    else {
+        panic!("expected replace-first operator");
+    };
+    assert_eq!(pattern.render(input), "${i}");
+    assert_eq!(replacement.slice(input), "${dep}");
+    assert_eq!(replacement_word_ast.render(input), "${dep}");
+}
+
+#[test]
 fn test_decode_cooked_word_keeps_variable_after_literal_backslash() {
     let cooked = r#"\$HOME"#;
     let span = Span::from_positions(Position::new(), Position::new().advanced_by(cooked));

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3785,18 +3785,31 @@ impl<'a> Parser<'a> {
                                     source_backed,
                                 );
                                 let pattern = self.pattern_from_source_text(&pattern_text);
-                                let replacement =
+                                let (replacement, consumed_closing_brace) =
                                     if Self::consume_word_char_if(&mut chars, &mut cursor, '/') {
-                                        self.read_source_text_while(
+                                        let replacement = self.read_brace_operand(
                                             &mut chars,
                                             &mut cursor,
-                                            |ch| ch != '}',
                                             source_backed,
+                                        );
+                                        (
+                                            replacement,
+                                            cursor.offset > 0
+                                                && self.input[..cursor.offset].ends_with('}'),
                                         )
                                     } else {
-                                        self.empty_source_text(cursor)
+                                        (self.empty_source_text(cursor), false)
                                     };
-                                Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                                if !consumed_closing_brace {
+                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                                }
+                                if !Span::from_positions(part_start, cursor)
+                                    .slice(self.input)
+                                    .ends_with('}')
+                                    && self.input[cursor.offset..].starts_with('}')
+                                {
+                                    cursor.advance('}');
+                                }
                                 let operator = if replace_all {
                                     ParameterOp::ReplaceAll {
                                         pattern,
@@ -4061,18 +4074,31 @@ impl<'a> Parser<'a> {
                                 source_backed,
                             );
                             let pattern = self.pattern_from_source_text(&pattern_text);
-                            let replacement =
+                            let (replacement, consumed_closing_brace) =
                                 if Self::consume_word_char_if(&mut chars, &mut cursor, '/') {
-                                    self.read_source_text_while(
+                                    let replacement = self.read_brace_operand(
                                         &mut chars,
                                         &mut cursor,
-                                        |ch| ch != '}',
                                         source_backed,
+                                    );
+                                    (
+                                        replacement,
+                                        cursor.offset > 0
+                                            && self.input[..cursor.offset].ends_with('}'),
                                     )
                                 } else {
-                                    self.empty_source_text(cursor)
+                                    (self.empty_source_text(cursor), false)
                                 };
-                            Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                            if !consumed_closing_brace {
+                                Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                            }
+                            if !Span::from_positions(part_start, cursor)
+                                .slice(self.input)
+                                .ends_with('}')
+                                && self.input[cursor.offset..].starts_with('}')
+                            {
+                                cursor.advance('}');
+                            }
                             let operator = if replace_all {
                                 ParameterOp::ReplaceAll {
                                     pattern,
@@ -4365,18 +4391,31 @@ impl<'a> Parser<'a> {
                                 source_backed,
                             );
                             let pattern = self.pattern_from_source_text(&pattern_text);
-                            let replacement =
+                            let (replacement, consumed_closing_brace) =
                                 if Self::consume_word_char_if(&mut chars, &mut cursor, '/') {
-                                    self.read_source_text_while(
+                                    let replacement = self.read_brace_operand(
                                         &mut chars,
                                         &mut cursor,
-                                        |ch| ch != '}',
                                         source_backed,
+                                    );
+                                    (
+                                        replacement,
+                                        cursor.offset > 0
+                                            && self.input[..cursor.offset].ends_with('}'),
                                     )
                                 } else {
-                                    self.empty_source_text(cursor)
+                                    (self.empty_source_text(cursor), false)
                                 };
-                            Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                            if !consumed_closing_brace {
+                                Self::consume_word_char_if(&mut chars, &mut cursor, '}');
+                            }
+                            if !Span::from_positions(part_start, cursor)
+                                .slice(self.input)
+                                .ends_with('}')
+                                && self.input[cursor.offset..].starts_with('}')
+                            {
+                                cursor.advance('}');
+                            }
                             let operator = if replace_all {
                                 ParameterOp::ReplaceAll {
                                     pattern,


### PR DESCRIPTION
## Summary
- fix `X025` coverage for replacement expansions with nested or escaped pattern and replacement bodies
- preserve `X025` detection for replacement expansions inside expanding heredocs, including tab-stripped heredocs
- add parser and linter regressions for the corpus cases that were previously missed

## Root Cause
Complex replacement expansions could end up with truncated spans when the pattern or replacement contained nested parameter expansions or heavier escaping. Separately, expanding heredoc bodies could miss `X025` facts because the parsed body-part spans drifted in some tab-stripped heredoc shapes.

## Impact
`X025` now reports the same replacement-expansion portability issues across normal words, assignments, and heredoc bodies that showed up in the targeted corpus run.

## Validation
- `cargo test -p shuck-parser test_parameter_replacement -- --nocapture`
- `cargo test -p shuck-parser unquoted_heredoc_body -- --nocapture`
- `cargo test -p shuck-linter replacement_expansion -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X025`
