### PR TITLE
Use parser-backed surface facts for parameter expansions

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1020,7 +1020,9 @@ fn collect_positional_parameter_operator_spans_in_arithmetic(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    if expression_ast.is_some_and(arithmetic_expr_has_positional_parameter_operator) {
+    if expression_ast.is_some_and(|expression_ast| {
+        arithmetic_expr_has_positional_parameter_operator(expression_ast, source)
+    }) {
         spans.push(Span::from_positions(
             expansion_span.start,
             expansion_span.start,
@@ -1081,20 +1083,23 @@ fn collect_positional_parameter_operator_spans_in_arithmetic(
     }
 }
 
-fn arithmetic_expr_has_positional_parameter_operator(expression: &ArithmeticExprNode) -> bool {
+fn arithmetic_expr_has_positional_parameter_operator(
+    expression: &ArithmeticExprNode,
+    source: &str,
+) -> bool {
     let mut should_report = false;
     query::visit_arithmetic_words(expression, &mut |word| {
-        if word_has_unquoted_positional_parameter_concatenation(word) {
+        if word_has_unquoted_positional_parameter_operator_neighbors(word, source) {
             should_report = true;
         }
     });
     should_report
 }
 
-fn word_has_unquoted_positional_parameter_concatenation(word: &Word) -> bool {
+fn word_has_unquoted_positional_parameter_operator_neighbors(word: &Word, source: &str) -> bool {
     word.parts.iter().enumerate().any(|(index, part)| {
         part_is_unquoted_positional_parameter(&part.kind)
-            && (index > 0 || index + 1 < word.parts.len())
+            && positional_parameter_part_has_operator_neighbor(word, index, source)
     })
 }
 
@@ -1131,6 +1136,23 @@ fn part_is_unquoted_positional_parameter(part: &WordPart) -> bool {
 
 fn name_is_positional_parameter(name: &Name) -> bool {
     !name.as_str().is_empty() && name.as_str().bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn positional_parameter_part_has_operator_neighbor(
+    word: &Word,
+    index: usize,
+    source: &str,
+) -> bool {
+    let Some(part) = word.parts.get(index) else {
+        return false;
+    };
+
+    let prefix = &source[word.span.start.offset..part.span.start.offset];
+    let suffix = &source[part.span.end.offset..word.span.end.offset];
+    let prev = prefix.chars().rev().find(|ch| !ch.is_whitespace());
+    let next = suffix.chars().find(|ch| !ch.is_whitespace());
+
+    prev.is_some_and(is_left_operand_neighbor) || next.is_some_and(is_right_operand_neighbor)
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -1370,7 +1392,7 @@ fn is_unicode_smart_quote(char: char) -> bool {
 mod tests {
     use super::{
         SubscriptSpanIndex, arithmetic_expr_has_positional_parameter_operator,
-        word_has_unquoted_positional_parameter_concatenation,
+        word_has_unquoted_positional_parameter_operator_neighbors,
     };
     use shuck_ast::{Command, Position, Span, WordPart};
     use shuck_parser::parser::Parser;
@@ -1402,22 +1424,22 @@ mod tests {
     }
 
     #[test]
-    fn detects_internal_positional_parameter_concatenation_in_arithmetic_words() {
+    fn detects_operator_like_neighbors_around_positional_parameters_in_arithmetic_words() {
         for text in ["$1$2", "$1suffix", "prefix$1", "${1}x"] {
             let word = Parser::parse_word_string(text);
             assert!(
-                word_has_unquoted_positional_parameter_concatenation(&word),
+                word_has_unquoted_positional_parameter_operator_neighbors(&word, text),
                 "expected {text:?} to be flagged",
             );
         }
     }
 
     #[test]
-    fn ignores_isolated_or_quoted_positional_parameters_in_arithmetic_words() {
-        for text in ["$1", "${1}", "\"$1\"", "'$1'"] {
+    fn ignores_non_operator_neighbors_around_positional_parameters_in_arithmetic_words() {
+        for text in ["$1", "${1}", "\"$1\"", "'$1'", "16#$1"] {
             let word = Parser::parse_word_string(text);
             assert!(
-                !word_has_unquoted_positional_parameter_concatenation(&word),
+                !word_has_unquoted_positional_parameter_operator_neighbors(&word, text),
                 "expected {text:?} to be ignored",
             );
         }
@@ -1451,7 +1473,8 @@ mod tests {
             .expect("expected parsed arithmetic expression");
 
         assert!(arithmetic_expr_has_positional_parameter_operator(
-            expression_ast
+            expression_ast,
+            source
         ));
     }
 }

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -116,18 +116,20 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     fn record_array_reference(&mut self, span: Span) {
-        let Some(span) = plain_array_reference_span(span, self.source) else {
+        if self
+            .facts
+            .indexed_array_references
+            .iter()
+            .any(|fragment| fragment.span() == span)
+        {
             return;
-        };
+        }
         self.facts
             .indexed_array_references
             .push(IndexedArrayReferenceFragmentFact { span });
     }
 
     fn record_substring_expansion(&mut self, span: Span) {
-        let Some(span) = plain_substring_expansion_span(span, self.source) else {
-            return;
-        };
         if self
             .facts
             .substring_expansions
@@ -142,9 +144,6 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     fn record_case_modification(&mut self, span: Span) {
-        let Some(span) = plain_case_modification_span(span, self.source) else {
-            return;
-        };
         if self
             .facts
             .case_modifications
@@ -159,9 +158,6 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     fn record_replacement_expansion(&mut self, span: Span) {
-        let Some(span) = plain_replacement_expansion_span(span, self.source) else {
-            return;
-        };
         if self
             .facts
             .replacement_expansions
@@ -388,6 +384,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         .push(LegacyArithmeticFragmentFact { span: part.span });
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
+                        expression_ast.as_ref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
@@ -405,6 +402,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 } => {
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
+                        expression_ast.as_ref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
@@ -605,6 +603,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         .push(LegacyArithmeticFragmentFact { span: part.span });
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
+                        expression_ast.as_ref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
@@ -622,6 +621,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 } => {
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
+                        expression_ast.as_ref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
@@ -1013,242 +1013,21 @@ fn reference_has_array_subscript(reference: &VarRef) -> bool {
     reference.subscript.is_some()
 }
 
-fn plain_array_reference_span(span: Span, source: &str) -> Option<Span> {
-    let text = span.slice(source);
-    let inner = text.strip_prefix("${")?.strip_suffix('}')?;
-    if inner.starts_with('#') || inner.starts_with('!') || !inner.ends_with(']') {
-        return None;
-    }
-
-    let open = inner.find('[')?;
-    let close = inner.rfind(']')?;
-    if close != inner.len() - 1 || close <= open {
-        return None;
-    }
-
-    Some(span)
-}
-
-fn plain_substring_expansion_span(span: Span, source: &str) -> Option<Span> {
-    let text = span.slice(source);
-    let relative_start = text.find("${")?;
-    let start = span.start.advanced_by(&text[..relative_start]);
-    let after_start = &source[start.offset..];
-    let relative_end = after_start.find('}')?;
-    let end = start.advanced_by(&after_start[..relative_end + '}'.len_utf8()]);
-    let candidate = &after_start[..relative_end + '}'.len_utf8()];
-
-    is_plain_substring_expansion_text(candidate).then_some(Span::from_positions(start, end))
-}
-
-fn is_plain_substring_expansion_text(text: &str) -> bool {
-    let Some(inner) = text
-        .strip_prefix("${")
-        .and_then(|text| text.strip_suffix('}'))
-    else {
-        return false;
-    };
-    if inner.starts_with('#') || inner.starts_with('!') {
-        return false;
-    }
-
-    let Some(colon_index) = inner.find(':') else {
-        return false;
-    };
-    let name = &inner[..colon_index];
-    if !looks_like_plain_substring_target(name) {
-        return false;
-    }
-    let suffix = &inner[colon_index + 1..];
-    if suffix.is_empty() {
-        return false;
-    }
-    if matches!(suffix.chars().next(), Some('-' | '=' | '+' | '?')) {
-        return false;
-    }
-
-    true
-}
-
-fn looks_like_plain_substring_target(name: &str) -> bool {
-    if name.is_empty() || name.contains('[') || name.contains(']') {
-        return false;
-    }
-
-    matches!(name, "@" | "*" | "?" | "-" | "$")
-        || name.bytes().all(|byte| byte.is_ascii_digit())
-        || is_shell_name(name)
-}
-
-fn plain_case_modification_span(span: Span, source: &str) -> Option<Span> {
-    let text = span.slice(source);
-    let relative_start = text.find("${")?;
-    let start = span.start.advanced_by(&text[..relative_start]);
-    let after_start = &source[start.offset..];
-    let relative_end = after_start.find('}')?;
-    let end = start.advanced_by(&after_start[..relative_end + '}'.len_utf8()]);
-    let candidate = &after_start[..relative_end + '}'.len_utf8()];
-
-    is_plain_case_modification_text(candidate).then_some(Span::from_positions(start, end))
-}
-
-fn is_plain_case_modification_text(text: &str) -> bool {
-    let Some(inner) = text
-        .strip_prefix("${")
-        .and_then(|text| text.strip_suffix('}'))
-    else {
-        return false;
-    };
-    if inner.starts_with('#') || inner.starts_with('!') {
-        return false;
-    }
-
-    let mut index = 0;
-    let chars = inner.chars().collect::<Vec<_>>();
-    while index < chars.len()
-        && (chars[index].is_ascii_alphanumeric()
-            || chars[index] == '_'
-            || matches!(chars[index], '@' | '*'))
-    {
-        index += 1;
-    }
-
-    if index == 0 {
-        return false;
-    }
-
-    if chars.get(index) == Some(&'[') {
-        let mut close = index + 1;
-        while close < chars.len() && chars[close] != ']' {
-            close += 1;
-        }
-        if close == chars.len() {
-            return false;
-        }
-        index = close + 1;
-    }
-
-    let Some(&operator) = chars.get(index) else {
-        return false;
-    };
-    if !matches!(operator, '^' | ',') {
-        return false;
-    }
-
-    true
-}
-
-fn plain_replacement_expansion_span(span: Span, source: &str) -> Option<Span> {
-    let text = span.slice(source);
-    let (relative_start, relative_end) = next_parameter_expansion_candidate(text, 0)?;
-    let start = span.start.advanced_by(&text[..relative_start]);
-    let end = span.start.advanced_by(&text[..relative_end]);
-    let candidate = &text[relative_start..relative_end];
-
-    is_plain_replacement_expansion_text(candidate).then_some(Span::from_positions(start, end))
-}
-
-fn is_plain_replacement_expansion_text(text: &str) -> bool {
-    let Some(inner) = text
-        .strip_prefix("${")
-        .and_then(|text| text.strip_suffix('}'))
-    else {
-        return false;
-    };
-    if inner.starts_with('#') || inner.starts_with('!') {
-        return false;
-    }
-
-    let mut index = 0;
-    let chars = inner.chars().collect::<Vec<_>>();
-    while index < chars.len()
-        && (chars[index].is_ascii_alphanumeric()
-            || chars[index] == '_'
-            || matches!(chars[index], '@' | '*'))
-    {
-        index += 1;
-    }
-
-    if index == 0 {
-        return false;
-    }
-
-    if chars.get(index) == Some(&'[') {
-        let mut close = index + 1;
-        while close < chars.len() && chars[close] != ']' {
-            close += 1;
-        }
-        if close == chars.len() {
-            return false;
-        }
-        index = close + 1;
-    }
-
-    if chars.get(index) != Some(&'/') {
-        return false;
-    }
-
-    index += 1;
-    if chars.get(index) == Some(&'/') {
-        index += 1;
-    }
-
-    index < chars.len()
-}
-
-fn next_parameter_expansion_candidate(text: &str, search_start: usize) -> Option<(usize, usize)> {
-    let bytes = text.as_bytes();
-    let mut index = search_start;
-
-    while index + 1 < bytes.len() {
-        match bytes[index] {
-            b'\\' => {
-                index += 2;
-            }
-            b'$' if bytes[index + 1] == b'{' => {
-                let start = index;
-                index += 2;
-                let mut depth = 1;
-
-                while index < bytes.len() {
-                    match bytes[index] {
-                        b'\\' => {
-                            index += 2;
-                        }
-                        b'$' if index + 1 < bytes.len() && bytes[index + 1] == b'{' => {
-                            depth += 1;
-                            index += 2;
-                        }
-                        b'}' => {
-                            depth -= 1;
-                            index += 1;
-                            if depth == 0 {
-                                return Some((start, index));
-                            }
-                        }
-                        _ => {
-                            index += 1;
-                        }
-                    }
-                }
-
-                return None;
-            }
-            _ => {
-                index += 1;
-            }
-        }
-    }
-
-    None
-}
-
 fn collect_positional_parameter_operator_spans_in_arithmetic(
     expansion_span: Span,
+    expression_ast: Option<&ArithmeticExprNode>,
     expression: &SourceText,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
+    if expression_ast.is_some_and(arithmetic_expr_has_positional_parameter_operator) {
+        spans.push(Span::from_positions(
+            expansion_span.start,
+            expansion_span.start,
+        ));
+        return;
+    }
+
     let text = expression.slice(source);
     let mut should_report = false;
     let mut state = ArithmeticScanState::default();
@@ -1300,6 +1079,58 @@ fn collect_positional_parameter_operator_spans_in_arithmetic(
             expansion_span.start,
         ));
     }
+}
+
+fn arithmetic_expr_has_positional_parameter_operator(expression: &ArithmeticExprNode) -> bool {
+    let mut should_report = false;
+    query::visit_arithmetic_words(expression, &mut |word| {
+        if word_has_unquoted_positional_parameter_concatenation(word) {
+            should_report = true;
+        }
+    });
+    should_report
+}
+
+fn word_has_unquoted_positional_parameter_concatenation(word: &Word) -> bool {
+    word.parts.iter().enumerate().any(|(index, part)| {
+        part_is_unquoted_positional_parameter(&part.kind)
+            && (index > 0 || index + 1 < word.parts.len())
+    })
+}
+
+fn part_is_unquoted_positional_parameter(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => name_is_positional_parameter(name),
+        WordPart::Parameter(parameter) => matches!(
+            &parameter.syntax,
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+                if reference.subscript.is_none()
+                    && name_is_positional_parameter(&reference.name)
+        ),
+        WordPart::ArrayAccess(reference) => {
+            reference.subscript.is_none() && name_is_positional_parameter(&reference.name)
+        }
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::DoubleQuoted { .. }
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn name_is_positional_parameter(name: &Name) -> bool {
+    !name.as_str().is_empty() && name.as_str().bytes().all(|byte| byte.is_ascii_digit())
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -1537,8 +1368,12 @@ fn is_unicode_smart_quote(char: char) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{SubscriptSpanIndex, plain_replacement_expansion_span};
-    use shuck_ast::{Position, Span};
+    use super::{
+        SubscriptSpanIndex, arithmetic_expr_has_positional_parameter_operator,
+        word_has_unquoted_positional_parameter_concatenation,
+    };
+    use shuck_ast::{Command, Position, Span, WordPart};
+    use shuck_parser::parser::Parser;
 
     fn span(start: usize, end: usize) -> Span {
         Span::from_positions(
@@ -1567,20 +1402,56 @@ mod tests {
     }
 
     #[test]
-    fn plain_replacement_expansion_span_handles_complex_replacements() {
-        for text in [
-            r#"${dest_dir//\'/\'\\\'\'}"#,
-            r#"${TERMUX_PKG_VERSION//-/.}"#,
-            r#"${TERMUX_PKG_VERSION_EDITED//${INCORRECT_SYMBOLS:0:1}${INCORRECT_SYMBOLS:1:1}/${INCORRECT_SYMBOLS:0:1}.${INCORRECT_SYMBOLS:1:1}}"#,
-            r#"${GITHUB_GRAPHQL_QUERIES[$BATCH * $BATCH_SIZE]//\\/}"#,
-            r#"${run_depends/${i}/${dep}}"#,
-        ] {
-            assert_eq!(
-                plain_replacement_expansion_span(span(0, text.len()), text)
-                    .expect("expected replacement expansion span")
-                    .slice(text),
-                text
+    fn detects_internal_positional_parameter_concatenation_in_arithmetic_words() {
+        for text in ["$1$2", "$1suffix", "prefix$1", "${1}x"] {
+            let word = Parser::parse_word_string(text);
+            assert!(
+                word_has_unquoted_positional_parameter_concatenation(&word),
+                "expected {text:?} to be flagged",
             );
         }
+    }
+
+    #[test]
+    fn ignores_isolated_or_quoted_positional_parameters_in_arithmetic_words() {
+        for text in ["$1", "${1}", "\"$1\"", "'$1'"] {
+            let word = Parser::parse_word_string(text);
+            assert!(
+                !word_has_unquoted_positional_parameter_concatenation(&word),
+                "expected {text:?} to be ignored",
+            );
+        }
+    }
+
+    #[test]
+    fn detects_positional_parameter_operator_in_parsed_arithmetic_shell_word() {
+        let source = "#!/bin/sh\necho \"$(( value + $1suffix ))\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = output.file.body.stmts.first().expect("expected command");
+        let Command::Simple(command) = &command.command else {
+            panic!("expected simple command");
+        };
+        let expression_ast = command.args[0]
+            .parts
+            .iter()
+            .find_map(|part| match &part.kind {
+                WordPart::DoubleQuoted { parts, .. } => parts.iter().find_map(|part| {
+                    if let WordPart::ArithmeticExpansion {
+                        expression_ast: Some(expression_ast),
+                        ..
+                    } = &part.kind
+                    {
+                        Some(expression_ast)
+                    } else {
+                        None
+                    }
+                }),
+                _ => None,
+            })
+            .expect("expected parsed arithmetic expression");
+
+        assert!(arithmetic_expr_has_positional_parameter_operator(
+            expression_ast
+        ));
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
@@ -60,6 +60,23 @@ echo \"$(( x ? $1 : y ))\"
     }
 
     #[test]
+    fn reports_concatenated_positional_parameters_in_valid_arithmetic_words() {
+        let source = "\
+#!/bin/sh
+echo \"$(( value + $1suffix ))\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PositionalParamAsOperator),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 7);
+        assert_eq!(diagnostics[0].span.end, diagnostics[0].span.start);
+    }
+
+    #[test]
     fn ignores_non_positional_parameter_expansions_in_arithmetic() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
@@ -93,6 +93,20 @@ echo \"$(( ${#1} ))\"
     }
 
     #[test]
+    fn ignores_base_prefixed_literals_that_use_positional_parameters() {
+        let source = "\
+#!/bin/sh
+echo \"$(( 16#$1 ))\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PositionalParamAsOperator),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_dollar_tokens_inside_single_quoted_command_substitutions() {
         let source = "\
 #!/bin/sh


### PR DESCRIPTION
## Summary
- replace the surface-level `${...}` reparse helpers with spans taken from the parsed parameter-expansion AST for array references, substrings, case modifications, and replacement expansions
- use parsed arithmetic shell words to detect positional parameters that end up in operator-like slots, while keeping the raw text scan as a fallback when no arithmetic AST is available
- add focused regression tests for the new parser-backed paths and the positional-parameter rule

## Why
`crates/shuck-linter/src/facts/surface.rs` had effectively become a second parser for several parameter-expansion forms and for one arithmetic adjacency check. The parser and AST already expose most of that structure, so this change moves the linter back to consuming parser output instead of rediscovering it from raw text.

## Impact
- surface facts now stay aligned with parser semantics instead of maintaining their own `${...}` recognizers
- the linter drops the nested-brace replacement scan and other duplicated parameter-expansion parsing logic
- malformed arithmetic expressions still keep the existing fallback behavior when no typed arithmetic AST is available

## Validation
- `cargo fmt --all`
- `cargo test -p shuck-linter surface::tests`
- `cargo test -p shuck-linter positional_param_as_operator`
- `cargo test -p shuck-linter builds_surface_fragment_facts`