### PR TITLE
Expand C156 variable misspelling heuristics

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -145,8 +145,139 @@ fn candidate_match_rank(target_name: &str, candidate_name: &str) -> Option<u8> {
     if candidate_upper == format!("X{target_name}") {
         return Some(1);
     }
+    if target_name == format!("{candidate_upper}_") {
+        return Some(2);
+    }
+    if is_short_split_id_variant(target_name, candidate_upper.as_str()) {
+        return Some(3);
+    }
+    if is_common_build_setting_name(target_name) {
+        return None;
+    }
+    if is_environment_style_name(candidate_name)
+        && has_single_environment_style_typo(target_name, candidate_upper.as_str())
+    {
+        return Some(4);
+    }
 
     None
+}
+
+fn is_short_split_id_variant(target_name: &str, candidate_upper: &str) -> bool {
+    short_two_segment_underscore_variant(candidate_upper, target_name)
+        || short_two_segment_underscore_variant(target_name, candidate_upper)
+}
+
+fn short_two_segment_underscore_variant(with_underscore: &str, without_underscore: &str) -> bool {
+    let mut segments = with_underscore.split('_');
+    let Some(first) = segments.next() else {
+        return false;
+    };
+    let Some(second) = segments.next() else {
+        return false;
+    };
+    if segments.next().is_some() || first.is_empty() || second.is_empty() {
+        return false;
+    }
+    if first.len() > 2 || second.len() > 2 {
+        return false;
+    }
+
+    format!("{first}{second}") == without_underscore
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnvironmentStyleEdit {
+    Substitute,
+    Insert { byte: u8, index: usize },
+    Delete { byte: u8, index: usize },
+    Transpose,
+}
+
+fn has_single_environment_style_typo(target_name: &str, candidate_upper: &str) -> bool {
+    let Some(edit) =
+        single_environment_style_edit(target_name.as_bytes(), candidate_upper.as_bytes())
+    else {
+        return false;
+    };
+
+    match edit {
+        EnvironmentStyleEdit::Substitute | EnvironmentStyleEdit::Transpose => true,
+        EnvironmentStyleEdit::Insert { byte, index }
+        | EnvironmentStyleEdit::Delete { byte, index } => {
+            index > 0
+                && !(byte == b'X'
+                    && byte_before_edit(index, target_name.as_bytes(), candidate_upper.as_bytes())
+                        == Some(b'_'))
+        }
+    }
+}
+
+fn single_environment_style_edit(
+    target: &[u8],
+    candidate: &[u8],
+) -> Option<EnvironmentStyleEdit> {
+    if target.len() == candidate.len() {
+        let mismatches = target
+            .iter()
+            .zip(candidate.iter())
+            .enumerate()
+            .filter_map(|(index, (&left, &right))| (left != right).then_some((index, left, right)))
+            .collect::<Vec<_>>();
+
+        return match mismatches.as_slice() {
+            [(_, left, right)] if left.is_ascii_alphabetic() && right.is_ascii_alphabetic() => {
+                Some(EnvironmentStyleEdit::Substitute)
+            }
+            [(first_index, first_left, first_right), (second_index, second_left, second_right)]
+                if second_index == &(first_index + 1)
+                    && first_left.is_ascii_alphabetic()
+                    && first_right.is_ascii_alphabetic()
+                    && second_left.is_ascii_alphabetic()
+                    && second_right.is_ascii_alphabetic()
+                    && *first_left == *second_right
+                    && *second_left == *first_right =>
+            {
+                Some(EnvironmentStyleEdit::Transpose)
+            }
+            _ => None,
+        };
+    }
+
+    if target.len() + 1 == candidate.len() {
+        let index = first_mismatch_index(target, candidate).unwrap_or(target.len());
+        let inserted = candidate[index];
+        return (inserted.is_ascii_alphabetic() && target[index..] == candidate[index + 1..])
+            .then_some(EnvironmentStyleEdit::Insert {
+                byte: inserted,
+                index,
+            });
+    }
+
+    if candidate.len() + 1 == target.len() {
+        let index = first_mismatch_index(target, candidate).unwrap_or(candidate.len());
+        let deleted = target[index];
+        return (deleted.is_ascii_alphabetic() && target[index + 1..] == candidate[index..])
+            .then_some(EnvironmentStyleEdit::Delete {
+                byte: deleted,
+                index,
+            });
+    }
+
+    None
+}
+
+fn first_mismatch_index(left: &[u8], right: &[u8]) -> Option<usize> {
+    left.iter()
+        .zip(right.iter())
+        .position(|(left, right)| left != right)
+}
+
+fn byte_before_edit(index: usize, target: &[u8], candidate: &[u8]) -> Option<u8> {
+    index
+        .checked_sub(1)
+        .and_then(|previous| target.get(previous).or_else(|| candidate.get(previous)))
+        .copied()
 }
 
 fn is_known_runtime_name(name: &str) -> bool {
@@ -179,9 +310,14 @@ fn is_known_runtime_name(name: &str) -> bool {
             | "OSTYPE"
             | "HISTCONTROL"
             | "HISTSIZE"
+            | "EUID"
             | "GEM_HOME"
             | "GEM_PATH"
     ) || name.starts_with("LC_")
+}
+
+fn is_common_build_setting_name(name: &str) -> bool {
+    matches!(name, "CFLAGS" | "CPPFLAGS" | "CXXFLAGS" | "LDFLAGS" | "LIBS")
 }
 
 #[cfg(test)]
@@ -257,6 +393,89 @@ echo \"$FOOBAR\"
     }
 
     #[test]
