### PR TITLE
Fix remaining zsh parser corpus failures

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -834,6 +834,9 @@ pub enum ForSyntax {
         do_span: Span,
         done_span: Span,
     },
+    InDirect {
+        in_span: Option<Span>,
+    },
     InBrace {
         in_span: Option<Span>,
         left_brace_span: Span,
@@ -844,6 +847,10 @@ pub enum ForSyntax {
         right_paren_span: Span,
         do_span: Span,
         done_span: Span,
+    },
+    ParenDirect {
+        left_paren_span: Span,
+        right_paren_span: Span,
     },
     ParenBrace {
         left_paren_span: Span,

--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -845,6 +845,17 @@ fn format_for(command: &ForCommand, formatter: &mut ShellFormatter<'_, '_>) -> F
                 finish_block("done", formatter)
             }
         }
+        ForSyntax::InDirect { .. } => {
+            if let Some(words) = &command.words {
+                write!(formatter, [token(" in")])?;
+                for word in words {
+                    write!(formatter, [space()])?;
+                    word.format().fmt(formatter)?;
+                }
+            }
+            write!(formatter, [space()])?;
+            format_inline_stmts(&command.body, formatter)
+        }
         ForSyntax::ParenDoDone { .. } => {
             write!(formatter, [token(" (")])?;
             for (index, word) in command
@@ -871,6 +882,22 @@ fn format_for(command: &ForCommand, formatter: &mut ShellFormatter<'_, '_>) -> F
                 )?;
                 finish_block("done", formatter)
             }
+        }
+        ForSyntax::ParenDirect { .. } => {
+            write!(formatter, [token(" (")])?;
+            for (index, word) in command
+                .words
+                .iter()
+                .flat_map(|words| words.iter())
+                .enumerate()
+            {
+                if index > 0 {
+                    write!(formatter, [space()])?;
+                }
+                word.format().fmt(formatter)?;
+            }
+            write!(formatter, [token(") ")])?;
+            format_inline_stmts(&command.body, formatter)
         }
         ForSyntax::InBrace { .. } => {
             if let Some(words) = &command.words {

--- a/crates/shuck-formatter/src/streaming.rs
+++ b/crates/shuck-formatter/src/streaming.rs
@@ -1064,6 +1064,17 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     self.finish_block("done");
                 }
             }
+            ForSyntax::InDirect { .. } => {
+                if let Some(words) = &command.words {
+                    self.write_text(" in");
+                    for word in words {
+                        self.write_space();
+                        self.write_word(word);
+                    }
+                }
+                self.write_space();
+                self.format_inline_stmts(&command.body)?;
+            }
             ForSyntax::ParenDoDone { .. } => {
                 self.write_text(" (");
                 for (index, word) in command
@@ -1089,6 +1100,22 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     )?;
                     self.finish_block("done");
                 }
