### PR TITLE
Implement C030 missing bracket space rule

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C022.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C022.sh
@@ -2,8 +2,8 @@
 
 # Invalid: an empty test expression has no operands
 [ ]
-test
 
 # Valid: populated tests are fine
 [ "$value" ]
+test
 test "$value"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C030.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C030.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+if [ -d /tmp]; then
+  :
+fi

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -980,6 +980,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::TruthyLiteralTest) {
             rules::correctness::truthy_literal_test::truthy_literal_test(self);
         }
+        if self.is_rule_enabled(Rule::MissingBracketSpace) {
+            rules::correctness::missing_bracket_space::missing_bracket_space(self);
+        }
         if self.is_rule_enabled(Rule::EscapedNegationInTest) {
             rules::correctness::escaped_negation_in_test::escaped_negation_in_test(self);
         }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2140,6 +2140,7 @@ pub struct CommandFact<'a> {
     substitution_facts: Box<[SubstitutionFact]>,
     options: CommandOptionFacts<'a>,
     scope_read_source_words: Box<[PathWordFact<'a>]>,
+    glued_closing_bracket_operand_span: Option<Span>,
     simple_test: Option<SimpleTestFact<'a>>,
     conditional: Option<ConditionalFact<'a>>,
 }
@@ -2199,6 +2200,10 @@ impl<'a> CommandFact<'a> {
 
     pub fn scope_read_source_words(&self) -> &[PathWordFact<'a>] {
         &self.scope_read_source_words
+    }
+
+    pub fn glued_closing_bracket_operand_span(&self) -> Option<Span> {
+        self.glued_closing_bracket_operand_span
     }
 
     pub fn simple_test(&self) -> Option<&SimpleTestFact<'a>> {
@@ -2983,6 +2988,8 @@ impl<'a> LinterFactsBuilder<'a> {
             let redirect_facts =
                 build_redirect_facts(visit.redirects, self.source, command_zsh_options.as_ref());
             let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
+            let glued_closing_bracket_operand_span =
+                build_glued_closing_bracket_operand_span(visit.command, self.source);
             let simple_test =
                 build_simple_test_fact(visit.command, self.source, self._file_context);
             let conditional = build_conditional_fact(visit.command, self.source);
@@ -2997,6 +3004,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 substitution_facts: Vec::new().into_boxed_slice(),
                 options,
                 scope_read_source_words: Vec::new().into_boxed_slice(),
+                glued_closing_bracket_operand_span,
                 simple_test,
                 conditional,
             });
@@ -10513,6 +10521,48 @@ fn build_simple_test_fact<'a>(
     })
 }
 
