### PR TITLE
Refine S029 literal brace detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4920,9 +4920,6 @@ fn build_literal_brace_spans(
 
         let is_find_exec_placeholder_word = is_find_exec_placeholder_word(commands, fact, source);
         let is_xargs_replacement_word = is_xargs_replacement_word(commands, fact, source);
-        let has_nested_escaped_parameter_word =
-            word_has_nested_escaped_parameter_expansion(fact.word(), source);
-
         spans.extend(
             fact.word()
                 .brace_syntax()
@@ -4938,7 +4935,6 @@ fn build_literal_brace_spans(
                 .filter(|brace| {
                     brace.span.slice(source) != "{}"
                         && !brace_span_has_escaped_dollar_prefix(brace.span, source)
-                        && !has_nested_escaped_parameter_word
                         && !is_find_exec_placeholder_word
                         && !is_xargs_replacement_word
                 })
@@ -4947,12 +4943,10 @@ fn build_literal_brace_spans(
 
         if !is_find_exec_placeholder_word && !is_xargs_replacement_word {
             spans.extend(unclassified_literal_brace_spans(fact.word(), source));
-            if !has_nested_escaped_parameter_word {
-                spans.extend(escaped_parameter_expansion_brace_edge_spans(
-                    fact.word(),
-                    source,
-                ));
-            }
+            spans.extend(escaped_parameter_expansion_brace_edge_spans(
+                fact.word(),
+                source,
+            ));
         }
     }
 
@@ -5183,8 +5177,8 @@ fn brace_character_spans(span: Span, source: &str) -> Vec<Span> {
     text.char_indices()
         .filter(|&(_, ch)| matches!(ch, '{' | '}'))
         .map(|(offset, _)| {
-                let position = span.start.advanced_by(&text[..offset]);
-                Span::from_positions(position, position)
+            let position = span.start.advanced_by(&text[..offset]);
+            Span::from_positions(position, position)
         })
         .collect()
 }
@@ -5198,18 +5192,6 @@ fn brace_span_has_escaped_dollar_prefix(span: Span, source: &str) -> bool {
 
     span.start.offset >= "\\$".len()
         && source[span.start.offset - "\\$".len()..span.start.offset] == *"\\$"
-}
-
-fn word_has_nested_escaped_parameter_expansion(word: &Word, source: &str) -> bool {
-    let text = word.span.slice(source);
-    let Some(escaped_start) = text.find("\\${") else {
-        return false;
-    };
-    let outer_start = escaped_start + '\\'.len_utf8();
-    let Some(outer_end) = find_runtime_parameter_closing_brace(text, outer_start) else {
-        return false;
-    };
-    text[outer_start + "${".len()..outer_end - '}'.len_utf8()].contains("${")
 }
 
 fn brace_syntax_with_whitespace_is_literal(brace: shuck_ast::BraceSyntax, source: &str) -> bool {
@@ -5228,13 +5210,16 @@ fn brace_syntax_with_whitespace_is_literal(brace: shuck_ast::BraceSyntax, source
 
         if ch == '\\' {
             index += ch_len;
+            if text[index..].starts_with("\r\n") {
+                index += "\r\n".len();
+                continue;
+            }
             if text[index..].starts_with('\n') {
                 index += '\n'.len_utf8();
                 continue;
             }
-            if text[index..].starts_with("\r\n") {
-                index += "\r\n".len();
-                continue;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
             }
             continue;
         }
@@ -5789,7 +5774,7 @@ fn raw_escaped_parameter_brace_edge_spans(word: &Word, source: &str) -> Vec<Span
     let mut index = 0usize;
     let mut previous_char = None;
     let mut previous_char_escaped = false;
-    let mut escaped_parameter_stack = Vec::new();
+    let mut escaped_parameter_stack: Vec<(usize, bool)> = Vec::new();
     let mut parameter_depth = 0usize;
 
     while index < text.len() {
@@ -5832,14 +5817,19 @@ fn raw_escaped_parameter_brace_edge_spans(word: &Word, source: &str) -> Vec<Span
 
         if ch == '{' {
             if previous_char == Some('$') && previous_char_escaped {
-                escaped_parameter_stack.push(index);
+                escaped_parameter_stack.push((index, false));
             } else if previous_char == Some('$') && !previous_char_escaped {
+                if let Some((_, has_nested_parameter_inside)) = escaped_parameter_stack.last_mut() {
+                    *has_nested_parameter_inside = true;
+                }
                 parameter_depth += 1;
             }
         } else if ch == '}' {
             if parameter_depth > 0 {
                 parameter_depth -= 1;
-            } else if let Some(open_offset) = escaped_parameter_stack.pop()
+            } else if let Some((open_offset, has_nested_parameter_inside)) =
+                escaped_parameter_stack.pop()
+                && !has_nested_parameter_inside
                 && !brace_pair_matches_nonliteral_syntax(word, open_offset, index)
             {
                 let open = span.start.advanced_by(&text[..open_offset]);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4918,38 +4918,54 @@ fn build_literal_brace_spans(
             continue;
         }
 
+        let is_find_exec_placeholder_word = is_find_exec_placeholder_word(commands, fact, source);
+        let is_xargs_replacement_word = is_xargs_replacement_word(commands, fact, source);
+        let has_nested_escaped_parameter_word =
+            word_has_nested_escaped_parameter_expansion(fact.word(), source);
+
         spans.extend(
             fact.word()
                 .brace_syntax()
                 .iter()
                 .copied()
+                .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
                 .filter(|brace| {
-                    brace.kind == BraceSyntaxKind::Literal
-                        && brace.quote_context == BraceQuoteContext::Unquoted
+                    matches!(
+                        brace.kind,
+                        BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
+                    ) || brace_syntax_with_whitespace_is_literal(*brace, source)
                 })
                 .filter(|brace| {
-                    !is_find_exec_placeholder(commands, fact, brace.span, source)
-                        && !is_xargs_inline_replace_option(commands, fact, brace.span, source)
+                    brace.span.slice(source) != "{}"
+                        && !brace_span_has_escaped_dollar_prefix(brace.span, source)
+                        && !has_nested_escaped_parameter_word
+                        && !is_find_exec_placeholder_word
+                        && !is_xargs_replacement_word
                 })
-                .flat_map(|brace| brace_literal_edge_spans(brace.span, source)),
+                .flat_map(|brace| brace_character_spans(brace.span, source)),
         );
 
-        spans.extend(escaped_parameter_expansion_brace_edge_spans(
-            fact.word(),
-            source,
-        ));
+        if !is_find_exec_placeholder_word && !is_xargs_replacement_word {
+            spans.extend(unclassified_literal_brace_spans(fact.word(), source));
+            if !has_nested_escaped_parameter_word {
+                spans.extend(escaped_parameter_expansion_brace_edge_spans(
+                    fact.word(),
+                    source,
+                ));
+            }
+        }
     }
 
+    spans.extend(uncovered_command_brace_spans(commands, source));
     spans
 }
 
-fn is_find_exec_placeholder(
+fn is_find_exec_placeholder_word(
     commands: &[CommandFact<'_>],
     fact: &WordFact<'_>,
-    brace_span: Span,
     source: &str,
 ) -> bool {
-    if brace_span.slice(source) != "{}" {
+    if !word_is_empty_brace_pair_variant(fact.word(), source) {
         return false;
     }
     if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
@@ -4961,18 +4977,11 @@ fn is_find_exec_placeholder(
         return true;
     }
 
-    if command
-        .body_name_word()
-        .is_some_and(|name_word| name_word.span == fact.span())
-    {
-        return false;
-    }
-
     commands.iter().any(|command| {
-        command.stmt().span.start.offset <= brace_span.start.offset
-            && command.stmt().span.end.offset >= brace_span.end.offset
+        command.stmt().span.start.offset <= fact.span().start.offset
+            && command.stmt().span.end.offset >= fact.span().end.offset
             && is_find_exec_command(command, source)
-    }) || line_has_find_exec_placeholder_context(source, brace_span)
+    }) || line_has_find_exec_placeholder_context(source, fact.span())
 }
 
 fn is_find_exec_command(command: &CommandFact<'_>, source: &str) -> bool {
@@ -5039,10 +5048,9 @@ fn line_has_find_exec_placeholder_context(source: &str, brace_span: Span) -> boo
         && has_exec_terminator_after
 }
 
-fn is_xargs_inline_replace_option(
+fn is_xargs_replacement_word(
     commands: &[CommandFact<'_>],
     fact: &WordFact<'_>,
-    brace_span: Span,
     source: &str,
 ) -> bool {
     if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
@@ -5056,9 +5064,7 @@ fn is_xargs_inline_replace_option(
 
     xargs_replacement_spans(command.body_args(), source)
         .into_iter()
-        .any(|span| {
-            span.start.offset <= brace_span.start.offset && span.end.offset >= brace_span.end.offset
-        })
+        .any(|span| span == fact.word().span)
 }
 
 fn xargs_replacement_spans(args: &[&Word], source: &str) -> Vec<Span> {
@@ -5172,27 +5178,311 @@ fn shellish_words(text: &str) -> Vec<&str> {
     words
 }
 
-fn brace_literal_edge_spans(span: Span, source: &str) -> Vec<Span> {
+fn brace_character_spans(span: Span, source: &str) -> Vec<Span> {
     let text = span.slice(source);
-    let Some(open_offset) = text.find('{') else {
-        return Vec::new();
-    };
-    let Some(close_offset) = text.rfind('}') else {
-        return Vec::new();
-    };
+    text.char_indices()
+        .filter_map(|(offset, ch)| {
+            matches!(ch, '{' | '}').then(|| {
+                let position = span.start.advanced_by(&text[..offset]);
+                Span::from_positions(position, position)
+            })
+        })
+        .collect()
+}
 
-    let open = span.start.advanced_by(&text[..open_offset]);
-    let close = span.start.advanced_by(&text[..close_offset]);
-    vec![
-        Span::from_positions(open, open),
-        Span::from_positions(close, close),
-    ]
+fn brace_span_has_escaped_dollar_prefix(span: Span, source: &str) -> bool {
+    let span_text = span.slice(source);
+    if span_text.starts_with("${") {
+        return span.start.offset >= '\\'.len_utf8()
+            && source[span.start.offset - '\\'.len_utf8()..span.start.offset] == *"\\";
+    }
+
+    span.start.offset >= "\\$".len()
+        && source[span.start.offset - "\\$".len()..span.start.offset] == *"\\$"
+}
+
+fn word_has_nested_escaped_parameter_expansion(word: &Word, source: &str) -> bool {
+    let text = word.span.slice(source);
+    let Some(escaped_start) = text.find("\\${") else {
+        return false;
+    };
+    let outer_start = escaped_start + '\\'.len_utf8();
+    let Some(outer_end) = find_runtime_parameter_closing_brace(text, outer_start) else {
+        return false;
+    };
+    text[outer_start + "${".len()..outer_end - '}'.len_utf8()].contains("${")
+}
+
+fn brace_syntax_with_whitespace_is_literal(brace: shuck_ast::BraceSyntax, source: &str) -> bool {
+    if !matches!(brace.kind, BraceSyntaxKind::Expansion(_)) {
+        return false;
+    }
+
+    let text = brace.span.slice(source);
+    let mut index = 0usize;
+
+    while index < text.len() {
+        let Some(ch) = text[index..].chars().next() else {
+            break;
+        };
+        let ch_len = ch.len_utf8();
+
+        if ch == '\\' {
+            index += ch_len;
+            if text[index..].starts_with('\n') {
+                index += '\n'.len_utf8();
+                continue;
+            }
+            if text[index..].starts_with("\r\n") {
+                index += "\r\n".len();
+                continue;
+            }
+            continue;
+        }
+
+        if ch.is_whitespace() {
+            return true;
+        }
+
+        index += ch_len;
+    }
+
+    false
+}
+
+fn word_is_empty_brace_pair_variant(word: &Word, source: &str) -> bool {
+    matches!(word.span.slice(source), "{}" | "\\{\\}")
+}
+
+fn unclassified_literal_brace_spans(word: &Word, source: &str) -> Vec<Span> {
+    let span = word.span;
+    let text = span.slice(source);
+    let mut excluded = Vec::new();
+    collect_dynamic_brace_exclusions(
+        &word.parts,
+        span.start.offset,
+        span.end.offset,
+        source,
+        &mut excluded,
+    );
+    excluded.extend(
+        word.brace_syntax()
+            .iter()
+            .map(|brace| DynamicBraceExcludedSpan {
+                start_offset: brace.span.start.offset - span.start.offset,
+                end_offset: brace.span.end.offset - span.start.offset,
+                kind: DynamicBraceExcludedSpanKind::RuntimeShellSyntax,
+            }),
+    );
+    excluded.sort_by_key(|span| (span.start_offset, span.end_offset));
+
+    let mut spans = Vec::new();
+    let mut excluded_index = 0usize;
+    let mut index = 0usize;
+    let mut unmatched_opens = Vec::new();
+
+    while index < text.len() {
+        while let Some(excluded_span) = excluded.get(excluded_index).copied() {
+            if excluded_span.end_offset <= index {
+                excluded_index += 1;
+                continue;
+            }
+            if excluded_span.start_offset > index {
+                break;
+            }
+
+            index = excluded_span.end_offset;
+            excluded_index += 1;
+        }
+
+        if index >= text.len() {
+            break;
+        }
+
+        let Some(ch) = text[index..].chars().next() else {
+            break;
+        };
+        let ch_len = ch.len_utf8();
+
+        if text[index..].starts_with("\\${")
+            && let Some(end_offset) =
+                find_runtime_parameter_closing_brace(text, index + '\\'.len_utf8())
+        {
+            index = end_offset;
+            continue;
+        }
+
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
+            continue;
+        }
+
+        if ch == '{' {
+            unmatched_opens.push(index);
+        } else if ch == '}' {
+            if unmatched_opens.pop().is_none() {
+                let position = span.start.advanced_by(&text[..index]);
+                spans.push(Span::from_positions(position, position));
+            }
+        }
+
+        index += ch_len;
+    }
+
+    spans.extend(unmatched_opens.into_iter().map(|offset| {
+        let position = span.start.advanced_by(&text[..offset]);
+        Span::from_positions(position, position)
+    }));
+
+    spans
+}
+
+fn uncovered_command_brace_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+
+    for command in commands {
+        let Command::Simple(simple) = command.command() else {
+            continue;
+        };
+        let command_span = command.span();
+        let mut covered = Vec::new();
+
+        if !simple.name.span.slice(source).is_empty() {
+            covered.push(simple.name.span);
+        }
+        covered.extend(simple.args.iter().map(|word| word.span));
+        covered.extend(simple.assignments.iter().map(|assignment| assignment.span));
+        covered.extend(command.redirects().iter().map(|redirect| redirect.span));
+        covered.extend(
+            command
+                .redirects()
+                .iter()
+                .filter_map(|redirect| redirect.fd_var_span),
+        );
+        covered.extend(
+            command
+                .redirects()
+                .iter()
+                .filter_map(|redirect| redirect_fd_var_brace_span(redirect, source)),
+        );
+        covered.extend(
+            command
+                .redirects()
+                .iter()
+                .filter_map(|redirect| redirect.fd_var_span),
+        );
+
+        if covered.is_empty() {
+            continue;
+        }
+
+        covered.sort_by_key(|span| (span.start.offset, span.end.offset));
+
+        let mut cursor = command_span.start.offset;
+        for span in covered {
+            if span.start.offset > cursor {
+                spans.extend(raw_uncovered_brace_spans(
+                    command_span,
+                    cursor,
+                    span.start.offset,
+                    source,
+                ));
+            }
+            cursor = cursor.max(span.end.offset);
+        }
+
+        if command_span.end.offset > cursor {
+            spans.extend(raw_uncovered_brace_spans(
+                command_span,
+                cursor,
+                command_span.end.offset,
+                source,
+            ));
+        }
+    }
+
+    spans
+}
+
+fn redirect_fd_var_brace_span(redirect: &Redirect, source: &str) -> Option<Span> {
+    let fd_var_span = redirect.fd_var_span?;
+    let start_offset = fd_var_span.start.offset.checked_sub('{'.len_utf8())?;
+    let end_offset = fd_var_span.end.offset.checked_add('}'.len_utf8())?;
+    if source.get(start_offset..fd_var_span.start.offset)? != "{" {
+        return None;
+    }
+    if source.get(fd_var_span.end.offset..end_offset)? != "}" {
+        return None;
+    }
+
+    Some(Span::from_positions(
+        Position {
+            line: fd_var_span.start.line,
+            column: fd_var_span.start.column.checked_sub(1)?,
+            offset: start_offset,
+        },
+        Position {
+            line: fd_var_span.end.line,
+            column: fd_var_span.end.column + 1,
+            offset: end_offset,
+        },
+    ))
+}
+
+fn raw_uncovered_brace_spans(
+    command_span: Span,
+    gap_start: usize,
+    gap_end: usize,
+    source: &str,
+) -> Vec<Span> {
+    let text = &source[gap_start..gap_end];
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    let mut spans = Vec::new();
+    let mut index = 0usize;
+    while index < text.len() {
+        let Some(ch) = text[index..].chars().next() else {
+            break;
+        };
+        let ch_len = ch.len_utf8();
+
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
+            continue;
+        }
+
+        if ch == '#' {
+            break;
+        }
+
+        if matches!(ch, '{' | '}') {
+            let absolute_offset = gap_start + index;
+            let position = command_span
+                .start
+                .advanced_by(&source[command_span.start.offset..absolute_offset]);
+            spans.push(Span::from_positions(position, position));
+        }
+
+        index += ch_len;
+    }
+
+    spans
 }
 
 #[derive(Debug, Clone, Copy)]
 struct LiteralBraceCandidate {
     open_offset: usize,
     after_escaped_dollar: bool,
+    has_excluded_content_inside: bool,
+    has_nested_parameter_inside: bool,
     has_runtime_shell_sigil_inside: bool,
     has_brace_expansion_delimiter: bool,
 }
@@ -5216,7 +5506,13 @@ fn escaped_parameter_expansion_brace_edge_spans(word: &Word, source: &str) -> Ve
     let mut spans = Vec::new();
     let mut literal_stack: Vec<LiteralBraceCandidate> = Vec::new();
     let mut excluded = Vec::new();
-    collect_dynamic_brace_exclusions(&word.parts, span.start.offset, source, &mut excluded);
+    collect_dynamic_brace_exclusions(
+        &word.parts,
+        span.start.offset,
+        span.end.offset,
+        source,
+        &mut excluded,
+    );
     excluded.sort_by_key(|span| (span.start_offset, span.end_offset));
     let mut excluded_index = 0usize;
     let mut index = 0usize;
@@ -5239,9 +5535,15 @@ fn escaped_parameter_expansion_brace_edge_spans(word: &Word, source: &str) -> Ve
             {
                 current.has_runtime_shell_sigil_inside = true;
             }
+            if let Some(current) = literal_stack.last_mut() {
+                current.has_excluded_content_inside = true;
+            }
             if excluded_span.kind == DynamicBraceExcludedSpanKind::RuntimeShellSyntax
-                && previous_char == Some('$')
-                && previous_char_escaped
+                && excluded_runtime_syntax_has_escaped_dollar_prefix(
+                    text,
+                    excluded_span.start_offset,
+                    excluded_span.end_offset,
+                )
             {
                 let excluded_text = &text[excluded_span.start_offset..excluded_span.end_offset];
                 let open_offset = if excluded_text.starts_with("${") {
@@ -5292,9 +5594,17 @@ fn escaped_parameter_expansion_brace_edge_spans(word: &Word, source: &str) -> Ve
         }
 
         if ch == '{' {
+            if previous_char == Some('$')
+                && !previous_char_escaped
+                && let Some(candidate) = literal_stack.last_mut()
+            {
+                candidate.has_nested_parameter_inside = true;
+            }
             literal_stack.push(LiteralBraceCandidate {
                 open_offset: index,
                 after_escaped_dollar: previous_char == Some('$') && previous_char_escaped,
+                has_excluded_content_inside: false,
+                has_nested_parameter_inside: false,
                 has_runtime_shell_sigil_inside: false,
                 has_brace_expansion_delimiter: false,
             });
@@ -5311,7 +5621,10 @@ fn escaped_parameter_expansion_brace_edge_spans(word: &Word, source: &str) -> Ve
         } else if ch == '}'
             && let Some(candidate) = literal_stack.pop()
             && index > candidate.open_offset + 1
-            && (candidate.after_escaped_dollar || candidate.has_runtime_shell_sigil_inside)
+            && (candidate.after_escaped_dollar
+                || candidate.has_excluded_content_inside
+                || candidate.has_runtime_shell_sigil_inside)
+            && !(candidate.after_escaped_dollar && candidate.has_nested_parameter_inside)
             && !candidate.has_brace_expansion_delimiter
             && !brace_pair_matches_nonliteral_syntax(word, candidate.open_offset, index)
         {
@@ -5330,9 +5643,31 @@ fn escaped_parameter_expansion_brace_edge_spans(word: &Word, source: &str) -> Ve
     spans
 }
 
+fn excluded_runtime_syntax_has_escaped_dollar_prefix(
+    text: &str,
+    start_offset: usize,
+    end_offset: usize,
+) -> bool {
+    let start_offset = start_offset.min(text.len());
+    let end_offset = end_offset.min(text.len());
+    if start_offset >= end_offset {
+        return false;
+    }
+
+    let excluded_text = &text[start_offset..end_offset];
+    if excluded_text.starts_with("${") {
+        return text[..start_offset].ends_with('\\');
+    }
+    if excluded_text.starts_with('{') {
+        return text[..start_offset].ends_with("\\$");
+    }
+    false
+}
+
 fn collect_dynamic_brace_exclusions(
     parts: &[WordPartNode],
     word_base_offset: usize,
+    word_end_offset: usize,
     source: &str,
     out: &mut Vec<DynamicBraceExcludedSpan>,
 ) {
@@ -5369,13 +5704,80 @@ fn collect_dynamic_brace_exclusions(
             | WordPart::IndirectExpansion { .. }
             | WordPart::PrefixMatch { .. }
             | WordPart::Transformation { .. }
-            | WordPart::ZshQualifiedGlob(_) => out.push(DynamicBraceExcludedSpan {
-                start_offset: part.span.start.offset - word_base_offset,
-                end_offset: part.span.end.offset - word_base_offset,
-                kind: DynamicBraceExcludedSpanKind::RuntimeShellSyntax,
-            }),
+            | WordPart::ZshQualifiedGlob(_) => out.push(runtime_shell_dynamic_brace_exclusion(
+                part,
+                word_base_offset,
+                word_end_offset,
+                source,
+            )),
         }
     }
+}
+
+fn runtime_shell_dynamic_brace_exclusion(
+    part: &WordPartNode,
+    word_base_offset: usize,
+    word_end_offset: usize,
+    source: &str,
+) -> DynamicBraceExcludedSpan {
+    let start_offset = part.span.start.offset - word_base_offset;
+    let mut end_offset = part.span.end.offset - word_base_offset;
+    let part_text = part.span.slice(source);
+    let word_text = &source[word_base_offset..word_end_offset.min(source.len())];
+
+    if let Some(relative_parameter_start) = part_text.find("${") {
+        end_offset = find_runtime_parameter_closing_brace(
+            word_text,
+            start_offset + relative_parameter_start,
+        )
+        .map_or(end_offset, |closing_offset| end_offset.max(closing_offset));
+    }
+
+    DynamicBraceExcludedSpan {
+        start_offset,
+        end_offset,
+        kind: DynamicBraceExcludedSpanKind::RuntimeShellSyntax,
+    }
+}
+
+fn find_runtime_parameter_closing_brace(text: &str, start_offset: usize) -> Option<usize> {
+    if start_offset >= text.len() || !text[start_offset..].starts_with("${") {
+        return None;
+    }
+
+    let mut index = start_offset + "${".len();
+    let mut depth = 1usize;
+
+    while index < text.len() {
+        if text[index..].starts_with("${") {
+            depth += 1;
+            index += "${".len();
+            continue;
+        }
+
+        let ch = text[index..].chars().next()?;
+
+        if ch == '\\' {
+            index += ch.len_utf8();
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
+            continue;
+        }
+
+        if ch == '}' {
+            depth -= 1;
+            index += ch.len_utf8();
+            if depth == 0 {
+                return Some(index);
+            }
+            continue;
+        }
+
+        index += ch.len_utf8();
+    }
+
+    None
 }
 
 fn raw_escaped_parameter_brace_edge_spans(word: &Word, source: &str) -> Vec<Span> {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5186,12 +5186,10 @@ fn brace_character_spans(span: Span, source: &str) -> Vec<Span> {
 fn brace_span_has_escaped_dollar_prefix(span: Span, source: &str) -> bool {
     let span_text = span.slice(source);
     if span_text.starts_with("${") {
-        return span.start.offset >= '\\'.len_utf8()
-            && source[span.start.offset - '\\'.len_utf8()..span.start.offset] == *"\\";
+        return has_odd_backslash_run_before(source, span.start.offset);
     }
 
-    span.start.offset >= "\\$".len()
-        && source[span.start.offset - "\\$".len()..span.start.offset] == *"\\$"
+    has_escaped_dollar_before(source, span.start.offset)
 }
 
 fn brace_syntax_with_whitespace_is_literal(brace: shuck_ast::BraceSyntax, source: &str) -> bool {
@@ -5638,12 +5636,33 @@ fn excluded_runtime_syntax_has_escaped_dollar_prefix(
 
     let excluded_text = &text[start_offset..end_offset];
     if excluded_text.starts_with("${") {
-        return text[..start_offset].ends_with('\\');
+        return has_odd_backslash_run_before(text, start_offset);
     }
     if excluded_text.starts_with('{') {
-        return text[..start_offset].ends_with("\\$");
+        return has_escaped_dollar_before(text, start_offset);
     }
     false
+}
+
+fn has_odd_backslash_run_before(text: &str, offset: usize) -> bool {
+    let offset = offset.min(text.len());
+    text[..offset]
+        .chars()
+        .rev()
+        .take_while(|&ch| ch == '\\')
+        .count()
+        % 2
+        == 1
+}
+
+fn has_escaped_dollar_before(text: &str, offset: usize) -> bool {
+    let offset = offset.min(text.len());
+    let prefix = &text[..offset];
+    let Some((dollar_offset, '$')) = prefix.char_indices().next_back() else {
+        return false;
+    };
+
+    has_odd_backslash_run_before(text, dollar_offset)
 }
 
 fn collect_dynamic_brace_exclusions(

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5197,14 +5197,47 @@ fn brace_syntax_with_whitespace_is_literal(brace: shuck_ast::BraceSyntax, source
         return false;
     }
 
+    #[derive(Clone, Copy)]
+    enum QuoteState {
+        Single,
+        Double,
+    }
+
     let text = brace.span.slice(source);
     let mut index = 0usize;
+    let mut quote_state = None;
 
     while index < text.len() {
         let Some(ch) = text[index..].chars().next() else {
             break;
         };
         let ch_len = ch.len_utf8();
+
+        if let Some(state) = quote_state {
+            match state {
+                QuoteState::Single => {
+                    if ch == '\'' {
+                        quote_state = None;
+                    }
+                    index += ch_len;
+                    continue;
+                }
+                QuoteState::Double => {
+                    if ch == '\\' {
+                        index += ch_len;
+                        if let Some(escaped) = text[index..].chars().next() {
+                            index += escaped.len_utf8();
+                        }
+                        continue;
+                    }
+                    if ch == '"' {
+                        quote_state = None;
+                    }
+                    index += ch_len;
+                    continue;
+                }
+            }
+        }
 
         if ch == '\\' {
             index += ch_len;
@@ -5219,6 +5252,18 @@ fn brace_syntax_with_whitespace_is_literal(brace: shuck_ast::BraceSyntax, source
             if let Some(escaped) = text[index..].chars().next() {
                 index += escaped.len_utf8();
             }
+            continue;
+        }
+
+        if ch == '\'' {
+            quote_state = Some(QuoteState::Single);
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '"' {
+            quote_state = Some(QuoteState::Double);
+            index += ch_len;
             continue;
         }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5181,11 +5181,10 @@ fn shellish_words(text: &str) -> Vec<&str> {
 fn brace_character_spans(span: Span, source: &str) -> Vec<Span> {
     let text = span.slice(source);
     text.char_indices()
-        .filter_map(|(offset, ch)| {
-            matches!(ch, '{' | '}').then(|| {
+        .filter(|&(_, ch)| matches!(ch, '{' | '}'))
+        .map(|(offset, _)| {
                 let position = span.start.advanced_by(&text[..offset]);
                 Span::from_positions(position, position)
-            })
         })
         .collect()
 }
@@ -5322,11 +5321,9 @@ fn unclassified_literal_brace_spans(word: &Word, source: &str) -> Vec<Span> {
 
         if ch == '{' {
             unmatched_opens.push(index);
-        } else if ch == '}' {
-            if unmatched_opens.pop().is_none() {
-                let position = span.start.advanced_by(&text[..index]);
-                spans.push(Span::from_positions(position, position));
-            }
+        } else if ch == '}' && unmatched_opens.pop().is_none() {
+            let position = span.start.advanced_by(&text[..index]);
+            spans.push(Span::from_positions(position, position));
         }
 
         index += ch_len;

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -21,7 +21,7 @@ pub fn literal_braces(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_literal_unquoted_brace_pair_edges() {
@@ -85,10 +85,13 @@ ln -sfr $TERMUX_PREFIX/lib/libaircrack-${m}{-$_LT_VER,}.so
     }
 
     #[test]
-    fn ignores_xargs_inline_replace_options() {
+    fn ignores_multiline_brace_expansions_with_line_continuations() {
         let source = "\
 #!/bin/bash
-xargs -I{} basename \"{}\"
+cp -a $TARNAM/{AUTHOR.txt,\\
+CONTRIBUTORS.md,COPYING.txt,ChangeLog.md,\\
+OFL.txt,README.md,documentation} \\
+   $PKG/usr/doc/$PRGNAM-$VERSION/
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
@@ -96,24 +99,73 @@ xargs -I{} basename \"{}\"
     }
 
     #[test]
-    fn reports_xargs_like_literals_after_option_parsing_stops() {
+    fn ignores_literal_braces_inside_trailing_comments() {
+        let source = "\
+#!/bin/bash
+python3 -m installer --destdir \"$PKG\" dist/*.whl # > ${CWD}/INSTALL.OUTPUT 2>&1
+n=\"$node_number\" # nodenumber_id e.g. network.city.${N}.0
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_xargs_inline_replace_options() {
+        let source = "\
+#!/bin/bash
+xargs -I{} basename {}
+xargs -0 -I {} mv {} {}.new
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_empty_brace_pairs_even_after_option_parsing_stops() {
         let source = "\
 #!/bin/bash
 xargs printf -I{}
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
-        assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.column, 16);
-        assert_eq!(diagnostics[1].span.start.column, 17);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]
-    fn reports_literal_braces_for_non_find_exec_forms() {
+    fn reports_nonempty_xargs_like_literals_after_option_parsing_stops() {
         let source = "\
 #!/bin/bash
-echo {} +
-myfind -exec echo {} \\;
+xargs printf -I{x}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.column, 16);
+        assert_eq!(diagnostics[1].span.start.column, 18);
+    }
+
+    #[test]
+    fn ignores_empty_brace_pairs_in_general_literals() {
+        let source = "\
+#!/bin/bash
+echo {}
+echo address:{}
+echo Block={}
+jq . <<<{}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_nonempty_literal_braces_for_non_find_exec_forms() {
+        let source = "\
+#!/bin/bash
+echo {value} +
+myfind -exec echo {value} \\;
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
@@ -133,6 +185,50 @@ echo [0-9a-f]{$HASHLEN}
     }
 
     #[test]
+    fn reports_template_placeholder_braces() {
+        let source = "\
+#!/bin/bash
+go list -f {{.Dir}} \"$path\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert_eq!(diagnostics.len(), 4);
+        assert_eq!(diagnostics[0].span.start.column, 12);
+        assert_eq!(diagnostics[1].span.start.column, 13);
+        assert_eq!(diagnostics[2].span.start.column, 18);
+        assert_eq!(diagnostics[3].span.start.column, 19);
+    }
+
+    #[test]
+    fn reports_standalone_and_lone_literal_braces() {
+        let source = "\
+#!/bin/bash
+nft add set inet shellcrash cn_ip6 { type ipv6_addr \\; flags interval \\; }
+cut -d} -f1
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 36);
+        assert_eq!(diagnostics[1].span.start.line, 2);
+        assert_eq!(diagnostics[1].span.start.column, 74);
+        assert_eq!(diagnostics[2].span.start.line, 3);
+        assert_eq!(diagnostics[2].span.start.column, 7);
+    }
+
+    #[test]
+    fn ignores_escaped_dollar_before_real_parameter_expansion() {
+        let source = "\
+#!/bin/bash
+crash_v_new=$(eval echo \\$${crashcore}_v)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_plain_parameter_expansion_braces_next_to_brace_expansion() {
         let source = "\
 #!/bin/bash
@@ -141,5 +237,114 @@ echo TERMUX_SUBPKG_INCLUDE=\\\"$(find ${_ADD_PREFIX}lib{,32} -name '*.a' -o -nam
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_parameter_expansions_in_assignment_only_commands() {
+        let source = "\
+#!/bin/sh
+if [ ${COMPLIANCE_FINDINGS_FOUND} -eq 0 ]; then COMPLIANCE=\"${GREEN}V\"; else COMPLIANCE=\"${RED}X\"; fi
+TARGET=${1:-/dev/stdin}
+NTPSERVER=\"${curArg}\"
+crypt=${crypt//\\\\/\\\\\\\\}
+crypt=${crypt//\\//\\\\\\/}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralBraces).with_shell(ShellDialect::Sh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_assignment_only_parameter_expansions_in_bash_mode() {
+        let source = "\
+#!/bin/bash
+if [ -e /usr/bin/wx-config ]; then GUI=${GUI:-yes}; else GUI=${GUI:-no}; fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralBraces).with_shell(ShellDialect::Bash),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_escaped_find_exec_placeholders() {
+        let source = "\
+#!/bin/bash
+find $TERMUX_PKG_SRCDIR -mindepth 1 -maxdepth 1 -exec cp -a \\{\\} ./ \\;
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_nested_parameter_expansion_braces() {
+        let source = "\
+#!/bin/bash
+local args=${*:1:${#@}-1}
+eval ac_env_${ac_var}_set=\\${${ac_var}+set}
+if eval \\${ac_cv_prog_make_${ac_make}_set+:} false; then :
+  :
+fi
+__rvm_find \"${rvm_bin_path:=$rvm_path/bin}\" -name \\*${ruby_at_gemset} -exec rm -rf '{}' \\;
+exec {IPC_FIFO_FD}<>\"$IPC_FIFO\"
+exec {IPC_FIFO_FD}>&-
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_simple_escaped_parameter_braces_even_with_later_expansions() {
+        let source = "\
+#!/bin/bash
+./configure --libdir=\\${exec_prefix}/lib${LIBDIRSUFFIX}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+        let positions = diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+            .collect::<Vec<_>>();
+
+        assert_eq!(positions, vec![(2, 24), (2, 36)]);
+    }
+
+    #[test]
+    fn reports_nft_literal_braces_with_dropped_raw_tokens() {
+        let source = "\
+#!/bin/bash
+nft add rule inet shellcrash $1 tcp dport {\"$mix_port, $redir_port, $tproxy_port\"} return
+nft add rule inet shellcrash $1 udp dport {443, 8443} return
+nft add rule inet shellcrash mark_out meta mark $fwmark meta l4proto {tcp, udp} tproxy to :$tproxy_port
+nft add chain inet fw4 forward { type filter hook forward priority filter \\; } 2>/dev/null
+nft add chain inet fw4 input { type filter hook input priority filter \\; } 2>/dev/null
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+        let positions = diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            positions,
+            vec![
+                (2, 43),
+                (2, 82),
+                (3, 43),
+                (3, 53),
+                (4, 70),
+                (4, 79),
+                (5, 32),
+                (5, 78),
+                (6, 30),
+                (6, 74),
+            ]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -99,6 +99,17 @@ OFL.txt,README.md,documentation} \\
     }
 
     #[test]
+    fn ignores_brace_expansions_with_escaped_spaces() {
+        let source = "\
+#!/bin/bash
+echo {alpha,\\ beta}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_literal_braces_inside_trailing_comments() {
         let source = "\
 #!/bin/bash
@@ -313,6 +324,21 @@ exec {IPC_FIFO_FD}>&-
             .collect::<Vec<_>>();
 
         assert_eq!(positions, vec![(2, 24), (2, 36)]);
+    }
+
+    #[test]
+    fn reports_simple_escaped_parameter_braces_even_after_nested_escape() {
+        let source = "\
+#!/bin/bash
+echo \\${${name}}/\\${fallback}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+        let positions = diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+            .collect::<Vec<_>>();
+
+        assert_eq!(positions, vec![(2, 20), (2, 29)]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -110,6 +110,17 @@ echo {alpha,\\ beta}
     }
 
     #[test]
+    fn ignores_brace_expansions_with_quoted_spaces() {
+        let source = "\
+#!/bin/bash
+echo {alpha,\"beta gamma\"}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_literal_braces_inside_trailing_comments() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -196,6 +196,17 @@ echo [0-9a-f]{$HASHLEN}
     }
 
     #[test]
+    fn ignores_even_backslash_runs_before_parameter_expansions() {
+        let source = "\
+#!/bin/bash
+echo \\\\${name}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_template_placeholder_braces() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck/tests/testdata/corpus-metadata/s029.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s029.yaml
@@ -69,3 +69,45 @@ reviewed_divergences:
     column: 108
     end_column: 108
     reason: "This U-Boot loader script uses escaped brace variables in command strings that ShellCheck still reports at this closing-brace location."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 1296
+    end_line: 1296
+    column: 31
+    end_column: 31
+    reason: "This generated configure helper carries an escaped parameter template through `eval` in project-closure context, so the remaining opening-brace anchor is reviewed as standalone corpus drift rather than a live S029 bug."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 1296
+    end_line: 1296
+    column: 45
+    end_column: 45
+    reason: "This generated configure helper carries an escaped parameter template through `eval` in project-closure context, so the remaining closing-brace anchor is reviewed as standalone corpus drift rather than a live S029 bug."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 1298
+    end_line: 1298
+    column: 34
+    end_column: 34
+    reason: "This generated configure helper repeats the same escaped-parameter template pattern in project-closure context, so the opening-brace anchor is reviewed as corpus-only divergence."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 1298
+    end_line: 1298
+    column: 48
+    end_column: 48
+    reason: "This generated configure helper repeats the same escaped-parameter template pattern in project-closure context, so the closing-brace anchor is reviewed as corpus-only divergence."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 2528
+    end_line: 2528
+    column: 11
+    end_column: 11
+    reason: "This later configure probe keeps an escaped parameter template inside an `eval` cache check, and the remaining opening-brace hit is treated as project-closure corpus drift."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 2528
+    end_line: 2528
+    column: 44
+    end_column: 44
+    reason: "This later configure probe keeps an escaped parameter template inside an `eval` cache check, and the remaining closing-brace hit is treated as project-closure corpus drift."


### PR DESCRIPTION
## Summary
- refine S029 brace-span facts to ignore assignment-only and nested parameter expansions, escaped placeholders, fd-variable redirects, comment tails, and multiline continuation forms
- add focused literal-braces regression tests for the new coverage and exclusions
- record the reviewed configure-script divergence in the S029 corpus metadata

## Testing
- cargo test -p shuck-linter literal_braces
- cargo test -p shuck-parser lexer
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S029 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10

## Notes
- the full targeted S029 corpus run is improved but still has 9 blocking fixtures remaining
