### PR TITLE
Refine S001 unquoted expansion matching

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2257,6 +2257,7 @@ pub struct LinterFacts<'a> {
     if_condition_command_ids: FxHashSet<CommandId>,
     elif_condition_command_ids: FxHashSet<CommandId>,
     scalar_bindings: FxHashMap<FactSpan, &'a Word>,
+    loop_bindings: FxHashMap<FactSpan, Box<[&'a Word]>>,
     broken_assoc_key_spans: Vec<Span>,
     comma_array_assignment_spans: Vec<Span>,
     presence_tested_names: FxHashSet<Name>,
@@ -2421,6 +2422,16 @@ impl<'a> LinterFacts<'a> {
 
     pub(crate) fn scalar_binding_values(&self) -> &FxHashMap<FactSpan, &'a Word> {
         &self.scalar_bindings
+    }
+
+    pub fn loop_binding_values(&self, span: Span) -> Option<&[&'a Word]> {
+        self.loop_bindings
+            .get(&FactSpan::new(span))
+            .map(Box::as_ref)
+    }
+
+    pub(crate) fn loop_binding_value_sets(&self) -> &FxHashMap<FactSpan, Box<[&'a Word]>> {
+        &self.loop_bindings
     }
 
     pub fn broken_assoc_key_spans(&self) -> &[Span] {
@@ -2821,6 +2832,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut if_condition_command_ids = FxHashSet::default();
         let mut elif_condition_command_ids = FxHashSet::default();
         let mut scalar_bindings = FxHashMap::default();
+        let mut loop_bindings = FxHashMap::default();
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
         let mut words = Vec::new();
@@ -2864,7 +2876,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 elif_condition_command_ids.insert(id);
             }
 
-            collect_scalar_bindings(visit.command, &mut scalar_bindings);
+            collect_scalar_bindings(visit.command, &mut scalar_bindings, &mut loop_bindings);
             collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
             collect_comma_array_assignment_spans(
                 visit.command,
@@ -3199,6 +3211,7 @@ impl<'a> LinterFactsBuilder<'a> {
             if_condition_command_ids,
             elif_condition_command_ids,
             scalar_bindings,
+            loop_bindings,
             broken_assoc_key_spans,
             comma_array_assignment_spans,
             presence_tested_names,
@@ -12527,6 +12540,7 @@ fn trap_action_word<'a>(command: &'a Command, source: &str) -> Option<&'a Word> 
 fn collect_scalar_bindings<'a>(
     command: &'a Command,
     scalar_bindings: &mut FxHashMap<FactSpan, &'a Word>,
+    loop_bindings: &mut FxHashMap<FactSpan, Box<[&'a Word]>>,
 ) {
     for assignment in query::command_assignments(command) {
         let AssignmentValue::Scalar(word) = &assignment.value else {
@@ -12543,6 +12557,27 @@ fn collect_scalar_bindings<'a>(
             continue;
         };
         scalar_bindings.insert(FactSpan::new(assignment.target.name_span), word);
+    }
+
+    match command {
+        Command::Compound(CompoundCommand::For(command)) => {
+            let Some(words) = &command.words else {
+                return;
+            };
+            let values = words.iter().collect::<Vec<_>>().into_boxed_slice();
+            for target in &command.targets {
+                if target.name.is_some() {
+                    loop_bindings.insert(FactSpan::new(target.span), values.clone());
+                }
+            }
+        }
+        Command::Compound(CompoundCommand::Foreach(command)) => {
+            loop_bindings.insert(
+                FactSpan::new(command.variable_span),
+                command.words.iter().collect::<Vec<_>>().into_boxed_slice(),
+            );
+        }
+        _ => {}
     }
 }
 
@@ -13343,6 +13378,33 @@ done
                 .scalar_binding_value(second_binding_span)
                 .map(|word| word.span.slice(source)),
             Some("2")
+        );
+    }
+
+    #[test]
+    fn indexes_loop_bindings_from_for_words() {
+        let source = "#!/bin/bash\nfor i in 16 32 64; do printf '%s\\n' \"$i\"; done\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let loop_binding_span = match &output.file.body[0].command {
+            shuck_ast::Command::Compound(shuck_ast::CompoundCommand::For(command)) => {
+                command.targets[0].span
+            }
+            _ => panic!("expected for command"),
+        };
+
+        assert_eq!(
+            facts
+                .loop_binding_values(loop_binding_span)
+                .expect("expected loop binding values")
+                .iter()
+                .map(|word| word.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["16", "32", "64"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -3,8 +3,10 @@ use shuck_ast::{
     BourneParameterExpansion, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp,
     RedirectKind, SourceText, Span, VarRef, Word, WordPart, WordPartNode,
 };
-use shuck_semantic::BindingId;
-use shuck_semantic::{BindingAttributes, BindingKind, SemanticAnalysis, SemanticModel};
+use shuck_semantic::{
+    BindingAttributes, BindingKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
+};
+use shuck_semantic::{BindingId, BlockId, ReferenceId, ReferenceKind};
 
 use crate::{FactSpan, LinterFacts};
 
@@ -80,6 +82,7 @@ impl<'a> SafeValueIndex<'a> {
         let maybe_uninitialized_refs = analysis
             .uninitialized_references()
             .iter()
+            .filter(|uninitialized| uninitialized.certainty == UninitializedCertainty::Possible)
             .map(|uninitialized| FactSpan::new(semantic.reference(uninitialized.reference).span))
             .collect();
 
@@ -193,6 +196,14 @@ impl<'a> SafeValueIndex<'a> {
         if bindings.is_empty() {
             return false;
         }
+        if self.maybe_uninitialized_refs.contains(&FactSpan::new(at))
+            && !bindings
+                .iter()
+                .copied()
+                .any(|binding_id| self.binding_dominates_reference(binding_id, name, at))
+        {
+            return false;
+        }
 
         bindings
             .into_iter()
@@ -281,6 +292,75 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         bindings
+    }
+
+    fn binding_dominates_reference(&self, binding_id: BindingId, name: &Name, at: Span) -> bool {
+        let Some(reference_id) = self.reference_id_for_name_at(name, at) else {
+            return false;
+        };
+        let Some(reference_block) = self.block_for_reference(reference_id) else {
+            return false;
+        };
+        let Some(binding_block) = self.block_for_binding(binding_id) else {
+            return false;
+        };
+        if binding_block == reference_block {
+            return true;
+        }
+
+        let cfg = self.analysis.cfg();
+        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let mut stack = vec![cfg.entry()];
+        let mut seen = FxHashSet::default();
+        while let Some(block_id) = stack.pop() {
+            if block_id == binding_block
+                || unreachable.contains(&block_id)
+                || !seen.insert(block_id)
+            {
+                continue;
+            }
+            if block_id == reference_block {
+                return false;
+            }
+            for (successor, _) in cfg.successors(block_id) {
+                stack.push(*successor);
+            }
+        }
+
+        true
+    }
+
+    fn reference_id_for_name_at(&self, name: &Name, at: Span) -> Option<ReferenceId> {
+        self.semantic
+            .references()
+            .iter()
+            .find(|reference| {
+                reference.span == at
+                    && &reference.name == name
+                    && !matches!(
+                        reference.kind,
+                        ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
+                    )
+            })
+            .map(|reference| reference.id)
+    }
+
+    fn block_for_binding(&self, binding_id: BindingId) -> Option<BlockId> {
+        self.analysis
+            .cfg()
+            .blocks()
+            .iter()
+            .find(|block| block.bindings.contains(&binding_id))
+            .map(|block| block.id)
+    }
+
+    fn block_for_reference(&self, reference_id: ReferenceId) -> Option<BlockId> {
+        self.analysis
+            .cfg()
+            .blocks()
+            .iter()
+            .find(|block| block.references.contains(&reference_id))
+            .map(|block| block.id)
     }
 
     fn transformation_is_safe(
@@ -605,6 +685,30 @@ if [ \"$foo\" = \"\" ]; then foo=0; fi
         let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
 
         let Command::Simple(command) = &output.file.body[2].command else {
+            panic!("expected simple test command");
+        };
+
+        assert!(!safe_values.word_is_safe(&command.args[0], SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn conditionally_initialized_names_stay_unsafe() {
+        let source = "\
+#!/bin/bash
+if [ \"$1\" = yes ]; then
+  foo=0
+fi
+[ $foo -eq 1 ]
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let Command::Simple(command) = &output.file.body[1].command else {
             panic!("expected simple test command");
         };
 

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -219,7 +219,7 @@ impl<'a> SafeValueIndex<'a> {
         let result = if let Some(word) = self.scalar_bindings.get(&binding_key).copied() {
             self.word_is_safe(word, query)
         } else if let Some(words) = self.loop_bindings.get(&binding_key) {
-            let words = words.iter().copied().collect::<Vec<_>>();
+            let words = words.to_vec();
             !words.is_empty() && words.into_iter().all(|word| self.word_is_safe(word, query))
         } else {
             false

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -27,6 +27,7 @@ impl SafeValueQuery {
         match context {
             ExpansionContext::CommandName
             | ExpansionContext::CommandArgument
+            | ExpansionContext::HereString
             | ExpansionContext::DeclarationAssignmentValue => Some(Self::Argv),
             ExpansionContext::RedirectTarget(_) => Some(Self::RedirectTarget),
             ExpansionContext::CasePattern
@@ -63,6 +64,7 @@ pub struct SafeValueIndex<'a> {
     facts: &'a LinterFacts<'a>,
     source: &'a str,
     scalar_bindings: FxHashMap<FactSpan, &'a Word>,
+    loop_bindings: FxHashMap<FactSpan, Box<[&'a Word]>>,
     maybe_uninitialized_refs: FxHashSet<FactSpan>,
     memo: FxHashMap<(FactSpan, SafeValueQuery), bool>,
     visiting: FxHashSet<(FactSpan, SafeValueQuery)>,
@@ -87,6 +89,7 @@ impl<'a> SafeValueIndex<'a> {
             facts,
             source,
             scalar_bindings: facts.scalar_binding_values().clone(),
+            loop_bindings: facts.loop_binding_value_sets().clone(),
             maybe_uninitialized_refs,
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
@@ -182,11 +185,8 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn name_is_safe(&mut self, name: &Name, at: Span, query: SafeValueQuery) -> bool {
-        if safe_special_parameter(name) {
+        if safe_special_parameter(name) || safe_numeric_shell_variable(name) {
             return true;
-        }
-        if self.maybe_uninitialized_refs.contains(&FactSpan::new(at)) {
-            return false;
         }
 
         let bindings = self.safe_bindings_for_name(name, at);
@@ -218,6 +218,9 @@ impl<'a> SafeValueIndex<'a> {
 
         let result = if let Some(word) = self.scalar_bindings.get(&binding_key).copied() {
             self.word_is_safe(word, query)
+        } else if let Some(words) = self.loop_bindings.get(&binding_key) {
+            let words = words.iter().copied().collect::<Vec<_>>();
+            !words.is_empty() && words.into_iter().all(|word| self.word_is_safe(word, query))
         } else {
             false
         };
@@ -456,6 +459,10 @@ fn safe_special_parameter(name: &Name) -> bool {
     matches!(name.as_str(), "@" | "#" | "?" | "$" | "!" | "-")
 }
 
+fn safe_numeric_shell_variable(name: &Name) -> bool {
+    matches!(name.as_str(), "PPID")
+}
+
 #[cfg(test)]
 mod tests {
     use shuck_ast::Command;
@@ -474,6 +481,10 @@ mod tests {
 
         assert_eq!(
             SafeValueQuery::from_context(ExpansionContext::CommandArgument),
+            Some(SafeValueQuery::Argv)
+        );
+        assert_eq!(
+            SafeValueQuery::from_context(ExpansionContext::HereString),
             Some(SafeValueQuery::Argv)
         );
         assert_eq!(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -188,13 +188,13 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn name_is_safe(&mut self, name: &Name, at: Span, query: SafeValueQuery) -> bool {
-        if safe_special_parameter(name) || safe_numeric_shell_variable(name) {
+        if safe_special_parameter(name) {
             return true;
         }
 
         let bindings = self.safe_bindings_for_name(name, at);
         if bindings.is_empty() {
-            return false;
+            return safe_numeric_shell_variable(name);
         }
         if self.maybe_uninitialized_refs.contains(&FactSpan::new(at))
             && !bindings
@@ -713,6 +713,28 @@ fi
         };
 
         assert!(!safe_values.word_is_safe(&command.args[0], SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn reassigned_ppid_stops_being_treated_as_runtime_safe() {
+        let source = "\
+#!/bin/sh
+PPID='a b'
+printf '%s\\n' $PPID
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let Command::Simple(command) = &output.file.body[1].command else {
+            panic!("expected simple command");
+        };
+
+        assert!(!safe_values.word_is_safe(&command.args[1], SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -74,7 +74,7 @@ fn report_word_expansions(
     safe_values: &mut SafeValueIndex<'_>,
     fact: &WordFact<'_>,
     context: ExpansionContext,
-    colon_command_argument: bool,
+    in_colon_command: bool,
 ) {
     if !fact.analysis().hazards.field_splitting && !fact.analysis().hazards.pathname_matching {
         return;
@@ -82,7 +82,7 @@ fn report_word_expansions(
 
     let scalar_spans = fact.scalar_expansion_spans();
     let array_spans = fact.unquoted_array_expansion_spans();
-    let assign_default_spans = if colon_command_argument {
+    let assign_default_spans = if in_colon_command && context == ExpansionContext::CommandArgument {
         word_unquoted_assign_default_spans(fact.word())
     } else {
         Default::default()
@@ -281,6 +281,23 @@ printf '%s\\n' ${z:=fallback}
                 .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.slice(source)))
                 .collect::<Vec<_>>(),
             vec![(2, "$other"), (3, "${z:=fallback}")]
+        );
+    }
+
+    #[test]
+    fn keeps_colon_assign_default_reports_for_here_strings_and_redirect_targets() {
+        let source = "\
+#!/bin/bash
+: <<< ${x:=fallback} >${y:=out}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${x:=fallback}", "${y:=out}"]
         );
     }
 
@@ -542,6 +559,26 @@ if [ \"$foo\" = \"\" ]; then
   foo=0
 fi
 if [ $foo -eq 1 ]; then :; fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$foo"]
+        );
+    }
+
+    #[test]
+    fn reports_conditionally_initialized_bindings_with_unknown_fallbacks() {
+        let source = "\
+#!/bin/bash
+if [ \"$1\" = yes ]; then
+  foo=0
+fi
+printf '%s\\n' $foo
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -499,6 +499,28 @@ printf '%s\\n' $(ps -o comm= -p $PPID)
     }
 
     #[test]
+    fn reports_reassigned_ppid_in_sh_mode() {
+        let source = "\
+#!/bin/sh
+PPID='a b'
+printf '%s\\n' $PPID
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/pkg.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$PPID"]
+        );
+    }
+
+    #[test]
     fn skips_safe_here_string_operands() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1,6 +1,8 @@
+use rustc_hash::FxHashSet;
+
 use crate::{
     Checker, ExpansionContext, Rule, SafeValueIndex, SafeValueQuery, ShellDialect, Violation,
-    WordFact, word_unquoted_star_parameter_spans,
+    WordFact, word_unquoted_assign_default_spans, word_unquoted_star_parameter_spans,
 };
 
 pub struct UnquotedExpansion;
@@ -17,6 +19,13 @@ impl Violation for UnquotedExpansion {
 
 pub fn unquoted_expansion(checker: &mut Checker) {
     let source = checker.source();
+    let colon_command_ids = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is(":"))
+        .map(|fact| fact.id())
+        .collect::<FxHashSet<_>>();
     let mut safe_values = SafeValueIndex::build(
         checker.semantic(),
         checker.semantic_analysis(),
@@ -33,7 +42,13 @@ pub fn unquoted_expansion(checker: &mut Checker) {
             continue;
         }
 
-        report_word_expansions(&mut spans, &mut safe_values, fact, context);
+        report_word_expansions(
+            &mut spans,
+            &mut safe_values,
+            fact,
+            context,
+            colon_command_ids.contains(&fact.command_id()),
+        );
     }
 
     drop(safe_values);
@@ -47,6 +62,7 @@ fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool 
     match context {
         ExpansionContext::CommandName
         | ExpansionContext::CommandArgument
+        | ExpansionContext::HereString
         | ExpansionContext::RedirectTarget(_) => true,
         ExpansionContext::DeclarationAssignmentValue => shell != ShellDialect::Bash,
         _ => false,
@@ -58,6 +74,7 @@ fn report_word_expansions(
     safe_values: &mut SafeValueIndex<'_>,
     fact: &WordFact<'_>,
     context: ExpansionContext,
+    colon_command_argument: bool,
 ) {
     if !fact.analysis().hazards.field_splitting && !fact.analysis().hazards.pathname_matching {
         return;
@@ -65,11 +82,17 @@ fn report_word_expansions(
 
     let scalar_spans = fact.scalar_expansion_spans();
     let array_spans = fact.unquoted_array_expansion_spans();
+    let assign_default_spans = colon_command_argument
+        .then(|| word_unquoted_assign_default_spans(fact.word()))
+        .unwrap_or_default();
     let star_spans = word_unquoted_star_parameter_spans(fact.word(), array_spans);
     if scalar_spans.is_empty() && star_spans.is_empty() {
         return;
     }
-    if context == ExpansionContext::CommandName && !fact.has_literal_affixes() {
+    if context == ExpansionContext::CommandName
+        && !fact.has_literal_affixes()
+        && fact.word().parts.len() == 1
+    {
         return;
     }
     let query = SafeValueQuery::from_context(context)
@@ -78,6 +101,9 @@ fn report_word_expansions(
     for (part, part_span) in fact.word().parts_with_spans() {
         let report_unquoted_star = star_spans.contains(&part_span);
         if !scalar_spans.contains(&part_span) && !report_unquoted_star {
+            continue;
+        }
+        if assign_default_spans.contains(&part_span) {
             continue;
         }
         if safe_values.part_is_safe(part, part_span, query) {
@@ -158,7 +184,7 @@ printf '%s\\n' prefix\"$HOME\"/$suffix
     }
 
     #[test]
-    fn skips_for_lists_but_still_reports_redirect_targets() {
+    fn skips_for_lists_but_reports_here_strings_and_redirect_targets() {
         let source = "\
 #!/bin/bash
 for item in $first \"$second\"; do :; done
@@ -171,7 +197,7 @@ cat <<< $here >$out
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$out"]
+            vec!["$here", "$out"]
         );
     }
 
@@ -239,17 +265,42 @@ printf '%s\\n' ${name@U}
     }
 
     #[test]
-    fn skips_plain_expansion_command_names() {
+    fn skips_colon_assign_default_expansions_but_keeps_regular_argument_cases() {
+        let source = "\
+#!/bin/bash
+: ${x:=fallback} $other
+printf '%s\\n' ${z:=fallback}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.slice(source)))
+                .collect::<Vec<_>>(),
+            vec![(2, "$other"), (3, "${z:=fallback}")]
+        );
+    }
+
+    #[test]
+    fn skips_plain_expansion_command_names_but_reports_composite_command_words() {
         let source = "\
 #!/bin/bash
 $CC -c file.c
 if $TERMUX_ON_DEVICE_BUILD; then
   :
 fi
+${CC}${FLAGS} file.c
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CC}", "${FLAGS}"]
+        );
     }
 
     #[test]
@@ -403,6 +454,66 @@ printf '%s\\n' $n $s $glob $split $copy $alias
                 .collect::<Vec<_>>(),
             vec!["$glob", "$split"]
         );
+    }
+
+    #[test]
+    fn skips_safe_literal_bindings_inside_nested_command_substitutions() {
+        let source = "\
+#!/bin/bash
+URL=https://example.com/file.tgz
+FILE=$(basename $URL)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_safe_numeric_shell_variables() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' $(ps -o comm= -p $PPID)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_safe_here_string_operands() {
+        let source = "\
+#!/bin/bash
+URL=https://example.com/file.tgz
+cat <<< $URL
+cat <<< $PPID
+v='a b'
+cat <<< $v
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$v"]
+        );
+    }
+
+    #[test]
+    fn skips_safe_literal_loop_variables() {
+        let source = "\
+#!/bin/bash
+for v in one two; do
+  unset $v
+done
+for i in 16 32 64; do
+  cmd ${i}x${i}! \"$i\"
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -82,9 +82,11 @@ fn report_word_expansions(
 
     let scalar_spans = fact.scalar_expansion_spans();
     let array_spans = fact.unquoted_array_expansion_spans();
-    let assign_default_spans = colon_command_argument
-        .then(|| word_unquoted_assign_default_spans(fact.word()))
-        .unwrap_or_default();
+    let assign_default_spans = if colon_command_argument {
+        word_unquoted_assign_default_spans(fact.word())
+    } else {
+        Default::default()
+    };
     let star_spans = word_unquoted_star_parameter_spans(fact.word(), array_spans);
     if scalar_spans.is_empty() && star_spans.is_empty() {
         return;


### PR DESCRIPTION
## Summary
- refine S001 matching for unquoted expansions in here-strings and composite command words
- track literal `for` loop bindings in linter facts so safe loop variables are not reported spuriously
- avoid overlapping with the assign-default under `:` case that belongs to S062

## Why
The remaining S001 corpus deltas included real analysis gaps in how we classified safe values and command-word contexts. This change fixes those cases in the rule and fact layers instead of masking them with new divergence metadata.

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter unquoted_expansion -- --nocapture`
- `cargo test -p shuck-linter safe_value -- --nocapture`
- `cargo test -p shuck-linter indexes_loop_bindings_from_for_words -- --nocapture`
- targeted S001 large corpus run

## Result
The S001 targeted large corpus run improved from `blocking=1421` to `blocking=1041` without adding new ignore metadata.
