### PR TITLE
Fix C001 parsing for nested default operands

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1311,6 +1311,22 @@ spinner
     }
 
     #[test]
+    fn nested_default_operand_followed_by_later_expansion_keeps_assignment_live() {
+        let diagnostics = lint_for_rule(
+            "\
+#!/bin/sh
+foo=bar
+default=/tmp
+cmd=\"${home:-\"${default}\"}'${foo}'\"
+printf '%s\\n' \"$cmd\"
+",
+            Rule::UnusedAssignment,
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn unused_append_assignment_is_not_flagged() {
         let diagnostics = lint_for_rule("#!/bin/bash\nfoo+=bar\n", Rule::UnusedAssignment);
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3085,7 +3085,8 @@ impl<'a> Lexer<'a> {
                 '}' if !in_single && (!in_double || depth > double_quote_depth) => {
                     self.advance();
                     Self::push_capture_char(content, '}');
-                    if literal_brace_depth > 0
+                    if depth == 1
+                        && literal_brace_depth > 0
                         && self.has_later_top_level_param_expansion_closer(depth)
                     {
                         literal_brace_depth -= 1;

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3051,6 +3051,7 @@ impl<'a> Lexer<'a> {
         let mut literal_brace_depth = 0usize;
         let mut in_single = false;
         let mut in_double = false;
+        let mut double_quote_depth = 0usize;
         while let Some(c) = self.peek_char() {
             if in_single {
                 match c {
@@ -3081,7 +3082,7 @@ impl<'a> Lexer<'a> {
             }
 
             match c {
-                '}' if !in_single && (!in_double || depth > 1) => {
+                '}' if !in_single && (!in_double || depth > double_quote_depth) => {
                     self.advance();
                     Self::push_capture_char(content, '}');
                     if literal_brace_depth > 0
@@ -3105,6 +3106,7 @@ impl<'a> Lexer<'a> {
                     Self::push_capture_char(content, '"');
                     self.advance();
                     in_double = !in_double;
+                    double_quote_depth = if in_double { depth } else { 0 };
                 }
                 '\'' => {
                     Self::push_capture_char(content, '\'');
@@ -3191,6 +3193,7 @@ impl<'a> Lexer<'a> {
         let mut depth = target_depth;
         let mut in_single = false;
         let mut in_double = false;
+        let mut double_quote_depth = 0usize;
 
         while let Some(ch) = chars.next() {
             if in_single {
@@ -3208,13 +3211,19 @@ impl<'a> Lexer<'a> {
 
             if in_double {
                 match ch {
-                    '"' => in_double = false,
+                    '"' => {
+                        in_double = false;
+                        double_quote_depth = 0;
+                    }
                     '\\' => {
                         chars.next();
                     }
                     '$' if chars.peek() == Some(&'{') => {
                         chars.next();
                         depth += 1;
+                    }
+                    '}' if depth > double_quote_depth => {
+                        depth -= 1;
                     }
                     _ => {}
                 }
@@ -3224,7 +3233,10 @@ impl<'a> Lexer<'a> {
             match ch {
                 '\n' if depth == target_depth => return false,
                 '\'' => in_single = true,
-                '"' => in_double = true,
+                '"' => {
+                    in_double = true;
+                    double_quote_depth = depth;
+                }
                 '\\' => {
                     chars.next();
                 }
@@ -3232,7 +3244,7 @@ impl<'a> Lexer<'a> {
                     chars.next();
                     depth += 1;
                 }
-                '}' if !in_single && (!in_double || depth > target_depth) => {
+                '}' => {
                     if depth == target_depth {
                         return true;
                     }

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3081,7 +3081,7 @@ impl<'a> Lexer<'a> {
             }
 
             match c {
-                '}' if !in_single && !in_double => {
+                '}' if !in_single && (!in_double || depth > 1) => {
                     self.advance();
                     Self::push_capture_char(content, '}');
                     if literal_brace_depth > 0
@@ -3232,7 +3232,7 @@ impl<'a> Lexer<'a> {
                     chars.next();
                     depth += 1;
                 }
-                '}' => {
+                '}' if !in_single && (!in_double || depth > target_depth) => {
                     if depth == target_depth {
                         return true;
                     }

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2065,6 +2065,83 @@ fn test_parameter_default_operand_does_not_absorb_later_double_quoted_expansion(
 }
 
 #[test]
+fn test_nested_default_operand_keeps_quoted_right_brace_literal() {
+    let input = "echo \"${outer:-${inner:-\"}\"}}\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    let [
+        WordPartNode {
+            kind: WordPart::DoubleQuoted { parts, .. },
+            ..
+        },
+    ] = word.parts.as_slice()
+    else {
+        panic!("expected one double-quoted argument");
+    };
+
+    let [
+        WordPartNode {
+            kind: WordPart::Parameter(parameter),
+            ..
+        },
+    ] = parts.as_slice()
+    else {
+        panic!("expected one parameter expansion in outer quotes");
+    };
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+        operand: Some(operand),
+        operand_word_ast: Some(operand_word_ast),
+        ..
+    }) = &parameter.syntax
+    else {
+        panic!("expected outer parameter operation with parsed operand");
+    };
+    assert_eq!(operand.slice(input), "${inner:-\"}\"}");
+
+    let [
+        WordPartNode {
+            kind: WordPart::Parameter(parameter),
+            ..
+        },
+    ] = operand_word_ast.parts.as_slice()
+    else {
+        panic!("expected nested parameter expansion in outer operand");
+    };
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+        operand: Some(operand),
+        operand_word_ast: Some(operand_word_ast),
+        ..
+    }) = &parameter.syntax
+    else {
+        panic!("expected inner parameter operation with parsed operand");
+    };
+    assert_eq!(operand.slice(input), "\"}\"");
+
+    let [
+        WordPartNode {
+            kind:
+                WordPart::DoubleQuoted {
+                    parts: quoted_parts,
+                    ..
+                },
+            ..
+        },
+    ] = operand_word_ast.parts.as_slice()
+    else {
+        panic!("expected quoted inner operand word");
+    };
+    let [literal] = quoted_parts.as_slice() else {
+        panic!("expected quoted operand to contain a single literal brace");
+    };
+    assert_eq!(literal.span.slice(input), "}");
+}
+
+#[test]
 fn test_array_target_parameter_operations_normalize_to_bourne_operations() {
     let input = "echo ${arr[0]//x/y} ${arr[@],,} ${arr[1]^^pattern}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1995,10 +1995,12 @@ fn test_parameter_default_operand_does_not_absorb_later_double_quoted_expansion(
     };
     let word = &command.args[0];
 
-    let [WordPartNode {
-        kind: WordPart::DoubleQuoted { parts, .. },
-        ..
-    }] = word.parts.as_slice()
+    let [
+        WordPartNode {
+            kind: WordPart::DoubleQuoted { parts, .. },
+            ..
+        },
+    ] = word.parts.as_slice()
     else {
         panic!("expected one double-quoted argument");
     };
@@ -2020,17 +2022,25 @@ fn test_parameter_default_operand_does_not_absorb_later_double_quoted_expansion(
     };
     assert_eq!(operand.slice(input), "\"${default}\"");
     assert_eq!(operand_word_ast.render(input), "${default}");
-    let [WordPartNode {
-        kind: WordPart::DoubleQuoted { parts: operand_parts, .. },
-        ..
-    }] = operand_word_ast.parts.as_slice()
+    let [
+        WordPartNode {
+            kind:
+                WordPart::DoubleQuoted {
+                    parts: operand_parts,
+                    ..
+                },
+            ..
+        },
+    ] = operand_word_ast.parts.as_slice()
     else {
         panic!("expected quoted operand word");
     };
-    let [WordPartNode {
-        kind: WordPart::Parameter(parameter),
-        ..
-    }] = operand_parts.as_slice()
+    let [
+        WordPartNode {
+            kind: WordPart::Parameter(parameter),
+            ..
+        },
+    ] = operand_parts.as_slice()
     else {
         panic!("expected nested parameter expansion inside operand");
     };

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1986,6 +1986,75 @@ fn test_parameter_expansion_operand_stays_source_backed() {
 }
 
 #[test]
+fn test_parameter_default_operand_does_not_absorb_later_double_quoted_expansion() {
+    let input = "echo \"${home:-\"${default}\"}'${foo}'\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    let [WordPartNode {
+        kind: WordPart::DoubleQuoted { parts, .. },
+        ..
+    }] = word.parts.as_slice()
+    else {
+        panic!("expected one double-quoted argument");
+    };
+
+    let [first, second, third, fourth] = parts.as_slice() else {
+        panic!("expected parameter, quote, parameter, quote parts: {parts:#?}");
+    };
+
+    let WordPart::Parameter(parameter) = &first.kind else {
+        panic!("expected leading parameter expansion, got {:?}", first.kind);
+    };
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+        operand: Some(operand),
+        operand_word_ast: Some(operand_word_ast),
+        ..
+    }) = &parameter.syntax
+    else {
+        panic!("expected parameter operation with parsed operand");
+    };
+    assert_eq!(operand.slice(input), "\"${default}\"");
+    assert_eq!(operand_word_ast.render(input), "${default}");
+    let [WordPartNode {
+        kind: WordPart::DoubleQuoted { parts: operand_parts, .. },
+        ..
+    }] = operand_word_ast.parts.as_slice()
+    else {
+        panic!("expected quoted operand word");
+    };
+    let [WordPartNode {
+        kind: WordPart::Parameter(parameter),
+        ..
+    }] = operand_parts.as_slice()
+    else {
+        panic!("expected nested parameter expansion inside operand");
+    };
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) =
+        &parameter.syntax
+    else {
+        panic!("expected operand to preserve the nested default expansion");
+    };
+    assert_eq!(reference.name.as_str(), "default");
+
+    assert_eq!(second.span.slice(input), "'");
+    let WordPart::Parameter(parameter) = &third.kind else {
+        panic!("expected later parameter expansion, got {:?}", third.kind);
+    };
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) =
+        &parameter.syntax
+    else {
+        panic!("expected simple access expansion");
+    };
+    assert_eq!(reference.name.as_str(), "foo");
+    assert_eq!(fourth.span.slice(input), "'");
+}
+
+#[test]
 fn test_array_target_parameter_operations_normalize_to_bourne_operations() {
     let input = "echo ${arr[0]//x/y} ${arr[@],,} ${arr[1]^^pattern}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2142,6 +2142,83 @@ fn test_nested_default_operand_keeps_quoted_right_brace_literal() {
 }
 
 #[test]
+fn test_literal_brace_before_quoted_nested_default_does_not_absorb_later_expansion() {
+    let input = "echo \"${outer:-{{\"${inner}}\"}}${after}\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    let [
+        WordPartNode {
+            kind: WordPart::DoubleQuoted { parts, .. },
+            ..
+        },
+    ] = word.parts.as_slice()
+    else {
+        panic!("expected one double-quoted argument");
+    };
+
+    let [first, second] = parts.as_slice() else {
+        panic!("expected outer and later parameter expansions: {parts:#?}");
+    };
+
+    let WordPart::Parameter(parameter) = &first.kind else {
+        panic!("expected leading parameter expansion, got {:?}", first.kind);
+    };
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+        operand: Some(operand),
+        operand_word_ast: Some(operand_word_ast),
+        ..
+    }) = &parameter.syntax
+    else {
+        panic!("expected outer parameter operation with parsed operand");
+    };
+    assert_eq!(operand.slice(input), "{{\"${inner}}\"}");
+
+    let [literal_prefix, quoted_suffix, literal_suffix] = operand_word_ast.parts.as_slice() else {
+        panic!("expected literal, quoted, literal operand structure: {operand_word_ast:#?}");
+    };
+    assert_eq!(literal_prefix.span.slice(input), "{{");
+    let WordPart::DoubleQuoted {
+        parts: quoted_parts,
+        ..
+    } = &quoted_suffix.kind
+    else {
+        panic!(
+            "expected quoted middle segment in outer operand, got {:?}",
+            quoted_suffix.kind
+        );
+    };
+    let [nested, quoted_literal_suffix] = quoted_parts.as_slice() else {
+        panic!("expected nested parameter and literal brace in quoted suffix");
+    };
+    let WordPart::Parameter(parameter) = &nested.kind else {
+        panic!("expected nested parameter expansion, got {:?}", nested.kind);
+    };
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) =
+        &parameter.syntax
+    else {
+        panic!("expected inner access expansion");
+    };
+    assert_eq!(reference.name.as_str(), "inner");
+    assert_eq!(quoted_literal_suffix.span.slice(input), "}");
+    assert_eq!(literal_suffix.span.slice(input), "}");
+
+    let WordPart::Parameter(parameter) = &second.kind else {
+        panic!("expected later parameter expansion, got {:?}", second.kind);
+    };
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) =
+        &parameter.syntax
+    else {
+        panic!("expected later access expansion");
+    };
+    assert_eq!(reference.name.as_str(), "after");
+}
+
+#[test]
 fn test_array_target_parameter_operations_normalize_to_bourne_operations() {
     let input = "echo ${arr[0]//x/y} ${arr[@],,} ${arr[1]^^pattern}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4694,7 +4694,7 @@ impl<'a> Parser<'a> {
                     literal_brace_depth += 1;
                     current.push(Self::next_word_char_unwrap(chars, cursor));
                 }
-                '}' if !in_single && !in_double => {
+                '}' if !in_single && (!in_double || depth > 1) => {
                     if depth == 1 && literal_brace_depth > 0 {
                         let mut remaining = chars.clone();
                         remaining.next();
@@ -5192,7 +5192,7 @@ impl<'a> Parser<'a> {
                     Self::next_word_char_unwrap(chars, cursor);
                     length_start = Some(*cursor);
                 }
-                '}' if !in_single && !in_double => {
+                '}' if !in_single && (!in_double || parameter_brace_depth > 0) => {
                     if parameter_brace_depth > 0 {
                         parameter_brace_depth -= 1;
                         let consumed = Self::next_word_char_unwrap(chars, cursor);
@@ -5313,7 +5313,7 @@ impl<'a> Parser<'a> {
                         operand.push(ch);
                     }
                 }
-                '}' if !in_single && !in_double => {
+                '}' if !in_single && (!in_double || depth > 1) => {
                     if depth == 1 && literal_brace_depth > 0 {
                         let mut remaining = chars.clone();
                         remaining.next();
@@ -5380,7 +5380,7 @@ impl<'a> Parser<'a> {
                     chars.next();
                     depth += 1;
                 }
-                '}' if !in_single && !in_double => {
+                '}' if !in_single && (!in_double || depth > target_depth) => {
                     if depth == target_depth {
                         return true;
                     }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4660,6 +4660,7 @@ impl<'a> Parser<'a> {
         let mut literal_brace_depth = 0usize;
         let mut in_single = false;
         let mut in_double = false;
+        let mut double_quote_depth = 0usize;
 
         while let Some(&c) = chars.peek() {
             match c {
@@ -4681,6 +4682,7 @@ impl<'a> Parser<'a> {
                 }
                 '"' if !in_single => {
                     in_double = !in_double;
+                    double_quote_depth = if in_double { depth } else { 0 };
                     current.push(Self::next_word_char_unwrap(chars, cursor));
                 }
                 '$' if !in_single => {
@@ -4694,7 +4696,7 @@ impl<'a> Parser<'a> {
                     literal_brace_depth += 1;
                     current.push(Self::next_word_char_unwrap(chars, cursor));
                 }
-                '}' if !in_single && (!in_double || depth > 1) => {
+                '}' if !in_single && (!in_double || depth > double_quote_depth) => {
                     if depth == 1 && literal_brace_depth > 0 {
                         let mut remaining = chars.clone();
                         remaining.next();
@@ -5126,6 +5128,7 @@ impl<'a> Parser<'a> {
         let mut literal_brace_depth = 0usize;
         let mut in_single = false;
         let mut in_double = false;
+        let mut double_quote_parameter_depth = 0usize;
         let mut escaped = false;
         let mut offset_text = (!source_backed).then(String::new);
         let mut length_text = (!source_backed).then(String::new);
@@ -5157,6 +5160,8 @@ impl<'a> Parser<'a> {
                 }
                 '"' if !in_single => {
                     in_double = !in_double;
+                    double_quote_parameter_depth =
+                        if in_double { parameter_brace_depth } else { 0 };
                     let consumed = Self::next_word_char_unwrap(chars, cursor);
                     if let Some(text) = length_text.as_mut().or(offset_text.as_mut()) {
                         text.push(consumed);
@@ -5192,7 +5197,9 @@ impl<'a> Parser<'a> {
                     Self::next_word_char_unwrap(chars, cursor);
                     length_start = Some(*cursor);
                 }
-                '}' if !in_single && (!in_double || parameter_brace_depth > 0) => {
+                '}' if !in_single
+                    && (!in_double || parameter_brace_depth > double_quote_parameter_depth) =>
+                {
                     if parameter_brace_depth > 0 {
                         parameter_brace_depth -= 1;
                         let consumed = Self::next_word_char_unwrap(chars, cursor);
@@ -5258,6 +5265,7 @@ impl<'a> Parser<'a> {
         let mut literal_brace_depth = 0usize;
         let mut in_single = false;
         let mut in_double = false;
+        let mut double_quote_depth = 0usize;
         let mut escaped = false;
         let mut operand = (!source_backed).then(String::new);
 
@@ -5288,6 +5296,7 @@ impl<'a> Parser<'a> {
                 }
                 '"' if !in_single => {
                     in_double = !in_double;
+                    double_quote_depth = if in_double { depth } else { 0 };
                     let ch = Self::next_word_char_unwrap(chars, cursor);
                     if let Some(operand) = operand.as_mut() {
                         operand.push(ch);
@@ -5313,7 +5322,7 @@ impl<'a> Parser<'a> {
                         operand.push(ch);
                     }
                 }
-                '}' if !in_single && (!in_double || depth > 1) => {
+                '}' if !in_single && (!in_double || depth > double_quote_depth) => {
                     if depth == 1 && literal_brace_depth > 0 {
                         let mut remaining = chars.clone();
                         remaining.next();
@@ -5364,6 +5373,7 @@ impl<'a> Parser<'a> {
         let mut depth = target_depth;
         let mut in_single = false;
         let mut in_double = false;
+        let mut double_quote_depth = 0usize;
         let mut escaped = false;
 
         while let Some(ch) = chars.next() {
@@ -5375,12 +5385,15 @@ impl<'a> Parser<'a> {
             match ch {
                 '\\' if !in_single => escaped = true,
                 '\'' if !in_double => in_single = !in_single,
-                '"' if !in_single => in_double = !in_double,
+                '"' if !in_single => {
+                    in_double = !in_double;
+                    double_quote_depth = if in_double { depth } else { 0 };
+                }
                 '$' if !in_single && chars.peek() == Some(&'{') => {
                     chars.next();
                     depth += 1;
                 }
-                '}' if !in_single && (!in_double || depth > target_depth) => {
+                '}' if !in_single && (!in_double || depth > double_quote_depth) => {
                     if depth == target_depth {
                         return true;
                     }


### PR DESCRIPTION
## Summary
- fix brace-closing logic for nested `${...}` while parsing double-quoted parameter operands
- add parser regression coverage for `"${home:-"${default}"}'${foo}'"`
- add an end-to-end C001 regression so later expansions keep assignments live

## Root cause
Nested parameter expansions inside a double-quoted default operand could absorb a later `${...}` expansion. That caused C001 to miss the later read and report some assignments as unused.

## Validation
- `cargo test -p shuck-parser`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001`

The targeted corpus comparison still has remaining C001 deltas overall, but this fix removes the earlier false positive in `89luca89__distrobox__distrobox-create` and improves the blocking count from 1514 to 1513.
