### PR TITLE
Align S047 with ShellCheck SC2012 behavior

### DIFF
--- a/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
@@ -1,3 +1,5 @@
+use shuck_ast::Span;
+
 use crate::{Checker, CommandSubstitutionKind, Rule, ShellDialect, Violation};
 
 pub struct LsInSubstitution;
@@ -26,15 +28,83 @@ pub fn ls_in_substitution(checker: &mut Checker) {
         .commands()
         .iter()
         .flat_map(|fact| fact.substitution_facts().iter())
-        .filter(|substitution| {
-            substitution.kind() == CommandSubstitutionKind::Command
-                && substitution.body_contains_ls()
-                && substitution.stdout_is_captured()
+        .flat_map(|substitution| {
+            (substitution.kind() == CommandSubstitutionKind::Command
+                && substitution.stdout_is_captured())
+            .then(|| processed_ls_pipeline_spans(checker, substitution.span()))
+            .into_iter()
+            .flatten()
         })
-        .map(|substitution| substitution.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || LsInSubstitution);
+}
+
+fn processed_ls_pipeline_spans(checker: &Checker, substitution_span: Span) -> Vec<Span> {
+    checker
+        .facts()
+        .pipelines()
+        .iter()
+        .filter(|pipeline| span_contains(substitution_span, pipeline.span()))
+        .flat_map(|pipeline| {
+            pipeline
+                .segments()
+                .windows(2)
+                .enumerate()
+                .filter_map(|(index, pair)| {
+                    (left_segment_is_s047_ls_candidate(checker, pair[0].command_id())
+                        && !matches!(pair[1].static_utility_name(), Some("grep" | "xargs")))
+                    .then(|| pipeline_ls_command_span(checker, pipeline, index))
+                })
+        })
+        .collect()
+}
+
+fn left_segment_is_s047_ls_candidate(
+    checker: &Checker,
+    command_id: crate::facts::CommandId,
+) -> bool {
+    let command = checker.facts().command(command_id);
+
+    command.literal_name() == Some("ls")
+        && command.wrappers().is_empty()
+        && !command_has_leading_glob_operand(checker, command)
+}
+
+fn pipeline_ls_command_span(
+    checker: &Checker,
+    pipeline: &crate::PipelineFact<'_>,
+    segment_index: usize,
+) -> Span {
+    let command = checker
+        .facts()
+        .command(pipeline.segments()[segment_index].command_id());
+    let span = Span {
+        start: command.span_in_source(checker.source()).start,
+        end: pipeline.operators()[segment_index].span().start,
+    };
+
+    trim_trailing_whitespace(span, checker.source())
+}
+
+fn span_contains(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+}
+
+fn command_has_leading_glob_operand(checker: &Checker, command: &crate::CommandFact<'_>) -> bool {
+    command
+        .file_operand_words()
+        .first()
+        .and_then(|word| word.span.slice(checker.source()).chars().next())
+        .is_some_and(|ch| matches!(ch, '*' | '?' | '['))
+}
+
+fn trim_trailing_whitespace(span: Span, source: &str) -> Span {
+    let trimmed = span.slice(source).trim_end();
+    Span {
+        start: span.start,
+        end: span.start.advanced_by(trimmed),
+    }
 }
 
 #[cfg(test)]
@@ -43,7 +113,7 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_raw_ls_command_substitutions() {
+    fn reports_processed_ls_command_substitutions() {
         let source = "\
 #!/bin/bash
 LAYOUTS=\"$(ls layout.*.h | cut -d. -f2 | xargs echo)\"
@@ -51,10 +121,7 @@ LAYOUTS=\"$(ls layout.*.h | cut -d. -f2 | xargs echo)\"
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LsInSubstitution));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].span.slice(source),
-            "$(ls layout.*.h | cut -d. -f2 | xargs echo)"
-        );
+        assert_eq!(diagnostics[0].span.slice(source), "ls layout.*.h");
     }
 
     #[test]
@@ -64,9 +131,34 @@ LAYOUTS=\"$(ls layout.*.h | cut -d. -f2 | xargs echo)\"
 plain=\"$(command ls)\"
 quiet=\"$(ls >/dev/null)\"
 empty=\"$(printf foo)\"
