### PR TITLE
Improve C001 parity for shell state and slice parsing

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1249,6 +1249,68 @@ printf '%s\\n' \"${arr[@]}\"
     }
 
     #[test]
+    fn assignments_used_in_process_substitution_are_not_flagged() {
+        let diagnostics = lint(
+            "\
+#!/bin/bash
+f() {
+  local opts
+  case \"$1\" in
+    a) opts=alpha ;;
+    *) opts=beta ;;
+  esac
+  while IFS= read -r line; do :; done < <(printf '%s\\n' \"$opts\")
+}
+f a
+",
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 8);
+        assert_eq!(diagnostics[0].span.slice(
+            "#!/bin/bash\nf() {\n  local opts\n  case \"$1\" in\n    a) opts=alpha ;;\n    *) opts=beta ;;\n  esac\n  while IFS= read -r line; do :; done < <(printf '%s\\n' \"$opts\")\n}\nf a\n"
+        ), "line");
+    }
+
+    #[test]
+    fn overwritten_empty_initializers_only_report_the_later_dead_assignment() {
+        let source = "\
+#!/bin/bash
+f() {
+  local foo=
+  foo=bar
+}
+f
+";
+        let diagnostics = lint_for_rule(source, Rule::UnusedAssignment);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
+    }
+
+    #[test]
+    fn substring_offset_arithmetic_reads_do_not_trigger_unused_assignment() {
+        let diagnostics = lint(
+            "\
+#!/bin/bash
+spinner() {
+  local chars=\"/-\\\\|\"
+  local spin_i=0
+  while true; do
+    printf '%s\\n' \"${chars:spin_i++%${#chars}:1}\"
+  done
+}
+spinner
+",
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn unused_append_assignment_is_not_flagged() {
         let diagnostics = lint_for_rule("#!/bin/bash\nfoo+=bar\n", Rule::UnusedAssignment);
 
@@ -1316,6 +1378,22 @@ f
     }
 
     #[test]
+    fn getopts_runtime_state_assignments_are_not_flagged() {
+        let source = "\
+#!/bin/sh
+f() {
+  local flag OPTIND=1 OPTARG='' OPTERR=0
+  while getopts 'a:' flag; do :; done
+}
+f
+";
+        let diagnostics = lint_for_rule(source, Rule::UnusedAssignment);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UnusedAssignment);
+        assert_eq!(diagnostics[0].span.slice(source), "flag");
+    }
+
+    #[test]
     fn global_ifs_assignment_is_not_flagged_but_unrelated_assignment_is() {
         let source = "\
 #!/bin/bash
@@ -1340,6 +1418,36 @@ LC_ALL=C
 LC_TIME=C
 unused=1
 echo ok
+";
+        let diagnostics = lint_for_rule(source, Rule::UnusedAssignment);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UnusedAssignment);
+        assert_eq!(diagnostics[0].span.slice(source), "unused");
+    }
+
+    #[test]
+    fn special_runtime_assignments_are_not_flagged_but_unrelated_assignment_is() {
+        let source = "\
+#!/bin/bash
+HOME=/tmp/home
+SHELL=/bin/bash
+TERM=xterm-256color
+USER=builder
+PWD=/tmp/work
+HISTFILE=/tmp/history
+HISTFILESIZE=unlimited
+HISTIGNORE='ls:bg:fg:history'
+HISTSIZE=-1
+HISTTIMEFORMAT='%F %T '
+COMP_WORDBREAKS=\"${COMP_WORDBREAKS//:/}\"
+PROMPT_COMMAND='history -a'
+PS1='prompt> '
+PS2='continuation> '
+PS3=''
+PS4='+ '
+COLUMNS=1
+READLINE_POINT=0
+unused=1
 ";
         let diagnostics = lint_for_rule(source, Rule::UnusedAssignment);
         assert_eq!(diagnostics.len(), 1);

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -5923,31 +5923,6 @@ impl<'a> Parser<'a> {
         text
     }
 
-    fn read_source_text_while<F>(
-        &self,
-        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
-        cursor: &mut Position,
-        mut predicate: F,
-        source_backed: bool,
-    ) -> SourceText
-    where
-        F: FnMut(char) -> bool,
-    {
-        let start = *cursor;
-        if source_backed {
-            while let Some(&ch) = chars.peek() {
-                if !predicate(ch) {
-                    break;
-                }
-                Self::next_word_char_unwrap(chars, cursor);
-            }
-            SourceText::source(Span::from_positions(start, *cursor))
-        } else {
-            let text = Self::read_word_while(chars, cursor, predicate);
-            self.source_text(text, start, *cursor)
-        }
-    }
-
     fn rebase_redirects(redirects: &mut [Redirect], base: Position) {
         for redirect in redirects {
             redirect.span = redirect.span.rebased(base);

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -698,6 +698,41 @@ fn test_substring_and_array_slice_attach_arithmetic_companion_asts() {
 }
 
 #[test]
+fn test_substring_offset_preserves_postfix_and_nested_length_arithmetic() {
+    let input = "echo \"${chars:spin_i++%${#chars}:1}\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+
+    let WordPart::DoubleQuoted { parts, .. } = &command.args[0].parts[0].kind else {
+        panic!("expected double-quoted word");
+    };
+
+    let (_, offset_ast, length_ast) = expect_substring_part(&parts[0].kind);
+    let ArithmeticExpr::Binary { left, op, right } = &offset_ast
+        .as_ref()
+        .expect("expected offset arithmetic AST")
+        .kind
+    else {
+        panic!("expected modulo offset expression");
+    };
+    assert_eq!(*op, ArithmeticBinaryOp::Modulo);
+    let ArithmeticExpr::Postfix { expr, op } = &left.kind else {
+        panic!("expected postfix increment on the left side");
+    };
+    assert_eq!(*op, ArithmeticPostfixOp::Increment);
+    expect_variable(expr, "spin_i");
+    expect_shell_word(right, input, "${#chars}");
+    expect_number(
+        length_ast.as_ref().expect("expected substring length AST"),
+        input,
+        "1",
+    );
+}
+
+#[test]
 fn test_non_arithmetic_subscripts_leave_companion_ast_empty() {
     let input = "echo ${arr[@]} ${arr[*]} ${map[\"key\"]}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4051,23 +4051,11 @@ impl<'a> Parser<'a> {
                                 continue;
                             } else {
                                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                                let offset = self.read_source_text_while(
+                                let (offset, length) = self.read_parameter_slice_parts(
                                     &mut chars,
                                     &mut cursor,
-                                    |c| c != ':' && c != '}',
                                     source_backed,
                                 );
-                                let length =
-                                    if Self::consume_word_char_if(&mut chars, &mut cursor, ':') {
-                                        Some(self.read_source_text_while(
-                                            &mut chars,
-                                            &mut cursor,
-                                            |c| c != '}',
-                                            source_backed,
-                                        ))
-                                    } else {
-                                        None
-                                    };
                                 Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                                 self.array_slice_word_part(
                                     self.parameter_var_ref(
@@ -4374,24 +4362,11 @@ impl<'a> Parser<'a> {
                                     )
                                 }
                                 _ => {
-                                    let offset = self.read_source_text_while(
+                                    let (offset, length) = self.read_parameter_slice_parts(
                                         &mut chars,
                                         &mut cursor,
-                                        |ch| ch != ':' && ch != '}',
                                         source_backed,
                                     );
-                                    let length =
-                                        if Self::consume_word_char_if(&mut chars, &mut cursor, ':')
-                                        {
-                                            Some(self.read_source_text_while(
-                                                &mut chars,
-                                                &mut cursor,
-                                                |ch| ch != '}',
-                                                source_backed,
-                                            ))
-                                        } else {
-                                            None
-                                        };
                                     Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                                     self.substring_word_part(
                                         self.parameter_var_ref(
@@ -5121,6 +5096,139 @@ impl<'a> Parser<'a> {
             length,
             length_ast,
             length_word_ast,
+        }
+    }
+
+    fn read_parameter_slice_parts(
+        &self,
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+        cursor: &mut Position,
+        source_backed: bool,
+    ) -> (SourceText, Option<SourceText>) {
+        let start = *cursor;
+        let mut offset_end = None;
+        let mut length_start = None;
+        let mut parameter_brace_depth = 0usize;
+        let mut literal_brace_depth = 0usize;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+        let mut offset_text = (!source_backed).then(String::new);
+        let mut length_text = (!source_backed).then(String::new);
+
+        while let Some(&ch) = chars.peek() {
+            if escaped {
+                let consumed = Self::next_word_char_unwrap(chars, cursor);
+                if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                    text.push(consumed);
+                }
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' if !in_single => {
+                    escaped = true;
+                    let consumed = Self::next_word_char_unwrap(chars, cursor);
+                    if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                        text.push(consumed);
+                    }
+                }
+                '\'' if !in_double => {
+                    in_single = !in_single;
+                    let consumed = Self::next_word_char_unwrap(chars, cursor);
+                    if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                        text.push(consumed);
+                    }
+                }
+                '"' if !in_single => {
+                    in_double = !in_double;
+                    let consumed = Self::next_word_char_unwrap(chars, cursor);
+                    if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                        text.push(consumed);
+                    }
+                }
+                '$' if !in_single => {
+                    let consumed = Self::next_word_char_unwrap(chars, cursor);
+                    if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                        text.push(consumed);
+                    }
+                    if chars.peek() == Some(&'{') {
+                        parameter_brace_depth += 1;
+                        let brace = Self::next_word_char_unwrap(chars, cursor);
+                        if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                            text.push(brace);
+                        }
+                    }
+                }
+                '{' if !in_single && !in_double => {
+                    literal_brace_depth += 1;
+                    let consumed = Self::next_word_char_unwrap(chars, cursor);
+                    if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                        text.push(consumed);
+                    }
+                }
+                ':' if !in_single
+                    && !in_double
+                    && parameter_brace_depth == 0
+                    && literal_brace_depth == 0
+                    && length_start.is_none() =>
+                {
+                    offset_end = Some(*cursor);
+                    Self::next_word_char_unwrap(chars, cursor);
+                    length_start = Some(*cursor);
+                }
+                '}' if !in_single && !in_double => {
+                    if parameter_brace_depth > 0 {
+                        parameter_brace_depth -= 1;
+                        let consumed = Self::next_word_char_unwrap(chars, cursor);
+                        if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                            text.push(consumed);
+                        }
+                    } else if literal_brace_depth > 0 {
+                        literal_brace_depth -= 1;
+                        let consumed = Self::next_word_char_unwrap(chars, cursor);
+                        if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                            text.push(consumed);
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                _ => {
+                    let consumed = Self::next_word_char_unwrap(chars, cursor);
+                    if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
+                        text.push(consumed);
+                    }
+                }
+            }
+        }
+
+        if source_backed {
+            match (offset_end, length_start) {
+                (Some(offset_end), Some(length_start)) => (
+                    SourceText::source(Span::from_positions(start, offset_end)),
+                    Some(SourceText::source(Span::from_positions(
+                        length_start,
+                        *cursor,
+                    ))),
+                ),
+                _ => (
+                    SourceText::source(Span::from_positions(start, *cursor)),
+                    None,
+                ),
+            }
+        } else {
+            match (offset_end, length_start) {
+                (Some(offset_end), Some(length_start)) => (
+                    self.source_text(offset_text.unwrap_or_default(), start, offset_end),
+                    Some(self.source_text(length_text.unwrap_or_default(), length_start, *cursor)),
+                ),
+                _ => (
+                    self.source_text(offset_text.unwrap_or_default(), start, *cursor),
+                    None,
+                ),
+            }
         }
     }
 

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -63,5 +63,6 @@ bitflags! {
         const DECLARATION_INITIALIZED = 0b0010_0000_0000;
         const IMPORTED_POSSIBLE      = 0b0100_0000_0000;
         const IMPORTED_FUNCTION      = 0b1000_0000_0000;
+        const EMPTY_INITIALIZER      = 0b0001_0000_0000_0000;
     }
 }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -977,6 +977,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             (kind, self.current_scope())
         });
         attributes |= assignment_binding_attributes(assignment);
