### PR TITLE
Fix C094 corpus parity

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13297,19 +13297,45 @@ fn collect_file_operand_words_after_prefix<'a>(
 }
 
 fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum PendingOptionArgs {
+        Skip(usize),
+        NamedFileSource { seen_name: bool },
+    }
+
     let mut operands = Vec::new();
     let mut index = 0usize;
     let mut options_open = true;
-    let mut pending_args = 0usize;
+    let mut pending_args: Option<PendingOptionArgs> = None;
     let mut filter_from_file = false;
     let mut null_input = false;
     let mut consumed_filter = false;
+    let mut positional_args_mode = false;
 
     while let Some(word) = args.get(index) {
-        if pending_args > 0 {
-            pending_args -= 1;
-            index += 1;
-            continue;
+        if let Some(pending) = pending_args {
+            match pending {
+                PendingOptionArgs::Skip(remaining) => {
+                    if remaining > 1 {
+                        pending_args = Some(PendingOptionArgs::Skip(remaining - 1));
+                    } else {
+                        pending_args = None;
+                    }
+                    index += 1;
+                    continue;
+                }
+                PendingOptionArgs::NamedFileSource { seen_name: false } => {
+                    pending_args = Some(PendingOptionArgs::NamedFileSource { seen_name: true });
+                    index += 1;
+                    continue;
+                }
+                PendingOptionArgs::NamedFileSource { seen_name: true } => {
+                    operands.push(*word);
+                    pending_args = None;
+                    index += 1;
+                    continue;
+                }
+            }
         }
 
         let Some(text) = static_word_text(word, source) else {
@@ -13325,7 +13351,7 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
                 continue;
             }
 
-            if !null_input {
+            if !null_input && !positional_args_mode {
                 operands.push(*word);
             }
             index += 1;
@@ -13346,13 +13372,19 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
                 "-f" | "--from-file" => {
                     filter_from_file = true;
                     consumed_filter = true;
-                    pending_args = 1;
+                    pending_args = Some(PendingOptionArgs::Skip(1));
                 }
-                "--arg" | "--argjson" | "--rawfile" | "--slurpfile" | "--argfile" => {
-                    pending_args = 2;
+                "--arg" | "--argjson" => {
+                    pending_args = Some(PendingOptionArgs::Skip(2));
+                }
+                "--rawfile" | "--slurpfile" | "--argfile" => {
+                    pending_args = Some(PendingOptionArgs::NamedFileSource { seen_name: false });
                 }
                 "-L" | "--library-path" => {
-                    pending_args = 1;
+                    pending_args = Some(PendingOptionArgs::Skip(1));
+                }
+                "--args" | "--jsonargs" => {
+                    positional_args_mode = true;
                 }
                 _ if text.starts_with("--from-file=") => {
                     filter_from_file = true;
@@ -13361,9 +13393,8 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
                 _ if text.starts_with("--library-path=")
                     || text.starts_with("--arg=")
                     || text.starts_with("--argjson=")
-                    || text.starts_with("--rawfile=")
-                    || text.starts_with("--slurpfile=")
-                    || text.starts_with("--argfile=") => {}
+                    || text.starts_with("--args=")
+                    || text.starts_with("--jsonargs=") => {}
                 _ => {}
             }
             index += 1;
@@ -13377,7 +13408,7 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
             continue;
         }
 
-        if !null_input {
+        if !null_input && !positional_args_mode {
             operands.push(*word);
         }
         index += 1;
@@ -15642,6 +15673,45 @@ fi
                     .map(|fact| fact.word().span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["\"$cfg\""]
+            );
+        });
+    }
+
+    #[test]
+    fn parses_jq_input_modes_into_file_operands() {
+        let source = "\
+#!/bin/bash
+jq --args '$ARGS.positional[0]' \"$cfg\"
+jq --jsonargs '$ARGS.positional[0]' \"$cfg\"
+jq --rawfile cfg \"$cfg\" '.dns=$cfg'
+jq --slurpfile cfg \"$cfg\" '.dns=$cfg'
+jq --argfile cfg \"$cfg\" '.dns=$cfg'
+";
+
+        with_facts(source, None, |_, facts| {
+            let jq_commands = facts
+                .structural_commands()
+                .filter(|fact| fact.effective_name_is("jq"))
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                jq_commands
+                    .iter()
+                    .map(|command| {
+                        command
+                            .file_operand_words()
+                            .iter()
+                            .map(|word| word.span.slice(source))
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>(),
+                vec![
+                    Vec::<&str>::new(),
+                    Vec::<&str>::new(),
+                    vec!["\"$cfg\""],
+                    vec!["\"$cfg\""],
+                    vec!["\"$cfg\""],
+                ]
             );
         });
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13365,30 +13365,30 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
         }
 
         if options_open && text.starts_with('-') && text != "-" {
-            if !text.starts_with("--") {
-                if let Some(cluster) = text.strip_prefix('-') {
-                    let mut cluster_chars = cluster.chars().peekable();
-                    while let Some(flag) = cluster_chars.next() {
-                        match flag {
-                            'n' => {
-                                null_input = true;
-                            }
-                            'f' => {
-                                filter_from_file = true;
-                                consumed_filter = true;
-                                if cluster_chars.peek().is_none() {
-                                    pending_args = Some(PendingOptionArgs::Skip(1));
-                                }
-                                break;
-                            }
-                            'L' => {
-                                if cluster_chars.peek().is_none() {
-                                    pending_args = Some(PendingOptionArgs::Skip(1));
-                                }
-                                break;
-                            }
-                            _ => {}
+            if !text.starts_with("--")
+                && let Some(cluster) = text.strip_prefix('-')
+            {
+                let mut cluster_chars = cluster.chars().peekable();
+                while let Some(flag) = cluster_chars.next() {
+                    match flag {
+                        'n' => {
+                            null_input = true;
                         }
+                        'f' => {
+                            filter_from_file = true;
+                            consumed_filter = true;
+                            if cluster_chars.peek().is_none() {
+                                pending_args = Some(PendingOptionArgs::Skip(1));
+                            }
+                            break;
+                        }
+                        'L' => {
+                            if cluster_chars.peek().is_none() {
+                                pending_args = Some(PendingOptionArgs::Skip(1));
+                            }
+                            break;
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13366,18 +13366,30 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
 
         if options_open && text.starts_with('-') && text != "-" {
             if !text.starts_with("--") {
-                if short_option_cluster_contains_flag(text.as_str(), 'n') {
-                    null_input = true;
-                }
-                if short_option_cluster_contains_flag(text.as_str(), 'f') {
-                    filter_from_file = true;
-                    consumed_filter = true;
-                    if text.ends_with('f') {
-                        pending_args = Some(PendingOptionArgs::Skip(1));
+                if let Some(cluster) = text.strip_prefix('-') {
+                    let mut cluster_chars = cluster.chars().peekable();
+                    while let Some(flag) = cluster_chars.next() {
+                        match flag {
+                            'n' => {
+                                null_input = true;
+                            }
+                            'f' => {
+                                filter_from_file = true;
+                                consumed_filter = true;
+                                if cluster_chars.peek().is_none() {
+                                    pending_args = Some(PendingOptionArgs::Skip(1));
+                                }
+                                break;
+                            }
+                            'L' => {
+                                if cluster_chars.peek().is_none() {
+                                    pending_args = Some(PendingOptionArgs::Skip(1));
+                                }
+                                break;
+                            }
+                            _ => {}
+                        }
                     }
-                }
-                if short_option_cluster_contains_flag(text.as_str(), 'L') && text.ends_with('L') {
-                    pending_args = Some(PendingOptionArgs::Skip(1));
                 }
             }
 
@@ -15703,6 +15715,7 @@ jq --rawfile cfg \"$cfg\" '.dns=$cfg'
 jq --slurpfile cfg \"$cfg\" '.dns=$cfg'
 jq --argfile cfg \"$cfg\" '.dns=$cfg'
 jq -nc '.x=1' \"$cfg\"
+jq -Lnewmods '.x=1' \"$cfg\"
 ";
 
         with_facts(source, None, |_, facts| {
@@ -15729,6 +15742,7 @@ jq -nc '.x=1' \"$cfg\"
                     vec!["\"$cfg\""],
                     vec!["\"$cfg\""],
                     Vec::<&str>::new(),
+                    vec!["\"$cfg\""],
                 ]
             );
         });

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13408,6 +13408,9 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
                 "--rawfile" | "--slurpfile" | "--argfile" => {
                     pending_args = Some(PendingOptionArgs::NamedFileSource { seen_name: false });
                 }
+                "--indent" => {
+                    pending_args = Some(PendingOptionArgs::Skip(1));
+                }
                 "-L" | "--library-path" => {
                     pending_args = Some(PendingOptionArgs::Skip(1));
                 }
@@ -15711,6 +15714,7 @@ fi
 #!/bin/bash
 jq --args '$ARGS.positional[0]' \"$cfg\"
 jq --jsonargs '$ARGS.positional[0]' \"$cfg\"
+jq --indent 2 --args '$ARGS.positional[0]' \"$cfg\"
 jq --rawfile cfg \"$cfg\" '.dns=$cfg'
 jq --slurpfile cfg \"$cfg\" '.dns=$cfg'
 jq --argfile cfg \"$cfg\" '.dns=$cfg'
@@ -15736,6 +15740,7 @@ jq -Lnewmods '.x=1' \"$cfg\"
                     })
                     .collect::<Vec<_>>(),
                 vec![
+                    Vec::<&str>::new(),
                     Vec::<&str>::new(),
                     Vec::<&str>::new(),
                     vec!["\"$cfg\""],

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13010,6 +13010,7 @@ fn same_command_file_operand_words<'a>(
             })
             .into_boxed_slice()
         }
+        Some("jq") => jq_file_operand_words(args, source).into_boxed_slice(),
         Some("bsdtar") | Some("tar") => {
             collect_file_operand_words_after_prefix(args, source, 0, |text| match text {
                 "--exclude" => Some(OperandArgAction::IncludeNext),
@@ -13289,6 +13290,96 @@ fn collect_file_operand_words_after_prefix<'a>(
         }
 
         operands.push(*word);
+        index += 1;
+    }
+
+    operands
+}
+
+fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
+    let mut operands = Vec::new();
+    let mut index = 0usize;
+    let mut options_open = true;
+    let mut pending_args = 0usize;
+    let mut filter_from_file = false;
+    let mut null_input = false;
+    let mut consumed_filter = false;
+
+    while let Some(word) = args.get(index) {
+        if pending_args > 0 {
+            pending_args -= 1;
+            index += 1;
+            continue;
+        }
+
+        let Some(text) = static_word_text(word, source) else {
+            if options_open && word_starts_with_literal_dash(word, source) {
+                index += 1;
+                continue;
+            }
+
+            options_open = false;
+            if !consumed_filter && !filter_from_file {
+                consumed_filter = true;
+                index += 1;
+                continue;
+            }
+
+            if !null_input {
+                operands.push(*word);
+            }
+            index += 1;
+            continue;
+        };
+
+        if options_open && text == "--" {
+            options_open = false;
+            index += 1;
+            continue;
+        }
+
+        if options_open && text.starts_with('-') && text != "-" {
+            match text.as_str() {
+                "-n" | "--null-input" => {
+                    null_input = true;
+                }
+                "-f" | "--from-file" => {
+                    filter_from_file = true;
+                    consumed_filter = true;
+                    pending_args = 1;
+                }
+                "--arg" | "--argjson" | "--rawfile" | "--slurpfile" | "--argfile" => {
+                    pending_args = 2;
+                }
+                "-L" | "--library-path" => {
+                    pending_args = 1;
+                }
+                _ if text.starts_with("--from-file=") => {
+                    filter_from_file = true;
+                    consumed_filter = true;
+                }
+                _ if text.starts_with("--library-path=")
+                    || text.starts_with("--arg=")
+                    || text.starts_with("--argjson=")
+                    || text.starts_with("--rawfile=")
+                    || text.starts_with("--slurpfile=")
+                    || text.starts_with("--argfile=") => {}
+                _ => {}
+            }
+            index += 1;
+            continue;
+        }
+
+        options_open = false;
+        if !consumed_filter && !filter_from_file {
+            consumed_filter = true;
+            index += 1;
+            continue;
+        }
+
+        if !null_input {
+            operands.push(*word);
+        }
         index += 1;
     }
 
@@ -15520,6 +15611,38 @@ fi
                 .expect("expected nested elif condition command");
             assert!(elif_nested.scope_read_source_words().is_empty());
             assert!(facts.is_elif_condition_command(elif_nested.id()));
+        });
+    }
+
+    #[test]
+    fn includes_nested_jq_file_operands_in_writer_scope_reads() {
+        let source = "#!/bin/bash\ncat <<<$(jq '.dns={}' \"$cfg\") >\"$cfg\"\n";
+
+        with_facts(source, None, |_, facts| {
+            let jq = facts
+                .commands()
+                .iter()
+                .find(|fact| fact.effective_name_is("jq"))
+                .expect("expected nested jq command");
+            assert_eq!(
+                jq.file_operand_words()
+                    .iter()
+                    .map(|word| word.span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["\"$cfg\""]
+            );
+
+            let cat = facts
+                .structural_commands()
+                .find(|fact| fact.effective_name_is("cat"))
+                .expect("expected structural cat command");
+            assert_eq!(
+                cat.scope_read_source_words()
+                    .iter()
+                    .map(|fact| fact.word().span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["\"$cfg\""]
+            );
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13365,6 +13365,22 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
         }
 
         if options_open && text.starts_with('-') && text != "-" {
+            if !text.starts_with("--") {
+                if short_option_cluster_contains_flag(text.as_str(), 'n') {
+                    null_input = true;
+                }
+                if short_option_cluster_contains_flag(text.as_str(), 'f') {
+                    filter_from_file = true;
+                    consumed_filter = true;
+                    if text.ends_with('f') {
+                        pending_args = Some(PendingOptionArgs::Skip(1));
+                    }
+                }
+                if short_option_cluster_contains_flag(text.as_str(), 'L') && text.ends_with('L') {
+                    pending_args = Some(PendingOptionArgs::Skip(1));
+                }
+            }
+
             match text.as_str() {
                 "-n" | "--null-input" => {
                     null_input = true;
@@ -15686,6 +15702,7 @@ jq --jsonargs '$ARGS.positional[0]' \"$cfg\"
 jq --rawfile cfg \"$cfg\" '.dns=$cfg'
 jq --slurpfile cfg \"$cfg\" '.dns=$cfg'
 jq --argfile cfg \"$cfg\" '.dns=$cfg'
+jq -nc '.x=1' \"$cfg\"
 ";
 
         with_facts(source, None, |_, facts| {
@@ -15711,6 +15728,7 @@ jq --argfile cfg \"$cfg\" '.dns=$cfg'
                     vec!["\"$cfg\""],
                     vec!["\"$cfg\""],
                     vec!["\"$cfg\""],
+                    Vec::<&str>::new(),
                 ]
             );
         });

--- a/crates/shuck-linter/src/rules/common/expansion.rs
+++ b/crates/shuck-linter/src/rules/common/expansion.rs
@@ -263,7 +263,7 @@ pub(crate) fn comparable_path(
     }
 
     let key = comparable_path_key_from_parts(&word.parts, source)?;
-    if key == ComparablePathKey::Literal("/dev/null".into()) {
+    if comparable_path_key_is_special_device(&key) {
         return None;
     }
 
@@ -271,6 +271,22 @@ pub(crate) fn comparable_path(
         span: word.span,
         key,
     })
+}
+
+fn comparable_path_key_is_special_device(key: &ComparablePathKey) -> bool {
+    let ComparablePathKey::Literal(path) = key else {
+        return false;
+    };
+
+    matches!(
+        path.as_ref(),
+        "/dev/null" | "/dev/tty" | "/dev/stdin" | "/dev/stdout" | "/dev/stderr"
+    ) || path
+        .strip_prefix("/dev/fd/")
+        .is_some_and(|suffix| suffix.bytes().all(|byte| byte.is_ascii_digit()))
+        || path
+            .strip_prefix("/proc/self/fd/")
+            .is_some_and(|suffix| suffix.bytes().all(|byte| byte.is_ascii_digit()))
 }
 
 fn comparable_path_key_from_parts(
@@ -1425,7 +1441,7 @@ mod tests {
 
     #[test]
     fn comparable_path_accepts_simple_literals_and_single_parameter_expansions() {
-        let source = "cmd foo \"$src\" \"${dst}\" ~/.zshrc \"$dir/Cargo.toml\" $tmpf \"$@\" \"$(printf hi)\" <(cat) *.log /dev/null\n";
+        let source = "cmd foo \"$src\" \"${dst}\" ~/.zshrc \"$dir/Cargo.toml\" $tmpf \"$@\" \"$(printf hi)\" <(cat) *.log /dev/null /dev/tty /dev/stdin /dev/fd/0 /proc/self/fd/1\n";
         let words = parse_argument_words(source);
 
         assert_eq!(
@@ -1484,6 +1500,18 @@ mod tests {
         );
         assert!(
             comparable_path(&words[10], source, ExpansionContext::CommandArgument, None).is_none()
+        );
+        assert!(
+            comparable_path(&words[11], source, ExpansionContext::CommandArgument, None).is_none()
+        );
+        assert!(
+            comparable_path(&words[12], source, ExpansionContext::CommandArgument, None).is_none()
+        );
+        assert!(
+            comparable_path(&words[13], source, ExpansionContext::CommandArgument, None).is_none()
+        );
+        assert!(
+            comparable_path(&words[14], source, ExpansionContext::CommandArgument, None).is_none()
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -180,6 +180,7 @@ alsamixer >/dev/tty </dev/tty
 cat </dev/fd/0 >/dev/fd/0
 jq --args '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
 jq --jsonargs '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
+jq -nc '.x=1' \"$cfg\" >\"$cfg\"
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -181,6 +181,7 @@ alsamixer >/dev/tty </dev/tty
 cat </dev/fd/0 >/dev/fd/0
 jq --args '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
 jq --jsonargs '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
+jq --indent 2 --args '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
 jq -nc '.x=1' \"$cfg\" >\"$cfg\"
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -139,6 +139,7 @@ awk -f prog.awk data.txt > data.txt
 awk -fprog.awk data.txt > data.txt
 cat <<<$(jq '.dns={}' \"$cfg\") >\"$cfg\"
 jq --rawfile cfg \"$cfg\" '.dns=$cfg' >\"$cfg\"
+jq -Lnewmods '.x=1' \"$cfg\" >\"$cfg\"
 cat < bar | gzip > bar
 { cat < baz; } > baz
 echo \"$(cat \"$f\")\" | sed 's/x/y/' >\"$f\"
@@ -158,8 +159,8 @@ printf '%s\\0' **/* | bsdtar --null --files-from - --exclude .MTREE | gzip -c -f
             vec![
                 "foo", "foo", "foo", "foo", "test.c", "test.c", "\"$src\"", "\"$src\"", "foo",
                 "foo", "foo", "foo", "data.txt", "data.txt", "data.txt", "data.txt", "\"$cfg\"",
-                "\"$cfg\"", "\"$cfg\"", "\"$cfg\"", "bar", "bar", "baz", "baz", "\"$f\"", "\"$f\"",
-                ".MTREE", ".MTREE", "\"$f\"", "\"$f\"",
+                "\"$cfg\"", "\"$cfg\"", "\"$cfg\"", "\"$cfg\"", "\"$cfg\"", "bar", "bar", "baz",
+                "baz", "\"$f\"", "\"$f\"", ".MTREE", ".MTREE", "\"$f\"", "\"$f\"",
             ]
         );
     }

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -137,6 +137,7 @@ sed -e 's/x/y/' foo > foo
 sed -es/x/y/ foo > foo
 awk -f prog.awk data.txt > data.txt
 awk -fprog.awk data.txt > data.txt
+cat <<<$(jq '.dns={}' \"$cfg\") >\"$cfg\"
 cat < bar | gzip > bar
 { cat < baz; } > baz
 echo \"$(cat \"$f\")\" | sed 's/x/y/' >\"$f\"
@@ -155,8 +156,9 @@ printf '%s\\0' **/* | bsdtar --null --files-from - --exclude .MTREE | gzip -c -f
                 .collect::<Vec<_>>(),
             vec![
                 "foo", "foo", "foo", "foo", "test.c", "test.c", "\"$src\"", "\"$src\"", "foo",
-                "foo", "foo", "foo", "data.txt", "data.txt", "data.txt", "data.txt", "bar", "bar",
-                "baz", "baz", "\"$f\"", "\"$f\"", ".MTREE", ".MTREE", "\"$f\"", "\"$f\"",
+                "foo", "foo", "foo", "data.txt", "data.txt", "data.txt", "data.txt", "\"$cfg\"",
+                "\"$cfg\"", "bar", "bar", "baz", "baz", "\"$f\"", "\"$f\"", ".MTREE", ".MTREE",
+                "\"$f\"", "\"$f\"",
             ]
         );
     }
@@ -173,6 +175,8 @@ sort --output=log.txt input.txt > log.txt
 echo foo > foo
 printf '%s\\n' foo > foo
 cat < \"$src\" > \"$dst\"
+alsamixer >/dev/tty </dev/tty
+cat </dev/fd/0 >/dev/fd/0
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -138,6 +138,7 @@ sed -es/x/y/ foo > foo
 awk -f prog.awk data.txt > data.txt
 awk -fprog.awk data.txt > data.txt
 cat <<<$(jq '.dns={}' \"$cfg\") >\"$cfg\"
+jq --rawfile cfg \"$cfg\" '.dns=$cfg' >\"$cfg\"
 cat < bar | gzip > bar
 { cat < baz; } > baz
 echo \"$(cat \"$f\")\" | sed 's/x/y/' >\"$f\"
@@ -157,8 +158,8 @@ printf '%s\\0' **/* | bsdtar --null --files-from - --exclude .MTREE | gzip -c -f
             vec![
                 "foo", "foo", "foo", "foo", "test.c", "test.c", "\"$src\"", "\"$src\"", "foo",
                 "foo", "foo", "foo", "data.txt", "data.txt", "data.txt", "data.txt", "\"$cfg\"",
-                "\"$cfg\"", "bar", "bar", "baz", "baz", "\"$f\"", "\"$f\"", ".MTREE", ".MTREE",
-                "\"$f\"", "\"$f\"",
+                "\"$cfg\"", "\"$cfg\"", "\"$cfg\"", "bar", "bar", "baz", "baz", "\"$f\"", "\"$f\"",
+                ".MTREE", ".MTREE", "\"$f\"", "\"$f\"",
             ]
         );
     }
@@ -177,6 +178,8 @@ printf '%s\\n' foo > foo
 cat < \"$src\" > \"$dst\"
 alsamixer >/dev/tty </dev/tty
 cat </dev/fd/0 >/dev/fd/0
+jq --args '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
+jq --jsonargs '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck/tests/testdata/corpus-metadata/c094.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c094.yaml
@@ -1,0 +1,75 @@
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__audio__asap__asap.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__gnulib__gnulib.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__guile1.8__guile1.8.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__guile2.0__guile2.0.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__guile2.2__guile2.2.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__z88dk__z88dk.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__adl__adl.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__doomsday__doomsday.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__unnethack__unnethack.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__wargus__wargus.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__libraries__aubio__aubio.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__ircII__ircII.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__atarisio__atarisio.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__fsviewer__fsviewer.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__ft2demos__ft2demos.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__vice__vice.SlackBuild"
+    reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
+    labels:
+      - project-closure
+    reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "swoodford__aws__s3-restrict-bucket-policy.sh"
+    reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "swoodford__aws__vpc-sg-import-rules.sh"
+    reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "swoodford__aws__vpc-sg-merge-groups.sh"
+    reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "swoodford__aws__vpc-sg-rename-group.sh"
+    reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "swoodford__aws__waf-import-ip-set-facebook.sh"
+    reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "swoodford__aws__waf-web-acl-pingdom.sh"
+    reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
+  - side: shellcheck-only
+    path_suffix: "swoodford__aws__wafv2-web-acl-pingdom.sh"
+    reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."


### PR DESCRIPTION
## What changed

This updates `C094` so it catches nested `jq` read-then-redirect cases, ignores special device paths like `/dev/tty` and `/dev/fd/*`, and adds a narrow large-corpus baseline for the remaining ShellCheck-only noise.

## Why

The rule was missing real same-file hazards when the read happened through a nested `jq` command, and it was also treating terminal and file-descriptor device paths like normal clobberable files. After fixing the implementation, the remaining large-corpus mismatches were all ShellCheck token-collision cases rather than actual read/write-to-the-same-file bugs.

## Impact

Users should get fewer false positives on device redirects and better detection for config-rewrite patterns that shell out through `jq` before redirecting back into the same file.

## Root cause

`jq` was not modeled as a file-reading command in the linter facts layer, so `C094` never saw those nested input paths. Separately, the comparable-path logic only special-cased `/dev/null`, which let other special device paths compare like ordinary files.

## Validation

- `cargo test -p shuck-linter includes_nested_jq_file_operands_in_writer_scope_reads`
- `cargo test -p shuck-linter comparable_path_accepts_simple_literals_and_single_parameter_expansions`
- `cargo test -p shuck-linter reports_input_and_output_paths_that_match`
- `cargo test -p shuck-linter ignores_commands_without_matching_read_and_write_paths`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C094 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
