### PR TITLE
Fix truncated escaped-quote variable names

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1979,6 +1979,20 @@ foo=\"$foo\"
     }
 
     #[test]
+    fn undefined_variable_ignores_bound_name_between_escaped_quote_literals() {
+        let diagnostics = lint_for_rule(
+            "\
+#!/bin/sh
+archname=archive
+echo Self-extractable archive \\\"$archname\\\" successfully created.
+",
+            Rule::UndefinedVariable,
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn unquoted_heredoc_generated_shell_text_reports_c006() {
         let diagnostics = lint_for_rule(
             "\

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1605,7 +1605,7 @@ impl<'a> Lexer<'a> {
                     } else {
                         // Escaped character: backslash quotes the next char
                         // (quote removal — only the literal char survives)
-                        if matches!(next, '$' | '`') {
+                        if matches!(next, '$' | '`' | '"' | '\'') {
                             Self::push_capture_char(&mut word, '\x00');
                         }
                         Self::push_capture_char(&mut word, next);

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1141,7 +1141,10 @@ fn test_escaped_quote_literal_does_not_truncate_following_variable_name() {
     };
     let word = &command.args[0];
 
-    assert_eq!(top_level_part_slices(word, input), vec!["\\\"", "$archname", "\\\""]);
+    assert_eq!(
+        top_level_part_slices(word, input),
+        vec!["\\\"", "$archname", "\\\""]
+    );
     assert!(word_part_tree_contains_variable(&word.parts, "archname"));
     assert!(!word_part_tree_contains_variable(&word.parts, "archnam"));
 }

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1132,6 +1132,21 @@ fn test_mixed_segment_word_preserves_expansion_boundaries() {
 }
 
 #[test]
+fn test_escaped_quote_literal_does_not_truncate_following_variable_name() {
+    let input = "echo \\\"$archname\\\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    assert_eq!(top_level_part_slices(word, input), vec!["\\\"", "$archname", "\\\""]);
+    assert!(word_part_tree_contains_variable(&word.parts, "archname"));
+    assert!(!word_part_tree_contains_variable(&word.parts, "archnam"));
+}
+
+#[test]
 fn test_assignment_value_preserves_mixed_quoted_boundaries() {
     let input = "foo=\"$bar\"baz echo\n";
     let script = Parser::new(input).parse().unwrap().file;


### PR DESCRIPTION
## Summary
- preserve the lexer escape sentinel for escaped single and double quotes so decoded words keep following variable names intact
- add parser and linter regressions for words shaped like `\"$archname\"`
- keep the `C006` fix scoped to code and tests without pulling in the local bug-doc edit

## Root Cause
The lexer was dropping the backslash before literal quote characters without preserving the internal escaped-character marker that the parser uses for other escaped metacharacters. That let `\"$archname\"` decode as if the quotes were real delimiters, which chopped the variable reference down to `archnam` and produced a false `C006` report.

## Validation
- `cargo test -p shuck-parser -p shuck-linter`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_RULES=C006 SHUCK_LARGE_CORPUS_MAPPED_ONLY=1 SHUCK_LARGE_CORPUS_KEEP_GOING=1 nix --extra-experimental-features 'nix-command flakes' develop --command cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`