### PR TITLE
Fix C039 large-corpus heuristics

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -18680,6 +18680,31 @@ say \"configure\" now
     }
 
     #[test]
+    fn open_double_quote_surface_facts_track_backslash_prefixed_literal_gap_fragments() {
+        let source = "\
+#!/bin/sh
+echo \"line one
+line two\"\\foo\"tail\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let open = facts
+                .open_double_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+            let close = facts
+                .suspect_closing_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+
+            assert_eq!(open, vec![(2, 6)]);
+            assert_eq!(close, vec![(3, 9)]);
+        });
+    }
+
+    #[test]
     fn open_double_quote_surface_facts_ignore_empty_prefix_multiline_quotes_with_literal_suffix() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -8935,6 +8935,7 @@ impl<'a> WordFactCollector<'a> {
                     static_word_text(&command.name, self.source).as_deref() == Some("trap");
                 let variable_set_operand =
                     surface::simple_command_variable_set_operand(command, self.source);
+                let mut saw_open_double_quote = false;
                 if surface_command_name.as_deref() == Some("unset") {
                     for word in &command.args {
                         self.surface.record_unset_array_target_word(word);
@@ -8945,14 +8946,19 @@ impl<'a> WordFactCollector<'a> {
                         .collect_split_suspect_closing_quote_fragment_in_words(&command.args);
                 }
                 for word in &command.args {
-                    let surface_word_context = if variable_set_operand
+                    let base_surface_word_context = if variable_set_operand
                         .is_some_and(|operand| std::ptr::eq(word, operand))
                     {
                         surface_context.variable_set_operand()
                     } else {
                         surface_context
                     };
-                    self.surface.collect_word(word, surface_word_context);
+                    let surface_word_context = if saw_open_double_quote {
+                        base_surface_word_context.without_open_double_quote_scan()
+                    } else {
+                        base_surface_word_context
+                    };
+                    saw_open_double_quote |= self.surface.collect_word(word, surface_word_context);
                     if !trap_command {
                         self.push_word(
                             word,
@@ -9036,7 +9042,9 @@ impl<'a> WordFactCollector<'a> {
                 let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
                 for operand in &command.operands {
                     match operand {
-                        DeclOperand::Flag(word) => self.surface.collect_word(word, surface_context),
+                        DeclOperand::Flag(word) => {
+                            self.surface.collect_word(word, surface_context);
+                        }
                         DeclOperand::Dynamic(word) => {
                             self.surface.collect_word(word, surface_context);
                             self.push_word(
@@ -18576,6 +18584,153 @@ if [[ \"$@\" =~ x ]]; then :; fi
                 .expect("expected pipeline tail");
             assert_eq!(tail.static_utility_name(), Some("kill"));
             assert!(tail.static_utility_name_is("kill"));
+        });
+    }
+
+    #[test]
+    fn open_double_quote_surface_facts_track_live_expansion_gaps() {
+        let source = "\
+#!/bin/bash
+echo \"#!/bin/bash
+
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\\$(dirname \"\\$0\")
+if [[ \"\\$@\" =~ (^| )-runs=[0-9]+($| ) ]]
+then
+  mem_settings='-Xmx1900m:-Xss900k'
+else
+  mem_settings='-Xmx2048m:-Xss1024k'
+fi
+
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\\$this_dir \\
+  \\$this_dir/jazzer_driver                        \\
+  --agent_path=\\$this_dir/jazzer_agent_deploy.jar \\
+  --cp=$RUNTIME_CLASSPATH                         \\
+  --target_class=$fuzzer_basename                 \\
+  --jvm_args=\"\\$mem_settings\"                     \\
+  \\$@\" > $OUT/$fuzzer_basename
+";
+
+        with_facts(source, None, |_, facts| {
+            let open = facts
+                .open_double_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+            let close = facts
+                .suspect_closing_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+
+            assert_eq!(open, vec![(6, 11)]);
+            assert_eq!(close, vec![(13, 17)]);
+        });
+    }
+
+    #[test]
+    fn open_double_quote_surface_facts_ignore_escaped_literal_gaps() {
+        let source = "\
+#!/bin/bash
+echo \"#!/bin/bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\\$(dirname \"\\$0\")
+mem_settings='-Xmx2048m:-Xss1024k'
+if [[ \"\\$@\" =~ (^| )-runs=[0-9]+($| ) ]]; then
+  mem_settings='-Xmx1900m:-Xss900k'
+fi
+LD_LIBRARY_PATH=\\\"\\$JVM_LD_LIBRARY_PATH\\\":\\$this_dir \\
+\\$this_dir/jazzer_driver --agent_path=\\$this_dir/jazzer_agent_deploy.jar \\
+--cp=$RUNTIME_CLASSPATH \\
+--target_class=$fuzzer_basename \\
+--jvm_args=\"\\$mem_settings\" \\
+\"\\$@\"\" > $OUT/$fuzzer_basename
+";
+
+        with_facts(source, None, |_, facts| {
+            assert!(facts.open_double_quote_fragments().is_empty());
+            assert!(facts.suspect_closing_quote_fragments().is_empty());
+        });
+    }
+
+    #[test]
+    fn open_double_quote_surface_facts_track_literal_gap_fragments() {
+        let source = "\
+#!/bin/sh
+echo \"help text
+say \"configure\" now
+\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let open = facts
+                .open_double_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+            let close = facts
+                .suspect_closing_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+
+            assert_eq!(open, vec![(2, 6)]);
+            assert_eq!(close, vec![(3, 5)]);
+        });
+    }
+
+    #[test]
+    fn open_double_quote_surface_facts_track_empty_prefix_multiline_fragments() {
+        let source = "\
+#!/bin/sh
+echo \"\"\"#!/usr/bin/env bash
+echo \"GEM_HOME FIRST: \\$GEM_HOME\"
+\"\"\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let open = facts
+                .open_double_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+            let close = facts
+                .suspect_closing_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+
+            assert_eq!(open, vec![(2, 8)]);
+            assert_eq!(close, vec![(3, 6)]);
+        });
+    }
+
+    #[test]
+    fn open_double_quote_surface_facts_report_only_first_fragment_per_word() {
+        let source = "\
+#!/bin/sh
+echo \"\"\"#!/usr/bin/env bash
+echo \"GEM_HOME FIRST: \\$GEM_HOME\"
+
+echo \"GEM_PATH: \\$GEM_PATH\"
+echo \"GEM_HOME: \\$GEM_HOME\"
+\"\"\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let open = facts
+                .open_double_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+            let close = facts
+                .suspect_closing_quote_fragments()
+                .iter()
+                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+                .collect::<Vec<_>>();
+
+            assert_eq!(open, vec![(2, 8)]);
+            assert_eq!(close, vec![(3, 6)]);
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -8954,7 +8954,7 @@ impl<'a> WordFactCollector<'a> {
                         surface_context
                     };
                     let surface_word_context = if saw_open_double_quote
-                        && !surface::word_has_leading_reopened_double_quote_window(
+                        && !surface::word_has_reopened_double_quote_window(
                             word,
                             self.source,
                             surface_command_name.as_deref(),

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -18706,6 +18706,20 @@ echo \"GEM_HOME FIRST: \\$GEM_HOME\"
     }
 
     #[test]
+    fn open_double_quote_surface_facts_ignore_valid_multiline_quotes_with_suffix_expansion() {
+        let source = "\
+#!/bin/sh
+echo \"line one
+line two\"$suffix
+";
+
+        with_facts(source, None, |_, facts| {
+            assert!(facts.open_double_quote_fragments().is_empty());
+            assert!(facts.suspect_closing_quote_fragments().is_empty());
+        });
+    }
+
+    #[test]
     fn open_double_quote_surface_facts_report_only_first_fragment_per_word() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -8953,7 +8953,12 @@ impl<'a> WordFactCollector<'a> {
                     } else {
                         surface_context
                     };
-                    let surface_word_context = if saw_open_double_quote {
+                    let surface_word_context = if saw_open_double_quote
+                        && !surface::word_has_leading_reopened_double_quote_window(
+                            word,
+                            self.source,
+                            surface_command_name.as_deref(),
+                        ) {
                         base_surface_word_context.without_open_double_quote_scan()
                     } else {
                         base_surface_word_context

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -18680,28 +18680,16 @@ say \"configure\" now
     }
 
     #[test]
-    fn open_double_quote_surface_facts_track_empty_prefix_multiline_fragments() {
+    fn open_double_quote_surface_facts_ignore_empty_prefix_multiline_quotes_with_literal_suffix() {
         let source = "\
 #!/bin/sh
-echo \"\"\"#!/usr/bin/env bash
-echo \"GEM_HOME FIRST: \\$GEM_HOME\"
-\"\"\"
+echo \"\"\"line one
+line two\"suffix
 ";
 
         with_facts(source, None, |_, facts| {
-            let open = facts
-                .open_double_quote_fragments()
-                .iter()
-                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
-                .collect::<Vec<_>>();
-            let close = facts
-                .suspect_closing_quote_fragments()
-                .iter()
-                .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
-                .collect::<Vec<_>>();
-
-            assert_eq!(open, vec![(2, 8)]);
-            assert_eq!(close, vec![(3, 6)]);
+            assert!(facts.open_double_quote_fragments().is_empty());
+            assert!(facts.suspect_closing_quote_fragments().is_empty());
         });
     }
 
@@ -18720,14 +18708,27 @@ line two\"$suffix
     }
 
     #[test]
+    fn open_double_quote_surface_facts_ignore_empty_prefix_multiline_quotes_with_suffix_expansion()
+    {
+        let source = "\
+#!/bin/sh
+echo \"\"\"line one
+line two\"$suffix
+";
+
+        with_facts(source, None, |_, facts| {
+            assert!(facts.open_double_quote_fragments().is_empty());
+            assert!(facts.suspect_closing_quote_fragments().is_empty());
+        });
+    }
+
+    #[test]
     fn open_double_quote_surface_facts_report_only_first_fragment_per_word() {
         let source = "\
 #!/bin/sh
-echo \"\"\"#!/usr/bin/env bash
-echo \"GEM_HOME FIRST: \\$GEM_HOME\"
-
-echo \"GEM_PATH: \\$GEM_PATH\"
-echo \"GEM_HOME: \\$GEM_HOME\"
+echo \"help text
+say \"configure\" now
+then \"install\" later
 \"\"\"
 ";
 
@@ -18743,8 +18744,8 @@ echo \"GEM_HOME: \\$GEM_HOME\"
                 .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
                 .collect::<Vec<_>>();
 
-            assert_eq!(open, vec![(2, 8)]);
-            assert_eq!(close, vec![(3, 6)]);
+            assert_eq!(open, vec![(2, 6)]);
+            assert_eq!(close, vec![(3, 5)]);
         });
     }
 

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1510,6 +1510,10 @@ fn literal_open_double_quote_gap_looks_suspicious(span: Span, source: &str) -> b
     true
 }
 
+fn empty_double_quoted_fragment(part: &WordPartNode, source: &str) -> bool {
+    matches!(part.kind, WordPart::DoubleQuoted { .. }) && part.span.slice(source) == "\"\""
+}
+
 fn is_nested_parameter_expansion(parameter: &shuck_ast::ParameterExpansion, source: &str) -> bool {
     matches!(&parameter.syntax, ParameterExpansionSyntax::Bourne(_))
         && contains_nested_parameter_marker(parameter.raw_body.slice(source).trim_start())

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1333,7 +1333,7 @@ fn suspect_double_quote_spans(
         .collect()
 }
 
-pub(super) fn word_has_leading_reopened_double_quote_window(
+pub(super) fn word_has_reopened_double_quote_window(
     word: &Word,
     source: &str,
     command_name: Option<&str>,
@@ -1350,7 +1350,7 @@ pub(super) fn word_has_leading_reopened_double_quote_window(
             current,
             middle,
             next,
-        ) && (index == 0 || (index == 1 && double_quoted_part_is_empty(&word.parts[0], source)))
+        )
     })
 }
 

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1313,25 +1313,15 @@ fn suspect_double_quote_spans(
             let [current, middle, next] = window else {
                 return None;
             };
-            let WordPart::DoubleQuoted { parts, .. } = &current.kind else {
-                return None;
-            };
-            if !matches!(next.kind, WordPart::DoubleQuoted { .. })
-                || !current.span.slice(source).contains('\n')
-                || double_quoted_parts_contain_live_scalar(parts)
-            {
-                return None;
-            }
-
-            let has_scalar_gap = middle_part_is_live_scalar_gap(middle);
-            let has_word_literal_gap = index == 0
-                && matches!(command_name, Some("echo" | "printf"))
-                && !double_quoted_parts_contain_command_like_substitution(parts)
-                && middle_part_is_word_like_literal_gap(middle, source);
-            let has_triple_quote_literal_gap = index > 0
-                && double_quoted_part_is_empty(&word.parts[index - 1], source)
-                && middle_part_is_word_like_literal_gap(middle, source);
-            if !has_scalar_gap && !has_word_literal_gap && !has_triple_quote_literal_gap {
+            if !suspicious_reopened_double_quote_window(
+                word,
+                source,
+                command_name,
+                index,
+                current,
+                middle,
+                next,
+            ) {
                 return None;
             }
 
@@ -1341,6 +1331,58 @@ fn suspect_double_quote_spans(
             ))
         })
         .collect()
+}
+
+pub(super) fn word_has_leading_reopened_double_quote_window(
+    word: &Word,
+    source: &str,
+    command_name: Option<&str>,
+) -> bool {
+    word.parts.windows(3).enumerate().any(|(index, window)| {
+        let [current, middle, next] = window else {
+            return false;
+        };
+        suspicious_reopened_double_quote_window(
+            word,
+            source,
+            command_name,
+            index,
+            current,
+            middle,
+            next,
+        ) && (index == 0 || (index == 1 && double_quoted_part_is_empty(&word.parts[0], source)))
+    })
+}
+
+fn suspicious_reopened_double_quote_window(
+    word: &Word,
+    source: &str,
+    command_name: Option<&str>,
+    index: usize,
+    current: &WordPartNode,
+    middle: &WordPartNode,
+    next: &WordPartNode,
+) -> bool {
+    let WordPart::DoubleQuoted { parts, .. } = &current.kind else {
+        return false;
+    };
+    if !matches!(next.kind, WordPart::DoubleQuoted { .. })
+        || !current.span.slice(source).contains('\n')
+        || double_quoted_parts_contain_live_scalar(parts)
+    {
+        return false;
+    }
+
+    let has_scalar_gap = middle_part_is_live_scalar_gap(middle);
+    let has_word_literal_gap = index == 0
+        && matches!(command_name, Some("echo" | "printf"))
+        && !double_quoted_parts_contain_command_like_substitution(parts)
+        && middle_part_is_word_like_literal_gap(middle, source);
+    let has_triple_quote_literal_gap = index > 0
+        && double_quoted_part_is_empty(&word.parts[index - 1], source)
+        && middle_part_is_word_like_literal_gap(middle, source);
+
+    has_scalar_gap || has_word_literal_gap || has_triple_quote_literal_gap
 }
 
 fn double_quoted_parts_contain_live_scalar(parts: &[WordPartNode]) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1503,11 +1503,29 @@ fn literal_open_double_quote_gap_looks_suspicious(span: Span, source: &str) -> b
         return false;
     }
 
-    if text.starts_with('\\') {
+    if escaped_dollar_literal_gap(text) {
         return false;
     }
 
     true
+}
+
+fn escaped_dollar_literal_gap(text: &str) -> bool {
+    let mut saw_escaped_dollar = false;
+    let mut chars = text.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            continue;
+        }
+
+        saw_escaped_dollar = true;
+        if chars.next() != Some('$') {
+            return false;
+        }
+    }
+
+    saw_escaped_dollar
 }
 
 fn is_nested_parameter_expansion(parameter: &shuck_ast::ParameterExpansion, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1510,10 +1510,6 @@ fn literal_open_double_quote_gap_looks_suspicious(span: Span, source: &str) -> b
     true
 }
 
-fn empty_double_quoted_fragment(part: &WordPartNode, source: &str) -> bool {
-    matches!(part.kind, WordPart::DoubleQuoted { .. }) && part.span.slice(source) == "\"\""
-}
-
 fn is_nested_parameter_expansion(parameter: &shuck_ast::ParameterExpansion, source: &str) -> bool {
     matches!(&parameter.syntax, ParameterExpansionSyntax::Bourne(_))
         && contains_nested_parameter_marker(parameter.raw_body.slice(source).trim_start())

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -60,7 +60,7 @@ impl<'a> SurfaceScanContext<'a> {
         }
     }
 
-    fn without_open_double_quote_scan(self) -> Self {
+    pub(super) fn without_open_double_quote_scan(self) -> Self {
         Self {
             collect_open_double_quotes: false,
             ..self
@@ -206,7 +206,8 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    pub(super) fn collect_word(&mut self, word: &Word, context: SurfaceScanContext<'_>) {
+    pub(super) fn collect_word(&mut self, word: &Word, context: SurfaceScanContext<'_>) -> bool {
+        let open_double_quote_count = self.facts.open_double_quotes.len();
         collect_unicode_smart_quote_spans_in_word_parts(
             &word.parts,
             self.source,
@@ -217,6 +218,7 @@ impl<'a> SurfaceFragmentSink<'a> {
             self.collect_open_double_quote_fragments(word, context.command_name);
         }
         self.collect_word_parts(&word.parts, context);
+        self.facts.open_double_quotes.len() > open_double_quote_count
     }
 
     pub(super) fn collect_heredoc_body(
@@ -647,7 +649,9 @@ impl<'a> SurfaceFragmentSink<'a> {
                     }
                     self.collect_patterns(patterns, context);
                 }
-                PatternPart::Word(word) => self.collect_word(word, context),
+                PatternPart::Word(word) => {
+                    self.collect_word(word, context);
+                }
                 PatternPart::CharClass(_) if context.collect_pattern_charclasses => {
                     self.facts.pattern_charclass_spans.push(span);
                     if context.nested_word_command {
@@ -705,7 +709,9 @@ impl<'a> SurfaceFragmentSink<'a> {
     ) {
         for redirect in redirects {
             match redirect.word_target() {
-                Some(word) => self.collect_word(word, context),
+                Some(word) => {
+                    self.collect_word(word, context);
+                }
                 None => {
                     let heredoc = redirect.heredoc().expect("expected heredoc redirect");
                     if heredoc.delimiter.expands_body {
@@ -1477,6 +1483,31 @@ fn closing_double_quote_span(span: Span, source: &str) -> Option<Span> {
     let quote_offset = text.rfind('"')?;
     let start = span.start.advanced_by(&text[..quote_offset]);
     Some(Span::from_positions(start, start))
+}
+
+fn open_double_quote_gap_looks_suspicious(part: &WordPartNode, source: &str) -> bool {
+    match &part.kind {
+        WordPart::Literal(_) => literal_open_double_quote_gap_looks_suspicious(part.span, source),
+        WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::DoubleQuoted { .. }
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ProcessSubstitution { .. } => false,
+        _ => true,
+    }
+}
+
+fn literal_open_double_quote_gap_looks_suspicious(span: Span, source: &str) -> bool {
+    let text = span.slice(source).trim();
+    if text.is_empty() {
+        return false;
+    }
+
+    if text.starts_with('\\') {
+        return false;
+    }
+
+    true
 }
 
 fn is_nested_parameter_expansion(parameter: &shuck_ast::ParameterExpansion, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -255,21 +255,21 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     pub(super) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
-        for span in words
-            .iter()
-            .flat_map(|word| split_suspect_closing_quote_spans(word, self.source))
-        {
-            if self
-                .facts
-                .suspect_closing_quotes
-                .iter()
-                .any(|fragment| fragment.span() == span)
-            {
-                continue;
+        for (index, word) in words.iter().enumerate() {
+            let has_later_words = index + 1 < words.len();
+            for span in split_suspect_closing_quote_spans(word, self.source, has_later_words) {
+                if self
+                    .facts
+                    .suspect_closing_quotes
+                    .iter()
+                    .any(|fragment| fragment.span() == span)
+                {
+                    continue;
+                }
+                self.facts
+                    .suspect_closing_quotes
+                    .push(SuspectClosingQuoteFragmentFact { span });
             }
-            self.facts
-                .suspect_closing_quotes
-                .push(SuspectClosingQuoteFragmentFact { span });
         }
     }
 
@@ -1415,7 +1415,8 @@ fn middle_part_is_word_like_literal_gap(part: &WordPartNode, source: &str) -> bo
     let WordPart::Literal(text) = &part.kind else {
         return false;
     };
-    split_quote_tail_is_suspicious(text.as_str(source, part.span))
+    let text = text.as_str(source, part.span);
+    split_quote_tail_is_suspicious(text) || backslash_prefixed_word_like_literal_gap(text)
 }
 
 fn double_quoted_part_is_empty(part: &WordPartNode, source: &str) -> bool {
@@ -1428,7 +1429,11 @@ fn double_quoted_part_is_empty(part: &WordPartNode, source: &str) -> bool {
     })
 }
 
-fn split_suspect_closing_quote_spans(word: &Word, source: &str) -> Vec<Span> {
+fn split_suspect_closing_quote_spans(
+    word: &Word,
+    source: &str,
+    has_later_words: bool,
+) -> Vec<Span> {
     word.parts
         .windows(2)
         .enumerate()
@@ -1453,7 +1458,9 @@ fn split_suspect_closing_quote_spans(word: &Word, source: &str) -> Vec<Span> {
 
             let span = closing_double_quote_span(current.span, source)?;
             if span.start.column == 1
-                || (index > 0 && double_quoted_part_is_empty(&word.parts[index - 1], source))
+                || (index > 0
+                    && double_quoted_part_is_empty(&word.parts[index - 1], source)
+                    && has_later_words)
             {
                 Some(span)
             } else {
@@ -1485,29 +1492,12 @@ fn closing_double_quote_span(span: Span, source: &str) -> Option<Span> {
     Some(Span::from_positions(start, start))
 }
 
-fn open_double_quote_gap_looks_suspicious(part: &WordPartNode, source: &str) -> bool {
-    match &part.kind {
-        WordPart::Literal(_) => literal_open_double_quote_gap_looks_suspicious(part.span, source),
-        WordPart::ZshQualifiedGlob(_)
-        | WordPart::SingleQuoted { .. }
-        | WordPart::DoubleQuoted { .. }
-        | WordPart::CommandSubstitution { .. }
-        | WordPart::ProcessSubstitution { .. } => false,
-        _ => true,
-    }
-}
-
-fn literal_open_double_quote_gap_looks_suspicious(span: Span, source: &str) -> bool {
-    let text = span.slice(source).trim();
-    if text.is_empty() {
+fn backslash_prefixed_word_like_literal_gap(text: &str) -> bool {
+    let text = text.trim();
+    let Some(stripped) = text.strip_prefix('\\') else {
         return false;
-    }
-
-    if escaped_dollar_literal_gap(text) {
-        return false;
-    }
-
-    true
+    };
+    !escaped_dollar_literal_gap(text) && split_quote_tail_is_suspicious(stripped)
 }
 
 fn escaped_dollar_literal_gap(text: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
+++ b/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
@@ -79,6 +79,23 @@ echo \"alpha
     }
 
     #[test]
+    fn reports_independent_reopened_quote_windows_across_multiple_arguments() {
+        let source = "\
+#!/bin/bash
+echo \"a
+\"$x\"b\" \"c
+\"$y\"d\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 6);
+        assert_eq!(diagnostics[1].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.start.column, 8);
+    }
+
+    #[test]
     fn ignores_multiline_triple_quote_script_builders() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
+++ b/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
@@ -96,6 +96,23 @@ echo \"a
     }
 
     #[test]
+    fn reports_independent_reopened_quote_windows_with_prefixed_later_arguments() {
+        let source = "\
+#!/bin/bash
+echo \"a
+\"$x\"b\" pre\"c
+\"$y\"d\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 6);
+        assert_eq!(diagnostics[1].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.start.column, 11);
+    }
+
+    #[test]
     fn ignores_multiline_triple_quote_script_builders() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck/tests/testdata/corpus-metadata/c039.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c039.yaml
@@ -19,3 +19,11 @@ reviewed_divergences:
     labels:
       - project-closure
     reason: "This Proxmox helper writes a systemd unit with a multiline `echo \"[Unit]...` block. The remaining C039 hit appears only on the project-closure copy, so it stays reviewed instead of broadening the rule."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__projects__ox-ruby__build.sh"
+    line: 37
+    reason: "This OSS-Fuzz wrapper uses an `echo \"\"\"...` block that collapses the shell into an ambiguous quote state. ShellCheck keeps SC1078 on the first empty-prefix opener, while Shuck now avoids that location to preserve valid multiline concatenations like `\"\"\"line...\"suffix`."
+  - side: shuck-only
+    path_suffix: "google__oss-fuzz__projects__ox-ruby__build.sh"
+    line: 50
+    reason: "After the same collapsed `echo \"\"\"...` wrapper, Shuck still surfaces a later C039 location inside the carried-over command body. That follow-on hit stays reviewed instead of restoring the unsafe empty-prefix fallback."

--- a/crates/shuck/tests/testdata/corpus-metadata/c039.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c039.yaml
@@ -1,0 +1,21 @@
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    labels:
+      - project-closure
+    reason: "This project-closure libtool configure copy still carries SC1078 on nested single-quoted export-script text. C039 stays scoped to reopened double-quoted fragments, so this generated single-quote string remains a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    labels:
+      - shell-collapse
+    reason: "This libtool wrapper is already shell-collapsed into a malformed quote state before the continued `$ECHO \"\\` block, so the remaining C039 hit is treated as a reviewed shell-collapse artifact."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__packages__luvit__build.sh"
+    labels:
+      - project-closure
+    reason: "This Termux recipe is compared through a project-closure path that sources `packages/lit/build.sh` inside a quoted URL fragment. Shuck still sees the reopened quote around that sourced command substitution, while the standalone file does not surface SC1078."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__install__heimdall-dashboard-install.sh"
+    labels:
+      - project-closure
+    reason: "This Proxmox helper writes a systemd unit with a multiline `echo \"[Unit]...` block. The remaining C039 hit appears only on the project-closure copy, so it stays reviewed instead of broadening the rule."


### PR DESCRIPTION
## Summary
- tighten the C039 surface-fragment heuristic so it keeps real reopened double-quote cases while skipping escaped placeholder gaps that showed up across large-corpus wrapper scripts
- stop cascading C039 detections across later arguments in the same malformed simple command
- add targeted fact-layer regressions for live-expansion gaps, escaped literal gaps, literal nested quotes, empty-prefix `"""` cases, and the one-report-per-command behavior
- record the remaining project-closure and shell-collapse corpus tail as reviewed C039 divergences instead of widening the rule into unrelated behavior

## Root Cause
The previous heuristic treated too many multiline double-quoted fragments as suspicious whenever another quoted fragment appeared later in the parsed word. That over-reported on generated wrapper scripts in the large corpus, especially when the gap was only escaped literal shell text such as `\$0`, `\$@`, or similar placeholders. Fixing the predicate at the fact layer let the rule stay architecture-compliant while matching the oracle much more closely.

## Testing
- `cargo fmt`
- `cargo test -p shuck-linter open_double_quote`
- `cargo test -p shuck-linter suspect_closing_quote`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C039`