### PR TITLE
Align shebang rules with current ShellCheck

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4718,20 +4718,48 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         return ShebangHeaderFacts::default();
     };
     let line = first_line_text.trim_end_matches('\r');
+    let mut indented_shebang_span = None;
+    let mut space_after_hash_bang_span = None;
+    let mut shebang_not_on_first_line_span = None;
 
-    let trimmed = line.trim_start_matches(char::is_whitespace);
-    let indented_shebang_span = (trimmed.len() != line.len() && trimmed.starts_with("#!"))
-        .then(|| line_span(1, first_line_offset, line));
+    for line_index in 0.. {
+        let Some((offset, raw_line)) = nth_source_line(source, line_index) else {
+            break;
+        };
+        let line = raw_line.trim_end_matches('\r');
+        let header_like = source_line_is_header_like(line);
+        let shebang_candidate = source_line_has_shebang_candidate(line);
+        let indented_candidate = source_line_has_leading_whitespace_before_shebang_candidate(line);
+        let space_after_hash_offset = shebang_space_after_hash_offset_in_line(line);
+        let line_number = line_index + 1;
 
-    let space_after_hash_bang_span = line
-        .strip_prefix('#')
-        .and_then(|rest| rest.starts_with(char::is_whitespace).then_some(rest))
-        .and_then(|rest| {
-            rest.trim_start_matches(char::is_whitespace)
-                .starts_with('!')
-                .then_some(())
-        })
-        .map(|()| line_span(1, first_line_offset, line));
+        if indented_shebang_span.is_none() && indented_candidate {
+            indented_shebang_span = Some(point_span(line_number, 1, offset));
+        }
+        if space_after_hash_bang_span.is_none()
+            && let Some(space_offset) = space_after_hash_offset
+        {
+            space_after_hash_bang_span = Some(point_span(
+                line_number,
+                space_offset + 1,
+                offset + space_offset,
+            ));
+        }
+        if line_index > 0 && shebang_candidate {
+            shebang_not_on_first_line_span = Some(point_span(line_number, 1, offset));
+        }
+
+        if line_index == 0 {
+            if shebang_candidate || !header_like {
+                break;
+            }
+            continue;
+        }
+
+        if shebang_candidate || !header_like {
+            break;
+        }
+    }
 
     let first_line_shellcheck_shell_directive = line
         .strip_prefix('#')
@@ -4741,11 +4769,6 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
                 .to_ascii_lowercase()
                 .starts_with("shellcheck shell=")
         });
-    let first_line_header_like = line.trim_start().is_empty() || line.trim_start().starts_with('#');
-    let shebang_not_on_first_line_span = nth_source_line(source, 1).and_then(|(offset, line)| {
-        let line = line.trim_end_matches('\r');
-        (first_line_header_like && line.starts_with("#!")).then(|| line_span(2, offset, line))
-    });
     let missing_shebang_line_span = (!line.trim_start().starts_with("#!")
         && space_after_hash_bang_span.is_none()
         && shebang_not_on_first_line_span.is_none()
@@ -4784,6 +4807,40 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         non_absolute_shebang_span,
         enables_errexit,
     }
