### PR TITLE
Fix S001 safe bindings in command substitutions

### DIFF
--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -791,4 +791,60 @@ esac
 
         assert!(safe_values.word_is_safe(&command.args[0], SafeValueQuery::Argv));
     }
+
+    #[test]
+    fn if_else_safe_literal_bindings_stay_safe() {
+        let source = "\
+#!/bin/bash
+if [ \"$1\" = h ]; then
+  humanreadable=-h
+else
+  humanreadable=-m
+fi
+free ${humanreadable}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let Command::Simple(command) = &output.file.body[1].command else {
+            panic!("expected simple command");
+        };
+
+        assert!(safe_values.word_is_safe(&command.args[0], SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn if_else_safe_literal_bindings_stay_safe_inside_command_substitutions() {
+        let source = "\
+#!/bin/bash
+if [ \"$1\" = h ]; then
+  humanreadable=-h
+else
+  humanreadable=-m
+fi
+value=\"$(free ${humanreadable} | awk '{print $2}')\"
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.is_nested_word_command() && fact.span().slice(source) == "${humanreadable}"
+            })
+            .expect("expected nested command argument fact");
+
+        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+    }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -667,6 +667,38 @@ esac
     }
 
     #[test]
+    fn skips_if_else_safe_literal_bindings() {
+        let source = "\
+#!/bin/bash
+if [ \"$1\" = h ]; then
+  humanreadable=-h
+else
+  humanreadable=-m
+fi
+free ${humanreadable}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_if_else_safe_literal_bindings_inside_command_substitutions() {
+        let source = "\
+#!/bin/bash
+if [ \"$1\" = h ]; then
+  humanreadable=-h
+else
+  humanreadable=-m
+fi
+value=\"$(free ${humanreadable} | awk '{print $2}')\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_safe_indirect_and_transformed_bindings() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1222,22 +1222,14 @@ fn compute_initialized_name_states_dense(
 
             let predecessors = cfg.predecessors(block.id);
             let mut incoming_definite = if let Some(first_predecessor) = predecessors.first() {
-                let mut state = definite_out[first_predecessor.index()].clone();
-                if entry_blocks.contains(&block.id) {
-                    state.union_with(&entry_definite);
-                }
-                state
+                definite_out[first_predecessor.index()].clone()
             } else if entry_blocks.contains(&block.id) {
                 entry_definite.clone()
             } else {
                 DenseBitSet::new(name_count)
             };
             for predecessor in predecessors.iter().skip(1) {
-                let mut predecessor_state = definite_out[predecessor.index()].clone();
-                if entry_blocks.contains(&block.id) {
-                    predecessor_state.union_with(&entry_definite);
-                }
-                incoming_definite.intersect_with(&predecessor_state);
+                incoming_definite.intersect_with(&definite_out[predecessor.index()]);
             }
 
             let mut outgoing_maybe = incoming_maybe.clone();

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1221,14 +1221,25 @@ fn compute_initialized_name_states_dense(
             }
 
             let predecessors = cfg.predecessors(block.id);
-            let mut incoming_definite = if let Some(first_predecessor) = predecessors.first() {
-                definite_out[first_predecessor.index()].clone()
-            } else if entry_blocks.contains(&block.id) {
+            let uses_virtual_entry_boundary = entry_blocks.contains(&block.id)
+                && predecessors.iter().all(|predecessor| {
+                    cfg.successors(*predecessor)
+                        .iter()
+                        .any(|(successor, kind)| {
+                            *successor == block.id && *kind == EdgeKind::LoopBack
+                        })
+                });
+            let mut incoming_definite = if uses_virtual_entry_boundary {
                 entry_definite.clone()
+            } else if let Some(first_predecessor) = predecessors.first() {
+                definite_out[first_predecessor.index()].clone()
             } else {
                 DenseBitSet::new(name_count)
             };
-            for predecessor in predecessors.iter().skip(1) {
+            for (predecessor_index, predecessor) in predecessors.iter().enumerate() {
+                if !uses_virtual_entry_boundary && predecessor_index == 0 {
+                    continue;
+                }
                 incoming_definite.intersect_with(&definite_out[predecessor.index()]);
             }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1220,16 +1220,24 @@ fn compute_initialized_name_states_dense(
                 incoming_maybe.union_with(&entry_maybe);
             }
 
-            let mut incoming_definite = if entry_blocks.contains(&block.id) {
+            let predecessors = cfg.predecessors(block.id);
+            let mut incoming_definite = if let Some(first_predecessor) = predecessors.first() {
+                let mut state = definite_out[first_predecessor.index()].clone();
+                if entry_blocks.contains(&block.id) {
+                    state.union_with(&entry_definite);
+                }
+                state
+            } else if entry_blocks.contains(&block.id) {
                 entry_definite.clone()
-            } else if cfg.predecessors(block.id).is_empty() {
-                DenseBitSet::new(name_count)
             } else {
-                definite_out[cfg.predecessors(block.id)[0].index()].clone()
+                DenseBitSet::new(name_count)
             };
-            let predecessor_offset = usize::from(!entry_blocks.contains(&block.id));
-            for predecessor in cfg.predecessors(block.id).iter().skip(predecessor_offset) {
-                incoming_definite.intersect_with(&definite_out[predecessor.index()]);
+            for predecessor in predecessors.iter().skip(1) {
+                let mut predecessor_state = definite_out[predecessor.index()].clone();
+                if entry_blocks.contains(&block.id) {
+                    predecessor_state.union_with(&entry_definite);
+                }
+                incoming_definite.intersect_with(&predecessor_state);
             }
 
             let mut outgoing_maybe = incoming_maybe.clone();

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4230,6 +4230,22 @@ f
     }
 
     #[test]
+    fn scope_entry_loops_preserve_possible_uninitialized_names() {
+        let source = "\
+while command; do
+  flag=1
+done
+printf '%s\\n' \"$flag\"
+";
+        let model = model(source);
+
+        assert_eq!(
+            uninitialized_details(&model),
+            vec![("flag".to_owned(), UninitializedCertainty::Possible)]
+        );
+    }
+
+    #[test]
     fn sourced_helper_function_reads_do_not_keep_assignments_live_until_called() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3454,6 +3454,22 @@ printf '%s\\n' \
     }
 
     #[test]
+    fn branch_initialized_names_stay_initialized_inside_command_substitutions() {
+        let source = "\
+if [ \"$1\" = h ]; then
+  humanreadable=-h
+else
+  humanreadable=-m
+fi
+value=\"$(free ${humanreadable} | awk '{print $2}')\"
+";
+        let model = model(source);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_absent(&["humanreadable"], &uninitialized);
+    }
+
+    #[test]
     fn assign_default_parameter_expansion_initializes_later_reads() {
         let source = "\
 printf '%s\\n' \"${config_path:=/tmp/default}\"

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4202,6 +4202,34 @@ fi
     }
 
     #[test]
+    fn local_shadowing_can_clear_imported_initialization_before_nested_command_substitutions() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("helper.sh");
+        fs::write(
+            &main,
+            "\
+#!/bin/bash
+. ./helper.sh
+f() {
+  local flag
+  printf '%s\\n' \"$(
+    printf '%s\\n' \"$flag\"
+  )\"
+}
+f
+",
+        )
+        .unwrap();
+        fs::write(&helper, "flag=1\n").unwrap();
+
+        let model = model_at_path(&main);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_present(&["flag"], &uninitialized);
+    }
+
+    #[test]
     fn sourced_helper_function_reads_do_not_keep_assignments_live_until_called() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");


### PR DESCRIPTION
## Summary
- fix semantic definite-initialization tracking for nested scope entry blocks that also have predecessor flow
- keep S001 safe-value analysis from treating branch-initialized safe literals as possibly uninitialized inside command substitutions
- add regression coverage in `shuck-semantic` and `shuck-linter` for safe branch-initialized bindings in both direct argv positions and nested `$(...)` command arguments

## Root Cause
The definite-initialization dataflow treated scope-entry bindings as a separate intersected source instead of unioning them into each predecessor path before intersection. For nested command substitutions, that caused names that were definitely initialized across outer branches to be downgraded to "possibly uninitialized," which then bubbled up as false-positive S001 reports.

## Validation
- `cargo test -p shuck-semantic branch_initialized_names_stay_initialized_inside_command_substitutions -- --nocapture`
- `cargo test -p shuck-linter safe_literal_bindings -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001`
  - blocking S001 compatibility diffs dropped from 814 to 767 after this fix
