### PR TITLE
Fix X007 false positives for dollar quotes inside double quotes

### DIFF
--- a/crates/shuck-linter/src/rules/portability/ansi_c_quoting.rs
+++ b/crates/shuck-linter/src/rules/portability/ansi_c_quoting.rs
@@ -52,7 +52,7 @@ mod tests {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$'line\\n'", "$'inner'", "$'tab\\t'"]
+            vec!["$'line\\n'", "$'tab\\t'"]
         );
     }
 
@@ -86,6 +86,21 @@ mod tests {
 _socat_cert_cmd=\"echo '${_cmdpfx}show ssl cert' | socat '${_statssock}' - | grep -q '^${_pem}$'\"
 _socat_crtlist_show_cmd=\"echo '${_cmdpfx}show ssl crt-list' | socat '${_statssock}' - | grep -q '^${Le_Deploy_haproxy_pem_path}$'\"
 _socat_cert_commit_cmd=\"echo '${_cmdpfx}commit ssl cert ${_pem}' | socat '${_statssock}' - | grep -q '^Success!$'\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AnsiCQuoting).with_shell(ShellDialect::Sh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_dollar_quote_like_text_inside_double_quotes() {
+        let source = "\
+#!/bin/sh
+eval \"$1=$'${!1}'\"
+printf '%s\\n' \"$'inner'\"
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1720,6 +1720,31 @@ fn test_dollar_quoted_words_preserve_quote_variants() {
 }
 
 #[test]
+fn test_dollar_quotes_stay_literal_inside_double_quotes() {
+    let input = "printf \"%s\" \"$'inner'\" \"$\\\"inner\\\"\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    assert_eq!(command.args.len(), 3);
+
+    for arg in &command.args[1..] {
+        let WordPart::DoubleQuoted { parts, .. } = &arg.parts[0].kind else {
+            panic!("expected double-quoted word");
+        };
+        assert_eq!(arg.render_syntax(input), arg.span.slice(input));
+        assert!(
+            !parts.iter().any(|part| matches!(
+                part.kind,
+                WordPart::SingleQuoted { .. } | WordPart::DoubleQuoted { dollar: true, .. }
+            )),
+            "double-quoted contents should keep nested dollar-quote syntax literal: {parts:#?}"
+        );
+    }
+}
+
+#[test]
 fn test_word_part_spans_track_nested_array_expansions() {
     let input = "echo ${arr[$RANDOM % ${#arr[@]}]}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3097,7 +3097,10 @@ impl<'a> Parser<'a> {
                         content_start,
                         true,
                         DecodeWordPartsOptions {
-                            parse_dollar_quotes: true,
+                            // `$'...'` and `$"..."` are literal inside ordinary
+                            // double quotes, so nested decoding must not
+                            // reactivate dollar-quote parsing here.
+                            parse_dollar_quotes: false,
                             parse_process_substitutions: false,
                             ..DecodeWordPartsOptions::default()
                         },
@@ -3110,7 +3113,10 @@ impl<'a> Parser<'a> {
                         content_start,
                         false,
                         DecodeWordPartsOptions {
-                            parse_dollar_quotes: true,
+                            // `$'...'` and `$"..."` are literal inside ordinary
+                            // double quotes, so nested decoding must not
+                            // reactivate dollar-quote parsing here.
+                            parse_dollar_quotes: false,
                             parse_process_substitutions: false,
                             ..DecodeWordPartsOptions::default()
                         },
@@ -3373,7 +3379,10 @@ impl<'a> Parser<'a> {
                         content_start,
                         true,
                         DecodeWordPartsOptions {
-                            parse_dollar_quotes: true,
+                            // Localized `$"..."` content uses double-quote
+                            // semantics, so nested `$'...'` and `$"..."` stay
+                            // literal here as well.
+                            parse_dollar_quotes: false,
                             parse_process_substitutions: false,
                             ..DecodeWordPartsOptions::default()
                         },
@@ -3386,7 +3395,10 @@ impl<'a> Parser<'a> {
                         content_start,
                         false,
                         DecodeWordPartsOptions {
-                            parse_dollar_quotes: true,
+                            // Localized `$"..."` content uses double-quote
+                            // semantics, so nested `$'...'` and `$"..."` stay
+                            // literal here as well.
+                            parse_dollar_quotes: false,
                             parse_process_substitutions: false,
                             ..DecodeWordPartsOptions::default()
                         },
@@ -4989,7 +5001,9 @@ impl<'a> Parser<'a> {
             base,
             source_backed,
             DecodeWordPartsOptions {
-                parse_dollar_quotes: true,
+                // Double-quoted segment contents treat `$'...'` and `$"..."`
+                // as literal text, not nested quote forms.
+                parse_dollar_quotes: false,
                 parse_process_substitutions: false,
                 ..DecodeWordPartsOptions::default()
             },


### PR DESCRIPTION
## Summary
- treat `$'...'` and `$"..."` as literal text when they appear inside double-quoted content
- add parser coverage for nested dollar-quote syntax inside double quotes
- update the X007 portability tests to keep flagging real ANSI-C quotes while ignoring double-quoted lookalikes

## Root cause
The parser was re-enabling dollar-quote decoding while recursively decoding the contents of double-quoted segments. That turned text like `"$'inner'"` and `eval "$1=$'${!1}'"` into synthetic ANSI-C quote fragments, which in turn made X007 report false positives.

## Validation
- `cargo test -p shuck-parser test_dollar_quotes_stay_literal_inside_double_quotes -- --nocapture`
- `cargo test -p shuck-linter ansi_c_quoting -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X007`