### PR TITLE
Document the no-walking-or-parsing rule for lint rules

### DIFF
--- a/.claude/skills/fix-rule/SKILL.md
+++ b/.claude/skills/fix-rule/SKILL.md
@@ -18,6 +18,35 @@ judgment call on every delta is: **is ShellCheck right or is shuck right?** When
 shuck is wrong, the fix belongs at whatever layer actually caused the problem —
 not hacked into the rule just to satisfy the oracle.
 
+## The hard architectural constraint
+
+Before you change anything, internalize this: **rule files in
+`crates/shuck-linter/src/rules/` must not parse, scan, or walk anything.**
+They are cheap filters over precomputed facts and semantic data. All
+structural discovery lives in lower layers:
+
+- Tokenizing/parsing source → `crates/shuck-parser`
+- Bindings, references, scopes, CFG, dataflow → `crates/shuck-semantic`
+- Normalized commands, words, redirects, tests, pipelines, loops, surface
+  fragments, etc. → `crates/shuck-linter/src/facts.rs` and `src/facts/`
+
+Rule files **must not**:
+
+- Walk or recurse through AST nodes (no `walk_commands`, `iter_commands`,
+  manual child recursion).
+- Re-parse or re-scan `checker.source()` to discover shell structure.
+- Normalize commands, classify words/tests/redirects, parse command options,
+  or otherwise recompute what the fact builder is responsible for.
+- Import from `crate::rules::common::*` (rule-facing types come from the
+  crate root or a rule-local helper module).
+- Reference AST traversal types blocked by the architecture test in
+  `src/rules/mod.rs` (`WordPart`, `ConditionalExpr`, `iter_commands`,
+  `query::`, etc.).
+
+If a fix tempts you to do any of those things in the rule file, **stop and
+push the work down a layer.** See `crates/shuck-linter/AGENTS.md` for the full
+contract.
+
 ## Before you start
 
 Read these files to understand the rule and its current state:
@@ -27,6 +56,7 @@ Read these files to understand the rule and its current state:
 3. The rule's facts (if any): `crates/shuck-linter/src/facts.rs` — search for the rule name
 4. The bug document (if one exists): `docs/bugs/CXXX.md`
 5. Existing corpus-metadata (if any): `crates/shuck/tests/testdata/corpus-metadata/cXXX.yaml`
+6. The linter architecture contract: `crates/shuck-linter/AGENTS.md`
 
 ## Step 1: Set up the worktree
 
@@ -121,7 +151,9 @@ nix --extra-experimental-features 'nix-command flakes' develop --command \
 
 This is the most important part. Fixing at the wrong layer creates tech debt
 that compounds — a hack in the rule to work around a parser bug means every
-future rule hitting the same construct will need the same hack.
+future rule hitting the same construct will need the same hack. **And rules
+are not allowed to compensate for missing structural data by walking or
+parsing themselves** (see "The hard architectural constraint" above).
 
 ### Identify the layer
 
@@ -142,31 +174,54 @@ Symptoms: bindings/references are wrong, scope assignment is off, def-use
 chains miss a connection. The AST is correct but the semantic analysis
 misinterprets it. Check by querying the semantic model directly.
 
-**Layer 4 — Fact generation** (`crates/shuck-linter/src/facts.rs`)
+**Layer 4 — Fact generation** (`crates/shuck-linter/src/facts.rs` and
+`src/facts/`)
 Symptoms: the semantic model is correct but the linter-level facts derived
 from it are wrong. A test fact misclassifies an operand, a command fact
-normalizes incorrectly. Check by inspecting the facts for the failing fixture.
+normalizes incorrectly, a needed structural summary doesn't exist yet. Check
+by inspecting the facts for the failing fixture. **If a rule needs structural
+data that no fact exposes, the fix is to add the fact here — not to walk the
+AST in the rule.**
 
 **Layer 5 — Rule implementation** (`crates/shuck-linter/src/rules/`)
