### PR TITLE
Carry companion word ASTs through expansions

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1338,8 +1338,10 @@ pub enum BourneParameterExpansion {
         reference: VarRef,
         offset: SourceText,
         offset_ast: Option<ArithmeticExprNode>,
+        offset_word_ast: Word,
         length: Option<SourceText>,
         length_ast: Option<ArithmeticExprNode>,
+        length_word_ast: Option<Word>,
     },
     Operation {
         reference: VarRef,
@@ -1368,6 +1370,36 @@ impl BourneParameterExpansion {
             | Self::Indices { .. }
             | Self::PrefixMatch { .. }
             | Self::Slice { .. }
+            | Self::Transformation { .. } => None,
+        }
+    }
+
+    pub fn offset_word_ast(&self) -> Option<&Word> {
+        match self {
+            Self::Slice {
+                offset_word_ast, ..
+            } => Some(offset_word_ast),
+            Self::Access { .. }
+            | Self::Length { .. }
+            | Self::Indices { .. }
+            | Self::Indirect { .. }
+            | Self::PrefixMatch { .. }
+            | Self::Operation { .. }
+            | Self::Transformation { .. } => None,
+        }
+    }
+
+    pub fn length_word_ast(&self) -> Option<&Word> {
+        match self {
+            Self::Slice {
+                length_word_ast, ..
+            } => length_word_ast.as_ref(),
+            Self::Access { .. }
+            | Self::Length { .. }
+            | Self::Indices { .. }
+            | Self::Indirect { .. }
+            | Self::PrefixMatch { .. }
+            | Self::Operation { .. }
             | Self::Transformation { .. } => None,
         }
     }
@@ -1909,6 +1941,7 @@ pub enum HeredocBodyPart {
     ArithmeticExpansion {
         expression: SourceText,
         expression_ast: Option<ArithmeticExprNode>,
+        expression_word_ast: Word,
         syntax: ArithmeticExpansionSyntax,
     },
     Parameter(Box<ParameterExpansion>),
@@ -2274,6 +2307,8 @@ pub enum WordPart {
         expression: SourceText,
         /// Typed arithmetic view of `expression`.
         expression_ast: Option<ArithmeticExprNode>,
+        /// Parsed shell-word view of `expression`.
+        expression_word_ast: Word,
         syntax: ArithmeticExpansionSyntax,
     },
     /// Unified parameter-expansion family for `${...}` forms.
@@ -2284,6 +2319,7 @@ pub enum WordPart {
         reference: VarRef,
         operator: ParameterOp,
         operand: Option<SourceText>,
+        operand_word_ast: Option<Word>,
         colon_variant: bool,
     },
     /// Length expansion ${#var}
@@ -2300,9 +2336,13 @@ pub enum WordPart {
         offset: SourceText,
         /// Typed arithmetic view of `offset` when it parses as arithmetic.
         offset_ast: Option<ArithmeticExprNode>,
+        /// Parsed shell-word view of `offset`.
+        offset_word_ast: Word,
         length: Option<SourceText>,
         /// Typed arithmetic view of `length` when it parses as arithmetic.
         length_ast: Option<ArithmeticExprNode>,
+        /// Parsed shell-word view of `length`.
+        length_word_ast: Option<Word>,
     },
     /// Array slice `${arr[@]:offset:length}`
     ArraySlice {
@@ -2310,9 +2350,13 @@ pub enum WordPart {
         offset: SourceText,
         /// Typed arithmetic view of `offset` when it parses as arithmetic.
         offset_ast: Option<ArithmeticExprNode>,
+        /// Parsed shell-word view of `offset`.
+        offset_word_ast: Word,
         length: Option<SourceText>,
         /// Typed arithmetic view of `length` when it parses as arithmetic.
         length_ast: Option<ArithmeticExprNode>,
+        /// Parsed shell-word view of `length`.
+        length_word_ast: Option<Word>,
     },
     /// Indirect expansion `${!var}` - expands to value of variable named by var's value
     /// Optionally composed with an operator: `${!var:-default}`, `${!var:=val}`, etc.
@@ -2320,6 +2364,7 @@ pub enum WordPart {
         reference: VarRef,
         operator: Option<ParameterOp>,
         operand: Option<SourceText>,
+        operand_word_ast: Option<Word>,
         colon_variant: bool,
     },
     /// Prefix matching `${!prefix*}` or `${!prefix@}` - names of variables with given prefix
@@ -2644,6 +2689,7 @@ fn fmt_word_part_with_source_mode(
             operator,
             operand,
             colon_variant,
+            ..
         } => match operator {
             ParameterOp::UseDefault => {
                 let c = if *colon_variant { ":" } else { "" };
@@ -2827,6 +2873,7 @@ fn fmt_word_part_with_source_mode(
             operator,
             operand,
             colon_variant,
+            ..
         } => {
             let mut reference_syntax = String::new();
             fmt_var_ref_with_source(&mut reference_syntax, reference, source)?;

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -3634,6 +3634,9 @@ mod tests {
                         reference: plain_ref("PREFIXED_VERSION"),
                         operator: ParameterOp::UseDefault,
                         operand: Some("$PROVIDED_VERSION".into()),
+                        operand_word_ast: Some(word(vec![WordPart::Variable(
+                            "PROVIDED_VERSION".into(),
+                        )])),
                         colon_variant: true,
                     },
                     Span::new(),
@@ -3775,6 +3778,7 @@ mod tests {
         let w = word(vec![WordPart::ArithmeticExpansion {
             expression: "1+2".into(),
             expression_ast: None,
+            expression_word_ast: Word::literal("1+2"),
             syntax: ArithmeticExpansionSyntax::DollarParenParen,
         }]);
         assert_eq!(format!("{w}"), "$((1+2))");
@@ -3816,8 +3820,10 @@ mod tests {
             reference: plain_ref("var"),
             offset: "2".into(),
             offset_ast: None,
+            offset_word_ast: Word::literal("2"),
             length: Some("3".into()),
             length_ast: None,
+            length_word_ast: Some(Word::literal("3")),
         }]);
         assert_eq!(format!("{w}"), "${var:2:3}");
     }
@@ -3828,8 +3834,10 @@ mod tests {
             reference: plain_ref("var"),
             offset: "2".into(),
             offset_ast: None,
+            offset_word_ast: Word::literal("2"),
             length: None,
             length_ast: None,
+            length_word_ast: None,
         }]);
         assert_eq!(format!("{w}"), "${var:2}");
     }
