### PR TITLE
Fix C082 negation span matching

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/escaped_negation_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/escaped_negation_in_test.rs
@@ -34,7 +34,18 @@ fn report_span(fact: &SimpleTestFact<'_>, source: &str) -> Option<Span> {
         return None;
     }
 
-    escaped_negation_is_operator(fact, source).then_some(leading.span)
+    if !escaped_negation_is_operator(fact, source) {
+        return None;
+    }
+
+    match fact.shape() {
+        SimpleTestShape::Unary | SimpleTestShape::Binary => fact
+            .effective_operator_word()
+            .map(|word| word.span)
+            .or(Some(leading.span)),
+        SimpleTestShape::Other => Some(leading.span),
+        SimpleTestShape::Empty | SimpleTestShape::Truthy => None,
+    }
 }
 
 fn escaped_negation_is_operator(fact: &SimpleTestFact<'_>, source: &str) -> bool {
@@ -100,7 +111,7 @@ test \\! -n \"$value\"
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["\\!", "\\!", "\\!"]
+            vec!["-f", "-n", "\\!"]
         );
     }
 

--- a/crates/shuck/tests/testdata/corpus-metadata/c082.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c082.yaml
@@ -1,3 +1,3 @@
 comparison_target_notes:
-  - current_shellcheck_code: "SC2057"
-    reason: "The pinned ShellCheck oracle currently classifies leading \\! test syntax under its generic unknown-operator warning instead of the older SC2302 mapping carried by this authored rule."
+  - current_shellcheck_code: "SC2302"
+    reason: "The pinned ShellCheck oracle now reports leading \\! test syntax as SC2057, so the older SC2302 target should be skipped when comparing this rule."


### PR DESCRIPTION
## Summary
- report C082 on the effective test operator instead of the escaped `\!` token
- update the C082 comparison-target metadata so the corpus follows the current `SC2057` oracle behavior
- keep the rule behavior stable while tightening the diagnostic span

## Testing
- cargo test -p shuck-linter escaped_negation_in_test -- --nocapture
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C082