### PR TITLE
Fix C150 conformance

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C150.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C150.sh
@@ -9,7 +9,7 @@ items=old
 (items=new)
 printf '%s\n' "$items"
 
-# Valid: pipeline-child updates belong to the pipeline-specific rule.
+# Invalid: pipeline-child updates stay in the child shell.
 count=0
 printf '%s\n' x | while read -r _; do count=1; done
 echo "$count"

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7054,6 +7054,9 @@ fn build_nonpersistent_assignment_spans(
         if !is_reportable_subshell_assignment(binding.kind, binding.attributes) {
             continue;
         }
+        if !is_reportable_nonpersistent_assignment_name(&binding.name) {
+            continue;
+        }
 
         let Some(nonpersistent_scope) =
             innermost_nonpersistent_scope_span(semantic, binding.span.start.offset)
@@ -7067,7 +7070,6 @@ fn build_nonpersistent_assignment_spans(
             .push(CandidateSubshellAssignment {
                 binding_id: binding.id,
                 assignment_span: binding.span,
-                kind: nonpersistent_scope.kind,
                 subshell_start: nonpersistent_scope.span.start.offset,
                 subshell_end: nonpersistent_scope.span.end.offset,
             });
@@ -7075,6 +7077,9 @@ fn build_nonpersistent_assignment_spans(
 
     for binding in semantic.bindings() {
         if !is_persistent_subshell_reset_binding(binding.kind, binding.attributes) {
+            continue;
+        }
+        if !is_reportable_nonpersistent_assignment_name(&binding.name) {
             continue;
         }
         if is_within_any_nonpersistent_scope(semantic, binding.span.start.offset) {
@@ -7094,6 +7099,9 @@ fn build_nonpersistent_assignment_spans(
         ) {
             continue;
         }
+        if !is_reportable_nonpersistent_assignment_name(&reference.name) {
+            continue;
+        }
         if candidate_bindings_by_name.contains_key(&reference.name) {
             command_id_query_offsets.push(reference.span.start.offset);
             relevant_references.push(reference);
@@ -7102,18 +7110,28 @@ fn build_nonpersistent_assignment_spans(
 
     let innermost_command_ids_by_offset =
         build_innermost_command_ids_by_offset(commands, command_id_query_offsets);
+    let command_end_offsets = commands
+        .iter()
+        .map(|command| (command.id(), command.span().end.offset))
+        .collect::<FxHashMap<_, _>>();
     let persistent_reset_offsets_by_name: FxHashMap<Name, Vec<PersistentReset>> =
         persistent_reset_offsets_by_name
             .into_iter()
             .map(|(name, offsets)| {
                 let resets = offsets
                     .into_iter()
-                    .map(|offset| PersistentReset {
-                        offset,
-                        command_id: precomputed_command_id_for_offset(
-                            &innermost_command_ids_by_offset,
+                    .map(|offset| {
+                        let command_id =
+                            precomputed_command_id_for_offset(&innermost_command_ids_by_offset, offset);
+                        let command_end_offset = command_id
+                            .and_then(|id| command_end_offsets.get(&id).copied())
+                            .unwrap_or(offset);
+
+                        PersistentReset {
                             offset,
-                        ),
+                            command_id,
+                            command_end_offset,
+                        }
                     })
                     .collect();
                 (name, resets)
@@ -7136,7 +7154,7 @@ fn build_nonpersistent_assignment_spans(
             reference.span.start.offset,
         );
         let resolved = semantic.resolved_binding(reference.id);
-        let mut matched_nonpipeline_candidate = false;
+        let mut matched_candidate = false;
         for candidate in candidate_ids {
             if reference.span.start.offset <= candidate.subshell_end
                 || has_intervening_persistent_reset(
@@ -7154,18 +7172,19 @@ fn build_nonpersistent_assignment_spans(
             }
 
             side_effect_spans.push(candidate.assignment_span);
-            if !matches!(candidate.kind, NonpersistentAssignmentKind::Pipeline) {
-                matched_nonpipeline_candidate = true;
-            }
+            matched_candidate = true;
         }
 
-        if matched_nonpipeline_candidate {
+        if matched_candidate {
             later_use_spans.push(reference.span);
         }
     }
 
     for binding in semantic.bindings() {
         if !is_reportable_subshell_later_use_binding(binding.kind, binding.attributes) {
+            continue;
+        }
+        if !is_reportable_nonpersistent_assignment_name(&binding.name) {
             continue;
         }
 
@@ -7177,7 +7196,7 @@ fn build_nonpersistent_assignment_spans(
             .get(&binding.name)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
-        let mut matched_nonpipeline_candidate = false;
+        let mut matched_candidate = false;
         for candidate in candidate_ids {
             if binding.span.start.offset <= candidate.subshell_end
                 || has_intervening_persistent_reset(
@@ -7191,12 +7210,10 @@ fn build_nonpersistent_assignment_spans(
             }
 
             side_effect_spans.push(candidate.assignment_span);
-            if !matches!(candidate.kind, NonpersistentAssignmentKind::Pipeline) {
-                matched_nonpipeline_candidate = true;
-            }
+            matched_candidate = true;
         }
 
-        if matched_nonpipeline_candidate {
+        if matched_candidate {
             later_use_spans.push(binding.span);
         }
     }
@@ -7218,6 +7235,7 @@ fn build_nonpersistent_assignment_spans(
 fn is_reportable_subshell_assignment(kind: BindingKind, attributes: BindingAttributes) -> bool {
     match kind {
         BindingKind::Assignment
+        | BindingKind::ParameterDefaultAssignment
         | BindingKind::AppendAssignment
         | BindingKind::ArrayAssignment
         | BindingKind::LoopVariable
@@ -7230,7 +7248,6 @@ fn is_reportable_subshell_assignment(kind: BindingKind, attributes: BindingAttri
             attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
                 && !attributes.contains(BindingAttributes::LOCAL)
         }
-        BindingKind::ParameterDefaultAssignment => false,
         BindingKind::Imported => false,
         BindingKind::FunctionDefinition | BindingKind::Nameref => false,
     }
@@ -7242,6 +7259,7 @@ fn is_reportable_subshell_later_use_binding(
 ) -> bool {
     match kind {
         BindingKind::AppendAssignment => true,
+        BindingKind::ArithmeticAssignment => true,
         BindingKind::Declaration(_) => {
             attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
                 && !attributes.contains(BindingAttributes::LOCAL)
@@ -7253,7 +7271,6 @@ fn is_reportable_subshell_later_use_binding(
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
-        | BindingKind::ArithmeticAssignment
         | BindingKind::ParameterDefaultAssignment
         | BindingKind::FunctionDefinition
         | BindingKind::Imported
@@ -7261,25 +7278,21 @@ fn is_reportable_subshell_later_use_binding(
     }
 }
 
+fn is_reportable_nonpersistent_assignment_name(name: &Name) -> bool {
+    name.as_str() != "IFS"
+}
+
 #[derive(Debug, Clone, Copy)]
 struct CandidateSubshellAssignment {
     binding_id: shuck_semantic::BindingId,
     assignment_span: Span,
-    kind: NonpersistentAssignmentKind,
     subshell_start: usize,
     subshell_end: usize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NonpersistentAssignmentKind {
-    Pipeline,
-    Subshell,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct NonpersistentScopeSpan {
     span: Span,
-    kind: NonpersistentAssignmentKind,
 }
 
 #[derive(Debug, Default)]
@@ -7292,6 +7305,7 @@ struct NonpersistentAssignmentSpans {
 struct PersistentReset {
     offset: usize,
     command_id: Option<CommandId>,
+    command_end_offset: usize,
 }
 
 fn innermost_nonpersistent_scope_span(
@@ -7304,15 +7318,14 @@ fn innermost_nonpersistent_scope_span(
         .iter()
         .find(|candidate| candidate.id == scope)
         .map(|candidate| candidate.span)?;
-    let kind = match semantic.scope_kind(scope) {
-        shuck_semantic::ScopeKind::Pipeline => NonpersistentAssignmentKind::Pipeline,
-        shuck_semantic::ScopeKind::Subshell | shuck_semantic::ScopeKind::CommandSubstitution => {
-            NonpersistentAssignmentKind::Subshell
-        }
+    match semantic.scope_kind(scope) {
+        shuck_semantic::ScopeKind::Pipeline
+        | shuck_semantic::ScopeKind::Subshell
+        | shuck_semantic::ScopeKind::CommandSubstitution => {}
         shuck_semantic::ScopeKind::Function(_) | shuck_semantic::ScopeKind::File => return None,
-    };
+    }
 
-    Some(NonpersistentScopeSpan { span, kind })
+    Some(NonpersistentScopeSpan { span })
 }
 
 fn is_within_any_nonpersistent_scope(semantic: &SemanticModel, offset: usize) -> bool {
@@ -7331,6 +7344,7 @@ fn is_within_any_nonpersistent_scope(semantic: &SemanticModel, offset: usize) ->
 fn is_persistent_subshell_reset_binding(kind: BindingKind, attributes: BindingAttributes) -> bool {
     match kind {
         BindingKind::Assignment
+        | BindingKind::ParameterDefaultAssignment
         | BindingKind::AppendAssignment
         | BindingKind::ArrayAssignment
         | BindingKind::LoopVariable
@@ -7343,7 +7357,6 @@ fn is_persistent_subshell_reset_binding(kind: BindingKind, attributes: BindingAt
             attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
                 && !attributes.contains(BindingAttributes::LOCAL)
         }
-        BindingKind::ParameterDefaultAssignment => false,
         BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref => false,
     }
 }
@@ -7355,8 +7368,14 @@ fn has_intervening_persistent_reset(
     event_command_id: Option<CommandId>,
 ) -> bool {
     resets.iter().any(|reset| {
-        reset.offset > candidate_end
-            && reset.offset < event_offset
+        let effective_offset = if reset.offset > candidate_end {
+            reset.offset
+        } else {
+            reset.command_end_offset
+        };
+
+        effective_offset > candidate_end
+            && effective_offset < event_offset
             && event_command_id.is_none_or(|event_id| reset.command_id != Some(event_id))
     })
 }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7121,8 +7121,10 @@ fn build_nonpersistent_assignment_spans(
                 let resets = offsets
                     .into_iter()
                     .map(|offset| {
-                        let command_id =
-                            precomputed_command_id_for_offset(&innermost_command_ids_by_offset, offset);
+                        let command_id = precomputed_command_id_for_offset(
+                            &innermost_command_ids_by_offset,
+                            offset,
+                        );
                         let command_end_offset = command_id
                             .and_then(|id| command_end_offsets.get(&id).copied())
                             .unwrap_or(offset);

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C150_C150.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C150_C150.sh.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 233
+assertion_line: 286
 ---
 C150 assignment to `$count` inside a subshell does not update the outer shell
  --> <source>:6:7
@@ -12,4 +12,10 @@ C150 assignment to `$items` inside a subshell does not update the outer shell
   --> <source>:10:16
    |
 10 | printf '%s\n' "$items"
+   |
+
+C150 assignment to `$count` inside a subshell does not update the outer shell
+  --> <source>:15:7
+   |
+15 | echo "$count"
    |

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -57,12 +57,31 @@ printf '%s\\n' \"$items\"
     }
 
     #[test]
-    fn ignores_pipeline_cases_and_parent_reassignments() {
+    fn reports_pipeline_child_reads_that_happen_after_the_pipeline_finishes() {
         let source = "\
 #!/bin/sh
 count=0
 printf '%s\\n' x | while read -r _; do count=1; done
 echo \"$count\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$count"]
+        );
+    }
+
+    #[test]
+    fn ignores_parent_reassignments_after_nonpersistent_updates() {
+        let source = "\
+#!/bin/sh
 items=old
 (items=new)
 items=latest
@@ -92,6 +111,27 @@ demo() {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_parameter_default_reads_after_pipeline_assignments() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' x | while read -r _; do : \"${value:=inner}\"; done
+printf '%s\\n' \"${value:=outer}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${value:=outer}"]
+        );
     }
 
     #[test]
@@ -128,6 +168,59 @@ snapshot=\"$(
   value=inner
   printf '%s\\n' \"$value\"
 )\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_later_arithmetic_assignments_after_pipeline_updates() {
+        let source = "\
+#!/bin/bash
+PASS=0
+printf '%s\\n' x | while read -r _; do PASS=1; done
+((PASS++))
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["PASS"]
+        );
+    }
+
+    #[test]
+    fn ignores_ifs_reads_after_pipeline_updates() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' x | while read -r _; do IFS=:; done
+printf '%s\\n' \"$IFS\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_inner_command_substitution_updates_when_the_parent_assignment_resets_the_name() {
+        let source = "\
+#!/bin/sh
+k1=0
+k1=\"$(printf '%s' 1 || k1=0)\"
+printf '%s\\n' \"$k1\"
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -73,6 +73,19 @@ echo \"$count\"
     }
 
     #[test]
+    fn reports_parameter_default_assignments_inside_pipeline_children() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' x | while read -r _; do : \"${value:=inner}\"; done
+printf '%s\\n' \"${value:=outer}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "value");
+    }
+
+    #[test]
     fn reports_command_substitution_assignment_sites_that_have_later_outer_reads() {
         let source = "\
 #!/bin/bash
@@ -92,6 +105,31 @@ echo \"$value\"
                 .collect::<Vec<_>>(),
             vec!["value"]
         );
+    }
+
+    #[test]
+    fn ignores_ifs_assignments_inside_pipeline_children() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' x | while read -r _; do IFS=:; done
+printf '%s\\n' \"$IFS\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_inner_command_substitution_updates_when_the_parent_assignment_resets_the_name() {
+        let source = "\
+#!/bin/sh
+k1=0
+k1=\"$(printf '%s' 1 || k1=0)\"
+printf '%s\\n' \"$k1\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck/tests/testdata/corpus-metadata/c150.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c150.yaml
@@ -108,3 +108,44 @@ reviewed_divergences:
     labels:
       - project-closure
     reason: "This tools helper's remaining C150 hits depend on sourced helper-side effects for `HOME` inside project-closure analysis, which shuck does not yet lift into later-read facts."
+  - side: shuck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__bin__find_broken_symlinks.sh"
+    line: 53
+    end_line: 53
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This script sources shared HariSekhon bash helpers before the pipeline. The remaining `exitcode` later-read depends on project-closure shell state rather than the standalone file text, so we record the closure-sensitive comparison."
+  - side: shuck-only
+    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "These gist listing and detail loops compare through directive-handling and project-closure after sourcing user configuration. The remaining C150 hits are closure-sensitive pipeline noise rather than stable standalone mismatches."
+  - side: shuck-only
+    path_suffix: "aristocratos__bashtop__bashtop"
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "Bashtop bootstraps runtime state from sourced config and theme files before these `proc[...]` reads. The remaining C150 hits only reproduce in the directive-handling/project-closure harness, so they are recorded as closure-sensitive noise."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
+    labels:
+      - project-closure
+    reason: "This monitoring generator repeatedly sources per-network data files and helper state. The remaining shuck-only C150 hits in this file are closure-sensitive monitor wiring rather than stable standalone mismatches."
+  - side: shellcheck-only
+    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
+    labels:
+      - project-closure
+    reason: "This monitoring generator repeatedly sources per-network data files and helper state. The remaining shellcheck-only C150 hits depend on project-closure globals that shuck does not yet lift across sourced helper boundaries."
+  - side: shuck-only
+    path_suffix: "oh-my-fish__oh-my-fish__bin__install"
+    labels:
+      - project-closure
+    reason: "This installer is written for fish rather than a Bourne shell, so the project-closure shell-collapsed comparison is not a reliable SC2031 oracle for these `OMF_PATH` reads."
+  - side: shuck-only
+    path_suffix: "xwmx__nb__nb"
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "These nb helper sections run inside a directive-heavy project context that sources wrapper code before reusing locals. The remaining C150 hits are closure-sensitive comparison noise rather than standalone mismatches."


### PR DESCRIPTION
## Summary
- improve C150 fact collection for pipeline child later-reads, parameter-default assignments, arithmetic follow-up uses, and outer reset handling after command substitutions
- add focused rule coverage for subshell-local-assignment and subshell-side-effect behavior, plus update the C150 fixture and snapshot
- record the remaining reviewed large-corpus exceptions for C150 in corpus metadata

## Why
C150 still had compatibility gaps around nonpersistent assignments that were either being missed or misclassified. Tightening the shared fact layer closes those gaps while keeping the known closure-sensitive exceptions explicit.

## Validation
- `cargo test -p shuck-linter subshell_local_assignment`
- `cargo test -p shuck-linter subshell_side_effect`
- `cargo test -p shuck-linter --lib`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C150`