+            }
+            ForSyntax::ParenDirect { .. } => {
+                self.write_text(" (");
+                for (index, word) in command
+                    .words
+                    .iter()
+                    .flat_map(|words| words.iter())
+                    .enumerate()
+                {
+                    if index > 0 {
+                        self.write_space();
+                    }
+                    self.write_word(word);
+                }
+                self.write_text(") ");
+                self.format_inline_stmts(&command.body)?;
             }
             ForSyntax::InBrace { .. } => {
                 if let Some(words) = &command.words {

--- a/crates/shuck-parser/src/parser/arithmetic.rs
+++ b/crates/shuck-parser/src/parser/arithmetic.rs
@@ -835,6 +835,27 @@ impl<'a> ArithmeticParser<'a> {
                 }
                 Ok(index)
             }
+            '#' if self.dialect == ShellDialect::Zsh => {
+                let Some(next) = self.char_at(start + 2) else {
+                    return Ok(start + 2);
+                };
+                let mut index = start + 2;
+
+                if is_ident_start(next) {
+                    index += next.len_utf8();
+                    while let Some(ch) = self.char_at(index) {
+                        if is_ident_continue(ch) {
+                            index += ch.len_utf8();
+                        } else {
+                            break;
+                        }
+                    }
+                } else if next.is_ascii_digit() || is_special_parameter(next) {
+                    index += next.len_utf8();
+                }
+
+                Ok(index)
+            }
             ch if is_special_parameter(ch) => Ok(start + 1 + ch.len_utf8()),
             ch if is_ident_start(ch) => {
                 let mut index = start + 1 + ch.len_utf8();

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -2847,7 +2847,8 @@ impl<'a> Parser<'a> {
                 || (allow_brace_body
                     && !stmts.is_empty()
                     && (self.at(TokenKind::LeftBrace)
-                        || self.current_token_is_compact_zsh_brace_body()))
+                        || self.current_token_is_compact_zsh_brace_body())
+                    && self.current_brace_starts_zsh_loop_body_fact())
             {
                 break;
             }
@@ -2862,6 +2863,27 @@ impl<'a> Parser<'a> {
         }
 
         Ok(stmts)
+    }
+
+    fn current_brace_starts_zsh_loop_body_fact(&mut self) -> bool {
+        let checkpoint = self.checkpoint();
+        let reaches_do = loop {
+            if self.skip_newlines().is_err() {
+                break false;
+            }
+            if self.is_keyword(Keyword::Do) {
+                break true;
+            }
+            if self.current_token.is_none() {
+                break false;
+            }
+            if self.parse_command_list_required().is_err() {
+                break false;
+            }
+        };
+        self.restore(checkpoint);
+
+        !reaches_do
     }
 
     fn current_token_is_compact_zsh_brace_body(&mut self) -> bool {

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -840,51 +840,66 @@ impl<'a> Parser<'a> {
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
-        let (mut syntax, then_branch, brace_style) =
-            if allow_brace_syntax && self.at(TokenKind::LeftBrace) {
-                let (then_branch, left_brace_span, right_brace_span) = self
-                    .parse_brace_enclosed_stmt_seq(
-                        "syntax error: empty then clause",
-                        BraceBodyContext::IfClause,
-                    )?;
-                self.record_zsh_brace_if_span(left_brace_span);
-                (
-                    IfSyntax::Brace {
-                        left_brace_span,
-                        right_brace_span,
-                    },
-                    then_branch,
-                    true,
-                )
-            } else {
-                let then_span = self.current_span;
-                self.expect_keyword(Keyword::Then)?;
-                self.skip_newlines()?;
+        let (mut syntax, then_branch, brace_style) = if allow_brace_syntax
+            && self.at(TokenKind::LeftBrace)
+        {
+            let (then_branch, left_brace_span, right_brace_span) = self
+                .parse_brace_enclosed_stmt_seq(
+                    "syntax error: empty then clause",
+                    BraceBodyContext::IfClause,
+                )?;
+            self.record_zsh_brace_if_span(left_brace_span);
+            (
+                IfSyntax::Brace {
+                    left_brace_span,
+                    right_brace_span,
+                },
+                then_branch,
+                true,
+            )
+        } else if let Some((then_branch, left_brace_span, right_brace_span)) = allow_brace_syntax
+            .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::IfClause))
+            .transpose()?
+            .flatten()
+        {
+            self.record_zsh_brace_if_span(left_brace_span);
+            (
+                IfSyntax::Brace {
+                    left_brace_span,
+                    right_brace_span,
+                },
+                then_branch,
+                true,
+            )
+        } else {
+            let then_span = self.current_span;
+            self.expect_keyword(Keyword::Then)?;
+            self.skip_newlines()?;
 
-                let then_start = self.current_span.start;
-                let then_branch = self.parse_compound_list_until(IF_BODY_TERMINATORS)?;
-                let then_branch_span = Span::from_positions(then_start, self.current_span.start);
+            let then_start = self.current_span.start;
+            let then_branch = self.parse_compound_list_until(IF_BODY_TERMINATORS)?;
+            let then_branch_span = Span::from_positions(then_start, self.current_span.start);
 
-                let then_branch = if then_branch.is_empty() {
-                    if self.dialect == ShellDialect::Zsh && self.is_keyword(Keyword::Elif) {
-                        Self::stmt_seq_with_span(then_branch_span, Vec::new())
-                    } else {
-                        self.pop_depth();
-                        return Err(self.error("syntax error: empty then clause"));
-                    }
+            let then_branch = if then_branch.is_empty() {
+                if self.dialect == ShellDialect::Zsh && self.is_keyword(Keyword::Elif) {
+                    Self::stmt_seq_with_span(then_branch_span, Vec::new())
                 } else {
-                    Self::stmt_seq_with_span(then_branch_span, then_branch)
-                };
-
-                (
-                    IfSyntax::ThenFi {
-                        then_span,
-                        fi_span: Span::new(),
-                    },
-                    then_branch,
-                    false,
-                )
+                    self.pop_depth();
+                    return Err(self.error("syntax error: empty then clause"));
+                }
+            } else {
+                Self::stmt_seq_with_span(then_branch_span, then_branch)
             };
+
+            (
+                IfSyntax::ThenFi {
+                    then_span,
+                    fi_span: Span::new(),
+                },
+                then_branch,
+                false,
+            )
+        };
 
         // Parse elif branches
         let mut elif_branches = Vec::new();
@@ -899,15 +914,20 @@ impl<'a> Parser<'a> {
             let elif_condition = Self::stmt_seq_with_span(elif_condition_span, elif_condition);
 
             let elif_body = if brace_style {
-                if !self.at(TokenKind::LeftBrace) {
+                if self.at(TokenKind::LeftBrace) {
+                    self.parse_brace_enclosed_stmt_seq(
+                        "syntax error: empty elif clause",
+                        BraceBodyContext::IfClause,
+                    )?
+                    .0
+                } else if let Some((body, _, _)) =
+                    self.try_parse_compact_zsh_brace_body(BraceBodyContext::IfClause)?
+                {
+                    body
+                } else {
                     self.pop_depth();
                     return Err(self.error("expected '{' to start elif clause"));
                 }
-                self.parse_brace_enclosed_stmt_seq(
-                    "syntax error: empty elif clause",
-                    BraceBodyContext::IfClause,
-                )?
-                .0
             } else {
                 self.expect_keyword(Keyword::Then)?;
                 let elif_body_region_start = self.current_span.start;
@@ -946,17 +966,22 @@ impl<'a> Parser<'a> {
             let else_region_start = self.current_span.start;
             self.skip_newlines()?;
             if brace_style {
-                if !self.at(TokenKind::LeftBrace) {
+                if self.at(TokenKind::LeftBrace) {
+                    Some(
+                        self.parse_brace_enclosed_stmt_seq(
+                            "syntax error: empty else clause",
+                            BraceBodyContext::IfClause,
+                        )?
+                        .0,
+                    )
+                } else if let Some((body, _, _)) =
+                    self.try_parse_compact_zsh_brace_body(BraceBodyContext::IfClause)?
+                {
+                    Some(body)
+                } else {
                     self.pop_depth();
                     return Err(self.error("expected '{' to start else clause"));
                 }
-                Some(
-                    self.parse_brace_enclosed_stmt_seq(
-                        "syntax error: empty else clause",
-                        BraceBodyContext::IfClause,
-                    )?
-                    .0,
-                )
             } else {
                 let else_start = self.current_span.start;
                 let branch = self.parse_compound_list(Keyword::Fi)?;
@@ -1044,7 +1069,27 @@ impl<'a> Parser<'a> {
                     continue;
                 }
                 match self.current_token_kind {
-                    Some(kind) if kind.is_word_like() => {
+                    Some(kind)
+                        if kind.is_word_like()
+                            || (self.dialect == ShellDialect::Zsh
+                                && matches!(kind, TokenKind::LeftParen)) =>
+                    {
+                        if self.dialect == ShellDialect::Zsh
+                            && self
+                                .current_token
+                                .as_ref()
+                                .is_some_and(|token| !token.flags.is_synthetic())
+                        {
+                            let start = self.current_span.start;
+                            if let Some((text, end)) = self.scan_source_word(start) {
+                                let span = Span::from_positions(start, end);
+                                let word = self.parse_word_with_context(&text, span, start, true);
+                                self.advance_past_word(&word);
+                                words.push(word);
+                                continue;
+                            }
+                        }
+
                         let word = self
                             .take_current_word_and_advance()
                             .ok_or_else(|| self.error("expected for word"))?;
@@ -1133,6 +1178,17 @@ impl<'a> Parser<'a> {
                     right_brace_span,
                 )
             }
+            ForHeaderSurface::In { in_span }
+                if allow_zsh_targets && !self.is_keyword(Keyword::Do) =>
+            {
+                let stmt = self.parse_single_stmt_command()?;
+                let span = stmt.span;
+                (
+                    Self::stmt_seq_with_span(span, vec![stmt]),
+                    ForSyntax::InDirect { in_span },
+                    span,
+                )
+            }
             ForHeaderSurface::In { in_span } => {
                 let do_span = if self.is_keyword(Keyword::Do) {
                     self.current_span
@@ -1169,6 +1225,21 @@ impl<'a> Parser<'a> {
                         done_span,
                     },
                     done_span,
+                )
+            }
+            ForHeaderSurface::Paren {
+                left_paren_span,
+                right_paren_span,
+            } if allow_zsh_targets && !self.is_keyword(Keyword::Do) => {
+                let stmt = self.parse_single_stmt_command()?;
+                let span = stmt.span;
+                (
+                    Self::stmt_seq_with_span(span, vec![stmt]),
+                    ForSyntax::ParenDirect {
+                        left_paren_span,
+                        right_paren_span,
+                    },
+                    span,
                 )
             }
             ForHeaderSurface::Paren {
@@ -1842,34 +1913,64 @@ impl<'a> Parser<'a> {
 
         // Parse condition
         let condition_start = self.current_span.start;
-        let condition = self.parse_compound_list(Keyword::Do)?;
+        let allow_brace_body = self.dialect == ShellDialect::Zsh && self.zsh_brace_bodies_enabled();
+        let condition = self.parse_loop_condition_until_body_start(allow_brace_body)?;
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
-        // Expect 'do'
-        self.expect_keyword(Keyword::Do)?;
-        self.skip_newlines()?;
+        let (body, end_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
+            let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
+            let span = Self::compound_span(&body);
+            (
+                Self::stmt_seq_with_span(
+                    span,
+                    vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
+                        Box::new(body),
+                        Vec::new(),
+                    ))],
+                ),
+                self.current_span,
+            )
+        } else if let Some((body, left_brace_span, right_brace_span)) = allow_brace_body
+            .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::Ordinary))
+            .transpose()?
+            .flatten()
+        {
+            let brace_group = CompoundCommand::BraceGroup(body);
+            let span = left_brace_span.merge(right_brace_span);
+            (
+                Self::stmt_seq_with_span(
+                    span,
+                    vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
+                        Box::new(brace_group),
+                        Vec::new(),
+                    ))],
+                ),
+                right_brace_span,
+            )
+        } else {
+            self.expect_keyword(Keyword::Do)?;
+            self.skip_newlines()?;
 
-        // Parse body
-        let body_start = self.current_span.start;
-        let body = self.parse_compound_list(Keyword::Done)?;
-        let body_span = Span::from_positions(body_start, self.current_span.start);
+            let body_start = self.current_span.start;
+            let body = self.parse_compound_list(Keyword::Done)?;
+            let body_span = Span::from_positions(body_start, self.current_span.start);
 
-        // Bash requires at least one command in loop body
-        if body.is_empty() && self.dialect != ShellDialect::Zsh {
-            self.pop_depth();
-            return Err(self.error("syntax error: empty while loop body"));
-        }
-        let body = Self::stmt_seq_with_span(body_span, body);
+            if body.is_empty() && self.dialect != ShellDialect::Zsh {
+                self.pop_depth();
+                return Err(self.error("syntax error: empty while loop body"));
+            }
+            let body = Self::stmt_seq_with_span(body_span, body);
 
-        // Expect 'done'
-        self.expect_keyword(Keyword::Done)?;
+            self.expect_keyword(Keyword::Done)?;
+            (body, self.current_span)
+        };
 
         self.pop_depth();
         Ok(CompoundCommand::While(WhileCommand {
             condition,
             body,
-            span: start_span.merge(self.current_span),
+            span: start_span.merge(end_span),
         }))
     }
 
@@ -1882,34 +1983,64 @@ impl<'a> Parser<'a> {
 
         // Parse condition
         let condition_start = self.current_span.start;
-        let condition = self.parse_compound_list(Keyword::Do)?;
+        let allow_brace_body = self.dialect == ShellDialect::Zsh && self.zsh_brace_bodies_enabled();
+        let condition = self.parse_loop_condition_until_body_start(allow_brace_body)?;
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
-        // Expect 'do'
-        self.expect_keyword(Keyword::Do)?;
-        self.skip_newlines()?;
+        let (body, end_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
+            let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
+            let span = Self::compound_span(&body);
+            (
+                Self::stmt_seq_with_span(
+                    span,
+                    vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
+                        Box::new(body),
+                        Vec::new(),
+                    ))],
+                ),
+                self.current_span,
+            )
+        } else if let Some((body, left_brace_span, right_brace_span)) = allow_brace_body
+            .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::Ordinary))
+            .transpose()?
+            .flatten()
+        {
+            let brace_group = CompoundCommand::BraceGroup(body);
+            let span = left_brace_span.merge(right_brace_span);
+            (
+                Self::stmt_seq_with_span(
+                    span,
+                    vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
+                        Box::new(brace_group),
+                        Vec::new(),
+                    ))],
+                ),
+                right_brace_span,
+            )
+        } else {
+            self.expect_keyword(Keyword::Do)?;
+            self.skip_newlines()?;
 
-        // Parse body
-        let body_start = self.current_span.start;
-        let body = self.parse_compound_list(Keyword::Done)?;
-        let body_span = Span::from_positions(body_start, self.current_span.start);
+            let body_start = self.current_span.start;
+            let body = self.parse_compound_list(Keyword::Done)?;
+            let body_span = Span::from_positions(body_start, self.current_span.start);
 
-        // Bash requires at least one command in loop body
-        if body.is_empty() && self.dialect != ShellDialect::Zsh {
-            self.pop_depth();
-            return Err(self.error("syntax error: empty until loop body"));
-        }
-        let body = Self::stmt_seq_with_span(body_span, body);
+            if body.is_empty() && self.dialect != ShellDialect::Zsh {
+                self.pop_depth();
+                return Err(self.error("syntax error: empty until loop body"));
+            }
+            let body = Self::stmt_seq_with_span(body_span, body);
 
-        // Expect 'done'
-        self.expect_keyword(Keyword::Done)?;
+            self.expect_keyword(Keyword::Done)?;
+            (body, self.current_span)
+        };
 
         self.pop_depth();
         Ok(CompoundCommand::Until(UntilCommand {
             condition,
             body,
-            span: start_span.merge(self.current_span),
+            span: start_span.merge(end_span),
         }))
     }
 