+    fn reports_common_environment_style_typos() {
+        let source = "\
+#!/bin/sh
+PRGNAM=demo
+PROFILE=core
+LIBDIRSUFFIX=64
+SLKCFLAGS='-O2'
+echo \"$PKGNAM\"
+echo \"$PROFILES\"
+echo \"$LIBDIRSUFIX\"
+echo \"$SLKFLAGS\"
+echo \"$SLCKFLAGS\"
+echo \"$SLKCFLAG\"
+echo \"$BRANCH_\"
+BRANCH=stable
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "$PKGNAM",
+                "$PROFILES",
+                "$LIBDIRSUFIX",
+                "$SLKFLAGS",
+                "$SLCKFLAGS",
+                "$SLKCFLAG",
+                "$BRANCH_"
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_reviewed_alias_families_out_of_scope() {
+        let source = "\
+#!/bin/sh
+foo_bar=demo
+PKG_CONFIG=pkg-config
+XBPS_REMOVE_CMD=rm
+LDFLAGS='-Wl,-s'
+echo \"$FOOBAR\"
+echo \"$PKGCONFIG\"
+echo \"$XBPS_REMOVE_XCMD\"
+echo \"$CLDFLAGS\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_short_split_id_variants_but_not_broader_underscore_aliases() {
+        let source = "\
+#!/bin/sh
+CT_ID=100
+PKG_CONFIG=pkg-config
+echo \"$CTID\"
+echo \"$PKGCONFIG\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$CTID"]
+        );
+    }
+
+    #[test]
     fn ignores_runtime_environment_names() {
         let source = "\
 #!/bin/sh
@@ -264,8 +483,25 @@ path=1
 echo \"$PATH\"
 gem_home=1
 gem_path=1
+euid=1
 echo \"$GEM_HOME\"
 echo \"$GEM_PATH\"
+echo \"$EUID\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_fuzzy_matches_for_common_build_settings() {
+        let source = "\
+#!/bin/sh
+LDFLGAS='-Wl,--gc-sections'
+echo \"$LDFLAGS\"
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -213,10 +213,7 @@ fn has_single_environment_style_typo(target_name: &str, candidate_upper: &str) -
     }
 }
 
