### PR TITLE
Reuse cached exact dataflow for scope summaries

### DIFF
--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -86,6 +86,7 @@ pub(crate) struct ExactVariableDataflow {
     unreachable_blocks: DenseBitSet,
     reaching_definitions: OnceLock<DenseReachingDefinitions>,
     initialized_name_states: OnceLock<DenseInitializedNameStates>,
+    scope_components: OnceLock<Vec<ExactScopeComponent>>,
 }
 
 impl ExactVariableDataflow {
@@ -115,6 +116,21 @@ impl ExactVariableDataflow {
                 context.entry_bindings,
             )
         })
+    }
+
+    fn scope_components<'a>(&'a self, context: &DataflowContext<'_>) -> &'a [ExactScopeComponent] {
+        self.scope_components
+            .get_or_init(|| {
+                let reaching_definitions = self.reaching_definitions(context);
+                compute_scope_components_dense(
+                    context.cfg,
+                    context.scopes.len(),
+                    context.cfg.blocks().len(),
+                    context.bindings.len(),
+                    &reaching_definitions.reaching_out,
+                )
+            })
+            .as_slice()
     }
 
     pub(crate) fn reaching_bindings_for_reference(
@@ -191,6 +207,7 @@ pub(crate) fn build_exact_variable_dataflow(
         unreachable_blocks,
         reaching_definitions: OnceLock::new(),
         initialized_name_states: OnceLock::new(),
+        scope_components: OnceLock::new(),
     }
 }
 
@@ -328,13 +345,7 @@ fn analyze_unused_assignments_exact(
                 .expect("synthetic read name interned")
         })
         .collect::<Vec<_>>();
