### PR TITLE
Record reviewed X019 pyenv divergence

### DIFF
--- a/crates/shuck/tests/testdata/corpus-metadata/x019.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x019.yaml
@@ -5,6 +5,15 @@ reviewed_divergences:
       - helper-library
       - test-harness
     reason: "This zunit test harness is exercising zsh plugin behavior through the `${lines[@]}` capture array, so the remaining X019 hits are test-only array references that appear after the corpus path collapses the helper into portable sh."
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__pyenv.d__rehash__source.bash"
+    line: 11
+    end_line: 11
+    column: 42
+    end_column: 53
+    labels:
+      - project-closure
+    reason: "This shim builder is already Bash-specific, and the shell-collapse comparison path still maps the same `${shims[@]}` array use back to slightly different columns between the two analyzers."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__pyenv.d__rehash__source.bash"
     line: 11


### PR DESCRIPTION
## Summary
- add a narrow `shuck-only` reviewed divergence entry for `pyenv__pyenv__pyenv.d__rehash__source.bash` in `x019.yaml`
- scope the match to the exact `project-closure` location drift on the `${shims[@]}` array reference
- keep the existing `shellcheck-only` divergence so the pair documents both sides of the same corpus-only mismatch

## Why
The remaining X019 blocker was not a rule implementation bug. Shuck and ShellCheck were both flagging the same Bash-only array use in a shell-collapsed fixture, but they anchored it to slightly different columns. Recording that reviewed divergence keeps the corpus signal clean without weakening the X019 rule.

## Impact
This removes the last rule-specific compatibility blocker for X019 and preserves the intended linter behavior.

## Validation
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X019 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=90`

## Notes
- the default rule-specific corpus run still hits the known unrelated large-corpus timeout on `termux__termux-packages__scripts__config.guess`; raising the Shuck timeout confirms X019 itself is clean