+bare=\"$(ls)\"
+grep=\"$(ls | grep foo)\"
+escaped_grep=\"$(ls | \\grep foo)\"
+wrapped=\"$(command ls /tmp | head -n 1)\"
+globbed=\"$(ls *.html | xargs -I% basename % | head -1)\"
+xargs_only=\"$(ls /tmp | xargs -n 1 basename)\"
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LsInSubstitution));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_ls_pipelines_with_non_grep_consumers() {
+        let source = "\
+#!/bin/sh
+count=\"$(ls | wc -l)\"
+legacy=\"$(ls | egrep foo)\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LsInSubstitution));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["ls", "ls"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
@@ -51,11 +51,11 @@ fn processed_ls_pipeline_spans(checker: &Checker, substitution_span: Span) -> Ve
                 .segments()
                 .windows(2)
                 .enumerate()
-                .filter_map(|(index, pair)| {
-                    (left_segment_is_s047_ls_candidate(checker, pair[0].command_id())
-                        && !matches!(pair[1].static_utility_name(), Some("grep" | "xargs")))
-                    .then(|| pipeline_ls_command_span(checker, pipeline, index))
+                .filter(|(_, pair)| {
+                    left_segment_is_s047_ls_candidate(checker, pair[0].command_id())
+                        && !matches!(pair[1].static_utility_name(), Some("grep" | "xargs"))
                 })
+                .map(|(index, _)| pipeline_ls_command_span(checker, pipeline, index))
         })
         .collect()
 }

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S047_S047.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S047_S047.sh.snap
@@ -3,7 +3,7 @@ source: crates/shuck-linter/src/rules/style/mod.rs
 assertion_line: 90
 ---
 S047 avoid capturing `ls` output in command substitutions; use a glob or `find` instead