@@ -3840,8 +3848,10 @@ mod tests {
             reference: selector_ref("arr", SubscriptSelector::At),
             offset: "1".into(),
             offset_ast: None,
+            offset_word_ast: Word::literal("1"),
             length: Some("2".into()),
             length_ast: None,
+            length_word_ast: Some(Word::literal("2")),
         }]);
         assert_eq!(format!("{w}"), "${arr[@]:1:2}");
     }
@@ -3852,8 +3862,10 @@ mod tests {
             reference: selector_ref("arr", SubscriptSelector::At),
             offset: "1".into(),
             offset_ast: None,
+            offset_word_ast: Word::literal("1"),
             length: None,
             length_ast: None,
+            length_word_ast: None,
         }]);
         assert_eq!(format!("{w}"), "${arr[@]:1}");
     }
@@ -3864,6 +3876,7 @@ mod tests {
             reference: plain_ref("ref"),
             operator: None,
             operand: None,
+            operand_word_ast: None,
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${!ref}");
@@ -4003,6 +4016,7 @@ mod tests {
             reference: plain_ref("var"),
             operator: ParameterOp::UseDefault,
             operand: Some("fallback".into()),
+            operand_word_ast: Some(Word::literal("fallback")),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:-fallback}");
@@ -4014,6 +4028,7 @@ mod tests {
             reference: plain_ref("var"),
             operator: ParameterOp::UseDefault,
             operand: Some("fallback".into()),
+            operand_word_ast: Some(Word::literal("fallback")),
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var-fallback}");
@@ -4025,6 +4040,7 @@ mod tests {
             reference: plain_ref("var"),
             operator: ParameterOp::AssignDefault,
             operand: Some("val".into()),
+            operand_word_ast: Some(Word::literal("val")),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:=val}");
@@ -4036,6 +4052,7 @@ mod tests {
             reference: plain_ref("var"),
             operator: ParameterOp::UseReplacement,
             operand: Some("alt".into()),
+            operand_word_ast: Some(Word::literal("alt")),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:+alt}");
@@ -4047,6 +4064,7 @@ mod tests {
             reference: plain_ref("var"),
             operator: ParameterOp::Error,
             operand: Some("msg".into()),
+            operand_word_ast: Some(Word::literal("msg")),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:?msg}");
@@ -4061,6 +4079,7 @@ mod tests {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
             },
             operand: None,
+            operand_word_ast: None,
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var#pat}");
@@ -4072,6 +4091,7 @@ mod tests {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
             },
             operand: None,
+            operand_word_ast: None,
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var##pat}");
@@ -4083,6 +4103,7 @@ mod tests {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
             },
             operand: None,
+            operand_word_ast: None,
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var%pat}");
@@ -4094,6 +4115,7 @@ mod tests {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
             },
             operand: None,
+            operand_word_ast: None,
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var%%pat}");
@@ -4109,6 +4131,7 @@ mod tests {
                 replacement_word_ast: Word::literal("new"),
             },
             operand: None,
+            operand_word_ast: None,
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var/old/new}");
@@ -4121,6 +4144,7 @@ mod tests {
                 replacement_word_ast: Word::literal("new"),
             },
             operand: None,