-    let scope_components = compute_scope_components_dense(
-        context.cfg,
-        context.scopes.len(),
-        context.cfg.blocks().len(),
-        context.bindings.len(),
-        &reaching_definitions.reaching_out,
-    );
+    let scope_components = exact.scope_components(context);
     let interprocedural_reads = if context.call_sites.is_empty() {
         None
     } else {
@@ -1379,34 +1390,17 @@ fn block_exits_component(
 }
 
 pub(crate) fn summarize_scope_provided_bindings(
-    cfg: &ControlFlowGraph,
-    scopes: &[Scope],
-    bindings: &[Binding],
-    entry_bindings: &[BindingId],
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
     scope: ScopeId,
 ) -> Vec<ProvidedBinding> {
-    let mut names = NameTable::default();
-    for binding in bindings {
-        names.intern(&binding.name);
-    }
-    let binding_data = build_dense_binding_data(bindings, scopes, &names);
-    let reaching_definitions =
-        compute_reaching_definitions_dense(cfg, bindings, &binding_data, entry_bindings);
-    let initialized_states =
-        compute_initialized_name_states_dense(cfg, bindings, &binding_data, entry_bindings);
-    let scope_components = compute_scope_components_dense(
-        cfg,
-        scopes.len(),
-        cfg.blocks().len(),
-        bindings.len(),
-        &reaching_definitions.reaching_out,
-    );
-    let exit_blocks = exit_blocks_for_scope(cfg, &scope_components, scope);
+    let exit_blocks = exit_blocks_for_scope(context.cfg, exact.scope_components(context), scope);
     if exit_blocks.is_empty() {
         return Vec::new();
     }
 
-    let eligible_names = bindings
+    let eligible_names = context
+        .bindings
         .iter()
         .filter(|binding| {
             binding.scope == scope
@@ -1416,6 +1410,7 @@ pub(crate) fn summarize_scope_provided_bindings(
         .map(|binding| binding.name.clone())
         .collect::<FxHashSet<_>>();
 
+    let initialized_states = exact.initialized_name_states(context);
     let mut maybe_counts = FxHashMap::<Name, usize>::default();
     let mut definite_counts = FxHashMap::<Name, usize>::default();
 
@@ -1424,7 +1419,7 @@ pub(crate) fn summarize_scope_provided_bindings(
         let definite_names = &initialized_states.definite_out[exit_block.index()];
 
         for name in &eligible_names {
-            let Some(name_id) = names.get(name) else {
+            let Some(name_id) = exact.names.get(name) else {
                 continue;
             };
             if maybe_names.contains(name_id.index()) {
@@ -1464,32 +1459,18 @@ pub(crate) fn summarize_scope_provided_bindings(
 }
 
 pub(crate) fn summarize_scope_provided_functions(
-    cfg: &ControlFlowGraph,
-    scopes: &[Scope],
-    bindings: &[Binding],
-    entry_bindings: &[BindingId],
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
     scope: ScopeId,
 ) -> Vec<ProvidedBinding> {
-    let mut names = NameTable::default();
-    for binding in bindings {
-        names.intern(&binding.name);
-    }
-    let binding_data = build_dense_binding_data(bindings, scopes, &names);
-    let reaching_definitions =
-        compute_reaching_definitions_dense(cfg, bindings, &binding_data, entry_bindings);
-    let scope_components = compute_scope_components_dense(
-        cfg,
-        scopes.len(),
-        cfg.blocks().len(),
-        bindings.len(),
-        &reaching_definitions.reaching_out,
-    );
-    let exit_blocks = exit_blocks_for_scope(cfg, &scope_components, scope);
+    let reaching_definitions = exact.reaching_definitions(context);
+    let exit_blocks = exit_blocks_for_scope(context.cfg, exact.scope_components(context), scope);
     if exit_blocks.is_empty() {
         return Vec::new();
     }
 
-    let eligible_names = bindings
+    let eligible_names = context
+        .bindings
         .iter()
         .filter(|binding| binding.scope == scope && function_binding_certainty(binding).is_some())
         .map(|binding| binding.name.clone())
@@ -1502,16 +1483,16 @@ pub(crate) fn summarize_scope_provided_functions(
         let reaching = &reaching_definitions.reaching_out[exit_block.index()];
 
         for name in &eligible_names {
-            let Some(name_id) = names.get(name) else {
+            let Some(name_id) = exact.names.get(name) else {
                 continue;
             };
             let mut maybe_present = false;
             let mut definite_present = false;
-            for binding_index in binding_data.bindings_for_name[name_id.index()].iter_ones() {
+            for binding_index in exact.binding_data.bindings_for_name[name_id.index()].iter_ones() {
                 if !reaching.contains(binding_index) {
                     continue;
                 }
-                let binding = &bindings[binding_index];
+                let binding = &context.bindings[binding_index];
                 if binding.scope != scope {
                     continue;
                 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1011,26 +1011,20 @@ impl<'model> SemanticAnalysis<'model> {
     }
 
     pub(crate) fn summarize_scope_provided_bindings(&self, scope: ScopeId) -> Vec<ProvidedBinding> {
-        dataflow::summarize_scope_provided_bindings(
-            self.cfg(),
-            &self.model.scopes,
-            &self.model.bindings,
-            &self.model.entry_bindings,
-            scope,
-        )
+        let cfg = self.cfg();
+        let exact = self.exact_variable_dataflow();
+        let context = self.model.dataflow_context(cfg);
+        dataflow::summarize_scope_provided_bindings(&context, exact, scope)
     }
 
     pub(crate) fn summarize_scope_provided_functions(
         &self,
         scope: ScopeId,
     ) -> Vec<ProvidedBinding> {
-        dataflow::summarize_scope_provided_functions(
-            self.cfg(),
-            &self.model.scopes,
-            &self.model.bindings,
-            &self.model.entry_bindings,
-            scope,
-        )
+        let cfg = self.cfg();
+        let exact = self.exact_variable_dataflow();
+        let context = self.model.dataflow_context(cfg);
+        dataflow::summarize_scope_provided_functions(&context, exact, scope)
     }
 
     fn compute_overwritten_functions(&self) -> Vec<OverwrittenFunction> {
@@ -2462,6 +2456,65 @@ emoji[smile]=2
                 .map(|reference| model.reference(reference.reference).name.to_string())
                 .collect::<Vec<_>>(),
             vec!["UNDEF"]
+        );
+    }
+
+    #[test]
+    fn scope_summary_queries_reuse_exact_variable_dataflow_bundle() {
+        let model = model(
+            "\
+outer=1
+foo() {
+  local skip=0
+  inner=2
+}
+",
+        );
+        let foo_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "foo") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .unwrap();
+        let analysis = model.analysis();
+
+        assert!(analysis.exact_variable_dataflow.get().is_none());
+
+        let root_bindings = analysis.summarize_scope_provided_bindings(ScopeId(0));
+        let bundle_ptr = analysis.exact_variable_dataflow() as *const ExactVariableDataflow;
+        let foo_bindings = analysis.summarize_scope_provided_bindings(foo_scope);
+        let function_ptr = analysis.exact_variable_dataflow() as *const ExactVariableDataflow;
+        let root_functions = analysis.summarize_scope_provided_functions(ScopeId(0));
+        let reused_ptr = analysis.exact_variable_dataflow() as *const ExactVariableDataflow;
+
+        assert_eq!(bundle_ptr, function_ptr);
+        assert_eq!(bundle_ptr, reused_ptr);
+        assert_eq!(
+            root_bindings
+                .iter()
+                .map(|binding| binding.name.to_string())
+                .collect::<Vec<_>>(),
+            vec!["outer"]
+        );
+        assert_eq!(
+            foo_bindings
+                .iter()
+                .map(|binding| binding.name.to_string())
+                .collect::<Vec<_>>(),
+            vec!["inner"]
+        );
+        assert_eq!(
+            root_functions
+                .iter()
+                .map(|binding| binding.name.to_string())
+                .collect::<Vec<_>>(),
+            vec!["foo"]
         );
     }
 


### PR DESCRIPTION
## Summary
- route scope summary queries through `SemanticAnalysis`'s cached exact variable dataflow
- cache scope components alongside the existing dense dataflow state
- add a regression test that verifies scope summary queries reuse the shared bundle

## Why
Large-corpus source-closure summarization was recomputing whole-file reaching-definitions and initialized-name state for every function scope in a sourced helper. For `aristocratos__bashtop__test__test_helper.bash`, resolving `source bashtop` caused repeated full-program dataflow over the sourced `bashtop` file and made the wrapper fixture much slower than the sourced file itself.

## Impact
On the same mini large-corpus repro used during investigation:
- `aristocratos__bashtop__test__test_helper.bash`: about `9.4s` -> about `0.37s`
- `aristocratos__bashtop__bashtop`: stays around `0.7s` and becomes the dominant cost

## Testing
- `cargo test -p shuck-semantic`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_ROOT=/tmp/shuck-mini-corpus SHUCK_LARGE_CORPUS_TIMING=1 cargo test -p shuck large_corpus_conforms_with_shellcheck --test large_corpus -- --ignored --nocapture`