+fn build_glued_closing_bracket_operand_span(command: &Command, source: &str) -> Option<Span> {
+    let Command::Simple(command) = command else {
+        return None;
+    };
+    if static_word_text(&command.name, source).as_deref() != Some("[") {
+        return None;
+    }
+
+    let args = command.args.iter().collect::<Vec<_>>();
+    let last = args.last()?;
+    let text = last.span.slice(source);
+    if text == "]" || !text.ends_with(']') || text.ends_with("\\]") {
+        return None;
+    }
+
+    glued_closing_bracket_unary_operand_span(&args, source)
+}
+
+fn glued_closing_bracket_unary_operand_span(args: &[&Word], source: &str) -> Option<Span> {
+    let [first, second] = args else {
+        let [bang, operator, operand] = args else {
+            return None;
+        };
+        return (bang.span.slice(source) == "!"
+            && simple_test_is_unary_operator(operator.span.slice(source))
+            && operand
+                .span
+                .slice(source)
+                .strip_suffix(']')
+                .is_some_and(|prefix| !prefix.is_empty()))
+        .then_some(Span::from_positions(operand.span.start, operand.span.start));
+    };
+
+    (simple_test_is_unary_operator(first.span.slice(source))
+        && second
+            .span
+            .slice(source)
+            .strip_suffix(']')
+            .is_some_and(|prefix| !prefix.is_empty()))
+    .then_some(Span::from_positions(second.span.start, second.span.start))
+}
+
 fn simple_test_shape(operand_count: usize) -> SimpleTestShape {
     match operand_count {
         0 => SimpleTestShape::Empty,
@@ -10565,6 +10615,37 @@ fn simple_test_is_binary_operator(operator: &str) -> bool {
             | "-ef"
             | "-a"
             | "-o"
+    )
+}
+
+fn simple_test_is_unary_operator(operator: &str) -> bool {
+    matches!(
+        operator,
+        "-e" | "-a"
+            | "-f"
+            | "-d"
+            | "-c"
+            | "-b"
+            | "-p"
+            | "-S"
+            | "-L"
+            | "-h"
+            | "-k"
+            | "-g"
+            | "-u"
+            | "-G"
+            | "-O"
+            | "-N"
+            | "-r"
+            | "-w"
+            | "-x"
+            | "-s"
+            | "-t"
+            | "-z"
+            | "-n"
+            | "-o"
+            | "-v"
+            | "-R"
     )
 }
 
@@ -16548,6 +16629,37 @@ test
                 .find(|(text, _)| text == "[ missing")
                 .map(|(_, fact)| fact.simple_test());
             assert!(matches!(missing_closer, Some(None)));
+        });
+    }
+
+    #[test]
+    fn records_glued_closing_bracket_operand_spans_for_unary_tests() {
+        let source = "\
+#!/bin/sh
+[ -d /tmp]
+[ ! -a /tmp]
+[ \"$dir\" = /tmp]
+[ -d /tmp ]
+";
+
+        with_facts(source, None, |_, facts| {
+            let commands = facts.structural_commands().collect::<Vec<_>>();
+            assert_eq!(commands.len(), 4);
+
+            assert_eq!(
+                commands[0]
+                    .glued_closing_bracket_operand_span()
+                    .map(|span| (span.start.line, span.start.column)),
+                Some((2, 6))
+            );
+            assert_eq!(
+                commands[1]
+                    .glued_closing_bracket_operand_span()
+                    .map(|span| (span.start.line, span.start.column)),
+                Some((3, 8))
+            );
+            assert_eq!(commands[2].glued_closing_bracket_operand_span(), None);
+            assert_eq!(commands[3].glued_closing_bracket_operand_span(), None);
         });
     }
 

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -109,6 +109,7 @@ declare_rules! {
     ("C020", Category::Correctness, Severity::Warning, TruthyLiteralTest),
     ("C021", Category::Correctness, Severity::Warning, ConstantCaseSubject),
     ("C022", Category::Correctness, Severity::Error, EmptyTest),
+    ("C030", Category::Correctness, Severity::Error, MissingBracketSpace),
     ("C025", Category::Correctness, Severity::Warning, PositionalTenBraces),
     ("C035", Category::Correctness, Severity::Error, MissingFi),
     ("C036", Category::Correctness, Severity::Error, BrokenTestEnd),
@@ -815,6 +816,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-073" => Some(Rule::TruthyLiteralTest),
         "SH-074" => Some(Rule::ConstantCaseSubject),
         "SH-075" => Some(Rule::EmptyTest),
+        "SH-098" => Some(Rule::MissingBracketSpace),
         "SH-134" => Some(Rule::PipeToKill),
         "SH-086" => Some(Rule::PositionalTenBraces),
         "SH-106" => Some(Rule::MissingFi),
@@ -1159,6 +1161,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-073"), Some(Rule::TruthyLiteralTest));
         assert_eq!(code_to_rule("SH-074"), Some(Rule::ConstantCaseSubject));
         assert_eq!(code_to_rule("SH-075"), Some(Rule::EmptyTest));
+        assert_eq!(code_to_rule("C030"), Some(Rule::MissingBracketSpace));
+        assert_eq!(code_to_rule("SH-098"), Some(Rule::MissingBracketSpace));
         assert_eq!(code_to_rule("SH-134"), Some(Rule::PipeToKill));
         assert_eq!(code_to_rule("SH-086"), Some(Rule::PositionalTenBraces));
         assert_eq!(code_to_rule("C035"), Some(Rule::MissingFi));

--- a/crates/shuck-linter/src/rules/correctness/empty_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/empty_test.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, SimpleTestShape, Violation};
+use crate::{Checker, Rule, SimpleTestShape, SimpleTestSyntax, Violation};
 
 pub struct EmptyTest;
 
@@ -21,7 +21,11 @@ pub fn empty_test(checker: &mut Checker) {
             fact.simple_test()
                 .map(|simple_test| (fact.span(), simple_test))
         })
