### PR TITLE
Document C110 reviewed divergence

### DIFF
--- a/crates/shuck/tests/testdata/corpus-metadata/c110.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c110.yaml
@@ -1,0 +1,8 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__academic__stellarsolver__stellarsolver.SlackBuild"
+    line: 88
+    column: 23
+    end_line: 88
+    end_column: 24
+    reason: "This SlackBuild compares a quoted expansion that resembles an assignment, and the pinned ShellCheck build does not emit SC2341 for it. Shuck keeps the stricter warning here, so the corpus comparison should ignore this site."


### PR DESCRIPTION
## Summary
- add a reviewed divergence entry for the remaining C110 SlackBuild corpus fixture
- document that the pinned ShellCheck build does not emit SC2341 there while Shuck intentionally keeps the stricter warning

## Testing
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C110