### PR TITLE
Report benchmark deltas on PRs instead of gating

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,6 +172,7 @@ jobs:
       actions: read
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,11 +260,13 @@ jobs:
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
         run: |
+          benchmark_report_dir="$RUNNER_TEMP/benchmark-report"
+          mkdir -p "$benchmark_report_dir"
           python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
             --repo-root "$GITHUB_WORKSPACE/base" \
             --save-baseline main \
             --noplot \
-            2>&1 | tee "$RUNNER_TEMP/benchmark-report/base.log"
+            2>&1 | tee "$benchmark_report_dir/base.log"
       - name: "Determine baseline metadata"
         id: baseline-metadata
         if: always()
@@ -294,11 +296,13 @@ jobs:
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
         run: |
+          benchmark_report_dir="$RUNNER_TEMP/benchmark-report"
+          mkdir -p "$benchmark_report_dir"
           python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
             --repo-root "$GITHUB_WORKSPACE/head" \
             --baseline main \
             --noplot \
-            2>&1 | tee "$RUNNER_TEMP/benchmark-report/head.log"
+            2>&1 | tee "$benchmark_report_dir/head.log"
       - name: "Build benchmark report"
         id: render-benchmark-report
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,124 @@ jobs:
       - name: "Run tests"
         run: cargo test --workspace --all-features
 
