### PR TITLE
Fix C101 IFS backslash detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2260,6 +2260,7 @@ pub struct LinterFacts<'a> {
     loop_bindings: FxHashMap<FactSpan, Box<[&'a Word]>>,
     broken_assoc_key_spans: Vec<Span>,
     comma_array_assignment_spans: Vec<Span>,
+    ifs_literal_backslash_assignment_value_spans: Vec<Span>,
     presence_tested_names: FxHashSet<Name>,
     subscript_index_reference_spans: FxHashSet<FactSpan>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
@@ -2439,6 +2440,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn comma_array_assignment_spans(&self) -> &[Span] {
         &self.comma_array_assignment_spans
+    }
+
+    pub fn ifs_literal_backslash_assignment_value_spans(&self) -> &[Span] {
+        &self.ifs_literal_backslash_assignment_value_spans
     }
 
     pub fn is_if_condition_command(&self, id: CommandId) -> bool {
@@ -2829,6 +2834,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut loop_bindings = FxHashMap::default();
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
+        let mut ifs_literal_backslash_assignment_value_spans = Vec::new();
         let mut words = Vec::new();
         let mut compound_assignment_value_word_spans = FxHashSet::default();
         let mut array_assignment_split_word_indices = Vec::new();
@@ -2876,6 +2882,11 @@ impl<'a> LinterFactsBuilder<'a> {
                 visit.command,
                 self.source,
                 &mut comma_array_assignment_spans,
+            );
+            collect_ifs_literal_backslash_assignment_value_spans(
+                visit.command,
+                self.source,
+                &mut ifs_literal_backslash_assignment_value_spans,
             );
             let normalized = command::normalize_command(visit.command, self.source);
             let command_zsh_options = effective_command_zsh_options(
@@ -3201,6 +3212,7 @@ impl<'a> LinterFactsBuilder<'a> {
             loop_bindings,
             broken_assoc_key_spans,
             comma_array_assignment_spans,
+            ifs_literal_backslash_assignment_value_spans,
             presence_tested_names,
             subscript_index_reference_spans,
             compound_assignment_value_word_spans,
@@ -12829,6 +12841,44 @@ fn collect_comma_array_assignment_spans(command: &Command, source: &str, spans: 
     }
 }
 
+fn collect_ifs_literal_backslash_assignment_value_spans(
+    command: &Command,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for assignment in query::command_assignments(command) {
+        if let Some(span) = ifs_literal_backslash_assignment_value_span(assignment, source) {
+            spans.push(span);
+        }
+    }
+
+    for operand in query::declaration_operands(command) {
+        let DeclOperand::Assignment(assignment) = operand else {
+            continue;
+        };
+        if let Some(span) = ifs_literal_backslash_assignment_value_span(assignment, source) {
+            spans.push(span);
+        }
+    }
+}
+
+fn ifs_literal_backslash_assignment_value_span(
+    assignment: &Assignment,
+    source: &str,
+) -> Option<Span> {
+    if assignment.target.name.as_str() != "IFS" {
+        return None;
+    }
+
+    let AssignmentValue::Scalar(word) = &assignment.value else {
+        return None;
+    };
+
+    static_word_text(word, source)
+        .is_some_and(|text| text.contains('\\'))
+        .then_some(word.span)
+}
+
 fn comma_array_assignment_span(assignment: &Assignment, source: &str) -> Option<Span> {
     let AssignmentValue::Compound(array) = &assignment.value else {
         return None;
@@ -13598,6 +13648,31 @@ complex[$((i+=1))]+=x
                 "(foo,{x,y},bar)"
             ]
         );
+    }
+
+    #[test]
+    fn collects_ifs_literal_backslash_assignment_value_spans() {
+        let source = "\
+#!/bin/bash
+IFS='\\n'
+export IFS=\"x\\n\"
+while IFS='\\ \\|\\ ' read -r serial board_serial; do
+  :
+done < /dev/null
+declare IFS='prefix\\nsuffix'
+IFS=$'\\n'
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .ifs_literal_backslash_assignment_value_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["'\\n'", "\"x\\n\"", "'\\ \\|\\ '", "'prefix\\nsuffix'"]
+            );
+        });
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/ifs_set_to_literal_backslash_n.rs
+++ b/crates/shuck-linter/src/rules/correctness/ifs_set_to_literal_backslash_n.rs
@@ -1,6 +1,4 @@
-use shuck_ast::{Assignment, AssignmentValue, BuiltinCommand, Command, DeclOperand, Span};
-
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
 
 pub struct IfsSetToLiteralBackslashN;
 
