### PR TITLE
Fix S023 escaped @ handling

### DIFF
--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -45,6 +45,7 @@ fn is_regular_plain_word_escape_target(byte: u8) -> bool {
         byte,
         b' ' | b'\t'
             | b'\n'
+            | b'@'
             | b'#'
             | b'$'
             | b'`'
@@ -160,5 +161,18 @@ ${bindir}/foo\\_bar
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
 
         assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn ignores_escaped_at_signs() {
+        let source = "\
+#!/bin/bash
+echo foo\\@bar
+echo \"$rvm_path\"/gems/*\\@
+cp --no-preserve=mode,ownership -rf \"${GOPATH}\"/pkg/mod/\"${go_module}\"\\@* ./\"${go_module##*/}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
+
+        assert!(diagnostics.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- stop `S023` from flagging `\@` as a needless escape
- add a regression test for plain-word and path/glob `\@` cases

## Why
`S023` was over-reporting `\@` even though current ShellCheck behavior treats it as acceptable in this context. That showed up as shuck-only compatibility diffs in the large corpus run.

## Validation
- `cargo test -p shuck-linter escaped_underscore -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S023`
- `cargo test --workspace`
