### PR TITLE
Add S015 reviewed divergence

### DIFF
--- a/crates/shuck/tests/testdata/corpus-metadata/s015.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s015.yaml
@@ -1,0 +1,8 @@
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__mame__mame.SlackBuild"
+    line: 166
+    end_line: 166
+    column: 12
+    end_column: 22
+    reason: "This loop uses a quoted scalar expansion, which ShellCheck reports as SC2066, but S015 is intentionally scoped to quoted star-splat loop items."


### PR DESCRIPTION
## Summary
- add a narrow reviewed divergence for the remaining S015 large-corpus fixture
- document that the mame SlackBuild warning is a quoted scalar loop item, while S015 is intentionally limited to quoted `"$*"` star-splat loops

## Testing
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S015