+            operand_word_ast: None,
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var//old/new}");
@@ -4133,6 +4157,7 @@ mod tests {
                 reference: plain_ref("var"),
                 operator: op,
                 operand: None,
+                operand_word_ast: None,
                 colon_variant: false,
             }]);
             assert_eq!(format!("{w}"), expected);

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -219,6 +219,7 @@ fn render_heredoc_body_part(
             expression,
             expression_ast,
             syntax,
+            ..
         } => {
             if matches!(syntax, ArithmeticExpansionSyntax::LegacyBracket) {
                 push_trimmed_arithmetic_expansion_source(
@@ -361,6 +362,7 @@ fn render_word_part(
             expression,
             expression_ast,
             syntax,
+            ..
         } => {
             if matches!(syntax, ArithmeticExpansionSyntax::LegacyBracket) {
                 push_trimmed_arithmetic_expansion_source(
@@ -420,6 +422,7 @@ fn render_word_part(
             operator,
             operand,
             colon_variant,
+            ..
         } => render_parameter_expansion(
             rendered,
             reference,
@@ -455,6 +458,7 @@ fn render_word_part(
             offset_ast,
             length,
             length_ast,
+            ..
         }
         | WordPart::ArraySlice {
             reference,
@@ -462,6 +466,7 @@ fn render_word_part(
             offset_ast,
             length,
             length_ast,
+            ..
         } => {
             rendered.push_str("${");
             push_var_ref(rendered, reference, source, options);
@@ -478,6 +483,7 @@ fn render_word_part(
             operator,
             operand,
             colon_variant,
+            ..
         } => {
             rendered.push_str("${!");
             push_var_ref(rendered, reference, source, options);
@@ -1219,6 +1225,7 @@ fn push_parameter_word(
             offset_ast,
             length,
             length_ast,
+            ..
         } => {
             rendered.push_str("${");
             push_var_ref(rendered, reference, source, options);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -27,7 +27,6 @@ use shuck_ast::{
     ZshQualifiedGlob,
 };
 use shuck_indexer::Indexer;
-use shuck_parser::parser::Parser;
 use shuck_semantic::{
     BindingAttributes, BindingId, BindingKind, ScopeId, SemanticModel, ZshOptionState,
 };
@@ -6852,8 +6851,8 @@ fn collect_status_parameter_spans_in_word_part(
             }
         }
         WordPart::ArithmeticExpansion {
-            expression,
             expression_ast,
+            expression_word_ast,
             ..
         } => {
             if let Some(expression) = expression_ast {
@@ -6861,25 +6860,34 @@ fn collect_status_parameter_spans_in_word_part(
                     collect_status_parameter_spans_in_word(word, source, spans);
                 });
             } else {
-                collect_status_parameter_spans_in_source_text(expression, source, spans);
+                collect_status_parameter_spans_in_word(expression_word_ast, source, spans);
             }
         }
         WordPart::Parameter(parameter) => {
             collect_status_parameter_spans_in_parameter_expansion(parameter, source, spans);
         }
         WordPart::ParameterExpansion {
-            reference, operand, ..
+            reference,
+            operand,
+            operand_word_ast,
+            ..
         }
         | WordPart::IndirectExpansion {
-            reference, operand, ..
+            reference,
+            operand,
+            operand_word_ast,
+            ..
         } => {
             if reference.name.as_str() == "?" {
                 spans.push(part.span);
             }
             collect_status_parameter_spans_in_var_ref(reference, source, spans);
-            if let Some(operand) = operand {
-                collect_status_parameter_spans_in_source_text(operand, source, spans);
-            }
+            collect_status_parameter_spans_in_fragment(
+                operand_word_ast.as_ref(),
+                operand.as_ref(),
+                source,
+                spans,
+            );
         }
         WordPart::Length(reference)
         | WordPart::ArrayAccess(reference)
@@ -6893,17 +6901,19 @@ fn collect_status_parameter_spans_in_word_part(
         }
         WordPart::Substring {
             reference,
-            offset,
             offset_ast,
-            length,
+            offset_word_ast,
             length_ast,
+            length_word_ast,
+            ..
         }
         | WordPart::ArraySlice {
             reference,
-            offset,
             offset_ast,
-            length,
+            offset_word_ast,
             length_ast,
+            length_word_ast,
+            ..
         } => {
             if reference.name.as_str() == "?" {
                 spans.push(part.span);
@@ -6914,16 +6924,16 @@ fn collect_status_parameter_spans_in_word_part(
                     collect_status_parameter_spans_in_word(word, source, spans);
                 });
             } else {
-                collect_status_parameter_spans_in_source_text(offset, source, spans);
+                collect_status_parameter_spans_in_word(offset_word_ast, source, spans);
             }
-            match (length_ast.as_ref(), length.as_ref()) {
+            match (length_ast.as_ref(), length_word_ast.as_ref()) {
                 (Some(length_ast), _) => {
                     query::visit_arithmetic_words(length_ast, &mut |word| {
                         collect_status_parameter_spans_in_word(word, source, spans);
                     });
                 }
-                (None, Some(length)) => {
-                    collect_status_parameter_spans_in_source_text(length, source, spans);
+                (None, Some(length_word_ast)) => {
+                    collect_status_parameter_spans_in_word(length_word_ast, source, spans);
                 }
                 (None, None) => {}
             }
@@ -6967,10 +6977,11 @@ fn collect_status_parameter_spans_in_parameter_expansion(
             }
             BourneParameterExpansion::Slice {
                 reference,
-                offset,
                 offset_ast,
-                length,
+                offset_word_ast,
                 length_ast,
+                length_word_ast,
+                ..
             } => {
                 collect_status_parameter_spans_in_var_ref(reference, source, spans);
                 if let Some(offset_ast) = offset_ast {
@@ -6978,17 +6989,17 @@ fn collect_status_parameter_spans_in_parameter_expansion(
                         collect_status_parameter_spans_in_word(word, source, spans);
                     });
                 } else {
-                    collect_status_parameter_spans_in_source_text(offset, source, spans);
+                    collect_status_parameter_spans_in_word(offset_word_ast, source, spans);
                 }
 
-                match (length_ast.as_ref(), length.as_ref()) {
+                match (length_ast.as_ref(), length_word_ast.as_ref()) {
                     (Some(length_ast), _) => {
                         query::visit_arithmetic_words(length_ast, &mut |word| {
                             collect_status_parameter_spans_in_word(word, source, spans);
                         });
                     }
-                    (None, Some(length)) => {
-                        collect_status_parameter_spans_in_source_text(length, source, spans);
+                    (None, Some(length_word_ast)) => {
+                        collect_status_parameter_spans_in_word(length_word_ast, source, spans);
                     }
                     (None, None) => {}
                 }
@@ -7105,20 +7116,6 @@ fn collect_status_parameter_spans_in_conditional_expr(
             collect_status_parameter_spans_in_var_ref(reference, source, spans);
         }
     }
-}
-
-fn collect_status_parameter_spans_in_source_text(
-    text: &SourceText,
-    source: &str,
-    spans: &mut Vec<Span>,
-) {
-    let snippet = text.slice(source);
-    if !snippet.contains("$?") {
-        return;
-    }
-
-    let word = Parser::parse_word_fragment(source, snippet, text.span());
-    collect_status_parameter_spans_in_word(&word, source, spans);
 }
 
 fn collect_status_parameter_spans_in_fragment(
@@ -9160,17 +9157,28 @@ fn collect_arithmetic_expansion_spans_from_parts(
                 command_substitution_spans,
             ),
             WordPart::ArithmeticExpansion {
-                expression_ast: Some(expression),
+                expression_ast,
+                expression_word_ast,
                 ..
             } => {
-                query::visit_arithmetic_words(expression, &mut |word| {
-                    collect_arithmetic_context_spans_in_word(
-                        word,
+                if let Some(expression) = expression_ast {
+                    query::visit_arithmetic_words(expression, &mut |word| {
+                        collect_arithmetic_context_spans_in_word(
+                            word,
+                            collect_dollar_spans,
+                            dollar_spans,
+                            command_substitution_spans,
+                        );
+                    });
+                } else {
+                    collect_arithmetic_expansion_spans_from_parts(
+                        &expression_word_ast.parts,
+                        source,
                         collect_dollar_spans,
                         dollar_spans,
                         command_substitution_spans,
                     );
-                });
+                }
             }
             WordPart::Parameter(parameter) => collect_arithmetic_spans_in_parameter_expansion(
                 parameter,
@@ -9194,18 +9202,18 @@ fn collect_arithmetic_expansion_spans_from_parts(
             ),
             WordPart::Substring {
                 reference,
-                offset,
                 offset_ast,
-                length,
+                offset_word_ast,
                 length_ast,
+                length_word_ast,
                 ..
             }
             | WordPart::ArraySlice {
                 reference,
-                offset,
                 offset_ast,
-                length,
+                offset_word_ast,
                 length_ast,
+                length_word_ast,
                 ..
             } => {
                 collect_arithmetic_spans_in_var_ref(
@@ -9223,8 +9231,8 @@ fn collect_arithmetic_expansion_spans_from_parts(
                         command_substitution_spans,
                     );
                 } else {
-                    collect_arithmetic_spans_in_source_text(
-                        offset,
+                    collect_arithmetic_expansion_spans_from_parts(
+                        &offset_word_ast.parts,
                         source,
                         collect_dollar_spans,
                         dollar_spans,
@@ -9238,9 +9246,9 @@ fn collect_arithmetic_expansion_spans_from_parts(
                         dollar_spans,
                         command_substitution_spans,
                     );
-                } else if let Some(length) = length {
-                    collect_arithmetic_spans_in_source_text(
-                        length,
+                } else if let Some(length_word_ast) = length_word_ast {
+                    collect_arithmetic_expansion_spans_from_parts(
+                        &length_word_ast.parts,
                         source,
                         collect_dollar_spans,
                         dollar_spans,
@@ -9248,11 +9256,7 @@ fn collect_arithmetic_expansion_spans_from_parts(
                     );
                 }
             }
-            WordPart::ArithmeticExpansion {
-                expression_ast: None,
-                ..
-            }
-            | WordPart::Literal(_)
+            WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
             | WordPart::Variable(_)
             | WordPart::CommandSubstitution { .. }
@@ -9313,10 +9317,10 @@ fn collect_arithmetic_spans_in_parameter_expansion(
             }
             BourneParameterExpansion::Slice {
                 reference,
-                offset,
                 offset_ast,
-                length,
+                offset_word_ast,
                 length_ast,
+                length_word_ast,
                 ..
             } => {
                 collect_arithmetic_spans_in_var_ref(
@@ -9334,8 +9338,8 @@ fn collect_arithmetic_spans_in_parameter_expansion(
                         command_substitution_spans,
                     );
                 } else {
-                    collect_arithmetic_spans_in_source_text(
-                        offset,
+                    collect_arithmetic_expansion_spans_from_parts(
+                        &offset_word_ast.parts,
                         source,
                         collect_dollar_spans,
                         dollar_spans,
@@ -9349,9 +9353,9 @@ fn collect_arithmetic_spans_in_parameter_expansion(
                         dollar_spans,
                         command_substitution_spans,
                     );
-                } else if let Some(length) = length {
-                    collect_arithmetic_spans_in_source_text(
-                        length,
+                } else if let Some(length_word_ast) = length_word_ast {
+                    collect_arithmetic_expansion_spans_from_parts(
+                        &length_word_ast.parts,
                         source,
                         collect_dollar_spans,
                         dollar_spans,
@@ -9388,27 +9392,6 @@ fn collect_arithmetic_spans_in_parameter_expansion(
             ZshExpansionTarget::Empty => {}
         },
     }
-}
-
-fn collect_arithmetic_spans_in_source_text(
-    text: &SourceText,
-    source: &str,
-    collect_dollar_spans: bool,
-    dollar_spans: &mut Vec<Span>,
-    command_substitution_spans: &mut Vec<Span>,
-) {
-    if !text.is_source_backed() {
-        return;
-    }
-
-    let word = Parser::parse_word_fragment(source, text.slice(source), text.span());
-    collect_arithmetic_expansion_spans_from_parts(
-        &word.parts,
-        source,
-        collect_dollar_spans,
-        dollar_spans,
-        command_substitution_spans,
-    );
 }
 
 fn word_classification_from_analysis(analysis: ExpansionAnalysis) -> WordClassification {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -443,6 +443,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     reference,
                     operator,
                     operand,
+                    operand_word_ast,
                     ..
                 } => {
                     if matches!(
@@ -469,7 +470,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     self.collect_parameter_operator_patterns(
                         operator,
                         operand.as_ref(),
-                        None,
+                        operand_word_ast.as_ref(),
                         context,
                     );
                 }
@@ -514,6 +515,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     reference,
                     operator: Some(operator),
                     operand,
+                    operand_word_ast,
                     ..
                 } => {
                     self.record_var_ref_subscript(reference);
@@ -526,7 +528,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     self.collect_parameter_operator_patterns(
                         operator,
                         operand.as_ref(),
-                        None,
+                        operand_word_ast.as_ref(),
                         context,
                     );
                 }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2044,10 +2044,12 @@ impl<'a> Parser<'a> {
             WordPart::ArithmeticExpansion {
                 expression,
                 expression_ast,
+                expression_word_ast,
                 syntax,
             } => HeredocBodyPart::ArithmeticExpansion {
                 expression,
                 expression_ast,
+                expression_word_ast,
                 syntax,
             },
             WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(Box::new(parameter)),
@@ -3827,12 +3829,16 @@ impl<'a> Parser<'a> {
                 reference,
                 operator,
                 operand,
+                operand_word_ast,
                 ..
             } => {
                 Self::materialize_var_ref_source_backing(reference, source);
                 Self::materialize_parameter_operator_source_backing(operator, source);
                 if let Some(operand) = operand {
                     Self::materialize_source_text_source_backing(operand, source);
+                }
+                if let Some(word_ast) = operand_word_ast {
+                    Self::materialize_word_source_backing(word_ast, source);
                 }
             }
             WordPart::ArrayAccess(reference)
@@ -3846,25 +3852,33 @@ impl<'a> Parser<'a> {
                 reference,
                 offset,
                 offset_ast,
+                offset_word_ast,
                 length,
                 length_ast,
+                length_word_ast,
                 ..
             }
             | WordPart::ArraySlice {
                 reference,
                 offset,
                 offset_ast,
+                offset_word_ast,
                 length,
                 length_ast,
+                length_word_ast,
                 ..
             } => {
                 Self::materialize_var_ref_source_backing(reference, source);
                 Self::materialize_source_text_source_backing(offset, source);
+                Self::materialize_word_source_backing(offset_word_ast, source);
                 if let Some(expr) = offset_ast {
                     Self::materialize_arithmetic_expr_source_backing(expr, source);
                 }
                 if let Some(length) = length {
                     Self::materialize_source_text_source_backing(length, source);
+                }
+                if let Some(word_ast) = length_word_ast {
+                    Self::materialize_word_source_backing(word_ast, source);
                 }
                 if let Some(expr) = length_ast {
                     Self::materialize_arithmetic_expr_source_backing(expr, source);
@@ -3874,6 +3888,7 @@ impl<'a> Parser<'a> {
                 reference,
                 operator,
                 operand,
+                operand_word_ast,
                 ..
             } => {
                 Self::materialize_var_ref_source_backing(reference, source);
@@ -3883,13 +3898,18 @@ impl<'a> Parser<'a> {
                 if let Some(operand) = operand {
                     Self::materialize_source_text_source_backing(operand, source);
                 }
+                if let Some(word_ast) = operand_word_ast {
+                    Self::materialize_word_source_backing(word_ast, source);
+                }
             }
             WordPart::ArithmeticExpansion {
                 expression,
                 expression_ast,
+                expression_word_ast,
                 ..
             } => {
                 Self::materialize_source_text_source_backing(expression, source);
+                Self::materialize_word_source_backing(expression_word_ast, source);
                 if let Some(expr) = expression_ast {
                     Self::materialize_arithmetic_expr_source_backing(expr, source);
                 }
@@ -3982,16 +4002,22 @@ impl<'a> Parser<'a> {
                     reference,
                     offset,
                     offset_ast,
+                    offset_word_ast,
                     length,
                     length_ast,
+                    length_word_ast,
                 } => {
                     Self::materialize_var_ref_source_backing(reference, source);
                     Self::materialize_source_text_source_backing(offset, source);
+                    Self::materialize_word_source_backing(offset_word_ast, source);
                     if let Some(expr) = offset_ast {
                         Self::materialize_arithmetic_expr_source_backing(expr, source);
                     }
                     if let Some(length) = length {
                         Self::materialize_source_text_source_backing(length, source);
+                    }
+                    if let Some(word_ast) = length_word_ast {
+                        Self::materialize_word_source_backing(word_ast, source);
                     }
                     if let Some(expr) = length_ast {
                         Self::materialize_arithmetic_expr_source_backing(expr, source);
@@ -4229,9 +4255,11 @@ impl<'a> Parser<'a> {
             HeredocBodyPart::ArithmeticExpansion {
                 expression,
                 expression_ast,
+                expression_word_ast,
                 ..
             } => {
                 expression.rebased(base);
+                Self::rebase_word(expression_word_ast, base);
                 if let Some(expr) = expression_ast {
                     Self::rebase_arithmetic_expr(expr, base);
                 }
@@ -4259,6 +4287,7 @@ impl<'a> Parser<'a> {
                 reference,
                 operator,
                 operand,
+                operand_word_ast,
                 ..
             } => {
                 Self::rebase_var_ref(reference, base);
@@ -4294,6 +4323,9 @@ impl<'a> Parser<'a> {
                 if let Some(operand) = operand {
                     operand.rebased(base);
                 }
+                if let Some(word_ast) = operand_word_ast {
+                    Self::rebase_word(word_ast, base);
+                }
             }
             WordPart::ArrayAccess(reference)
             | WordPart::Length(reference)
@@ -4304,25 +4336,33 @@ impl<'a> Parser<'a> {
                 reference,
                 offset,
                 offset_ast,
+                offset_word_ast,
                 length,
                 length_ast,
+                length_word_ast,
                 ..
             }
             | WordPart::ArraySlice {
                 reference,
                 offset,
                 offset_ast,
+                offset_word_ast,
                 length,
                 length_ast,
+                length_word_ast,
                 ..
             } => {
                 Self::rebase_var_ref(reference, base);
                 offset.rebased(base);
+                Self::rebase_word(offset_word_ast, base);
                 if let Some(expr) = offset_ast {
                     Self::rebase_arithmetic_expr(expr, base);
                 }
                 if let Some(length) = length {
                     length.rebased(base);
+                }
+                if let Some(word_ast) = length_word_ast {
+                    Self::rebase_word(word_ast, base);
                 }
                 if let Some(expr) = length_ast {
                     Self::rebase_arithmetic_expr(expr, base);
@@ -4332,6 +4372,7 @@ impl<'a> Parser<'a> {
                 reference,
                 operator,
                 operand,
+                operand_word_ast,
                 ..
             } => {
                 Self::rebase_var_ref(reference, base);
@@ -4341,13 +4382,18 @@ impl<'a> Parser<'a> {
                 if let Some(operand) = operand {
                     operand.rebased(base);
                 }
+                if let Some(word_ast) = operand_word_ast {
+                    Self::rebase_word(word_ast, base);
+                }
             }
             WordPart::ArithmeticExpansion {
                 expression,
                 expression_ast,
+                expression_word_ast,
                 ..
             } => {
                 expression.rebased(base);
+                Self::rebase_word(expression_word_ast, base);
                 if let Some(expr) = expression_ast {
                     Self::rebase_arithmetic_expr(expr, base);
                 }
@@ -4442,16 +4488,22 @@ impl<'a> Parser<'a> {
                     reference,
                     offset,
                     offset_ast,
+                    offset_word_ast,
                     length,
                     length_ast,
+                    length_word_ast,
                 } => {
                     Self::rebase_var_ref(reference, base);
                     offset.rebased(base);
+                    Self::rebase_word(offset_word_ast, base);
                     if let Some(expr) = offset_ast {
                         Self::rebase_arithmetic_expr(expr, base);
                     }
                     if let Some(length) = length {
                         length.rebased(base);
+                    }
+                    if let Some(word_ast) = length_word_ast {
+                        Self::rebase_word(word_ast, base);
                     }
                     if let Some(expr) = length_ast {
                         Self::rebase_arithmetic_expr(expr, base);
@@ -4847,17 +4899,15 @@ impl<'a> Parser<'a> {
                 reference,
                 operator,
                 operand,
+                operand_word_ast,
                 colon_variant,
-            } => {
-                let operand_word_ast = self.parse_optional_source_text_as_word(operand.as_ref());
-                Some(BourneParameterExpansion::Operation {
-                    reference,
-                    operator: self.enrich_parameter_operator(operator),
-                    operand,
-                    operand_word_ast,
-                    colon_variant,
-                })
-            }
+            } => Some(BourneParameterExpansion::Operation {
+                reference,
+                operator: self.enrich_parameter_operator(operator),
+                operand,
+                operand_word_ast,
+                colon_variant,
+            }),
             WordPart::Length(reference) | WordPart::ArrayLength(reference) => {
                 Some(BourneParameterExpansion::Length { reference })
             }
@@ -4871,37 +4921,41 @@ impl<'a> Parser<'a> {
                 reference,
                 offset,
                 offset_ast,
+                offset_word_ast,
                 length,
                 length_ast,
+                length_word_ast,
             }
             | WordPart::ArraySlice {
                 reference,
                 offset,
                 offset_ast,
+                offset_word_ast,
                 length,
                 length_ast,
+                length_word_ast,
             } => Some(BourneParameterExpansion::Slice {
                 reference,
                 offset,
                 offset_ast,
+                offset_word_ast,
                 length,
                 length_ast,
+                length_word_ast,
             }),
             WordPart::IndirectExpansion {
                 reference,
                 operator,
                 operand,
+                operand_word_ast,
                 colon_variant,
-            } => {
-                let operand_word_ast = self.parse_optional_source_text_as_word(operand.as_ref());
-                Some(BourneParameterExpansion::Indirect {
-                    reference,
-                    operator: operator.map(|operator| self.enrich_parameter_operator(operator)),
-                    operand,
-                    operand_word_ast,
-                    colon_variant,
-                })
-            }
+            } => Some(BourneParameterExpansion::Indirect {
+                reference,
+                operator: operator.map(|operator| self.enrich_parameter_operator(operator)),
+                operand,
+                operand_word_ast,
+                colon_variant,
+            }),
             WordPart::PrefixMatch { prefix, kind } => {
                 Some(BourneParameterExpansion::PrefixMatch { prefix, kind })
             }

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -420,6 +420,7 @@ fn expect_indirect_expansion_part(
             operator,
             operand,
             colon_variant,
+            ..
         } => (
             reference,
             operator.as_ref(),

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1925,6 +1925,7 @@ impl<'a> Parser<'a> {
                 operator,
                 operand,
                 colon_variant,
+                ..
             } => {
                 out.push_str("${");
                 self.push_var_ref_syntax(out, reference);
@@ -1983,6 +1984,7 @@ impl<'a> Parser<'a> {
                 operator,
                 operand,
                 colon_variant,
+                ..
             } => {
                 out.push_str("${!");
                 self.push_var_ref_syntax(out, reference);
@@ -3360,11 +3362,10 @@ impl<'a> Parser<'a> {
                     };
                     Self::push_word_part(
                         parts,
-                        WordPart::ArithmeticExpansion {
-                            expression_ast: self.parse_source_text_as_arithmetic(&expression).ok(),
+                        self.arithmetic_expansion_word_part(
                             expression,
-                            syntax: ArithmeticExpansionSyntax::DollarParenParen,
-                        },
+                            ArithmeticExpansionSyntax::DollarParenParen,
+                        ),
                         part_start,
                         cursor,
                     );
@@ -3484,11 +3485,10 @@ impl<'a> Parser<'a> {
                 };
                 Self::push_word_part(
                     parts,
-                    WordPart::ArithmeticExpansion {
-                        expression_ast: self.parse_source_text_as_arithmetic(&expression).ok(),
+                    self.arithmetic_expansion_word_part(
                         expression,
-                        syntax: ArithmeticExpansionSyntax::LegacyBracket,
-                    },
+                        ArithmeticExpansionSyntax::LegacyBracket,
+                    ),
                     part_start,
                     cursor,
                 );
@@ -3641,12 +3641,7 @@ impl<'a> Parser<'a> {
                             {
                                 WordPart::ArrayIndices(reference)
                             } else {
-                                WordPart::IndirectExpansion {
-                                    reference,
-                                    operator: None,
-                                    operand: None,
-                                    colon_variant: false,
-                                }
+                                self.indirect_expansion_word_part(reference, None, None, false)
                             },
                             part_start,
                             cursor,
@@ -3666,14 +3661,14 @@ impl<'a> Parser<'a> {
                             let operand =
                                 self.read_brace_operand(&mut chars, &mut cursor, source_backed);
                             let part = self.parameter_word_part_from_legacy(
-                                WordPart::IndirectExpansion {
-                                    reference: self.parameter_var_ref(
+                                self.indirect_expansion_word_part(
+                                    self.parameter_var_ref(
                                         part_start, "${!", &var_name, subscript, cursor,
                                     ),
-                                    operator: Some(operator),
-                                    operand: Some(operand),
-                                    colon_variant: true,
-                                },
+                                    Some(operator),
+                                    Some(operand),
+                                    true,
+                                ),
                                 part_start,
                                 cursor,
                                 source_backed,
@@ -3723,14 +3718,14 @@ impl<'a> Parser<'a> {
                             _ => unreachable!(),
                         };
                         let part = self.parameter_word_part_from_legacy(
-                            WordPart::IndirectExpansion {
-                                reference: self.parameter_var_ref(
+                            self.indirect_expansion_word_part(
+                                self.parameter_var_ref(
                                     part_start, "${!", &var_name, subscript, cursor,
                                 ),
-                                operator: Some(operator),
-                                operand: Some(operand),
-                                colon_variant: false,
-                            },
+                                Some(operator),
+                                Some(operand),
+                                false,
+                            ),
                             part_start,
                             cursor,
                             source_backed,
@@ -3751,12 +3746,12 @@ impl<'a> Parser<'a> {
                                 } else {
                                     ParameterOp::RemovePrefixShort { pattern }
                                 };
-                                WordPart::IndirectExpansion {
+                                self.indirect_expansion_word_part(
                                     reference,
-                                    operator: Some(operator),
-                                    operand: None,
-                                    colon_variant: false,
-                                }
+                                    Some(operator),
+                                    None,
+                                    false,
+                                )
                             }
                             '%' => {
                                 let longest =
@@ -3769,12 +3764,12 @@ impl<'a> Parser<'a> {
                                 } else {
                                     ParameterOp::RemoveSuffixShort { pattern }
                                 };
-                                WordPart::IndirectExpansion {
+                                self.indirect_expansion_word_part(
                                     reference,
-                                    operator: Some(operator),
-                                    operand: None,
-                                    colon_variant: false,
-                                }
+                                    Some(operator),
+                                    None,
+                                    false,
+                                )
                             }
                             '/' => {
                                 let replace_all =
@@ -3825,12 +3820,12 @@ impl<'a> Parser<'a> {
                                         replacement,
                                     }
                                 };
-                                WordPart::IndirectExpansion {
+                                self.indirect_expansion_word_part(
                                     reference,
-                                    operator: Some(operator),
-                                    operand: None,
-                                    colon_variant: false,
-                                }
+                                    Some(operator),
+                                    None,
+                                    false,
+                                )
                             }
                             _ => unreachable!(),
                         };
@@ -3930,8 +3925,8 @@ impl<'a> Parser<'a> {
                                     '?' => ParameterOp::Error,
                                     _ => unreachable!(),
                                 };
-                                WordPart::ParameterExpansion {
-                                    reference: self.parameter_var_ref(
+                                self.parameter_expansion_word_part(
+                                    self.parameter_var_ref(
                                         part_start,
                                         "${",
                                         &var_name,
@@ -3939,9 +3934,9 @@ impl<'a> Parser<'a> {
                                         cursor,
                                     ),
                                     operator,
-                                    operand: Some(operand),
-                                    colon_variant: true,
-                                }
+                                    Some(operand),
+                                    true,
+                                )
                             } else if self.zsh_parameter_suffix_looks_like_modifier(&mut chars) {
                                 let tail =
                                     self.read_brace_operand(&mut chars, &mut cursor, source_backed);
@@ -3976,13 +3971,8 @@ impl<'a> Parser<'a> {
                                         None
                                     };
                                 Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                let offset_ast =
-                                    self.maybe_parse_source_text_as_arithmetic(&offset);
-                                let length_ast = length.as_ref().and_then(|length| {
-                                    self.maybe_parse_source_text_as_arithmetic(length)
-                                });
-                                WordPart::ArraySlice {
-                                    reference: self.parameter_var_ref(
+                                self.array_slice_word_part(
+                                    self.parameter_var_ref(
                                         part_start,
                                         "${",
                                         &var_name,
@@ -3990,10 +3980,8 @@ impl<'a> Parser<'a> {
                                         cursor,
                                     ),
                                     offset,
-                                    offset_ast,
                                     length,
-                                    length_ast,
-                                }
+                                )
                             }
                         } else if matches!(next_c, '-' | '+' | '=' | '?') {
                             let op_char = Self::next_word_char_unwrap(&mut chars, &mut cursor);
@@ -4006,8 +3994,8 @@ impl<'a> Parser<'a> {
                                 '?' => ParameterOp::Error,
                                 _ => unreachable!(),
                             };
-                            WordPart::ParameterExpansion {
-                                reference: self.parameter_var_ref(
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(
                                     part_start,
                                     "${",
                                     &var_name,
@@ -4015,9 +4003,9 @@ impl<'a> Parser<'a> {
                                     cursor,
                                 ),
                                 operator,
-                                operand: Some(operand),
-                                colon_variant: false,
-                            }
+                                Some(operand),
+                                false,
+                            )
                         } else if next_c == '#' {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             let longest = Self::consume_word_char_if(&mut chars, &mut cursor, '#');
@@ -4029,8 +4017,8 @@ impl<'a> Parser<'a> {
                             } else {
                                 ParameterOp::RemovePrefixShort { pattern }
                             };
-                            WordPart::ParameterExpansion {
-                                reference: self.parameter_var_ref(
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(
                                     part_start,
                                     "${",
                                     &var_name,
@@ -4038,9 +4026,9 @@ impl<'a> Parser<'a> {
                                     cursor,
                                 ),
                                 operator,
-                                operand: None,
-                                colon_variant: false,
-                            }
+                                None,
+                                false,
+                            )
                         } else if next_c == '%' {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             let longest = Self::consume_word_char_if(&mut chars, &mut cursor, '%');
@@ -4052,8 +4040,8 @@ impl<'a> Parser<'a> {
                             } else {
                                 ParameterOp::RemoveSuffixShort { pattern }
                             };
-                            WordPart::ParameterExpansion {
-                                reference: self.parameter_var_ref(
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(
                                     part_start,
                                     "${",
                                     &var_name,
@@ -4061,9 +4049,9 @@ impl<'a> Parser<'a> {
                                     cursor,
                                 ),
                                 operator,
-                                operand: None,
-                                colon_variant: false,
-                            }
+                                None,
+                                false,
+                            )
                         } else if next_c == '/' {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             let replace_all =
@@ -4114,8 +4102,8 @@ impl<'a> Parser<'a> {
                                     replacement,
                                 }
                             };
-                            WordPart::ParameterExpansion {
-                                reference: self.parameter_var_ref(
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(
                                     part_start,
                                     "${",
                                     &var_name,
@@ -4123,9 +4111,9 @@ impl<'a> Parser<'a> {
                                     cursor,
                                 ),
                                 operator,
-                                operand: None,
-                                colon_variant: false,
-                            }
+                                None,
+                                false,
+                            )
                         } else if next_c == '^' {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             let operator =
@@ -4144,8 +4132,8 @@ impl<'a> Parser<'a> {
                                         source_backed,
                                     ))
                                 };
-                            WordPart::ParameterExpansion {
-                                reference: self.parameter_var_ref(
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(
                                     part_start,
                                     "${",
                                     &var_name,
@@ -4154,8 +4142,8 @@ impl<'a> Parser<'a> {
                                 ),
                                 operator,
                                 operand,
-                                colon_variant: false,
-                            }
+                                false,
+                            )
                         } else if next_c == ',' {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             let operator =
@@ -4174,8 +4162,8 @@ impl<'a> Parser<'a> {
                                         source_backed,
                                     ))
                                 };
-                            WordPart::ParameterExpansion {
-                                reference: self.parameter_var_ref(
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(
                                     part_start,
                                     "${",
                                     &var_name,
@@ -4184,8 +4172,8 @@ impl<'a> Parser<'a> {
                                 ),
                                 operator,
                                 operand,
-                                colon_variant: false,
-                            }
+                                false,
+                            )
                         } else if next_c == '@' {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             if chars.peek().is_some() {
@@ -4278,14 +4266,14 @@ impl<'a> Parser<'a> {
                                         '?' => ParameterOp::Error,
                                         _ => unreachable!(),
                                     };
-                                    WordPart::ParameterExpansion {
-                                        reference: self.parameter_var_ref(
+                                    self.parameter_expansion_word_part(
+                                        self.parameter_var_ref(
                                             part_start, "${", &var_name, None, cursor,
                                         ),
                                         operator,
-                                        operand: Some(operand),
-                                        colon_variant: true,
-                                    }
+                                        Some(operand),
+                                        true,
+                                    )
                                 }
                                 _ => {
                                     let offset = self.read_source_text_while(
@@ -4307,20 +4295,13 @@ impl<'a> Parser<'a> {
                                             None
                                         };
                                     Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                    let offset_ast =
-                                        self.maybe_parse_source_text_as_arithmetic(&offset);
-                                    let length_ast = length.as_ref().and_then(|length| {
-                                        self.maybe_parse_source_text_as_arithmetic(length)
-                                    });
-                                    WordPart::Substring {
-                                        reference: self.parameter_var_ref(
+                                    self.substring_word_part(
+                                        self.parameter_var_ref(
                                             part_start, "${", &var_name, None, cursor,
                                         ),
                                         offset,
-                                        offset_ast,
                                         length,
-                                        length_ast,
-                                    }
+                                    )
                                 }
                             }
                         }
@@ -4335,13 +4316,12 @@ impl<'a> Parser<'a> {
                                 '?' => ParameterOp::Error,
                                 _ => unreachable!(),
                             };
-                            WordPart::ParameterExpansion {
-                                reference: self
-                                    .parameter_var_ref(part_start, "${", &var_name, None, cursor),
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
                                 operator,
-                                operand: Some(operand),
-                                colon_variant: false,
-                            }
+                                Some(operand),
+                                false,
+                            )
                         }
                         '#' => {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
@@ -4354,13 +4334,12 @@ impl<'a> Parser<'a> {
                             } else {
                                 ParameterOp::RemovePrefixShort { pattern }
                             };
-                            WordPart::ParameterExpansion {
-                                reference: self
-                                    .parameter_var_ref(part_start, "${", &var_name, None, cursor),
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
                                 operator,
-                                operand: None,
-                                colon_variant: false,
-                            }
+                                None,
+                                false,
+                            )
                         }
                         '%' => {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
@@ -4373,13 +4352,12 @@ impl<'a> Parser<'a> {
                             } else {
                                 ParameterOp::RemoveSuffixShort { pattern }
                             };
-                            WordPart::ParameterExpansion {
-                                reference: self
-                                    .parameter_var_ref(part_start, "${", &var_name, None, cursor),
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
                                 operator,
-                                operand: None,
-                                colon_variant: false,
-                            }
+                                None,
+                                false,
+                            )
                         }
                         '/' => {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
@@ -4431,13 +4409,12 @@ impl<'a> Parser<'a> {
                                     replacement,
                                 }
                             };
-                            WordPart::ParameterExpansion {
-                                reference: self
-                                    .parameter_var_ref(part_start, "${", &var_name, None, cursor),
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
                                 operator,
-                                operand: None,
-                                colon_variant: false,
-                            }
+                                None,
+                                false,
+                            )
                         }
                         '^' => {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
@@ -4457,13 +4434,12 @@ impl<'a> Parser<'a> {
                                         source_backed,
                                     ))
                                 };
-                            WordPart::ParameterExpansion {
-                                reference: self
-                                    .parameter_var_ref(part_start, "${", &var_name, None, cursor),
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
                                 operator,
                                 operand,
-                                colon_variant: false,
-                            }
+                                false,
+                            )
                         }
                         ',' => {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
@@ -4483,13 +4459,12 @@ impl<'a> Parser<'a> {
                                         source_backed,
                                     ))
                                 };
-                            WordPart::ParameterExpansion {
-                                reference: self
-                                    .parameter_var_ref(part_start, "${", &var_name, None, cursor),
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
                                 operator,
                                 operand,
-                                colon_variant: false,
-                            }
+                                false,
+                            )
                         }
                         '@' => {
                             Self::next_word_char_unwrap(&mut chars, &mut cursor);
@@ -4855,6 +4830,99 @@ impl<'a> Parser<'a> {
         source_backed: bool,
     ) -> Word {
         self.decode_word_text_preserving_quotes_if_needed(s, span, base, source_backed)
+    }
+
+    fn arithmetic_expansion_word_part(
+        &self,
+        expression: SourceText,
+        syntax: ArithmeticExpansionSyntax,
+    ) -> WordPart {
+        WordPart::ArithmeticExpansion {
+            expression_ast: self.parse_source_text_as_arithmetic(&expression).ok(),
+            expression_word_ast: self.parse_source_text_as_word(&expression),
+            expression,
+            syntax,
+        }
+    }
+
+    fn parameter_expansion_word_part(
+        &self,
+        reference: VarRef,
+        operator: ParameterOp,
+        operand: Option<SourceText>,
+        colon_variant: bool,
+    ) -> WordPart {
+        let operand_word_ast = self.parse_optional_source_text_as_word(operand.as_ref());
+        WordPart::ParameterExpansion {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            colon_variant,
+        }
+    }
+
+    fn indirect_expansion_word_part(
+        &self,
+        reference: VarRef,
+        operator: Option<ParameterOp>,
+        operand: Option<SourceText>,
+        colon_variant: bool,
+    ) -> WordPart {
+        let operand_word_ast = self.parse_optional_source_text_as_word(operand.as_ref());
+        WordPart::IndirectExpansion {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            colon_variant,
+        }
+    }
+
+    fn substring_word_part(
+        &self,
+        reference: VarRef,
+        offset: SourceText,
+        length: Option<SourceText>,
+    ) -> WordPart {
+        let offset_ast = self.maybe_parse_source_text_as_arithmetic(&offset);
+        let offset_word_ast = self.parse_source_text_as_word(&offset);
+        let length_ast = length
+            .as_ref()
+            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length));
+        let length_word_ast = self.parse_optional_source_text_as_word(length.as_ref());
+        WordPart::Substring {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+        }
+    }
+
+    fn array_slice_word_part(
+        &self,
+        reference: VarRef,
+        offset: SourceText,
+        length: Option<SourceText>,
+    ) -> WordPart {
+        let offset_ast = self.maybe_parse_source_text_as_arithmetic(&offset);
+        let offset_word_ast = self.parse_source_text_as_word(&offset);
+        let length_ast = length
+            .as_ref()
+            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length));
+        let length_word_ast = self.parse_optional_source_text_as_word(length.as_ref());
+        WordPart::ArraySlice {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+        }
     }
 
     /// Read operand for brace expansion (everything until closing brace)

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1351,6 +1351,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 reference,
                 operator,
                 operand,
+                operand_word_ast,
                 ..
             } => {
                 let reference_id = self.visit_var_ref_reference(
@@ -1375,7 +1376,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.visit_parameter_operator_operand(
                     operator,
                     operand.as_ref(),
-                    None,
+                    operand_word_ast.as_ref(),
                     kind,
                     flow,
                     nested_regions,
@@ -1431,7 +1432,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     span,
                 );
             }
-            WordPart::IndirectExpansion { reference, .. } => {
+            WordPart::IndirectExpansion {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                ..
+            } => {
                 let id = self.visit_var_ref_reference(
                     reference,
                     if matches!(kind, WordVisitKind::Conditional) {
@@ -1444,6 +1451,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     span,
                 );
                 self.indirect_expansion_refs.insert(id);
+                if let Some(operator) = operator {
+                    self.visit_parameter_operator_operand(
+                        operator,
+                        operand.as_ref(),
+                        operand_word_ast.as_ref(),
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                }
             }
             WordPart::Substring {
                 reference,
@@ -3818,6 +3835,7 @@ mod tests {
                 },
                 operator: ParameterOp::UseDefault,
                 operand: Some(SourceText::from("fallback")),
+                operand_word_ast: Some(Word::literal("fallback")),
                 colon_variant: true,
             },
         ]))]);


### PR DESCRIPTION
## Summary
- thread parser-owned companion word ASTs through arithmetic and parameter expansion nodes
- remove the remaining downstream status/arithmetic reparses from linter facts and surface consumers
- update semantic/parser tests and fixtures to rely on the parser-backed AST fields

## Testing
- cargo test -p shuck-parser -p shuck-indexer -p shuck-semantic -p shuck-linter
