### PR TITLE
Fix X006 quoted regex false positives

### DIFF
--- a/crates/shuck-linter/src/rules/portability/process_substitution.rs
+++ b/crates/shuck-linter/src/rules/portability/process_substitution.rs
@@ -71,4 +71,28 @@ cat <(printf '%s\n' hi) > >(wc -c)
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_regex_text_that_only_looks_like_process_substitution() {
+        let source = "\
+#!/bin/sh
+value=$(printf '%s\n' \"<record_id>([^<]*)</record_id>\")
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::ProcessSubstitution));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_regex_text_in_nested_pipeline_command_substitution() {
+        let source = "\
+#!/bin/sh
+_record_id=$(echo \"$response\" | _egrep_o \"<record_id>([^<]*)</record_id><type>TXT</type><host>$fulldomain</host>\" | _egrep_o \"<record_id>([^<]*)</record_id>\" | sed -r \"s/<record_id>([^<]*)<\\/record_id>/\\1/\" | tail -n 1)
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::ProcessSubstitution));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
 }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2867,7 +2867,7 @@ impl<'a> Parser<'a> {
                 LexedWordSegmentKind::DoubleQuoted | LexedWordSegmentKind::DollarDoubleQuoted
                     if Self::word_text_needs_parse(text) =>
                 {
-                    let inner = self.decode_word_text(
+                    let inner = self.decode_quoted_segment_text(
                         text,
                         content_span,
                         content_span.start,
@@ -2956,7 +2956,7 @@ impl<'a> Parser<'a> {
                 }
                 LexedWordSegmentKind::DoubleQuoted | LexedWordSegmentKind::DollarDoubleQuoted => {
                     if Self::word_text_needs_parse(text) {
-                        let inner = self.decode_word_text(
+                        let inner = self.decode_quoted_segment_text(
                             text,
                             content_span,
                             content_span.start,

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1142,6 +1142,82 @@ fn test_process_substitution_like_text_inside_double_quotes_stays_literal() {
 }
 
 #[test]
+fn test_process_substitution_like_regex_inside_nested_command_substitution_stays_literal() {
+    let input = "value=$(printf '%s\\n' \"<record_id>([^<]*)</record_id>\")\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Scalar(value) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+    let WordPart::CommandSubstitution { body, .. } = &value.parts[0].kind else {
+        panic!("expected command substitution");
+    };
+
+    let inner = expect_simple(&body[0]);
+    for word in &inner.args {
+        assert!(
+            !word
+                .parts
+                .iter()
+                .any(|part| matches!(part.kind, WordPart::ProcessSubstitution { .. })),
+            "{:#?}",
+            word.parts
+        );
+    }
+}
+
+#[test]
+fn test_process_substitution_like_regex_inside_nested_pipeline_command_substitution_stays_literal()
+{
+    let input = "_record_id=$(echo \"$response\" | _egrep_o \"<record_id>([^<]*)</record_id><type>TXT</type><host>$fulldomain</host>\" | _egrep_o \"<record_id>([^<]*)</record_id>\" | sed -r \"s/<record_id>([^<]*)<\\/record_id>/\\1/\" | tail -n 1)\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Scalar(value) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+    let WordPart::CommandSubstitution { body, .. } = &value.parts[0].kind else {
+        panic!("expected command substitution");
+    };
+
+    fn word_has_process_substitution(word: &Word) -> bool {
+        word.parts.iter().any(|part| match &part.kind {
+            WordPart::ProcessSubstitution { .. } => true,
+            WordPart::DoubleQuoted { parts, .. } => parts
+                .iter()
+                .any(|part| matches!(part.kind, WordPart::ProcessSubstitution { .. })),
+            _ => false,
+        })
+    }
+
+    fn stmt_has_process_substitution(stmt: &Stmt) -> bool {
+        command_has_process_substitution(&stmt.command)
+    }
+
+    fn command_has_process_substitution(command: &AstCommand) -> bool {
+        match command {
+            AstCommand::Simple(command) => command.args.iter().any(word_has_process_substitution),
+            AstCommand::Binary(binary)
+                if matches!(binary.op, BinaryOp::Pipe | BinaryOp::PipeAll) =>
+            {
+                stmt_has_process_substitution(&binary.left)
+                    || stmt_has_process_substitution(&binary.right)
+            }
+            _ => false,
+        }
+    }
+
+    for stmt in body.iter() {
+        assert!(!stmt_has_process_substitution(stmt), "{:#?}", stmt);
+    }
+}
+
+#[test]
 fn test_escaped_process_substitution_like_text_stays_literal() {
     let input = "echo \\<(printf hi) \\>(printf bye)\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4763,6 +4763,26 @@ impl<'a> Parser<'a> {
         self.word_with_parts(parts, span)
     }
 
+    pub(super) fn decode_quoted_segment_text(
+        &mut self,
+        s: &str,
+        span: Span,
+        base: Position,
+        source_backed: bool,
+    ) -> Word {
+        self.decode_word_text_with_options(
+            s,
+            span,
+            base,
+            source_backed,
+            DecodeWordPartsOptions {
+                parse_dollar_quotes: true,
+                parse_process_substitutions: false,
+                ..DecodeWordPartsOptions::default()
+            },
+        )
+    }
+
     pub(super) fn decode_heredoc_body_text(
         &mut self,
         s: &str,


### PR DESCRIPTION
## Summary
- fix an `X006` false positive where quoted regex text like `>([^<]*)` inside nested `$(...)` pipelines was misparsed as process substitution
- route lexed double-quoted segment decoding through a parser helper that disables process-substitution parsing for quoted content
- add parser and linter regressions covering both simple nested command substitutions and the full pipeline-shaped corpus case

## Root Cause
Lexed double-quoted segments in the parser were decoded through the default word path, which still allowed process substitution recognition. In nested command substitutions, that let quoted regex text in `_egrep_o` and `sed` arguments produce bogus `ProcessSubstitution` nodes, which surfaced as `X006` warnings in plain `sh` scripts.

## Impact
This keeps `X006` focused on real `<(...)` and `>(...)` syntax instead of warning on quoted regex and replacement text, improving corpus conformance and reducing noise in portability checks.

## Validation
- `cargo test -p shuck-parser -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X006`