+}
+
+fn source_line_is_header_like(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.is_empty() || trimmed.starts_with('#')
+}
+
+fn source_line_has_shebang_candidate(line: &str) -> bool {
+    let trimmed = line.trim_start_matches(char::is_whitespace);
+    trimmed.starts_with("#!") || shebang_space_after_hash_offset_in_line(trimmed).is_some()
+}
+
+fn source_line_has_leading_whitespace_before_shebang_candidate(line: &str) -> bool {
+    let trimmed = line.trim_start_matches(char::is_whitespace);
+    trimmed.len() != line.len() && source_line_has_shebang_candidate(line)
+}
+
+fn shebang_space_after_hash_offset_in_line(line: &str) -> Option<usize> {
+    let trimmed = line.trim_start_matches(char::is_whitespace);
+    let leading_whitespace_len = line.len().saturating_sub(trimmed.len());
+    let rest = trimmed.strip_prefix('#')?;
+    let whitespace_len = rest
+        .len()
+        .saturating_sub(rest.trim_start_matches(char::is_whitespace).len());
+    (whitespace_len > 0 && rest[whitespace_len..].starts_with('!'))
+        .then_some(leading_whitespace_len + 1)
+}
+
+fn point_span(line_number: usize, column: usize, offset: usize) -> Span {
+    Span::at(Position {
+        line: line_number,
+        column,
+        offset,
+    })
 }
 
 fn parse_shebang_words(shebang: &str) -> Vec<&str> {

--- a/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
@@ -30,7 +30,19 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 1);
-        assert_eq!(diagnostics[0].span.slice(source), " #!/bin/sh");
+        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.end.column, 1);
+    }
+
+    #[test]
+    fn reports_indented_shebang_after_header_prelude() {
+        let source = "\n #!/bin/sh\n:\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::IndentedShebang));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.end.column, 1);
     }
 
     #[test]
@@ -39,7 +51,6 @@ mod tests {
             "#!/bin/sh\n:\n",
             "#! /bin/sh\n:\n",
             "\n#!/bin/sh\n:\n",
-            "# comment\n #!/bin/sh\n:\n",
             "\t# not a shebang\n:\n",
         ] {
             let diagnostics =

--- a/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
@@ -33,7 +33,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.slice(source), "#!/bin/sh");
+        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.end.column, 1);
     }
 
     #[test]
@@ -49,6 +50,20 @@ mod tests {
     }
 
     #[test]
