### PR TITLE
Refine S001 safe-value flow analysis

### DIFF
--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -59,6 +59,7 @@ impl SafeValueQuery {
 
 pub struct SafeValueIndex<'a> {
     semantic: &'a SemanticModel,
+    analysis: &'a SemanticAnalysis<'a>,
     facts: &'a LinterFacts<'a>,
     source: &'a str,
     scalar_bindings: FxHashMap<FactSpan, &'a Word>,
@@ -82,6 +83,7 @@ impl<'a> SafeValueIndex<'a> {
 
         Self {
             semantic,
+            analysis,
             facts,
             source,
             scalar_bindings: facts.scalar_binding_values().clone(),
@@ -187,10 +189,14 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let Some(binding) = self.semantic.visible_binding(name, at) else {
+        let bindings = self.safe_bindings_for_name(name, at);
+        if bindings.is_empty() {
             return false;
-        };
-        self.binding_is_safe(binding.id, query)
+        }
+
+        bindings
+            .into_iter()
+            .all(|binding_id| self.binding_is_safe(binding_id, query))
     }
 
     fn binding_is_safe(&mut self, binding_id: BindingId, query: SafeValueQuery) -> bool {
@@ -241,15 +247,34 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let Some(binding) = self.semantic.visible_binding(&reference.name, at) else {
+        let bindings = self.safe_bindings_for_name(&reference.name, at);
+        if bindings.is_empty() {
             return false;
-        };
-        let targets = self.semantic.indirect_targets_for_binding(binding.id);
-        !targets.is_empty()
-            && targets
-                .iter()
-                .copied()
-                .all(|target| self.binding_is_safe(target, query))
+        }
+
+        bindings.into_iter().all(|binding_id| {
+            let targets = self.semantic.indirect_targets_for_binding(binding_id);
+            !targets.is_empty()
+                && targets
+                    .iter()
+                    .copied()
+                    .all(|target| self.binding_is_safe(target, query))
+        })
+    }
+
+    fn safe_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
+        let mut bindings = self.analysis.reaching_bindings_for_name(name, at);
+        if bindings.len() == 1 {
+            let mut expanded = self.analysis.visible_bindings_bypassing(name, bindings[0], at);
+            if !expanded.is_empty() {
+                expanded.push(bindings[0]);
+                expanded.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+                expanded.dedup();
+                bindings = expanded;
+            }
+        }
+
+        bindings
     }
 
     fn transformation_is_safe(
@@ -547,5 +572,83 @@ mod tests {
                 .iter()
                 .all(|word| !safe_values.word_is_safe(word, SafeValueQuery::Quoted))
         );
+    }
+
+    #[test]
+    fn conditional_safe_fallbacks_do_not_hide_unsafe_bindings() {
+        let source = "\
+#!/bin/bash
+foo=$(printf '%s' \"$1\")
+if [ \"$foo\" = \"\" ]; then foo=0; fi
+[ $foo -eq 1 ]
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let Command::Simple(command) = &output.file.body[2].command else {
+            panic!("expected simple test command");
+        };
+
+        assert!(!safe_values.word_is_safe(&command.args[0], SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn unconditional_safe_overwrites_stay_safe() {
+        let source = "\
+#!/bin/bash
+foo=$(printf '%s' \"$1\")
+foo=0
+[ $foo -eq 1 ]
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let Command::Simple(command) = &output.file.body[2].command else {
+            panic!("expected simple test command");
+        };
+
+        assert!(safe_values.word_is_safe(&command.args[0], SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_arm_safe_overwrites_stay_safe() {
+        let source = "\
+#!/bin/bash
+foo=$BAR
+case $1 in
+    settings)
+        foo=0
+        [ $foo -eq 1 ]
+        ;;
+esac
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let Command::Compound(shuck_ast::CompoundCommand::Case(case_command)) =
+            &output.file.body[1].command
+        else {
+            panic!("expected case command");
+        };
+        let Command::Simple(command) = &case_command.cases[0].body[1].command else {
+            panic!("expected simple test command");
+        };
+
+        assert!(safe_values.word_is_safe(&command.args[0], SafeValueQuery::Argv));
     }
 }

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -265,10 +265,13 @@ impl<'a> SafeValueIndex<'a> {
     fn safe_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
         let mut bindings = self.analysis.reaching_bindings_for_name(name, at);
         if bindings.len() == 1 {
-            let mut expanded = self.analysis.visible_bindings_bypassing(name, bindings[0], at);
+            let mut expanded = self
+                .analysis
+                .visible_bindings_bypassing(name, bindings[0], at);
             if !expanded.is_empty() {
                 expanded.push(bindings[0]);
-                expanded.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+                expanded
+                    .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
                 expanded.dedup();
                 bindings = expanded;
             }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -421,6 +421,80 @@ if [ $x -eq 0 ]; then :; fi
     }
 
     #[test]
+    fn reports_conditionally_sanitized_test_operands() {
+        let source = "\
+#!/bin/bash
+foo=$BAR
+if [ \"$foo\" = \"\" ]; then
+  foo=0
+fi
+if [ $foo -eq 1 ]; then :; fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$foo"]
+        );
+    }
+
+    #[test]
+    fn skips_straight_line_safe_overwrites_in_test_operands() {
+        let source = "\
+#!/bin/bash
+foo=$BAR
+foo=0
+if [ $foo -eq 1 ]; then :; fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_case_arm_safe_overwrites_in_test_operands() {
+        let source = "\
+#!/bin/bash
+foo=$BAR
+case $1 in
+  settings)
+    foo=0
+    if [ $foo -eq 1 ]; then :; fi
+    ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_case_arm_safe_overwrites_even_with_nested_conditional_updates() {
+        let source = "\
+#!/bin/bash
+foo=$BAR
+case $1 in
+  settings)
+    foo=1
+    while [ $# -gt 1 ]; do
+      shift
+      case $1 in
+        --no) foo=0 ;;
+      esac
+    done
+    if [ $foo -eq 1 ]; then :; fi
+    ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_safe_indirect_and_transformed_bindings() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -34,6 +34,7 @@ pub(crate) struct BuildOutput {
     pub(crate) scopes: Vec<Scope>,
     pub(crate) bindings: Vec<Binding>,
     pub(crate) references: Vec<Reference>,
+    pub(crate) reference_index: FxHashMap<Name, Vec<ReferenceId>>,
     pub(crate) predefined_runtime_refs: FxHashSet<ReferenceId>,
     pub(crate) guarded_parameter_refs: FxHashSet<ReferenceId>,
     pub(crate) binding_index: FxHashMap<Name, Vec<BindingId>>,
@@ -60,6 +61,7 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     scopes: Vec<Scope>,
     bindings: Vec<Binding>,
     references: Vec<Reference>,
+    reference_index: FxHashMap<Name, Vec<ReferenceId>>,
     predefined_runtime_refs: FxHashSet<ReferenceId>,
     guarded_parameter_refs: FxHashSet<ReferenceId>,
     binding_index: FxHashMap<Name, Vec<BindingId>>,
@@ -129,6 +131,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             scopes: vec![file_scope],
             bindings: Vec::new(),
             references: Vec::new(),
+            reference_index: FxHashMap::default(),
             predefined_runtime_refs: FxHashSet::default(),
             guarded_parameter_refs: FxHashSet::default(),
             binding_index: FxHashMap::default(),
@@ -165,6 +168,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             scopes: builder.scopes,
             bindings: builder.bindings,
             references: builder.references,
+            reference_index: builder.reference_index,
             predefined_runtime_refs: builder.predefined_runtime_refs,
             guarded_parameter_refs: builder.guarded_parameter_refs,
             binding_index: builder.binding_index,
@@ -2381,6 +2385,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             scope,
             span,
         });
+        self.reference_index
+            .entry(name.clone())
+            .or_default()
+            .push(id);
         if self.guarded_parameter_operand_depth > 0 {
             self.guarded_parameter_refs.insert(id);
         }

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -116,6 +116,38 @@ impl ExactVariableDataflow {
             )
         })
     }
+
+    pub(crate) fn reaching_bindings_for_reference(
+        &self,
+        context: &DataflowContext<'_>,
+        reference: &Reference,
+    ) -> Vec<BindingId> {
+        let Some(block_id) = self.reference_blocks[reference.id.index()] else {
+            return Vec::new();
+        };
+        if self.unreachable_blocks.contains(block_id.index()) {
+            return Vec::new();
+        }
+
+        let Some(name_id) = self.names.get(&reference.name) else {
+            return Vec::new();
+        };
+        let incoming = &self.reaching_definitions(context).reaching_in[block_id.index()];
+
+        self.binding_data.bindings_for_name[name_id.index()]
+            .iter_ones()
+            .filter(|binding_index| incoming.contains(*binding_index))
+            .map(|binding_index| BindingId(binding_index as u32))
+            .collect()
+    }
+
+    pub(crate) fn binding_block(&self, binding_id: BindingId) -> Option<BlockId> {
+        self.binding_blocks[binding_id.index()]
+    }
+
+    pub(crate) fn reference_block(&self, reference: &Reference) -> Option<BlockId> {
+        self.reference_blocks[reference.id.index()]
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -277,6 +277,7 @@ pub struct SemanticModel {
     scope_lookup: ScopeLookup,
     bindings: Vec<Binding>,
     references: Vec<Reference>,
+    reference_index: FxHashMap<Name, Vec<ReferenceId>>,
     predefined_runtime_refs: FxHashSet<ReferenceId>,
     guarded_parameter_refs: FxHashSet<ReferenceId>,
     binding_index: FxHashMap<Name, Vec<BindingId>>,
@@ -329,6 +330,12 @@ impl SemanticModel {
     }
 
     fn from_build_output(built: builder::BuildOutput) -> Self {
+        let mut reference_index = built.reference_index;
+        for reference_ids in reference_index.values_mut() {
+            reference_ids.sort_by_key(|reference_id| {
+                built.references[reference_id.index()].span.start.offset
+            });
+        }
         let indirect_targets_by_binding =
             build_indirect_targets_by_binding(&built.bindings, &built.indirect_target_hints);
         let indirect_targets_by_reference = build_indirect_targets_by_reference(
@@ -350,6 +357,7 @@ impl SemanticModel {
             scope_lookup,
             bindings: built.bindings,
             references: built.references,
+            reference_index,
             predefined_runtime_refs: built.predefined_runtime_refs,
             guarded_parameter_refs: built.guarded_parameter_refs,
             binding_index: built.binding_index,
@@ -897,15 +905,27 @@ impl<'model> SemanticAnalysis<'model> {
     }
 
     fn reference_for_name_at(&self, name: &Name, at: Span) -> Option<&Reference> {
-        self.model.references.iter().find(|reference| {
-            reference.name == *name
-                && reference.span.start.offset >= at.start.offset
-                && reference.span.end.offset <= at.end.offset
-                && !matches!(
-                    reference.kind,
-                    ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
-                )
-        })
+        let references = self.model.reference_index.get(name)?;
+        let first_candidate = references.partition_point(|reference_id| {
+            self.model.references[reference_id.index()]
+                .span
+                .start
+                .offset
+                < at.start.offset
+        });
+
+        references[first_candidate..]
+            .iter()
+            .find_map(|reference_id| {
+                let reference = &self.model.references[reference_id.index()];
+                (reference.span.start.offset >= at.start.offset
+                    && reference.span.end.offset <= at.end.offset
+                    && !matches!(
+                        reference.kind,
+                        ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
+                    ))
+                .then_some(reference)
+            })
     }
 
     pub fn reaching_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
@@ -3164,6 +3184,39 @@ f
             .collect::<Vec<_>>();
         assert!(!unused.contains(&"IFS"));
         assert!(unused.contains(&"unused"));
+    }
+
+    #[test]
+    fn reaching_bindings_lookup_picks_later_same_name_reference() {
+        let source = "\
+#!/bin/bash
+foo=1
+printf '%s\\n' \"$foo\"
+foo=2
+printf '%s\\n' \"$foo\"
+";
+        let model = model(source);
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| {
+                binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment)
+            })
+            .map(|binding| binding.id)
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 2);
+
+        let target_reference = model
+            .references()
+            .iter()
+            .rev()
+            .find(|reference| reference.name == "foo")
+            .expect("expected foo reference");
+        let reaching = model
+            .analysis()
+            .reaching_bindings_for_name(&target_reference.name, target_reference.span);
+
+        assert_eq!(reaching, vec![foo_bindings[1]]);
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -455,6 +455,15 @@ impl SemanticModel {
         None
     }
 
+    #[doc(hidden)]
+    pub fn binding_visible_at(&self, binding_id: BindingId, at: Span) -> bool {
+        let binding = self.binding(binding_id);
+        binding.span.start.offset <= at.start.offset
+            && self
+                .ancestor_scopes(self.scope_at(at.start.offset))
+                .any(|scope| scope == binding.scope)
+    }
+
     pub fn defined_anywhere(&self, name: &Name) -> bool {
         self.binding_index.contains_key(name)
     }
@@ -887,6 +896,81 @@ impl<'model> SemanticAnalysis<'model> {
             .as_slice()
     }
 
+    fn reference_for_name_at(&self, name: &Name, at: Span) -> Option<&Reference> {
+        self.model.references.iter().find(|reference| {
+            reference.name == *name
+                && reference.span.start.offset >= at.start.offset
+                && reference.span.end.offset <= at.end.offset
+                && !matches!(
+                    reference.kind,
+                    ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
+                )
+        })
+    }
+
+    pub fn reaching_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
+        let cfg = self.cfg();
+        let context = self.model.dataflow_context(cfg);
+        let exact = self.exact_variable_dataflow();
+
+        if let Some(reference) = self.reference_for_name_at(name, at) {
+            let reaching = exact.reaching_bindings_for_reference(&context, reference);
+            if !reaching.is_empty() {
+                return reaching;
+            }
+        }
+
+        self.model
+            .visible_binding(name, at)
+            .map(|binding| vec![binding.id])
+            .unwrap_or_default()
+    }
+
+    #[doc(hidden)]
+    pub fn visible_bindings_bypassing(
+        &self,
+        name: &Name,
+        binding_id: BindingId,
+        at: Span,
+    ) -> Vec<BindingId> {
+        let cfg = self.cfg();
+        let exact = self.exact_variable_dataflow();
+        let Some(reference) = self.reference_for_name_at(name, at) else {
+            return Vec::new();
+        };
+        let Some(reference_block) = exact.reference_block(reference) else {
+            return Vec::new();
+        };
+        let Some(binding_block) = exact.binding_block(binding_id) else {
+            return Vec::new();
+        };
+        if reference_block == binding_block {
+            return Vec::new();
+        }
+
+        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        if unreachable.contains(&reference_block) || unreachable.contains(&binding_block) {
+            return Vec::new();
+        }
+
+        self.model
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter(|other_binding| *other_binding != binding_id)
+            .filter(|other_binding| self.model.binding_visible_at(*other_binding, at))
+            .filter_map(|other_binding| {
+                exact
+                    .binding_block(other_binding)
+                    .filter(|other_block| !unreachable.contains(other_block))
+                    .filter(|other_block| {
+                        block_reaches_without(cfg, *other_block, reference_block, binding_block)
+                    })
+                    .map(|_| other_binding)
+            })
+            .collect()
+    }
+
     pub fn dead_code(&self) -> &[DeadCode] {
         self.dead_code
             .get_or_init(|| dataflow::analyze_dead_code(self.cfg()))
@@ -1302,6 +1386,34 @@ fn blocks_have_path(
             .copied()
             .any(|end| reachability.reaches(start, end))
     })
+}
+
+fn block_reaches_without(
+    cfg: &ControlFlowGraph,
+    start: BlockId,
+    end: BlockId,
+    avoided: BlockId,
+) -> bool {
+    if start == avoided {
+        return false;
+    }
+
+    let mut visited = FxHashSet::default();
+    let mut stack = vec![start];
+
+    while let Some(block) = stack.pop() {
+        if block == avoided || !visited.insert(block) {
+            continue;
+        }
+        if block == end {
+            return true;
+        }
+        for (successor, _) in cfg.successors(block) {
+            stack.push(*successor);
+        }
+    }
+
+    false
 }
 
 struct ReachabilityCache<'a> {


### PR DESCRIPTION
## Summary
- refine S001 safe-value lookup to use reaching bindings instead of trusting the nearest visible binding
- widen safe-value analysis only when an earlier visible binding can still reach the reference by bypassing the chosen binding
- add regressions for conditional sanitization misses and safe `case`-arm overwrites

## Why
The root cause was that S001 treated a conditionally assigned numeric fallback as if it dominated later test operands. That let a safe branch-local overwrite hide an earlier unsafe value and suppressed real unquoted-expansion reports.

## Impact
- restores missed S001 diagnostics for conditionally sanitized test operands
- preserves safe straight-line and `case`-arm overwrites
- improves the targeted S001 corpus run from 10518 to 10490 compatibility blockers

## Validation
- `cargo test -p shuck-linter safe_value`
- `cargo test -p shuck-linter unquoted_expansion`
- `make test`
- `cargo test --workspace`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001`