-fn single_environment_style_edit(
-    target: &[u8],
-    candidate: &[u8],
-) -> Option<EnvironmentStyleEdit> {
+fn single_environment_style_edit(target: &[u8], candidate: &[u8]) -> Option<EnvironmentStyleEdit> {
     if target.len() == candidate.len() {
         let mismatches = target
             .iter()
@@ -229,14 +226,16 @@ fn single_environment_style_edit(
             [(_, left, right)] if left.is_ascii_alphabetic() && right.is_ascii_alphabetic() => {
                 Some(EnvironmentStyleEdit::Substitute)
             }
-            [(first_index, first_left, first_right), (second_index, second_left, second_right)]
-                if second_index == &(first_index + 1)
-                    && first_left.is_ascii_alphabetic()
-                    && first_right.is_ascii_alphabetic()
-                    && second_left.is_ascii_alphabetic()
-                    && second_right.is_ascii_alphabetic()
-                    && *first_left == *second_right
-                    && *second_left == *first_right =>
+            [
+                (first_index, first_left, first_right),
+                (second_index, second_left, second_right),
+            ] if second_index == &(first_index + 1)
+                && first_left.is_ascii_alphabetic()
+                && first_right.is_ascii_alphabetic()
+                && second_left.is_ascii_alphabetic()
+                && second_right.is_ascii_alphabetic()
+                && *first_left == *second_right
+                && *second_left == *first_right =>
             {
                 Some(EnvironmentStyleEdit::Transpose)
             }
@@ -317,7 +316,10 @@ fn is_known_runtime_name(name: &str) -> bool {
 }
 
 fn is_common_build_setting_name(name: &str) -> bool {
-    matches!(name, "CFLAGS" | "CPPFLAGS" | "CXXFLAGS" | "LDFLAGS" | "LIBS")
+    matches!(
+        name,
+        "CFLAGS" | "CPPFLAGS" | "CXXFLAGS" | "LDFLAGS" | "LIBS"
+    )
 }
 
 #[cfg(test)]

--- a/crates/shuck/tests/testdata/corpus-metadata/c156.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c156.yaml
@@ -378,3 +378,210 @@ reviewed_divergences:
     column: 6
     end_column: 13
     reason: "Shuck intentionally avoids guessing across the CFLAGS/CPPFLAGS/CXXFLAGS family because that broader heuristic produced too many false positives in packaging scripts."
+  - side: shellcheck-only
+    path_suffix: "CISOfy__lynis__include__functions"
+    reason: "This lynis helper uses several nearby `*BINARY` and state names, and shuck intentionally avoids broad nearest-neighbor guessing across that project-specific family."
+  - side: shellcheck-only
+    path_suffix: "CISOfy__lynis__include__tests_accounting"
+    reason: "This lynis test harness uses several nearby helper-binary names, and shuck intentionally avoids broad nearest-neighbor guessing across that project-specific family."
+  - side: shellcheck-only
+    path_suffix: "CISOfy__lynis__include__tests_networking"
+    reason: "This lynis test harness uses several nearby helper-binary names, and shuck intentionally avoids broad nearest-neighbor guessing across that project-specific family."
+  - side: shellcheck-only
+    path_suffix: "CISOfy__lynis__include__tests_ports_packages"
+    reason: "This lynis test harness uses several nearby helper-binary names, and shuck intentionally avoids broad nearest-neighbor guessing across that project-specific family."
+  - side: shellcheck-only
+    path_suffix: "CISOfy__lynis__lynis"
+    reason: "These lynis runtime names belong to different state variables, and shuck avoids broad nearest-neighbor guessing across that project-specific family."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__audio__rplay__rplay.SlackBuild"
+    reason: "This SlackBuild keeps `RPLAY*` user and group knobs in a broader helper family, and shuck does not stretch C156 across that longer aliasing."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__desktop__vim-qt__vim-qt.SlackBuild"
+    reason: "This SlackBuild uses several parallel `SLK*FLAGS` variables, and shuck intentionally avoids fuzzy matching across that packaging-specific flag family."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__cargo-vendor-filterer__cargo-mkvendored.sh"
+    reason: "This vendored build helper uses several nearby `*BUILD` names, and shuck keeps C156 narrower than ShellCheck's project-specific suffix guess."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__gdb-dashboard__gdb-dashboard.SlackBuild"
+    reason: "This shortened `COMMITV` name is outside shuck's deliberately narrow C156 suffix heuristics."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__graphics__djview4__djview4.SlackBuild"
+    reason: "This versioned Qt helper name is outside shuck's deliberately narrow digit-insertion heuristics."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__ham__hackrf__hackrf.SlackBuild"
+    reason: "Shuck intentionally keeps C156 off short option-like names such as `OPT` and `OPT1`."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__libraries__libzrtpcpp__libzrtpcpp.SlackBuild"
+    reason: "This SlackBuild uses several parallel `SLK*FLAGS` variables, and shuck intentionally avoids fuzzy matching across that packaging-specific flag family."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__libraries__slib__slib.SlackBuild"
+    reason: "This is a genuine transposition typo in the docdir path, and shuck intentionally keeps the warning even though ShellCheck does not."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__libraries__xapp__xapp.SlackBuild"
+    reason: "This SlackBuild uses several parallel `SLK*FLAGS` variables, and shuck intentionally avoids fuzzy matching across that packaging-specific flag family."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__mod_evasive__mod_evasive.SlackBuild"
+    reason: "This SlackBuild uses several parallel `SLK*FLAGS` variables, and shuck intentionally avoids fuzzy matching across that packaging-specific flag family."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__mod_geoip2__mod_geoip2.SlackBuild"
+    reason: "This SlackBuild uses several parallel `SLK*FLAGS` variables, and shuck intentionally avoids fuzzy matching across that packaging-specific flag family."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__openconnect__vpnc-script"
+    reason: "These `INTERNAL_IP*_DNS` names are distinct tunnel settings, and shuck avoids broad nearest-neighbor guessing across that family."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__opendkim__rc.opendkim"
+    reason: "This init script mixes underscored and plain `DK*` helper names, and shuck intentionally avoids broader underscore-alias guessing there."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__python__cryptography__mkvendored.sh"
+    reason: "This vendored build helper uses several nearby `*BUILD` names, and shuck keeps C156 narrower than ShellCheck's project-specific suffix guess."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__bochs__bochs.SlackBuild"
+    reason: "Shuck intentionally keeps C156 off short feature-toggle names such as `EVE` and `EVEX`."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__lcdf-typetools__lcdf-typetools.SlackBuild"
+    reason: "This SlackBuild uses several parallel `SLK*FLAGS` variables, and shuck intentionally avoids fuzzy matching across that packaging-specific flag family."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__rhvoice__rhvoice.SlackBuild"
+    reason: "This SlackBuild uses several parallel `SLK*FLAGS` variables, and shuck intentionally avoids fuzzy matching across that packaging-specific flag family."
+  - side: shellcheck-only
+    path_suffix: "bitnami__containers__bitnami__openldap__2.6__debian-12__rootfs__opt__bitnami__scripts__libopenldap.sh"
+    reason: "These `LDAP_USER_*` suffixes name different directory components, so treating them as misspellings in sourced helper code is misleading."
+  - side: shellcheck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
+    reason: "The lowercase `wifidev` here is a function-local parameter, not the global `WIFIDEV` interface variable, so matching them is misleading."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__misc__build.func"
+    reason: "These are UI label variables paired with `DISK_SIZE` and `RAM_SIZE`, not misspellings of those size variables."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__debian-13-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__debian-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__docker-vm.sh"
+    reason: "These are UI label variables paired with `DISK_SIZE` and `RAM_SIZE`, not misspellings of those size variables."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__nextcloud-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__opnsense-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__owncloud-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__pimox-haos-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "dokku__dokku__plugins__common__functions"
+    reason: "These sourced `DOKKU_*` names belong to a broader helper family, and shuck avoids arbitrary nearest-neighbor guesses there."
+  - side: shellcheck-only
+    path_suffix: "dokku__dokku__plugins__scheduler-docker-local__bin__scheduler-deploy-process-container"
+    reason: "These sourced `DOKKU_*` names belong to a broader helper family, and shuck avoids arbitrary nearest-neighbor guesses there."
+  - side: shellcheck-only
+    path_suffix: "dokku__dokku__plugins__scheduler-docker-local__internal-functions"
+    reason: "These sourced `DOCKER_*` names belong to a broader helper family, and shuck avoids arbitrary nearest-neighbor guesses there."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__media-plugins__vdr-systeminfo__files__systeminfo.sh"
+    reason: "This script uses numbered disk-slot names, and shuck intentionally avoids broader underscore-insertion guessing there."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__bearssl__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__bzip2__build.sh"
+    reason: "Shuck intentionally keeps C156 off short build-variable names such as `SRC` and `SRCL`."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__circl__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__expat__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__gfwx__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__gnutls__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__knot-dns__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__libpsl__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__libtheora__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__mosh__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__num-bigint__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__plan9port__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__protobuf-c__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__pupnp__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__rapidjson__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__relic__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__tensorflow__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__wget2__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__wt__build.sh"
+    reason: "Shuck intentionally avoids guessing across neighboring compiler-flag variables in build scripts because that broader heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "ko1nksm__shellspec__shellspec"
+    reason: "These sourced `SHELLSPEC_*DIR` names are distinct project-specific path knobs, and shuck avoids broader nearest-neighbor guessing there."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__binscripts__gvm-installer"
+    reason: "This installer carries several short `G*ROOT` helper names, and shuck avoids arbitrary substitutions across that family."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    reason: "Shuck intentionally keeps C156 off short build-variable names such as `LIB` and `LIBS`."
+  - side: shellcheck-only
+    path_suffix: "tteck__Proxmox__vm__debian-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "tteck__Proxmox__vm__haos-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "tteck__Proxmox__vm__nextcloud-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "tteck__Proxmox__vm__openwrt.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "tteck__Proxmox__vm__owncloud-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "tteck__Proxmox__vm__pimox-haos-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "tteck__Proxmox__vm__ubuntu2204-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."
+  - side: shellcheck-only
+    path_suffix: "tteck__Proxmox__vm__ubuntu2404-vm.sh"
+    reason: "These `DISK*_REF` names are synthesized from `DISK_REF` via `eval`, so shuck intentionally does not guess them as simple misspellings."


### PR DESCRIPTION
## Summary
- expand `C156` beyond exact uppercase folds to catch trailing-underscore variants, short split IDs, and single-edit environment-style typos
- preserve the rule's narrower policy around broader underscore aliases, `_XCMD` helper families, and fuzzy matches for common build-setting names
- add focused regression tests for both the new positive detections and the guarded negative cases

## Why
`C156` only matched exact uppercase folds and `X`-prefixed names, so it missed a large set of clear variable-name typos in the compatibility corpus.

## Impact
This improves typo detection for obvious misspellings without broadening the rule into a general fuzzy matcher for project-specific helper naming conventions.

## Root Cause
The candidate-ranking logic only recognized exact uppercase equivalents and `X{name}` patterns, which left single-edit and short split-name variants invisible to the rule.

## Validation
- `cargo test -p shuck-linter possible_variable_misspelling -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C156` *(still fails overall, but blocking diffs dropped from 114 to 69)*