@@ -10,79 +8,18 @@ impl Violation for IfsSetToLiteralBackslashN {
     }
 
     fn message(&self) -> String {
-        "IFS contains a literal \\n sequence".to_owned()
+        "backslashes in IFS stay literal".to_owned()
     }
 }
 
 pub fn ifs_set_to_literal_backslash_n(checker: &mut Checker) {
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .flat_map(|fact| command_assignment_spans(fact.command(), source))
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || IfsSetToLiteralBackslashN);
-}
-
-fn command_assignment_spans(command: &Command, source: &str) -> Vec<Span> {
-    match command {
-        Command::Simple(command) => command
-            .assignments
-            .iter()
-            .filter_map(|assignment| {
-                assignment_value_contains_literal_backslash_n(assignment, source)
-            })
-            .collect(),
-        Command::Builtin(command) => builtin_assignments(command)
-            .iter()
-            .filter_map(|assignment| {
-                assignment_value_contains_literal_backslash_n(assignment, source)
-            })
-            .collect(),
-        Command::Decl(command) => command
-            .assignments
-            .iter()
-            .chain(command.operands.iter().filter_map(|operand| match operand {
-                DeclOperand::Assignment(assignment) => Some(assignment),
-                DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Dynamic(_) => None,
-            }))
-            .filter_map(|assignment| {
-                assignment_value_contains_literal_backslash_n(assignment, source)
-            })
-            .collect(),
-        Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => Vec::new(),
-    }
-}
-
-fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
-    match command {
-        BuiltinCommand::Break(command) => &command.assignments,
-        BuiltinCommand::Continue(command) => &command.assignments,
-        BuiltinCommand::Return(command) => &command.assignments,
-        BuiltinCommand::Exit(command) => &command.assignments,
-    }
-}
-
-fn assignment_value_contains_literal_backslash_n(
-    assignment: &Assignment,
-    source: &str,
-) -> Option<Span> {
-    if assignment.target.name.as_str() != "IFS" {
-        return None;
-    }
-
-    let AssignmentValue::Scalar(word) = &assignment.value else {
-        return None;
-    };
-
-    static_word_text(word, source)
-        .is_some_and(|text| text.contains("\\n"))
-        .then_some(word.span)
+    checker.report_all_dedup(
+        checker
+            .facts()
+            .ifs_literal_backslash_assignment_value_spans()
+            .to_vec(),
+        || IfsSetToLiteralBackslashN,
+    );
 }
 
 #[cfg(test)]
@@ -93,9 +30,12 @@ mod tests {
     #[test]
     fn anchors_on_ifs_assignment_values() {
         let source = "\
-#!/bin/sh
+#!/bin/bash
 IFS='\\n'
 export IFS=\"x\\n\"
+while IFS='\\ \\|\\ ' read -r serial board_serial; do
+  :
+done < /dev/null
 foo() {
   local IFS='\\n\\t'
 }
@@ -112,15 +52,22 @@ bar='\\n'
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["'\\n'", "\"x\\n\"", "'\\n\\t'", "'prefix\\nsuffix'"]
+            vec![
+                "'\\n'",
+                "\"x\\n\"",
+                "'\\ \\|\\ '",
+                "'\\n\\t'",
+                "'prefix\\nsuffix'",
+            ]
         );
     }
 
     #[test]
     fn ignores_non_literal_or_non_ifs_assignments() {
         let source = "\
-#!/bin/sh
+#!/bin/bash
 IFS=$'\\n'
+IFS=' | '
 foo='\\n'
 bar=bar-n
 ";

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C101_C101.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C101_C101.sh.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
 ---
-C101 IFS contains a literal \n sequence
+C101 backslashes in IFS stay literal
  --> <source>:3:11
   |
 3 | while IFS='\n' read -r comp; do

--- a/docs/rules/C101.yaml
+++ b/docs/rules/C101.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: IFS is set to the literal string \n instead of a newline.
-rationale: Use IFS=$'\n' in bash or a literal newline in POSIX sh.
+description: IFS contains literal backslashes instead of separator characters.
+rationale: Backslashes stay literal in IFS. Use real separator characters, `$'...'` in bash, or `printf` when you need escapes.
 source:
   shell_checks_rule: rules/SH-234.yaml
   shell_checks_example: examples/234.sh


### PR DESCRIPTION
## Summary
- move `C101`'s `IFS` assignment scan into linter facts so the rule stays a thin fact consumer
- flag any static `IFS` assignment value containing literal backslashes, not just `\\n`
- update the rule docs and snapshot wording to match the broader behavior

## Why
`C101` only matched literal `\\n` sequences, which missed real ShellCheck-compatible cases like `IFS='\\ \\|\\ '`. That left a blocking large-corpus implementation diff.

## Impact
This brings `C101` into line with the live oracle for static `IFS` backslash assignments and keeps the rule implementation within the repo's fact-based architecture.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C101`