-        .filter(|(_, fact)| fact.shape() == SimpleTestShape::Empty && !fact.empty_test_suppressed())
+        .filter(|(_, fact)| {
+            fact.syntax() == SimpleTestSyntax::Bracket
+                && fact.shape() == SimpleTestShape::Empty
+                && !fact.empty_test_suppressed()
+        })
         .map(|(span, _)| span)
         .collect::<Vec<_>>();
 
@@ -30,30 +34,19 @@ pub fn empty_test(checker: &mut Checker) {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
-    use crate::test::test_snippet_at_path;
+    use crate::test::test_snippet;
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn shellspec_parameters_blocks_are_ignored() {
+    fn ignores_empty_test_builtin_calls() {
         let source = "\
-Describe 'clone'
-Parameters
-  \"test\"
-  \"test$SHELLSPEC_LF\"
-End
-
+#!/bin/sh
 test
+test || __() { :; }
+test \"\" && exit
 ";
-        let diagnostics = test_snippet_at_path(
-            Path::new("/tmp/ko1nksm__shellspec__spec__core__clone_spec.sh"),
-            source,
-            &LinterSettings::for_rule(Rule::EmptyTest),
-        );
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EmptyTest));
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule, Rule::EmptyTest);
-        assert_eq!(diagnostics[0].span.slice(source).trim_end(), "test");
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
@@ -1,7 +1,6 @@
-use shuck_ast::Span;
 use std::collections::HashSet;
 
-use crate::{Checker, CommandFact, Rule, Violation};
+use crate::{Checker, Rule, Violation};
 
 pub struct MissingBracketSpace;
 
@@ -16,87 +15,16 @@ impl Violation for MissingBracketSpace {
 }
 
 pub fn missing_bracket_space(checker: &mut Checker) {
-    let source = checker.source();
     let mut seen_lines = HashSet::new();
     let spans = checker
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| missing_bracket_space_span(fact, source))
+        .filter_map(|fact| fact.glued_closing_bracket_operand_span())
         .filter(|span| seen_lines.insert(span.start.line))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || MissingBracketSpace);
