### PR TITLE
Fix S070 command substitution handling

### DIFF
--- a/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
+++ b/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
@@ -15,6 +15,13 @@ impl Violation for DoubleQuoteNesting {
     }
 }
 
+fn span_is_strictly_inside(span: &shuck_ast::Span, host: &shuck_ast::Span) -> bool {
+    host.start.offset <= span.start.offset
+        && span.end.offset <= host.end.offset
+        && span.start.offset != host.start.offset
+        && span.end.offset != host.end.offset
+}
+
 pub fn double_quote_nesting(checker: &mut Checker) {
     let source = checker.source();
     let spans = checker
@@ -35,7 +42,6 @@ pub fn double_quote_nesting(checker: &mut Checker) {
                 .facts()
                 .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue),
         )
-        .filter(|fact| !fact.is_nested_word_command())
         .flat_map(|fact| {
             let mut candidate_spans = fact
                 .unquoted_scalar_expansion_spans()
@@ -45,9 +51,16 @@ pub fn double_quote_nesting(checker: &mut Checker) {
                 .collect::<Vec<_>>();
             candidate_spans.extend(fact.unquoted_command_substitution_spans().iter().copied());
 
+            let host_substitution_spans = fact.command_substitution_spans();
+
             word_unquoted_scalar_between_double_quoted_segments_spans(fact.word(), &candidate_spans)
                 .into_iter()
                 .chain(word_nested_dynamic_double_quote_spans(fact.word()))
+                .filter(|span| {
+                    !host_substitution_spans
+                        .iter()
+                        .any(|host| span_is_strictly_inside(span, host))
+                })
         })
         .collect::<Vec<_>>();
 
@@ -105,5 +118,41 @@ case \"$line\" in \"status-filtered \"$status\"*) : ;; esac
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DoubleQuoteNesting));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_reopened_quotes_inside_unquoted_command_substitution_bodies() {
+        let source = "\
+#!/bin/bash
+now=$(grep -aE '^5' \"$LISTFILE\" | sed -n \"\"$rule_link\"p\" | awk '{print $2}')
+server=$(grep -aE '^3|^4' \"$LISTFILE\" | sed -n \"\"$server_link\"p\" | awk '{print $3}')
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DoubleQuoteNesting));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$rule_link", "$server_link"]
+        );
+    }
+
+    #[test]
+    fn ignores_nested_command_arguments_that_are_fully_quoted_inside_quoted_substitutions() {
+        let source = "\
+#!/bin/bash
+files+=(\"$(basename \"${file%.desktop}\")\")
+candidates+=(\"$(echo \"$line\" | cut -d' ' -f2-)\")
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DoubleQuoteNesting));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            Vec::<&str>::new()
+        );
     }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/s070.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s070.yaml
@@ -17,3 +17,83 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "scripts/termux__termux-packages__x11-packages__kitty__build.sh"
     reason: "S070 intentionally flags split quoting in assignment entries built from sourced command substitutions; current ShellCheck releases do not emit matching SC2027 diagnostics for these rows."
