### PR TITLE
Index unquoted command-argument uses for C130

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2285,6 +2285,7 @@ pub struct LinterFacts<'a> {
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
     words: Vec<WordFact<'a>>,
     word_index: FxHashMap<FactSpan, Vec<usize>>,
+    unquoted_command_argument_use_offsets: FxHashMap<Name, Vec<usize>>,
     array_assignment_split_word_indices: Vec<usize>,
     function_headers: Vec<FunctionHeaderFact<'a>>,
     function_body_without_braces_spans: Vec<Span>,
@@ -2531,6 +2532,18 @@ impl<'a> LinterFacts<'a> {
             .get(&FactSpan::new(span))
             .and_then(|indices| indices.first().copied())
             .map(|index| &self.words[index])
+    }
+
+    pub fn has_later_unquoted_command_argument_use(
+        &self,
+        name: &Name,
+        after_offset: usize,
+    ) -> bool {
+        self.unquoted_command_argument_use_offsets
+            .get(name)
+            .is_some_and(|offsets| {
+                offsets.partition_point(|offset| *offset <= after_offset) < offsets.len()
+            })
     }
 
     pub fn array_assignment_split_word_facts(&self) -> impl Iterator<Item = &WordFact<'a>> + '_ {
@@ -3233,6 +3246,8 @@ impl<'a> LinterFactsBuilder<'a> {
         for (index, fact) in words.iter().enumerate() {
             word_index.entry(fact.key()).or_default().push(index);
         }
+        let unquoted_command_argument_use_offsets =
+            build_unquoted_command_argument_use_offsets(self.semantic, &words);
 
         LinterFacts {
             commands,
@@ -3251,6 +3266,7 @@ impl<'a> LinterFactsBuilder<'a> {
             compound_assignment_value_word_spans,
             words,
             word_index,
+            unquoted_command_argument_use_offsets,
             array_assignment_split_word_indices,
             function_headers,
             function_body_without_braces_spans,
@@ -3327,6 +3343,43 @@ impl<'a> LinterFactsBuilder<'a> {
     }
 }
 
+#[derive(Debug, Default)]
+struct ContainingSpanIndex {
+    starts: Vec<usize>,
+    prefix_max_ends: Vec<usize>,
+}
+
+impl ContainingSpanIndex {
+    fn new(spans: &[Span]) -> Self {
+        let mut bounds = spans
+            .iter()
+            .map(|span| (span.start.offset, span.end.offset))
+            .collect::<Vec<_>>();
+        bounds.sort_unstable();
+
+        let mut starts = Vec::with_capacity(bounds.len());
+        let mut prefix_max_ends = Vec::with_capacity(bounds.len());
+        let mut max_end = 0usize;
+        for (start, end) in bounds {
+            starts.push(start);
+            max_end = max_end.max(end);
+            prefix_max_ends.push(max_end);
+        }
+
+        Self {
+            starts,
+            prefix_max_ends,
+        }
+    }
+
+    fn contains(&self, span: Span) -> bool {
+        let candidate_count = self
+            .starts
+            .partition_point(|start| *start <= span.start.offset);
+        candidate_count != 0 && self.prefix_max_ends[candidate_count - 1] >= span.end.offset
+    }
+}
+
 fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
     let mut spans = commands
         .iter()
@@ -3340,6 +3393,47 @@ fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: 
     let mut seen = FxHashSet::default();
     spans.retain(|span| seen.insert(FactSpan::new(*span)));
     spans
+}
+
+fn build_unquoted_command_argument_use_offsets(
+    semantic: &SemanticModel,
+    words: &[WordFact<'_>],
+) -> FxHashMap<Name, Vec<usize>> {
+    let unquoted_command_argument_spans = words
+        .iter()
+        .filter(|fact| fact.expansion_context() == Some(ExpansionContext::CommandArgument))
+        .filter(|fact| fact.classification().quote == WordQuote::Unquoted)
+        .map(WordFact::span)
+        .collect::<Vec<_>>();
+    if unquoted_command_argument_spans.is_empty() {
+        return FxHashMap::default();
+    }
+
+    let unquoted_command_argument_index =
+        ContainingSpanIndex::new(&unquoted_command_argument_spans);
+    let mut offsets_by_name = FxHashMap::<Name, Vec<usize>>::default();
+    for reference in semantic.references() {
+        if matches!(
+            reference.kind,
+            shuck_semantic::ReferenceKind::DeclarationName
+        ) {
+            continue;
+        }
+        if !unquoted_command_argument_index.contains(reference.span) {
+            continue;
+        }
+        offsets_by_name
+            .entry(reference.name.clone())
+            .or_default()
+            .push(reference.span.start.offset);
+    }
+
+    for offsets in offsets_by_name.values_mut() {
+        offsets.sort_unstable();
+        offsets.dedup();
+    }
+
+    offsets_by_name
 }
 
 fn echo_uses_escape_interpreting_flag(command: &CommandFact<'_>) -> bool {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -3343,43 +3343,6 @@ impl<'a> LinterFactsBuilder<'a> {
     }
 }
 
-#[derive(Debug, Default)]
-struct ContainingSpanIndex {
-    starts: Vec<usize>,
-    prefix_max_ends: Vec<usize>,
-}
-
-impl ContainingSpanIndex {
-    fn new(spans: &[Span]) -> Self {
-        let mut bounds = spans
-            .iter()
-            .map(|span| (span.start.offset, span.end.offset))
-            .collect::<Vec<_>>();
-        bounds.sort_unstable();
-
-        let mut starts = Vec::with_capacity(bounds.len());
-        let mut prefix_max_ends = Vec::with_capacity(bounds.len());
-        let mut max_end = 0usize;
-        for (start, end) in bounds {
-            starts.push(start);
-            max_end = max_end.max(end);
-            prefix_max_ends.push(max_end);
-        }
-
-        Self {
-            starts,
-            prefix_max_ends,
-        }
-    }
-
-    fn contains(&self, span: Span) -> bool {
-        let candidate_count = self
-            .starts
-            .partition_point(|start| *start <= span.start.offset);
-        candidate_count != 0 && self.prefix_max_ends[candidate_count - 1] >= span.end.offset
-    }
-}
-
 fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
     let mut spans = commands
         .iter()
@@ -3399,33 +3362,48 @@ fn build_unquoted_command_argument_use_offsets(
     semantic: &SemanticModel,
     words: &[WordFact<'_>],
 ) -> FxHashMap<Name, Vec<usize>> {
-    let unquoted_command_argument_spans = words
+    let unquoted_command_argument_word_spans = words
         .iter()
         .filter(|fact| fact.expansion_context() == Some(ExpansionContext::CommandArgument))
         .filter(|fact| fact.classification().quote == WordQuote::Unquoted)
         .map(WordFact::span)
         .collect::<Vec<_>>();
-    if unquoted_command_argument_spans.is_empty() {
+    if unquoted_command_argument_word_spans.is_empty() {
         return FxHashMap::default();
     }
 
-    let unquoted_command_argument_index =
-        ContainingSpanIndex::new(&unquoted_command_argument_spans);
+    let references = semantic.references();
+    let mut reference_indices = references
+        .iter()
+        .enumerate()
+        .filter(|(_, reference)| {
+            !matches!(
+                reference.kind,
+                shuck_semantic::ReferenceKind::DeclarationName
+            )
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    reference_indices.sort_unstable_by_key(|&index| references[index].span.start.offset);
+
     let mut offsets_by_name = FxHashMap::<Name, Vec<usize>>::default();
-    for reference in semantic.references() {
-        if matches!(
-            reference.kind,
-            shuck_semantic::ReferenceKind::DeclarationName
-        ) {
-            continue;
+    for word_span in unquoted_command_argument_word_spans {
+        let first_reference = reference_indices
+            .partition_point(|&index| references[index].span.start.offset < word_span.start.offset);
+        for &index in &reference_indices[first_reference..] {
+            let reference = &references[index];
+            if reference.span.start.offset > word_span.end.offset {
+                break;
+            }
+            if !contains_span(word_span, reference.span) {
+                continue;
+            }
+
+            offsets_by_name
+                .entry(reference.name.clone())
+                .or_default()
+                .push(word_span.start.offset);
         }
-        if !unquoted_command_argument_index.contains(reference.span) {
-            continue;
-        }
-        offsets_by_name
-            .entry(reference.name.clone())
-            .or_default()
-            .push(reference.span.start.offset);
     }
 
     for offsets in offsets_by_name.values_mut() {

--- a/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
@@ -1,7 +1,6 @@
 use shuck_ast::{Assignment, AssignmentValue, BuiltinCommand, Command, DeclOperand, Span};
-use shuck_semantic::ReferenceKind;
 
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote};
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext};
 
 pub struct AppendWithEscapedQuotes;
 
@@ -114,22 +113,10 @@ fn escaped_quote_append_span(
 }
 
 fn has_later_unquoted_command_argument_use(checker: &Checker<'_>, assignment: &Assignment) -> bool {
-    checker
-        .facts()
-        .expansion_word_facts(ExpansionContext::CommandArgument)
-        .filter(|fact| fact.classification().quote == WordQuote::Unquoted)
-        .filter(|fact| fact.span().start.offset > assignment.target.name_span.start.offset)
-        .any(|fact| {
-            checker.semantic().references().iter().any(|reference| {
-                reference.kind != ReferenceKind::DeclarationName
-                    && reference.name.as_str() == assignment.target.name.as_str()
-                    && contains_span(fact.span(), reference.span)
-            })
-        })
-}
-
-fn contains_span(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    checker.facts().has_later_unquoted_command_argument_use(
+        &assignment.target.name,
+        assignment.target.name_span.start.offset,
+    )
 }
 
 #[cfg(test)]
@@ -172,6 +159,21 @@ CFLAGS=\" -DDIR=\\\"$PREFIX/share/\\\"\"\nCFLAGS+=\" -DDIR=$PREFIX/share/\"\nCFL
 GO_LDFLAGS=\"\"
 GO_LDFLAGS+=\" -X \\\"main.GitVersion=$VERSION\\\"\"\n\
 go build -ldflags \"$GO_LDFLAGS\"\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_escaped_quote_appends_without_later_unquoted_argument_use() {
+        let source = "\
+#!/bin/sh
+echo $CFLAGS
+CFLAGS+=\" -DDIR=\\\"$PREFIX/share/\\\"\"\n\
+printf '%s\\n' \"$CFLAGS\"\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),

--- a/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_with_escaped_quotes.rs
@@ -183,6 +183,19 @@ printf '%s\\n' \"$CFLAGS\"\n";
     }
 
     #[test]
+    fn ignores_quoted_uses_in_earlier_unquoted_command_substitutions() {
+        let source = "\
+#!/bin/bash
+echo $(CFLAGS+=\" -DDIR=\\\"$PREFIX/share/\\\"\"; printf '%s\\n' \"$CFLAGS\")\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AppendWithEscapedQuotes),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_subscripted_appends() {
         let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- build a fact-level index of unquoted command-argument reference offsets by name
- have C130 query the cached index instead of rescanning all command-argument words and semantic references per candidate assignment
- add a regression test covering escaped-quote appends that only have earlier unquoted uses

## Why
`AppendWithEscapedQuotes` was slow on large files because each `+=` candidate scanned every later unquoted command-argument word and then scanned all semantic references again to find matching variable uses. On `xwmx__nb__nb`, that repeated work made C130 a dominant hotspot.

This change moves the expensive join into `LinterFacts`, where we already build other reusable linter-side summaries once per file. The rule becomes a cheap name-and-offset lookup backed by a sorted per-name offset list.

## Impact
On the `xwmx__nb__nb` mini corpus repro:
- full-file timing improved from about `10.7s-12.4s` to `4.67s`
- `C130`-only timing improved from about `7.2s` to `2.53s`

After this change, the remaining dominant hotspot on `xwmx__nb__nb` is `build_case_pattern_shadow_facts`, not C130.

## Validation
- `cargo test -p shuck-linter append_with_escaped_quotes`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_ROOT=/tmp/shuck-mini-corpus-nb SHUCK_LARGE_CORPUS_TIMING=1 cargo test -p shuck large_corpus_conforms_with_shellcheck --test large_corpus -- --ignored --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 SHUCK_LARGE_CORPUS_ROOT=/tmp/shuck-mini-corpus-nb SHUCK_LARGE_CORPUS_TIMING=1 SHUCK_LARGE_CORPUS_RULES=C130 cargo test -p shuck large_corpus_conforms_with_shellcheck --test large_corpus -- --ignored --nocapture`