-}
-
-fn missing_bracket_space_span(fact: &CommandFact<'_>, source: &str) -> Option<Span> {
-    if !fact.static_utility_name_is("[") {
-        return None;
-    }
-
-    let args = fact.body_args();
-    let last = args.last()?;
-    let text = last.span.slice(source);
-    if text == "]" || !text.ends_with(']') || text.ends_with("\\]") {
-        return None;
-    }
-
-    unary_glued_test(args, source)
-}
-
-fn unary_glued_test(args: &[&shuck_ast::Word], source: &str) -> Option<Span> {
-    let [first, second] = args else {
-        let [bang, operator, operand] = args else {
-            return None;
-        };
-        return (bang.span.slice(source) == "!"
-            && is_unary_test_operator(operator.span.slice(source))
-            && operand
-                .span
-                .slice(source)
-                .strip_suffix(']')
-                .is_some_and(|prefix| !prefix.is_empty()))
-        .then_some(Span::from_positions(operand.span.start, operand.span.start));
-    };
-
-    (is_unary_test_operator(first.span.slice(source))
-        && second
-            .span
-            .slice(source)
-            .strip_suffix(']')
-            .is_some_and(|prefix| !prefix.is_empty()))
-    .then_some(Span::from_positions(second.span.start, second.span.start))
-}
-
-fn is_unary_test_operator(text: &str) -> bool {
-    matches!(
-        text,
-        "-e" | "-a"
-            | "-f"
-            | "-d"
-            | "-b"
-            | "-c"
-            | "-p"
-            | "-S"
-            | "-L"
-            | "-h"
-            | "-g"
-            | "-k"
-            | "-u"
-            | "-G"
-            | "-O"
-            | "-N"
-            | "-r"
-            | "-v"
-            | "-w"
-            | "-x"
-            | "-s"
-            | "-t"
-            | "-z"
-            | "-n"
-            | "-o"
-            | "-R"
-    )
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
@@ -1,0 +1,166 @@
+use shuck_ast::Span;
+use std::collections::HashSet;
+
+use crate::{Checker, CommandFact, Rule, Violation};
+
+pub struct MissingBracketSpace;
+
+impl Violation for MissingBracketSpace {
+    fn rule() -> Rule {
+        Rule::MissingBracketSpace
+    }
+
+    fn message(&self) -> String {
+        "this unary `[` test operator is missing its operand before the closing `]`".to_owned()
+    }
+}
+
+pub fn missing_bracket_space(checker: &mut Checker) {
+    let source = checker.source();
+    let mut seen_lines = HashSet::new();
+    let spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter_map(|fact| missing_bracket_space_span(fact, source))
+        .filter(|span| seen_lines.insert(span.start.line))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || MissingBracketSpace);
+}
+
+fn missing_bracket_space_span(fact: &CommandFact<'_>, source: &str) -> Option<Span> {
+    if !fact.static_utility_name_is("[") {
+        return None;
+    }
+
+    let args = fact.body_args();
+    let last = args.last()?;
+    let text = last.span.slice(source);
+    if text == "]" || !text.ends_with(']') || text.ends_with("\\]") {
+        return None;
+    }
+
+    unary_glued_test(args, source)
+}
+
+fn unary_glued_test(args: &[&shuck_ast::Word], source: &str) -> Option<Span> {
+    let [first, second] = args else {
+        let [bang, operator, operand] = args else {
+            return None;
+        };
+        return (bang.span.slice(source) == "!"
+            && is_unary_test_operator(operator.span.slice(source))
+            && operand
+                .span
+                .slice(source)
+                .strip_suffix(']')
+                .is_some_and(|prefix| !prefix.is_empty()))
+        .then_some(Span::from_positions(operand.span.start, operand.span.start));
+    };
+
+    (is_unary_test_operator(first.span.slice(source))
+        && second
+            .span
+            .slice(source)
+            .strip_suffix(']')
+            .is_some_and(|prefix| !prefix.is_empty()))
+    .then_some(Span::from_positions(second.span.start, second.span.start))
+}
+
+fn is_unary_test_operator(text: &str) -> bool {
+    matches!(
+        text,
+        "-n"
+            | "-z"
+            | "-b"
+            | "-c"
+            | "-d"
+            | "-e"
+            | "-f"
+            | "-g"
+            | "-h"
+            | "-k"
+            | "-p"
+            | "-r"
+            | "-s"
+            | "-t"
+            | "-u"
+            | "-v"
+            | "-w"
+            | "-x"
+            | "-L"
+            | "-O"
+            | "-G"
+            | "-S"
+            | "-N"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_bracket_tests_with_a_glued_closing_bracket() {
+        let source = "\
+#!/bin/sh
+if [ -d /tmp]; then
+  :
+fi
+if [ \"$dir\" = /tmp]; then
+  :
+fi
+if [ -n \"$dir\"]; then
+  :
+fi
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::MissingBracketSpace));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .collect::<Vec<_>>(),
+            vec![(2, 9), (8, 9)]
+        );
+    }
+
+    #[test]
+    fn keeps_only_the_first_unary_match_per_line() {
+        let source = "\
+#!/bin/sh
+if [ ! -d \"$a\"] || [ ! -d \"$b\"]; then
+  :
+fi
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::MissingBracketSpace));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            (diagnostics[0].span.start.line, diagnostics[0].span.start.column),
+            (2, 11)
+        );
+    }
+
+    #[test]
+    fn ignores_well_spaced_or_differently_malformed_tests() {
+        let source = "\
+#!/bin/sh
+if [ -d /tmp ]; then
+  :
+fi
+if [ x = \"]\"; then
+  :
+fi
+echo /tmp]
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::MissingBracketSpace));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
@@ -71,29 +71,31 @@ fn unary_glued_test(args: &[&shuck_ast::Word], source: &str) -> Option<Span> {
 fn is_unary_test_operator(text: &str) -> bool {
     matches!(
         text,
-        "-n"
-            | "-z"
+        "-e" | "-a"
+            | "-f"
+            | "-d"
             | "-b"
             | "-c"
-            | "-d"
-            | "-e"
-            | "-f"
-            | "-g"
-            | "-h"
-            | "-k"
             | "-p"
-            | "-r"
-            | "-s"
-            | "-t"
+            | "-S"
+            | "-L"
+            | "-h"
+            | "-g"
+            | "-k"
             | "-u"
+            | "-G"
+            | "-O"
+            | "-N"
+            | "-r"
             | "-v"
             | "-w"
             | "-x"
-            | "-L"
-            | "-O"
-            | "-G"
-            | "-S"
-            | "-N"
+            | "-s"
+            | "-t"
+            | "-z"
+            | "-n"
+            | "-o"
+            | "-R"
     )
 }
 
@@ -115,6 +117,9 @@ fi
 if [ -n \"$dir\"]; then
   :
 fi
+if [ -a /tmp]; then
+  :
+fi
 ";
         let diagnostics =
             test_snippet(source, &LinterSettings::for_rule(Rule::MissingBracketSpace));
@@ -124,7 +129,7 @@ fi
                 .iter()
                 .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
                 .collect::<Vec<_>>(),
-            vec![(2, 9), (8, 9)]
+            vec![(2, 9), (8, 9), (11, 9)]
         );
     }
 
