### PR TITLE
Fix S004 command substitution parity

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -899,6 +899,9 @@ pub struct SubstitutionFact {
     body_contains_echo: bool,
     body_contains_grep: bool,
     body_has_multiple_statements: bool,
+    body_is_pgrep_lookup: bool,
+    body_is_seq_utility: bool,
+    body_has_commands: bool,
     bash_file_slurp: bool,
     host_word_span: Span,
     host_kind: SubstitutionHostKind,
@@ -945,7 +948,17 @@ impl SubstitutionFact {
     pub fn body_has_multiple_statements(&self) -> bool {
         self.body_has_multiple_statements
     }
+    pub fn body_is_pgrep_lookup(&self) -> bool {
+        self.body_is_pgrep_lookup
+    }
 
+    pub fn body_is_seq_utility(&self) -> bool {
+        self.body_is_seq_utility
+    }
+
+    pub fn body_has_commands(&self) -> bool {
+        self.body_has_commands
+    }
     pub fn is_bash_file_slurp(&self) -> bool {
         self.bash_file_slurp
     }
@@ -17021,6 +17034,31 @@ printf '%s\\n' $0 $1 $* $@
             assert!(argument_words.contains(&"$1".to_owned()));
             assert!(argument_words.contains(&"$*".to_owned()));
             assert!(argument_words.contains(&"$@".to_owned()));
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_for_filename_builder_command_substitutions() {
+        let source = "\
+#!/bin/bash
+/sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION\\_$(echo ${KERNEL} | tr '-' '_')-$ARCH-$BUILD$TAG.$PKGTYPE
+";
+
+        with_facts(source, None, |_, facts| {
+            let fact = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source).contains("$(echo ${KERNEL} | tr '-' '_')"))
+                .expect("expected makepkg output argument fact");
+
+            assert_eq!(
+                fact.unquoted_command_substitution_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["$(echo ${KERNEL} | tr '-' '_')"],
+                "parts: {:?}",
+                fact.word().parts
+            );
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -17047,7 +17047,11 @@ printf '%s\\n' $0 $1 $* $@
         with_facts(source, None, |_, facts| {
             let fact = facts
                 .expansion_word_facts(ExpansionContext::CommandArgument)
-                .find(|fact| fact.span().slice(source).contains("$(echo ${KERNEL} | tr '-' '_')"))
+                .find(|fact| {
+                    fact.span()
+                        .slice(source)
+                        .contains("$(echo ${KERNEL} | tr '-' '_')")
+                })
                 .expect("expected makepkg output argument fact");
 
             assert_eq!(

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -388,11 +388,7 @@ fn classify_substitution_body<'a>(
             commands,
             command_ids_by_span,
         ),
-        body_is_seq_utility: substitution_body_is_seq_utility(
-            body,
-            commands,
-            command_ids_by_span,
-        ),
+        body_is_seq_utility: substitution_body_is_seq_utility(body, commands, command_ids_by_span),
         body_has_commands: !visits.is_empty(),
         bash_file_slurp: matches!(visits.as_slice(), [visit] if is_bash_file_slurp_command(visit.command, visit.redirects, source)),
     }

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -167,6 +167,9 @@ fn collect_or_update_substitution_facts_from_occurrences<'a>(
             body_contains_echo: body_facts.body_contains_echo,
             body_contains_grep: body_facts.body_contains_grep,
             body_has_multiple_statements: body_facts.body_has_multiple_statements,
+            body_is_pgrep_lookup: body_facts.body_is_pgrep_lookup,
+            body_is_seq_utility: body_facts.body_is_seq_utility,
+            body_has_commands: body_facts.body_has_commands,
             bash_file_slurp: body_facts.bash_file_slurp,
             host_word_span: host_span,
             host_kind,
@@ -335,6 +338,9 @@ struct SubstitutionBodyFacts {
     body_contains_echo: bool,
     body_contains_grep: bool,
     body_has_multiple_statements: bool,
+    body_is_pgrep_lookup: bool,
+    body_is_seq_utility: bool,
+    body_has_commands: bool,
     bash_file_slurp: bool,
 }
 
@@ -377,6 +383,17 @@ fn classify_substitution_body<'a>(
         body_contains_echo: substitution_body_contains_echo(body, source),
         body_contains_grep: substitution_body_contains_grep(body, source),
         body_has_multiple_statements: body.stmts.len() > 1,
+        body_is_pgrep_lookup: substitution_body_is_pgrep_lookup(
+            body,
+            commands,
+            command_ids_by_span,
+        ),
+        body_is_seq_utility: substitution_body_is_seq_utility(
+            body,
+            commands,
+            command_ids_by_span,
+        ),
+        body_has_commands: !visits.is_empty(),
         bash_file_slurp: matches!(visits.as_slice(), [visit] if is_bash_file_slurp_command(visit.command, visit.redirects, source)),
     }
 }
@@ -2062,6 +2079,29 @@ fn substitution_body_is_find<'a>(
     matches!(body.as_slice(), [stmt] if stmt_effective_name_is(stmt, "find", commands, command_ids_by_span))
 }
 
+fn substitution_body_is_pgrep_lookup<'a>(
+    body: &'a StmtSeq,
+    commands: &[CommandFact<'a>],
+    command_ids_by_span: &CommandLookupIndex,
+) -> bool {
+    matches!(
+        body.as_slice(),
+        [stmt]
+            if stmt_effective_or_literal_basename_is(stmt, "pgrep", commands, command_ids_by_span)
+    )
+}
+
+fn substitution_body_is_seq_utility<'a>(
+    body: &'a StmtSeq,
+    commands: &[CommandFact<'a>],
+    command_ids_by_span: &CommandLookupIndex,
+) -> bool {
+    matches!(
+        body.as_slice(),
+        [stmt] if stmt_effective_or_literal_basename_is(stmt, "seq", commands, command_ids_by_span)
+    )
+}
+
 fn substitution_body_is_simple_command_named<'a>(
     body: &'a StmtSeq,
     name: &str,
@@ -2090,4 +2130,17 @@ fn stmt_literal_name_is<'a>(
 ) -> bool {
     command_fact_for_stmt(stmt, commands, command_ids_by_span).and_then(CommandFact::literal_name)
         == Some(name)
+}
+
+fn stmt_effective_or_literal_basename_is<'a>(
+    stmt: &'a Stmt,
+    name: &str,
+    commands: &[CommandFact<'a>],
+    command_ids_by_span: &CommandLookupIndex,
+) -> bool {
+    command_fact_for_stmt(stmt, commands, command_ids_by_span)
+        .and_then(CommandFact::effective_or_literal_name)
+        .is_some_and(|command_name| {
+            command_name == name || command_name.rsplit('/').next() == Some(name)
+        })
 }

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -1,8 +1,9 @@
 use shuck_ast::{
     ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
-    BinaryCommand, BinaryOp, BuiltinCommand, Command, CompoundCommand, ConditionalExpr,
-    DeclOperand, FunctionDef, HeredocBodyPartNode, Pattern, PatternPart, Redirect, Stmt, StmtSeq,
-    Subscript, VarRef, Word, WordPart, WordPartNode, ZshGlobSegment,
+    BinaryCommand, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand,
+    ConditionalExpr, DeclOperand, FunctionDef, HeredocBodyPartNode, ParameterExpansion,
+    ParameterExpansionSyntax, Pattern, PatternPart, Redirect, Stmt, StmtSeq, Subscript, VarRef,
+    Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment,
 };
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct WalkContext {
@@ -659,6 +660,67 @@ fn collect_word_part_visits<'a, F>(
                     }
                 }
             }
