### PR TITLE
Fix large-corpus timeout in unused assignment branch collapse

### DIFF
--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -5,7 +5,7 @@ use shuck_ast::Span;
 use crate::runtime::RuntimePrelude;
 use crate::{
     Binding, BindingAttributes, BindingId, BindingKind, BlockId, CallSite, ContractCertainty,
-    ControlFlowGraph, FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, Reference,
+    ControlFlowGraph, EdgeKind, FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, Reference,
     ReferenceId, ReferenceKind, Scope, ScopeId, ScopeKind, SpanKey, SyntheticRead,
 };
 use std::sync::OnceLock;
@@ -472,6 +472,13 @@ fn collapse_redundant_branch_unused_assignment_ids(
             .collect();
     }
 
+    if cfg_has_no_branching_edges(cfg) {
+        return unused_assignments
+            .iter()
+            .map(|unused| unused.binding)
+            .collect();
+    }
+
     let bindings_by_name = build_bindings_by_name(bindings);
     let unused_binding_ids = unused_assignments
         .iter()
@@ -498,6 +505,17 @@ fn collapse_redundant_branch_unused_assignment_ids(
             .then_some(unused.binding)
         })
         .collect()
+}
+
+fn cfg_has_no_branching_edges(cfg: &ControlFlowGraph) -> bool {
+    cfg.blocks().iter().all(|block| {
+        cfg.predecessors(block.id).len() <= 1
+            && cfg.successors(block.id).len() <= 1
+            && cfg
+                .successors(block.id)
+                .iter()
+                .all(|(_, edge)| matches!(edge, EdgeKind::Sequential))
+    })
 }
 
 struct RedundantBranchUnusedAssignmentContext<'a> {
@@ -545,6 +563,15 @@ fn should_suppress_redundant_branch_unused_assignment(
         return false;
     };
 
+    if block_can_reach(
+        context.cfg,
+        binding_block,
+        next_binding_block,
+        context.reachability_cache,
+    ) {
+        return false;
+    }
+
     if !context.unused_binding_ids.contains(&next_binding_id) {
         return false;
     }
@@ -554,12 +581,7 @@ fn should_suppress_redundant_branch_unused_assignment(
         return false;
     }
 
-    !block_can_reach(
-        context.cfg,
-        binding_block,
-        next_binding_block,
-        context.reachability_cache,
-    )
+    true
 }
 
 fn participates_in_unused_assignment_reporting(
@@ -591,6 +613,14 @@ fn block_can_reach(
     reachability_cache: &mut [Option<DenseBitSet>],
 ) -> bool {
     if from == to {
+        return true;
+    }
+
+    if cfg
+        .successors(from)
+        .iter()
+        .any(|(successor, _)| *successor == to)
+    {
         return true;
     }
 

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2461,6 +2461,20 @@ fi
     }
 
     #[test]
+    fn linear_duplicate_assignments_with_unrelated_reads_keep_all_reported_ids() {
+        let source = "\
+emoji[grinning]=1
+printf '%s\n' \"$OTHER\"
+emoji[smile]=2
+";
+        let model = model(source);
+        let all_bindings = model.bindings_for(&Name::from("emoji")).to_vec();
+        let binding_ids = model.analysis().dataflow().unused_assignment_ids().to_vec();
+
+        assert_eq!(binding_ids, all_bindings);
+    }
+
+    #[test]
     fn branch_join_defs_used_in_later_function_body_are_all_live() {
         let source = "\
 if command -v code >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- short-circuit redundant unused-assignment collapse for CFGs with no branching edges
- reject suppression candidates early when the next same-name binding is already reachable
- add a regression test covering linear duplicate assignments with unrelated reads

## Why
The large-corpus fixture `v1s1t0r1sh3r3__airgeddon__language_strings.sh` was spending most of its time in unused-assignment post-processing rather than parsing or semantic model construction.

The slow path was the branch-collapse logic for unused assignments. On long straight-line runs of same-name bindings, it scanned the remaining tail and performed reachability work even when the next assignment was obviously reachable, which turned this file into a performance outlier on CI.

## Impact
This keeps the branch-collapse behavior for mutually exclusive branches, but avoids the expensive suppression work on linear flows and on obviously reachable next bindings. The target file now completes much faster locally and no longer spends most of its runtime in `unused_assignments()`.

## Validation
- `cargo fmt --all`
- `cargo test -q -p shuck-semantic tests::mutually_exclusive_unused_branch_assignments_collapse_to_one_reported_id -- --exact`
- `cargo test -q -p shuck-semantic tests::partially_used_branch_assignments_keep_each_dead_arm_reported -- --exact`
- `cargo test -q -p shuck-semantic tests::linear_duplicate_assignments_with_unrelated_reads_keep_all_reported_ids -- --exact`
- `cargo test -q -p shuck-semantic tests::precise_unused_assignments_match_dataflow_for_representative_cases -- --exact`
- `cargo test -q -p shuck-semantic tests::precompute_unused_assignments_skips_dataflow_for_linear_duplicate_assignments -- --exact`
- `cargo test -q -p shuck-semantic tests::variable_dataflow_results_do_not_depend_on_query_order -- --exact`
- `/usr/bin/time -lp cargo run -q -p shuck -- check --no-cache --output-format concise .cache/large-corpus/scripts/v1s1t0r1sh3r3__airgeddon__language_strings.sh`

Local timing for the target file was about 1.76s wall clock after the fix.