### PR TITLE
Handle remaining S001 mosh divergence

### DIFF
--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -275,6 +275,23 @@ No NODE_VERSION provided; no .nvmrc file found\"
     }
 
     #[test]
+    fn reports_expansions_wrapped_in_escaped_literal_quotes() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' -DPACKAGE_VERSION=\\\"$TERMUX_PKG_VERSION\\\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$TERMUX_PKG_VERSION"]
+        );
+    }
+
+    #[test]
     fn reports_decl_assignment_values_in_sh_mode() {
         let source = "\
 local _patch=$TERMUX_PKG_BUILDER_DIR/file.diff

--- a/crates/shuck/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s001.yaml
@@ -1401,6 +1401,13 @@ reviewed_divergences:
     path_suffix: "termux__termux-packages__packages__mop__build.sh"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__mosh__build.sh"
+    line: 27
+    end_line: 27
+    column: 23
+    end_column: 42
+    reason: "The backslashes turn the surrounding double quotes into literal bytes instead of shell quoting, so a spaced package version still splits here and Shuck's S001 matches runtime behavior."
+  - side: shuck-only
     path_suffix: "termux__termux-packages__packages__myman__build.sh"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shuck-only


### PR DESCRIPTION
## Summary
- add an `S001` regression test for unquoted expansions wrapped in escaped literal quotes
- record the remaining `termux mosh` corpus mismatch as a narrow reviewed divergence

## Why
The remaining `S001` implementation diff came from:

```sh
-DPACKAGE_VERSION=\"$TERMUX_PKG_VERSION\"
```

Those backslashes produce literal double-quote bytes instead of shell quoting, so a value with spaces still splits at runtime. Shuck was already correct to report `S001` here, while the current ShellCheck oracle stayed silent.

## Impact
- preserves the existing `S001` behavior instead of weakening it for an oracle-specific gap
- documents the reviewed divergence at the exact corpus location
- keeps this escaped-literal-quote shape covered by a unit test

## Validation
- `cargo test -p shuck-linter reports_expansions_wrapped_in_escaped_literal_quotes -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001`
- `cargo test --workspace`
