### PR TITLE
Fix C131 to match SC2090 behavior

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C131.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C131.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
 
-f() {
-  $cmd
-}
-
-f
+args='--name "hello world"'
+printf '%s\n' $args

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -761,6 +761,7 @@ pub struct WordFact<'a> {
     operand_class: Option<TestOperandClass>,
     static_text: Option<Box<str>>,
     has_literal_affixes: bool,
+    contains_shell_quoting_literals: bool,
     scalar_expansion_spans: Box<[Span]>,
     unquoted_scalar_expansion_spans: Box<[Span]>,
     array_expansion_spans: Box<[Span]>,
@@ -842,6 +843,10 @@ impl<'a> WordFact<'a> {
 
     pub fn has_literal_affixes(&self) -> bool {
         self.has_literal_affixes
+    }
+
+    pub fn contains_shell_quoting_literals(&self) -> bool {
+        self.contains_shell_quoting_literals
     }
 
     pub fn scalar_expansion_spans(&self) -> &[Span] {
@@ -8676,6 +8681,10 @@ impl<'a> WordFactCollector<'a> {
             key,
             static_text: static_word_text(word_ref, self.source).map(String::into_boxed_str),
             has_literal_affixes: word_has_literal_affixes(word_ref),
+            contains_shell_quoting_literals: word_contains_shell_quoting_literals(
+                word_ref,
+                self.source,
+            ),
             scalar_expansion_spans: span::scalar_expansion_part_spans(word_ref, self.source)
                 .into_boxed_slice(),
             unquoted_scalar_expansion_spans: span::unquoted_scalar_expansion_part_spans(
@@ -9395,6 +9404,55 @@ fn word_has_literal_affixes(word: &Word) -> bool {
             WordPart::Literal(_) | WordPart::SingleQuoted { .. } | WordPart::DoubleQuoted { .. }
         )
     })
+}
+
+fn word_contains_shell_quoting_literals(word: &Word, source: &str) -> bool {
+    word_parts_contain_shell_quoting_literals(&word.parts, source)
+}
+
+fn word_parts_contain_shell_quoting_literals(parts: &[WordPartNode], source: &str) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Literal(text) => {
+            text_contains_shell_quoting_literals(text.as_str(source, part.span))
+        }
+        WordPart::SingleQuoted { value, .. } => {
+            text_contains_shell_quoting_literals(value.slice(source))
+        }
+        WordPart::DoubleQuoted { parts, .. } => {
+            word_parts_contain_shell_quoting_literals(parts, source)
+        }
+        _ => false,
+    })
+}
+
+fn text_contains_shell_quoting_literals(text: &str) -> bool {
+    if text.contains(['"', '\'']) {
+        return true;
+    }
+
+    let chars = text.chars().collect::<Vec<_>>();
+    let mut index = 0usize;
+    while index < chars.len() {
+        if chars[index] != '\\' {
+            index += 1;
+            continue;
+        }
+
+        let mut end = index + 1;
+        while end < chars.len() && chars[end] == '\\' {
+            end += 1;
+        }
+        if chars
+            .get(end)
+            .is_some_and(|next| next.is_whitespace() || matches!(next, '"' | '\''))
+        {
+            return true;
+        }
+
+        index = end;
+    }
+
+    false
 }
 
 fn is_shell_variable_name(name: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C131_C131.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C131_C131.sh.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 157
+assertion_line: 284
 ---
-C131 variable expansion is being used as a command name inside a function
- --> <source>:4:3
+C131 unquoted expansion will not honor quotes or escapes stored in this variable
+ --> <source>:4:15
   |
-4 |   $cmd
+4 | printf '%s\n' $args
   |

--- a/crates/shuck-linter/src/rules/correctness/variable_as_command_name.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_as_command_name.rs
@@ -1,6 +1,9 @@
-use shuck_semantic::ScopeKind;
+use rustc_hash::FxHashSet;
+use shuck_ast::{Command, DeclOperand, Span};
+use shuck_semantic::{BindingId, BindingKind, Reference, ReferenceKind};
 
-use crate::{Checker, ExpansionContext, Rule, Violation, WordQuote};
+use crate::facts::CommandId;
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext};
 
 pub struct VariableAsCommandName;
 
