### PR TITLE
Preserve escaped parameter replacement literals

### DIFF
--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2135,6 +2135,34 @@ fn test_parameter_replacement_pattern_cooks_escaped_slash() {
 }
 
 #[test]
+fn test_parameter_replacement_pattern_keeps_escaped_dollar_literal() {
+    let input = r#"echo "${d//\$ORIGIN/$origin}""#;
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double-quoted argument");
+    };
+    let (_, operator, _) = expect_parameter_operation_part(&parts[0].kind);
+    let ParameterOp::ReplaceAll { pattern, .. } = operator else {
+        panic!("expected replace-all operator");
+    };
+
+    assert_eq!(pattern.render(input), "$ORIGIN");
+    assert!(matches!(
+        &pattern.parts[..],
+        [PatternPartNode {
+            kind: PatternPart::Literal(text),
+            ..
+        }] if text == "$ORIGIN"
+    ));
+}
+
+#[test]
 fn test_parameter_replacement_word_keeps_escaped_single_quotes_literal() {
     let input = r#"echo ${dest_dir//\'/\'\\\'\'}"#;
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -552,6 +552,7 @@ impl<'a> Parser<'a> {
             DecodeWordPartsOptions {
                 preserve_quote_fragments: true,
                 parse_dollar_quotes: true,
+                preserve_escaped_expansion_literals: text.is_source_backed(),
                 ..DecodeWordPartsOptions::default()
             },
             &mut parts,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5053,6 +5053,20 @@ printf '%s\\n' \"${map[swift-cmark]}\" \"${map[$dynamic_key]}\"
     }
 
     #[test]
+    fn escaped_parameter_replacement_patterns_do_not_register_variable_reads() {
+        let source = "\
+#!/bin/bash
+d=lib
+origin=/tmp
+echo \"${d//\\$ORIGIN/$origin}\"
+";
+        let model = model(source);
+        let unresolved = unresolved_names(&model);
+
+        assert!(unresolved.is_empty(), "unexpected unresolved refs: {unresolved:?}");
+    }
+
+    #[test]
     fn recorded_program_and_cfg_capture_non_arithmetic_var_ref_nested_regions() {
         let source = "\
 [[ -v assoc[\"$(printf inner)\"] ]]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5063,7 +5063,10 @@ echo \"${d//\\$ORIGIN/$origin}\"
         let model = model(source);
         let unresolved = unresolved_names(&model);
 
-        assert!(unresolved.is_empty(), "unexpected unresolved refs: {unresolved:?}");
+        assert!(
+            unresolved.is_empty(),
+            "unexpected unresolved refs: {unresolved:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve escaped `$` literals when decoding source-backed parameter replacement patterns
- add parser and semantic regressions for `${d//\$ORIGIN/$origin}` so escaped replacement patterns do not create bogus unresolved references

## Why
The C156 compatibility delta came from `${d//\$ORIGIN/$origin}` being treated as if `ORIGIN` were a real variable read inside the replacement pattern.

## Root cause
`pattern_from_source_text` decoded source-backed replacement patterns without preserving escaped expansion literals, so `\$ORIGIN` was parsed as a live expansion instead of a literal pattern fragment.

## Validation
- `cargo test -p shuck-parser -p shuck-semantic`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C156`
- `cargo test --workspace`