+        if assignment_has_empty_initializer(assignment, self.source) {
+            attributes |= BindingAttributes::EMPTY_INITIALIZER;
+        }
         if assignment.target.subscript.is_some()
             && !attributes.contains(BindingAttributes::ASSOC)
             && self
@@ -2775,6 +2778,13 @@ fn assignment_value_span(assignment: &Assignment) -> Span {
     match &assignment.value {
         AssignmentValue::Scalar(word) => word.span,
         AssignmentValue::Compound(array) => array.span,
+    }
+}
+
+fn assignment_has_empty_initializer(assignment: &Assignment, source: &str) -> bool {
+    match &assignment.value {
+        AssignmentValue::Scalar(word) => static_word_text(word, source).as_deref() == Some(""),
+        AssignmentValue::Compound(array) => array.elements.is_empty(),
     }
 }
 

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -613,7 +613,10 @@ impl<'a> GraphBuilder<'a> {
                 self.build_loop_command(command_id, *body, loops)
             }
             RecordedCommandKind::Case { arms } => self.build_case(command_id, *arms, loops),
-            RecordedCommandKind::BraceGroup { body } => self.build_sequence(*body, loops),
+            RecordedCommandKind::BraceGroup { body } => {
+                let sequence = self.build_sequence(*body, loops);
+                self.wrap_sequence_with_command_header(command_id, sequence, loops)
+            }
             RecordedCommandKind::Subshell { body, .. } => {
                 let block = self.command_block(command.span);
                 self.attach_nested_regions(block, command.nested_regions, loops);
@@ -644,6 +647,28 @@ impl<'a> GraphBuilder<'a> {
                 }
             }
         }
