### PR TITLE
Refine S009 echoed command substitution detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -898,6 +898,7 @@ pub struct SubstitutionFact {
     body_contains_ls: bool,
     body_contains_echo: bool,
     body_contains_grep: bool,
+    body_has_multiple_statements: bool,
     bash_file_slurp: bool,
     host_word_span: Span,
     host_kind: SubstitutionHostKind,
@@ -939,6 +940,10 @@ impl SubstitutionFact {
 
     pub fn body_contains_grep(&self) -> bool {
         self.body_contains_grep
+    }
+
+    pub fn body_has_multiple_statements(&self) -> bool {
+        self.body_has_multiple_statements
     }
 
     pub fn is_bash_file_slurp(&self) -> bool {
@@ -15409,6 +15414,40 @@ printf '%s\\n' `date` $(uname) <(cat /etc/hosts)
                 false,
             )));
             assert!(substitutions.contains(&("<(cat /etc/hosts)".to_owned(), None, false,)));
+        });
+    }
+
+    #[test]
+    fn tracks_multi_statement_substitution_bodies() {
+        let source = "\
+#!/bin/sh
+single=$(printf '%s\\n' ok)
+multiple=$(printf '%s\\n' one; printf '%s\\n' two)
+conditional=$( [[ -n $value ]] && printf '%s\\n' ok )
+";
+
+        with_facts(source, None, |_, facts| {
+            let substitutions = facts
+                .commands()
+                .iter()
+                .flat_map(|fact| fact.substitution_facts().iter().copied())
+                .map(|fact| {
+                    (
+                        fact.span().slice(source).to_owned(),
+                        fact.body_has_multiple_statements(),
+                    )
+                })
+                .collect::<std::collections::HashMap<_, _>>();
+
+            assert_eq!(substitutions.get("$(printf '%s\\n' ok)"), Some(&false));
+            assert_eq!(
+                substitutions.get("$(printf '%s\\n' one; printf '%s\\n' two)"),
+                Some(&true)
+            );
+            assert_eq!(
+                substitutions.get("$( [[ -n $value ]] && printf '%s\\n' ok )"),
+                Some(&false)
+            );
         });
     }
 

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -166,6 +166,7 @@ fn collect_or_update_substitution_facts_from_occurrences<'a>(
             body_contains_ls: body_facts.body_contains_ls,
             body_contains_echo: body_facts.body_contains_echo,
             body_contains_grep: body_facts.body_contains_grep,
+            body_has_multiple_statements: body_facts.body_has_multiple_statements,
             bash_file_slurp: body_facts.bash_file_slurp,
             host_word_span: host_span,
             host_kind,
@@ -333,6 +334,7 @@ struct SubstitutionBodyFacts {
     body_contains_ls: bool,
     body_contains_echo: bool,
     body_contains_grep: bool,
+    body_has_multiple_statements: bool,
     bash_file_slurp: bool,
 }
 
@@ -374,6 +376,7 @@ fn classify_substitution_body<'a>(
         body_contains_ls: substitution_body_contains_ls(body, commands, command_ids_by_span),
         body_contains_echo: substitution_body_contains_echo(body, source),
         body_contains_grep: substitution_body_contains_grep(body, source),
+        body_has_multiple_statements: body.stmts.len() > 1,
         bash_file_slurp: matches!(visits.as_slice(), [visit] if is_bash_file_slurp_command(visit.command, visit.redirects, source)),
     }
 }

--- a/crates/shuck-linter/src/rules/style/echoed_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/echoed_command_substitution.rs
@@ -2,6 +2,7 @@ use crate::{
     Checker, CommandSubstitutionKind, ExpansionContext, Rule, SubstitutionHostKind, Violation,
     WordFactContext,
 };
+
 pub struct EchoedCommandSubstitution;
 
 impl Violation for EchoedCommandSubstitution {
@@ -20,26 +21,33 @@ pub fn echoed_command_substitution(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("echo"))
-        .flat_map(|fact| {
-            fact.substitution_facts()
-                .iter()
-                .filter(|substitution| {
-                    substitution.kind() == CommandSubstitutionKind::Command
-                        && matches!(
-                            substitution.host_kind(),
-                            SubstitutionHostKind::CommandArgument
-                        )
+        .filter_map(|fact| {
+            let [word] = fact.body_args() else {
+                return None;
+            };
+
+            checker
+                .facts()
+                .word_fact(
+                    word.span,
+                    WordFactContext::Expansion(ExpansionContext::CommandArgument),
+                )
+                .filter(|fact| fact.classification().has_plain_command_substitution())
+                .filter(|_| {
+                    !fact.substitution_facts().iter().any(|substitution| {
+                        substitution.kind() == CommandSubstitutionKind::Command
+                            && matches!(
+                                substitution.host_kind(),
+                                SubstitutionHostKind::CommandArgument
+                            )
+                            && substitution.host_word_span() == word.span
+                            && (substitution.is_bash_file_slurp()
+                                || substitution.body_has_multiple_statements()
+                                || (substitution.uses_backtick_syntax()
+                                    && !substitution.unquoted_in_host()))
+                    })
                 })
-                .filter_map(|substitution| {
-                    checker
-                        .facts()
-                        .word_fact(
-                            substitution.host_word_span(),
-                            WordFactContext::Expansion(ExpansionContext::CommandArgument),
-                        )
-                        .filter(|fact| fact.classification().has_plain_command_substitution())
-                        .map(|_| substitution.host_word_span())
-                })
+                .map(|_| word.span)
         })
         .collect::<Vec<_>>();
 
@@ -70,8 +78,30 @@ mod tests {
     }
 
     #[test]
-    fn reports_plain_substitutions_in_any_echo_argument() {
-        let source = "echo prefix $(date)\necho \"$(date)\"\n";
+    fn ignores_echoes_with_extra_arguments() {
+        let source = "echo prefix $(date)\necho \"$(date)\" suffix\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::EchoedCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_echo_flag_forms_and_bash_file_slurps() {
+        let source = "echo -n \"$(date)\"\necho -e \"$(date)\"\necho \"$(< file.txt)\"\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::EchoedCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_single_argument_echoes_inside_binary_command_lists() {
+        let source = "value=\"$(true && echo \"$(date)\")\"\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::EchoedCommandSubstitution),
@@ -82,7 +112,20 @@ mod tests {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$(date)", "\"$(date)\""]
+            vec!["\"$(date)\""]
         );
+    }
+
+    #[test]
+    fn ignores_quoted_backticks_and_multi_statement_substitutions() {
+        let source = r#"SCRIPT=$(echo "`basename "$0"`")
+value=$(echo $(printf '%s\n' one; printf '%s\n' two) | tr -d ' ')
+"#;
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::EchoedCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- refine S009 so it only fires when `echo` is effectively forwarding a single plain command substitution
- track whether command substitution bodies contain multiple top-level statements and use that in the rule filter
- add regression coverage for extra echo args, `echo -n/-e`, bash file slurps, quoted backticks, binary command lists, and multi-statement substitutions

## Verification
- `cargo test -p shuck-linter tracks_multi_statement_substitution_bodies -- --nocapture`
- `cargo test -p shuck-linter echoed_command_substitution -- --nocapture`
- `cargo test -p shuck-linter rules::style::tests::rules::rule_echoedcommandsubstitution_path_new_s009_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S009` (`149` blocking diffs down to `1` remaining parser-side under-report in `RetroPie__RetroPie-Setup__scriptmodules__supplementary__launchingimages.sh:249`)