@@ -141,7 +146,10 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
-            (diagnostics[0].span.start.line, diagnostics[0].span.start.column),
+            (
+                diagnostics[0].span.start.line,
+                diagnostics[0].span.start.column
+            ),
             (2, 11)
         );
     }

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -73,6 +73,7 @@ pub mod loop_without_end;
 pub mod malformed_arithmetic_in_condition;
 pub mod mapfile_process_substitution;
 pub mod misquoted_heredoc_close;
+pub mod missing_bracket_space;
 pub mod missing_done_in_for_loop;
 pub mod missing_fi;
 pub mod missing_semicolon_before_brace;
@@ -169,6 +170,7 @@ mod tests {
     #[test_case(Rule::TruthyLiteralTest, Path::new("C020.sh"))]
     #[test_case(Rule::ConstantCaseSubject, Path::new("C021.sh"))]
     #[test_case(Rule::EmptyTest, Path::new("C022.sh"))]
+    #[test_case(Rule::MissingBracketSpace, Path::new("C030.sh"))]
     #[test_case(Rule::PositionalTenBraces, Path::new("C025.sh"))]
     #[test_case(Rule::MissingFi, Path::new("C035.sh"))]
     #[test_case(Rule::BrokenTestEnd, Path::new("C036.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C022_C022.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C022_C022.sh.snap
@@ -6,9 +6,3 @@ C022 test expression is empty
   |
 4 | [ ]
   |
-
-C022 test expression is empty
- --> <source>:5:1
-  |
-5 | test
-  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C030_C030.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C030_C030.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C030 this unary `[` test operator is missing its operand before the closing `]`
+ --> <source>:2:9
+  |
+2 | if [ -d /tmp]; then
+  |

--- a/docs/rules/C022.yaml
+++ b/docs/rules/C022.yaml
@@ -3,7 +3,7 @@ legacy_name: empty-test
 new_category: Correctness
 new_code: C022
 runtime_kind: ast
-shellcheck_code: SC1019
+shellcheck_code: SC2212
 shells:
   - sh
   - bash

--- a/docs/rules/C030.yaml
+++ b/docs/rules/C030.yaml
@@ -3,6 +3,7 @@ legacy_name: missing-bracket-space
 new_category: Correctness
 new_code: C030
 runtime_kind: ast
+shellcheck_code: SC1019
 shells:
   - sh
   - bash


### PR DESCRIPTION
## Summary
- implement C030 as a selectable correctness rule in the linter registry and checker
- add a focused rule implementation, fixture, and snapshot for glued closing brackets in unary `[` tests
- keep the ShellCheck ownership reassignment out of this PR so the follow-up mapping work can land separately

## Testing
- cargo test -p shuck-linter missing_bracket_space -- --nocapture
- cargo test -p shuck-linter rule_missingbracketspace_path_new_c030_sh_expects -- --nocapture
- cargo test -p shuck-linter resolves_legacy_shuck_aliases -- --nocapture