- --> <source>:2:10
+ --> <source>:2:12
   |
 2 | LAYOUTS="$(ls layout.*.h | cut -d. -f2 | xargs echo)"
   |

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -121,9 +121,6 @@ impl ShellCheckCodeMap {
         if number == 2293 {
             return vec![Rule::LsPipedToXargs];
         }
-        if number == 2294 {
-            return vec![Rule::LsInSubstitution, Rule::EvalOnArray];
-        }
         if number == 2281 {
             return vec![Rule::BackslashBeforeClosingBacktick];
         }
@@ -195,7 +192,8 @@ impl Default for ShellCheckCodeMap {
             (2009, Rule::PsGrepPipeline),
             (2010, Rule::LsGrepPipeline),
             (2293, Rule::LsPipedToXargs),
-            (2294, Rule::LsInSubstitution),
+            // ShellCheck 0.11.0 reports processed `ls` command substitutions as SC2012.
+            (2012, Rule::LsInSubstitution),
             (2263, Rule::RedundantSpacesInEcho),
             // ShellCheck 0.11.0 reports stderr-before-stdout redirect ordering as SC2069.
             // Keep SC2306 as the authored suppression code and compare against the live code.
@@ -698,7 +696,7 @@ impl Default for ShellCheckCodeMap {
                     (2199, Rule::ArraySliceInComparison),
                     (2124, Rule::QuotedArraySlice),
                     (2128, Rule::QuotedBashSource),
-                    (2294, Rule::LsInSubstitution),
+                    (2012, Rule::LsInSubstitution),
                     (2291, Rule::UnquotedVariableInSed),
                     (2026, Rule::UnquotedWordBetweenQuotes),
                     (2027, Rule::DoubleQuoteNesting),
@@ -936,8 +934,6 @@ impl Default for ShellCheckCodeMap {
                 (3072, Rule::CaretNegationInBracket),
                 (3033, Rule::HyphenatedFunctionName),
                 (2009, Rule::DoubleParenGrouping),
-                (2294, Rule::LsInSubstitution),
-                (2294, Rule::EvalOnArray),
                 (2069, Rule::StderrBeforeStdoutRedirect),
                 (2373, Rule::CaseGlobReachability),
                 (2374, Rule::CaseDefaultBeforeGlob),
@@ -1058,7 +1054,8 @@ mod tests {
         );
         assert_eq!(map.resolve("SC2094"), Some(Rule::RedirectClobbersInput));
         assert_eq!(map.resolve("SC2293"), Some(Rule::LsPipedToXargs));
-        assert_eq!(map.resolve("SC2294"), Some(Rule::LsInSubstitution));
+        assert_eq!(map.resolve("SC2012"), Some(Rule::LsInSubstitution));
+        assert_eq!(map.resolve("SC2294"), Some(Rule::EvalOnArray));
         assert_eq!(map.resolve("SC2048"), Some(Rule::UnquotedDollarStar));
         assert_eq!(map.resolve("2048"), Some(Rule::UnquotedDollarStar));
         assert_eq!(map.resolve("SC2198"), Some(Rule::AtSignInStringCompare));
@@ -1180,7 +1177,8 @@ mod tests {
         assert_eq!(map.resolve_all("SC2128"), vec![Rule::QuotedBashSource]);
         assert_eq!(map.resolve_all("SC2327"), vec![Rule::QuotedBashSource]);
         assert_eq!(map.resolve("SC2293"), Some(Rule::LsPipedToXargs));
-        assert_eq!(map.resolve("SC2294"), Some(Rule::LsInSubstitution));
+        assert_eq!(map.resolve("SC2012"), Some(Rule::LsInSubstitution));
+        assert_eq!(map.resolve("SC2294"), Some(Rule::EvalOnArray));
         assert_eq!(map.resolve("SC2144"), Some(Rule::GlobInTestDirectory));
         assert_eq!(map.resolve("SC2166"), Some(Rule::CompoundTestOperator));
         assert_eq!(map.resolve("SC2331"), Some(Rule::AFlagInDoubleBracket));
@@ -1269,10 +1267,8 @@ mod tests {
             vec![Rule::BacktickOutputToCommand]
         );
         assert_eq!(map.resolve_all("SC2293"), vec![Rule::LsPipedToXargs]);
-        assert_eq!(
-            map.resolve_all("SC2294"),
-            vec![Rule::LsInSubstitution, Rule::EvalOnArray]
-        );
+        assert_eq!(map.resolve_all("SC2012"), vec![Rule::LsInSubstitution]);
+        assert_eq!(map.resolve_all("SC2294"), vec![Rule::EvalOnArray]);
         assert_eq!(map.resolve_all("SC2048"), vec![Rule::UnquotedDollarStar]);
         assert_eq!(map.resolve_all("2048"), vec![Rule::UnquotedDollarStar]);
         assert_eq!(map.resolve_all("SC2263"), vec![Rule::RedundantSpacesInEcho]);
@@ -1805,7 +1801,7 @@ mod tests {
             (2306, Rule::StderrBeforeStdoutRedirect),
             (2358, Rule::RedirectBeforePipe),
             (2293, Rule::LsPipedToXargs),
-            (2294, Rule::LsInSubstitution),
+            (2012, Rule::LsInSubstitution),
             (2263, Rule::RedundantSpacesInEcho),
             (2069, Rule::StderrBeforeStdoutRedirect),
             (2317, Rule::RedirectClobbersInput),
@@ -2224,7 +2220,7 @@ mod tests {
         assert!(comparison.contains(&(2341, Rule::ConstantInTestAssignment)));
         assert!(comparison.contains(&(2360, Rule::ExprSubstrInTest)));
         assert!(comparison.contains(&(2293, Rule::LsPipedToXargs)));
-        assert!(comparison.contains(&(2294, Rule::LsInSubstitution)));
+        assert!(comparison.contains(&(2012, Rule::LsInSubstitution)));
         assert!(comparison.contains(&(2265, Rule::RedundantReturnStatus)));
         assert!(comparison.contains(&(2276, Rule::FunctionBodyWithoutBraces)));
         assert!(comparison.contains(&(2362, Rule::LocalDeclareCombined)));

--- a/crates/shuck/tests/testdata/corpus-metadata/s047.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s047.yaml
@@ -1,94 +1,77 @@
 reviewed_divergences:
   - side: shellcheck-only
-    path_suffix: "megastep__makeself__test__appendtest"
-    reason: "ShellCheck 0.11.0 also uses SC2294 for the unrelated eval-on-array family on this shared code path, while Shuck intentionally keeps S047 focused on raw `ls` command substitutions."
+    path_suffix: "SlackBuildsOrg__slackbuilds__desktop__luna-wallpapers__luna-wallpapers.SlackBuild"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
   - side: shellcheck-only
-    path_suffix: "pyenv__pyenv__pyenv.d__rehash__conda.bash"
-    reason: "ShellCheck 0.11.0 also uses SC2294 for the unrelated eval-on-array family on this shared code path, while Shuck intentionally keeps S047 focused on raw `ls` command substitutions."
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__netqmail__tests__makechroot"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
   - side: shellcheck-only
-    path_suffix: "pyenv__pyenv__pyenv.d__rehash__source.bash"
-    reason: "ShellCheck 0.11.0 also uses SC2294 for the unrelated eval-on-array family on this shared code path, while Shuck intentionally keeps S047 focused on raw `ls` command substitutions."
+    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
+    reason: "These remaining SC2012 sites are process-substitution `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
   - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__extras__rails"
-    reason: "ShellCheck 0.11.0 also uses SC2294 for the unrelated eval-on-array family on this shared code path, while Shuck intentionally keeps S047 focused on raw `ls` command substitutions."
-  - side: shuck-only
-    path_suffix: "acmesh-official__acme.sh__deploy__unifi.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "asdf-vm__asdf__lib__utils.bash"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "bats-core__bats-core__bin__bats"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "nvm-sh__nvm__install.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "pi-hole__pi-hole__advanced__Scripts__piholeDebug.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "rbenv__rbenv__libexec__rbenv-init"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__base_install"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__emscripten__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__glib__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__libsoldout__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__opencl-vendor-driver__postinst.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__parallel__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__pypy3__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__pypy__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-build__mybuild.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "bittorf__kalua__openwrt-monitoring__backup_this_server.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "bittorf__kalua__openwrt-monitoring__compress_vds_files.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "bittorf__kalua__openwrt-monitoring__crashlog_build_html.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__ct__zigbee2mqtt.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__infra__base-images__base-builder__compile_afl"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__docker-client__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__freeradius__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__go-coredns__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__keystone__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__libpcap__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__mysql-server__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__ngolo-fuzzing-x__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__openweave__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__suricata__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__unicorn__build.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "leebaird__discover__newModules.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__rust__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__root-packages__docker__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__scripts__build-bootstraps.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__scripts__build__termux_step_setup_cgct_environment.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__carbonyl-host-tools__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__carbonyl__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__chromium-host-tools__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__chromium__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__electron-for-code-oss__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__electron-host-tools-for-code-oss__build.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__qt5-qmake__termux-build-qmake.sh"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__srcpkgs__u-boot-menu__files__kernel.d__extlinux"
-    reason: "ShellCheck 0.11.0 does not report SC2294 for this repo-authored S047 shape in this helper, but Shuck intentionally flags the raw `ls` captured in command substitution."
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__build__termux_step_massage.sh"
+    line: 170
+    reason: "This SC2012 site appears in an array-subscript command substitution, which the current S047 corpus comparison keeps out of scope while the rule stays focused on direct processed-output substitutions."
+  - side: shellcheck-only
+    path_suffix: "void-linux__void-packages__srcpkgs__sbsigntool__files__kernel.d__sbsigntool.post-install"
+    reason: "These remaining SC2012 sites are plain `ls` pipelines outside command substitution, while S047 is intentionally scoped to processed `ls` inside command substitutions."

--- a/docs/rules/S047.yaml
+++ b/docs/rules/S047.yaml
@@ -3,7 +3,7 @@ legacy_name: ls-in-substitution
 new_category: Style
 new_code: S047
 runtime_kind: ast
-shellcheck_code: SC2294
+shellcheck_code: SC2012
 shells:
   - sh
   - bash


### PR DESCRIPTION
## What changed
- aligned `S047` with the live ShellCheck oracle by remapping it from `SC2294` to `SC2012`
- narrowed `S047` to processed `ls` output inside command substitutions and anchored reports on the inner `ls` segment
- excluded adjacent shapes that ShellCheck routes to other rules, including wrapped `ls`, `ls | grep`, `ls | xargs`, and leading-glob operand cases
- refreshed `s047` corpus metadata for remaining reviewed `SC2012` divergences outside this rule's command-substitution scope

## Why
`S047` had drifted from current ShellCheck behavior. The rule was still comparing against `SC2294`, which ShellCheck 0.11.0 now uses for the eval-on-array family, while the real `ls`-in-substitution warning family compares under `SC2012`.

## Impact
This keeps `S047` focused on its intended behavior, improves span anchoring, and removes false positives from neighboring warning families during large-corpus conformance runs.

## Root cause
The compatibility mapping and rule shape were both stale relative to the current oracle: the ShellCheck code bucket changed, and Shuck was still reporting some broader `ls` pipeline forms that ShellCheck classifies elsewhere or outside this rule's scope.

## Validation
- `cargo test -p shuck-linter ls_in_substitution -- --nocapture`
- `cargo test -p shuck-linter shellcheck_map -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_RULES=S047 ... cargo test -p shuck --test large_corpus large_corpus_conforms_with_shellcheck -- --ignored --nocapture`
