### PR TITLE
Ignore nested word guards in presence inference

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2280,6 +2280,7 @@ pub struct LinterFacts<'a> {
     comma_array_assignment_spans: Vec<Span>,
     ifs_literal_backslash_assignment_value_spans: Vec<Span>,
     presence_tested_names: FxHashSet<Name>,
+    nested_presence_test_spans: FxHashMap<Name, Vec<Span>>,
     subscript_index_reference_spans: FxHashSet<FactSpan>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
     words: Vec<WordFact<'a>>,
@@ -2474,6 +2475,19 @@ impl<'a> LinterFacts<'a> {
 
     pub fn presence_tested_names(&self) -> &FxHashSet<Name> {
         &self.presence_tested_names
+    }
+
+    pub fn is_presence_tested_name(&self, name: &Name, span: Span) -> bool {
+        self.presence_tested_names.contains(name)
+            || self
+                .nested_presence_test_spans
+                .get(name)
+                .is_some_and(|spans| {
+                    spans
+                        .iter()
+                        .copied()
+                        .any(|outer| contains_span(outer, span))
+                })
     }
 
     pub fn is_subscript_index_reference(&self, span: Span) -> bool {
@@ -3231,7 +3245,8 @@ impl<'a> LinterFactsBuilder<'a> {
             broken_assoc_key_spans,
             comma_array_assignment_spans,
             ifs_literal_backslash_assignment_value_spans,
-            presence_tested_names,
+            presence_tested_names: presence_tested_names.global_names,
+            nested_presence_test_spans: presence_tested_names.nested_command_spans_by_name,
             subscript_index_reference_spans,
             compound_assignment_value_word_spans,
             words,

--- a/crates/shuck-linter/src/facts/presence.rs
+++ b/crates/shuck-linter/src/facts/presence.rs
@@ -1,35 +1,77 @@
 use super::*;
 
+#[derive(Debug, Default)]
+pub(super) struct PresenceTestedNames {
+    pub(super) global_names: FxHashSet<Name>,
+    pub(super) nested_command_spans_by_name: FxHashMap<Name, Vec<Span>>,
+}
+
 pub(super) fn build_presence_tested_names(
     commands: &[CommandFact<'_>],
     source: &str,
-) -> FxHashSet<Name> {
-    let mut names = FxHashSet::default();
+) -> PresenceTestedNames {
+    let mut global_names = FxHashSet::default();
+    let mut nested_command_spans_by_name = FxHashMap::<Name, Vec<Span>>::default();
 
     for command in commands {
-        // Presence-test suppression is global today, so nested word commands
-        // must not contribute names that would silence unrelated plain uses.
-        if command.is_nested_word_command() {
-            continue;
-        }
+        let mut command_names = FxHashSet::default();
 
         if let Some(simple_test) = command.simple_test() {
             collect_presence_tested_names_from_simple_test_operands(
                 simple_test.operands(),
                 source,
-                &mut names,
+                &mut command_names,
             );
         }
 
         if let Some(conditional) = command.conditional() {
             collect_presence_tested_names_from_conditional_expr(
                 conditional.root().expression(),
-                &mut names,
+                &mut command_names,
             );
+        }
+
+        if command.is_nested_word_command() {
+            let span = outermost_nested_presence_scope_span(commands, command);
+            for name in command_names {
+                nested_command_spans_by_name
+                    .entry(name)
+                    .or_default()
+                    .push(span);
+            }
+        } else {
+            global_names.extend(command_names);
         }
     }
 
-    names
+    for spans in nested_command_spans_by_name.values_mut() {
+        spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+        spans.dedup();
+    }
+
+    PresenceTestedNames {
+        global_names,
+        nested_command_spans_by_name,
+    }
+}
+
+fn outermost_nested_presence_scope_span(
+    commands: &[CommandFact<'_>],
+    command: &CommandFact<'_>,
+) -> Span {
+    commands
+        .iter()
+        .filter(|candidate| {
+            candidate.is_nested_word_command() && contains_span(candidate.span(), command.span())
+        })
+        .map(CommandFact::span)
+        .min_by(|left, right| {
+            left.start
+                .offset
+                .cmp(&right.start.offset)
+                .then_with(|| right.end.offset.cmp(&left.end.offset))
+        })
+        .unwrap_or_else(|| command.span())
 }
 
 fn collect_presence_tested_names_from_simple_test_operands(

--- a/crates/shuck-linter/src/facts/presence.rs
+++ b/crates/shuck-linter/src/facts/presence.rs
@@ -7,6 +7,12 @@ pub(super) fn build_presence_tested_names(
     let mut names = FxHashSet::default();
 
     for command in commands {
+        // Presence-test suppression is global today, so nested word commands
+        // must not contribute names that would silence unrelated plain uses.
+        if command.is_nested_word_command() {
+            continue;
+        }
+
         if let Some(simple_test) = command.simple_test() {
             collect_presence_tested_names_from_simple_test_operands(
                 simple_test.operands(),

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -2353,6 +2353,17 @@ printf '%s\\n' \"$missing\"
     }
 
     #[test]
+    fn undefined_variable_keeps_nested_word_guard_suppression_inside_same_substitution() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"$([ -n \"$missing\" ] && printf '%s' \"$missing\")\"
+";
+        let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn unread_name_only_declarations_are_not_flagged() {
         let diagnostics = lint(
             "\

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -2336,6 +2336,23 @@ echo \"$guarded\" \"$truthy\" \"$chain_left\" \"$chain_right\" \"$or_left\" \"$o
     }
 
     #[test]
+    fn undefined_variable_nested_word_guards_do_not_suppress_plain_uses() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"${fallback:-$([ \"$missing\" ])}\"
+printf '%s\\n' \"$missing\"
+";
+        let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
+
+        assert!(
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic.message.contains("missing") && diagnostic.span.start.line == 3
+            }),
+            "diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
     fn unread_name_only_declarations_are_not_flagged() {
         let diagnostics = lint(
             "\

--- a/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
@@ -28,8 +28,7 @@ pub(super) fn is_reportable_variable_reference(
     }
     if checker
         .facts()
-        .presence_tested_names()
-        .contains(&reference.name)
+        .is_presence_tested_name(&reference.name, reference.span)
     {
         return false;
     }


### PR DESCRIPTION
## Summary
- exclude nested word commands from global presence-tested name inference
- add a regression test covering a parameter-expansion fallback that contains a nested test command

## Why
Nested commands discovered inside parameter-expansion operands were being folded into the global presence-tested name set. That let a guard-like test such as `${fallback:-$([ "$missing" ])}` suppress an unrelated undefined-variable diagnostic for a later plain `$missing` read.

## Impact
Undefined-variable reporting keeps honoring supported top-level guard patterns, but nested word-command guards no longer mute unrelated diagnostics elsewhere in the script.

## Validation
- `cargo test -p shuck-linter`