+  - side: shuck-only
+    path_suffix: "scripts/SlackBuildsOrg__slackbuilds__network__nessus__doinst.sh"
+    line: 42
+    reason: "This line rejoins double-quoted text around a legacy backtick substitution. Shuck keeps warning because the substitution result is still unquoted at the join point, while the current oracle classifies legacy backticks under other codes instead of SC2027."
+  - side: shuck-only
+    path_suffix: "scripts/alpinelinux__aports__community__dnscrypt-proxy__dnscrypt-proxy.setup"
+    line: 128
+    reason: "This grep argument is assembled by reopening double quotes around `$SCRIPT`. Shuck keeps the split-quote warning here, while the current oracle misses SC2027 for this grep pattern."
+  - side: shuck-only
+    path_suffix: "scripts/alpinelinux__aports__community__gnunet__setup-gnunet-user"
+    line: 7
+    reason: "This usage string rejoins double-quoted text around a legacy backtick substitution. Shuck keeps warning because the substitution result is still unquoted at the join point, while the current oracle classifies legacy backticks under other codes instead of SC2027."
+  - side: shuck-only
+    path_suffix: "scripts/alpinelinux__aports__community__gnunet__setup-gnunet-user"
+    line: 11
+    reason: "This usage string rejoins double-quoted text around a legacy backtick substitution. Shuck keeps warning because the substitution result is still unquoted at the join point, while the current oracle classifies legacy backticks under other codes instead of SC2027."
+  - side: shuck-only
+    path_suffix: "scripts/bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__jenkins__run.sh"
+    line: 29
+    reason: "This launcher argument embeds a quoted default value inside `${var:-...}`. Shuck keeps warning on the reopened quote shape inside the parameter-expansion default, while the current oracle does not surface SC2027 for that form."
+  - side: shuck-only
+    path_suffix: "scripts/bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__jenkins__run.sh"
+    line: 30
+    reason: "This launcher argument embeds a quoted default value inside `${var:-...}`. Shuck keeps warning on the reopened quote shape inside the parameter-expansion default, while the current oracle does not surface SC2027 for that form."
+  - side: shuck-only
+    path_suffix: "scripts/bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__jenkins__run.sh"
+    line: 36
+    reason: "This launcher argument embeds a quoted default value inside `${var:-...}`. Shuck keeps warning on the reopened quote shape inside the parameter-expansion default, while the current oracle does not surface SC2027 for that form."
+  - side: shuck-only
+    path_suffix: "scripts/bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__jenkins__run.sh"
+    line: 37
+    reason: "This launcher argument embeds a quoted default value inside `${var:-...}`. Shuck keeps warning on the reopened quote shape inside the parameter-expansion default, while the current oracle does not surface SC2027 for that form."
+  - side: shuck-only
+    path_suffix: "scripts/bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__jenkins__run.sh"
+    line: 38
+    reason: "This launcher argument embeds a quoted default value inside `${var:-...}`. Shuck keeps warning on the reopened quote shape inside the parameter-expansion default, while the current oracle does not surface SC2027 for that form."
+  - side: shuck-only
+    path_suffix: "scripts/bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__jenkins__run.sh"
+    line: 39
+    reason: "This launcher argument embeds a quoted default value inside `${var:-...}`. Shuck keeps warning on the reopened quote shape inside the parameter-expansion default, while the current oracle does not surface SC2027 for that form."
+  - side: shellcheck-only
+    path_suffix: "scripts/moovweb__gvm__examples__native__ltmain.sh"
+    line: 3910
+    reason: "This generated `ltmain.sh` comment documents literal `$0` and `\"$@\"` text. The current shell-collapse oracle surfaces SC2027 here, while S070 is intentionally scoped to executable shell words rather than comment text."
+  - side: shuck-only
+    path_suffix: "scripts/moovweb__gvm__examples__native__ltmain.sh"
+    line: 8651
+    reason: "This generated `ltmain.sh` line rejoins double-quoted text around a legacy backtick substitution. Shuck keeps warning because the substitution result is still unquoted at the join point, while the current oracle classifies legacy backticks under other codes instead of SC2027."
+  - side: shuck-only
+    path_suffix: "scripts/scop__bash-completion__completions-core__cvs.bash"
+    line: 338
+    reason: "This completion helper trims a prefix with a quoted parameter-expansion removal pattern. Shuck keeps warning on the reopened quote inside that operator form, while the current oracle omits SC2027 for it."
+  - side: shuck-only
+    path_suffix: "scripts/scop__bash-completion__completions-core__mutt.bash"
+    line: 130
+    reason: "This completion helper trims a prefix with a quoted parameter-expansion removal pattern. Shuck keeps warning on the reopened quote inside that operator form, while the current oracle omits SC2027 for it."
+  - side: shuck-only
+    path_suffix: "scripts/scop__bash-completion__completions-core__pkg_delete.bash"
+    line: 13
+    reason: "This completion helper trims a prefix with a quoted parameter-expansion removal pattern. Shuck keeps warning on the reopened quote inside that operator form, while the current oracle omits SC2027 for it."
+  - side: shuck-only
+    path_suffix: "scripts/scop__bash-completion__completions-core__portupgrade.bash"
+    line: 13
+    reason: "This completion helper trims a prefix with a quoted parameter-expansion removal pattern. Shuck keeps warning on the reopened quote inside that operator form, while the current oracle omits SC2027 for it."
+  - side: shuck-only
+    path_suffix: "scripts/scop__bash-completion__completions-fallback__mount.linux.bash"
+    line: 201
+    reason: "This completion helper trims a prefix with a quoted parameter-expansion removal pattern. Shuck keeps warning on the reopened quote inside that operator form, while the current oracle omits SC2027 for it."
+  - side: shuck-only
+    path_suffix: "scripts/v1s1t0r1sh3r3__airgeddon__airgeddon.sh"
+    line: 1219
+    reason: "This associative-array lookup quotes the dynamic key inside the expansion subscript. Shuck keeps warning on the reopened quote shape in that key expression, while the current oracle omits SC2027 for this array-subscript form."
+  - side: shuck-only
+    path_suffix: "scripts/v1s1t0r1sh3r3__airgeddon__airgeddon.sh"
+    line: 1229
+    reason: "This associative-array lookup quotes the dynamic key inside the expansion subscript. Shuck keeps warning on the reopened quote shape in that key expression, while the current oracle omits SC2027 for this array-subscript form."
+  - side: shuck-only
+    path_suffix: "scripts/v1s1t0r1sh3r3__airgeddon__airgeddon.sh"
+    line: 1284
+    reason: "This associative-array lookup quotes the dynamic key inside the expansion subscript. Shuck keeps warning on the reopened quote shape in that key expression, while the current oracle omits SC2027 for this array-subscript form."


### PR DESCRIPTION
## Summary
- fix `S070` so it can report reopened quote patterns inside unquoted command-substitution bodies
- avoid false positives when the outer word only wraps fully quoted nested substitution arguments
- record the remaining reviewed `S070` oracle and policy divergences in corpus metadata

## Why
`S070` was skipping nested word-command facts entirely and also letting outer words claim spans that really belonged to nested command substitutions. That combination missed real `SC2027`-style cases like `sed -n ""$rule_link"p"` while still flagging some fully quoted nested substitution arguments.

## Impact
The rule now handles nested command substitutions more precisely, and the targeted large-corpus compatibility run for `S070` is back to zero blocking diffs.

## Validation
- `cargo test -p shuck-linter double_quote_nesting`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S070`