-Symptoms: the facts are correct but the rule's filtering logic has a gap. It
-reports a violation where it shouldn't (missing filter) or misses one it
-should catch (incomplete matching). This is the only layer where the fix
-belongs in the rule file itself.
+Symptoms: the facts are correct but the rule's filtering predicate has a gap.
+It reports a violation where it shouldn't (missing filter) or misses one it
+should catch (incomplete matching over correct facts). This is the only layer
+where the fix belongs in the rule file itself, and the fix should still be a
+filter over existing facts — not new traversal or parsing.
+
+### The "where does this fix go?" decision
+
+Ask, in order:
+
+1. Is the AST wrong for this snippet? → fix the parser (Layer 1/2).
+2. Is the AST right but the semantic model misinterprets it? → fix the
+   semantic layer (Layer 3).
+3. Is the semantic model right but the rule has no fact that exposes the
+   distinction it needs? → add or extend a fact in `facts.rs` (Layer 4).
+4. Are the facts right and the rule is just filtering wrong? → fix the
+   predicate in the rule file (Layer 5).
+
+If you ever find yourself wanting to add `walk_commands`, `iter_commands`,
+substring/regex scanning of `checker.source()`, `WordPart`/`ConditionalExpr`
+matching, command-name normalization, option parsing, or test-operand
+reconstruction inside a rule file — the answer is Layer 4 (add or extend a
+fact), not Layer 5. The architecture test in
+`crates/shuck-linter/src/rules/mod.rs` will fail the build if you try.
 
 ### Making the fix
 
 Once you've identified the layer:
 
 1. Write a **minimal reproducer** — the smallest shell snippet that triggers the wrong behavior
-2. Add it as a unit test at the appropriate layer (parser test, semantic test, or linter fixture)
+2. Add it as a unit test at the appropriate layer (parser test, semantic test, fact test, or linter fixture)
 3. Fix the issue at that layer
-4. Run the layer's own tests to confirm the fix: `cargo test -p shuck-parser`, `cargo test -p shuck-linter`, etc.
-5. Run the full workspace tests to check for regressions: `cargo test --workspace`
-6. Accept any updated snapshots: `cargo insta accept --workspace`
-
-For fact generation changes, remember the CLAUDE.md rule: new structural
-data goes in `LinterFacts` in `facts.rs`, and rule files consume it from
-there. Rule files should not add direct AST walks.
+4. If the fix is a new/extended fact, surface it via `LinterFacts` and update
+   the rule to consume it. Do not bypass the fact and add traversal in the
+   rule.
+5. Run the layer's own tests to confirm the fix: `cargo test -p shuck-parser`, `cargo test -p shuck-semantic`, `cargo test -p shuck-linter`, etc.
+6. Run the full workspace tests to check for regressions: `cargo test --workspace`
+7. Accept any updated snapshots: `cargo insta accept --workspace`
 
 ## Step 5: Record oracle divergences in corpus-metadata
 