@@ -10,44 +13,257 @@ impl Violation for VariableAsCommandName {
     }
 
     fn message(&self) -> String {
-        "variable expansion is being used as a command name inside a function".to_owned()
+        "unquoted expansion will not honor quotes or escapes stored in this variable".to_owned()
     }
 }
 
 pub fn variable_as_command_name(checker: &mut Checker) {
+    let references = checker.semantic().references();
+    let mut reference_indices = references
+        .iter()
+        .enumerate()
+        .filter(|(_, reference)| {
+            !matches!(
+                reference.kind,
+                ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
+            )
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    reference_indices.sort_unstable_by_key(|&index| references[index].span.start.offset);
+
+    let unsafe_bindings = unsafe_shell_quoting_bindings(checker, references, &reference_indices);
+    if unsafe_bindings.is_empty() {
+        return;
+    }
+
     let spans = checker
         .facts()
-        .expansion_word_facts(ExpansionContext::CommandName)
+        .word_facts()
+        .iter()
         .filter_map(|fact| {
-            let command = checker.facts().command(fact.command_id());
-            if !is_inside_function(checker, command) {
+            let context = fact.expansion_context()?;
+            if !matches_sc2090_context(context) {
                 return None;
             }
-            if fact.classification().quote != WordQuote::Unquoted {
-                return None;
-            }
-            if !fact.classification().has_scalar_expansion() {
-                return None;
-            }
-            if fact.has_literal_affixes() {
+            if context != ExpansionContext::CommandName && command_is_eval(checker, fact.command_id()) {
                 return None;
             }
 
-            fact.scalar_expansion_spans().first().copied()
+            Some(
+                fact.unquoted_scalar_expansion_spans()
+                    .iter()
+                    .copied()
+                    .filter(|span| {
+                        expansion_span_uses_unsafe_binding(
+                            *span,
+                            checker,
+                            references,
+                            &reference_indices,
+                            &unsafe_bindings,
+                        )
+                    }),
+            )
         })
+        .flatten()
         .collect::<Vec<_>>();
+    let mut spans = spans;
+    spans.extend(export_name_spans(checker, &unsafe_bindings));
 
     checker.report_all_dedup(spans, || VariableAsCommandName);
 }
 
-fn is_inside_function(checker: &Checker<'_>, fact: &crate::facts::CommandFact<'_>) -> bool {
-    let scope = checker.semantic().scope_at(fact.stmt().span.start.offset);
-    checker.semantic().ancestor_scopes(scope).any(|ancestor| {
-        matches!(
-            checker.semantic().scope_kind(ancestor),
-            ScopeKind::Function(_)
-        )
-    })
+fn unsafe_shell_quoting_bindings(
+    checker: &Checker<'_>,
+    references: &[Reference],
+    reference_indices: &[usize],
+) -> FxHashSet<BindingId> {
+    let scalar_bindings = checker
+        .semantic()
+        .bindings()
+        .iter()
+        .filter_map(|binding| {
+            let context = binding_assignment_context(binding.kind)?;
+            let word = checker.facts().scalar_binding_value(binding.span)?;
+            Some((binding.id, word.span, context))
+        })
+        .collect::<Vec<_>>();
+
+    let mut unsafe_bindings = scalar_bindings
+        .iter()
+        .filter_map(|(binding_id, word_span, context)| {
+            let fact = checker.facts().word_fact(*word_span, *context)?;
+            fact.contains_shell_quoting_literals().then_some(*binding_id)
+        })
+        .collect::<FxHashSet<_>>();
+
+    loop {
+        let mut changed = false;
+        for (binding_id, word_span, context) in &scalar_bindings {
+            if unsafe_bindings.contains(binding_id) {
+                continue;
+            }
+            let Some(fact) = checker.facts().word_fact(*word_span, *context) else {
+                continue;
+            };
+            if fact.scalar_expansion_spans().iter().copied().any(|span| {
+                plain_expansion_span_uses_unsafe_binding(
+                    span,
+                    checker,
+                    references,
+                    reference_indices,
+                    &unsafe_bindings,
+                )
+            }) {
+                unsafe_bindings.insert(*binding_id);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    unsafe_bindings
+}
+
+fn binding_assignment_context(kind: BindingKind) -> Option<WordFactContext> {
+    match kind {
+        BindingKind::Assignment | BindingKind::AppendAssignment => {
+            Some(WordFactContext::Expansion(ExpansionContext::AssignmentValue))
+        }
+        BindingKind::Declaration(_) => Some(WordFactContext::Expansion(
+            ExpansionContext::DeclarationAssignmentValue,
+        )),
+        BindingKind::ParameterDefaultAssignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::FunctionDefinition
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment
+        | BindingKind::Nameref
+        | BindingKind::Imported => None,
+    }
+}
+
+fn matches_sc2090_context(context: ExpansionContext) -> bool {
+    matches!(
+        context,
+        ExpansionContext::CommandName
+            | ExpansionContext::CommandArgument
+            | ExpansionContext::RedirectTarget(_)
+            | ExpansionContext::HereString
+    )
+}
+
+fn command_is_eval(checker: &Checker<'_>, command_id: CommandId) -> bool {
+    checker.facts().command(command_id).effective_or_literal_name() == Some("eval")
+}
+
+fn export_name_spans(checker: &Checker<'_>, unsafe_bindings: &FxHashSet<BindingId>) -> Vec<Span> {
+    checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|command| {
+            let Command::Decl(clause) = command.command() else {
+                return Vec::new();
+            };
+            if clause.variant.as_str() != "export" {
+                return Vec::new();
+            }
+
+            clause
+                .operands
+                .iter()
+                .filter_map(|operand| {
+                    let DeclOperand::Name(reference) = operand else {
+                        return None;
+                    };
+                    checker
+                        .semantic()
+                        .visible_binding(&reference.name, reference.span)
+                        .filter(|binding| unsafe_bindings.contains(&binding.id))
+                        .map(|_| reference.span)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn expansion_span_uses_unsafe_binding(
+    expansion_span: Span,
+    checker: &Checker<'_>,
+    references: &[Reference],
+    reference_indices: &[usize],
+    unsafe_bindings: &FxHashSet<BindingId>,
+) -> bool {
+    let first_reference = reference_indices
+        .partition_point(|&index| references[index].span.start.offset < expansion_span.start.offset);
+
+    for &index in &reference_indices[first_reference..] {
+        let reference = &references[index];
+        if reference.span.start.offset > expansion_span.end.offset {
+            break;
+        }
+        if !contains_span(expansion_span, reference.span) {
+            continue;
+        }
+        if checker
+            .semantic()
+            .resolved_binding(reference.id)
+            .is_some_and(|binding| unsafe_bindings.contains(&binding.id))
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn plain_expansion_span_uses_unsafe_binding(
+    expansion_span: Span,
+    checker: &Checker<'_>,
+    references: &[Reference],
+    reference_indices: &[usize],
+    unsafe_bindings: &FxHashSet<BindingId>,
+) -> bool {
+    let first_reference = reference_indices
+        .partition_point(|&index| references[index].span.start.offset < expansion_span.start.offset);
+
+    for &index in &reference_indices[first_reference..] {
+        let reference = &references[index];
+        if reference.span.start.offset > expansion_span.end.offset {
+            break;
+        }
+        if !contains_span(expansion_span, reference.span)
+            || !expansion_span_is_plain_reference(expansion_span, reference, checker.source())
+        {
+            continue;
+        }
+        if checker
+            .semantic()
+            .resolved_binding(reference.id)
+            .is_some_and(|binding| unsafe_bindings.contains(&binding.id))
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn expansion_span_is_plain_reference(expansion_span: Span, reference: &Reference, source: &str) -> bool {
+    let text = expansion_span.slice(source);
+    text == format!("${}", reference.name.as_str())
+        || text == format!("${{{}}}", reference.name.as_str())
+}
+
+fn contains_span(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
 
 #[cfg(test)]
@@ -56,13 +272,11 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_unquoted_variable_command_names_inside_functions() {
+    fn reports_unquoted_argument_uses_of_shell_encoded_values() {
         let source = "\
 #!/bin/sh
-f() {
-  $cmd hello
-}
-f
+args='--name \"hello world\"'
+printf '%s\n' $args
 ";
         let diagnostics = test_snippet(
             source,
@@ -70,19 +284,58 @@ f
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "$cmd");
+        assert_eq!(diagnostics[0].span.slice(source), "$args");
     }
 
     #[test]
-    fn ignores_quoted_variables_and_top_level_commands() {
+    fn reports_command_names_here_strings_and_composite_words() {
         let source = "\
-#!/bin/sh
-cmd=echo
-f() {
-  \"$cmd\" hello
-}
-$cmd world
-f
+#!/bin/bash
+cmd='printf \"hello world\"'
+args='--name \"hello world\"'
+$cmd
+printf '%s\n' foo${args}bar
+cat <<< $args
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::VariableAsCommandName),
+        );
+
+        let spans = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.span.slice(source).to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(spans, vec!["$cmd", "${args}", "$args"]);
+    }
+
+    #[test]
+    fn propagates_shell_encoded_values_through_intermediate_scalars() {
+        let source = "\
+#!/bin/bash
+toolchain=\"--llvm-targets-to-build='X86;ARM;AArch64'\"
+build_flags=\"$toolchain --install-prefix=/tmp\"
+printf '%s\n' $build_flags
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::VariableAsCommandName),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "$build_flags");
+    }
+
+    #[test]
+    fn ignores_safe_quoted_and_eval_uses() {
+        let source = "\
+#!/bin/bash
+cmd=printf
+args='--name \"hello world\"'
+$cmd '%s\n' ok
+printf '%s\n' \"$args\"
+cat <<< \"$args\"
+eval printf '%s\n' $args
 ";
         let diagnostics = test_snippet(
             source,
@@ -93,13 +346,28 @@ f
     }
 
     #[test]
-    fn ignores_command_substitutions_without_variable_expansions() {
+    fn reports_exporting_shell_encoded_values() {
         let source = "\
 #!/bin/sh
-f() {
-  $(printf echo) hello
-}
-f
+args='--name \"hello world\"'
+export args
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::VariableAsCommandName),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "args");
+    }
+
+    #[test]
+    fn does_not_propagate_through_substring_transformations() {
+        let source = "\
+#!/bin/bash
+style=\"\\`'\"
+quote=\"${style:1:1}\"\n\
+export quote
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/variable_as_command_name.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_as_command_name.rs
@@ -46,7 +46,9 @@ pub fn variable_as_command_name(checker: &mut Checker) {
             if !matches_sc2090_context(context) {
                 return None;
             }
-            if context != ExpansionContext::CommandName && command_is_eval(checker, fact.command_id()) {
+            if context != ExpansionContext::CommandName
+                && command_is_eval(checker, fact.command_id())
+            {
                 return None;
             }
 
@@ -93,7 +95,8 @@ fn unsafe_shell_quoting_bindings(
         .iter()
         .filter_map(|(binding_id, word_span, context)| {
             let fact = checker.facts().word_fact(*word_span, *context)?;
-            fact.contains_shell_quoting_literals().then_some(*binding_id)
+            fact.contains_shell_quoting_literals()
+                .then_some(*binding_id)
         })
         .collect::<FxHashSet<_>>();
 
@@ -129,9 +132,9 @@ fn unsafe_shell_quoting_bindings(
 
 fn binding_assignment_context(kind: BindingKind) -> Option<WordFactContext> {
     match kind {
-        BindingKind::Assignment | BindingKind::AppendAssignment => {
-            Some(WordFactContext::Expansion(ExpansionContext::AssignmentValue))
-        }
+        BindingKind::Assignment | BindingKind::AppendAssignment => Some(
+            WordFactContext::Expansion(ExpansionContext::AssignmentValue),
+        ),
         BindingKind::Declaration(_) => Some(WordFactContext::Expansion(
             ExpansionContext::DeclarationAssignmentValue,
         )),
@@ -160,7 +163,11 @@ fn matches_sc2090_context(context: ExpansionContext) -> bool {
 }
 
 fn command_is_eval(checker: &Checker<'_>, command_id: CommandId) -> bool {
-    checker.facts().command(command_id).effective_or_literal_name() == Some("eval")
+    checker
+        .facts()
+        .command(command_id)
+        .effective_or_literal_name()
+        == Some("eval")
 }
 
 fn export_name_spans(checker: &Checker<'_>, unsafe_bindings: &FxHashSet<BindingId>) -> Vec<Span> {
@@ -201,8 +208,9 @@ fn expansion_span_uses_unsafe_binding(
     reference_indices: &[usize],
     unsafe_bindings: &FxHashSet<BindingId>,
 ) -> bool {
-    let first_reference = reference_indices
-        .partition_point(|&index| references[index].span.start.offset < expansion_span.start.offset);
+    let first_reference = reference_indices.partition_point(|&index| {
+        references[index].span.start.offset < expansion_span.start.offset
+    });
 
     for &index in &reference_indices[first_reference..] {
         let reference = &references[index];
@@ -231,8 +239,9 @@ fn plain_expansion_span_uses_unsafe_binding(
     reference_indices: &[usize],
     unsafe_bindings: &FxHashSet<BindingId>,
 ) -> bool {
-    let first_reference = reference_indices
-        .partition_point(|&index| references[index].span.start.offset < expansion_span.start.offset);
+    let first_reference = reference_indices.partition_point(|&index| {
+        references[index].span.start.offset < expansion_span.start.offset
+    });
 
     for &index in &reference_indices[first_reference..] {
         let reference = &references[index];
@@ -256,7 +265,11 @@ fn plain_expansion_span_uses_unsafe_binding(
     false
 }
 
-fn expansion_span_is_plain_reference(expansion_span: Span, reference: &Reference, source: &str) -> bool {
+fn expansion_span_is_plain_reference(
+    expansion_span: Span,
+    reference: &Reference,
+    source: &str,
+) -> bool {
     let text = expansion_span.slice(source);
     text == format!("${}", reference.name.as_str())
         || text == format!("${{{}}}", reference.name.as_str())

--- a/docs/rules/C131.yaml
+++ b/docs/rules/C131.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: An unquoted variable is used as a command name in a function.
-rationale: Quote the variable or validate its content before execution.
+description: An unquoted expansion reuses a variable that stores shell-style quoting or escapes.
+rationale: Build argv with arrays, `set --`, or helper functions instead of storing quoting syntax in a scalar.
 source:
   shell_checks_rule: rules/SH-308.yaml
   shell_checks_example: examples/308.sh
@@ -19,9 +19,5 @@ examples:
     source: shell-checks/examples/308.sh
     code: |
       #!/bin/sh
-      # shellcheck disable=2154,3024,2086,2034,2089
-      myfunc() {
-      	CFLAGS+=" -DDIR=\"$PREFIX/share/\""
-      	$CC $CFLAGS -c test.c -o test.o
-      }
-      myfunc
+      args='--name "hello world"'
+      printf '%s\n' $args


### PR DESCRIPTION
## Summary
- update C131 to model unsafe shell-style quoting text instead of the old dynamic-command-name interpretation
- propagate that state through simple scalar composition, skip `eval` argument sites, and cover `export name` when the binding already carries unsafe shell text
- refresh the C131 docs, fixture, and snapshot for the corrected behavior

## Testing
- cargo test -p shuck-linter variable_as_command_name
- cargo test -p shuck-linter rules::correctness::tests::rules
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C131
