### PR TITLE
Remove redundant parser fallback reparsing

### DIFF
--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -4,8 +4,6 @@ use shuck_ast::{
     HeredocBodyPartNode, Pattern, PatternPart, PatternPartNode, Redirect, RedirectKind, Stmt,
     StmtSeq, Subscript, TextRange, TextSize, VarRef, Word, WordPart, WordPartNode, ZshGlobSegment,
 };
-use shuck_parser::parser::Parser;
-
 /// A syntactic region that affects lint rule behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegionKind {
@@ -100,7 +98,7 @@ impl RegionIndex {
 }
 
 struct RegionCollector<'a> {
-    source: &'a str,
+    _source: &'a str,
     single_quoted: Vec<TextRange>,
     double_quoted: Vec<TextRange>,
     heredocs: Vec<TextRange>,
@@ -113,7 +111,7 @@ struct RegionCollector<'a> {
 impl<'a> RegionCollector<'a> {
     fn new(source: &'a str) -> Self {
         Self {
-            source,
+            _source: source,
             single_quoted: Vec::new(),
             double_quoted: Vec::new(),
             heredocs: Vec::new(),
@@ -567,9 +565,10 @@ impl<'a> RegionCollector<'a> {
             return;
         }
 
-        let text = subscript.syntax_source_text();
-        let word = Parser::parse_word_fragment(self.source, text.slice(self.source), text.span());
-        self.visit_word(&word);
+        debug_assert!(
+            subscript.word_ast().is_some(),
+            "ordinary subscripts should always carry a word AST"
+        );
     }
 
     fn visit_arithmetic_shell_words(&mut self, expression: &shuck_ast::ArithmeticExprNode) {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4030,12 +4030,14 @@ fn collect_base_prefix_spans_in_fragment(
         return;
     }
 
-    if let Some(word) = word {
-        collect_base_prefix_spans_in_word(word, source, spans);
-    } else {
-        let word = Parser::parse_word_fragment(source, snippet, text.span());
-        collect_base_prefix_spans_in_word(&word, source, spans);
-    }
+    debug_assert!(
+        word.is_some(),
+        "parser-backed fragment text should always carry a word AST"
+    );
+    let Some(word) = word else {
+        return;
+    };
+    collect_base_prefix_spans_in_word(word, source, spans);
 }
 
 fn collect_base_prefix_spans_in_text(span: Span, source: &str, spans: &mut Vec<Span>) {
@@ -7110,7 +7112,13 @@ fn collect_status_parameter_spans_in_source_text(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_status_parameter_spans_in_fragment(None, Some(text), source, spans);
+    let snippet = text.slice(source);
+    if !snippet.contains("$?") {
+        return;
+    }
+
+    let word = Parser::parse_word_fragment(source, snippet, text.span());
+    collect_status_parameter_spans_in_word(&word, source, spans);
 }
 
 fn collect_status_parameter_spans_in_fragment(
@@ -7126,12 +7134,14 @@ fn collect_status_parameter_spans_in_fragment(
     if !snippet.contains("$?") {
         return;
     }
-    if let Some(word) = word {
-        collect_status_parameter_spans_in_word(word, source, spans);
-    } else {
-        let word = Parser::parse_word_fragment(source, snippet, text.span());
-        collect_status_parameter_spans_in_word(&word, source, spans);
-    }
+    debug_assert!(
+        word.is_some(),
+        "parser-backed fragment text should always carry a word AST"
+    );
+    let Some(word) = word else {
+        return;
+    };
+    collect_status_parameter_spans_in_word(word, source, spans);
 }
 
 fn build_redirect_facts<'a>(

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -677,12 +677,14 @@ impl<'a> SurfaceFragmentSink<'a> {
             return;
         }
 
-        if let Some(word) = word {
-            self.collect_word(word, context.without_open_double_quote_scan());
-        } else {
-            let word = Parser::parse_word_fragment(self.source, snippet, text.span());
-            self.collect_word(&word, context.without_open_double_quote_scan());
-        }
+        debug_assert!(
+            word.is_some(),
+            "parser-backed fragment text should always carry a word AST"
+        );
+        let Some(word) = word else {
+            return;
+        };
+        self.collect_word(word, context.without_open_double_quote_scan());
     }
 
     fn collect_zsh_qualified_glob(

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -4,8 +4,6 @@ use shuck_ast::{
     DeclOperand, FunctionDef, HeredocBodyPartNode, Pattern, PatternPart, Redirect, Stmt, StmtSeq,
     Subscript, VarRef, Word, WordPart, WordPartNode, ZshGlobSegment,
 };
-use shuck_parser::parser::Parser;
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct WalkContext {
     pub(crate) loop_depth: usize,
@@ -213,7 +211,7 @@ fn collect_var_ref_subscript_words<'a>(reference: &'a VarRef, words: &mut Vec<&'
     );
 }
 
-fn collect_subscript_words(subscript: Option<&Subscript>, source: &str, words: &mut Vec<Word>) {
+fn collect_subscript_words(subscript: Option<&Subscript>, _source: &str, words: &mut Vec<Word>) {
     let Some(subscript) = subscript else {
         return;
     };
@@ -232,12 +230,10 @@ fn collect_subscript_words(subscript: Option<&Subscript>, source: &str, words: &
         return;
     }
 
-    let text = subscript.syntax_source_text();
-    words.push(Parser::parse_word_fragment(
-        source,
-        text.slice(source),
-        text.span(),
-    ));
+    debug_assert!(
+        subscript.word_ast().is_some(),
+        "ordinary subscripts should always carry a word AST"
+    );
 }
 
 fn collect_optional_arithmetic_words<'a>(
@@ -805,11 +801,15 @@ fn collect_heredoc_body_part_visits<'a, F>(
 
 #[cfg(test)]
 mod tests {
-    use shuck_ast::{Command, StmtSeq, Word, WordPart};
+    use shuck_ast::{
+        BourneParameterExpansion, Command, ParameterExpansionSyntax, StmtSeq, VarRef, Word,
+        WordPart,
+    };
     use shuck_parser::parser::Parser;
 
     use super::{
-        CommandWalkOptions, ConditionKind, iter_commands, pipeline_segments, walk_commands,
+        CommandWalkOptions, ConditionKind, iter_commands, pipeline_segments,
+        visit_var_ref_subscript_words_with_source, walk_commands,
     };
 
     fn parse_commands(source: &str) -> StmtSeq {
@@ -826,6 +826,21 @@ mod tests {
             }
         }
         Some(result)
+    }
+
+    fn parameter_access_reference(word: &Word) -> &VarRef {
+        let [part] = word.parts.as_slice() else {
+            panic!("expected single parameter part");
+        };
+        let WordPart::Parameter(parameter) = &part.kind else {
+            panic!("expected parameter part, got {:?}", part.kind);
+        };
+        let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) =
+            &parameter.syntax
+        else {
+            panic!("expected access expansion, got {:?}", parameter.syntax);
+        };
+        reference
     }
 
     #[test]
@@ -996,5 +1011,30 @@ done
             .collect::<Vec<_>>();
 
         assert_eq!(segments, vec!["printf", "command", "tee"]);
+    }
+
+    #[test]
+    fn visit_var_ref_subscript_words_uses_parser_backed_subscript_words() {
+        let source = "echo ${map[$key]} ${map[@]}\n";
+        let commands = parse_commands(source);
+        let Command::Simple(command) = &commands.stmts[0].command else {
+            panic!("expected simple command");
+        };
+
+        let ordinary = parameter_access_reference(&command.args[0]);
+        let selector = parameter_access_reference(&command.args[1]);
+
+        let mut ordinary_words = Vec::new();
+        visit_var_ref_subscript_words_with_source(ordinary, source, &mut |word| {
+            ordinary_words.push(word.render_syntax(source));
+        });
+
+        let mut selector_words = Vec::new();
+        visit_var_ref_subscript_words_with_source(selector, source, &mut |word| {
+            selector_words.push(word.render_syntax(source));
+        });
+
+        assert_eq!(ordinary_words, vec!["$key"]);
+        assert!(selector_words.is_empty());
     }
 }

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -459,6 +459,82 @@ fn expect_binary(stmt: &Stmt) -> &BinaryCommand {
     command
 }
 
+#[test]
+fn ordinary_subscripts_keep_word_asts_while_selectors_do_not() {
+    let input = "echo ${map[$key]} ${map[@]}\n";
+    let output = Parser::new(input).parse().unwrap();
+    let command = expect_simple(&output.file.body.stmts[0]);
+
+    let ordinary = expect_array_access(&command.args[0]);
+    let ordinary_subscript = expect_subscript(ordinary, input, "$key");
+    assert_eq!(
+        ordinary_subscript
+            .word_ast()
+            .expect("expected ordinary subscript word AST")
+            .render_syntax(input),
+        "$key"
+    );
+
+    let selector = expect_array_access(&command.args[1]);
+    let selector_subscript = expect_subscript(selector, input, "@");
+    assert!(selector_subscript.word_ast().is_none());
+}
+
+#[test]
+fn parser_backed_parameter_fragments_keep_word_asts() {
+    let bash_input = "echo ${name:-$fallback}\n";
+    let bash_output = Parser::new(bash_input).parse().unwrap();
+    let bash_command = expect_simple(&bash_output.file.body.stmts[0]);
+    let bash_parameter = expect_parameter(&bash_command.args[0]);
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+        operand_word_ast,
+        ..
+    }) = &bash_parameter.syntax
+    else {
+        panic!("expected parameter operation");
+    };
+    assert_eq!(
+        operand_word_ast
+            .as_ref()
+            .expect("expected operand word AST")
+            .render_syntax(bash_input),
+        "$fallback"
+    );
+
+    let zsh_input = "echo ${(j.:.)name//foo/$bar}\n";
+    let zsh_output = Parser::with_dialect(zsh_input, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let zsh_command = expect_simple(&zsh_output.file.body.stmts[0]);
+    let zsh_parameter = expect_parameter(&zsh_command.args[0]);
+    let ParameterExpansionSyntax::Zsh(syntax) = &zsh_parameter.syntax else {
+        panic!("expected zsh parameter expansion");
+    };
+    assert_eq!(
+        syntax.modifiers[0]
+            .argument_word_ast()
+            .expect("expected zsh modifier argument word AST")
+            .render_syntax(zsh_input),
+        ":"
+    );
+    let Some(ZshExpansionOperation::ReplacementOperation {
+        pattern_word_ast,
+        replacement_word_ast,
+        ..
+    }) = syntax.operation.as_ref()
+    else {
+        panic!("expected zsh replacement operation");
+    };
+    assert_eq!(pattern_word_ast.render_syntax(zsh_input), "foo");
+    assert_eq!(
+        replacement_word_ast
+            .as_ref()
+            .expect("expected zsh replacement word AST")
+            .render_syntax(zsh_input),
+        "$bar"
+    );
+}
+
 mod commands;
 mod heredocs;
 mod redirects;

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -9,7 +9,7 @@ use shuck_ast::{
     WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
 };
 use shuck_indexer::Indexer;