@@ -2199,9 +2330,6 @@ impl<'a> Parser<'a> {
         let text = span.slice(self.input);
         let trimmed_start = text.len() - text.trim_start_matches(char::is_whitespace).len();
         let trimmed_end = text.trim_end_matches(char::is_whitespace).len();
-        if trimmed_end <= trimmed_start {
-            return None;
-        }
         let start = span.start.advanced_by(&text[..trimmed_start]);
         let end = span.start.advanced_by(&text[..trimmed_end]);
         Some(Span::from_positions(start, end))
@@ -2661,7 +2789,10 @@ impl<'a> Parser<'a> {
             }
 
             if self.is_keyword(Keyword::Then)
-                || (allow_brace_body && !stmts.is_empty() && self.at(TokenKind::LeftBrace))
+                || (allow_brace_body
+                    && !stmts.is_empty()
+                    && (self.at(TokenKind::LeftBrace)
+                        || self.current_token_is_compact_zsh_brace_body()))
             {
                 break;
             }
@@ -2701,6 +2832,41 @@ impl<'a> Parser<'a> {
         self.restore(checkpoint);
 
         !reaches_then
+    }
+
+    fn parse_loop_condition_until_body_start(
+        &mut self,
+        allow_brace_body: bool,
+    ) -> Result<Vec<Stmt>> {
+        let mut stmts = Vec::with_capacity(2);
+
+        loop {
+            self.skip_newlines()?;
+
+            if self.is_keyword(Keyword::Do)
+                || (allow_brace_body
+                    && !stmts.is_empty()
+                    && (self.at(TokenKind::LeftBrace)
+                        || self.current_token_is_compact_zsh_brace_body()))
+            {
+                break;
+            }
+
+            if self.current_token.is_none() {
+                break;
+            }
+
+            let command_stmts = self.parse_command_list_required()?;
+            self.apply_stmt_list_effects(&command_stmts);
+            stmts.extend(command_stmts);
+        }
+
+        Ok(stmts)
+    }
+
+    fn current_token_is_compact_zsh_brace_body(&mut self) -> bool {
+        self.current_source_like_word_text()
+            .is_some_and(|text| text.starts_with('{') && text.ends_with('}'))
     }
 
     fn peek_zsh_always_span(&mut self) -> Option<Span> {
@@ -2797,6 +2963,83 @@ impl<'a> Parser<'a> {
         Self::rebase_stmt_seq(&mut output.file.body, inner_start);
         self.advance();
         Ok(Some(CompoundCommand::BraceGroup(output.file.body)))
+    }
+
+    fn try_parse_compact_zsh_brace_body(
+        &mut self,
+        context: BraceBodyContext,
+    ) -> Result<Option<(StmtSeq, Span, Span)>> {
+        if self.dialect != ShellDialect::Zsh
+            || !self.zsh_brace_bodies_enabled()
+            || !self.at_word_like()
+        {
+            return Ok(None);
+        }
+
+        let Some(body_text) = self.current_source_like_word_text() else {
+            return Ok(None);
+        };
+        let body_text = body_text.into_owned();
+        let Some(inner) = body_text
+            .strip_prefix('{')
+            .and_then(|body| body.strip_suffix('}'))
+        else {
+            return Ok(None);
+        };
+
+        if !inner.is_empty()
+            && !inner.chars().any(|ch| {
+                matches!(
+                    ch,
+                    ' ' | '\t' | '\n' | ';' | '&' | '|' | '<' | '>' | '$' | '"' | '\'' | '(' | ')'
+                )
+            })
+        {
+            return Ok(None);
+        }
+
+        let nested_profile = self
+            .current_zsh_options()
+            .cloned()
+            .map(|options| ShellProfile::with_zsh_options(self.dialect, options))
+            .unwrap_or_else(|| self.shell_profile.clone());
+        let mut nested =
+            Parser::with_limits_and_profile(inner, self.max_depth, self.max_fuel, nested_profile);
+        nested.aliases = self.aliases.clone();
+        nested.expand_aliases = self.expand_aliases;
+        nested.expand_next_word = self.expand_next_word;
+
+        let word_span = self.current_span;
+        let inner_start = word_span.start.advanced_by("{");
+        let mut output = nested.parse();
+        if output.is_err() {
+            return Err(self.rebase_nested_parse_error(output.strict_error(), inner_start));
+        }
+        Self::rebase_stmt_seq(&mut output.file.body, inner_start);
+
+        let left_brace_span = Span::from_positions(word_span.start, inner_start);
+        let right_brace_start = word_span
+            .start
+            .advanced_by(&body_text[..body_text.len() - 1]);
+        let right_brace_span = Span::from_positions(right_brace_start, word_span.end);
+        let body = Self::stmt_seq_with_span(
+            Span::from_positions(inner_start, right_brace_start),
+            output.file.body.stmts,
+        );
+
+        if body.is_empty()
+            && !(self.dialect == ShellDialect::Zsh && matches!(context, BraceBodyContext::Function))
+        {
+            let message = match context {
+                BraceBodyContext::Function => "syntax error: empty brace group",
+                BraceBodyContext::IfClause => "syntax error: empty then clause",
+                BraceBodyContext::Ordinary => "syntax error: empty brace group",
+            };
+            return Err(self.error(message));
+        }
+
+        self.advance();
+        Ok(Some((body, left_brace_span, right_brace_span)))
     }
 
     fn should_consume_right_brace_as_literal_argument(

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -2388,14 +2388,78 @@ impl<'a> Lexer<'a> {
 
         let mut depth = 2;
         while let Some(c) = self.peek_char() {
-            Self::push_capture_char(content, c);
-            self.advance();
-            if c == '(' {
-                depth += 1;
-            } else if c == ')' {
-                depth -= 1;
-                if depth == 0 {
-                    return true;
+            match c {
+                '\\' => {
+                    Self::push_capture_char(content, c);
+                    self.advance();
+                    if let Some(next) = self.peek_char() {
+                        Self::push_capture_char(content, next);
+                        self.advance();
+                    }
+                }
+                '\'' => {
+                    Self::push_capture_char(content, c);
+                    self.advance();
+                    while let Some(quoted) = self.peek_char() {
+                        Self::push_capture_char(content, quoted);
+                        self.advance();
+                        if quoted == '\'' {
+                            break;
+                        }
+                    }
+                }
+                '"' => {
+                    let mut escaped = false;
+                    Self::push_capture_char(content, c);
+                    self.advance();
+                    while let Some(quoted) = self.peek_char() {
+                        Self::push_capture_char(content, quoted);
+                        self.advance();
+                        if escaped {
+                            escaped = false;
+                            continue;
+                        }
+                        match quoted {
+                            '\\' => escaped = true,
+                            '"' => break,
+                            _ => {}
+                        }
+                    }
+                }
+                '`' => {
+                    let mut escaped = false;
+                    Self::push_capture_char(content, c);
+                    self.advance();
+                    while let Some(quoted) = self.peek_char() {
+                        Self::push_capture_char(content, quoted);
+                        self.advance();
+                        if escaped {
+                            escaped = false;
+                            continue;
+                        }
+                        match quoted {
+                            '\\' => escaped = true,
+                            '`' => break,
+                            _ => {}
+                        }
+                    }
+                }
+                '(' => {
+                    Self::push_capture_char(content, c);
+                    self.advance();
+                    depth += 1;
+                }
+                ')' => {
+                    Self::push_capture_char(content, c);
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 {
+                        return true;
+                    }
+                }
+                _ => {
+                    Self::push_capture_char(content, c);
+                    self.advance();
                 }
             }
         }
@@ -4674,6 +4738,23 @@ mod tests {
         let body = &source[..consumed];
 
         assert_eq!(body, source);
+    }
+
+    #[test]
+    fn test_lexer_handles_quoted_right_paren_inside_command_substitution_nested_in_arithmetic() {
+        let source = "echo \"$(echo \"$(( $(printf ')') + 1 ))\")\"";
+        let mut lexer = Lexer::new(source);
+
+        let first = lexer.next_lexed_token().expect("expected first token");
+        assert!(first.kind.is_word_like(), "{:?}", first.kind);
+        assert_eq!(first.word_string().as_deref(), Some("echo"));
+
+        let second = lexer.next_lexed_token().expect("expected second token");
+        assert!(second.kind.is_word_like(), "{:?}", second.kind);
+        assert_eq!(
+            second.word_string().as_deref(),
+            Some("$(echo \"$(( $(printf ')') + 1 ))\")")
+        );
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1499,28 +1499,13 @@ impl<'a> Lexer<'a> {
 
                 // Check for $( - command substitution or arithmetic
                 if self.peek_char() == Some('(') {
-                    Self::push_capture_char(&mut word, '(');
-                    self.advance();
-
-                    // Check for $(( - arithmetic expansion
-                    if self.peek_char() == Some('(') {
-                        Self::push_capture_char(&mut word, '(');
-                        self.advance();
-                        // Read until ))
-                        let mut depth = 2;
-                        while let Some(c) = self.peek_char() {
-                            Self::push_capture_char(&mut word, c);
-                            self.advance();
-                            if c == '(' {
-                                depth += 1;
-                            } else if c == ')' {
-                                depth -= 1;
-                                if depth == 0 {
-                                    break;
-                                }
-                            }
+                    if self.second_char() == Some('(') {
+                        if !self.read_arithmetic_expansion_into(&mut word) {
+                            return Err(LexerErrorKind::CommandSubstitution);
                         }
                     } else {
+                        Self::push_capture_char(&mut word, '(');
+                        self.advance();
                         if !self.read_command_subst_into(&mut word) {
                             return Err(LexerErrorKind::CommandSubstitution);
                         }
@@ -2317,9 +2302,13 @@ impl<'a> Lexer<'a> {
                     Self::push_capture_char(&mut content, '$');
                     self.advance();
                     if self.peek_char() == Some('(') {
-                        Self::push_capture_char(&mut content, '(');
-                        self.advance();
-                        self.read_command_subst_into(&mut content);
+                        if self.second_char() == Some('(') {
+                            self.read_arithmetic_expansion_into(&mut content);
+                        } else {
+                            Self::push_capture_char(&mut content, '(');
+                            self.advance();
+                            self.read_command_subst_into(&mut content);
+                        }
                     } else if self.peek_char() == Some('{') {
                         Self::push_capture_char(&mut content, '{');
                         self.advance();
@@ -2386,6 +2375,32 @@ impl<'a> Lexer<'a> {
                 wrapper_span,
             ))
         }
+    }
+
+    fn read_arithmetic_expansion_into(&mut self, content: &mut Option<String>) -> bool {
+        debug_assert_eq!(self.peek_char(), Some('('));
+        debug_assert_eq!(self.second_char(), Some('('));
+
+        Self::push_capture_char(content, '(');
+        self.advance();
+        Self::push_capture_char(content, '(');
+        self.advance();
+
+        let mut depth = 2;
+        while let Some(c) = self.peek_char() {
+            Self::push_capture_char(content, c);
+            self.advance();
+            if c == '(' {
+                depth += 1;
+            } else if c == ')' {
+                depth -= 1;
+                if depth == 0 {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     /// Read command substitution content after `$(`, handling nested parens and quotes.
@@ -2658,11 +2673,18 @@ impl<'a> Lexer<'a> {
                                 Self::push_capture_char(content, '$');
                                 self.advance();
                                 if self.peek_char() == Some('(') {
-                                    Self::push_capture_char(content, '(');
-                                    self.advance();
-                                    if !self.read_command_subst_into_depth(content, subst_depth + 1)
-                                    {
-                                        return false;
+                                    if self.second_char() == Some('(') {
+                                        if !self.read_arithmetic_expansion_into(content) {
+                                            return false;
+                                        }
+                                    } else {
+                                        Self::push_capture_char(content, '(');
+                                        self.advance();
+                                        if !self
+                                            .read_command_subst_into_depth(content, subst_depth + 1)
+                                        {
+                                            return false;
+                                        }
                                     }
                                 }
                             }
@@ -3034,9 +3056,15 @@ impl<'a> Lexer<'a> {
                     Self::push_capture_char(content, '$');
                     self.advance();
                     if self.peek_char() == Some('(') {
-                        Self::push_capture_char(content, '(');
-                        self.advance();
-                        self.read_command_subst_into(content);
+                        if self.second_char() == Some('(') {
+                            if !self.read_arithmetic_expansion_into(content) {
+                                borrowable = false;
+                            }
+                        } else {
+                            Self::push_capture_char(content, '(');
+                            self.advance();
+                            self.read_command_subst_into(content);
+                        }
                     } else if self.peek_char() == Some('{') {
                         Self::push_capture_char(content, '{');
                         self.advance();

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -1880,12 +1880,15 @@ impl<'a> Parser<'a> {
                 .is_some_and(|options| options.short_repeat.is_definitely_off())
     }
 
-    fn zsh_brace_if_enabled(&self) -> bool {
+    fn zsh_brace_bodies_enabled(&self) -> bool {
         self.dialect.features().zsh_brace_if
-            && self.zsh_short_loops_enabled()
             && !self
                 .current_zsh_options()
                 .is_some_and(|options| options.ignore_braces.is_definitely_on())
+    }
+
+    fn zsh_brace_if_enabled(&self) -> bool {
+        self.zsh_brace_bodies_enabled()
     }
 
     fn zsh_glob_qualifiers_enabled_at(&self, offset: usize) -> bool {
@@ -3591,6 +3594,9 @@ impl<'a> Parser<'a> {
                         do_span: do_span.rebased(base),
                         done_span: done_span.rebased(base),
                     },
+                    ForSyntax::InDirect { in_span } => ForSyntax::InDirect {
+                        in_span: in_span.map(|span| span.rebased(base)),
+                    },
                     ForSyntax::InBrace {
                         in_span,
                         left_brace_span,
@@ -3610,6 +3616,13 @@ impl<'a> Parser<'a> {
                         right_paren_span: right_paren_span.rebased(base),
                         do_span: do_span.rebased(base),
                         done_span: done_span.rebased(base),
+                    },
+                    ForSyntax::ParenDirect {
+                        left_paren_span,
+                        right_paren_span,
+                    } => ForSyntax::ParenDirect {
+                        left_paren_span: left_paren_span.rebased(base),
+                        right_paren_span: right_paren_span.rebased(base),
                     },
                     ForSyntax::ParenBrace {
                         left_paren_span,

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -1735,6 +1735,39 @@ fn test_zsh_case_accepts_optional_suffix_group_after_literal_url() {
 }
 
 #[test]
+fn test_zsh_case_accepts_wrapper_alternatives_with_empty_first_pattern() {
+    let input = concat!(
+        "case ${ICE[proto]} in\n",
+        "  (|ftp(|s)|git|http(|s)|rsync|ssh) print ok ;;\n",
+        "esac\n",
+    );
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Case(command) = compound else {
+        panic!("expected case command");
+    };
+
+    let rendered = command.cases[0]
+        .patterns
+        .iter()
+        .map(|pattern| pattern.render_syntax(input))
+        .collect::<Vec<_>>();
+    assert_eq!(rendered.len(), 6);
+    assert_eq!(rendered[0], "");
+    assert!(rendered[1].starts_with("ftp"));
+    assert!(rendered[1].ends_with("(|s)"));
+    assert_eq!(rendered[2], "git");
+    assert!(rendered[3].starts_with("http"));
+    assert!(rendered[3].ends_with("(|s)"));
+    assert_eq!(rendered[4], "rsync");
+    assert_eq!(rendered[5], "ssh");
+}
+
+#[test]
 fn test_zsh_case_accepts_infix_group_with_trailing_wildcard() {
     let input = concat!(
         "case $widgets[$widget] in\n",
@@ -2794,6 +2827,51 @@ fn test_parse_zsh_anonymous_eval_callback_inside_worker_loop_with_always_followt
 }
 
 #[test]
+fn test_parse_zsh_while_loop_with_brace_body() {
+    let input = "while (( -- count + 1 )) {\n  echo hi\n}\n";
+    let output = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let (compound, redirects) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::While(command) = compound else {
+        panic!("expected while loop");
+    };
+
+    assert!(redirects.is_empty());
+    assert_eq!(command.body.len(), 1);
+    let (body_compound, body_redirects) = expect_compound(&command.body[0]);
+    let AstCompoundCommand::BraceGroup(body) = body_compound else {
+        panic!("expected brace-group loop body");
+    };
+    assert!(body_redirects.is_empty());
+    assert_eq!(body.len(), 1);
+}
+
+#[test]
+fn test_parse_zsh_while_loop_with_brace_body_after_setopt_noshortloops() {
+    let input = "f() {\n  setopt noshortloops\n  while (( count )) {\n    break\n  }\n}\n";
+    Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+}
+
+#[test]
+fn test_parse_zsh_function_compound_array_assignment_with_nested_parameter_length_in_arithmetic() {
+    let input = "f() {\n  [[ -n $foo ]] && region_highlight+=(\"$((buflen+7)) $((buflen+7+${#${(MS)POSTDISPLAY##<->##}})) fg=39,bold\")\n  return 0\n}\n";
+    Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+}
+
+#[test]
+fn test_parse_zsh_if_compact_brace_bodies_without_space_after_left_brace() {
+    let input = "f() { if (($4==0)){c=1;} elif (($4==1)){c=2;} else {c=3;}; echo ok; }\n";
+    Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+}
+
+#[test]
 fn test_parse_zsh_function_with_multiline_and_list_after_alias_lookup() {
     let input = "zsh-z_plugin_unload() {\n  emulate -L zsh\n\n  add-zsh-hook -D precmd _zshz_precmd\n  add-zsh-hook -d chpwd _zshz_chpwd\n\n  local x\n  for x in ${=ZSHZ[FUNCTIONS]}; do\n    (( ${+functions[$x]} )) && unfunction $x\n  done\n\n  unset ZSHZ\n\n  fpath=( \"${(@)fpath:#${0:A:h}}\" )\n\n  (( ${+aliases[${ZSHZ_CMD:-${_Z_CMD:-z}}]} )) &&\n    unalias ${ZSHZ_CMD:-${_Z_CMD:-z}}\n\n  unfunction $0\n}\n";
     Parser::with_dialect(input, ShellDialect::Zsh)
@@ -3356,6 +3434,21 @@ fn test_parse_zsh_midfile_unsetopt_short_loops_rejects_foreach_loop() {
         error,
         Error::Parse { message, .. } if message.contains("foreach loops")
     ));
+}
+
+#[test]
+fn test_parse_zsh_midfile_setopt_noshortloops_keeps_brace_if_enabled() {
+    let source = "setopt noshortloops\nif [[ $profile == ./* || $profile == /* ]] {\n  local localpkg=1\n} elif { ! .zinit-download-file-stdout $URL 0 1 2>/dev/null > $tmpfile } {\n  command rm -f $tmpfile\n}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let (compound, _) = expect_compound(&output.file.body[1]);
+    let AstCompoundCommand::If(command) = compound else {
+        panic!("expected if command");
+    };
+    assert!(matches!(command.syntax, IfSyntax::Brace { .. }));
+    assert_eq!(command.elif_branches.len(), 1);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -2283,6 +2283,38 @@ fn test_parse_zsh_while_with_char_literal_arithmetic_and_following_command() {
 }
 
 #[test]
+fn test_parse_zsh_while_condition_keeps_brace_group_before_do_boundary() {
+    let input = "while cmd1; { cmd2; }; do cmd3; done\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, redirects) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::While(command) = compound else {
+        panic!("expected while loop");
+    };
+    assert!(redirects.is_empty());
+    assert_eq!(command.condition.len(), 2);
+    assert_eq!(command.body.len(), 1);
+
+    assert_eq!(
+        expect_simple(&command.condition[0]).name.render(input),
+        "cmd1"
+    );
+
+    let (group, group_redirects) = expect_compound(&command.condition[1]);
+    let AstCompoundCommand::BraceGroup(condition_body) = group else {
+        panic!("expected brace group in while condition");
+    };
+    assert!(group_redirects.is_empty());
+    assert_eq!(condition_body.len(), 1);
+    assert_eq!(expect_simple(&condition_body[0]).name.render(input), "cmd2");
+
+    assert_eq!(expect_simple(&command.body[0]).name.render(input), "cmd3");
+}
+
+#[test]
 fn test_parse_zsh_repeat_body_with_bitwise_or_char_literal() {
     let input = "repeat 4; do\n  sysread -s1 c || return\n  (( rnd = (~(1 << 23) & rnd) << 8 | #c ))\n done\n";
     Parser::with_dialect(input, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -4032,6 +4032,55 @@ fn test_zsh_for_loop_preserves_paren_brace_syntax() {
 }
 
 #[test]
+fn test_zsh_for_loop_preserves_paren_direct_syntax() {
+    let source = "for topic_folder ($ZSH/*) if [ -d $topic_folder ]; then fpath=($topic_folder $fpath); fi\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let (compound, redirects) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::For(command) = compound else {
+        panic!("expected for loop");
+    };
+
+    assert!(redirects.is_empty());
+    assert!(matches!(
+        command.syntax,
+        ForSyntax::ParenDirect {
+            left_paren_span,
+            right_paren_span,
+        } if left_paren_span.slice(source) == "(" && right_paren_span.slice(source) == ")"
+    ));
+    assert_eq!(command.body.len(), 1);
+    assert!(matches!(command.body[0].command, AstCommand::Compound(_)));
+}
+
+#[test]
+fn test_zsh_for_loop_preserves_paren_glob_qualifier_word_list() {
+    let source =
+        "for ind_file ( ${^${(von)PUAssocArray}}.ind(DN.) ) {\n  command cat ${ind_file:r}\n}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let (compound, redirects) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::For(command) = compound else {
+        panic!("expected for loop");
+    };
+
+    assert!(redirects.is_empty());
+    assert_eq!(
+        command
+            .words
+            .as_ref()
+            .expect("expected parenthesized word list")
+            .iter()
+            .map(|word| word.span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["${^${(von)PUAssocArray}}.ind(DN.)"]
+    );
+    assert!(matches!(command.syntax, ForSyntax::ParenBrace { .. }));
+}
+
+#[test]
 fn test_zsh_for_loop_preserves_in_brace_syntax() {
     let source = "for part in a b; { echo $part; }\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)
@@ -4055,6 +4104,31 @@ fn test_zsh_for_loop_preserves_in_brace_syntax() {
         }
         other => panic!("expected in/brace syntax, got {other:?}"),
     }
+}
+
+#[test]
+fn test_zsh_for_loop_preserves_in_direct_syntax() {
+    let source = "for key in \"$key_info[Escape]\"{B,b} \"$key_info[Left]\"\n  bindkey -M emacs \"$key\" emacs-backward-word\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let (compound, redirects) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::For(command) = compound else {
+        panic!("expected for loop");
+    };
+
+    assert!(redirects.is_empty());
+    assert!(matches!(
+        command.syntax,
+        ForSyntax::InDirect {
+            in_span: Some(in_span),
+        } if in_span.slice(source) == "in"
+    ));
+    assert_eq!(command.body.len(), 1);
+    assert_eq!(
+        expect_simple(&command.body[0]).name.render(source),
+        "bindkey"
+    );
 }
 
 #[test]
@@ -5354,6 +5428,14 @@ fn test_parse_zsh_arithmetic_shell_word_lookup_with_nested_modifier() {
 }
 
 #[test]
+fn test_parse_zsh_arithmetic_shell_word_with_short_length_subscript_pattern() {
+    let source = "if (( ! $#functions[(i)n(odenv|vm)] )); then\n  return 1\nfi\n";
+    Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+}
+
+#[test]
 fn test_parse_zsh_arithmetic_shell_word_preserves_nested_length_target() {
     let source = "(( q_chars = ${#${cd//${~q}/}} ))\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)
@@ -5847,6 +5929,25 @@ fn test_zsh_brace_if_records_brace_syntax() {
     ));
     assert_eq!(command.elif_branches.len(), 1);
     assert!(command.else_branch.is_some());
+}
+
+#[test]
+fn test_zsh_brace_if_allows_brace_group_elif_conditions() {
+    let source = "if [[ $profile == ./* || $profile == /* ]] {\n  local localpkg=1\n} elif { ! .zinit-download-file-stdout $URL 0 1 2>/dev/null > $tmpfile } {\n  command rm -f $tmpfile\n}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let (compound, _) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::If(command) = compound else {
+        panic!("expected if command");
+    };
+
+    assert_eq!(command.elif_branches.len(), 1);
+    assert_eq!(command.elif_branches[0].0.len(), 1);
+    assert!(matches!(
+        command.elif_branches[0].0[0].command,
+        AstCommand::Compound(_)
+    ));
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1289,6 +1289,33 @@ fn test_dollar_paren_command_substitution_inside_double_quotes_preserves_nested_
 }
 
 #[test]
+fn test_dollar_paren_command_substitution_inside_double_quotes_handles_nested_arithmetic_with_quoted_right_paren()
+ {
+    let input = "echo \"$(echo \"$(( $(printf ')') + 1 ))\")\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double-quoted word");
+    };
+    let WordPart::CommandSubstitution { body, syntax } = &parts[0].kind else {
+        panic!("expected command substitution");
+    };
+    assert_eq!(*syntax, CommandSubstitutionSyntax::DollarParen);
+
+    let inner = expect_simple(&body[0]);
+    assert_eq!(inner.name.render(input), "echo");
+    assert_eq!(
+        inner.args[0].render_syntax(input),
+        "\"$(( $(printf ')') + 1 ))\""
+    );
+}
+
+#[test]
 fn test_escaped_backticks_inside_double_quotes_stay_literal() {
     let input = "echo \"pre \\`pwd\\` post\"\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1531,13 +1531,32 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if ch == '$'
-                && !in_single
-                && let Some(end) =
+            if ch == '$' && !in_single {
+                let next_offset = ch_start.offset + ch.len_utf8();
+                if self.input[next_offset..].starts_with("((")
+                    && let Some(consumed) =
+                        Self::scan_array_arithmetic_expansion_len(&self.input[next_offset + 2..])
+                {
+                    let end = next_offset + 2 + consumed;
+                    cursor = ch_start.advanced_by(&self.input[ch_start.offset..end]);
+                    continue;
+                }
+
+                if self.input[next_offset..].starts_with('{')
+                    && let Some(consumed) =
+                        Self::scan_array_parameter_expansion_len(&self.input[next_offset + 1..])
+                {
+                    let end = next_offset + 1 + consumed;
+                    cursor = ch_start.advanced_by(&self.input[ch_start.offset..end]);
+                    continue;
+                }
+
+                if let Some(end) =
                     Self::scan_raw_dollar_paren_substitution_end(self.input, ch_start.offset)
-            {
-                cursor = ch_start.advanced_by(&self.input[ch_start.offset..end]);
-                continue;
+                {
+                    cursor = ch_start.advanced_by(&self.input[ch_start.offset..end]);
+                    continue;
+                }
             }
 
             match ch {

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1229,11 +1229,11 @@ fn probe_invalid_zsh_fixture(path: &Path, timeout: Duration) -> Result<Option<St
     }
 
     let stderr = String::from_utf8_lossy(&status.stderr).trim().to_owned();
-    Ok(Some(
-        (!stderr.is_empty())
-            .then_some(stderr)
-            .unwrap_or_else(|| "non-zero exit status".to_owned()),
-    ))
+    Ok(Some(if !stderr.is_empty() {
+        stderr
+    } else {
+        "non-zero exit status".to_owned()
+    }))
 }
 
 fn fixture_failure_kind_for_message(message: &str, label: &str) -> FixtureFailureKind {

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -479,6 +479,7 @@ enum CorpusNoiseKind {
     Fish,
     ParseAbort,
     ShellCollapse,
+    InvalidZshFixture,
 }
 
 impl CorpusNoiseKind {
@@ -489,6 +490,7 @@ impl CorpusNoiseKind {
             Self::Fish => "fish",
             Self::ParseAbort => "parse-abort",
             Self::ShellCollapse => "shell-collapse",
+            Self::InvalidZshFixture => "invalid-zsh-fixture",
         }
     }
 }
@@ -1183,16 +1185,55 @@ fn evaluate_fixture_zsh_parse(
         };
 
     if let Err(err) = parse_result {
-        evaluation.harness_failure = Some(FixtureFailure {
-            kind: FixtureFailureKind::Other,
-            message: format_fixture_failure(
-                &fixture.path,
-                &[format!("shuck zsh parse/option extraction error: {err}")],
-            ),
-        });
+        match probe_invalid_zsh_fixture(&fixture.path, shuck_timeout) {
+            Ok(Some(zsh_err)) => {
+                evaluation.corpus_noise.push(format_fixture_failure(
+                    &fixture.path,
+                    &[
+                        format!(
+                            "corpus noise [{}]",
+                            CorpusNoiseKind::InvalidZshFixture.as_str()
+                        ),
+                        format!("shuck zsh parse/option extraction error: {err}"),
+                        format!("zsh -n rejected fixture: {zsh_err}"),
+                    ],
+                ));
+            }
+            Ok(None) | Err(_) => {
+                evaluation.harness_failure = Some(FixtureFailure {
+                    kind: FixtureFailureKind::Other,
+                    message: format_fixture_failure(
+                        &fixture.path,
+                        &[format!("shuck zsh parse/option extraction error: {err}")],
+                    ),
+                });
+            }
+        }
     }
 
     evaluation
+}
+
+fn probe_invalid_zsh_fixture(path: &Path, timeout: Duration) -> Result<Option<String>, String> {
+    let path = path.to_path_buf();
+    let status = run_with_timeout("zsh", timeout, move || {
+        Command::new("zsh")
+            .arg("-n")
+            .arg(&path)
+            .output()
+            .map_err(|err| format!("failed to run `zsh -n`: {err}"))
+    })??;
+
+    if status.status.success() {
+        return Ok(None);
+    }
+
+    let stderr = String::from_utf8_lossy(&status.stderr).trim().to_owned();
+    Ok(Some(
+        (!stderr.is_empty())
+            .then_some(stderr)
+            .unwrap_or_else(|| "non-zero exit status".to_owned()),
+    ))
 }
 
 fn fixture_failure_kind_for_message(message: &str, label: &str) -> FixtureFailureKind {


### PR DESCRIPTION
## Summary

This fixes the remaining zsh corpus parse failures uncovered by the large-corpus harness.

The parser now accepts the zsh forms that were still blocking the corpus pass, including compact brace bodies, direct-body `for` loops, zsh arithmetic `#` parameter forms, and the remaining word/lexer edge cases around nested arithmetic and brace-style bodies. The large-corpus harness also now treats fixtures that `zsh -n` rejects as invalid upstream inputs instead of reporting them as parser failures.

## Root Cause

A handful of zsh-only syntactic forms were still being tokenized or lowered too narrowly, so otherwise valid zsh fixtures were falling into parse errors. The large-corpus harness was also counting at least one upstream-invalid zsh fixture as a parser mismatch even though the shell itself rejects it.

## Validation

- `cargo test -p shuck-parser`
- `make test-large-corpus-zsh`
