### PR TITLE
Fix S029 false positives after escaped quotes

### DIFF
--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -131,4 +131,15 @@ echo [0-9a-f]{$HASHLEN}
 
         assert_eq!(diagnostics.len(), 4);
     }
+
+    #[test]
+    fn ignores_plain_parameter_expansion_braces_next_to_brace_expansion() {
+        let source = "\
+#!/bin/bash
+echo TERMUX_SUBPKG_INCLUDE=\\\"$(find ${_ADD_PREFIX}lib{,32} -name '*.a' -o -name '*.la' 2> /dev/null) $TERMUX_PKG_STATICSPLIT_EXTRA_PATTERNS\\\" > \"$_STATIC_SUBPACKAGE_FILE\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -254,6 +254,26 @@ fn test_parse_mixed_quoted_and_cooked_plain_continuation_keeps_variable_live() {
 }
 
 #[test]
+fn test_parse_escaped_quote_before_command_substitution_keeps_substitution_live() {
+    let input = "echo TERMUX_SUBPKG_INCLUDE=\\\"$(find ${_ADD_PREFIX}lib{,32})\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    assert!(
+        word.parts
+            .iter()
+            .any(|part| !matches!(part.kind, WordPart::Literal(_))),
+        "parts: {:?}",
+        word.parts
+    );
+    assert_eq!(word.brace_syntax().len(), 0);
+}
+
+#[test]
 fn test_parse_escaped_command_substitution_stays_literal_in_double_quotes() {
     let input = r#"echo "\$(pwd)""#;
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -609,9 +609,8 @@ impl<'a> Parser<'a> {
             return word;
         }
 
-        let preserve_quote_fragments =
-            Self::source_text_needs_quote_preserving_decode(s)
-                && (!source_backed || self.source_matches(span, s));
+        let preserve_quote_fragments = Self::source_text_needs_quote_preserving_decode(s)
+            && (!source_backed || self.source_matches(span, s));
 
         if preserve_quote_fragments {
             self.decode_fragment_word_text_with_escape_mode(

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -609,7 +609,11 @@ impl<'a> Parser<'a> {
             return word;
         }
 
-        if Self::source_text_needs_quote_preserving_decode(s) {
+        let preserve_quote_fragments =
+            Self::source_text_needs_quote_preserving_decode(s)
+                && (!source_backed || self.source_matches(span, s));
+
+        if preserve_quote_fragments {
             self.decode_fragment_word_text_with_escape_mode(
                 s,
                 span,


### PR DESCRIPTION
## Summary
- tighten quote-fragment preservation for source-backed plain words so literal escaped quotes are not reinterpreted as real quote delimiters
- add a parser regression for an escaped quote immediately before a command substitution
- add an `S029` regression covering the Termux-style `${_ADD_PREFIX}lib{,32}` shape

## Why
A plain word containing a literal `\"` before `$(...)` could be reparsed as if the quote had actually opened. That collapsed live substitutions into literal text, which in turn made `S029` treat `${...}` brace edges as literal-brace warnings.

## Impact
This keeps mixed escaped-quote words parsed structurally, preserves the intended escaped-parameter behavior, and removes the targeted large-corpus `S029` false positives without adding corpus metadata.

## Validation
- `cargo test -p shuck-parser`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S029`