-use shuck_parser::{ShellProfile, ZshEmulationMode, parser::Parser};
+use shuck_parser::{ShellProfile, ZshEmulationMode};
 
 use crate::binding::{Binding, BindingAttributes, BindingKind};
 use crate::call_graph::{CallGraph, CallSite, OverwrittenFunction};
@@ -1834,15 +1834,14 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
-        if let Some(word) = word {
-            self.visit_word_into(word, kind, flow, nested_regions);
-            return;
-        }
-        let Some(text) = text else {
+        let Some(word) = word else {
+            debug_assert!(
+                text.is_none(),
+                "parser-backed fragment text should always carry a word AST"
+            );
             return;
         };
-        let word = Parser::parse_word_fragment(self.source, text.slice(self.source), text.span());
-        self.visit_word_into(&word, kind, flow, nested_regions);
+        self.visit_word_into(word, kind, flow, nested_regions);
     }
 
     fn visit_parameter_operator_operand(


### PR DESCRIPTION
## Summary
- remove downstream reparsing for ordinary subscripts and parser-backed fragment helpers that already receive `word_ast`
- keep the remaining raw `SourceText` reparsing paths in `facts.rs` where the parser does not yet provide a companion word AST
- add regression coverage for ordinary subscript `word_ast` population and parser-backed parameter fragment ASTs

## Why
The parser already materializes `Subscript.word_ast` for ordinary subscripts, so several downstream fallback calls to `Parser::parse_word_fragment(...)` were duplicating work on normal parser output. Tightening those consumers to rely on parser-populated ASTs makes the invariant explicit and leaves only the truly text-only reparsing paths in place.

## Impact
This reduces redundant reparsing in production consumers across the semantic model, indexer, and linter while preserving the existing text-only arithmetic/status scanning paths that still need local parsing.

## Validation
- `cargo test -p shuck-parser -p shuck-indexer -p shuck-semantic -p shuck-linter`
- `cargo test -p shuck-indexer tracks_quoted_regions_inside_keyed_array_subscripts`