### PR TITLE
Preserve escaped expansion literals in parser AST

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -80,6 +80,7 @@ impl From<String> for SourceText {
 pub enum LiteralText {
     Source,
     Owned(Box<str>),
+    CookedSource(Box<str>),
 }
 
 impl LiteralText {
@@ -91,9 +92,20 @@ impl LiteralText {
         Self::Owned(text.into())
     }
 
+    pub fn cooked_source(text: impl Into<Box<str>>) -> Self {
+        Self::CookedSource(text.into())
+    }
+
     pub fn as_str<'a>(&'a self, source: &'a str, span: Span) -> &'a str {
         match self {
             Self::Source => span.slice(source),
+            Self::Owned(text) | Self::CookedSource(text) => text.as_ref(),
+        }
+    }
+
+    pub fn syntax_str<'a>(&'a self, source: &'a str, span: Span) -> &'a str {
+        match self {
+            Self::Source | Self::CookedSource(_) => span.slice(source),
             Self::Owned(text) => text.as_ref(),
         }
     }
@@ -103,11 +115,11 @@ impl LiteralText {
     }
 
     pub fn is_source_backed(&self) -> bool {
-        matches!(self, Self::Source)
+        matches!(self, Self::Source | Self::CookedSource(_))
     }
 
     pub fn is_empty(&self) -> bool {
-        matches!(self, Self::Owned(text) if text.is_empty())
+        matches!(self, Self::Owned(text) | Self::CookedSource(text) if text.is_empty())
     }
 }
 
@@ -125,7 +137,7 @@ impl From<String> for LiteralText {
 
 impl PartialEq<str> for LiteralText {
     fn eq(&self, other: &str) -> bool {
-        matches!(self, Self::Owned(text) if text.as_ref() == other)
+        matches!(self, Self::Owned(text) | Self::CookedSource(text) if text.as_ref() == other)
     }
 }
 
@@ -2450,7 +2462,7 @@ fn fmt_literal_text(
         Some(source) => f.write_str(text.as_str(source, span)),
         None => match text {
             LiteralText::Source => f.write_str("<source>"),
-            LiteralText::Owned(text) => f.write_str(text),
+            LiteralText::Owned(text) | LiteralText::CookedSource(text) => f.write_str(text),
         },
     }
 }
@@ -2465,7 +2477,7 @@ fn fmt_double_quoted_literal_text(
         Some(source) => text.as_str(source, span),
         None => match text {
             LiteralText::Source => "<source>",
-            LiteralText::Owned(text) => text,
+            LiteralText::Owned(text) | LiteralText::CookedSource(text) => text,
         },
     };
 
@@ -2490,7 +2502,14 @@ fn fmt_pattern_part_with_source_mode(
     mode: RenderMode,
 ) -> fmt::Result {
     match part {
-        PatternPart::Literal(text) => fmt_literal_text(f, text, span, source)?,
+        PatternPart::Literal(text) => match (mode, source) {
+            (RenderMode::Syntax, Some(source))
+                if text.is_source_backed() && span.end.offset <= source.len() =>
+            {
+                f.write_str(text.syntax_str(source, span))?
+            }
+            _ => fmt_literal_text(f, text, span, source)?,
+        },
         PatternPart::AnyString => f.write_str("*")?,
         PatternPart::AnyChar => f.write_str("?")?,
         PatternPart::CharClass(text) => match source {

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -3496,6 +3496,7 @@ impl<'a> Parser<'a> {
                             literal,
                             self.current_span.start,
                             self.current_span.end,
+                            true,
                         )),
                         self.current_span,
                     ));
@@ -3522,6 +3523,7 @@ impl<'a> Parser<'a> {
                             literal,
                             self.current_span.start,
                             self.current_span.end,
+                            true,
                         )),
                         self.current_span,
                     ));

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1605,6 +1605,9 @@ impl<'a> Lexer<'a> {
                     } else {
                         // Escaped character: backslash quotes the next char
                         // (quote removal — only the literal char survives)
+                        if matches!(next, '$' | '`') {
+                            Self::push_capture_char(&mut word, '\x00');
+                        }
                         Self::push_capture_char(&mut word, next);
                         self.advance();
                         if next == '{'
@@ -1743,7 +1746,13 @@ impl<'a> Lexer<'a> {
         }
 
         if let Some(word) = word {
-            Ok(LexedWordSegment::owned(LexedWordSegmentKind::Plain, word))
+            let span = Some(Span::from_positions(start, self.current_position()));
+            Ok(LexedWordSegment::owned_with_spans(
+                LexedWordSegmentKind::Plain,
+                word,
+                span,
+                span,
+            ))
         } else {
             let end = self.current_position();
             Ok(LexedWordSegment::borrowed(

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2791,11 +2791,12 @@ impl<'a> Parser<'a> {
 
     fn literal_part_from_text(&self, text: &str, span: Span, source_backed: bool) -> WordPartNode {
         WordPartNode::new(
-            WordPart::Literal(if source_backed {
-                LiteralText::source()
-            } else {
-                LiteralText::owned(text.to_string())
-            }),
+            WordPart::Literal(self.literal_text(
+                text.to_string(),
+                span.start,
+                span.end,
+                source_backed,
+            )),
             span,
         )
     }
@@ -3757,8 +3758,14 @@ impl<'a> Parser<'a> {
     }
 
     fn materialize_literal_text_source_backing(text: &mut LiteralText, span: Span, source: &str) {
-        if text.is_source_backed() {
-            *text = LiteralText::owned(span.slice(source).to_string());
+        match text {
+            LiteralText::Source => {
+                *text = LiteralText::owned(span.slice(source).to_string());
+            }
+            LiteralText::CookedSource(cooked) => {
+                *text = LiteralText::owned(cooked.to_string());
+            }
+            LiteralText::Owned(_) => {}
         }
     }
 
@@ -4672,21 +4679,35 @@ impl<'a> Parser<'a> {
         current: &mut String,
         current_start: Position,
         end: Position,
+        source_backed: bool,
     ) {
         if !current.is_empty() {
             Self::push_word_part(
                 parts,
-                WordPart::Literal(self.literal_text(std::mem::take(current), current_start, end)),
+                WordPart::Literal(self.literal_text(
+                    std::mem::take(current),
+                    current_start,
+                    end,
+                    source_backed,
+                )),
                 current_start,
                 end,
             );
         }
     }
 
-    fn literal_text(&self, text: String, start: Position, end: Position) -> LiteralText {
+    fn literal_text(
+        &self,
+        text: String,
+        start: Position,
+        end: Position,
+        source_backed: bool,
+    ) -> LiteralText {
         let span = Span::from_positions(start, end);
         if self.source_matches(span, &text) {
             LiteralText::source()
+        } else if source_backed {
+            LiteralText::cooked_source(text)
         } else {
             LiteralText::owned(text)
         }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2842,6 +2842,8 @@ impl<'a> Parser<'a> {
             let content_span = Self::segment_content_span(segment, span);
             let wrapper_span = Self::segment_wrapper_span(segment, span);
             let source_backed = segment.span().is_some() && !token.flags.is_synthetic();
+            let preserve_escaped_expansion_literals =
+                source_backed && !token.flags.has_cooked_text();
 
             return match segment.kind() {
                 LexedWordSegmentKind::SingleQuoted => Some(self.word_with_parts(
@@ -2857,14 +2859,15 @@ impl<'a> Parser<'a> {
                     vec![self.single_quoted_part_from_text(text, content_span, wrapper_span, true)],
                     span,
                 )),
-                LexedWordSegmentKind::Plain if Self::word_text_needs_parse(text) => {
-                    Some(self.decode_word_text_preserving_quotes_if_needed(
+                LexedWordSegmentKind::Plain if Self::word_text_needs_parse(text) => Some(
+                    self.decode_word_text_preserving_quotes_if_needed_with_escape_mode(
                         text,
                         span,
                         content_span.start,
                         source_backed,
-                    ))
-                }
+                        preserve_escaped_expansion_literals,
+                    ),
+                ),
                 LexedWordSegmentKind::DoubleQuoted | LexedWordSegmentKind::DollarDoubleQuoted
                     if Self::word_text_needs_parse(text) =>
                 {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2843,7 +2843,7 @@ impl<'a> Parser<'a> {
             let wrapper_span = Self::segment_wrapper_span(segment, span);
             let source_backed = segment.span().is_some() && !token.flags.is_synthetic();
             let preserve_escaped_expansion_literals =
-                source_backed && !token.flags.has_cooked_text();
+                source_backed && self.source_matches(content_span, text);
 
             return match segment.kind() {
                 LexedWordSegmentKind::SingleQuoted => Some(self.word_with_parts(
@@ -2935,6 +2935,8 @@ impl<'a> Parser<'a> {
             };
             let wrapper_span = segment.wrapper_span().unwrap_or(content_span);
             let source_backed = segment.span().is_some() && !token.flags.is_synthetic();
+            let preserve_escaped_expansion_literals =
+                source_backed && self.source_matches(content_span, text);
 
             match segment.kind() {
                 LexedWordSegmentKind::SingleQuoted => parts.push(
@@ -2946,11 +2948,12 @@ impl<'a> Parser<'a> {
                 LexedWordSegmentKind::Plain => {
                     if Self::word_text_needs_parse(text) {
                         parts.extend(
-                            self.decode_word_text_preserving_quotes_if_needed(
+                            self.decode_word_text_preserving_quotes_if_needed_with_escape_mode(
                                 text,
                                 content_span,
                                 content_span.start,
                                 source_backed,
+                                preserve_escaped_expansion_literals,
                             )
                             .parts,
                         );

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -172,6 +172,31 @@ fn test_parse_escaped_dollar_expansions_stay_literal_in_script_words() {
 }
 
 #[test]
+fn test_parse_escaped_backslash_then_variable_keeps_variable_live() {
+    let input = "echo \\\\$HOME\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+    assert!(matches!(
+        word.parts.as_slice(),
+        [
+            WordPartNode {
+                kind: WordPart::Literal(text),
+                ..
+            },
+            WordPartNode {
+                kind: WordPart::Variable(name),
+                ..
+            }
+        ] if text.as_str(input, word.parts[0].span) == "\\"
+            && name.as_str() == "HOME"
+    ));
+}
+
+#[test]
 fn test_parse_escaped_command_substitution_stays_literal_in_double_quotes() {
     let input = r#"echo "\$(pwd)""#;
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -197,6 +197,42 @@ fn test_parse_escaped_backslash_then_variable_keeps_variable_live() {
 }
 
 #[test]
+fn test_parse_mixed_quoted_and_cooked_plain_continuation_keeps_variable_live() {
+    let input = "echo \"x\"\\\\$HOME\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    assert!(matches!(
+        word.parts.as_slice(),
+        [
+            WordPartNode {
+                kind: WordPart::DoubleQuoted { parts, .. },
+                ..
+            },
+            WordPartNode {
+                kind: WordPart::Literal(text),
+                ..
+            },
+            WordPartNode {
+                kind: WordPart::Variable(name),
+                ..
+            }
+        ] if matches!(
+            parts.as_slice(),
+            [WordPartNode {
+                kind: WordPart::Literal(inner),
+                ..
+            }] if inner.as_str(input, parts[0].span) == "x"
+        ) && text.as_str(input, word.parts[1].span) == "\\"
+            && name.as_str() == "HOME"
+    ));
+}
+
+#[test]
 fn test_parse_escaped_command_substitution_stays_literal_in_double_quotes() {
     let input = r#"echo "\$(pwd)""#;
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -172,6 +172,27 @@ fn test_parse_escaped_dollar_expansions_stay_literal_in_script_words() {
 }
 
 #[test]
+fn test_parse_escaped_braced_parameter_with_nested_default_stays_literal() {
+    let input = r#"echo \${x:-$HOME}"#;
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    assert_eq!(word.render(input), "${x:-$HOME}");
+    assert_eq!(word.render_syntax(input), r#"\${x:-$HOME}"#);
+    assert!(matches!(
+        word.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::Literal(text),
+            ..
+        }] if text.is_source_backed() && text.as_str(input, word.parts[0].span) == "${x:-$HOME}"
+    ));
+}
+
+#[test]
 fn test_parse_escaped_backslash_then_variable_keeps_variable_live() {
     let input = "echo \\\\$HOME\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+fn word_part_tree_contains_variable(parts: &[WordPartNode], expected: &str) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Variable(name) => name == expected,
+        WordPart::DoubleQuoted { parts, .. } => word_part_tree_contains_variable(parts, expected),
+        _ => false,
+    })
+}
+
 #[test]
 fn test_current_word_cache_tracks_token_changes() {
     let input = "\"$foo\" bar\n";
@@ -121,6 +129,70 @@ fn test_parse_variable() {
     } else {
         panic!("expected simple command");
     }
+}
+
+#[test]
+fn test_parse_word_string_keeps_escaped_dollar_literal() {
+    let input = r#"\$HOME"#;
+    let word = Parser::parse_word_string(input);
+
+    assert_eq!(word.render(input), "$HOME");
+    assert_eq!(word.render_syntax(input), input);
+    assert!(matches!(
+        word.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::Literal(text),
+            ..
+        }] if text.is_source_backed() && text.as_str(input, word.parts[0].span) == "$HOME"
+    ));
+}
+
+#[test]
+fn test_parse_escaped_dollar_expansions_stay_literal_in_script_words() {
+    let input = r#"echo \$HOME \${USER}"#;
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    assert_eq!(command.args.len(), 2);
+
+    let expected = [("$HOME", r#"\$HOME"#), ("${USER}", r#"\${USER}"#)];
+    for (word, (decoded, syntax)) in command.args.iter().zip(expected) {
+        assert_eq!(word.render(input), decoded);
+        assert_eq!(word.render_syntax(input), syntax);
+        assert!(matches!(
+            word.parts.as_slice(),
+            [WordPartNode {
+                kind: WordPart::Literal(text),
+                ..
+            }] if text.is_source_backed() && text.as_str(input, word.parts[0].span) == decoded
+        ));
+    }
+}
+
+#[test]
+fn test_parse_escaped_command_substitution_stays_literal_in_double_quotes() {
+    let input = r#"echo "\$(pwd)""#;
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    assert_eq!(word.render(input), "$(pwd)");
+    assert_eq!(word.render_syntax(input), r#""\$(pwd)""#);
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double-quoted word");
+    };
+    assert!(matches!(
+        parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::Literal(text),
+            ..
+        }] if text.is_source_backed() && text.as_str(input, parts[0].span) == "$(pwd)"
+    ));
 }
 
 #[test]
@@ -1239,6 +1311,27 @@ fn test_escaped_process_substitution_like_text_stays_literal() {
 }
 
 #[test]
+fn test_escaped_backticks_stay_literal_unquoted() {
+    let input = "echo \\`pwd\\`\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    assert_eq!(word.render(input), "`pwd`");
+    assert_eq!(word.render_syntax(input), "\\`pwd\\`");
+    assert!(matches!(
+        word.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::Literal(text),
+            ..
+        }] if text.is_source_backed() && text.as_str(input, word.parts[0].span) == "`pwd`"
+    ));
+}
+
+#[test]
 fn test_unquoted_backtick_substitution_can_contain_spaces() {
     let input = "commands=(`pyenv-commands --sh`)\n";
     let script = Parser::new(input).parse().unwrap().file;
@@ -1745,9 +1838,7 @@ fn test_parameter_expansion_trim_operand_accepts_literal_left_brace_after_multil
         matches!(
             &part.kind,
             PatternPart::Word(word)
-                if word.parts.iter().any(
-                    |word_part| matches!(&word_part.kind, WordPart::Variable(name) if name == "_sub_domain")
-                )
+                if word_part_tree_contains_variable(&word.parts, "_sub_domain")
         )
     }));
 }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1635,7 +1635,7 @@ impl<'a> Parser<'a> {
         let trimmed_span = Span::from_positions(start, span.end);
         let literal = match literal {
             LiteralText::Source => LiteralText::source(),
-            LiteralText::Owned(text) => {
+            LiteralText::Owned(text) | LiteralText::CookedSource(text) => {
                 let split_at = start.offset.saturating_sub(span.start.offset);
                 LiteralText::owned(text.get(split_at..)?.to_string())
             }
@@ -2836,6 +2836,7 @@ impl<'a> Parser<'a> {
             source_backed,
             DecodeWordPartsOptions {
                 parse_dollar_quotes: true,
+                preserve_escaped_expansion_literals: source_backed,
                 ..DecodeWordPartsOptions::default()
             },
             parts,
@@ -2888,13 +2889,18 @@ impl<'a> Parser<'a> {
                 if current.is_empty() {
                     current_start = part_start;
                 }
-                current.push(ch);
                 current.push(Self::next_word_char_unwrap(&mut chars, &mut cursor));
                 continue;
             }
 
             if options.preserve_quote_fragments && ch == '\'' {
-                self.flush_literal_part(parts, &mut current, current_start, part_start);
+                self.flush_literal_part(
+                    parts,
+                    &mut current,
+                    current_start,
+                    part_start,
+                    source_backed,
+                );
 
                 let content_start = cursor;
                 let mut content = (!source_backed).then(String::new);
@@ -2951,7 +2957,13 @@ impl<'a> Parser<'a> {
             }
 
             if options.preserve_quote_fragments && ch == '"' {
-                self.flush_literal_part(parts, &mut current, current_start, part_start);
+                self.flush_literal_part(
+                    parts,
+                    &mut current,
+                    current_start,
+                    part_start,
+                    source_backed,
+                );
 
                 let content_start = cursor;
                 let mut content = (!source_backed).then(String::new);
@@ -3049,7 +3061,13 @@ impl<'a> Parser<'a> {
             }
 
             if ch == '`' {
-                self.flush_literal_part(parts, &mut current, current_start, part_start);
+                self.flush_literal_part(
+                    parts,
+                    &mut current,
+                    current_start,
+                    part_start,
+                    source_backed,
+                );
 
                 let inner_start = cursor;
                 let body = if source_backed {
@@ -3187,7 +3205,13 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            self.flush_literal_part(parts, &mut current, current_start, part_start);
+            self.flush_literal_part(
+                parts,
+                &mut current,
+                current_start,
+                part_start,
+                source_backed,
+            );
 
             if options.parse_dollar_quotes && chars.peek() == Some(&'\'') {
                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
@@ -4572,12 +4596,12 @@ impl<'a> Parser<'a> {
             }
         }
 
-        self.flush_literal_part(parts, &mut current, current_start, cursor);
+        self.flush_literal_part(parts, &mut current, current_start, cursor, source_backed);
 
         if parts.is_empty() {
             Self::push_word_part(
                 parts,
-                WordPart::Literal(self.literal_text(String::new(), base, cursor)),
+                WordPart::Literal(self.literal_text(String::new(), base, cursor, source_backed)),
                 base,
                 cursor,
             );
@@ -4795,6 +4819,7 @@ impl<'a> Parser<'a> {
             DecodeWordPartsOptions {
                 preserve_quote_fragments: true,
                 parse_dollar_quotes: true,
+                preserve_escaped_expansion_literals: source_backed,
                 ..DecodeWordPartsOptions::default()
             },
             &mut parts,

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2896,6 +2896,13 @@ impl<'a> Parser<'a> {
                 }
                 if let Some(literal_ch) = Self::next_word_char(&mut chars, &mut cursor) {
                     current.push(literal_ch);
+                    if literal_ch == '$' && chars.peek() == Some(&'{') {
+                        self.consume_escaped_braced_parameter_literal(
+                            &mut chars,
+                            &mut cursor,
+                            &mut current,
+                        );
+                    }
                 }
                 continue;
             }
@@ -2919,7 +2926,15 @@ impl<'a> Parser<'a> {
                 if current.is_empty() {
                     current_start = part_start;
                 }
-                current.push(Self::next_word_char_unwrap(&mut chars, &mut cursor));
+                let literal_ch = Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                current.push(literal_ch);
+                if literal_ch == '$' && chars.peek() == Some(&'{') {
+                    self.consume_escaped_braced_parameter_literal(
+                        &mut chars,
+                        &mut cursor,
+                        &mut current,
+                    );
+                }
                 continue;
             }
 
@@ -4641,6 +4656,78 @@ impl<'a> Parser<'a> {
                 base,
                 cursor,
             );
+        }
+    }
+
+    fn consume_escaped_braced_parameter_literal(
+        &self,
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+        cursor: &mut Position,
+        current: &mut String,
+    ) {
+        if chars.peek() != Some(&'{') {
+            return;
+        }
+
+        current.push(Self::next_word_char_unwrap(chars, cursor));
+
+        let mut depth = 1usize;
+        let mut literal_brace_depth = 0usize;
+        let mut in_single = false;
+        let mut in_double = false;
+
+        while let Some(&c) = chars.peek() {
+            match c {
+                '\\' if !in_single => {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    if let Some(&escaped) = chars.peek() {
+                        if !in_double || matches!(escaped, '$' | '"' | '\\' | '`' | '\n') {
+                            current.push(Self::next_word_char_unwrap(chars, cursor));
+                        } else {
+                            current.push('\\');
+                        }
+                    } else {
+                        current.push('\\');
+                    }
+                }
+                '\'' if !in_double => {
+                    in_single = !in_single;
+                    current.push(Self::next_word_char_unwrap(chars, cursor));
+                }
+                '"' if !in_single => {
+                    in_double = !in_double;
+                    current.push(Self::next_word_char_unwrap(chars, cursor));
+                }
+                '$' if !in_single => {
+                    current.push(Self::next_word_char_unwrap(chars, cursor));
+                    if chars.peek() == Some(&'{') {
+                        depth += 1;
+                        current.push(Self::next_word_char_unwrap(chars, cursor));
+                    }
+                }
+                '{' if !in_single && !in_double => {
+                    literal_brace_depth += 1;
+                    current.push(Self::next_word_char_unwrap(chars, cursor));
+                }
+                '}' if !in_single && !in_double => {
+                    if depth == 1 && literal_brace_depth > 0 {
+                        let mut remaining = chars.clone();
+                        remaining.next();
+                        if Self::brace_operand_has_later_top_level_closer(remaining, depth) {
+                            literal_brace_depth -= 1;
+                            current.push(Self::next_word_char_unwrap(chars, cursor));
+                            continue;
+                        }
+                    }
+
+                    current.push(Self::next_word_char_unwrap(chars, cursor));
+                    if depth == 1 {
+                        break;
+                    }
+                    depth -= 1;
+                }
+                _ => current.push(Self::next_word_char_unwrap(chars, cursor)),
+            }
         }
     }
 

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3129,7 +3129,13 @@ impl<'a> Parser<'a> {
                 && matches!(ch, '<' | '>')
                 && chars.peek() == Some(&'(')
             {
-                self.flush_literal_part(parts, &mut current, current_start, part_start);
+                self.flush_literal_part(
+                    parts,
+                    &mut current,
+                    current_start,
+                    part_start,
+                    source_backed,
+                );
 
                 let is_input = ch == '<';
                 Self::next_word_char_unwrap(&mut chars, &mut cursor);

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -586,6 +586,23 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
     ) -> Word {
+        self.decode_word_text_preserving_quotes_if_needed_with_escape_mode(
+            s,
+            span,
+            base,
+            source_backed,
+            source_backed,
+        )
+    }
+
+    pub(super) fn decode_word_text_preserving_quotes_if_needed_with_escape_mode(
+        &mut self,
+        s: &str,
+        span: Span,
+        base: Position,
+        source_backed: bool,
+        preserve_escaped_expansion_literals: bool,
+    ) -> Word {
         if !Self::source_text_needs_quote_preserving_decode(s)
             && let Some(word) = self.maybe_parse_zsh_qualified_glob_word(s, span, source_backed)
         {
@@ -593,9 +610,21 @@ impl<'a> Parser<'a> {
         }
 
         if Self::source_text_needs_quote_preserving_decode(s) {
-            self.decode_fragment_word_text(s, span, base, source_backed)
+            self.decode_fragment_word_text_with_escape_mode(
+                s,
+                span,
+                base,
+                source_backed,
+                preserve_escaped_expansion_literals,
+            )
         } else {
-            self.decode_word_text(s, span, base, source_backed)
+            self.decode_word_text_with_escape_mode(
+                s,
+                span,
+                base,
+                source_backed,
+                preserve_escaped_expansion_literals,
+            )
         }
     }
 
@@ -2823,11 +2852,12 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub(super) fn decode_word_parts_into(
+    fn decode_word_parts_into_with_escape_mode(
         &mut self,
         s: &str,
         base: Position,
         source_backed: bool,
+        preserve_escaped_expansion_literals: bool,
         parts: &mut Vec<WordPartNode>,
     ) {
         self.decode_word_parts_into_with_quote_fragments(
@@ -2836,7 +2866,7 @@ impl<'a> Parser<'a> {
             source_backed,
             DecodeWordPartsOptions {
                 parse_dollar_quotes: true,
-                preserve_escaped_expansion_literals: source_backed,
+                preserve_escaped_expansion_literals,
                 ..DecodeWordPartsOptions::default()
             },
             parts,
@@ -4786,8 +4816,25 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
     ) -> Word {
+        self.decode_word_text_with_escape_mode(s, span, base, source_backed, source_backed)
+    }
+
+    fn decode_word_text_with_escape_mode(
+        &mut self,
+        s: &str,
+        span: Span,
+        base: Position,
+        source_backed: bool,
+        preserve_escaped_expansion_literals: bool,
+    ) -> Word {
         let mut parts = Vec::new();
-        self.decode_word_parts_into(s, base, source_backed, &mut parts);
+        self.decode_word_parts_into_with_escape_mode(
+            s,
+            base,
+            source_backed,
+            preserve_escaped_expansion_literals,
+            &mut parts,
+        );
         self.word_with_parts(parts, span)
     }
 
@@ -4817,6 +4864,17 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
     ) -> Word {
+        self.decode_fragment_word_text_with_escape_mode(s, span, base, source_backed, source_backed)
+    }
+
+    fn decode_fragment_word_text_with_escape_mode(
+        &mut self,
+        s: &str,
+        span: Span,
+        base: Position,
+        source_backed: bool,
+        preserve_escaped_expansion_literals: bool,
+    ) -> Word {
         let mut parts = Vec::new();
         self.decode_word_parts_into_with_quote_fragments(
             s,
@@ -4825,7 +4883,7 @@ impl<'a> Parser<'a> {
             DecodeWordPartsOptions {
                 preserve_quote_fragments: true,
                 parse_dollar_quotes: true,
-                preserve_escaped_expansion_literals: source_backed,
+                preserve_escaped_expansion_literals,
                 ..DecodeWordPartsOptions::default()
             },
             &mut parts,

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1280,11 +1280,6 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
-        if part_starts_with_shell_expansion(part)
-            && span_is_backslash_escaped(self.source, part, span)
-        {
-            return;
-        }
         match part {
             WordPart::ZshQualifiedGlob(glob) => {
                 if zsh_qualified_glob_is_semantically_inert(glob) {
@@ -2913,86 +2908,6 @@ fn named_target_word(word: &Word, source: &str) -> Option<(Name, Span)> {
     is_name(&text).then_some((Name::from(text), word.span))
 }
 
-fn part_starts_with_shell_expansion(part: &WordPart) -> bool {
-    matches!(
-        part,
-        WordPart::Variable(_)
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::CommandSubstitution { .. }
-            | WordPart::ProcessSubstitution { .. }
-            | WordPart::ArithmeticExpansion { .. }
-    )
-}
-
-fn span_is_backslash_escaped(source: &str, part: &WordPart, span: Span) -> bool {
-    let Some(offset) = expansion_start_offset(source, part, span) else {
-        return false;
-    };
-    let bytes = source.as_bytes();
-    if offset == 0 || offset > bytes.len() {
-        return false;
-    }
-
-    let mut backslashes = 0usize;
-    let mut index = offset;
-    while index > 0 && bytes[index - 1] == b'\\' {
-        backslashes += 1;
-        index -= 1;
-    }
-
-    backslashes % 2 == 1
-}
-
-fn expansion_start_offset(source: &str, part: &WordPart, span: Span) -> Option<usize> {
-    let bytes = source.as_bytes();
-    let (line_start, line_end) = line_bounds(source, span.start.line)?;
-    let search_start = line_start
-        .saturating_add(span.start.column.saturating_sub(1))
-        .min(line_end);
-
-    (search_start..line_end).find(|&candidate| part_matches_expansion_start(bytes, candidate, part))
-}
-
-fn part_matches_expansion_start(bytes: &[u8], offset: usize, part: &WordPart) -> bool {
-    match part {
-        WordPart::Variable(_)
-        | WordPart::Parameter(_)
-        | WordPart::ParameterExpansion { .. }
-        | WordPart::ArithmeticExpansion { .. } => bytes[offset] == b'$',
-        WordPart::CommandSubstitution { .. } => matches!(bytes[offset], b'$' | b'`'),
-        WordPart::ProcessSubstitution { .. } => {
-            matches!(bytes[offset], b'<' | b'>') && bytes.get(offset + 1) == Some(&b'(')
-        }
-        _ => false,
-    }
-}
-
-fn line_bounds(source: &str, line_number: usize) -> Option<(usize, usize)> {
-    if line_number == 0 {
-        return None;
-    }
-
-    let mut line = 1usize;
-    let mut line_start = 0usize;
-    for (index, byte) in source.bytes().enumerate() {
-        if line == line_number {
-            let line_end = source[index..]
-                .find('\n')
-                .map(|relative| index + relative)
-                .unwrap_or(source.len());
-            return Some((line_start, line_end));
-        }
-
-        if byte == b'\n' {
-            line += 1;
-            line_start = index + 1;
-        }
-    }
-
-    (line == line_number).then_some((line_start, source.len()))
-}
-
 fn static_word_text(word: &Word, source: &str) -> Option<String> {
     let mut result = String::new();
     collect_static_word_text(&word.parts, source, &mut result).then_some(result)
@@ -3462,7 +3377,9 @@ fn depth_from_word(word: Option<&Word>) -> usize {
 fn single_literal_word(word: &Word) -> Option<&str> {
     match word.parts.as_slice() {
         [part] => match &part.kind {
-            WordPart::Literal(shuck_ast::LiteralText::Owned(text)) => Some(text.as_ref()),
+            WordPart::Literal(
+                shuck_ast::LiteralText::Owned(text) | shuck_ast::LiteralText::CookedSource(text),
+            ) => Some(text.as_ref()),
             _ => None,
         },
         _ => None,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4060,6 +4060,16 @@ EOF
     }
 
     #[test]
+    fn escaped_dollar_word_does_not_report_uninitialized_reads() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' \"\\$workdir\"
+";
+        let model = model(source);
+        assert!(model.analysis().uninitialized_references().is_empty());
+    }
+
+    #[test]
     fn unquoted_heredoc_body_reports_live_uninitialized_reads() {
         let source = "\
 archname=archive
@@ -4858,6 +4868,33 @@ source ./loader.bash
 #!/bin/bash
 SELF=\"${BASH_SOURCE}\"
 source \"$(dirname \"${SELF:-$0}\")/helper.bash\"
+",
+        )
+        .unwrap();
+        fs::write(&helper, "#!/bin/bash\necho \"$flag\"\n").unwrap();
+
+        let model = model_at_path(&main);
+
+        assert!(
+            !model.synthetic_reads.iter().any(|read| read.name == "flag"),
+            "synthetic reads: {:?}",
+            model.synthetic_reads
+        );
+        let unused = reportable_unused_names(&model);
+        assert!(unused.contains(&Name::from("flag")), "unused: {:?}", unused);
+    }
+
+    #[test]
+    fn escaped_bash_source_template_does_not_import_helper() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.bash");
+        let helper = temp.path().join("helper.bash");
+        fs::write(
+            &main,
+            "\
+#!/bin/bash
+flag=1
+source \"\\$(dirname \\\"${BASH_SOURCE[0]}\\\")/helper.bash\"
 ",
         )
         .unwrap();

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4070,6 +4070,16 @@ printf '%s\\n' \"\\$workdir\"
     }
 
     #[test]
+    fn escaped_parameter_expansion_with_nested_default_stays_inert() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' \\${workdir:-$fallback}
+";
+        let model = model(source);
+        assert!(model.analysis().uninitialized_references().is_empty());
+    }
+
+    #[test]
     fn unquoted_heredoc_body_reports_live_uninitialized_reads() {
         let source = "\
 archname=archive

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -528,11 +528,6 @@ fn collect_source_template_parts(
     saw_dynamic: &mut bool,
 ) -> bool {
     for part in word_parts {
-        if word_part_starts_with_shell_expansion(&part.kind)
-            && span_is_backslash_escaped(source, &part.kind, part.span)
-        {
-            continue;
-        }
         match &part.kind {
             WordPart::Literal(text) => {
                 let text = text.as_str(source, part.span);
@@ -877,85 +872,6 @@ fn render_template_candidate(
 
 fn path_to_template_string(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
-}
-fn word_part_starts_with_shell_expansion(part: &WordPart) -> bool {
-    matches!(
-        part,
-        WordPart::Variable(_)
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::CommandSubstitution { .. }
-            | WordPart::ProcessSubstitution { .. }
-            | WordPart::ArithmeticExpansion { .. }
-    )
-}
-
-fn span_is_backslash_escaped(source: &str, part: &WordPart, span: Span) -> bool {
-    let Some(offset) = expansion_start_offset(source, part, span) else {
-        return false;
-    };
-    let bytes = source.as_bytes();
-    if offset == 0 || offset > bytes.len() {
-        return false;
-    }
-
-    let mut backslashes = 0usize;
-    let mut index = offset;
-    while index > 0 && bytes[index - 1] == b'\\' {
-        backslashes += 1;
-        index -= 1;
-    }
-
-    backslashes % 2 == 1
-}
-
-fn expansion_start_offset(source: &str, part: &WordPart, span: Span) -> Option<usize> {
-    let bytes = source.as_bytes();
-    let (line_start, line_end) = line_bounds(source, span.start.line)?;
-    let search_start = line_start
-        .saturating_add(span.start.column.saturating_sub(1))
-        .min(line_end);
-
-    (search_start..line_end).find(|&candidate| part_matches_expansion_start(bytes, candidate, part))
-}
-
-fn part_matches_expansion_start(bytes: &[u8], offset: usize, part: &WordPart) -> bool {
-    match part {
-        WordPart::Variable(_)
-        | WordPart::Parameter(_)
-        | WordPart::ParameterExpansion { .. }
-        | WordPart::ArithmeticExpansion { .. } => bytes[offset] == b'$',
-        WordPart::CommandSubstitution { .. } => matches!(bytes[offset], b'$' | b'`'),
-        WordPart::ProcessSubstitution { .. } => {
-            matches!(bytes[offset], b'<' | b'>') && bytes.get(offset + 1) == Some(&b'(')
-        }
-        _ => false,
-    }
-}
-
-fn line_bounds(source: &str, line_number: usize) -> Option<(usize, usize)> {
-    if line_number == 0 {
-        return None;
-    }
-
-    let mut line = 1usize;
-    let mut line_start = 0usize;
-    for (index, byte) in source.bytes().enumerate() {
-        if line == line_number {
-            let line_end = source[index..]
-                .find('\n')
-                .map(|relative| index + relative)
-                .unwrap_or(source.len());
-            return Some((line_start, line_end));
-        }
-
-        if byte == b'\n' {
-            line += 1;
-            line_start = index + 1;
-        }
-    }
-
-    (line == line_number).then_some((line_start, source.len()))
 }
 
 fn resolve_literal_call_args_by_scope(


### PR DESCRIPTION
## Summary
- preserve escaped expansion starters as source-backed cooked literals in the parser AST
- keep decoded literal text for semantic/render consumers while preserving raw syntax rendering from spans
- remove the semantic-layer raw-source rescans and add parser and semantic regression coverage

## Root cause
Ordinary word lexing removed the escape marker before word parsing, so forms like `\$HOME`, `\$(pwd)`, and escaped backticks could still be reparsed as live expansions. The semantic layer worked around that by rescanning raw source bytes in two places to recover shell-surface intent.

## Impact
Escaped expansion starters now stay literal at the parser boundary, which lets semantic consumers rely on the AST instead of reparsing source text.

## Validation
- `cargo fmt`
- `cargo test -p shuck-parser -p shuck-semantic`