### PR TITLE
Tighten quoted regex significance

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
@@ -57,7 +57,7 @@ fn literal_uses_regex_significance(text: &str) -> bool {
 
         if matches!(
             char,
-            '.' | '[' | ']' | '(' | ')' | '{' | '}' | '*' | '+' | '?' | '|' | '^' | '$'
+            '.' | '[' | ']' | '(' | ')' | '*' | '+' | '?' | '|' | '^' | '$'
         ) {
             return true;
         }
@@ -77,6 +77,8 @@ mod tests {
 #!/bin/bash
 [[ \"$output\" =~ \"Error: No available formula\" ]]
 [[ \"$output\" =~ \"~user\" ]]
+[[ \"$output\" =~ \"{\" ]]
+[[ \"$output\" =~ \"a{1,3}\" ]]
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashRegex));
 


### PR DESCRIPTION
## Summary
- stop C009 from treating bare quoted braces as regex-significant on the right-hand side of `=~`
- keep reporting quoted operands that still carry real regex semantics such as quantifiers
- extend the quoted regex rule tests with the brace-only regression cases

## Testing
- cargo test -p shuck-linter rules::correctness::quoted_bash_regex::tests -- --nocapture
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C009