--- a/crates/shuck-linter/AGENTS.md
+++ b/crates/shuck-linter/AGENTS.md
@@ -1,0 +1,116 @@
+# AGENTS.md
+
+These instructions apply to `crates/shuck-linter`. Follow the repo-level
+`AGENTS.md` at the repo root first, then this file.
+
+## The layered architecture
+
+Linting is split into layers and each layer has a single job. Work at the
+lowest layer that gets the answer right; do not duplicate that work higher up.
+
+1. **Lexer / Parser** (`crates/shuck-parser`) — tokenizes and parses shell
+   source into an AST. Owns all source/text scanning.
+2. **AST** (`crates/shuck-ast`) — typed AST node definitions and span data.
+3. **Indexer** (`crates/shuck-indexer`) — precomputed positional indexes over
+   the source/AST. Cheap query surface.
+4. **Semantic model** (`crates/shuck-semantic`) — bindings, references,
+   scopes, declarations, source closure, call graph, CFG, dataflow.
+5. **Linter facts** (`crates/shuck-linter/src/facts.rs` and
+   `src/facts/`) — linter-owned structural summaries built once per file:
+   normalized commands, wrapper chains, option-shape summaries, word/expansion
+   facts, pipeline/loop/list facts, redirect/substitution facts, surface
+   fragment facts, test/conditional facts.
+6. **Rules** (`crates/shuck-linter/src/rules/{category}/`) — cheap filters
+   over facts plus rule-specific policy and wording.
+
+## Hard rules for rule files
+
+Rule files (`src/rules/{correctness,style,performance,portability,security}/*.rs`)
+**must not** parse, scan, walk, or otherwise re-derive structural information
+from source or AST. They are filters over precomputed data.
+
+Specifically, rule files **must not**:
+
+- Walk or recurse through AST nodes. No calls to `walk_commands`,
+  `iter_commands`, or any tree-traversal helper.
+- Re-parse or re-tokenize source text. No string scanning of `checker.source()`
+  to discover structure (substring searches for substantive analysis, regex
+  over raw source, manual quote/escape handling, etc.). Span slicing for a
+  literal equality check on already-classified data is fine; rediscovering
+  shell structure from raw text is not.
+- Normalize commands, classify words/redirects/substitutions, reconstruct
+  test operands, parse command options, or otherwise recompute anything that
+  is the job of the fact builder.
+- Import from `crate::rules::common::*`. Rule-facing shared types and helpers
+  must come from the crate root or a rule-local helper module.
+- Reach into AST node variants that signal traversal intent. The architecture
+  test in `src/rules/mod.rs` blocks tokens like `WordPart`, `WordPartNode`,
+  `ConditionalExpr`, `PatternPart`, `ParameterExpansionSyntax`,
+  `ZshExpansionTarget`, `ConditionalCommand`, `BourneParameterExpansion`,
+  `iter_commands`, and `query::` from appearing in rule files.
+
+If you reach for one of these, **stop**. The fix is to extend a lower layer:
+
+- Need new structural data per command/word/loop/test/redirect? Add it to
+  `LinterFacts` (or one of the fact submodules in `src/facts/`) and consume
+  the new field from the rule.
+- Need new bindings/references/scope/dataflow data? Extend
+  `crates/shuck-semantic` and surface it via `checker.semantic()`.
+- Need new tokenization or parsing behavior? Extend `crates/shuck-parser` and
+  let it propagate up through the AST and semantic layers.
+
+## What rule files look like
+
+A rule file should be small. The shape is:
+
+1. A `Violation` impl that returns the `Rule` code and a message.
+2. A free function `pub fn rule_name(checker: &mut Checker)` that:
+   - Iterates `checker.facts().*` (most rules) or `checker.semantic().*`
+     (binding/reference rules).
+   - Filters with rule-specific predicates.
+   - Collects spans and reports via `checker.report_all` or
+     `checker.report_all_dedup`.
+3. A `#[cfg(test)]` module with snippet tests covering positive and negative
+   cases. Snapshot-style fixtures live under `resources/test/fixtures/` and
+   are wired through the category `mod.rs`.
+
+Anything more — tree walking, source rescans, ad hoc command/word analysis —
+belongs in a lower layer.
+
+## Extending facts (the right escape hatch)
+
+When a rule needs information that no fact exposes:
+
+1. Add the new field/method to the appropriate fact in `src/facts.rs` or one
+   of the submodules under `src/facts/`. Build it inside `LinterFacts::build`
+   (or the relevant builder) so it is computed once per file.
+2. Re-export rule-facing types from the crate root if rules need to name them.
+3. Update the rule to consume the new fact field.
+4. Add or update unit tests at the fact layer alongside the rule's tests.
+
+This keeps repeated structural discovery in one place, keeps rule files cheap,
+and makes the same structural data available to every other rule that needs it.
+
+## Semantic vs. facts: which to use
+
+- Use `checker.semantic()` for variable bindings, references, scopes,
+  declarations, source closure, call graph, CFG, and dataflow facts. These are
+  the semantic model's responsibility.
+- Use `checker.facts()` for everything else: command shape, options, words,
+  expansions, pipelines, loops, tests, redirects, substitutions, surface
+  fragments. If the data feels structural and is not about variable
+  definition/use, it belongs in facts.
+
+If a rule looks like it needs both, pull whatever it needs out of each layer
+in the rule body — do not invent a new traversal in the rule to bridge them.
+
+## Enforcement
+
+- `src/rules/mod.rs` contains an architecture test
+  (`rule_modules_avoid_direct_ast_traversal_tokens`) that scans rule files for
+  forbidden tokens. CI fails if a rule file imports or names them. If you need
+  one of those types, the work belongs in the fact builder or semantic layer,
+  not in the rule.
+- New rules should be reviewed against this file. If a rule cannot be written
+  without breaking these rules, the missing piece is almost always a fact that
+  has not been built yet — build it.

--- a/crates/shuck-linter/CLAUDE.md
+++ b/crates/shuck-linter/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Add `crates/shuck-linter/AGENTS.md` (with `CLAUDE.md` symlink) that codifies the layered architecture (parser → AST → indexer → semantic → facts → rules) and enumerates the hard prohibitions on rule files: no AST walks, no source rescans, no command/word/option re-derivation, no `crate::rules::common::*` imports, and no traversal types blocked by the architecture test in `src/rules/mod.rs`.
- Update `.claude/skills/fix-rule/SKILL.md` with the same architectural constraint up front, link to the new linter `AGENTS.md`, and rewrite Step 4 with a "where does this fix go?" decision flow that pushes structural-data needs into the fact layer instead of the rule.

## Test plan

- [ ] Documentation only — no code changes.
- [ ] Verify `crates/shuck-linter/CLAUDE.md` resolves to `AGENTS.md` on a fresh clone.