+  benchmark-report:
+    name: "benchmark report"
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: "Install Rust toolchain"
+        working-directory: head
+        run: rustup show
+      - name: "Run baseline benchmarks"
+        id: benchmark-baseline
+        continue-on-error: true
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
+        run: |
+          mkdir -p "$RUNNER_TEMP/benchmark-report"
+          python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
+            --repo-root "$GITHUB_WORKSPACE/base" \
+            --save-baseline pr-base \
+            --noplot \
+            2>&1 | tee "$RUNNER_TEMP/benchmark-report/base.log"
+      - name: "Run PR benchmark comparison"
+        id: benchmark-compare
+        if: ${{ steps.benchmark-baseline.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
+        run: |
+          python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
+            --repo-root "$GITHUB_WORKSPACE/head" \
+            --baseline pr-base \
+            --noplot \
+            2>&1 | tee "$RUNNER_TEMP/benchmark-report/head.log"
+      - name: "Build benchmark report"
+        id: render-benchmark-report
+        if: always()
+        working-directory: head
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BENCHMARK_BASELINE_OUTCOME: ${{ steps.benchmark-baseline.outcome }}
+          BENCHMARK_COMPARE_OUTCOME: ${{ steps.benchmark-compare.outcome }}
+          BENCHMARK_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 scripts/benchmarks/criterion_pr_report.py \
+            --criterion-root "$CARGO_TARGET_DIR/criterion" \
+            --output "$RUNNER_TEMP/benchmark-report/comment.md" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --baseline-name pr-base \
+            --baseline-outcome "${BENCHMARK_BASELINE_OUTCOME:-skipped}" \
+            --compare-outcome "${BENCHMARK_COMPARE_OUTCOME:-skipped}" \
+            --run-url "$BENCHMARK_RUN_URL"
+          cat "$RUNNER_TEMP/benchmark-report/comment.md" >> "$GITHUB_STEP_SUMMARY"
+      - name: "Upload benchmark artifacts"
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: benchmark-report
+          if-no-files-found: ignore
+          path: |
+            ${{ runner.temp }}/benchmark-report
+            ${{ runner.temp }}/criterion-target/criterion
+      - name: "Post PR benchmark comment"
+        if: ${{ always() && steps.render-benchmark-report.outcome == 'success' && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          COMMENT_PATH: ${{ runner.temp }}/benchmark-report/comment.md
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- shuck-benchmark-report -->";
+            const body = fs.readFileSync(process.env.COMMENT_PATH, "utf8");
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => {
+              return comment.user.type === "Bot" && comment.body && comment.body.includes(marker);
+            });
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }
+
   fuzz-smoke:
     name: "fuzz smoke"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,10 +150,14 @@ jobs:
         run: |
           ./scripts/benchmarks/setup.sh hyperfine
           ./scripts/benchmarks/run.sh
+      - name: "Snapshot benchmark fixtures"
+        run: |
+          mkdir -p "$RUNNER_TEMP/macro-benchmark/fixtures"
+          cp "$GITHUB_WORKSPACE"/crates/shuck-benchmark/resources/files/*.sh "$RUNNER_TEMP/macro-benchmark/fixtures/"
       - name: "Pack benchmark baseline artifact"
         run: |
           mkdir -p "$RUNNER_TEMP/benchmark-baseline-artifact"
-          tar -C "$RUNNER_TEMP/macro-benchmark" -cf "$RUNNER_TEMP/benchmark-baseline-artifact/macro-cli-main-baseline.tar" baseline
+          tar -C "$RUNNER_TEMP/macro-benchmark" -cf "$RUNNER_TEMP/benchmark-baseline-artifact/macro-cli-main-baseline.tar" baseline fixtures
       - name: "Upload benchmark baseline artifact"
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
@@ -272,11 +276,13 @@ jobs:
         run: |
           benchmark_root="$RUNNER_TEMP/macro-benchmark"
           benchmark_report_dir="$RUNNER_TEMP/benchmark-report"
-          rm -rf "$benchmark_root/baseline"
-          mkdir -p "$benchmark_root/baseline" "$benchmark_report_dir"
+          rm -rf "$benchmark_root/baseline" "$benchmark_root/fixtures"
+          mkdir -p "$benchmark_root/baseline" "$benchmark_root/fixtures" "$benchmark_report_dir"
+          cp "$GITHUB_WORKSPACE/base"/crates/shuck-benchmark/resources/files/*.sh "$benchmark_root/fixtures/"
           export CARGO_TARGET_DIR="$benchmark_root/target"
           export SHUCK_BENCHMARK_MODE=shuck-only
           export SHUCK_BENCHMARK_OUTPUT_DIR="$benchmark_root/baseline"
+          export SHUCK_BENCHMARK_FIXTURES_DIR="$benchmark_root/fixtures"
           export SHUCK_BENCHMARK_REPO_ROOT="$GITHUB_WORKSPACE/base"
           "$GITHUB_WORKSPACE/head/scripts/benchmarks/setup.sh" hyperfine
           "$GITHUB_WORKSPACE/head/scripts/benchmarks/run.sh" \
@@ -315,6 +321,7 @@ jobs:
           export CARGO_TARGET_DIR="$benchmark_root/target"
           export SHUCK_BENCHMARK_MODE=shuck-only
           export SHUCK_BENCHMARK_OUTPUT_DIR="$benchmark_root/head"
+          export SHUCK_BENCHMARK_FIXTURES_DIR="$benchmark_root/fixtures"
           export SHUCK_BENCHMARK_REPO_ROOT="$GITHUB_WORKSPACE/head"
           "$GITHUB_WORKSPACE/head/scripts/benchmarks/setup.sh" hyperfine
           "$GITHUB_WORKSPACE/head/scripts/benchmarks/run.sh" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,13 +141,14 @@ jobs:
       - name: "Install macro benchmark dependencies"
         run: |
           sudo apt-get update
-          sudo apt-get install -y hyperfine shellcheck
+          sudo apt-get install -y hyperfine
       - name: "Build benchmark baseline artifact"
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/macro-benchmark/target
+          SHUCK_BENCHMARK_MODE: shuck-only
           SHUCK_BENCHMARK_OUTPUT_DIR: ${{ runner.temp }}/macro-benchmark/baseline
         run: |
-          ./scripts/benchmarks/setup.sh hyperfine shellcheck
+          ./scripts/benchmarks/setup.sh hyperfine
           ./scripts/benchmarks/run.sh
       - name: "Pack benchmark baseline artifact"
         run: |
@@ -184,7 +185,7 @@ jobs:
       - name: "Install macro benchmark dependencies"
         run: |
           sudo apt-get update
-          sudo apt-get install -y hyperfine shellcheck
+          sudo apt-get install -y hyperfine
       - name: "Prepare benchmark report directories"
         run: |
           mkdir -p "$RUNNER_TEMP/benchmark-report"
@@ -273,9 +274,10 @@ jobs:
           rm -rf "$benchmark_root/baseline"
           mkdir -p "$benchmark_root/baseline" "$benchmark_report_dir"
           export CARGO_TARGET_DIR="$benchmark_root/target"
+          export SHUCK_BENCHMARK_MODE=shuck-only
           export SHUCK_BENCHMARK_OUTPUT_DIR="$benchmark_root/baseline"
           export SHUCK_BENCHMARK_REPO_ROOT="$GITHUB_WORKSPACE/base"
-          "$GITHUB_WORKSPACE/head/scripts/benchmarks/setup.sh" hyperfine shellcheck
+          "$GITHUB_WORKSPACE/head/scripts/benchmarks/setup.sh" hyperfine
           "$GITHUB_WORKSPACE/head/scripts/benchmarks/run.sh" \
             2>&1 | tee "$benchmark_report_dir/base.log"
       - name: "Determine baseline metadata"
@@ -310,9 +312,10 @@ jobs:
           rm -rf "$benchmark_root/head"
           mkdir -p "$benchmark_root/head" "$benchmark_report_dir"
           export CARGO_TARGET_DIR="$benchmark_root/target"
+          export SHUCK_BENCHMARK_MODE=shuck-only
           export SHUCK_BENCHMARK_OUTPUT_DIR="$benchmark_root/head"
           export SHUCK_BENCHMARK_REPO_ROOT="$GITHUB_WORKSPACE/head"
-          "$GITHUB_WORKSPACE/head/scripts/benchmarks/setup.sh" hyperfine shellcheck
+          "$GITHUB_WORKSPACE/head/scripts/benchmarks/setup.sh" hyperfine
           "$GITHUB_WORKSPACE/head/scripts/benchmarks/run.sh" \
             2>&1 | tee "$benchmark_report_dir/head.log"
       - name: "Build benchmark report"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,6 +175,10 @@ jobs:
       - name: "Install Rust toolchain"
         working-directory: head
         run: rustup show
+      - name: "Prepare benchmark report directories"
+        run: |
+          mkdir -p "$RUNNER_TEMP/benchmark-report"
+          mkdir -p "$RUNNER_TEMP/benchmark-baseline-artifact"
       - name: "Resolve latest main baseline artifact"
         id: resolve-main-baseline
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -239,24 +243,23 @@ jobs:
           path: ${{ runner.temp }}/benchmark-baseline-artifact
       - name: "Extract main benchmark baseline artifact"
         id: extract-main-baseline
-        if: ${{ steps.download-main-baseline.outcome == 'success' }}
+        if: ${{ always() && steps.download-main-baseline.outcome == 'success' }}
         run: |
           mkdir -p "$RUNNER_TEMP/criterion-target"
           tar -xf "$RUNNER_TEMP/benchmark-baseline-artifact/criterion-main-baseline.tar" -C "$RUNNER_TEMP/criterion-target"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ steps.extract-main-baseline.outcome != 'success' }}
+        if: ${{ always() && steps.extract-main-baseline.outcome != 'success' }}
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
       - name: "Run fallback baseline benchmarks"
         id: benchmark-baseline-fallback
-        if: ${{ steps.extract-main-baseline.outcome != 'success' }}
+        if: ${{ always() && steps.extract-main-baseline.outcome != 'success' }}
         continue-on-error: true
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
         run: |
-          mkdir -p "$RUNNER_TEMP/benchmark-report"
           python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
             --repo-root "$GITHUB_WORKSPACE/base" \
             --save-baseline main \
@@ -286,12 +289,11 @@ jobs:
           echo "outcome=$baseline_outcome" >> "$GITHUB_OUTPUT"
       - name: "Run PR benchmark comparison"
         id: benchmark-compare
-        if: ${{ steps.extract-main-baseline.outcome == 'success' || steps.benchmark-baseline-fallback.outcome == 'success' }}
+        if: ${{ always() && (steps.extract-main-baseline.outcome == 'success' || steps.benchmark-baseline-fallback.outcome == 'success') }}
         continue-on-error: true
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
         run: |
-          mkdir -p "$RUNNER_TEMP/benchmark-report"
           python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
             --repo-root "$GITHUB_WORKSPACE/head" \
             --baseline main \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
     name: "benchmark main baseline"
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -138,21 +138,27 @@ jobs:
           save-if: true
       - name: "Install Rust toolchain"
         run: rustup show
+      - name: "Install macro benchmark dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y hyperfine shellcheck
       - name: "Build benchmark baseline artifact"
         env:
-          CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
+          CARGO_TARGET_DIR: ${{ runner.temp }}/macro-benchmark/target
+          SHUCK_BENCHMARK_OUTPUT_DIR: ${{ runner.temp }}/macro-benchmark/baseline
         run: |
-          python3 scripts/benchmarks/run_criterion.py --repo-root "$GITHUB_WORKSPACE" --save-baseline main --noplot
+          ./scripts/benchmarks/setup.sh hyperfine shellcheck
+          ./scripts/benchmarks/run.sh
       - name: "Pack benchmark baseline artifact"
         run: |
           mkdir -p "$RUNNER_TEMP/benchmark-baseline-artifact"
-          tar -C "$RUNNER_TEMP/criterion-target" -cf "$RUNNER_TEMP/benchmark-baseline-artifact/criterion-main-baseline.tar" criterion
+          tar -C "$RUNNER_TEMP/macro-benchmark" -cf "$RUNNER_TEMP/benchmark-baseline-artifact/macro-cli-main-baseline.tar" baseline
       - name: "Upload benchmark baseline artifact"
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: criterion-main-baseline
+          name: macro-cli-main-baseline
           if-no-files-found: error
-          path: ${{ runner.temp }}/benchmark-baseline-artifact/criterion-main-baseline.tar
+          path: ${{ runner.temp }}/benchmark-baseline-artifact/macro-cli-main-baseline.tar
           retention-days: 14
 
   benchmark-report:
@@ -160,7 +166,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     continue-on-error: true
-    timeout-minutes: 45
+    timeout-minutes: 25
     permissions:
       actions: read
       contents: read
@@ -175,17 +181,22 @@ jobs:
       - name: "Install Rust toolchain"
         working-directory: head
         run: rustup show
+      - name: "Install macro benchmark dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y hyperfine shellcheck
       - name: "Prepare benchmark report directories"
         run: |
           mkdir -p "$RUNNER_TEMP/benchmark-report"
           mkdir -p "$RUNNER_TEMP/benchmark-baseline-artifact"
+          mkdir -p "$RUNNER_TEMP/macro-benchmark"
       - name: "Resolve latest main baseline artifact"
         id: resolve-main-baseline
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const artifactName = "criterion-main-baseline";
+            const artifactName = "macro-cli-main-baseline";
             const { owner, repo } = context.repo;
             const runsResponse = await github.request(
               "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
@@ -236,7 +247,7 @@ jobs:
         if: ${{ steps.resolve-main-baseline.outputs.run-id != '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: criterion-main-baseline
+          name: macro-cli-main-baseline
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           run-id: ${{ steps.resolve-main-baseline.outputs.run-id }}
@@ -245,8 +256,7 @@ jobs:
         id: extract-main-baseline
         if: ${{ always() && steps.download-main-baseline.outcome == 'success' }}
         run: |
-          mkdir -p "$RUNNER_TEMP/criterion-target"
-          tar -xf "$RUNNER_TEMP/benchmark-baseline-artifact/criterion-main-baseline.tar" -C "$RUNNER_TEMP/criterion-target"
+          tar -xf "$RUNNER_TEMP/benchmark-baseline-artifact/macro-cli-main-baseline.tar" -C "$RUNNER_TEMP/macro-benchmark"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: ${{ always() && steps.extract-main-baseline.outcome != 'success' }}
         with:
@@ -257,15 +267,16 @@ jobs:
         id: benchmark-baseline-fallback
         if: ${{ always() && steps.extract-main-baseline.outcome != 'success' }}
         continue-on-error: true
-        env:
-          CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
         run: |
+          benchmark_root="$RUNNER_TEMP/macro-benchmark"
           benchmark_report_dir="$RUNNER_TEMP/benchmark-report"
-          mkdir -p "$benchmark_report_dir"
-          python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
-            --repo-root "$GITHUB_WORKSPACE/base" \
-            --save-baseline main \
-            --noplot \
+          rm -rf "$benchmark_root/baseline"
+          mkdir -p "$benchmark_root/baseline" "$benchmark_report_dir"
+          export CARGO_TARGET_DIR="$benchmark_root/target"
+          export SHUCK_BENCHMARK_OUTPUT_DIR="$benchmark_root/baseline"
+          export SHUCK_BENCHMARK_REPO_ROOT="$GITHUB_WORKSPACE/base"
+          "$GITHUB_WORKSPACE/head/scripts/benchmarks/setup.sh" hyperfine shellcheck
+          "$GITHUB_WORKSPACE/head/scripts/benchmarks/run.sh" \
             2>&1 | tee "$benchmark_report_dir/base.log"
       - name: "Determine baseline metadata"
         id: baseline-metadata
@@ -293,15 +304,16 @@ jobs:
         id: benchmark-compare
         if: ${{ always() && (steps.extract-main-baseline.outcome == 'success' || steps.benchmark-baseline-fallback.outcome == 'success') }}
         continue-on-error: true
-        env:
-          CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
         run: |
+          benchmark_root="$RUNNER_TEMP/macro-benchmark"
           benchmark_report_dir="$RUNNER_TEMP/benchmark-report"
-          mkdir -p "$benchmark_report_dir"
-          python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
-            --repo-root "$GITHUB_WORKSPACE/head" \
-            --baseline main \
-            --noplot \
+          rm -rf "$benchmark_root/head"
+          mkdir -p "$benchmark_root/head" "$benchmark_report_dir"
+          export CARGO_TARGET_DIR="$benchmark_root/target"
+          export SHUCK_BENCHMARK_OUTPUT_DIR="$benchmark_root/head"
+          export SHUCK_BENCHMARK_REPO_ROOT="$GITHUB_WORKSPACE/head"
+          "$GITHUB_WORKSPACE/head/scripts/benchmarks/setup.sh" hyperfine shellcheck
+          "$GITHUB_WORKSPACE/head/scripts/benchmarks/run.sh" \
             2>&1 | tee "$benchmark_report_dir/head.log"
       - name: "Build benchmark report"
         id: render-benchmark-report
@@ -313,15 +325,14 @@ jobs:
           BENCHMARK_BASELINE_SOURCE: ${{ steps.baseline-metadata.outputs.source }}
           BENCHMARK_COMPARE_OUTCOME: ${{ steps.benchmark-compare.outcome }}
           BENCHMARK_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          python3 scripts/benchmarks/criterion_pr_report.py \
-            --criterion-root "$CARGO_TARGET_DIR/criterion" \
+          python3 scripts/benchmarks/macro_pr_report.py \
+            --baseline-dir "$RUNNER_TEMP/macro-benchmark/baseline" \
+            --head-dir "$RUNNER_TEMP/macro-benchmark/head" \
             --output "$RUNNER_TEMP/benchmark-report/comment.md" \
             --base-sha "$BASELINE_SHA" \
             --head-sha "$HEAD_SHA" \
-            --baseline-name main \
             --baseline-source "$BENCHMARK_BASELINE_SOURCE" \
             --baseline-outcome "${BENCHMARK_BASELINE_OUTCOME:-skipped}" \
             --compare-outcome "${BENCHMARK_COMPARE_OUTCOME:-skipped}" \
@@ -335,7 +346,8 @@ jobs:
           if-no-files-found: ignore
           path: |
             ${{ runner.temp }}/benchmark-report
-            ${{ runner.temp }}/criterion-target/criterion
+            ${{ runner.temp }}/macro-benchmark/baseline
+            ${{ runner.temp }}/macro-benchmark/head
       - name: "Post PR benchmark comment"
         if: ${{ always() && steps.render-benchmark-report.outcome == 'success' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,37 @@ jobs:
       - name: "Run tests"
         run: cargo test --workspace --all-features
 
+  benchmark-main-baseline:
+    name: "benchmark main baseline"
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: true
+      - name: "Install Rust toolchain"
+        run: rustup show
+      - name: "Build benchmark baseline artifact"
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
+        run: |
+          python3 scripts/benchmarks/run_criterion.py --repo-root "$GITHUB_WORKSPACE" --save-baseline main --noplot
+      - name: "Pack benchmark baseline artifact"
+        run: |
+          mkdir -p "$RUNNER_TEMP/benchmark-baseline-artifact"
+          tar -C "$RUNNER_TEMP/criterion-target" -cf "$RUNNER_TEMP/benchmark-baseline-artifact/criterion-main-baseline.tar" criterion
+      - name: "Upload benchmark baseline artifact"
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: criterion-main-baseline
+          if-no-files-found: error
+          path: ${{ runner.temp }}/benchmark-baseline-artifact/criterion-main-baseline.tar
+          retention-days: 14
+
   benchmark-report:
     name: "benchmark report"
     if: ${{ github.event_name == 'pull_request' }}
@@ -131,14 +162,10 @@ jobs:
     continue-on-error: true
     timeout-minutes: 45
     permissions:
+      actions: read
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: base
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -148,8 +175,83 @@ jobs:
       - name: "Install Rust toolchain"
         working-directory: head
         run: rustup show
-      - name: "Run baseline benchmarks"
-        id: benchmark-baseline
+      - name: "Resolve latest main baseline artifact"
+        id: resolve-main-baseline
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const artifactName = "criterion-main-baseline";
+            const { owner, repo } = context.repo;
+            const runsResponse = await github.request(
+              "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+              {
+                owner,
+                repo,
+                workflow_id: "ci.yaml",
+                branch: "main",
+                event: "push",
+                status: "success",
+                per_page: 20,
+              },
+            );
+
+            for (const run of runsResponse.data.workflow_runs) {
+              const artifactsResponse = await github.request(
+                "GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+                {
+                  owner,
+                  repo,
+                  run_id: run.id,
+                  name: artifactName,
+                  per_page: 100,
+                },
+              );
+
+              const artifact = artifactsResponse.data.artifacts.find((candidate) => {
+                return candidate.name === artifactName && candidate.expired === false;
+              });
+
+              if (artifact) {
+                core.setOutput("run-id", String(run.id));
+                core.setOutput("baseline-sha", run.head_sha);
+                core.notice(
+                  `Using ${artifactName} from run ${run.id} (${run.head_sha.slice(0, 7)}).`,
+                );
+                return;
+              }
+            }
+
+            core.notice(
+              "No uploaded benchmark baseline artifact was found on successful main runs. Falling back to rebuilding the PR base baseline.",
+            );
+            core.setOutput("run-id", "");
+            core.setOutput("baseline-sha", "");
+      - name: "Download main benchmark baseline artifact"
+        id: download-main-baseline
+        if: ${{ steps.resolve-main-baseline.outputs.run-id != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: criterion-main-baseline
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.resolve-main-baseline.outputs.run-id }}
+          path: ${{ runner.temp }}/benchmark-baseline-artifact
+      - name: "Extract main benchmark baseline artifact"
+        id: extract-main-baseline
+        if: ${{ steps.download-main-baseline.outcome == 'success' }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/criterion-target"
+          tar -xf "$RUNNER_TEMP/benchmark-baseline-artifact/criterion-main-baseline.tar" -C "$RUNNER_TEMP/criterion-target"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: ${{ steps.extract-main-baseline.outcome != 'success' }}
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+      - name: "Run fallback baseline benchmarks"
+        id: benchmark-baseline-fallback
+        if: ${{ steps.extract-main-baseline.outcome != 'success' }}
         continue-on-error: true
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
@@ -157,19 +259,41 @@ jobs:
           mkdir -p "$RUNNER_TEMP/benchmark-report"
           python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
             --repo-root "$GITHUB_WORKSPACE/base" \
-            --save-baseline pr-base \
+            --save-baseline main \
             --noplot \
             2>&1 | tee "$RUNNER_TEMP/benchmark-report/base.log"
+      - name: "Determine baseline metadata"
+        id: baseline-metadata
+        if: always()
+        env:
+          DOWNLOADED_BASELINE_OUTCOME: ${{ steps.extract-main-baseline.outcome }}
+          DOWNLOADED_BASELINE_SHA: ${{ steps.resolve-main-baseline.outputs.baseline-sha }}
+          FALLBACK_BASELINE_OUTCOME: ${{ steps.benchmark-baseline-fallback.outcome }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          baseline_source="rebuilt from PR base checkout"
+          baseline_sha="$PR_BASE_SHA"
+          baseline_outcome="${FALLBACK_BASELINE_OUTCOME:-skipped}"
+
+          if [ "${DOWNLOADED_BASELINE_OUTCOME:-skipped}" = "success" ]; then
+            baseline_source="downloaded from the latest successful main CI artifact"
+            baseline_sha="${DOWNLOADED_BASELINE_SHA}"
+            baseline_outcome="success"
+          fi
+
+          echo "source=$baseline_source" >> "$GITHUB_OUTPUT"
+          echo "sha=$baseline_sha" >> "$GITHUB_OUTPUT"
+          echo "outcome=$baseline_outcome" >> "$GITHUB_OUTPUT"
       - name: "Run PR benchmark comparison"
         id: benchmark-compare
-        if: ${{ steps.benchmark-baseline.outcome == 'success' }}
+        if: ${{ steps.extract-main-baseline.outcome == 'success' || steps.benchmark-baseline-fallback.outcome == 'success' }}
         continue-on-error: true
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
         run: |
           python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
             --repo-root "$GITHUB_WORKSPACE/head" \
-            --baseline pr-base \
+            --baseline main \
             --noplot \
             2>&1 | tee "$RUNNER_TEMP/benchmark-report/head.log"
       - name: "Build benchmark report"
@@ -177,8 +301,9 @@ jobs:
         if: always()
         working-directory: head
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BENCHMARK_BASELINE_OUTCOME: ${{ steps.benchmark-baseline.outcome }}
+          BASELINE_SHA: ${{ steps.baseline-metadata.outputs.sha }}
+          BENCHMARK_BASELINE_OUTCOME: ${{ steps.baseline-metadata.outputs.outcome }}
+          BENCHMARK_BASELINE_SOURCE: ${{ steps.baseline-metadata.outputs.source }}
           BENCHMARK_COMPARE_OUTCOME: ${{ steps.benchmark-compare.outcome }}
           BENCHMARK_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
@@ -187,9 +312,10 @@ jobs:
           python3 scripts/benchmarks/criterion_pr_report.py \
             --criterion-root "$CARGO_TARGET_DIR/criterion" \
             --output "$RUNNER_TEMP/benchmark-report/comment.md" \
-            --base-sha "$BASE_SHA" \
+            --base-sha "$BASELINE_SHA" \
             --head-sha "$HEAD_SHA" \
-            --baseline-name pr-base \
+            --baseline-name main \
+            --baseline-source "$BENCHMARK_BASELINE_SOURCE" \
             --baseline-outcome "${BENCHMARK_BASELINE_OUTCOME:-skipped}" \
             --compare-outcome "${BENCHMARK_COMPARE_OUTCOME:-skipped}" \
             --run-url "$BENCHMARK_RUN_URL"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -291,6 +291,7 @@ jobs:
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/criterion-target
         run: |
+          mkdir -p "$RUNNER_TEMP/benchmark-report"
           python3 "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_criterion.py" \
             --repo-root "$GITHUB_WORKSPACE/head" \
             --baseline main \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
 
   benchmark-report:
     name: "benchmark report"
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 25
@@ -254,18 +254,18 @@ jobs:
           path: ${{ runner.temp }}/benchmark-baseline-artifact
       - name: "Extract main benchmark baseline artifact"
         id: extract-main-baseline
-        if: ${{ always() && steps.download-main-baseline.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.download-main-baseline.outcome == 'success' }}
         run: |
           tar -xf "$RUNNER_TEMP/benchmark-baseline-artifact/macro-cli-main-baseline.tar" -C "$RUNNER_TEMP/macro-benchmark"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ always() && steps.extract-main-baseline.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.extract-main-baseline.outcome != 'success' }}
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
       - name: "Run fallback baseline benchmarks"
         id: benchmark-baseline-fallback
-        if: ${{ always() && steps.extract-main-baseline.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.extract-main-baseline.outcome != 'success' }}
         continue-on-error: true
         run: |
           benchmark_root="$RUNNER_TEMP/macro-benchmark"
@@ -280,7 +280,7 @@ jobs:
             2>&1 | tee "$benchmark_report_dir/base.log"
       - name: "Determine baseline metadata"
         id: baseline-metadata
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           DOWNLOADED_BASELINE_OUTCOME: ${{ steps.extract-main-baseline.outcome }}
           DOWNLOADED_BASELINE_SHA: ${{ steps.resolve-main-baseline.outputs.baseline-sha }}
@@ -302,7 +302,7 @@ jobs:
           echo "outcome=$baseline_outcome" >> "$GITHUB_OUTPUT"
       - name: "Run PR benchmark comparison"
         id: benchmark-compare
-        if: ${{ always() && (steps.extract-main-baseline.outcome == 'success' || steps.benchmark-baseline-fallback.outcome == 'success') }}
+        if: ${{ !cancelled() && (steps.extract-main-baseline.outcome == 'success' || steps.benchmark-baseline-fallback.outcome == 'success') }}
         continue-on-error: true
         run: |
           benchmark_root="$RUNNER_TEMP/macro-benchmark"
@@ -317,7 +317,7 @@ jobs:
             2>&1 | tee "$benchmark_report_dir/head.log"
       - name: "Build benchmark report"
         id: render-benchmark-report
-        if: always()
+        if: ${{ !cancelled() }}
         working-directory: head
         env:
           BASELINE_SHA: ${{ steps.baseline-metadata.outputs.sha }}
@@ -339,7 +339,7 @@ jobs:
             --run-url "$BENCHMARK_RUN_URL"
           cat "$RUNNER_TEMP/benchmark-report/comment.md" >> "$GITHUB_STEP_SUMMARY"
       - name: "Upload benchmark artifacts"
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-report
@@ -349,7 +349,7 @@ jobs:
             ${{ runner.temp }}/macro-benchmark/baseline
             ${{ runner.temp }}/macro-benchmark/head
       - name: "Post PR benchmark comment"
-        if: ${{ always() && steps.render-benchmark-report.outcome == 'success' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ !cancelled() && steps.render-benchmark-report.outcome == 'success' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           COMMENT_PATH: ${{ runner.temp }}/benchmark-report/comment.md

--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,10 @@ bench:
 	cargo bench -p shuck-benchmark
 
 bench-save:
-	cargo bench -p shuck-benchmark -- --save-baseline=main
+	python3 scripts/benchmarks/run_criterion.py --repo-root . --save-baseline main
 
 bench-compare:
-	cargo bench -p shuck-benchmark -- --baseline=main
+	python3 scripts/benchmarks/run_criterion.py --repo-root . --baseline main
 
 bench-parser:
 	cargo bench -p shuck-benchmark --bench parser

--- a/scripts/benchmarks/criterion_pr_report.py
+++ b/scripts/benchmarks/criterion_pr_report.py
@@ -49,6 +49,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base-sha", required=True)
     parser.add_argument("--head-sha", required=True)
     parser.add_argument("--baseline-name", default="pr-base")
+    parser.add_argument("--baseline-source", default="prepared in this workflow")
     parser.add_argument("--baseline-outcome", default="success")
     parser.add_argument("--compare-outcome", default="success")
     parser.add_argument("--run-url", default="")
@@ -169,7 +170,8 @@ def render_report(args: argparse.Namespace, rows: list[BenchmarkRow]) -> str:
         "",
         "Positive deltas mean slower benchmark runs.",
         "",
-        f"- Baseline run: `{args.baseline_outcome}`",
+        f"- Baseline source: {args.baseline_source}",
+        f"- Baseline preparation: `{args.baseline_outcome}`",
         f"- Comparison run: `{args.compare_outcome}`",
     ]
 

--- a/scripts/benchmarks/criterion_pr_report.py
+++ b/scripts/benchmarks/criterion_pr_report.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+COMMENT_MARKER = "<!-- shuck-benchmark-report -->"
+REGRESSION_THRESHOLD = 3.0
+
+
+@dataclass(frozen=True)
+class Estimate:
+    point: float
+    lower: float
+    upper: float
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    group: str
+    case: str
+    baseline: Estimate
+    current: Estimate
+    change: Estimate
+
+    @property
+    def slug(self) -> str:
+        return f"{self.group}/{self.case}"
+
+    @property
+    def percent_change(self) -> float:
+        return self.change.point * 100.0
+
+    @property
+    def ci(self) -> str:
+        return f"{self.change.lower * 100.0:+.2f}% to {self.change.upper * 100.0:+.2f}%"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Markdown benchmark report from Criterion baseline artifacts."
+    )
+    parser.add_argument("--criterion-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--baseline-name", default="pr-base")
+    parser.add_argument("--baseline-outcome", default="success")
+    parser.add_argument("--compare-outcome", default="success")
+    parser.add_argument("--run-url", default="")
+    return parser.parse_args()
+
+
+def load_estimate(path: Path) -> Estimate:
+    payload = json.loads(path.read_text())
+    mean = payload["mean"]
+    interval = mean["confidence_interval"]
+    return Estimate(
+        point=float(mean["point_estimate"]),
+        lower=float(interval["lower_bound"]),
+        upper=float(interval["upper_bound"]),
+    )
+
+
+def collect_rows(criterion_root: Path, baseline_name: str) -> list[BenchmarkRow]:
+    rows: list[BenchmarkRow] = []
+    if not criterion_root.exists():
+        return rows
+
+    for group_dir in sorted(path for path in criterion_root.iterdir() if path.is_dir()):
+        for case_dir in sorted(path for path in group_dir.iterdir() if path.is_dir()):
+            baseline_path = case_dir / baseline_name / "estimates.json"
+            current_path = case_dir / "new" / "estimates.json"
+            change_path = case_dir / "change" / "estimates.json"
+            if not (baseline_path.is_file() and current_path.is_file() and change_path.is_file()):
+                continue
+
+            rows.append(
+                BenchmarkRow(
+                    group=group_dir.name,
+                    case=case_dir.name,
+                    baseline=load_estimate(baseline_path),
+                    current=load_estimate(current_path),
+                    change=load_estimate(change_path),
+                )
+            )
+
+    return rows
+
+
+def format_duration_ns(value: float) -> str:
+    units = [
+        ("s", 1_000_000_000.0),
+        ("ms", 1_000_000.0),
+        ("us", 1_000.0),
+        ("ns", 1.0),
+    ]
+    absolute = abs(value)
+    for suffix, scale in units:
+        if absolute >= scale or suffix == "ns":
+            return f"{value / scale:.2f} {suffix}"
+    raise AssertionError("unreachable")
+
+
+def aggregate_rows(rows: list[BenchmarkRow]) -> list[BenchmarkRow]:
+    preferred = [row for row in rows if row.case == "all"]
+    return preferred if preferred else rows
+
+
+def render_table(rows: list[BenchmarkRow], include_timings: bool) -> list[str]:
+    if not rows:
+        return ["No benchmark deltas were produced."]
+
+    header = (
+        "| Benchmark | Baseline | Head | Delta | 95% CI |"
+        if include_timings
+        else "| Benchmark | Delta | 95% CI |"
+    )
+    separator = (
+        "| --- | ---: | ---: | ---: | --- |"
+        if include_timings
+        else "| --- | ---: | --- |"
+    )
+    lines = [header, separator]
+
+    for row in rows:
+        delta = f"{row.percent_change:+.2f}%"
+        if include_timings:
+            lines.append(
+                "| {slug} | {baseline} | {current} | {delta} | {ci} |".format(
+                    slug=row.slug,
+                    baseline=format_duration_ns(row.baseline.point),
+                    current=format_duration_ns(row.current.point),
+                    delta=delta,
+                    ci=row.ci,
+                )
+            )
+        else:
+            lines.append(f"| {row.slug} | {delta} | {row.ci} |")
+
+    return lines
+
+
+def render_report(args: argparse.Namespace, rows: list[BenchmarkRow]) -> str:
+    base_short = args.base_sha[:7]
+    head_short = args.head_sha[:7]
+
+    aggregate = aggregate_rows(rows)
+    regressions = sorted(
+        [row for row in rows if row.percent_change > 0.0],
+        key=lambda row: row.percent_change,
+        reverse=True,
+    )[:5]
+    improvements = sorted(
+        [row for row in rows if row.percent_change < 0.0],
+        key=lambda row: row.percent_change,
+    )[:5]
+    flagged = [row for row in aggregate if row.percent_change >= REGRESSION_THRESHOLD]
+
+    lines = [
+        COMMENT_MARKER,
+        "## Benchmark Deltas",
+        "",
+        f"Compared `{head_short}` against Criterion baseline `{base_short}`.",
+        "",
+        "Positive deltas mean slower benchmark runs.",
+        "",
+        f"- Baseline run: `{args.baseline_outcome}`",
+        f"- Comparison run: `{args.compare_outcome}`",
+    ]
+
+    if args.run_url:
+        lines.append(f"- Workflow run: [details]({args.run_url})")
+
+    if args.baseline_outcome != "success" or args.compare_outcome != "success":
+        lines.extend(
+            [
+                "",
+                "Benchmark execution did not complete cleanly, so the tables below may be partial.",
+            ]
+        )
+
+    lines.extend(["", "### Aggregate Cases", ""])
+    lines.extend(render_table(aggregate, include_timings=True))
+
+    lines.extend(
+        [
+            "",
+            f"Flagged aggregate regressions over +{REGRESSION_THRESHOLD:.1f}%: {len(flagged)}",
+        ]
+    )
+
+    if regressions or improvements:
+        lines.extend(["", "<details>", "<summary>Largest per-case changes</summary>", ""])
+        if regressions:
+            lines.extend(["#### Regressions", ""])
+            lines.extend(render_table(regressions, include_timings=False))
+            lines.append("")
+        if improvements:
+            lines.extend(["#### Improvements", ""])
+            lines.extend(render_table(improvements, include_timings=False))
+            lines.append("")
+        lines.append("</details>")
+
+    if not rows:
+        lines.extend(
+            [
+                "",
+                "No Criterion comparison data was found under the shared benchmark target directory.",
+            ]
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    rows = collect_rows(args.criterion_root, args.baseline_name)
+    report = render_report(args, rows)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/macro_pr_report.py
+++ b/scripts/benchmarks/macro_pr_report.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+COMMENT_MARKER = "<!-- shuck-benchmark-report -->"
+REGRESSION_THRESHOLD = 5.0
+
+
+@dataclass(frozen=True)
+class MacroResult:
+    case: str
+    mean: float
+    stddev: float
+    minimum: float
+    maximum: float
+    exit_codes: tuple[int, ...]
+
+    @property
+    def has_failures(self) -> bool:
+        return any(code != 0 for code in self.exit_codes)
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    baseline: MacroResult
+    current: MacroResult
+
+    @property
+    def case(self) -> str:
+        return self.current.case
+
+    @property
+    def delta_pct(self) -> float:
+        if self.baseline.mean == 0.0:
+            return 0.0
+        return ((self.current.mean - self.baseline.mean) / self.baseline.mean) * 100.0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Markdown benchmark report from macro CLI benchmark JSON exports."
+    )
+    parser.add_argument("--baseline-dir", type=Path, required=True)
+    parser.add_argument("--head-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--baseline-source", default="prepared in this workflow")
+    parser.add_argument("--baseline-outcome", default="success")
+    parser.add_argument("--compare-outcome", default="success")
+    parser.add_argument("--run-url", default="")
+    return parser.parse_args()
+
+
+def load_macro_result(path: Path) -> MacroResult | None:
+    payload = json.loads(path.read_text())
+    results = payload.get("results", [])
+    if not results:
+        return None
+
+    shuck = results[0]
+    case = path.stem.removeprefix("bench-")
+    return MacroResult(
+        case=case,
+        mean=float(shuck["mean"]),
+        stddev=float(shuck.get("stddev", 0.0)),
+        minimum=float(shuck.get("min", shuck["mean"])),
+        maximum=float(shuck.get("max", shuck["mean"])),
+        exit_codes=tuple(int(code) for code in shuck.get("exit_codes", [])),
+    )
+
+
+def collect_rows(baseline_dir: Path, head_dir: Path) -> list[BenchmarkRow]:
+    if not (baseline_dir.exists() and head_dir.exists()):
+        return []
+
+    baseline_paths = {path.name: path for path in baseline_dir.glob("bench-*.json")}
+    head_paths = {path.name: path for path in head_dir.glob("bench-*.json")}
+    shared_names = sorted(
+        baseline_paths.keys() & head_paths.keys(),
+        key=lambda name: (name != "bench-all.json", name),
+    )
+
+    rows: list[BenchmarkRow] = []
+    for name in shared_names:
+        baseline = load_macro_result(baseline_paths[name])
+        current = load_macro_result(head_paths[name])
+        if baseline is None or current is None:
+            continue
+        rows.append(BenchmarkRow(baseline=baseline, current=current))
+    return rows
+
+
+def format_duration(seconds: float) -> str:
+    absolute = abs(seconds)
+    if absolute >= 1.0:
+        return f"{seconds:.2f} s"
+    if absolute >= 0.001:
+        return f"{seconds * 1_000.0:.2f} ms"
+    return f"{seconds * 1_000_000.0:.2f} us"
+
+
+def format_mean_stddev(result: MacroResult) -> str:
+    return f"{format_duration(result.mean)} +/- {format_duration(result.stddev)}"
+
+
+def format_exit_codes(result: MacroResult) -> str:
+    if not result.exit_codes:
+        return "none recorded"
+    return ",".join(str(code) for code in result.exit_codes)
+
+
+def render_table(rows: list[BenchmarkRow]) -> list[str]:
+    if not rows:
+        return ["No macro CLI benchmark deltas were produced."]
+
+    lines = [
+        "| Benchmark | Baseline | Head | Delta |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for row in rows:
+        lines.append(
+            "| {case} | {baseline} | {current} | {delta:+.2f}% |".format(
+                case=row.case,
+                baseline=format_mean_stddev(row.baseline),
+                current=format_mean_stddev(row.current),
+                delta=row.delta_pct,
+            )
+        )
+    return lines
+
+
+def render_report(args: argparse.Namespace, rows: list[BenchmarkRow]) -> str:
+    base_short = args.base_sha[:7]
+    head_short = args.head_sha[:7]
+
+    aggregate = [row for row in rows if row.case == "all"]
+    if not aggregate and rows:
+        aggregate = [rows[0]]
+
+    regressions = sorted(
+        [row for row in rows if row.delta_pct > 0.0],
+        key=lambda row: row.delta_pct,
+        reverse=True,
+    )[:5]
+    improvements = sorted(
+        [row for row in rows if row.delta_pct < 0.0],
+        key=lambda row: row.delta_pct,
+    )[:5]
+    flagged = [row for row in aggregate if row.delta_pct >= REGRESSION_THRESHOLD]
+    failed_rows = [row for row in rows if row.baseline.has_failures or row.current.has_failures]
+
+    lines = [
+        COMMENT_MARKER,
+        "## Macro CLI Benchmark Deltas",
+        "",
+        f"Compared `{head_short}` against macro CLI baseline `{base_short}`.",
+        "",
+        "Positive deltas mean slower `shuck check --no-cache` runs.",
+        "",
+        f"- Baseline source: {args.baseline_source}",
+        f"- Baseline preparation: `{args.baseline_outcome}`",
+        f"- Comparison run: `{args.compare_outcome}`",
+    ]
+
+    if args.run_url:
+        lines.append(f"- Workflow run: [details]({args.run_url})")
+
+    if args.baseline_outcome != "success" or args.compare_outcome != "success":
+        lines.extend(
+            [
+                "",
+                "Benchmark execution did not complete cleanly, so the tables below may be partial.",
+            ]
+        )
+
+    lines.extend(["", "### Aggregate", ""])
+    lines.extend(render_table(aggregate))
+    lines.extend(
+        [
+            "",
+            f"Flagged aggregate regressions over +{REGRESSION_THRESHOLD:.1f}%: {len(flagged)}",
+        ]
+    )
+
+    if len(rows) > len(aggregate):
+        lines.extend(["", "<details>", "<summary>Per-fixture macro deltas</summary>", ""])
+        lines.extend(render_table(rows))
+        lines.extend(["", "</details>"])
+
+    if regressions or improvements:
+        lines.extend(["", "<details>", "<summary>Largest changes</summary>", ""])
+        if regressions:
+            lines.extend(["#### Regressions", ""])
+            lines.extend(render_table(regressions))
+            lines.append("")
+        if improvements:
+            lines.extend(["#### Improvements", ""])
+            lines.extend(render_table(improvements))
+            lines.append("")
+        lines.append("</details>")
+
+    if failed_rows:
+        lines.extend(["", "<details>", "<summary>Non-zero benchmark exit codes</summary>", ""])
+        for row in failed_rows:
+            lines.append(
+                "- `{case}` baseline exit codes: `{baseline_codes}`; head exit codes: `{head_codes}`".format(
+                    case=row.case,
+                    baseline_codes=format_exit_codes(row.baseline),
+                    head_codes=format_exit_codes(row.current),
+                )
+            )
+        lines.extend(["", "</details>"])
+
+    if not rows:
+        lines.extend(
+            [
+                "",
+                "No macro CLI comparison data was found under the benchmark export directories.",
+            ]
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    rows = collect_rows(args.baseline_dir, args.head_dir)
+    report = render_report(args, rows)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/macro_pr_report.py
+++ b/scripts/benchmarks/macro_pr_report.py
@@ -64,8 +64,20 @@ def load_macro_result(path: Path) -> MacroResult | None:
     if not results:
         return None
 
-    shuck = results[0]
     case = path.stem.removeprefix("bench-")
+    shuck = next(
+        (
+            candidate
+            for candidate in results
+            if str(candidate.get("command", "")).startswith("shuck/")
+        ),
+        None,
+    )
+    if shuck is None and len(results) == 1:
+        shuck = results[0]
+    if shuck is None:
+        return None
+
     return MacroResult(
         case=case,
         mean=float(shuck["mean"]),

--- a/scripts/benchmarks/run.sh
+++ b/scripts/benchmarks/run.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 set -eu
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
 fixtures_dir="$repo_root/crates/shuck-benchmark/resources/files"
-shuck="$repo_root/target/release/shuck"
-cache_dir="$repo_root/.cache"
+target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
+shuck=${SHUCK_BENCHMARK_SHUCK_BIN:-"$target_dir/release/shuck"}
+cache_dir=${SHUCK_BENCHMARK_OUTPUT_DIR:-"$repo_root/.cache"}
 
 mkdir -p "$cache_dir"
 

--- a/scripts/benchmarks/run.sh
+++ b/scripts/benchmarks/run.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
-fixtures_dir="$repo_root/crates/shuck-benchmark/resources/files"
+fixtures_dir=${SHUCK_BENCHMARK_FIXTURES_DIR:-"$repo_root/crates/shuck-benchmark/resources/files"}
 target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
 shuck=${SHUCK_BENCHMARK_SHUCK_BIN:-"$target_dir/release/shuck"}
 cache_dir=${SHUCK_BENCHMARK_OUTPUT_DIR:-"$repo_root/.cache"}

--- a/scripts/benchmarks/run.sh
+++ b/scripts/benchmarks/run.sh
@@ -6,31 +6,65 @@ fixtures_dir="$repo_root/crates/shuck-benchmark/resources/files"
 target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
 shuck=${SHUCK_BENCHMARK_SHUCK_BIN:-"$target_dir/release/shuck"}
 cache_dir=${SHUCK_BENCHMARK_OUTPUT_DIR:-"$repo_root/.cache"}
+benchmark_mode=${SHUCK_BENCHMARK_MODE:-compare}
 
 mkdir -p "$cache_dir"
 
 for file in "$fixtures_dir"/*.sh; do
     name=$(basename "$file" .sh)
     echo "==> Benchmarking: $name"
-    hyperfine \
-        --ignore-failure \
-        --warmup 3 \
-        --runs 10 \
-        --export-json "$cache_dir/bench-$name.json" \
-        -n "shuck/$name" "$shuck check --no-cache $file" \
-        -n "shellcheck/$name" "shellcheck --severity=style $file" \
-        -n "shellcheck-no-ext/$name" "shellcheck --severity=style --extended-analysis=false $file"
+    case "$benchmark_mode" in
+        compare)
+            hyperfine \
+                --ignore-failure \
+                --warmup 3 \
+                --runs 10 \
+                --export-json "$cache_dir/bench-$name.json" \
+                -n "shuck/$name" "$shuck check --no-cache $file" \
+                -n "shellcheck/$name" "shellcheck --severity=style $file" \
+                -n "shellcheck-no-ext/$name" "shellcheck --severity=style --extended-analysis=false $file"
+            ;;
+        shuck-only)
+            hyperfine \
+                --ignore-failure \
+                --warmup 3 \
+                --runs 10 \
+                --export-json "$cache_dir/bench-$name.json" \
+                -n "shuck/$name" "$shuck check --no-cache $file"
+            ;;
+        *)
+            echo "ERROR: unsupported SHUCK_BENCHMARK_MODE=$benchmark_mode" >&2
+            exit 1
+            ;;
+    esac
 done
 
 set -- "$fixtures_dir"/*.sh
 
 echo "==> Benchmarking: all"
-hyperfine \
-    --ignore-failure \
-    --warmup 3 \
-    --runs 10 \
-    --export-json "$cache_dir/bench-all.json" \
-    --export-markdown "$cache_dir/bench-all.md" \
-    -n "shuck/all" "$shuck check --no-cache $*" \
-    -n "shellcheck/all" "shellcheck --severity=style $*" \
-    -n "shellcheck-no-ext/all" "shellcheck --severity=style --extended-analysis=false $*"
+case "$benchmark_mode" in
+    compare)
+        hyperfine \
+            --ignore-failure \
+            --warmup 3 \
+            --runs 10 \
+            --export-json "$cache_dir/bench-all.json" \
+            --export-markdown "$cache_dir/bench-all.md" \
+            -n "shuck/all" "$shuck check --no-cache $*" \
+            -n "shellcheck/all" "shellcheck --severity=style $*" \
+            -n "shellcheck-no-ext/all" "shellcheck --severity=style --extended-analysis=false $*"
+        ;;
+    shuck-only)
+        hyperfine \
+            --ignore-failure \
+            --warmup 3 \
+            --runs 10 \
+            --export-json "$cache_dir/bench-all.json" \
+            --export-markdown "$cache_dir/bench-all.md" \
+            -n "shuck/all" "$shuck check --no-cache $*"
+        ;;
+    *)
+        echo "ERROR: unsupported SHUCK_BENCHMARK_MODE=$benchmark_mode" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/benchmarks/run_criterion.py
+++ b/scripts/benchmarks/run_criterion.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 
 
@@ -46,15 +46,36 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_bench_names(repo_root: Path) -> list[str]:
-    manifest_path = repo_root / "crates" / "shuck-benchmark" / "Cargo.toml"
-    data = tomllib.loads(manifest_path.read_text())
-    benches = [
-        bench["name"]
-        for bench in data.get("bench", [])
-        if isinstance(bench, dict) and isinstance(bench.get("name"), str)
-    ]
+    metadata = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--manifest-path",
+            str(repo_root / "Cargo.toml"),
+            "--format-version",
+            "1",
+            "--no-deps",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    payload = json.loads(metadata.stdout)
+    benches: list[str] = []
+
+    for package in payload.get("packages", []):
+        if package.get("name") != "shuck-benchmark":
+            continue
+        benches = [
+            target["name"]
+            for target in package.get("targets", [])
+            if "bench" in target.get("kind", []) and isinstance(target.get("name"), str)
+        ]
+        break
+
     if not benches:
-        raise SystemExit(f"no Criterion benches found in {manifest_path}")
+        raise SystemExit("no Criterion benches found in cargo metadata for shuck-benchmark")
     return benches
 
 

--- a/scripts/benchmarks/run_criterion.py
+++ b/scripts/benchmarks/run_criterion.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run all shuck Criterion benchmarks with an explicit baseline mode."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        required=True,
+        help="Path to the shuck repository checkout to benchmark.",
+    )
+
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--save-baseline",
+        metavar="NAME",
+        help="Save benchmark results into the named Criterion baseline.",
+    )
+    mode.add_argument(
+        "--baseline",
+        metavar="NAME",
+        help="Compare benchmark results against the named Criterion baseline.",
+    )
+
+    parser.add_argument(
+        "--package",
+        default="shuck-benchmark",
+        help="Cargo package that owns the Criterion benches.",
+    )
+    parser.add_argument(
+        "--noplot",
+        action="store_true",
+        help="Disable Criterion plot generation.",
+    )
+    return parser.parse_args()
+
+
+def load_bench_names(repo_root: Path) -> list[str]:
+    manifest_path = repo_root / "crates" / "shuck-benchmark" / "Cargo.toml"
+    data = tomllib.loads(manifest_path.read_text())
+    benches = [
+        bench["name"]
+        for bench in data.get("bench", [])
+        if isinstance(bench, dict) and isinstance(bench.get("name"), str)
+    ]
+    if not benches:
+        raise SystemExit(f"no Criterion benches found in {manifest_path}")
+    return benches
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    bench_names = load_bench_names(repo_root)
+
+    command = ["cargo", "bench", "-p", args.package]
+    for bench_name in bench_names:
+        command.extend(["--bench", bench_name])
+
+    command.append("--")
+    if args.save_baseline is not None:
+        command.append(f"--save-baseline={args.save_baseline}")
+    else:
+        command.append(f"--baseline={args.baseline}")
+
+    if args.noplot:
+        command.append("--noplot")
+
+    print(f"Repository: {repo_root}")
+    print(f"Benches: {', '.join(bench_names)}")
+    print(f"Command: {' '.join(command)}")
+    completed = subprocess.run(command, cwd=repo_root)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmarks/setup.sh
+++ b/scripts/benchmarks/setup.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -eu
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
+target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
+shuck=${SHUCK_BENCHMARK_SHUCK_BIN:-"$target_dir/release/shuck"}
 
 if [ "$#" -eq 0 ]; then
     set -- hyperfine shellcheck
@@ -19,7 +21,7 @@ for binary in "$@"; do
 done
 
 echo "Setup complete."
-echo "  shuck:      $("$repo_root/target/release/shuck" --version 2>/dev/null || echo 'built')"
+echo "  shuck:      $("${shuck}" --version 2>/dev/null || echo 'built')"
 for binary in "$@"; do
     case "$binary" in
         hyperfine)

--- a/scripts/benchmarks/test_macro_pr_report.py
+++ b/scripts/benchmarks/test_macro_pr_report.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from macro_pr_report import load_macro_result
+
+
+class MacroPrReportTests(unittest.TestCase):
+    def test_selects_shuck_result_by_command_name(self) -> None:
+        payload = {
+            "results": [
+                {
+                    "command": "shellcheck/all",
+                    "mean": 9.9,
+                    "stddev": 0.1,
+                    "min": 9.8,
+                    "max": 10.0,
+                    "exit_codes": [0],
+                },
+                {
+                    "command": "shuck/all",
+                    "mean": 1.2,
+                    "stddev": 0.05,
+                    "min": 1.1,
+                    "max": 1.3,
+                    "exit_codes": [1],
+                },
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "bench-all.json"
+            path.write_text(json.dumps(payload))
+
+            result = load_macro_result(path)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.case, "all")
+        self.assertEqual(result.mean, 1.2)
+        self.assertEqual(result.exit_codes, (1,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmarks/test_run.py
+++ b/scripts/benchmarks/test_run.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_SCRIPT = REPO_ROOT / "scripts" / "benchmarks" / "run.sh"
+
+
+class RunBenchmarkScriptTests(unittest.TestCase):
+    def test_fixture_override_controls_bench_corpus(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            repo_root = temp_root / "repo"
+            default_fixtures = repo_root / "crates" / "shuck-benchmark" / "resources" / "files"
+            override_fixtures = temp_root / "override-fixtures"
+            output_dir = temp_root / "out"
+            fake_bin = temp_root / "bin"
+            hyperfine_log = temp_root / "hyperfine.log"
+
+            default_fixtures.mkdir(parents=True)
+            override_fixtures.mkdir(parents=True)
+            output_dir.mkdir()
+            fake_bin.mkdir()
+
+            (default_fixtures / "repo-only.sh").write_text("#!/bin/sh\necho repo\n")
+            (override_fixtures / "override-only.sh").write_text("#!/bin/sh\necho override\n")
+
+            fake_hyperfine = fake_bin / "hyperfine"
+            fake_hyperfine.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    printf '%s\\n' "$*" >> "{hyperfine_log}"
+                    exit 0
+                    """
+                )
+            )
+            fake_hyperfine.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{fake_bin}:{env['PATH']}",
+                    "SHUCK_BENCHMARK_MODE": "shuck-only",
+                    "SHUCK_BENCHMARK_OUTPUT_DIR": str(output_dir),
+                    "SHUCK_BENCHMARK_REPO_ROOT": str(repo_root),
+                    "SHUCK_BENCHMARK_FIXTURES_DIR": str(override_fixtures),
+                }
+            )
+
+            subprocess.run(
+                ["sh", str(RUN_SCRIPT)],
+                check=True,
+                cwd=REPO_ROOT,
+                env=env,
+            )
+
+            log = hyperfine_log.read_text()
+            self.assertIn("override-only", log)
+            self.assertNotIn("repo-only", log)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated `benchmark report` CI job that benchmarks the PR base and head against a shared Criterion baseline
- generate a Markdown benchmark summary, upload the raw artifacts, and keep a sticky PR comment updated with the latest deltas
- reuse the same explicit Criterion bench runner for local `make bench-save` and `make bench-compare`

## Why
The benchmark comparison work is useful review context, but it should not block merges. Posting the deltas on the PR keeps the signal visible without turning benchmark noise or reporting failures into a hard gate.

## Impact
Reviewers get a stable PR comment showing aggregate benchmark deltas and the largest per-case changes, while local benchmark commands continue to use the same explicit baseline flow as CI.

## Validation
- `python3 -m py_compile scripts/benchmarks/run_criterion.py scripts/benchmarks/criterion_pr_report.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "ci.yaml ok"'`
- `git diff --check`
- rendered a synthetic Criterion report through `scripts/benchmarks/criterion_pr_report.py` to verify the Markdown output