### PR TITLE
Fix S028 multiline quote detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -8759,8 +8759,10 @@ impl<'a> WordFactCollector<'a> {
                         self.surface.record_unset_array_target_word(word);
                     }
                 }
-                self.surface
-                    .collect_split_suspect_closing_quote_fragment_in_words(&command.args);
+                if matches!(surface_command_name.as_deref(), Some("echo" | "printf")) {
+                    self.surface
+                        .collect_split_suspect_closing_quote_fragment_in_words(&command.args);
+                }
                 for word in &command.args {
                     let surface_word_context = if variable_set_operand
                         .is_some_and(|operand| std::ptr::eq(word, operand))

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -8759,6 +8759,8 @@ impl<'a> WordFactCollector<'a> {
                         self.surface.record_unset_array_target_word(word);
                     }
                 }
+                self.surface
+                    .collect_split_suspect_closing_quote_fragment_in_words(&command.args);
                 for word in &command.args {
                     let surface_word_context = if variable_set_operand
                         .is_some_and(|operand| std::ptr::eq(word, operand))

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -240,24 +240,22 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     fn collect_open_double_quote_fragments(&mut self, word: &Word, command_name: Option<&str>) {
-        let Some((opening_span, closing_span)) =
-            first_suspect_double_quote_spans(word, self.source, command_name)
-        else {
-            return;
-        };
-
-        self.facts
-            .open_double_quotes
-            .push(OpenDoubleQuoteFragmentFact { span: opening_span });
-        self.facts
-            .suspect_closing_quotes
-            .push(SuspectClosingQuoteFragmentFact { span: closing_span });
+        for (opening_span, closing_span) in
+            suspect_double_quote_spans(word, self.source, command_name)
+        {
+            self.facts
+                .open_double_quotes
+                .push(OpenDoubleQuoteFragmentFact { span: opening_span });
+            self.facts
+                .suspect_closing_quotes
+                .push(SuspectClosingQuoteFragmentFact { span: closing_span });
+        }
     }
 
     pub(super) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
         for span in words
             .iter()
-            .filter_map(|word| split_suspect_closing_quote_span(word, self.source))
+            .flat_map(|word| split_suspect_closing_quote_spans(word, self.source))
         {
             if self
                 .facts
@@ -1297,15 +1295,15 @@ fn is_shell_name(text: &str) -> bool {
         && chars.all(|char| char == '_' || char.is_ascii_alphanumeric())
 }
 
-fn first_suspect_double_quote_spans(
+fn suspect_double_quote_spans(
     word: &Word,
     source: &str,
     command_name: Option<&str>,
-) -> Option<(Span, Span)> {
+) -> Vec<(Span, Span)> {
     word.parts
         .windows(3)
         .enumerate()
-        .find_map(|(index, window)| {
+        .filter_map(|(index, window)| {
             let [current, middle, next] = window else {
                 return None;
             };
@@ -1326,7 +1324,7 @@ fn first_suspect_double_quote_spans(
                 && middle_part_is_word_like_literal_gap(middle, source);
             let has_triple_quote_literal_gap = index > 0
                 && double_quoted_part_is_empty(&word.parts[index - 1], source)
-                && middle_part_is_nonempty_literal_gap(middle, source);
+                && middle_part_is_word_like_literal_gap(middle, source);
             if !has_scalar_gap && !has_word_literal_gap && !has_triple_quote_literal_gap {
                 return None;
             }
@@ -1336,6 +1334,7 @@ fn first_suspect_double_quote_spans(
                 closing_double_quote_span(current.span, source)?,
             ))
         })
+        .collect()
 }
 
 fn double_quoted_parts_contain_live_scalar(parts: &[WordPartNode]) -> bool {
@@ -1406,13 +1405,6 @@ fn middle_part_is_live_scalar_gap(part: &WordPartNode) -> bool {
     )
 }
 
-fn middle_part_is_nonempty_literal_gap(part: &WordPartNode, source: &str) -> bool {
-    let WordPart::Literal(text) = &part.kind else {
-        return false;
-    };
-    !text.as_str(source, part.span).is_empty()
-}
-
 fn middle_part_is_word_like_literal_gap(part: &WordPartNode, source: &str) -> bool {
     let WordPart::Literal(text) = &part.kind else {
         return false;
@@ -1430,20 +1422,39 @@ fn double_quoted_part_is_empty(part: &WordPartNode, source: &str) -> bool {
     })
 }
 
-fn split_suspect_closing_quote_span(word: &Word, source: &str) -> Option<Span> {
-    let text = word.span.slice(source);
-    if !text.contains('\n') {
-        return None;
-    }
+fn split_suspect_closing_quote_spans(word: &Word, source: &str) -> Vec<Span> {
+    word.parts
+        .windows(2)
+        .enumerate()
+        .filter_map(|window| {
+            let (index, [current, next]) = window else {
+                return None;
+            };
+            let WordPart::DoubleQuoted { .. } = &current.kind else {
+                return None;
+            };
+            let WordPart::Literal(text) = &next.kind else {
+                return None;
+            };
+            if !current.span.slice(source).contains('\n') {
+                return None;
+            }
 
-    let quote_offset = text.rfind('"')?;
-    let tail = text.get(quote_offset + 1..)?;
-    if !split_quote_tail_is_suspicious(tail) {
-        return None;
-    }
+            let tail = text.as_str(source, next.span);
+            if !split_quote_tail_is_suspicious(tail) {
+                return None;
+            }
 
-    let start = word.span.start.advanced_by(&text[..quote_offset]);
-    Some(Span::from_positions(start, start))
+            let span = closing_double_quote_span(current.span, source)?;
+            if span.start.column == 1
+                || (index > 0 && double_quoted_part_is_empty(&word.parts[index - 1], source))
+            {
+                Some(span)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn split_quote_tail_is_suspicious(text: &str) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -186,6 +186,11 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     pub(super) fn collect_words(&mut self, words: &[Word], context: SurfaceScanContext<'_>) {
+        if context.assignment_target.is_none()
+            && matches!(context.command_name, Some("echo" | "printf"))
+        {
+            self.collect_split_suspect_closing_quote_fragment_in_words(words);
+        }
         for word in words {
             self.collect_word(word, context);
         }
@@ -209,7 +214,7 @@ impl<'a> SurfaceFragmentSink<'a> {
             &mut self.facts.unicode_smart_quote_spans,
         );
         if context.collect_open_double_quotes && context.assignment_target.is_none() {
-            self.collect_open_double_quote_fragments(word);
+            self.collect_open_double_quote_fragments(word, context.command_name);
         }
         self.collect_word_parts(&word.parts, context);
     }
@@ -234,44 +239,39 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    fn collect_open_double_quote_fragments(&mut self, word: &Word) {
-        for (index, part) in word.parts.iter().enumerate() {
-            let WordPart::DoubleQuoted { .. } = &part.kind else {
-                continue;
-            };
-            if !part.span.slice(self.source).contains('\n') {
-                continue;
-            }
-            let Some(next_double_quoted_index) = word.parts[index + 1..]
-                .iter()
-                .position(|later| matches!(later.kind, WordPart::DoubleQuoted { .. }))
-                .map(|relative_index| index + 1 + relative_index)
-            else {
-                continue;
-            };
-            if word.parts[index + 1..next_double_quoted_index]
-                .iter()
-                .any(|between| {
-                    matches!(
-                        between.kind,
-                        WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. }
-                    )
-                })
-            {
-                continue;
-            }
-            let Some(span) = opening_double_quote_span(part.span, self.source) else {
-                continue;
-            };
-            self.facts
-                .open_double_quotes
-                .push(OpenDoubleQuoteFragmentFact { span });
-            if let Some(span) = closing_double_quote_span(part.span, self.source) {
-                self.facts
-                    .suspect_closing_quotes
-                    .push(SuspectClosingQuoteFragmentFact { span });
-            }
+    fn collect_open_double_quote_fragments(&mut self, word: &Word, command_name: Option<&str>) {
+        let Some((opening_span, closing_span)) =
+            first_suspect_double_quote_spans(word, self.source, command_name)
+        else {
+            return;
+        };
+
+        self.facts
+            .open_double_quotes
+            .push(OpenDoubleQuoteFragmentFact { span: opening_span });
+        self.facts
+            .suspect_closing_quotes
+            .push(SuspectClosingQuoteFragmentFact { span: closing_span });
+    }
+
+    pub(super) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
+        let Some(span) = words
+            .iter()
+            .find_map(|word| split_suspect_closing_quote_span(word, self.source))
+        else {
+            return;
+        };
+        if self
+            .facts
+            .suspect_closing_quotes
+            .iter()
+            .any(|fragment| fragment.span() == span)
+        {
+            return;
         }
+        self.facts
+            .suspect_closing_quotes
+            .push(SuspectClosingQuoteFragmentFact { span });
     }
 
     fn collect_single_quoted_fragments_in_heredoc_body_parts(
@@ -1296,6 +1296,163 @@ fn is_shell_name(text: &str) -> bool {
     };
     (first == '_' || first.is_ascii_alphabetic())
         && chars.all(|char| char == '_' || char.is_ascii_alphanumeric())
+}
+
+fn first_suspect_double_quote_spans(
+    word: &Word,
+    source: &str,
+    command_name: Option<&str>,
+) -> Option<(Span, Span)> {
+    word.parts
+        .windows(3)
+        .enumerate()
+        .find_map(|(index, window)| {
+            let [current, middle, next] = window else {
+                return None;
+            };
+            let WordPart::DoubleQuoted { parts, .. } = &current.kind else {
+                return None;
+            };
+            if !matches!(next.kind, WordPart::DoubleQuoted { .. })
+                || !current.span.slice(source).contains('\n')
+                || double_quoted_parts_contain_live_scalar(parts)
+            {
+                return None;
+            }
+
+            let has_scalar_gap = middle_part_is_live_scalar_gap(middle);
+            let has_word_literal_gap = index == 0
+                && matches!(command_name, Some("echo" | "printf"))
+                && !double_quoted_parts_contain_command_like_substitution(parts)
+                && middle_part_is_word_like_literal_gap(middle, source);
+            let has_triple_quote_literal_gap = index > 0
+                && double_quoted_part_is_empty(&word.parts[index - 1], source)
+                && middle_part_is_nonempty_literal_gap(middle, source);
+            if !has_scalar_gap && !has_word_literal_gap && !has_triple_quote_literal_gap {
+                return None;
+            }
+
+            Some((
+                opening_double_quote_span(current.span, source)?,
+                closing_double_quote_span(current.span, source)?,
+            ))
+        })
+}
+
+fn double_quoted_parts_contain_live_scalar(parts: &[WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Literal(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::CommandSubstitution { .. } => false,
+        WordPart::DoubleQuoted { parts, .. } => double_quoted_parts_contain_live_scalar(parts),
+        WordPart::Variable(_)
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::Parameter(_)
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. }
+        | WordPart::ZshQualifiedGlob(_) => true,
+    })
+}
+
+fn double_quoted_parts_contain_command_like_substitution(parts: &[WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Literal(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::Parameter(_)
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::Transformation { .. }
+        | WordPart::ZshQualifiedGlob(_) => false,
+        WordPart::DoubleQuoted { parts, .. } => {
+            double_quoted_parts_contain_command_like_substitution(parts)
+        }
+        WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => true,
+    })
+}
+
+fn middle_part_is_live_scalar_gap(part: &WordPartNode) -> bool {
+    matches!(
+        part.kind,
+        WordPart::Variable(_)
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::Transformation { .. }
+    )
+}
+
+fn middle_part_is_nonempty_literal_gap(part: &WordPartNode, source: &str) -> bool {
+    let WordPart::Literal(text) = &part.kind else {
+        return false;
+    };
+    !text.as_str(source, part.span).is_empty()
+}
+
+fn middle_part_is_word_like_literal_gap(part: &WordPartNode, source: &str) -> bool {
+    let WordPart::Literal(text) = &part.kind else {
+        return false;
+    };
+    split_quote_tail_is_suspicious(text.as_str(source, part.span))
+}
+
+fn double_quoted_part_is_empty(part: &WordPartNode, source: &str) -> bool {
+    let WordPart::DoubleQuoted { parts, .. } = &part.kind else {
+        return false;
+    };
+    parts.iter().all(|inner| match &inner.kind {
+        WordPart::Literal(text) => text.as_str(source, inner.span).is_empty(),
+        _ => false,
+    })
+}
+
+fn split_suspect_closing_quote_span(word: &Word, source: &str) -> Option<Span> {
+    let text = word.span.slice(source);
+    if !text.contains('\n') {
+        return None;
+    }
+
+    let quote_offset = text.rfind('"')?;
+    let tail = text.get(quote_offset + 1..)?;
+    if !split_quote_tail_is_suspicious(tail) {
+        return None;
+    }
+
+    let start = word.span.start.advanced_by(&text[..quote_offset]);
+    Some(Span::from_positions(start, start))
+}
+
+fn split_quote_tail_is_suspicious(text: &str) -> bool {
+    let mut chars = text.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic()) && chars.all(|char| !char.is_whitespace())
 }
 
 fn opening_double_quote_span(span: Span, source: &str) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -255,23 +255,22 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     pub(super) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
-        let Some(span) = words
+        for span in words
             .iter()
-            .find_map(|word| split_suspect_closing_quote_span(word, self.source))
-        else {
-            return;
-        };
-        if self
-            .facts
-            .suspect_closing_quotes
-            .iter()
-            .any(|fragment| fragment.span() == span)
+            .filter_map(|word| split_suspect_closing_quote_span(word, self.source))
         {
-            return;
+            if self
+                .facts
+                .suspect_closing_quotes
+                .iter()
+                .any(|fragment| fragment.span() == span)
+            {
+                continue;
+            }
+            self.facts
+                .suspect_closing_quotes
+                .push(SuspectClosingQuoteFragmentFact { span });
         }
-        self.facts
-            .suspect_closing_quotes
-            .push(SuspectClosingQuoteFragmentFact { span });
     }
 
     fn collect_single_quoted_fragments_in_heredoc_body_parts(

--- a/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
+++ b/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
@@ -46,4 +46,18 @@ mod tests {
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_sc2140_style_multiline_quote_joins() {
+        let source = "\
+#!/bin/bash
+echo \"[Unit]
+Description=Heimdall
+ExecStart=\"/usr/bin/php\" artisan serve
+WantedBy=multi-user.target\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
+++ b/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
@@ -60,4 +60,35 @@ WantedBy=multi-user.target\"
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn reports_each_reopened_quote_window_in_a_single_word() {
+        let source = "\
+#!/bin/bash
+echo \"alpha
+\"$foo\"beta
+\"$bar\"gamma\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 6);
+        assert_eq!(diagnostics[1].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.start.column, 6);
+    }
+
+    #[test]
+    fn ignores_multiline_triple_quote_script_builders() {
+        let source = "\
+#!/bin/bash
+echo \"\"\"#!/usr/bin/env bash
+echo \"GEM_HOME FIRST: \\$GEM_HOME\"
+echo \"GEM_PATH: \\$GEM_PATH\"
+\"\"\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
+++ b/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
@@ -54,4 +54,24 @@ WantedBy=multi-user.target\"
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn reports_each_split_suspicious_closing_quote_in_echo_arguments() {
+        let source = "\
+#!/bin/bash
+echo \"alpha
+\"_beta \"gamma
+\"_delta
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
+        assert_eq!(diagnostics[1].span.start.line, 4);
+        assert_eq!(diagnostics[1].span.start.column, 1);
+        assert_eq!(diagnostics[1].span.start, diagnostics[1].span.end);
+    }
 }

--- a/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
+++ b/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
@@ -125,4 +125,17 @@ echo \"GEM_PATH: \\$GEM_PATH\"
         assert_eq!(diagnostics[0].span.start.column, 6);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
+
+    #[test]
+    fn ignores_split_closing_quote_shapes_outside_echo_and_printf() {
+        let source = "\
+#!/bin/bash
+cat \"alpha
+\"_beta
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
+++ b/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
@@ -20,7 +20,7 @@ pub fn suspect_closing_quote(checker: &mut Checker) {
         .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || SuspectClosingQuote);
+    checker.report_all_dedup(spans, || SuspectClosingQuote);
 }
 
 #[cfg(test)]
@@ -38,5 +38,20 @@ mod tests {
         assert_eq!(diagnostics[0].span.start.line, 3);
         assert_eq!(diagnostics[0].span.start.column, 7);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
+    }
+
+    #[test]
+    fn ignores_sc2140_style_multiline_quote_joins() {
+        let source = "\
+#!/bin/bash
+echo \"[Unit]
+Description=Heimdall
+ExecStart=\"/usr/bin/php\" artisan serve
+WantedBy=multi-user.target\"
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
+++ b/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
@@ -74,4 +74,55 @@ echo \"alpha
         assert_eq!(diagnostics[1].span.start.column, 1);
         assert_eq!(diagnostics[1].span.start, diagnostics[1].span.end);
     }
+
+    #[test]
+    fn ignores_literal_double_quotes_inside_multiline_single_quoted_words() {
+        let source = "\
+#!/bin/bash
+echo 'alpha
+\"_beta'
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_each_reopened_quote_window_in_a_single_word() {
+        let source = "\
+#!/bin/bash
+echo \"alpha
+\"$foo\"beta
+\"$bar\"gamma\"
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
+        assert_eq!(diagnostics[1].span.start.line, 4);
+        assert_eq!(diagnostics[1].span.start.column, 1);
+        assert_eq!(diagnostics[1].span.start, diagnostics[1].span.end);
+    }
+
+    #[test]
+    fn reports_only_the_leading_triple_quote_script_builder_closing_quote() {
+        let source = "\
+#!/bin/bash
+echo \"\"\"#!/usr/bin/env bash
+echo \"GEM_HOME FIRST: \\$GEM_HOME\"
+echo \"GEM_PATH: \\$GEM_PATH\"
+\"\"\"
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.column, 6);
+        assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
+    }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/s028.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s028.yaml
@@ -1,0 +1,26 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "dylanaraps__neofetch__neofetch"
+    line: 2965
+    column: 57
+    end_column: 57
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This project-closure music helper builds the awk program through nested command-substitution text, and the remaining S028 hit is confined to that helper-side string assembly."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 8965
+    column: 16
+    end_column: 16
+    labels:
+      - project-closure
+    reason: "This libtool configure fragment lives inside a project-closure helper assignment, and shuck does not currently model that helper string body as a closing-quote S028 site."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 8967
+    column: 13
+    end_column: 13
+    labels:
+      - project-closure
+    reason: "This libtool configure fragment lives inside a project-closure helper assignment, and shuck does not currently model that helper string body as a closing-quote S028 site."


### PR DESCRIPTION
## Summary
- tighten S028 surface-fact generation so multiline reopened quote fragments only report when they match the shell-like boundary patterns we actually want
- add split-word suspect closing-quote handling for `echo` and `printf` argument lists, and deduplicate reporting spans
- record the remaining reviewed project-closure divergences in corpus metadata

## Testing
- cargo fmt --all
- cargo test -p shuck-linter reports_suspicious_opening_double_quote -- --nocapture
- cargo test -p shuck-linter reports_suspicious_closing_quote -- --nocapture
- cargo test -p shuck-linter ignores_sc2140_style_multiline_quote_joins -- --nocapture
- cargo test -p shuck-linter builds_surface_fragment_facts_and_static_utility_names -- --nocapture
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S028