+    }
+
+    fn wrap_sequence_with_command_header(
+        &mut self,
+        command_id: RecordedCommandId,
+        mut sequence: SequenceResult,
+        loops: &[LoopTarget],
+    ) -> SequenceResult {
+        let command = self.program.command(command_id);
+        if command.nested_regions.is_empty() {
+            return sequence;
+        }
+
+        let header = self.command_block(command.span);
+        self.attach_nested_regions(header, command.nested_regions, loops);
+        if let Some(entry) = sequence.entry {
+            self.add_edge(header, entry, EdgeKind::Sequential);
+        } else {
+            sequence.exits = vec![header];
+        }
+        sequence.entry = Some(header);
+        sequence
     }
 
     fn build_list(
@@ -678,8 +703,7 @@ impl<'a> GraphBuilder<'a> {
 
         let mut exits = current.exits;
         exits.extend(shortcut_exits);
-        self.attach_nested_regions_from_command(command);
-        SequenceResult { entry, exits }
+        self.wrap_sequence_with_command_header(command, SequenceResult { entry, exits }, loops)
     }
 
     fn build_if(
@@ -736,11 +760,14 @@ impl<'a> GraphBuilder<'a> {
             branch_exits.extend(false_exits);
         }
 
-        self.attach_nested_regions_from_command(command);
-        SequenceResult {
-            entry,
-            exits: branch_exits,
-        }
+        self.wrap_sequence_with_command_header(
+            command,
+            SequenceResult {
+                entry,
+                exits: branch_exits,
+            },
+            loops,
+        )
     }
 
     fn build_while_like(
@@ -792,11 +819,14 @@ impl<'a> GraphBuilder<'a> {
             }
         }
 
-        self.attach_nested_regions_from_command(command);
-        SequenceResult {
-            entry,
-            exits: vec![exit_block],
-        }
+        self.wrap_sequence_with_command_header(
+            command,
+            SequenceResult {
+                entry,
+                exits: vec![exit_block],
+            },
+            loops,
+        )
     }
 
     fn build_loop_command(
@@ -936,22 +966,6 @@ impl<'a> GraphBuilder<'a> {
             if let Some(entry) = sequence.entry {
                 self.scope_entries.entry(region.scope).or_insert(entry);
                 self.add_edge(block, entry, EdgeKind::Sequential);
-            }
-        }
-    }
-
-    fn attach_nested_regions_from_command(&mut self, command: RecordedCommandId) {
-        let command = self.program.command(command);
-        if command.nested_regions.is_empty() {
-            return;
-        }
-        if let Some(blocks) = self
-            .command_blocks
-            .get(&SpanKey::new(command.span))
-            .cloned()
-        {
-            for block in blocks {
-                self.attach_nested_regions(block, command.nested_regions, &[]);
             }
         }
     }

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -471,6 +471,17 @@ fn analyze_unused_assignments_exact(
         let reason = exact.binding_data.next_overwrite[binding.id.index()]
             .map(|by| UnusedReason::Overwritten { by })
             .unwrap_or(UnusedReason::ScopeEnd);
+        if binding
+            .attributes
+            .contains(BindingAttributes::EMPTY_INITIALIZER)
+            && let UnusedReason::Overwritten { by } = reason
+            && (binding.attributes.contains(BindingAttributes::LOCAL)
+                || exact.binding_blocks[by.index()].is_some_and(|overwrite_block| {
+                    is_straight_line_overwrite(context.cfg, block_id, overwrite_block)
+                }))
+        {
+            continue;
+        }
         unused_assignments.push(UnusedAssignment {
             binding: binding.id,
             reason,
@@ -675,6 +686,38 @@ fn block_can_reach(
     let can_reach = reachable.contains(to.index());
     reachability_cache[from.index()] = Some(reachable);
     can_reach
+}
+
+fn is_straight_line_overwrite(cfg: &ControlFlowGraph, from: BlockId, to: BlockId) -> bool {
+    if from == to {
+        return true;
+    }
+
+    let mut current = from;
+    let mut visited = DenseBitSet::new(cfg.blocks().len());
+    visited.insert(current.index());
+    loop {
+        let successors = cfg.successors(current);
+        if successors.len() != 1 {
+            return false;
+        }
+
+        let (next, edge) = successors[0];
+        if !matches!(edge, EdgeKind::Sequential) {
+            return false;
+        }
+        if cfg.predecessors(next).len() != 1 {
+            return false;
+        }
+        if next == to {
+            return true;
+        }
+        if visited.contains(next.index()) {
+            return false;
+        }
+        visited.insert(next.index());
+        current = next;
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2138,6 +2138,30 @@ outer
     }
 
     #[test]
+    fn substring_offset_arithmetic_tracks_postfix_updates() {
+        let source = "\
+#!/bin/bash
+spinner() {
+  local chars=\"/-\\\\|\"
+  local spin_i=0
+  while true; do
+    printf '%s\\n' \"${chars:spin_i++%${#chars}:1}\"
+  done
+}
+";
+        let model = model(source);
+        assert_arithmetic_usage(&model, "spin_i", 1, 1);
+
+        let unused = model
+            .analysis()
+            .unused_assignments()
+            .iter()
+            .map(|binding| model.binding(*binding).name.as_str())
+            .collect::<Vec<_>>();
+        assert!(!unused.contains(&"spin_i"), "unused bindings: {:?}", unused);
+    }
+
+    #[test]
     fn classifies_nameref_and_source_directives() {
         let source = "\
 declare -n ref=target
@@ -3159,6 +3183,59 @@ printf '%s\\n' \"${arr[@]}\"
     }
 
     #[test]
+    fn process_substitution_reads_keep_outer_assignments_live() {
+        let source = "\
+#!/bin/bash
+f() {
+  local opts
+  case \"$1\" in
+    a) opts=alpha ;;
+    *) opts=beta ;;
+  esac
+  while IFS= read -r line; do :; done < <(printf '%s\\n' \"$opts\")
+}
+f a
+";
+        let model = model(source);
+        let unused = reportable_unused_names(&model);
+
+        assert!(
+            !unused.contains(&Name::from("opts")),
+            "unused: {:?}",
+            unused
+        );
+        assert!(unused.contains(&Name::from("line")), "unused: {:?}", unused);
+    }
+
+    #[test]
+    fn overwritten_empty_initializers_do_not_report_the_placeholder_assignment() {
+        let plain = model(
+            "\
+#!/bin/bash
+foo=
+foo=bar
+",
+        );
+        let plain_unused = plain.analysis().unused_assignments().to_vec();
+        assert_eq!(plain_unused.len(), 1);
+        assert_eq!(plain.binding(plain_unused[0]).span.start.line, 3);
+
+        let local = model(
+            "\
+#!/bin/bash
+f() {
+  local foo=
+  foo=bar
+}
+f
+",
+        );
+        let local_unused = local.analysis().unused_assignments().to_vec();
+        assert_eq!(local_unused.len(), 1);
+        assert_eq!(local.binding(local_unused[0]).span.start.line, 4);
+    }
+
+    #[test]
     fn associative_compound_declaration_marks_binding_assoc_and_array() {
         let model = model("#!/bin/bash\ndeclare -A assoc=(one [foo]=bar [bar]+=baz)\n");
 
@@ -3276,6 +3353,67 @@ echo ok
             .map(|binding| model.binding(*binding).name.as_str())
             .collect::<Vec<_>>();
         for name in ["PATH", "CDPATH", "LANG", "LC_ALL", "LC_TIME"] {
+            assert!(!unused.contains(&name), "unused bindings: {:?}", unused);
+        }
+        assert!(unused.contains(&"unused"));
+    }
+
+    #[test]
+    fn special_runtime_assignments_are_treated_as_implicitly_used() {
+        let source = "\
+#!/bin/bash
+HOME=/tmp/home
+SHELL=/bin/bash
+TERM=xterm-256color
+USER=builder
+PWD=/tmp/work
+HISTFILE=/tmp/history
+HISTFILESIZE=unlimited
+HISTIGNORE='ls:bg:fg:history'
+HISTSIZE=-1
+HISTTIMEFORMAT='%F %T '
+COMP_WORDBREAKS=\"${COMP_WORDBREAKS//:/}\"
+PROMPT_COMMAND='history -a'
+PS1='prompt> '
+PS2='continuation> '
+PS3=''
+PS4='+ '
+COLUMNS=1
+READLINE_POINT=0
+unused=1
+";
+        let model = model(source);
+        model.analysis().dataflow();
+
+        let unused = model
+            .analysis()
+            .unused_assignments()
+            .iter()
+            .map(|binding| model.binding(*binding).name.as_str())
+            .collect::<Vec<_>>();
+        for name in [
+            "HOME",
+            "SHELL",
+            "TERM",
+            "USER",
+            "PWD",
+            "OPTIND",
+            "OPTARG",
+            "OPTERR",
+            "HISTFILE",
+            "HISTFILESIZE",
+            "HISTIGNORE",
+            "HISTSIZE",
+            "HISTTIMEFORMAT",
+            "COMP_WORDBREAKS",
+            "PROMPT_COMMAND",
+            "PS1",
+            "PS2",
+            "PS3",
+            "PS4",
+            "COLUMNS",
+            "READLINE_POINT",
+        ] {
             assert!(!unused.contains(&name), "unused bindings: {:?}", unused);
         }
         assert!(unused.contains(&"unused"));

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -2,6 +2,9 @@ use shuck_ast::{Name, Word};
 
 const COMMON_PREINITIALIZED: &[&str] = &[
     "IFS",
+    "OPTIND",
+    "OPTARG",
+    "OPTERR",
     "USER",
     "HOME",
     "SHELL",
@@ -26,7 +29,19 @@ const BASH_PREINITIALIZED: &[&str] = &[
     "BASH_VERSINFO",
     "OSTYPE",
     "HISTCONTROL",
+    "HISTFILE",
+    "HISTFILESIZE",
+    "HISTIGNORE",
     "HISTSIZE",
+    "HISTTIMEFORMAT",
+    "COLUMNS",
+    "PROMPT_COMMAND",
+    "PS1",
+    "PS2",
+    "PS3",
+    "PS4",
+    "READLINE_POINT",
+    "COMP_WORDBREAKS",
     "COMP_WORDS",
     "COMP_CWORD",
 ];
@@ -67,7 +82,8 @@ impl RuntimePrelude {
     }
 
     pub(crate) fn is_always_used_binding(&self, name: &Name) -> bool {
-        contains_name(self.always_used_bindings, name)
+        self.is_preinitialized(name)
+            || contains_name(self.always_used_bindings, name)
             || is_locale_binding(name)
             || (self.bash_enabled && contains_name(self.bash_always_used_bindings, name))
     }

--- a/crates/shuck/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c001.yaml
@@ -64,6 +64,12 @@ reviewed_divergences:
   - side: shuck-only
     path_contains: "tj__n__"
     reason: "These `n` installer helpers and tests pass transient state through helper functions and outer test harness calls. The remaining C001 hits in this repo family are reviewed harness-state handoffs rather than dead assignments."
+  - side: shuck-only
+    path_contains: "scop__bash-completion__"
+    reason: "The bash-completion project is a sourced helper library and compatibility layer that threads parser state, completion globals, and zsh bridge state through later completion callbacks and wrapper entrypoints. The remaining C001 hits in this repo family are reviewed helper-runtime handoffs rather than dead assignments in a standalone script."
+  - side: shuck-only
+    path_contains: "community-scripts__ProxmoxVE__"
+    reason: "These Proxmox helper scripts publish `var_*` template metadata and related provisioning state for the shared build/update framework sourced at startup. The remaining C001 hits in this repo family are reviewed framework handoffs that depend on project closure rather than dead local assignments."
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__libraries__bluez-alsa__bluez-alsa.conf"
     line: 19


### PR DESCRIPTION
## Summary

- improve C001 parity in the semantic model by keeping more real reads and shell-managed state live
- preserve nested `${...}` expressions inside substring and array-slice offsets so arithmetic updates like `spin_i++` are parsed and counted correctly
- record reviewed divergence families for bash-completion and ProxmoxVE helper/framework cases

## Root Cause

C001 still had several false positives from three places:

- control-flow and dataflow missed some real reads that occurred through nested command regions
- the runtime prelude under-modeled shell-managed variables such as `OPTIND`, `OPTARG`, and `OPTERR`
- parameter slice parsing truncated nested `${...}` content at the first inner `}`, which dropped arithmetic companion ASTs and hid reads from semantic analysis

## What Changed

- extended the semantic/runtime handling for additional shell-managed state and dead-assignment suppression cases
- tightened the parser so substring and array-slice offsets/lengths respect nested parameter braces
- added targeted parser, semantic, and linter regressions for the newly fixed cases
- added reviewed divergence entries for `scop__bash-completion__` and `community-scripts__ProxmoxVE__`

## Validation

- `cargo test -p shuck-parser`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter substring_offset_arithmetic_reads_do_not_trigger_unused_assignment -- --nocapture`
- `cargo test -p shuck-linter getopts_runtime_state_assignments_are_not_flagged -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001` (`blocking=1514`, `reviewed_divergences=901`)
