### PR TITLE
Align ShellCheck comparison mappings

### DIFF
--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -37,11 +37,19 @@ impl ShellCheckCodeMap {
         &self,
         selected_rules: Option<&RuleSet>,
     ) -> impl Iterator<Item = (u32, Rule)> + '_ {
-        self.comparison_mappings().chain(
+        let selected_only = [
             selected_rules
                 .filter(|rules| rules.contains(Rule::FunctionKeywordInSh))
                 .map(|_| (2112, Rule::FunctionKeywordInSh)),
-        )
+            // SC2089 is broader than C130's `+=`-only scope, so keep it out of mapped-only
+            // whole-corpus runs and only compare it when C130 is selected explicitly.
+            selected_rules
+                .filter(|rules| rules.contains(Rule::AppendWithEscapedQuotes))
+                .map(|_| (2089, Rule::AppendWithEscapedQuotes)),
+        ];
+
+        self.comparison_mappings()
+            .chain(selected_only.into_iter().flatten())
     }
 
     /// Look up a shellcheck code like `SC2086`.
@@ -202,7 +210,7 @@ impl Default for ShellCheckCodeMap {
             // Keep SC2358 as the authored compatibility code and compare directly.
             (2358, Rule::RedirectBeforePipe),
             // ShellCheck 0.11.0 reports read/write redirect collisions as SC2094.
-            // Keep SC2317 as the authored suppression code and compare against the live code.
+            // Keep SC2317 available as a legacy suppression alias.
             (2094, Rule::RedirectClobbersInput),
             // ShellCheck 0.11.0 reports single-quoted split-word cases as SC2026.
             // Keep SC2300 as a suppression alias for the authored S050 rule code.
@@ -308,7 +316,7 @@ impl Default for ShellCheckCodeMap {
             (2013, Rule::LineOrientedInput),
             (2015, Rule::ChainedTestBranches),
             // ShellCheck 0.11.0 reports `find -exec` pre-expansion warnings as SC2014.
-            // Keep SC2295 as a suppression alias for authored C078 metadata.
+            // Keep SC2295 available as a legacy suppression alias.
             (2014, Rule::UnquotedGlobsInFind),
             // ShellCheck 0.11.0 reports loop-list glob+expansion mixes as SC2231.
             // Keep SC2349 as a suppression alias for authored C114 metadata.
@@ -510,7 +518,6 @@ impl Default for ShellCheckCodeMap {
             (2255, Rule::SubstWithRedirect),
             (2256, Rule::SubstWithRedirectErr),
             (2265, Rule::RedundantReturnStatus),
-            (2089, Rule::AppendWithEscapedQuotes),
             // ShellCheck 0.11.0 reports declaration cross-reference warnings as SC2318.
             // Keep SC2384 as a suppression alias, but prefer the current code for comparisons.
             (2318, Rule::LocalCrossReference),
@@ -921,7 +928,7 @@ impl Default for ShellCheckCodeMap {
                 // warning, but authored S040 metadata and SC2268 suppressions should still map here.
                 (2268, Rule::BackslashBeforeCommand),
                 // ShellCheck 0.11.0 reports redirect collisions as SC2094.
-                // Keep SC2094 available as the live comparison alias for SC2317.
+                // Keep SC2317 available as a legacy suppression alias while SC2094 stays live.
                 (2094, Rule::RedirectClobbersInput),
                 (2351, Rule::XPrefixInTest),
                 (3062, Rule::DollarStringInSh),
@@ -974,6 +981,7 @@ impl Default for ShellCheckCodeMap {
                 (2329, Rule::IfsSetToLiteralBackslashN),
                 (2353, Rule::AssignmentToNumericVariable),
                 (2354, Rule::PlusPrefixInAssignment),
+                // Keep SC2377 available as a historical suppression alias for older C130 metadata.
                 (2377, Rule::AppendWithEscapedQuotes),
                 (2367, Rule::UncheckedDirectoryChangeInFunction),
                 (2368, Rule::ContinueOutsideLoopInFunction),
@@ -2332,7 +2340,7 @@ mod tests {
         assert!(!comparison.contains(&(2009, Rule::DoubleParenGrouping)));
         assert!(comparison.contains(&(2141, Rule::IfsSetToLiteralBackslashN)));
         assert!(comparison.contains(&(1097, Rule::IfsEqualsAmbiguity)));
-        assert!(comparison.contains(&(2089, Rule::AppendWithEscapedQuotes)));
+        assert!(!comparison.contains(&(2089, Rule::AppendWithEscapedQuotes)));
         assert!(comparison.contains(&(2318, Rule::LocalCrossReference)));
         assert!(comparison.contains(&(2290, Rule::SubshellInArithmetic)));
         assert!(comparison.contains(&(2282, Rule::BadVarName)));
@@ -2426,16 +2434,19 @@ mod tests {
     fn comparison_mappings_for_rules_include_selected_only_live_aliases() {
         let mut selected_rules = RuleSet::default();
         selected_rules.insert(Rule::FunctionKeywordInSh);
+        selected_rules.insert(Rule::AppendWithEscapedQuotes);
 
         let comparison = ShellCheckCodeMap::default()
             .comparison_mappings_for_rules(Some(&selected_rules))
             .collect::<std::collections::HashSet<_>>();
 
         assert!(comparison.contains(&(2112, Rule::FunctionKeywordInSh)));
+        assert!(comparison.contains(&(2089, Rule::AppendWithEscapedQuotes)));
 
         let unselected = ShellCheckCodeMap::default()
             .comparison_mappings()
             .collect::<std::collections::HashSet<_>>();
         assert!(!unselected.contains(&(2112, Rule::FunctionKeywordInSh)));
+        assert!(!unselected.contains(&(2089, Rule::AppendWithEscapedQuotes)));
     }
 }

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -3461,12 +3461,18 @@ mod tests {
 
     #[test]
     fn large_corpus_comparison_mappings_include_selected_rule_only_aliases() {
-        let selected_rules =
-            shuck_linter::RuleSet::from_iter([shuck_linter::Rule::FunctionKeywordInSh]);
+        let selected_rules = shuck_linter::RuleSet::from_iter([
+            shuck_linter::Rule::FunctionKeywordInSh,
+            shuck_linter::Rule::AppendWithEscapedQuotes,
+        ]);
         let mappings =
             large_corpus_comparison_mappings(Some(&selected_rules)).collect::<HashSet<_>>();
 
         assert!(mappings.contains(&(2112, shuck_linter::Rule::FunctionKeywordInSh)));
+        assert!(mappings.contains(&(2089, shuck_linter::Rule::AppendWithEscapedQuotes)));
+
+        let shared_mappings = large_corpus_comparison_mappings(None).collect::<HashSet<_>>();
+        assert!(!shared_mappings.contains(&(2089, shuck_linter::Rule::AppendWithEscapedQuotes)));
     }
 
     #[test]

--- a/docs/rules/C078.yaml
+++ b/docs/rules/C078.yaml
@@ -3,7 +3,7 @@ legacy_name: unquoted-globs-in-find
 new_category: Correctness
 new_code: C078
 runtime_kind: ast
-shellcheck_code: SC2295
+shellcheck_code: SC2014
 shells:
   - sh
   - bash

--- a/docs/rules/C094.yaml
+++ b/docs/rules/C094.yaml
@@ -3,7 +3,7 @@ legacy_name: redirect-clobbers-input
 new_category: Correctness
 new_code: C094
 runtime_kind: ast
-shellcheck_code: SC2317
+shellcheck_code: SC2094
 shells:
   - sh
   - bash

--- a/docs/rules/C130.yaml
+++ b/docs/rules/C130.yaml
@@ -3,7 +3,7 @@ legacy_name: append-with-escaped-quotes
 new_category: Correctness
 new_code: C130
 runtime_kind: ast
-shellcheck_code: SC2377
+shellcheck_code: SC2089
 shells:
   - sh
   - bash

--- a/docs/rules/S054.yaml
+++ b/docs/rules/S054.yaml
@@ -3,7 +3,7 @@ legacy_name: su-without-flag
 new_category: Style
 new_code: S054
 runtime_kind: ast
-shellcheck_code: SC2322
+shellcheck_code: SC2117
 shells:
   - sh
   - bash


### PR DESCRIPTION
## Summary
- align the canonical ShellCheck codes for `C078`, `C094`, `S054`, and `C130` with the live codes we compare against in corpus runs
- keep `SC2089` available for `C130` only when that rule is selected explicitly, instead of treating it as a shared whole-corpus comparison mapping
- add test coverage for the selected-only comparison behavior in both `shuck-linter` and the large-corpus harness

## Why
The large-corpus report was mixing two different issues:
- stale canonical metadata for several rules
- overly broad `SC2089` comparison behavior for `C130`

That broad `SC2089` mapping made the full report attribute unrelated ShellCheck findings to `C130`. This change keeps the compatibility metadata aligned while narrowing `C130` comparison to explicit rule-focused runs.

## Impact
This should reduce misleading compatibility noise in full large-corpus reports while preserving targeted `C130` debugging workflows.

The targeted `C130` corpus run still reports 17 implementation diffs after this change, which is expected and leaves the remaining work focused on real rule behavior instead of mapping spillover.

## Validation
- `cargo test -p shuck-linter shellcheck_map`
- `cargo test -p shuck large_corpus_comparison_mappings`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C130` (still fails with 17 blocking `C130` implementation diffs, but `mapping_issues=0`)

## Notes
`docs/rules/validate.sh` was not a clean signal in this worktree because the sibling `../shell-checks` repo is unavailable here, and it also reports pre-existing duplicate `shellcheck_code` entries unrelated to this change.