### PR TITLE
Handle S001 loop bindings from parameter slices

### DIFF
--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -231,7 +231,10 @@ impl<'a> SafeValueIndex<'a> {
             self.word_is_safe(word, query)
         } else if let Some(words) = self.loop_bindings.get(&binding_key) {
             let words = words.to_vec();
-            !words.is_empty() && words.into_iter().all(|word| self.word_is_safe(word, query))
+            !words.is_empty()
+                && words.into_iter().all(|word| {
+                    !word_contains_special_parameter_slice(word) && self.word_is_safe(word, query)
+                })
         } else {
             false
         };
@@ -543,6 +546,37 @@ fn safe_numeric_shell_variable(name: &Name) -> bool {
     matches!(name.as_str(), "PPID")
 }
 
+fn word_contains_special_parameter_slice(word: &Word) -> bool {
+    word.parts.iter().any(|part| {
+        part_contains_special_parameter_slice(&part.kind)
+            && !matches!(part.kind, WordPart::DoubleQuoted { .. })
+    })
+}
+
+fn part_contains_special_parameter_slice(part: &WordPart) -> bool {
+    match part {
+        WordPart::DoubleQuoted { parts, .. } => parts
+            .iter()
+            .any(|part| part_contains_special_parameter_slice(&part.kind)),
+        WordPart::Substring { reference, .. } => special_parameter_slice_reference(reference),
+        WordPart::Parameter(parameter) => parameter_contains_special_parameter_slice(parameter),
+        _ => false,
+    }
+}
+
+fn parameter_contains_special_parameter_slice(parameter: &ParameterExpansion) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Slice { reference, .. }) => {
+            special_parameter_slice_reference(reference)
+        }
+        ParameterExpansionSyntax::Bourne(_) | ParameterExpansionSyntax::Zsh(_) => false,
+    }
+}
+
+fn special_parameter_slice_reference(reference: &VarRef) -> bool {
+    matches!(reference.name.as_str(), "@" | "*")
+}
+
 #[cfg(test)]
 mod tests {
     use shuck_ast::Command;
@@ -735,6 +769,64 @@ printf '%s\\n' $PPID
         };
 
         assert!(!safe_values.word_is_safe(&command.args[1], SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn loop_bindings_derived_from_at_slices_stay_unsafe() {
+        let source = "\
+#!/bin/bash
+f() {
+  for v in ${@:2}; do
+    del $v
+  done
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$v"
+            })
+            .expect("expected loop-body command argument");
+
+        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn direct_at_slices_do_not_become_safe_value_failures() {
+        let source = "\
+#!/bin/bash
+f() {
+  dns_set ${@:2}
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${@:2}"
+            })
+            .expect("expected direct slice command argument");
+
+        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -558,6 +558,40 @@ done
     }
 
     #[test]
+    fn reports_loop_variables_derived_from_at_slices() {
+        let source = "\
+#!/bin/bash
+f() {
+  for v in ${@:2}; do
+    del $v
+  done
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$v"]
+        );
+    }
+
+    #[test]
+    fn skips_direct_at_slices_that_belong_to_array_split_handling() {
+        let source = "\
+#!/bin/bash
+f() {
+  dns_set ${@:2}
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_bindings_derived_from_arithmetic_values() {
         let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- stop `S001` loop-binding safe-value inference from treating special-parameter slices like `${@:2}` as scalar-safe inputs
- keep direct `${@:2}` command arguments out of `S001`, since those belong to the array-splitting family instead
- add focused coverage for both the loop-derived `$v` report and the direct `${@:2}` non-report

## Root cause
Loop binding safety reused the source word safety check without accounting for special-parameter slices. That let `for v in ${@:2}; do del $v; done` inherit a false safe classification and miss the unquoted `$v` diagnostic.

## Impact
This narrows one real `S001` shellcheck-only gap without expanding `S001` onto direct `${@:2}` call sites.

## Validation
- `cargo test -p shuck-linter at_slices -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001`
  - the targeted corpus still fails on the existing `S001` baseline (`768` blocking diffs), but the prior `shellcheck-only` miss at `233boy__v2ray__src__core.sh:1817` dropped out and the rerun did not keep the temporary direct `${@:2}` false positives