+    fn reports_shebang_after_multiple_header_lines() {
+        let source = "# comment\n\n#!/bin/sh\n:\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.end.column, 1);
+    }
+
+    #[test]
     fn ignores_non_header_second_line_shebangs() {
         for source in ["echo hi\n#!/bin/sh\n:\n", "cat <<EOF\n#!/bin/sh\nEOF\n"] {
             let diagnostics = test_snippet(
@@ -60,12 +75,11 @@ mod tests {
     }
 
     #[test]
-    fn ignores_first_line_or_malformed_second_line_shebangs() {
+    fn ignores_first_line_or_non_header_later_shebangs() {
         for source in [
             "#!/bin/sh\n:\n",
-            "\n# !/bin/sh\n:\n",
-            "\n #!/bin/sh\n:\n",
-            "\n\n#!/bin/sh\n:\n",
+            "echo hi\n#!/bin/sh\n:\n",
+            "cat <<EOF\n#!/bin/sh\nEOF\n",
         ] {
             let diagnostics = test_snippet(
                 source,

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C074_C074.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C074_C074.sh.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 268
+assertion_line: 284
 ---
 C074 remove the space so the shebang starts with `#!`
- --> <source>:1:1
+ --> <source>:1:2
   |
 1 | # !/bin/sh
   |

--- a/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
+++ b/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
@@ -30,7 +30,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 1);
-        assert_eq!(diagnostics[0].span.slice(source), "# !/bin/sh");
+        assert_eq!(diagnostics[0].span.start.column, 2);
+        assert_eq!(diagnostics[0].span.end.column, 2);
     }
 
     #[test]
@@ -38,8 +39,8 @@ mod tests {
         for source in [
             "#!/bin/sh\n:\n",
             " #!/bin/sh\n:\n",
-            "# comment\n# !/bin/sh\n",
-            "\n# !/bin/sh\n",
+            "# comment\n echo ok\n# !/bin/sh\n",
+            "echo ok\n# !/bin/sh\n",
         ] {
             let diagnostics =
                 test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
@@ -53,6 +54,18 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "#\t!/bin/sh");
+        assert_eq!(diagnostics[0].span.start.column, 2);
+        assert_eq!(diagnostics[0].span.end.column, 2);
+    }
+
+    #[test]
+    fn reports_space_after_hash_bang_after_header_prelude() {
+        let source = "\n# !/bin/sh\n:\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 2);
+        assert_eq!(diagnostics[0].span.end.column, 2);
     }
 }

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -476,8 +476,9 @@ impl Default for ShellCheckCodeMap {
             // Keep SC2285 as a suppression alias for the authored S043 rule code.
             (2148, Rule::MissingShebangLine),
             (2239, Rule::NonAbsoluteShebang),
-            (2286, Rule::IndentedShebang),
-            (2287, Rule::SpaceAfterHashBang),
+            (1114, Rule::IndentedShebang),
+            (1115, Rule::SpaceAfterHashBang),
+            (1128, Rule::ShebangNotOnFirstLine),
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (1133, Rule::LinebreakBeforeAnd),
@@ -568,7 +569,6 @@ impl Default for ShellCheckCodeMap {
             (1070, Rule::ZshRedirPipe),
             (1087, Rule::ZshPromptBracket),
             (1088, Rule::CshSyntaxInSh),
-            (1128, Rule::ShebangNotOnFirstLine),
             (1140, Rule::ZshBraceIf),
             (1141, Rule::ZshAlwaysBlock),
             (2091, Rule::IfDollarCommand),
@@ -828,8 +828,9 @@ impl Default for ShellCheckCodeMap {
                     (2154, Rule::UndefinedVariable),
                     (2148, Rule::MissingShebangLine),
                     (2239, Rule::NonAbsoluteShebang),
-                    (2286, Rule::IndentedShebang),
-                    (2287, Rule::SpaceAfterHashBang),
+                    (1114, Rule::IndentedShebang),
+                    (1115, Rule::SpaceAfterHashBang),
+                    (1128, Rule::ShebangNotOnFirstLine),
                     (2288, Rule::TemplateBraceInCommand),
                     (2289, Rule::CommentedContinuationLine),
                     (1133, Rule::LinebreakBeforeAnd),
@@ -1666,12 +1667,13 @@ mod tests {
         assert_eq!(map.resolve("SC2284"), Some(Rule::UnicodeQuoteInString));
         assert_eq!(map.resolve("SC2148"), Some(Rule::MissingShebangLine));
         assert_eq!(map.resolve("SC2285"), Some(Rule::MissingShebangLine));
+        assert_eq!(map.resolve("SC1114"), Some(Rule::IndentedShebang));
+        assert_eq!(map.resolve("SC1115"), Some(Rule::SpaceAfterHashBang));
+        assert_eq!(map.resolve("SC1128"), Some(Rule::ShebangNotOnFirstLine));
         assert_eq!(
             map.resolve_all("SC2318"),
             vec![Rule::LocalCrossReference, Rule::DuplicateShebangFlag]
         );
-        assert_eq!(map.resolve("SC2286"), Some(Rule::IndentedShebang));
-        assert_eq!(map.resolve("SC2287"), Some(Rule::SpaceAfterHashBang));
         assert_eq!(map.resolve("SC2288"), Some(Rule::TemplateBraceInCommand));
         assert_eq!(map.resolve("SC2289"), Some(Rule::CommentedContinuationLine));
         assert_eq!(map.resolve("SC2333"), Some(Rule::NonShellSyntaxInScript));
@@ -1975,8 +1977,9 @@ mod tests {
             (2283, Rule::DoubleParenGrouping),
             (2148, Rule::MissingShebangLine),
             (2285, Rule::MissingShebangLine),
-            (2286, Rule::IndentedShebang),
-            (2287, Rule::SpaceAfterHashBang),
+            (1114, Rule::IndentedShebang),
+            (1115, Rule::SpaceAfterHashBang),
+            (1128, Rule::ShebangNotOnFirstLine),
             (2288, Rule::TemplateBraceInCommand),
             (2289, Rule::CommentedContinuationLine),
             (2294, Rule::EvalOnArray),
@@ -2138,8 +2141,9 @@ mod tests {
             (2100, Rule::AssignmentLooksLikeComparison),
             (2319, Rule::AssignmentLooksLikeComparison),
             (2148, Rule::MissingShebangLine),
-            (2286, Rule::IndentedShebang),
-            (2287, Rule::SpaceAfterHashBang),
+            (1114, Rule::IndentedShebang),
+            (1115, Rule::SpaceAfterHashBang),
+            (1128, Rule::ShebangNotOnFirstLine),
             (2277, Rule::ExtglobInCasePattern),
         ]
         .into_iter()
@@ -2166,7 +2170,6 @@ mod tests {
             Rule::ArraySubscriptTest,
             Rule::ArraySubscriptCondition,
             Rule::ExtglobInTest,
-            Rule::ShebangNotOnFirstLine,
         ]);
 
         let unmapped: Vec<&str> = Rule::iter()
@@ -2391,6 +2394,8 @@ mod tests {
             (1070, Rule::ZshRedirPipe),
             (1087, Rule::ZshPromptBracket),
             (1088, Rule::CshSyntaxInSh),
+            (1114, Rule::IndentedShebang),
+            (1115, Rule::SpaceAfterHashBang),
             (1128, Rule::ShebangNotOnFirstLine),
             (1140, Rule::ZshBraceIf),
             (1141, Rule::ZshAlwaysBlock),

--- a/crates/shuck/tests/testdata/corpus-metadata/c075.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c075.yaml
@@ -1,3 +1,0 @@
-comparison_target_notes:
-  - current_shellcheck_code: "SC2288"
-    reason: "The nix-pinned ShellCheck oracle used by the large-corpus harness reports second-line shebang warnings as SC1128, while SC2288 is currently used for a different apostrophe-in-command warning family."

--- a/docs/rules/C073.yaml
+++ b/docs/rules/C073.yaml
@@ -3,7 +3,7 @@ legacy_name: indented-shebang
 new_category: Correctness
 new_code: C073
 runtime_kind: ast
-shellcheck_code: SC2286
+shellcheck_code: SC1114
 shells:
   - sh
   - bash

--- a/docs/rules/C074.yaml
+++ b/docs/rules/C074.yaml
@@ -3,7 +3,7 @@ legacy_name: space-after-hash-bang
 new_category: Correctness
 new_code: C074
 runtime_kind: ast
-shellcheck_code: SC2287
+shellcheck_code: SC1115
 shells:
   - sh
   - bash

--- a/docs/rules/C075.yaml
+++ b/docs/rules/C075.yaml
@@ -3,13 +3,13 @@ legacy_name: shebang-not-on-first-line
 new_category: Correctness
 new_code: C075
 runtime_kind: ast
-shellcheck_code: SC2288
+shellcheck_code: SC1128
 shells:
   - sh
   - bash
   - dash
   - ksh
-description: The shebang appears on the second line instead of the first.
+description: The shebang does not appear on the first line of the file.
 rationale: Move the shebang to the very first line of the file.
 source:
   shell_checks_rule: rules/SH-193.yaml


### PR DESCRIPTION
## Summary
- switch the shebang rules to ShellCheck's current live codes: `SC1114`, `SC1115`, and `SC1128`
- remove the obsolete `C075` compatibility metadata shim and stop preserving the old shebang-code aliases
- align the shebang fact builder with ShellCheck's header-prelude behavior and point-span locations

## Why
The shebang family had drifted from current ShellCheck behavior:
- `C073`, `C074`, and `C075` still advertised older codes in rule metadata and suppression mapping
- `C075` only considered line 2 instead of any later shebang candidate in the header prelude
- `C074` and `C075` anchored spans more broadly than ShellCheck, which caused location-only compatibility diffs

## Impact
- shebang findings now map directly to current ShellCheck codes
- large-corpus comparisons no longer need the old `C075` code-remap shim
- later-line malformed shebangs now match ShellCheck's combined reporting more closely

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter shellcheck_map`
- `cargo test -p shuck-linter indented_shebang`
- `cargo test -p shuck-linter space_after_hash_bang`
- `cargo test -p shuck-linter shebang_not_on_first_line`
- `cargo test -p shuck-linter rule_indentedshebang_path_new_c073_sh_expects`
- `cargo test -p shuck-linter rule_spaceafterhashbang_path_new_c074_sh_expects`
- `cargo test -p shuck-linter rule_shebangnotonfirstline_path_new_c075_sh_expects`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C073,C074,C075`
