### PR TITLE
Report large corpus warnings without masking CI failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,7 +186,7 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p target/large-corpus-report
-          nix develop --command make NIX_DEVELOP= test-large-corpus 2>&1 | tee target/large-corpus-report/latest.log
+          nix develop --command make NIX_DEVELOP= test-large-corpus 2>&1 | tee target/large-corpus-report/latest.log | python3 scripts/compact_large_corpus_log.py
       - name: "Generate HTML report"
         id: report
         if: always() && steps.large-corpus.outcome != 'cancelled'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,7 @@ jobs:
         run: tar --zstd -xf /tmp/shuck-cache.tar.zst -C "$GITHUB_WORKSPACE"
       - name: "Run large corpus tests"
         id: large-corpus
+        continue-on-error: true
         shell: bash
         run: |
           set -o pipefail
@@ -205,5 +206,5 @@ jobs:
           echo "Large corpus test outcome: ${{ steps.large-corpus.outcome }}" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.large-corpus.outcome }}" = "failure" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "This job is blocking, so large corpus failures fail CI after the report is generated." >> "$GITHUB_STEP_SUMMARY"
+            echo "This job is non-blocking, so large corpus failures are reported without failing CI." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,8 +182,9 @@ jobs:
         run: tar --zstd -xf /tmp/shuck-cache.tar.zst -C "$GITHUB_WORKSPACE"
       - name: "Run large corpus tests"
         id: large-corpus
-        continue-on-error: true
+        shell: bash
         run: |
+          set -o pipefail
           mkdir -p target/large-corpus-report
           nix develop --command make NIX_DEVELOP= test-large-corpus 2>&1 | tee target/large-corpus-report/latest.log
       - name: "Generate HTML report"
@@ -204,5 +205,5 @@ jobs:
           echo "Large corpus test outcome: ${{ steps.large-corpus.outcome }}" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.large-corpus.outcome }}" = "failure" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "This job is non-blocking for now, so corpus mismatches do not fail CI." >> "$GITHUB_STEP_SUMMARY"
+            echo "This job is blocking, so large corpus failures fail CI after the report is generated." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ large-corpus-report: ensure-cache
 	@mkdir -p "$(LARGE_CORPUS_REPORT_DIR)"
 	@status=0; \
 	$(MAKE) --no-print-directory test-large-corpus >"$(LARGE_CORPUS_REPORT_LOG)" 2>&1 || status=$$?; \
-	cat "$(LARGE_CORPUS_REPORT_LOG)"; \
+	$(UV_PYTHON) ./scripts/compact_large_corpus_log.py <"$(LARGE_CORPUS_REPORT_LOG)"; \
 	$(UV_PYTHON) ./scripts/large_corpus_report.py --log "$(LARGE_CORPUS_REPORT_LOG)" --output "$(LARGE_CORPUS_REPORT_HTML)"; \
 	echo "large corpus HTML report: $$(cd . && pwd)/$(LARGE_CORPUS_REPORT_HTML)"; \
 	if [ $$status -ne 0 ]; then \

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1704,8 +1704,7 @@ fn format_large_corpus_report(collection: &FixtureFailureCollection) -> String {
         sections.push(section);
     }
 
-    if let Some(section) = format_report_section("Harness Warnings", &collection.harness_warnings)
-    {
+    if let Some(section) = format_report_section("Harness Warnings", &collection.harness_warnings) {
         sections.push(section);
     }
 

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -792,14 +792,7 @@ fn large_corpus_conforms_with_shellcheck() {
         });
     let mut failure_collection = failure_collection;
     failure_collection.unsupported_shells = skipped_unsupported_shells;
-    let timeout_cap_note = if failure_collection.timeout_cap_reached {
-        format!(
-            "; reported the first {} fixture timeouts as warnings",
-            LARGE_CORPUS_TIMEOUT_FAILURE_CAP
-        )
-    } else {
-        String::new()
-    };
+    let timeout_cap_note = timeout_cap_note_suffix(failure_collection.timeout_cap_reached);
 
     eprintln!(
         "large corpus compatibility summary: blocking={} warnings={} fixtures={} unsupported_shells={} implementation_diffs={} mapping_issues={} reviewed_divergences={} corpus_noise={} harness_warnings={} harness_failures={}",
@@ -813,6 +806,10 @@ fn large_corpus_conforms_with_shellcheck() {
         failure_collection.corpus_noise.len(),
         failure_collection.harness_warnings.len(),
         failure_collection.harness_failures.len(),
+    );
+    emit_timeout_cap_note(
+        "large corpus compatibility",
+        failure_collection.timeout_cap_reached,
     );
     if failure_collection.blocking_failures() == 0 && failure_collection.has_nonblocking_items() {
         eprintln!("{}", format_large_corpus_report(&failure_collection));
@@ -860,14 +857,11 @@ fn large_corpus_zsh_fixtures_parse() {
     let failure_collection = collect_fixture_failures(&zsh_fixtures, cfg.keep_going, |fixture| {
         evaluate_fixture_zsh_parse(fixture, cfg.shuck_timeout)
     });
-    let timeout_cap_note = if failure_collection.timeout_cap_reached {
-        format!(
-            "; reported the first {} fixture timeouts as warnings",
-            LARGE_CORPUS_TIMEOUT_FAILURE_CAP
-        )
-    } else {
-        String::new()
-    };
+    let timeout_cap_note = timeout_cap_note_suffix(failure_collection.timeout_cap_reached);
+    emit_timeout_cap_note(
+        "large corpus zsh parse",
+        failure_collection.timeout_cap_reached,
+    );
 
     assert!(
         failure_collection.blocking_failures() == 0,
@@ -1692,6 +1686,31 @@ fn format_large_corpus_failure_report(collection: &FixtureFailureCollection) -> 
 
 fn format_large_corpus_report(collection: &FixtureFailureCollection) -> String {
     format_large_corpus_report_with_mode(collection, LargeCorpusReportMode::Full)
+}
+
+fn timeout_cap_note_message() -> String {
+    format!(
+        "only the first {} fixture timeouts were recorded as harness warnings; additional timeout fixtures were omitted",
+        LARGE_CORPUS_TIMEOUT_FAILURE_CAP
+    )
+}
+
+fn timeout_cap_note_suffix(timeout_cap_reached: bool) -> String {
+    if timeout_cap_reached {
+        format!("; {}", timeout_cap_note_message())
+    } else {
+        String::new()
+    }
+}
+
+fn timeout_cap_note_line(scope: &str, timeout_cap_reached: bool) -> Option<String> {
+    timeout_cap_reached.then(|| format!("{scope} note: {}.", timeout_cap_note_message()))
+}
+
+fn emit_timeout_cap_note(scope: &str, timeout_cap_reached: bool) {
+    if let Some(note) = timeout_cap_note_line(scope, timeout_cap_reached) {
+        eprintln!("{note}");
+    }
 }
 
 fn format_large_corpus_report_with_mode(
@@ -3786,6 +3805,21 @@ mod tests {
         assert!(!report.contains("Corpus Noise:"));
         assert!(!report.contains("Harness Warnings:"));
         assert!(report.contains("Nonblocking issue buckets were omitted"));
+    }
+
+    #[test]
+    fn timeout_cap_note_line_is_structured() {
+        assert_eq!(
+            timeout_cap_note_line("large corpus compatibility", true),
+            Some(format!(
+                "large corpus compatibility note: only the first {} fixture timeouts were recorded as harness warnings; additional timeout fixtures were omitted.",
+                LARGE_CORPUS_TIMEOUT_FAILURE_CAP
+            ))
+        );
+        assert_eq!(
+            timeout_cap_note_line("large corpus compatibility", false),
+            None
+        );
     }
 
     #[test]

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -726,6 +726,12 @@ impl FixtureFailureCollection {
     }
 }
 
+#[derive(Clone, Copy)]
+enum LargeCorpusReportMode {
+    Full,
+    BlockingOnly,
+}
+
 // ---------------------------------------------------------------------------
 // Main test
 // ---------------------------------------------------------------------------
@@ -819,7 +825,7 @@ fn large_corpus_conforms_with_shellcheck() {
         fixtures.len(),
         skipped_unsupported_shells,
         timeout_cap_note,
-        format_large_corpus_report(&failure_collection)
+        format_large_corpus_failure_report(&failure_collection)
     );
 }
 
@@ -869,7 +875,7 @@ fn large_corpus_zsh_fixtures_parse() {
         failure_collection.blocking_failures(),
         zsh_fixtures.len(),
         timeout_cap_note,
-        format_large_corpus_report(&failure_collection)
+        format_large_corpus_failure_report(&failure_collection)
     );
 }
 
@@ -924,7 +930,7 @@ where
             if timeout {
                 log_large_corpus_timeout(fixture);
             }
-            panic!("{}", format_large_corpus_report(&collection));
+            panic!("{}", format_large_corpus_failure_report(&collection));
         }
     }
 