+            WordPart::Parameter(parameter) => {
+                collect_parameter_expansion_visits(parameter, options, context, visitor);
+            }
+            WordPart::ParameterExpansion {
+                reference,
+                operand_word_ast,
+                ..
+            }
+            | WordPart::IndirectExpansion {
+                reference,
+                operand_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, options, context, visitor);
+                if let Some(word) = operand_word_ast.as_ref() {
+                    collect_word_visits(word, options, context, visitor);
+                }
+            }
+            WordPart::Length(reference)
+            | WordPart::ArrayAccess(reference)
+            | WordPart::ArrayLength(reference)
+            | WordPart::ArrayIndices(reference)
+            | WordPart::Transformation { reference, .. } => {
+                collect_var_ref_word_visits(reference, options, context, visitor);
+            }
+            WordPart::Substring {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPart::ArraySlice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, options, context, visitor);
+                if let Some(expression) = offset_ast.as_ref() {
+                    let mut arithmetic_words = Vec::new();
+                    collect_optional_arithmetic_words(Some(expression), &mut arithmetic_words);
+                    for word in arithmetic_words {
+                        collect_word_visits(word, options, context, visitor);
+                    }
+                } else {
+                    collect_word_visits(offset_word_ast, options, context, visitor);
+                }
+                if let Some(expression) = length_ast.as_ref() {
+                    let mut arithmetic_words = Vec::new();
+                    collect_optional_arithmetic_words(Some(expression), &mut arithmetic_words);
+                    for word in arithmetic_words {
+                        collect_word_visits(word, options, context, visitor);
+                    }
+                } else if let Some(word) = length_word_ast.as_ref() {
+                    collect_word_visits(word, options, context, visitor);
+                }
+            }
             WordPart::CommandSubstitution { body, .. }
             | WordPart::ProcessSubstitution { body, .. } => {
                 collect_command_visits(body, options, context, visitor);
@@ -666,18 +728,148 @@ fn collect_word_part_visits<'a, F>(
             WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
             | WordPart::Variable(_)
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::ArrayAccess(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::ArrayIndices(_)
-            | WordPart::Substring { .. }
-            | WordPart::ArraySlice { .. }
-            | WordPart::IndirectExpansion { .. }
             | WordPart::PrefixMatch { .. }
-            | WordPart::Transformation { .. } => {}
+            => {}
         }
+    }
+}
+
+fn collect_var_ref_word_visits<'a, F>(
+    reference: &'a VarRef,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
+    let mut words = Vec::new();
+    collect_var_ref_subscript_words(reference, &mut words);
+    for word in words {
+        collect_word_visits(word, options, context, visitor);
+    }
+}
+
+fn collect_parameter_expansion_visits<'a, F>(
+    parameter: &'a ParameterExpansion,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+            BourneParameterExpansion::Access { reference }
+            | BourneParameterExpansion::Length { reference }
+            | BourneParameterExpansion::Indices { reference }
+            | BourneParameterExpansion::Transformation { reference, .. } => {
+                collect_var_ref_word_visits(reference, options, context, visitor);
+            }
+            BourneParameterExpansion::Indirect {
+                reference,
+                operand_word_ast,
+                ..
+            }
+            | BourneParameterExpansion::Operation {
+                reference,
+                operand_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, options, context, visitor);
+                if let Some(word) = operand_word_ast.as_ref() {
+                    collect_word_visits(word, options, context, visitor);
+                }
+            }
+            BourneParameterExpansion::Slice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, options, context, visitor);
+                if let Some(expression) = offset_ast.as_ref() {
+                    let mut arithmetic_words = Vec::new();
+                    collect_optional_arithmetic_words(Some(expression), &mut arithmetic_words);
+                    for word in arithmetic_words {
+                        collect_word_visits(word, options, context, visitor);
+                    }
+                } else {
+                    collect_word_visits(offset_word_ast, options, context, visitor);
+                }
+                if let Some(expression) = length_ast.as_ref() {
+                    let mut arithmetic_words = Vec::new();
+                    collect_optional_arithmetic_words(Some(expression), &mut arithmetic_words);
+                    for word in arithmetic_words {
+                        collect_word_visits(word, options, context, visitor);
+                    }
+                } else if let Some(word) = length_word_ast.as_ref() {
+                    collect_word_visits(word, options, context, visitor);
+                }
+            }
+            BourneParameterExpansion::PrefixMatch { .. } => {}
+        },
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            collect_zsh_target_visits(&syntax.target, options, context, visitor);
+
+            for modifier in &syntax.modifiers {
+                if let Some(word) = modifier.argument_word_ast() {
+                    collect_word_visits(word, options, context, visitor);
+                }
+            }
+
+            if let Some(operation) = &syntax.operation {
+                match operation {
+                    shuck_ast::ZshExpansionOperation::PatternOperation { .. }
+                    | shuck_ast::ZshExpansionOperation::Defaulting { .. }
+                    | shuck_ast::ZshExpansionOperation::TrimOperation { .. }
+                    | shuck_ast::ZshExpansionOperation::Unknown { .. } => {
+                        if let Some(word) = operation.operand_word_ast() {
+                            collect_word_visits(word, options, context, visitor);
+                        }
+                    }
+                    shuck_ast::ZshExpansionOperation::ReplacementOperation { .. } => {
+                        if let Some(word) = operation.pattern_word_ast() {
+                            collect_word_visits(word, options, context, visitor);
+                        }
+                        if let Some(word) = operation.replacement_word_ast() {
+                            collect_word_visits(word, options, context, visitor);
+                        }
+                    }
+                    shuck_ast::ZshExpansionOperation::Slice { .. } => {
+                        if let Some(word) = operation.offset_word_ast() {
+                            collect_word_visits(word, options, context, visitor);
+                        }
+                        if let Some(word) = operation.length_word_ast() {
+                            collect_word_visits(word, options, context, visitor);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_zsh_target_visits<'a, F>(
+    target: &'a ZshExpansionTarget,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
+    match target {
+        ZshExpansionTarget::Reference(reference) => {
+            collect_var_ref_word_visits(reference, options, context, visitor);
+        }
+        ZshExpansionTarget::Nested(parameter) => {
+            collect_parameter_expansion_visits(parameter, options, context, visitor);
+        }
+        ZshExpansionTarget::Word(word) => {
+            collect_word_visits(word, options, context, visitor);
+        }
+        ZshExpansionTarget::Empty => {}
     }
 }
 
@@ -989,6 +1181,40 @@ done
                 ("bar".to_owned(), Some(ConditionKind::While), false, false),
                 ("baz".to_owned(), Some(ConditionKind::Elif), true, true),
                 ("qux".to_owned(), Some(ConditionKind::While), false, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn walk_commands_descends_into_parameter_expansion_operands() {
+        let source = "\
+printf '%s\\n' ${value:-$(expr $(nproc) + 1)}
+";
+        let commands = parse_commands(source);
+        let mut visits = Vec::new();
+
+        walk_commands(
+            &commands,
+            CommandWalkOptions {
+                descend_nested_word_commands: true,
+            },
+            &mut |visit, context| {
+                let Command::Simple(command) = visit.command else {
+                    return;
+                };
+                let Some(name) = static_word_text(&command.name, source) else {
+                    return;
+                };
+                visits.push((name, context.nested_word_command));
+            },
+        );
+
+        assert_eq!(
+            visits,
+            vec![
+                ("printf".to_owned(), false),
+                ("expr".to_owned(), true),
+                ("nproc".to_owned(), true),
             ]
         );
     }

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -728,8 +728,7 @@ fn collect_word_part_visits<'a, F>(
             WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
             | WordPart::Variable(_)
-            | WordPart::PrefixMatch { .. }
-            => {}
+            | WordPart::PrefixMatch { .. } => {}
         }
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -91,8 +91,8 @@ fn should_report_unquoted_command_substitution(
         | (
             ExpansionContext::DeclarationAssignmentValue,
             WordFactHostKind::AssignmentTargetSubscript
-                | WordFactHostKind::DeclarationNameSubscript
-                | WordFactHostKind::ArrayKeySubscript,
+            | WordFactHostKind::DeclarationNameSubscript
+            | WordFactHostKind::ArrayKeySubscript,
         ) => true,
         (ExpansionContext::DeclarationAssignmentValue, WordFactHostKind::Direct) => {
             checker.shell() == ShellDialect::Sh

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -1,5 +1,4 @@
-use crate::SubstitutionHostKind;
-use crate::{Checker, CommandSubstitutionKind, Rule, ShellDialect, Violation};
+use crate::{Checker, ExpansionContext, Rule, ShellDialect, Violation, WordFact, WordFactHostKind};
 
 pub struct UnquotedCommandSubstitution;
 
@@ -14,32 +13,95 @@ impl Violation for UnquotedCommandSubstitution {
 }
 
 pub fn unquoted_command_substitution(checker: &mut Checker) {
-    let spans = checker
+    let arithmetic_spans = checker.facts().arithmetic_command_substitution_spans();
+    let pgrep_spans = checker
         .facts()
         .commands()
         .iter()
+        .flat_map(|fact| fact.substitution_facts().iter())
+        .filter(|fact| fact.body_is_pgrep_lookup())
+        .map(|fact| fact.span())
+        .collect::<Vec<_>>();
+    let seq_spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| fact.substitution_facts().iter())
+        .filter(|fact| fact.body_is_seq_utility())
+        .map(|fact| fact.span())
+        .collect::<Vec<_>>();
+    let inert_spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| fact.substitution_facts().iter())
+        .filter(|fact| !fact.body_has_commands())
+        .map(|fact| fact.span())
+        .collect::<Vec<_>>();
+    let spans = checker
+        .facts()
+        .word_facts()
+        .iter()
         .flat_map(|fact| {
-            fact.substitution_facts()
+            fact.unquoted_command_substitution_spans()
                 .iter()
-                .filter(|substitution| substitution.kind() == CommandSubstitutionKind::Command)
-                .filter(|substitution| substitution.unquoted_in_host())
-                .filter(|substitution| {
-                    matches!(
-                        substitution.host_kind(),
-                        SubstitutionHostKind::CommandArgument
-                            | SubstitutionHostKind::HereStringOperand
-                            | SubstitutionHostKind::AssignmentTargetSubscript
-                            | SubstitutionHostKind::DeclarationNameSubscript
-                            | SubstitutionHostKind::ArrayKeySubscript
-                    ) || (substitution.host_kind()
-                        == SubstitutionHostKind::DeclarationAssignmentValue
-                        && checker.shell() == ShellDialect::Sh)
+                .copied()
+                .filter(|span| {
+                    should_report_unquoted_command_substitution(
+                        checker,
+                        fact,
+                        *span,
+                        arithmetic_spans,
+                        &pgrep_spans,
+                        &seq_spans,
+                        &inert_spans,
+                    )
                 })
-                .map(|substitution| substitution.span())
+                .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || UnquotedCommandSubstitution);
+}
+
+fn should_report_unquoted_command_substitution(
+    checker: &Checker,
+    fact: &WordFact<'_>,
+    span: shuck_ast::Span,
+    arithmetic_spans: &[shuck_ast::Span],
+    pgrep_spans: &[shuck_ast::Span],
+    seq_spans: &[shuck_ast::Span],
+    inert_spans: &[shuck_ast::Span],
+) -> bool {
+    if arithmetic_spans.contains(&span) || inert_spans.contains(&span) {
+        return false;
+    }
+
+    let Some(context) = fact.expansion_context() else {
+        return false;
+    };
+
+    match (context, fact.host_kind()) {
+        (ExpansionContext::CommandName, WordFactHostKind::Direct) => fact.has_literal_affixes(),
+        (ExpansionContext::HereString, WordFactHostKind::Direct)
+        | (ExpansionContext::RedirectTarget(_), WordFactHostKind::Direct)
+        | (ExpansionContext::DescriptorDupTarget(_), WordFactHostKind::Direct)
+        | (ExpansionContext::AssignmentValue, WordFactHostKind::AssignmentTargetSubscript)
+        | (ExpansionContext::AssignmentValue, WordFactHostKind::ArrayKeySubscript)
+        | (
+            ExpansionContext::DeclarationAssignmentValue,
+            WordFactHostKind::AssignmentTargetSubscript
+                | WordFactHostKind::DeclarationNameSubscript
+                | WordFactHostKind::ArrayKeySubscript,
+        ) => true,
+        (ExpansionContext::DeclarationAssignmentValue, WordFactHostKind::Direct) => {
+            checker.shell() == ShellDialect::Sh
+        }
+        (ExpansionContext::CommandArgument, WordFactHostKind::Direct) => {
+            !(pgrep_spans.contains(&span) || seq_spans.contains(&span))
+        }
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -65,10 +127,11 @@ mod tests {
     }
 
     #[test]
-    fn reports_here_strings_but_ignores_other_redirect_contexts() {
+    fn reports_command_names_and_redirect_targets() {
         let source = "\
 #!/bin/bash
-cat <<< $(printf here) <<< \"$(printf quoted-here)\" >$(printf out)
+$(pwd)/tool --flag
+cat <<< $(printf here) <<< \"$(printf quoted-here)\" >$(printf out) >&$(printf fd)
 printf '%s\\n' $(printf arg)
 ";
         let diagnostics = test_snippet(
@@ -81,7 +144,13 @@ printf '%s\\n' $(printf arg)
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$(printf here)", "$(printf arg)"]
+            vec![
+                "$(pwd)",
+                "$(printf here)",
+                "$(printf out)",
+                "$(printf fd)",
+                "$(printf arg)",
+            ]
         );
     }
 
@@ -164,6 +233,146 @@ declare other=$(printf declare)
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$(printf local)", "$(printf declare)"]
+        );
+    }
+
+    #[test]
+    fn ignores_bare_command_names_and_arithmetic() {
+        let source = "\
+#!/bin/sh
+$(printf helper) --flag
+printf '%s\\n' $(($(date +%s) - $(date +%s)))
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_pgrep_seq_and_comment_only_backticks_in_command_arguments() {
+        let source = "\
+#!/bin/bash
+if [ $(pgrep -f service) ]; then
+  :
+fi
+echo $(pgrep service)
+readlink /proc/$(pgrep -x service)/exe >/dev/null
+printf '%0.s-' $(seq 1 3)
+cmake \\
+  `# comment` \\
+  -DFOO=1
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_pidof_in_truthy_tests_and_kill() {
+        let source = "\
+#!/bin/sh
+if [ $(pidof service) ]; then
+  :
+fi
+kill $(pidof service)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(pidof service)", "$(pidof service)"]
+        );
+    }
+
+    #[test]
+    fn reports_non_truthy_test_operands_and_nested_parameter_expansion_commands() {
+        let source = "\
+#!/bin/sh
+if [ $(printf one) = one ]; then
+  :
+fi
+if [ $(command -v pigz) ]; then
+  :
+fi
+NUMJOBS=${NUMJOBS:-\" -j $(expr $(nproc) + 1) \"}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(printf one)", "$(command -v pigz)", "$(nproc)"]
+        );
+    }
+
+    #[test]
+    fn reports_filename_builder_command_substitutions() {
+        let source = "\
+#!/bin/bash
+/sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION\\_$(echo ${KERNEL} | tr '-' '_')-$ARCH-$BUILD$TAG.$PKGTYPE
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(echo ${KERNEL} | tr '-' '_')"]
+        );
+    }
+
+    #[test]
+    fn ignores_kill_pid_lists() {
+        let source = "\
+#!/bin/sh
+kill $(pgrep service)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_kill_pidfile_command_substitutions() {
+        let source = "\
+#!/bin/sh
+kill $(cat \"$pidfile\")
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(cat \"$pidfile\")"]
         );
     }
 }

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -2,7 +2,7 @@
 //!
 //! Tokenizes input into a stream of tokens with source position tracking.
 
-use std::{collections::VecDeque, ops::Range, sync::Arc};
+use std::{borrow::Cow, collections::VecDeque, ops::Range, sync::Arc};
 
 use memchr::{memchr, memchr_iter, memrchr};
 use shuck_ast::{Position, Span, TokenKind};
@@ -976,6 +976,19 @@ impl<'a> Lexer<'a> {
             .unwrap_or(&self.input[start.offset..self.offset])
     }
 
+    fn current_word_surface_text<'b>(
+        &'b self,
+        start: Position,
+        capture: &'b Option<String>,
+    ) -> Cow<'b, str> {
+        let text = self.current_word_text(start, capture);
+        if text.contains('\x00') {
+            Cow::Owned(text.chars().filter(|&ch| ch != '\x00').collect())
+        } else {
+            Cow::Borrowed(text)
+        }
+    }
+
     /// Get the next source-backed token from the input, skipping line comments.
     pub fn next_lexed_token(&mut self) -> Option<LexedToken<'a>> {
         self.skip_whitespace();
@@ -1596,7 +1609,7 @@ impl<'a> Lexer<'a> {
                         Self::push_capture_char(&mut word, next);
                         self.advance();
                         if next == '{'
-                            && self.current_word_text(start, &word) == "{"
+                            && self.current_word_surface_text(start, &word) == "{"
                             && self.escaped_brace_sequence_looks_like_brace_expansion()
                         {
                             let mut depth = 1;
@@ -1620,7 +1633,7 @@ impl<'a> Lexer<'a> {
                     Self::push_capture_char(&mut word, '\\');
                 }
             } else if ch == '('
-                && self.current_word_text(start, &word).ends_with('=')
+                && self.current_word_surface_text(start, &word).ends_with('=')
                 && self.looks_like_assoc_assign()
             {
                 // Associative compound assignment: var=([k]="v" ...) — keep entire
@@ -1674,7 +1687,7 @@ impl<'a> Lexer<'a> {
                 }
             } else if ch == '('
                 && self
-                    .current_word_text(start, &word)
+                    .current_word_surface_text(start, &word)
                     .ends_with(['@', '?', '*', '+', '!'])
             {
                 // Extglob: @(...), ?(...), *(...), +(...), !(...)

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1589,10 +1589,10 @@ impl<'a> Lexer<'a> {
                         self.advance();
                     } else {
                         // Escaped character: backslash quotes the next char
-                        // (quote removal — only the literal char survives)
-                        if matches!(next, '$' | '`' | '"' | '\'') {
-                            Self::push_capture_char(&mut word, '\x00');
-                        }
+                        // (quote removal — only the literal char survives).
+                        // Preserve source/decoded alignment with a sentinel so
+                        // downstream word decoding keeps later spans anchored.
+                        Self::push_capture_char(&mut word, '\x00');
                         Self::push_capture_char(&mut word, next);
                         self.advance();
                         if next == '{'

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -2,7 +2,7 @@
 //!
 //! Tokenizes input into a stream of tokens with source position tracking.
 
-use std::{borrow::Cow, collections::VecDeque, ops::Range, sync::Arc};
+use std::{collections::VecDeque, ops::Range, sync::Arc};
 
 use memchr::{memchr, memchr_iter, memrchr};
 use shuck_ast::{Position, Span, TokenKind};
@@ -976,17 +976,49 @@ impl<'a> Lexer<'a> {
             .unwrap_or(&self.input[start.offset..self.offset])
     }
 
-    fn current_word_surface_text<'b>(
+    fn current_word_surface_is_single_char(
+        &self,
+        start: Position,
+        capture: &Option<String>,
+        target: char,
+    ) -> bool {
+        let text = self.current_word_text(start, capture);
+        if !text.contains('\x00') {
+            let mut encoded = [0; 4];
+            return text == target.encode_utf8(&mut encoded);
+        }
+
+        let mut chars = text.chars().filter(|&ch| ch != '\x00');
+        matches!((chars.next(), chars.next()), (Some(ch), None) if ch == target)
+    }
+
+    fn current_word_surface_last_char<'b>(
         &'b self,
         start: Position,
         capture: &'b Option<String>,
-    ) -> Cow<'b, str> {
-        let text = self.current_word_text(start, capture);
-        if text.contains('\x00') {
-            Cow::Owned(text.chars().filter(|&ch| ch != '\x00').collect())
-        } else {
-            Cow::Borrowed(text)
-        }
+    ) -> Option<char> {
+        self.current_word_text(start, capture)
+            .chars()
+            .rev()
+            .find(|&ch| ch != '\x00')
+    }
+
+    fn current_word_surface_ends_with_char(
+        &self,
+        start: Position,
+        capture: &Option<String>,
+        target: char,
+    ) -> bool {
+        self.current_word_surface_last_char(start, capture) == Some(target)
+    }
+
+    fn current_word_surface_ends_with_extglob_prefix(
+        &self,
+        start: Position,
+        capture: &Option<String>,
+    ) -> bool {
+        self.current_word_surface_last_char(start, capture)
+            .is_some_and(|ch| matches!(ch, '@' | '?' | '*' | '+' | '!'))
     }
 
     /// Get the next source-backed token from the input, skipping line comments.
@@ -1609,7 +1641,7 @@ impl<'a> Lexer<'a> {
                         Self::push_capture_char(&mut word, next);
                         self.advance();
                         if next == '{'
-                            && self.current_word_surface_text(start, &word) == "{"
+                            && self.current_word_surface_is_single_char(start, &word, '{')
                             && self.escaped_brace_sequence_looks_like_brace_expansion()
                         {
                             let mut depth = 1;
@@ -1633,7 +1665,7 @@ impl<'a> Lexer<'a> {
                     Self::push_capture_char(&mut word, '\\');
                 }
             } else if ch == '('
-                && self.current_word_surface_text(start, &word).ends_with('=')
+                && self.current_word_surface_ends_with_char(start, &word, '=')
                 && self.looks_like_assoc_assign()
             {
                 // Associative compound assignment: var=([k]="v" ...) — keep entire
@@ -1685,10 +1717,7 @@ impl<'a> Lexer<'a> {
                         _ => {}
                     }
                 }
-            } else if ch == '('
-                && self
-                    .current_word_surface_text(start, &word)
-                    .ends_with(['@', '?', '*', '+', '!'])
+            } else if ch == '(' && self.current_word_surface_ends_with_extglob_prefix(start, &word)
             {
                 // Extglob: @(...), ?(...), *(...), +(...), !(...)
                 // Consume through matching ) including nested parens
@@ -5387,6 +5416,28 @@ EOF
             TokenKind::Word,
             Some(r#"m=([foo]="bar" [baz]="qux")"#),
         );
+        assert!(lexer.next_lexed_token().is_none());
+    }
+
+    #[test]
+    fn test_assoc_compound_assignment_after_escaped_literal_keeps_compound_word() {
+        let source = r#"foo\_bar=([foo]="bar" [baz]="qux")"#;
+        let mut lexer = Lexer::new(source);
+
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::Word);
+        assert_eq!(token.span.slice(source), source);
+        assert!(lexer.next_lexed_token().is_none());
+    }
+
+    #[test]
+    fn test_extglob_after_escaped_literal_keeps_suffix_group() {
+        let source = r#"foo\_bar@(baz|qux)"#;
+        let mut lexer = Lexer::new(source);
+
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::Word);
+        assert_eq!(token.span.slice(source), source);
         assert!(lexer.next_lexed_token().is_none());
     }
 

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -298,6 +298,38 @@ fn test_parse_escaped_command_substitution_stays_literal_in_double_quotes() {
 }
 
 #[test]
+fn test_parse_escaped_literal_before_command_substitution_keeps_following_substitution_live() {
+    let input = "echo $VERSION\\_$(echo hi)\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    assert!(matches!(
+        word.parts.as_slice(),
+        [
+            WordPartNode {
+                kind: WordPart::Variable(name),
+                ..
+            },
+            WordPartNode {
+                kind: WordPart::Literal(text),
+                ..
+            },
+            WordPartNode {
+                kind: WordPart::CommandSubstitution { body, .. },
+                span,
+            }
+        ] if name.as_str() == "VERSION"
+            && text.as_str(input, word.parts[1].span) == "_"
+            && span.slice(input) == "$(echo hi)"
+            && matches!(&body[0].command, AstCommand::Simple(inner) if inner.name.render(input) == "echo")
+    ));
+}
+
+#[test]
 fn test_parse_positional_parameters() {
     let parser = Parser::new("echo $@ $*");
     let script = parser.parse().unwrap().file;

--- a/crates/shuck/tests/testdata/corpus-metadata/s004.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s004.yaml
@@ -413,3 +413,102 @@ reviewed_divergences:
     labels:
       - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__modemu2k__modemu2k.SlackBuild"
+    line: 25
+    end_line: 25
+    reason: "ShellCheck stops after the malformed test expression later in this SlackBuild, so this earlier S004 site is kept as a reviewed divergence in the corpus comparison."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__modemu2k__modemu2k.SlackBuild"
+    line: 98
+    end_line: 98
+    reason: "ShellCheck stops after the malformed test expression earlier in this SlackBuild, so this later S004 site is kept as a reviewed divergence in the corpus comparison."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__firmware-gobi-2000__firmware-gobi-2000.SlackBuild"
+    line: 27
+    end_line: 27
+    reason: "ShellCheck aborts on the malformed test expression later in this SlackBuild, so this S004 site is treated as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "alpinelinux__aports__community__dnscrypt-proxy__dnscrypt-proxy.setup"
+    line: 212
+    end_line: 212
+    reason: "ShellCheck aborts on the malformed bracketed command later in this setup helper, so this S004 site is treated as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "alpinelinux__aports__community__dnscrypt-proxy__dnscrypt-proxy.setup"
+    line: 337
+    end_line: 337
+    reason: "ShellCheck aborts on the malformed bracketed command earlier in this setup helper, so this later S004 site is treated as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
+    line: 178
+    end_line: 178
+    labels:
+      - project-closure
+    reason: "This CGI helper is compared through a project-closure path, so the remaining S004 site is treated as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
+    line: 337
+    end_line: 337
+    labels:
+      - project-closure
+    reason: "This CGI helper is compared through a project-closure path, so the remaining S004 site is treated as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
+    line: 444
+    end_line: 444
+    labels:
+      - project-closure
+    reason: "This CGI helper is compared through a project-closure path, so the remaining S004 site is treated as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
+    line: 153
+    end_line: 153
+    labels:
+      - test-harness
+    reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
+  - side: shuck-only
+    path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
+    line: 154
+    end_line: 154
+    labels:
+      - test-harness
+    reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
+  - side: shuck-only
+    path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
+    line: 155
+    end_line: 155
+    labels:
+      - test-harness
+    reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
+  - side: shuck-only
+    path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
+    line: 160
+    end_line: 160
+    labels:
+      - test-harness
+    reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
+  - side: shuck-only
+    path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
+    line: 161
+    end_line: 161
+    labels:
+      - test-harness
+    reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
+  - side: shuck-only
+    path_suffix: "paulirish__dotfiles__.git-completion.bash"
+    line: 483
+    end_line: 483
+    labels:
+      - directive-handling
+      - helper-library
+      - shell-collapse
+    reason: "This helper-library completion script falls under a shell-collapsed oracle path, so the remaining S004 site is treated as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "paulirish__dotfiles__.git-completion.bash"
+    line: 2401
+    end_line: 2401
+    labels:
+      - directive-handling
+      - helper-library
+      - shell-collapse
+    reason: "This helper-library completion script falls under a shell-collapsed oracle path, so the remaining S004 site is treated as a reviewed divergence."


### PR DESCRIPTION
## Summary
- tighten S004 to match ShellCheck around unquoted command substitutions in redirect targets, mixed command names, test operands, and nested parameter-expansion cases
- extend linter facts so the rule stays a cheap filter over precomputed word and substitution facts instead of walking shell structure itself
- fix the parser span/alignment bug for escaped literals before command substitutions and record the remaining large-corpus oracle mismatches as reviewed S004 divergences

## Root Cause
A `$VERSION\_$(...)` word could lose source alignment during parsing after quote removal, which produced a mis-anchored empty command-substitution node downstream. That forced a temporary linter-side recovery path while debugging. This PR fixes the underlying parser behavior so S004 can rely on parser/AST/fact data instead of reparsing in rule code.

## Impact
- improves S004 parity on the large corpus, including filename-builder and nested-expansion cases
- keeps the rule architecture aligned with the repo contract by pushing structural handling into parser/facts layers
- adds regression coverage for the parser bug and the newly matched S004 behaviors

## Validation
- `cargo test -p shuck-parser test_parse_escaped_literal_before_command_substitution_keeps_following_substitution_live -- --nocapture`
- `cargo test -p shuck-linter unquoted_command_substitution -- --nocapture`
- `cargo test -p shuck-linter 'rule_unquotedcommandsubstitution_path_new_s004_sh_expects' -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S004`