@@ -1671,7 +1677,27 @@ fn format_compatibility_record(
     )
 }
 
+fn format_large_corpus_failure_report(collection: &FixtureFailureCollection) -> String {
+    let report =
+        format_large_corpus_report_with_mode(collection, LargeCorpusReportMode::BlockingOnly);
+    if !collection.has_nonblocking_items() {
+        return report;
+    }
+
+    format!(
+        "{}\n\nNonblocking issue buckets were omitted from the failing log output. See the compatibility summary counts above for skipped unsupported shells, mapping issues, reviewed divergences, corpus noise, and harness warnings.",
+        report
+    )
+}
+
 fn format_large_corpus_report(collection: &FixtureFailureCollection) -> String {
+    format_large_corpus_report_with_mode(collection, LargeCorpusReportMode::Full)
+}
+
+fn format_large_corpus_report_with_mode(
+    collection: &FixtureFailureCollection,
+    mode: LargeCorpusReportMode,
+) -> String {
     let mut sections = Vec::new();
 
     if let Some(section) =
@@ -1679,29 +1705,33 @@ fn format_large_corpus_report(collection: &FixtureFailureCollection) -> String {
     {
         sections.push(section);
     }
-    if let Some(section) = format_report_section("Mapping Issues", &collection.mapping_issues) {
-        sections.push(section);
-    }
-    if let Some(section) =
-        format_report_section("Reviewed Divergence", &collection.reviewed_divergences)
-    {
-        sections.push(section);
-    }
+    if matches!(mode, LargeCorpusReportMode::Full) {
+        if let Some(section) = format_report_section("Mapping Issues", &collection.mapping_issues) {
+            sections.push(section);
+        }
+        if let Some(section) =
+            format_report_section("Reviewed Divergence", &collection.reviewed_divergences)
+        {
+            sections.push(section);
+        }
 
-    let mut corpus_noise = collection.corpus_noise.clone();
-    if collection.unsupported_shells > 0 {
-        corpus_noise.push(format!(
-            "{} skipped: {} fixture(s)",
-            CorpusNoiseKind::UnsupportedShell.as_str(),
-            collection.unsupported_shells
-        ));
-    }
-    if let Some(section) = format_report_section("Corpus Noise", &corpus_noise) {
-        sections.push(section);
-    }
+        let mut corpus_noise = collection.corpus_noise.clone();
+        if collection.unsupported_shells > 0 {
+            corpus_noise.push(format!(
+                "{} skipped: {} fixture(s)",
+                CorpusNoiseKind::UnsupportedShell.as_str(),
+                collection.unsupported_shells
+            ));
+        }
+        if let Some(section) = format_report_section("Corpus Noise", &corpus_noise) {
+            sections.push(section);
+        }
 
-    if let Some(section) = format_report_section("Harness Warnings", &collection.harness_warnings) {
-        sections.push(section);
+        if let Some(section) =
+            format_report_section("Harness Warnings", &collection.harness_warnings)
+        {
+            sections.push(section);
+        }
     }
 
     if let Some(section) = format_report_section("Harness Failures", &collection.harness_failures) {
@@ -1738,6 +1768,7 @@ fn fixture_supported_for_large_corpus(
     if path_is_sample_file(&fixture.path)
         || path_is_fish_file(&fixture.path)
         || path_is_patch_file(&fixture.path)
+        || path_is_config_guess_file(&fixture.path)
         || fixture_is_repo_git_entry(fixture)
     {
         return false;
@@ -1753,6 +1784,7 @@ fn fixture_selected_for_large_corpus_zsh_parse(fixture: &LargeCorpusFixture) -> 
     if path_is_sample_file(&fixture.path)
         || path_is_fish_file(&fixture.path)
         || path_is_patch_file(&fixture.path)
+        || path_is_config_guess_file(&fixture.path)
         || fixture_is_repo_git_entry(fixture)
     {
         return false;
@@ -1811,6 +1843,12 @@ fn path_is_appledouble_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.starts_with("._"))
+}
+
+fn path_is_config_guess_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("config.guess"))
 }
 
 fn fixture_is_repo_git_entry(fixture: &LargeCorpusFixture) -> bool {
@@ -2033,6 +2071,7 @@ fn collect_fixtures(corpus_dir: &Path) -> Vec<LargeCorpusFixture> {
             || path_is_fish_file(&path)
             || path_is_patch_file(&path)
             || path_is_appledouble_file(&path)
+            || path_is_config_guess_file(&path)
         {
             continue;
         }
@@ -3257,6 +3296,20 @@ mod tests {
     }
 
     #[test]
+    fn config_guess_files_are_skipped_for_large_corpus() {
+        let fixture = LargeCorpusFixture {
+            path: PathBuf::from("build-aux/config.guess"),
+            cache_rel_path: PathBuf::from("build-aux/config.guess"),
+            shell: "sh".into(),
+            source_hash: String::new(),
+        };
+
+        assert!(path_is_config_guess_file(&fixture.path));
+        assert!(!fixture_supported_for_large_corpus(&fixture, None));
+        assert!(!fixture_selected_for_large_corpus_zsh_parse(&fixture));
+    }
+
+    #[test]
     fn shellcheck_parse_abort_classification() {
         let aborted = vec![
             ShellCheckDiagnostic {
@@ -3710,6 +3763,32 @@ mod tests {
     }
 
     #[test]
+    fn failure_report_omits_nonblocking_sections() {
+        let report = format_large_corpus_failure_report(&FixtureFailureCollection {
+            implementation_diffs: vec![
+                "/tmp/blocking.sh\n  shellcheck-only C001/SC2000 1:1-1:5 error blocking".into(),
+            ],
+            mapping_issues: vec![
+                "/tmp/mapping.sh\n  shellcheck-only C001/SC2000 1:1-1:5 warning mapping".into(),
+            ],
+            reviewed_divergences: vec![
+                "/tmp/reviewed.sh\n  shuck-only C001/SC2000 1:1-1:5 warning reviewed".into(),
+            ],
+            corpus_noise: vec!["parse-abort skipped: 1 fixture(s)".into()],
+            harness_warnings: vec!["/tmp/timeout.sh\n  shuck error: timed out".into()],
+            unsupported_shells: 2,
+            ..FixtureFailureCollection::default()
+        });
+
+        assert!(report.contains("Implementation Diffs:"));
+        assert!(!report.contains("Mapping Issues:"));
+        assert!(!report.contains("Reviewed Divergence:"));
+        assert!(!report.contains("Corpus Noise:"));
+        assert!(!report.contains("Harness Warnings:"));
+        assert!(report.contains("Nonblocking issue buckets were omitted"));
+    }
+
+    #[test]
     fn keep_going_captures_fixture_panics() {
         let fixture = fixture("panic.sh");
         let fixtures = vec![&fixture];
@@ -4099,7 +4178,7 @@ mod tests {
     }
 
     #[test]
-    fn collect_fixtures_skips_sample_fish_patch_and_appledouble_files() {
+    fn collect_fixtures_skips_sample_fish_patch_appledouble_and_config_guess_files() {
         let tempdir = tempfile::tempdir().unwrap();
         let scripts_dir = tempdir.path().join("scripts");
         let nested_dir = scripts_dir.join("nested");
@@ -4107,6 +4186,7 @@ mod tests {
 
         fs::write(scripts_dir.join("keep.sh"), "#!/bin/sh\necho keep\n").unwrap();
         fs::write(scripts_dir.join("._keep.sh"), "skip\n").unwrap();
+        fs::write(scripts_dir.join("config.guess"), "not a shell script\n").unwrap();
         fs::write(
             scripts_dir.join("pre-commit.sample"),
             "#!/bin/sh\necho skip\n",
@@ -4122,6 +4202,7 @@ mod tests {
         fs::write(nested_dir.join("prompt.fish"), "echo skip\n").unwrap();
         fs::write(nested_dir.join("fixup.diff"), "--- a/file\n+++ b/file\n").unwrap();
         fs::write(nested_dir.join("._nested.sh"), "skip\n").unwrap();
+        fs::write(nested_dir.join("config.guess"), "not a shell script\n").unwrap();
 
         let fixtures = collect_fixtures(tempdir.path());
         let collected_paths: Vec<_> = fixtures

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1807,6 +1807,12 @@ fn path_is_fish_file(path: &Path) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("fish"))
 }
 
+fn path_is_appledouble_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("._"))
+}
+
 fn fixture_is_repo_git_entry(fixture: &LargeCorpusFixture) -> bool {
     let Some(name) = fixture.path.file_name().and_then(|name| name.to_str()) else {
         return false;
@@ -2023,7 +2029,11 @@ fn collect_fixtures(corpus_dir: &Path) -> Vec<LargeCorpusFixture> {
         }
 
         let path = entry.path().to_path_buf();
-        if path_is_sample_file(&path) || path_is_fish_file(&path) || path_is_patch_file(&path) {
+        if path_is_sample_file(&path)
+            || path_is_fish_file(&path)
+            || path_is_patch_file(&path)
+            || path_is_appledouble_file(&path)
+        {
             continue;
         }
         let cache_rel_path = path
@@ -4089,13 +4099,14 @@ mod tests {
     }
 
     #[test]
-    fn collect_fixtures_skips_sample_fish_and_patch_files() {
+    fn collect_fixtures_skips_sample_fish_patch_and_appledouble_files() {
         let tempdir = tempfile::tempdir().unwrap();
         let scripts_dir = tempdir.path().join("scripts");
         let nested_dir = scripts_dir.join("nested");
         fs::create_dir_all(&nested_dir).unwrap();
 
         fs::write(scripts_dir.join("keep.sh"), "#!/bin/sh\necho keep\n").unwrap();
+        fs::write(scripts_dir.join("._keep.sh"), "skip\n").unwrap();
         fs::write(
             scripts_dir.join("pre-commit.sample"),
             "#!/bin/sh\necho skip\n",
@@ -4110,6 +4121,7 @@ mod tests {
         .unwrap();
         fs::write(nested_dir.join("prompt.fish"), "echo skip\n").unwrap();
         fs::write(nested_dir.join("fixup.diff"), "--- a/file\n+++ b/file\n").unwrap();
+        fs::write(nested_dir.join("._nested.sh"), "skip\n").unwrap();
 
         let fixtures = collect_fixtures(tempdir.path());
         let collected_paths: Vec<_> = fixtures

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -788,7 +788,7 @@ fn large_corpus_conforms_with_shellcheck() {
     failure_collection.unsupported_shells = skipped_unsupported_shells;
     let timeout_cap_note = if failure_collection.timeout_cap_reached {
         format!(
-            "; stopped after reaching timeout cap of {} fixture timeouts",
+            "; reported the first {} fixture timeouts as warnings",
             LARGE_CORPUS_TIMEOUT_FAILURE_CAP
         )
     } else {
@@ -856,7 +856,7 @@ fn large_corpus_zsh_fixtures_parse() {
     });
     let timeout_cap_note = if failure_collection.timeout_cap_reached {
         format!(
-            "; stopped after reaching timeout cap of {} fixture timeouts",
+            "; reported the first {} fixture timeouts as warnings",
             LARGE_CORPUS_TIMEOUT_FAILURE_CAP
         )
     } else {
@@ -959,10 +959,6 @@ where
             scope.spawn(move || {
                 let mut local_evaluations = Vec::new();
                 loop {
-                    if timeout_cap_reached.load(Ordering::Relaxed) {
-                        break;
-                    }
-
                     let index = next_index.fetch_add(1, Ordering::Relaxed);
                     if index >= fixtures.len() {
                         break;
@@ -3719,29 +3715,45 @@ mod tests {
     }
 
     #[test]
-    fn keep_going_stops_after_five_timeouts() {
+    fn keep_going_keeps_evaluating_after_timeout_warning_cap() {
         let fixtures: Vec<_> = (0..10)
             .map(|i| fixture(&format!("timeout-{i}.sh")))
             .collect();
         let fixture_refs: Vec<_> = fixtures.iter().collect();
         let seen = AtomicUsize::new(0);
+        let progress = LargeCorpusProgress::new(fixture_refs.len());
 
-        let failures = collect_fixture_failures(&fixture_refs, true, |fixture| {
-            seen.fetch_add(1, Ordering::Relaxed);
-            FixtureEvaluation {
-                harness_failure: Some(FixtureFailure {
-                    kind: FixtureFailureKind::Timeout,
-                    message: format_fixture_failure(
-                        &fixture.path,
-                        &[format!(
-                            "shuck error: {}",
-                            format_timeout_message("shuck", Duration::from_secs(30))
+        let failures = collect_fixture_failures_in_parallel(
+            &fixture_refs,
+            1,
+            &|fixture| {
+                seen.fetch_add(1, Ordering::Relaxed);
+                if fixture.path.ends_with("timeout-9.sh") {
+                    return FixtureEvaluation {
+                        implementation_diffs: vec![format_fixture_failure(
+                            &fixture.path,
+                            &[format!("{} failed", fixture.path.display())],
                         )],
-                    ),
-                }),
-                ..FixtureEvaluation::default()
-            }
-        });
+                        ..FixtureEvaluation::default()
+                    };
+                }
+
+                FixtureEvaluation {
+                    harness_failure: Some(FixtureFailure {
+                        kind: FixtureFailureKind::Timeout,
+                        message: format_fixture_failure(
+                            &fixture.path,
+                            &[format!(
+                                "shuck error: {}",
+                                format_timeout_message("shuck", Duration::from_secs(30))
+                            )],
+                        ),
+                    }),
+                    ..FixtureEvaluation::default()
+                }
+            },
+            &progress,
+        );
 
         assert!(failures.timeout_cap_reached);
         assert_eq!(
@@ -3749,7 +3761,9 @@ mod tests {
             LARGE_CORPUS_TIMEOUT_FAILURE_CAP
         );
         assert!(failures.harness_failures.is_empty());
-        assert!(seen.load(Ordering::Relaxed) <= fixture_refs.len());
+        assert_eq!(seen.load(Ordering::Relaxed), fixture_refs.len());
+        assert_eq!(failures.implementation_diffs.len(), 1);
+        assert!(failures.implementation_diffs[0].contains("timeout-9.sh"));
         assert!(
             failures
                 .harness_warnings

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -703,6 +703,7 @@ struct FixtureFailureCollection {
     mapping_issues: Vec<String>,
     reviewed_divergences: Vec<String>,
     corpus_noise: Vec<String>,
+    harness_warnings: Vec<String>,
     harness_failures: Vec<String>,
     unsupported_shells: usize,
     timeout_cap_reached: bool,
@@ -710,13 +711,18 @@ struct FixtureFailureCollection {
 
 impl FixtureFailureCollection {
     fn blocking_failures(&self) -> usize {
-        self.implementation_diffs.len() + self.mapping_issues.len() + self.harness_failures.len()
+        self.implementation_diffs.len() + self.harness_failures.len()
+    }
+
+    fn nonblocking_issue_count(&self) -> usize {
+        self.mapping_issues.len()
+            + self.reviewed_divergences.len()
+            + self.corpus_noise.len()
+            + self.harness_warnings.len()
     }
 
     fn has_nonblocking_items(&self) -> bool {
-        self.unsupported_shells > 0
-            || !self.reviewed_divergences.is_empty()
-            || !self.corpus_noise.is_empty()
+        self.unsupported_shells > 0 || self.nonblocking_issue_count() > 0
     }
 }
 
@@ -789,13 +795,21 @@ fn large_corpus_conforms_with_shellcheck() {
         String::new()
     };
 
+    eprintln!(
+        "large corpus compatibility summary: blocking={} warnings={} fixtures={} unsupported_shells={} implementation_diffs={} mapping_issues={} reviewed_divergences={} corpus_noise={} harness_warnings={} harness_failures={}",
+        failure_collection.blocking_failures(),
+        failure_collection.nonblocking_issue_count(),
+        fixtures.len(),
+        skipped_unsupported_shells,
+        failure_collection.implementation_diffs.len(),
+        failure_collection.mapping_issues.len(),
+        failure_collection.reviewed_divergences.len(),
+        failure_collection.corpus_noise.len(),
+        failure_collection.harness_warnings.len(),
+        failure_collection.harness_failures.len(),
+    );
     if failure_collection.blocking_failures() == 0 && failure_collection.has_nonblocking_items() {
-        eprintln!(
-            "large corpus non-blocking summary: reviewed divergence={}, corpus noise={}, unsupported-shell={}",
-            failure_collection.reviewed_divergences.len(),
-            failure_collection.corpus_noise.len(),
-            failure_collection.unsupported_shells,
-        );
+        eprintln!("{}", format_large_corpus_report(&failure_collection));
     }
 
     assert!(
@@ -893,9 +907,11 @@ where
 
     for fixture in fixtures {
         let evaluation = evaluate(fixture);
-        let has_blocking = evaluation.harness_failure.is_some()
-            || !evaluation.implementation_diffs.is_empty()
-            || !evaluation.mapping_issues.is_empty();
+        let has_blocking = evaluation
+            .harness_failure
+            .as_ref()
+            .is_some_and(|failure| failure.kind != FixtureFailureKind::Timeout)
+            || !evaluation.implementation_diffs.is_empty();
         let timeout = evaluation
             .harness_failure
             .as_ref()
@@ -1234,7 +1250,10 @@ fn merge_fixture_evaluation(
         .extend(evaluation.reviewed_divergences);
     collection.corpus_noise.extend(evaluation.corpus_noise);
     if let Some(failure) = evaluation.harness_failure {
-        collection.harness_failures.push(failure.message);
+        match failure.kind {
+            FixtureFailureKind::Timeout => collection.harness_warnings.push(failure.message),
+            FixtureFailureKind::Other => collection.harness_failures.push(failure.message),
+        }
     }
 }
 
@@ -1682,6 +1701,11 @@ fn format_large_corpus_report(collection: &FixtureFailureCollection) -> String {
         ));
     }
     if let Some(section) = format_report_section("Corpus Noise", &corpus_noise) {
+        sections.push(section);
+    }
+
+    if let Some(section) = format_report_section("Harness Warnings", &collection.harness_warnings)
+    {
         sections.push(section);
     }
 
@@ -3638,6 +3662,49 @@ mod tests {
     }
 
     #[test]
+    fn mapping_issues_are_nonblocking() {
+        let fixture = fixture("mapping.sh");
+        let fixtures = vec![&fixture];
+
+        let failures = collect_fixture_failures(&fixtures, false, |fixture| FixtureEvaluation {
+            mapping_issues: vec![format_fixture_failure(
+                &fixture.path,
+                &[format!("{} needs mapping review", fixture.path.display())],
+            )],
+            ..FixtureEvaluation::default()
+        });
+
+        assert_eq!(failures.blocking_failures(), 0);
+        assert_eq!(failures.mapping_issues.len(), 1);
+        assert!(failures.has_nonblocking_items());
+    }
+
+    #[test]
+    fn sequential_timeouts_become_harness_warnings() {
+        let fixture = fixture("timeout.sh");
+        let fixtures = vec![&fixture];
+
+        let failures = collect_fixture_failures(&fixtures, false, |fixture| FixtureEvaluation {
+            harness_failure: Some(FixtureFailure {
+                kind: FixtureFailureKind::Timeout,
+                message: format_fixture_failure(
+                    &fixture.path,
+                    &[format!(
+                        "shuck error: {}",
+                        format_timeout_message("shuck", Duration::from_secs(30))
+                    )],
+                ),
+            }),
+            ..FixtureEvaluation::default()
+        });
+
+        assert_eq!(failures.blocking_failures(), 0);
+        assert_eq!(failures.harness_warnings.len(), 1);
+        assert!(failures.harness_failures.is_empty());
+        assert!(failures.has_nonblocking_items());
+    }
+
+    #[test]
     fn keep_going_captures_fixture_panics() {
         let fixture = fixture("panic.sh");
         let fixtures = vec![&fixture];
@@ -3679,13 +3746,14 @@ mod tests {
 
         assert!(failures.timeout_cap_reached);
         assert_eq!(
-            failures.harness_failures.len(),
+            failures.harness_warnings.len(),
             LARGE_CORPUS_TIMEOUT_FAILURE_CAP
         );
+        assert!(failures.harness_failures.is_empty());
         assert!(seen.load(Ordering::Relaxed) <= fixture_refs.len());
         assert!(
             failures
-                .harness_failures
+                .harness_warnings
                 .iter()
                 .all(|failure| failure.contains("timed out after"))
         );

--- a/scripts/compact_large_corpus_log.py
+++ b/scripts/compact_large_corpus_log.py
@@ -17,10 +17,12 @@ SECTION_HEADERS = {
     "Harness Failures:",
 }
 MAX_BLOCKS_PER_SECTION = 8
+FIXTURE_HEADER_RE = re.compile(r"^/.*$")
 IMPORTANT_LINE_RES = [
     re.compile(r"^running \d+ tests$"),
     re.compile(r"^large corpus: processed \d+/\d+ fixtures"),
     re.compile(r"^large corpus compatibility summary: "),
+    re.compile(r"^large corpus (compatibility|zsh parse) note: "),
     re.compile(r"^large corpus .* had \d+ blocking issue\(s\) "),
     re.compile(r"^large corpus test skipped "),
     re.compile(r"^large corpus zsh parse skipped "),
@@ -93,9 +95,13 @@ def iter_compacted_lines(lines: list[str]) -> list[str]:
                 section = None
                 continue
 
-            if stripped == "":
+            if FIXTURE_HEADER_RE.match(stripped):
                 output.extend(flush_block(section))
+                section.current_block = [line]
             else:
+                if stripped == "" and not section.current_block:
+                    index += 1
+                    continue
                 section.current_block.append(line)
             index += 1
             continue

--- a/scripts/compact_large_corpus_log.py
+++ b/scripts/compact_large_corpus_log.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+"""Filter large-corpus test output down to the high-signal lines for CI logs."""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+SECTION_HEADERS = {
+    "Implementation Diffs:",
+    "Mapping Issues:",
+    "Reviewed Divergence:",
+    "Corpus Noise:",
+    "Harness Warnings:",
+    "Harness Failures:",
+}
+MAX_BLOCKS_PER_SECTION = 8
+IMPORTANT_LINE_RES = [
+    re.compile(r"^running \d+ tests$"),
+    re.compile(r"^large corpus: processed \d+/\d+ fixtures"),
+    re.compile(r"^large corpus compatibility summary: "),
+    re.compile(r"^large corpus .* had \d+ blocking issue\(s\) "),
+    re.compile(r"^large corpus test skipped "),
+    re.compile(r"^large corpus zsh parse skipped "),
+    re.compile(r"^thread 'large_corpus"),
+    re.compile(r"^test large_corpus_"),
+    re.compile(r"^failures:$"),
+    re.compile(r"^test result: "),
+    re.compile(r"^error: test failed"),
+    re.compile(r"^make: \*\*\*"),
+    re.compile(r"^Nonblocking issue buckets were omitted "),
+]
+
+
+class SectionState:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.printed_blocks = 0
+        self.suppressed_blocks = 0
+        self.current_block: list[str] = []
+
+
+def should_print_line(line: str) -> bool:
+    stripped = line.rstrip("\n")
+    if stripped in SECTION_HEADERS:
+        return True
+    return any(regex.search(stripped) for regex in IMPORTANT_LINE_RES)
+
+
+def flush_block(state: SectionState) -> list[str]:
+    if not state.current_block:
+        return []
+
+    block = state.current_block
+    state.current_block = []
+
+    if state.printed_blocks < MAX_BLOCKS_PER_SECTION:
+        state.printed_blocks += 1
+        return block + ["\n"]
+
+    state.suppressed_blocks += 1
+    return []
+
+
+def finish_section(state: SectionState) -> list[str]:
+    output = flush_block(state)
+    if state.suppressed_blocks > 0:
+        output.append(
+            f"... omitted {state.suppressed_blocks} additional entries from {state.name}\n"
+        )
+    return output
+
+
+def iter_compacted_lines(lines: list[str]) -> list[str]:
+    output: list[str] = []
+    section: SectionState | None = None
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.rstrip("\n")
+
+        if section is not None:
+            section_end = (
+                stripped in SECTION_HEADERS
+                or should_print_line(line)
+                and stripped not in {"", section.name}
+            )
+            if section_end:
+                output.extend(finish_section(section))
+                section = None
+                continue
+
+            if stripped == "":
+                output.extend(flush_block(section))
+            else:
+                section.current_block.append(line)
+            index += 1
+            continue
+
+        if stripped in SECTION_HEADERS:
+            output.append(line)
+            section = SectionState(stripped[:-1])
+        elif should_print_line(line):
+            output.append(line)
+
+        index += 1
+
+    if section is not None:
+        output.extend(finish_section(section))
+
+    return output
+
+
+def main() -> int:
+    compacted = iter_compacted_lines(sys.stdin.readlines())
+    sys.stdout.writelines(compacted)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/large_corpus_report.py
+++ b/scripts/large_corpus_report.py
@@ -26,6 +26,19 @@ MAIN_FAILURE_RE = re.compile(
     r"across (?P<fixtures>\d+) fixture\(s\)"
     r"(?: \((?P<skipped>\d+) skipped unsupported shells\))?"
 )
+MAIN_SUMMARY_RE = re.compile(
+    r"large corpus compatibility summary: "
+    r"blocking=(?P<blocking>\d+) "
+    r"warnings=(?P<warnings>\d+) "
+    r"fixtures=(?P<fixtures>\d+) "
+    r"unsupported_shells=(?P<skipped>\d+) "
+    r"implementation_diffs=(?P<implementation>\d+) "
+    r"mapping_issues=(?P<mapping>\d+) "
+    r"reviewed_divergences=(?P<reviewed>\d+) "
+    r"corpus_noise=(?P<noise>\d+) "
+    r"harness_warnings=(?P<harness_warnings>\d+) "
+    r"harness_failures=(?P<harness_failures>\d+)"
+)
 ZSH_FAILURE_RE = re.compile(
     r"large corpus zsh parse had (?P<blocking>\d+) blocking issue\(s\) "
     r"across (?P<fixtures>\d+) fixture\(s\)"
@@ -79,6 +92,7 @@ _SECTION_ORDER = [
     "Mapping Issues",
     "Reviewed Divergence",
     "Corpus Noise",
+    "Harness Warnings",
     "Harness Failures",
 ]
 
@@ -122,6 +136,30 @@ def require_main_harness_section(text: str, start_at: int = 0) -> str | None:
     if end == -1:
         return None
     return text[start:end]
+
+
+def find_first_section_start(text: str, start_at: int = 0) -> int:
+    positions = [
+        pos
+        for title in _SECTION_ORDER
+        if (pos := text.find(f"{title}:\n", start_at)) != -1
+    ]
+    return min(positions, default=-1)
+
+
+def extract_main_report_body(text: str) -> str | None:
+    anchor_match = MAIN_SUMMARY_RE.search(text) or MAIN_FAILURE_RE.search(text)
+    if not anchor_match:
+        return None
+
+    start = find_first_section_start(text, anchor_match.end())
+    if start == -1:
+        return None
+
+    end = text.find("\ntest large_corpus_conforms_with_shellcheck ...", start)
+    if end == -1:
+        end = len(text)
+    return text[start:end].rstrip("\n")
 
 
 def optional_zsh_harness_section(text: str) -> str | None:
@@ -240,6 +278,8 @@ def parse_fixture_entries(section: str | None) -> list[tuple[str, list[str]]]:
 def default_blocker_reason(bucket: str) -> str:
     if bucket == "Implementation Diff":
         return "Direct implementation mismatch with no comparison-target override."
+    if bucket == "Harness Warning":
+        return "Harness execution hit a non-blocking timeout or warning for this fixture."
     if bucket == "Harness Failure":
         return "Harness execution failed while evaluating this fixture."
     return "Comparison target or rule mapping could not be resolved cleanly."
@@ -399,6 +439,7 @@ def render_html(
     mapping_issues: int,
     reviewed_divergences: int,
     corpus_noise: int,
+    main_harness_warnings: int,
     main_harness_failures: int,
     zsh_blocking: int,
     zsh_fixture_entries: int,
@@ -495,7 +536,7 @@ def render_html(
         blocker_rows = """
             <tr>
               <td colspan="5">
-                <p class="metric-label">No blocking fixture entries were parsed from the main run.</p>
+                <p class="metric-label">No issue entries were parsed from the main run.</p>
               </td>
             </tr>
         """.strip()
@@ -970,12 +1011,12 @@ def render_html(
         <article class="card warn">
           <p class="kicker">Main run blockers</p>
           <p class="value">{format_number(main_blocking)}</p>
-          <p class="note">Across {format_number(main_fixture_entries)} fixture entries, with {format_number(unsupported_shells)} unsupported shells skipped.</p>
+          <p class="note">Across {format_number(main_fixture_entries)} sampled fixtures, with {format_number(unsupported_shells)} unsupported shells skipped.</p>
         </article>
         <article class="card warn">
           <p class="kicker">Zsh parse blockers</p>
           <p class="value">{format_number(zsh_blocking)}</p>
-          <p class="note">Across {format_number(zsh_fixture_entries)} fixture entries and {format_number(zsh_harness_failures)} zsh harness failures.</p>
+          <p class="note">Across {format_number(zsh_fixture_entries)} sampled fixtures and {format_number(zsh_harness_failures)} zsh harness failures.</p>
         </article>
       </div>
     </section>
@@ -1012,17 +1053,18 @@ def render_html(
     </section>
 
     <section class="section">
-      <h2>Other Failure Buckets</h2>
+      <h2>Other Issue Buckets</h2>
       <p>
         Outside the implementation-diff table, this log also reported {format_number(mapping_issues)}
         mapping issues, {format_number(reviewed_divergences)} reviewed divergences,
-        {format_number(corpus_noise)} corpus-noise parse failures, {format_number(main_harness_failures)}
-        main harness failures, and {panic_text}.
+        {format_number(corpus_noise)} corpus-noise parse failures,
+        {format_number(main_harness_warnings)} main harness warnings,
+        {format_number(main_harness_failures)} main harness failures, and {panic_text}.
       </p>
       <p class="note">
-        The table below stays fixture-focused on blocking entries from the main run. It includes
-        implementation diffs, mapping issues, and harness failures even when they are intentionally
-        excluded from the rule-mismatch table above.
+        The table below stays fixture-focused on main-run issue entries. It includes implementation
+        diffs, mapping issues, harness warnings, and harness failures even when they are intentionally
+        excluded from the rule-mismatch table above or no longer counted as blocking.
       </p>
       <div class="table-wrap">
         <table>
@@ -1032,7 +1074,7 @@ def render_html(
               <th>Fixture</th>
               <th>Records</th>
               <th>Codes</th>
-              <th>Why It Blocks</th>
+              <th>Why It Matters</th>
             </tr>
           </thead>
           <tbody>
@@ -1062,25 +1104,30 @@ def main() -> int:
         raise SystemExit(f"log file not found: {log_path}")
 
     text = log_path.read_text(encoding="utf-8")
-    sections = extract_sections(text)
+    main_report_body = extract_main_report_body(text) or ""
+    sections = extract_sections(main_report_body)
     implementation_section = sections.get("Implementation Diffs")
     mapping_section = sections.get("Mapping Issues")
     reviewed_section = sections.get("Reviewed Divergence")
     corpus_noise_section = sections.get("Corpus Noise")
-    main_harness_section = require_main_harness_section(
-        text, start_at=text.find("Implementation Diffs:\n")
-    )
+    harness_warning_section = sections.get("Harness Warnings")
+    main_harness_section = sections.get("Harness Failures")
     zsh_harness_section = optional_zsh_harness_section(text)
 
+    main_summary_match = MAIN_SUMMARY_RE.search(text)
     main_failure_match = MAIN_FAILURE_RE.search(text)
-    if not main_failure_match:
+    if not main_summary_match and not main_failure_match:
         raise SystemExit("could not find the main compatibility summary in the log")
     zsh_failure_match = ZSH_FAILURE_RE.search(text)
+    main_counts_match = main_summary_match or main_failure_match
+    if main_counts_match is None:
+        raise SystemExit("could not determine the main compatibility counts from the log")
 
     rule_summaries = parse_rule_summaries(implementation_section, repo_root)
     blocker_entries = (
         parse_blocker_entries("Implementation Diff", implementation_section)
         + parse_blocker_entries("Mapping Issue", mapping_section)
+        + parse_blocker_entries("Harness Warning", harness_warning_section)
         + parse_blocker_entries("Harness Failure", main_harness_section)
     )
     implementation_mismatches = sum(summary.mismatches for summary in rule_summaries)
@@ -1091,23 +1138,52 @@ def main() -> int:
         if side == "shellcheck-only"
     )
     shuck_only = implementation_mismatches - shellcheck_only
+    main_blocking = int(main_counts_match.group("blocking"))
+    main_fixture_entries = int(main_counts_match.group("fixtures"))
+    unsupported_shells = int(main_counts_match.group("skipped") or "0")
+    mapping_issue_count = (
+        int(main_summary_match.group("mapping"))
+        if main_summary_match
+        else count_diagnostic_records(mapping_section)
+    )
+    reviewed_divergence_count = (
+        int(main_summary_match.group("reviewed"))
+        if main_summary_match
+        else count_diagnostic_records(reviewed_section)
+    )
+    corpus_noise_count = (
+        int(main_summary_match.group("noise"))
+        if main_summary_match
+        else count_fixture_entries(corpus_noise_section)
+    )
+    main_harness_warning_count = (
+        int(main_summary_match.group("harness_warnings"))
+        if main_summary_match
+        else count_fixture_entries(harness_warning_section)
+    )
+    main_harness_failure_count = (
+        int(main_summary_match.group("harness_failures"))
+        if main_summary_match
+        else count_fixture_entries(main_harness_section)
+    )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     html_text = render_html(
         log_path=log_path,
         output_path=output_path,
         generated_at=datetime.now().astimezone(),
-        main_blocking=int(main_failure_match.group("blocking")),
-        main_fixture_entries=int(main_failure_match.group("fixtures")),
-        unsupported_shells=int(main_failure_match.group("skipped") or "0"),
+        main_blocking=main_blocking,
+        main_fixture_entries=main_fixture_entries,
+        unsupported_shells=unsupported_shells,
         main_processed_fixtures=main_fixture_total(text),
         implementation_mismatches=implementation_mismatches,
         shellcheck_only=shellcheck_only,
         shuck_only=shuck_only,
-        mapping_issues=count_diagnostic_records(mapping_section),
-        reviewed_divergences=count_diagnostic_records(reviewed_section),
-        corpus_noise=count_fixture_entries(corpus_noise_section),
-        main_harness_failures=count_fixture_entries(main_harness_section),
+        mapping_issues=mapping_issue_count,
+        reviewed_divergences=reviewed_divergence_count,
+        corpus_noise=corpus_noise_count,
+        main_harness_warnings=main_harness_warning_count,
+        main_harness_failures=main_harness_failure_count,
         zsh_blocking=int(zsh_failure_match.group("blocking")) if zsh_failure_match else 0,
         zsh_fixture_entries=int(zsh_failure_match.group("fixtures")) if zsh_failure_match else 0,
         zsh_harness_failures=count_fixture_entries(zsh_harness_section),

--- a/scripts/large_corpus_report.py
+++ b/scripts/large_corpus_report.py
@@ -152,13 +152,14 @@ def extract_main_report_body(text: str) -> str | None:
     if not anchor_match:
         return None
 
-    start = find_first_section_start(text, anchor_match.end())
+    end = text.find("\ntest large_corpus_conforms_with_shellcheck ...", anchor_match.end())
+    if end == -1:
+        end = len(text)
+
+    start = find_first_section_start(text[:end], anchor_match.end())
     if start == -1:
         return None
 
-    end = text.find("\ntest large_corpus_conforms_with_shellcheck ...", start)
-    if end == -1:
-        end = len(text)
     return text[start:end].rstrip("\n")
 
 

--- a/scripts/large_corpus_report.py
+++ b/scripts/large_corpus_report.py
@@ -39,6 +39,7 @@ MAIN_SUMMARY_RE = re.compile(
     r"harness_warnings=(?P<harness_warnings>\d+) "
     r"harness_failures=(?P<harness_failures>\d+)"
 )
+MAIN_TIMEOUT_NOTE_RE = re.compile(r"large corpus compatibility note: (?P<note>.+)")
 ZSH_FAILURE_RE = re.compile(
     r"large corpus zsh parse had (?P<blocking>\d+) blocking issue\(s\) "
     r"across (?P<fixtures>\d+) fixture\(s\)"
@@ -447,6 +448,7 @@ def render_html(
     corpus_noise: int,
     main_harness_warnings: int,
     main_harness_failures: int,
+    main_timeout_note: str | None,
     zsh_blocking: int,
     zsh_fixture_entries: int,
     zsh_harness_failures: int,
@@ -465,6 +467,11 @@ def render_html(
         )
     else:
         panic_text = "no worker-thread panic was detected in the parsed log"
+    timeout_note_html = (
+        f'\n      <p class="note">{html.escape(main_timeout_note)}</p>'
+        if main_timeout_note
+        else ""
+    )
 
     rule_rows = "\n".join(
         """
@@ -1073,6 +1080,7 @@ def render_html(
         and harness failures even when some of those buckets are intentionally excluded from the
         rule-mismatch table above or no longer counted as blocking.
       </p>
+      {timeout_note_html}
       <div class="table-wrap">
         <table>
           <thead>
@@ -1123,6 +1131,7 @@ def main() -> int:
 
     main_summary_match = MAIN_SUMMARY_RE.search(text)
     main_failure_match = MAIN_FAILURE_RE.search(text)
+    main_timeout_note_match = MAIN_TIMEOUT_NOTE_RE.search(text)
     if not main_summary_match and not main_failure_match:
         raise SystemExit("could not find the main compatibility summary in the log")
     zsh_failure_match = ZSH_FAILURE_RE.search(text)
@@ -1191,6 +1200,9 @@ def main() -> int:
         corpus_noise=corpus_noise_count,
         main_harness_warnings=main_harness_warning_count,
         main_harness_failures=main_harness_failure_count,
+        main_timeout_note=main_timeout_note_match.group("note")
+        if main_timeout_note_match
+        else None,
         zsh_blocking=int(zsh_failure_match.group("blocking")) if zsh_failure_match else 0,
         zsh_fixture_entries=int(zsh_failure_match.group("fixtures")) if zsh_failure_match else 0,
         zsh_harness_failures=count_fixture_entries(zsh_harness_section),

--- a/scripts/large_corpus_report.py
+++ b/scripts/large_corpus_report.py
@@ -95,6 +95,7 @@ _SECTION_ORDER = [
     "Harness Warnings",
     "Harness Failures",
 ]
+_OMITTED_NOTE_MARKER = "\n\nNonblocking issue buckets were omitted from the failing log output."
 
 
 def extract_sections(text: str) -> dict[str, str]:
@@ -120,8 +121,12 @@ def extract_sections(text: str) -> dict[str, str]:
                 body_end = found[idx + 1][0]
         else:
             # Last section — end at the next blank-line-separated block or EOF.
-            end_match = text.find("\n\ntest ", body_start)
-            body_end = end_match if end_match != -1 else len(text)
+            end_candidates = [len(text)]
+            if (omitted_note_match := text.find(_OMITTED_NOTE_MARKER, body_start)) != -1:
+                end_candidates.append(omitted_note_match)
+            if (end_match := text.find("\n\ntest ", body_start)) != -1:
+                end_candidates.append(end_match)
+            body_end = min(end_candidates)
         result[title] = text[body_start:body_end].rstrip("\n")
     return result
 
@@ -1063,9 +1068,10 @@ def render_html(
         {format_number(main_harness_failures)} main harness failures, and {panic_text}.
       </p>
       <p class="note">
-        The table below stays fixture-focused on main-run issue entries. It includes implementation
-        diffs, mapping issues, harness warnings, and harness failures even when they are intentionally
-        excluded from the rule-mismatch table above or no longer counted as blocking.
+        The table below stays fixture-focused on main-run issue entries. When the log includes
+        fixture-level detail, it includes implementation diffs, mapping issues, harness warnings,
+        and harness failures even when some of those buckets are intentionally excluded from the
+        rule-mismatch table above or no longer counted as blocking.
       </p>
       <div class="table-wrap">
         <table>
@@ -1143,7 +1149,15 @@ def main() -> int:
     main_fixture_entries = int(main_counts_match.group("fixtures"))
     unsupported_shells = int(main_counts_match.group("skipped") or "0")
     mapping_issue_count = count_diagnostic_records(mapping_section)
+    if mapping_issue_count == 0 and mapping_section is None and main_summary_match:
+        mapping_issue_count = int(main_summary_match.group("mapping"))
     reviewed_divergence_count = count_diagnostic_records(reviewed_section)
+    if (
+        reviewed_divergence_count == 0
+        and reviewed_section is None
+        and main_summary_match
+    ):
+        reviewed_divergence_count = int(main_summary_match.group("reviewed"))
     corpus_noise_count = (
         int(main_summary_match.group("noise"))
         if main_summary_match

--- a/scripts/large_corpus_report.py
+++ b/scripts/large_corpus_report.py
@@ -1142,16 +1142,8 @@ def main() -> int:
     main_blocking = int(main_counts_match.group("blocking"))
     main_fixture_entries = int(main_counts_match.group("fixtures"))
     unsupported_shells = int(main_counts_match.group("skipped") or "0")
-    mapping_issue_count = (
-        int(main_summary_match.group("mapping"))
-        if main_summary_match
-        else count_diagnostic_records(mapping_section)
-    )
-    reviewed_divergence_count = (
-        int(main_summary_match.group("reviewed"))
-        if main_summary_match
-        else count_diagnostic_records(reviewed_section)
-    )
+    mapping_issue_count = count_diagnostic_records(mapping_section)
+    reviewed_divergence_count = count_diagnostic_records(reviewed_section)
     corpus_noise_count = (
         int(main_summary_match.group("noise"))
         if main_summary_match

--- a/scripts/test_compact_large_corpus_log.py
+++ b/scripts/test_compact_large_corpus_log.py
@@ -52,6 +52,30 @@ class CompactLargeCorpusLogTests(unittest.TestCase):
         self.assertIn("... omitted 2 additional entries from Implementation Diffs", compacted)
         self.assertIn("test large_corpus_conforms_with_shellcheck ... FAILED", compacted)
 
+    def test_blank_lines_inside_one_fixture_do_not_hide_later_fixtures(self) -> None:
+        lines = ["Implementation Diffs:\n", "/tmp/noisy.sh\n"]
+        for i in range(8):
+            lines.extend(
+                [
+                    f"  shellcheck-only C001/SC2000 {i + 1}:1-{i + 1}:5 error example {i}\n",
+                    "\n",
+                ]
+            )
+        lines.extend(
+            [
+                "/tmp/second.sh\n",
+                "  shellcheck-only C001/SC2000 9:1-9:5 error second\n",
+                "\n",
+                "test large_corpus_conforms_with_shellcheck ... FAILED\n",
+            ]
+        )
+
+        compacted = "".join(MODULE.iter_compacted_lines(lines))
+
+        self.assertIn("/tmp/noisy.sh", compacted)
+        self.assertIn("/tmp/second.sh", compacted)
+        self.assertNotIn("additional entries from Implementation Diffs", compacted)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_compact_large_corpus_log.py
+++ b/scripts/test_compact_large_corpus_log.py
@@ -1,0 +1,57 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("compact_large_corpus_log.py")
+SPEC = importlib.util.spec_from_file_location("compact_large_corpus_log", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class CompactLargeCorpusLogTests(unittest.TestCase):
+    def test_keeps_high_signal_lines_and_drops_chatter(self) -> None:
+        lines = [
+            "Compiling shuck v0.0.7\n",
+            "running 2 tests\n",
+            "large corpus: processed 41/818 fixtures (5%)\n",
+            "large corpus compatibility summary: blocking=1 warnings=2 fixtures=3 unsupported_shells=0 implementation_diffs=1 mapping_issues=1 reviewed_divergences=1 corpus_noise=0 harness_warnings=0 harness_failures=0\n",
+            "test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 72 filtered out; finished in 267.03s\n",
+        ]
+
+        compacted = "".join(MODULE.iter_compacted_lines(lines))
+
+        self.assertNotIn("Compiling shuck", compacted)
+        self.assertIn("running 2 tests", compacted)
+        self.assertIn("large corpus: processed 41/818 fixtures (5%)", compacted)
+        self.assertIn("large corpus compatibility summary:", compacted)
+        self.assertIn("test result: FAILED.", compacted)
+
+    def test_truncates_large_sections_after_eight_blocks(self) -> None:
+        lines = ["Implementation Diffs:\n"]
+        for i in range(10):
+            lines.extend(
+                [
+                    f"/tmp/fixture-{i}.sh\n",
+                    f"  shellcheck-only C001/SC2000 {i + 1}:1-{i + 1}:5 error example {i}\n",
+                    "\n",
+                ]
+            )
+        lines.append("test large_corpus_conforms_with_shellcheck ... FAILED\n")
+
+        compacted = "".join(MODULE.iter_compacted_lines(lines))
+
+        for i in range(8):
+            self.assertIn(f"/tmp/fixture-{i}.sh", compacted)
+        self.assertNotIn("/tmp/fixture-8.sh", compacted)
+        self.assertNotIn("/tmp/fixture-9.sh", compacted)
+        self.assertIn("... omitted 2 additional entries from Implementation Diffs", compacted)
+        self.assertIn("test large_corpus_conforms_with_shellcheck ... FAILED", compacted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_large_corpus_report.py
+++ b/scripts/test_large_corpus_report.py
@@ -111,6 +111,36 @@ test large_corpus_conforms_with_shellcheck ... FAILED
         self.assertIn("5 corpus-noise parse failures,", html)
         self.assertIn("6 main harness warnings,", html)
 
+    def test_main_timeout_cap_note_is_rendered(self) -> None:
+        log = """large corpus compatibility summary: blocking=0 warnings=5 fixtures=1 unsupported_shells=0 implementation_diffs=0 mapping_issues=0 reviewed_divergences=0 corpus_noise=0 harness_warnings=5 harness_failures=0
+large corpus compatibility note: only the first 5 fixture timeouts were recorded as harness warnings; additional timeout fixtures were omitted.
+Harness Warnings:
+/tmp/main-fixture.sh
+  shuck error: timed out after 30.000s
+test large_corpus_conforms_with_shellcheck ... ok
+"""
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            log_path = Path(tempdir) / "large-corpus.log"
+            output_path = Path(tempdir) / "report.html"
+            log_path.write_text(log, encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--log",
+                    str(log_path),
+                    "--output",
+                    str(output_path),
+                ],
+                check=True,
+            )
+
+            html = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("only the first 5 fixture timeouts were recorded as harness warnings", html)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_large_corpus_report.py
+++ b/scripts/test_large_corpus_report.py
@@ -1,5 +1,7 @@
 import importlib.util
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -40,6 +42,41 @@ Harness Warnings:
         self.assertIsNotNone(body)
         self.assertIn("Mapping Issues:", body)
         self.assertNotIn("/tmp/zsh-fixture.sh", body)
+
+    def test_main_summary_keeps_mapping_and_reviewed_totals_record_based(self) -> None:
+        log = """large corpus compatibility summary: blocking=0 warnings=2 fixtures=1 unsupported_shells=0 implementation_diffs=0 mapping_issues=1 reviewed_divergences=1 corpus_noise=0 harness_warnings=0 harness_failures=0
+Mapping Issues:
+/tmp/main-fixture.sh
+  shellcheck-only S032/SC2209 1:1-1:5 warning reason=first mapping
+  shellcheck-only S032/SC2209 2:1-2:5 warning reason=second mapping
+
+Reviewed Divergence:
+/tmp/main-fixture.sh
+  shuck-only C001/SC2034 3:1-3:5 warning reason=first reviewed
+  shuck-only C001/SC2034 4:1-4:5 warning reason=second reviewed
+test large_corpus_conforms_with_shellcheck ... ok
+"""
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            log_path = Path(tempdir) / "large-corpus.log"
+            output_path = Path(tempdir) / "report.html"
+            log_path.write_text(log, encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--log",
+                    str(log_path),
+                    "--output",
+                    str(output_path),
+                ],
+                check=True,
+            )
+
+            html = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("mapping issues, 2 reviewed divergences", html)
 
 
 if __name__ == "__main__":

--- a/scripts/test_large_corpus_report.py
+++ b/scripts/test_large_corpus_report.py
@@ -1,0 +1,46 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("large_corpus_report.py")
+SPEC = importlib.util.spec_from_file_location("large_corpus_report", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class LargeCorpusReportParsingTests(unittest.TestCase):
+    def test_extract_main_report_body_ignores_sections_after_main_result(self) -> None:
+        log = """large corpus compatibility summary: blocking=0 warnings=0 fixtures=1 unsupported_shells=0 implementation_diffs=0 mapping_issues=0 reviewed_divergences=0 corpus_noise=0 harness_warnings=0 harness_failures=0
+test large_corpus_conforms_with_shellcheck ... ok
+Harness Warnings:
+/tmp/zsh-fixture.sh
+  shuck timed out after 30.000s
+"""
+
+        self.assertIsNone(MODULE.extract_main_report_body(log))
+
+    def test_extract_main_report_body_stays_within_main_test_span(self) -> None:
+        log = """large corpus compatibility summary: blocking=0 warnings=1 fixtures=1 unsupported_shells=0 implementation_diffs=0 mapping_issues=1 reviewed_divergences=0 corpus_noise=0 harness_warnings=0 harness_failures=0
+Mapping Issues:
+/tmp/main-fixture.sh
+  shellcheck-only S032/SC2209 1:1-1:5 warning reason=main issue
+test large_corpus_conforms_with_shellcheck ... ok
+Harness Warnings:
+/tmp/zsh-fixture.sh
+  shuck timed out after 30.000s
+"""
+
+        body = MODULE.extract_main_report_body(log)
+
+        self.assertIsNotNone(body)
+        self.assertIn("Mapping Issues:", body)
+        self.assertNotIn("/tmp/zsh-fixture.sh", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_large_corpus_report.py
+++ b/scripts/test_large_corpus_report.py
@@ -78,6 +78,39 @@ test large_corpus_conforms_with_shellcheck ... ok
 
         self.assertIn("mapping issues, 2 reviewed divergences", html)
 
+    def test_main_summary_falls_back_when_nonblocking_sections_are_omitted(self) -> None:
+        log = """large corpus compatibility summary: blocking=1 warnings=18 fixtures=1 unsupported_shells=2 implementation_diffs=1 mapping_issues=3 reviewed_divergences=4 corpus_noise=5 harness_warnings=6 harness_failures=0
+Implementation Diffs:
+/tmp/main-fixture.sh
+  shellcheck-only C001/SC2000 1:1-1:5 error reason=blocking
+
+Nonblocking issue buckets were omitted from the failing log output. See the compatibility summary counts above for skipped unsupported shells, mapping issues, reviewed divergences, corpus noise, and harness warnings.
+test large_corpus_conforms_with_shellcheck ... FAILED
+"""
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            log_path = Path(tempdir) / "large-corpus.log"
+            output_path = Path(tempdir) / "report.html"
+            log_path.write_text(log, encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--log",
+                    str(log_path),
+                    "--output",
+                    str(output_path),
+                ],
+                check=True,
+            )
+
+            html = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("3\n        mapping issues, 4 reviewed divergences,", html)
+        self.assertIn("5 corpus-noise parse failures,", html)
+        self.assertIn("6 main harness warnings,", html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- treat large-corpus mapping issues and timeout-based harness results as warnings that still appear in the text and HTML reports
- keep true harness failures blocking while teaching the HTML report generator to parse successful warning-only runs
- make the large-corpus CI step blocking again by removing continue-on-error and enabling pipefail on the tee pipeline

## Why

The large-corpus harness now allows reviewed warning buckets without failing locally, but the CI workflow was still set up to mask real test failures because the step was non-blocking and the piped command could lose the make exit status.

## Validation

- cargo test -p shuck --test large_corpus
- python3 -m py_compile scripts/large_corpus_report.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "workflow yaml ok"'
- make large-corpus-report
