### PR TITLE
Fix S019 corpus conformance

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -423,10 +423,7 @@ fn parse_simple_test_expression_segment<'a>(
             .as_deref()
             .is_some_and(simple_test_is_string_unary_operator) =>
         {
-            Some(SimpleTestExpression::StringUnary {
-                operator,
-                operand,
-            })
+            Some(SimpleTestExpression::StringUnary { operator, operand })
         }
         [] | [_, _, ..] => None,
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -415,7 +415,13 @@ fn simple_test_segment_is_expression(
 
     let expression_len = segment.len() - expression_start;
     match expression_len {
-        1 => true,
+        1 => {
+            let word = segment[expression_start];
+            !(simple_test_effective_operand_text(simple_test, start + expression_start, source)
+                .as_deref()
+                == Some("!")
+                && classify_word(word, source).quote == WordQuote::Unquoted)
+        }
         2 => simple_test_effective_operand_text(simple_test, start + expression_start, source)
             .as_deref()
             .is_some_and(simple_test_is_unary_operator),
@@ -17408,6 +17414,8 @@ test
 [ \"!\" \"-n\" qux ]
 [ -a foo ]
 [ -o foo ]
+[ ! -a baz ]
+[ ! -o quux ]
 [ foo -o -z baz ]
 [ -a foo -o -z baz ]
 [ foo \"-o\" \"-z\" baz ]
@@ -17502,6 +17510,30 @@ test
             );
             assert!(
                 quoted_literal
+                    .string_unary_expression_words(source)
+                    .is_empty()
+            );
+
+            let negated_unary_a = commands
+                .iter()
+                .find(|(text, _)| text == "[ ! -a baz ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected negated unary -a test fact");
+            assert!(negated_unary_a.truthy_expression_words(source).is_empty());
+            assert!(
+                negated_unary_a
+                    .string_unary_expression_words(source)
+                    .is_empty()
+            );
+
+            let negated_unary_o = commands
+                .iter()
+                .find(|(text, _)| text == "[ ! -o quux ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected negated unary -o test fact");
+            assert!(negated_unary_o.truthy_expression_words(source).is_empty());
+            assert!(
+                negated_unary_o
                     .string_unary_expression_words(source)
                     .is_empty()
             );

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -413,7 +413,7 @@ fn parse_simple_test_expression_segment<'a>(
 
     let expression = &segment[expression_start..];
     match expression {
-        [word] => Some(SimpleTestExpression::Truthy(*word)),
+        [word] => Some(SimpleTestExpression::Truthy(word)),
         [operator, operand]
             if simple_test_effective_operand_text(
                 simple_test,
@@ -424,8 +424,8 @@ fn parse_simple_test_expression_segment<'a>(
             .is_some_and(simple_test_is_string_unary_operator) =>
         {
             Some(SimpleTestExpression::StringUnary {
-                operator: *operator,
-                operand: *operand,
+                operator,
+                operand,
             })
         }
         [] | [_, _, ..] => None,

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -375,7 +375,9 @@ fn simple_test_expressions<'a>(
             && simple_test_effective_operand_text(simple_test, index, source)
                 .as_deref()
                 .is_some_and(simple_test_is_logical_connector);
-        if !is_connector && index != operands.len() {
+        let splits_segment = is_connector
+            && simple_test_segment_is_expression(simple_test, segment_start, index, source);
+        if !splits_segment && index != operands.len() {
             continue;
         }
 
@@ -389,6 +391,39 @@ fn simple_test_expressions<'a>(
     }
 
     expressions
+}
+
+fn simple_test_segment_is_expression(
+    simple_test: &SimpleTestFact<'_>,
+    start: usize,
+    end: usize,
+    source: &str,
+) -> bool {
+    if start >= end {
+        return false;
+    }
+
+    let segment = &simple_test.effective_operands()[start..end];
+    let mut expression_start = 0;
+    while expression_start + 1 < segment.len()
+        && simple_test_effective_operand_text(simple_test, start + expression_start, source)
+            .as_deref()
+            == Some("!")
+    {
+        expression_start += 1;
+    }
+
+    let expression_len = segment.len() - expression_start;
+    match expression_len {
+        1 => true,
+        2 => simple_test_effective_operand_text(simple_test, start + expression_start, source)
+            .as_deref()
+            .is_some_and(simple_test_is_unary_operator),
+        3 => simple_test_effective_operand_text(simple_test, start + expression_start + 1, source)
+            .as_deref()
+            .is_some_and(simple_test_is_binary_operator),
+        _ => false,
+    }
 }
 
 fn parse_simple_test_expression_segment<'a>(
@@ -17371,7 +17406,10 @@ test
 [ \"-n\" ]
 [ \"-n\" foo ]
 [ \"!\" \"-n\" qux ]
+[ -a foo ]
+[ -o foo ]
 [ foo -o -z baz ]
+[ -a foo -o -z baz ]
 [ foo \"-o\" \"-z\" baz ]
 [ -f file -a ! -z baz ]
 [ lhs = rhs ]
@@ -17506,6 +17544,22 @@ test
                 vec![("\"-n\"".to_owned(), "qux".to_owned())]
             );
 
+            let unary_and = commands
+                .iter()
+                .find(|(text, _)| text == "[ -a foo ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected unary -a test fact");
+            assert!(unary_and.truthy_expression_words(source).is_empty());
+            assert!(unary_and.string_unary_expression_words(source).is_empty());
+
+            let unary_or = commands
+                .iter()
+                .find(|(text, _)| text == "[ -o foo ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected unary -o test fact");
+            assert!(unary_or.truthy_expression_words(source).is_empty());
+            assert!(unary_or.string_unary_expression_words(source).is_empty());
+
             let mixed = commands
                 .iter()
                 .find(|(text, _)| text == "[ foo -o -z baz ]")
@@ -17521,6 +17575,30 @@ test
             );
             assert_eq!(
                 mixed
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("-z".to_owned(), "baz".to_owned())]
+            );
+
+            let unary_and_then_connector = commands
+                .iter()
+                .find(|(text, _)| text == "[ -a foo -o -z baz ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected unary -a with connector test fact");
+            assert!(
+                unary_and_then_connector
+                    .truthy_expression_words(source)
+                    .is_empty()
+            );
+            assert_eq!(
+                unary_and_then_connector
                     .string_unary_expression_words(source)
                     .into_iter()
                     .map(|(operator, operand)| {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -368,55 +368,68 @@ fn simple_test_expressions<'a>(
 ) -> Vec<SimpleTestExpression<'a>> {
     let operands = simple_test.effective_operands();
     let mut expressions = Vec::new();
-    let mut index = 0;
+    let mut segment_start = 0;
 
-    while index < operands.len() {
-        if simple_test_effective_operand_text(simple_test, index, source).as_deref() == Some("!") {
-            index += 1;
-            if index >= operands.len() {
-                break;
-            }
-        }
-
-        if simple_test_effective_operand_text(simple_test, index, source)
-            .as_deref()
-            .is_some_and(simple_test_is_string_unary_operator)
-        {
-            if let Some(operand) = operands.get(index + 1).copied() {
-                expressions.push(SimpleTestExpression::StringUnary {
-                    operator: operands[index],
-                    operand,
-                });
-            }
-            index += 2;
-        } else if index + 1 == operands.len()
-            || simple_test_effective_operand_text(simple_test, index + 1, source)
-                .as_deref()
-                .is_some_and(simple_test_is_logical_connector)
-        {
-            expressions.push(SimpleTestExpression::Truthy(operands[index]));
-            index += 1;
-        } else {
-            index += 1;
-            while index < operands.len()
-                && !simple_test_effective_operand_text(simple_test, index, source)
-                    .as_deref()
-                    .is_some_and(simple_test_is_logical_connector)
-            {
-                index += 1;
-            }
-        }
-
-        if index < operands.len()
+    for index in 0..=operands.len() {
+        let is_connector = index < operands.len()
             && simple_test_effective_operand_text(simple_test, index, source)
                 .as_deref()
-                .is_some_and(simple_test_is_logical_connector)
-        {
-            index += 1;
+                .is_some_and(simple_test_is_logical_connector);
+        if !is_connector && index != operands.len() {
+            continue;
         }
+
+        if let Some(expression) =
+            parse_simple_test_expression_segment(simple_test, segment_start, index, source)
+        {
+            expressions.push(expression);
+        }
+
+        segment_start = index + 1;
     }
 
     expressions
+}
+
+fn parse_simple_test_expression_segment<'a>(
+    simple_test: &'a SimpleTestFact<'a>,
+    start: usize,
+    end: usize,
+    source: &str,
+) -> Option<SimpleTestExpression<'a>> {
+    if start >= end {
+        return None;
+    }
+
+    let segment = &simple_test.effective_operands()[start..end];
+    let mut expression_start = 0;
+    while expression_start + 1 < segment.len()
+        && simple_test_effective_operand_text(simple_test, start + expression_start, source)
+            .as_deref()
+            == Some("!")
+    {
+        expression_start += 1;
+    }
+
+    let expression = &segment[expression_start..];
+    match expression {
+        [word] => Some(SimpleTestExpression::Truthy(*word)),
+        [operator, operand]
+            if simple_test_effective_operand_text(
+                simple_test,
+                start + expression_start,
+                source,
+            )
+            .as_deref()
+            .is_some_and(simple_test_is_string_unary_operator) =>
+        {
+            Some(SimpleTestExpression::StringUnary {
+                operator: *operator,
+                operand: *operand,
+            })
+        }
+        [] | [_, _, ..] => None,
+    }
 }
 
 fn simple_test_effective_operand_text(
@@ -426,7 +439,7 @@ fn simple_test_effective_operand_text(
 ) -> Option<String> {
     let word = simple_test.effective_operands().get(index).copied()?;
     let class = simple_test.effective_operand_class(index)?;
-    if !class.is_fixed_literal() || classify_word(word, source).quote != WordQuote::Unquoted {
+    if !class.is_fixed_literal() {
         return None;
     }
 
@@ -17358,7 +17371,11 @@ test
 [ ! bar ]
 [ -z baz ]
 [ ! -n qux ]
+[ \"-n\" ]
+[ \"-n\" foo ]
+[ \"!\" \"-n\" qux ]
 [ foo -o -z baz ]
+[ foo \"-o\" \"-z\" baz ]
 [ -f file -a ! -z baz ]
 [ lhs = rhs ]
 ";
@@ -17435,6 +17452,63 @@ test
                 vec![("-n".to_owned(), "qux".to_owned())]
             );
 
+            let quoted_literal = commands
+                .iter()
+                .find(|(text, _)| text == "[ \"-n\" ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected quoted literal test fact");
+            assert_eq!(
+                quoted_literal
+                    .truthy_expression_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["\"-n\""]
+            );
+            assert!(
+                quoted_literal
+                    .string_unary_expression_words(source)
+                    .is_empty()
+            );
+
+            let quoted_unary = commands
+                .iter()
+                .find(|(text, _)| text == "[ \"-n\" foo ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected quoted unary test fact");
+            assert_eq!(
+                quoted_unary
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("\"-n\"".to_owned(), "foo".to_owned())]
+            );
+
+            let quoted_negated_unary = commands
+                .iter()
+                .find(|(text, _)| text == "[ \"!\" \"-n\" qux ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected quoted negated unary test fact");
+            assert_eq!(
+                quoted_negated_unary
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("\"-n\"".to_owned(), "qux".to_owned())]
+            );
+
             let mixed = commands
                 .iter()
                 .find(|(text, _)| text == "[ foo -o -z baz ]")
@@ -17460,6 +17534,33 @@ test
                     })
                     .collect::<Vec<_>>(),
                 vec![("-z".to_owned(), "baz".to_owned())]
+            );
+
+            let quoted_connector = commands
+                .iter()
+                .find(|(text, _)| text == "[ foo \"-o\" \"-z\" baz ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected quoted connector test fact");
+            assert_eq!(
+                quoted_connector
+                    .truthy_expression_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["foo"]
+            );
+            assert_eq!(
+                quoted_connector
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("\"-z\"".to_owned(), "baz".to_owned())]
             );
 
             let chained = commands

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -305,6 +305,28 @@ impl<'a> SimpleTestFact<'a> {
             .collect()
     }
 
+    pub fn truthy_expression_words(&'a self, source: &str) -> Vec<&'a Word> {
+        simple_test_expressions(self, source)
+            .into_iter()
+            .filter_map(|expression| match expression {
+                SimpleTestExpression::Truthy(word) => Some(word),
+                SimpleTestExpression::StringUnary { .. } => None,
+            })
+            .collect()
+    }
+
+    pub fn string_unary_expression_words(&'a self, source: &str) -> Vec<(&'a Word, &'a Word)> {
+        simple_test_expressions(self, source)
+            .into_iter()
+            .filter_map(|expression| match expression {
+                SimpleTestExpression::StringUnary { operator, operand } => {
+                    Some((operator, operand))
+                }
+                SimpleTestExpression::Truthy(_) => None,
+            })
+            .collect()
+    }
+
     pub fn is_abort_like_bracket_test(&self, source: &str) -> bool {
         if self.syntax != SimpleTestSyntax::Bracket
             || self.effective_shape != SimpleTestShape::Other
@@ -330,6 +352,93 @@ impl<'a> SimpleTestFact<'a> {
             .then(|| Some((self.operand_class(0)?, self.operand_class(2)?)))
             .flatten()
     }
+}
+
+enum SimpleTestExpression<'a> {
+    Truthy(&'a Word),
+    StringUnary {
+        operator: &'a Word,
+        operand: &'a Word,
+    },
+}
+
+fn simple_test_expressions<'a>(
+    simple_test: &'a SimpleTestFact<'a>,
+    source: &str,
+) -> Vec<SimpleTestExpression<'a>> {
+    let operands = simple_test.effective_operands();
+    let mut expressions = Vec::new();
+    let mut index = 0;
+
+    while index < operands.len() {
+        if simple_test_effective_operand_text(simple_test, index, source).as_deref() == Some("!") {
+            index += 1;
+            if index >= operands.len() {
+                break;
+            }
+        }
+
+        if simple_test_effective_operand_text(simple_test, index, source)
+            .as_deref()
+            .is_some_and(simple_test_is_string_unary_operator)
+        {
+            if let Some(operand) = operands.get(index + 1).copied() {
+                expressions.push(SimpleTestExpression::StringUnary {
+                    operator: operands[index],
+                    operand,
+                });
+            }
+            index += 2;
+        } else if index + 1 == operands.len()
+            || simple_test_effective_operand_text(simple_test, index + 1, source)
+                .as_deref()
+                .is_some_and(simple_test_is_logical_connector)
+        {
+            expressions.push(SimpleTestExpression::Truthy(operands[index]));
+            index += 1;
+        } else {
+            index += 1;
+            while index < operands.len()
+                && !simple_test_effective_operand_text(simple_test, index, source)
+                    .as_deref()
+                    .is_some_and(simple_test_is_logical_connector)
+            {
+                index += 1;
+            }
+        }
+
+        if index < operands.len()
+            && simple_test_effective_operand_text(simple_test, index, source)
+                .as_deref()
+                .is_some_and(simple_test_is_logical_connector)
+        {
+            index += 1;
+        }
+    }
+
+    expressions
+}
+
+fn simple_test_effective_operand_text(
+    simple_test: &SimpleTestFact<'_>,
+    index: usize,
+    source: &str,
+) -> Option<String> {
+    let word = simple_test.effective_operands().get(index).copied()?;
+    let class = simple_test.effective_operand_class(index)?;
+    if !class.is_fixed_literal() || classify_word(word, source).quote != WordQuote::Unquoted {
+        return None;
+    }
+
+    static_word_text(word, source)
+}
+
+fn simple_test_is_logical_connector(text: &str) -> bool {
+    matches!(text, "-a" | "-o")
+}
+
+fn simple_test_is_string_unary_operator(text: &str) -> bool {
+    matches!(text, "-n" | "-z")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17238,6 +17347,147 @@ test
                 .find(|(text, _)| text == "[ missing")
                 .map(|(_, fact)| fact.simple_test());
             assert!(matches!(missing_closer, Some(None)));
+        });
+    }
+
+    #[test]
+    fn simple_test_fact_tracks_truthy_and_string_unary_subexpressions() {
+        let source = "\
+#!/bin/sh
+[ foo ]
+[ ! bar ]
+[ -z baz ]
+[ ! -n qux ]
+[ foo -o -z baz ]
+[ -f file -a ! -z baz ]
+[ lhs = rhs ]
+";
+
+        with_facts(source, None, |_, facts| {
+            let commands = facts
+                .structural_commands()
+                .map(|fact| (fact.span().slice(source).trim_end().to_owned(), fact))
+                .collect::<Vec<_>>();
+
+            let truthy = commands
+                .iter()
+                .find(|(text, _)| text == "[ foo ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected truthy test fact");
+            assert_eq!(
+                truthy
+                    .truthy_expression_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["foo"]
+            );
+
+            let negated_truthy = commands
+                .iter()
+                .find(|(text, _)| text == "[ ! bar ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected negated truthy test fact");
+            assert_eq!(
+                negated_truthy
+                    .truthy_expression_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["bar"]
+            );
+
+            let unary = commands
+                .iter()
+                .find(|(text, _)| text == "[ -z baz ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected unary test fact");
+            assert_eq!(
+                unary
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("-z".to_owned(), "baz".to_owned())]
+            );
+
+            let negated_unary = commands
+                .iter()
+                .find(|(text, _)| text == "[ ! -n qux ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected negated unary test fact");
+            assert_eq!(
+                negated_unary
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("-n".to_owned(), "qux".to_owned())]
+            );
+
+            let mixed = commands
+                .iter()
+                .find(|(text, _)| text == "[ foo -o -z baz ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected mixed test fact");
+            assert_eq!(
+                mixed
+                    .truthy_expression_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["foo"]
+            );
+            assert_eq!(
+                mixed
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("-z".to_owned(), "baz".to_owned())]
+            );
+
+            let chained = commands
+                .iter()
+                .find(|(text, _)| text == "[ -f file -a ! -z baz ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected chained test fact");
+            assert_eq!(
+                chained
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("-z".to_owned(), "baz".to_owned())]
+            );
+
+            let binary = commands
+                .iter()
+                .find(|(text, _)| text == "[ lhs = rhs ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected binary test fact");
+            assert!(binary.truthy_expression_words(source).is_empty());
+            assert!(binary.string_unary_expression_words(source).is_empty());
         });
     }
 

--- a/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
@@ -2,8 +2,7 @@ use shuck_ast::Span;
 
 use crate::{
     Checker, CommandSubstitutionKind, ConditionalNodeFact, ConditionalOperatorFamily,
-    ExpansionContext, Rule, SimpleTestOperatorFamily, SimpleTestShape, SubstitutionFact, Violation,
-    WordFactContext,
+    ExpansionContext, Rule, SubstitutionFact, Violation, WordFactContext,
 };
 
 pub struct GrepOutputInTest;
@@ -40,7 +39,11 @@ pub fn grep_output_in_test(checker: &mut Checker) {
                 ));
             }
             if let Some(conditional) = fact.conditional() {
-                spans.extend(collect_conditional_spans(conditional, &substitutions));
+                spans.extend(collect_conditional_spans(
+                    conditional,
+                    checker.source(),
+                    &substitutions,
+                ));
             }
             spans
         })
@@ -54,37 +57,30 @@ fn collect_simple_test_spans(
     simple_test: &crate::SimpleTestFact<'_>,
     substitutions: &[&SubstitutionFact],
 ) -> Vec<Span> {
-    match simple_test.shape() {
-        SimpleTestShape::Truthy => simple_test
-            .operands()
-            .first()
-            .copied()
-            .and_then(|word| {
-                word_fact_has_plain_command_substitution(checker, word.span, substitutions)
-                    .then_some(word.span)
-            })
+    let source = checker.source();
+    let mut spans = simple_test
+        .truthy_expression_words(source)
+        .into_iter()
+        .filter(|word| word_fact_has_plain_command_substitution(checker, word.span, substitutions))
+        .map(|word| shellcheck_truthy_test_span(source, word.span))
+        .collect::<Vec<_>>();
+
+    spans.extend(
+        simple_test
+            .string_unary_expression_words(source)
             .into_iter()
-            .collect(),
-        SimpleTestShape::Unary
-            if simple_test.operator_family() == SimpleTestOperatorFamily::StringUnary =>
-        {
-            simple_test
-                .operands()
-                .get(1)
-                .copied()
-                .and_then(|word| {
-                    word_fact_has_plain_command_substitution(checker, word.span, substitutions)
-                        .then_some(simple_test.operands()[0].span)
-                })
-                .into_iter()
-                .collect()
-        }
-        _ => Vec::new(),
-    }
+            .filter_map(|(operator, operand)| {
+                word_fact_has_plain_command_substitution(checker, operand.span, substitutions)
+                    .then_some(operator.span)
+            }),
+    );
+
+    spans
 }
 
 fn collect_conditional_spans(
     conditional: &crate::ConditionalFact<'_>,
+    source: &str,
     substitutions: &[&SubstitutionFact],
 ) -> Vec<Span> {
     let mut spans = Vec::new();
@@ -131,7 +127,7 @@ fn collect_conditional_spans(
             }) =>
         {
             if let Some(word) = bare_word.operand().word() {
-                spans.push(word.span);
+                spans.push(shellcheck_truthy_test_span(source, word.span));
             }
         }
         ConditionalNodeFact::Unary(unary)
@@ -170,7 +166,7 @@ fn collect_conditional_spans(
                 }) =>
             {
                 if let Some(word) = bare_word.operand().word() {
-                    spans.push(word.span);
+                    spans.push(shellcheck_truthy_test_span(source, word.span));
                 }
             }
             ConditionalNodeFact::Unary(unary)
@@ -195,6 +191,22 @@ fn collect_conditional_spans(
     }
 
     spans
+}
+
+fn shellcheck_truthy_test_span(source: &str, span: Span) -> Span {
+    let Some(next) = source
+        .get(span.end.offset..)
+        .and_then(|tail| tail.chars().next())
+    else {
+        return span;
+    };
+    if !matches!(next, ' ' | '\t') {
+        return span;
+    }
+
+    let end_offset = span.end.offset + next.len_utf8();
+    let separator = &source[span.end.offset..end_offset];
+    Span::from_positions(span.start, span.end.advanced_by(separator))
 }
 
 fn word_fact_has_plain_command_substitution(
@@ -291,7 +303,7 @@ mod tests {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$(grep foo file)"]
+            vec!["$(grep foo file) "]
         );
     }
 
@@ -306,5 +318,39 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepOutputInTest));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_negated_truthy_simple_tests() {
+        let source = "\
+#!/bin/sh
+[ ! \"$(grep foo input.txt)\" ]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepOutputInTest));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"$(grep foo input.txt)\" "]
+        );
+    }
+
+    #[test]
+    fn reports_string_unary_subexpressions_in_compound_simple_tests() {
+        let source = "\
+#!/bin/sh
+[ -f \"$path\" -a ! -z \"$(grep foo input.txt)\" ]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepOutputInTest));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-z"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
@@ -394,6 +394,8 @@ mod tests {
 #!/bin/sh
 [ -a \"$(grep foo input.txt)\" ]
 [ -o \"$(grep foo input.txt)\" ]
+[ ! -a \"$(grep foo input.txt)\" ]
+[ ! -o \"$(grep foo input.txt)\" ]
 [ -a \"$path\" -o -z \"$ok\" ]
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepOutputInTest));

--- a/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
@@ -353,4 +353,38 @@ mod tests {
             vec!["-z"]
         );
     }
+
+    #[test]
+    fn reports_quoted_string_unary_operators_in_simple_tests() {
+        let source = "\
+#!/bin/sh
+[ \"-n\" \"$(grep foo input.txt)\" ]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepOutputInTest));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"-n\""]
+        );
+    }
+
+    #[test]
+    fn reports_quoted_logical_connectors_in_simple_tests() {
+        let source = "\
+#!/bin/sh
+[ foo \"-o\" \"$(grep foo input.txt)\" ]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepOutputInTest));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"$(grep foo input.txt)\" "]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
@@ -387,4 +387,17 @@ mod tests {
             vec!["\"$(grep foo input.txt)\" "]
         );
     }
+
+    #[test]
+    fn ignores_unary_a_and_o_tests() {
+        let source = "\
+#!/bin/sh
+[ -a \"$(grep foo input.txt)\" ]
+[ -o \"$(grep foo input.txt)\" ]
+[ -a \"$path\" -o -z \"$ok\" ]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepOutputInTest));
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/s019.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s019.yaml
@@ -8,3 +8,32 @@ reviewed_divergences:
       - project-closure
       - test-harness
     reason: "This test harness keeps the legacy backtick pipeline inside a string test, and ShellCheck stays silent on SC2143 for that project-closure comparison. Shuck keeps the grep-output-in-test warning on the same legacy substitution shape."
+  - side: shuck-only
+    path_suffix: "scripts/SlackBuildsOrg__slackbuilds__network__jboss-as__rc.jboss-as"
+    line: 91
+    reason: "This startup script uses a legacy backtick pipeline inside a `-z` test. The current ShellCheck run classifies the same command substitution under backtick and quoting diagnostics instead of surfacing SC2143, while Shuck keeps the grep-output-in-test warning."
+  - side: shuck-only
+    path_suffix: "scripts/SlackBuildsOrg__slackbuilds__network__sshblock__rc.sshblock"
+    line: 11
+    reason: "This cron-hourly check wraps an `ls | grep` pipeline in legacy backticks inside a bracket test. The current ShellCheck output reports the backtick and pipeline issues under other codes but does not also emit SC2143, while Shuck still flags the grep-output-in-test pattern."
+  - side: shuck-only
+    path_suffix: "scripts/SlackBuildsOrg__slackbuilds__network__wildfly__rc.wildfly"
+    line: 96
+    reason: "This service script uses a legacy backtick pipeline inside a `-z` test. The current ShellCheck run classifies the same command substitution under backtick and quoting diagnostics instead of surfacing SC2143, while Shuck keeps the grep-output-in-test warning."
+  - side: shuck-only
+    path_suffix: "scripts/bittorf__kalua__openwrt-addons__usr__sbin__cron.monitoring"
+    line: 707
+    labels:
+      - project-closure
+    reason: "This hardware probe helper tests the printed output of a nested grep pipeline, and the broader project-closure fixture is consumed through command substitution elsewhere in the script. The current ShellCheck run does not surface SC2143 for this helper predicate, while Shuck keeps the grep-output-in-test warning."
+  - side: shuck-only
+    path_suffix: "scripts/docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
+    labels:
+      - test-harness
+    reason: "This test-harness file uses `[[ $(... | grep ...) ]]` helper predicates to inspect JSON-like Docker settings. The current ShellCheck run does not emit SC2143 for these harness checks, while Shuck consistently warns on using grep output as a boolean test."
+  - side: shuck-only
+    path_suffix: "scripts/spiritLHLS__one-click-installation-script__install_scripts__go.sh"
+    line: 163
+    labels:
+      - project-closure
+    reason: "This proxy setup guard uses a legacy backtick pipeline inside a conditional, and the current ShellCheck run reports only the backtick form rather than surfacing SC2143. Shuck keeps the grep-output-in-test warning on the same substitution shape."


### PR DESCRIPTION
## Summary
- extend simple-test facts so rules can inspect truthy and `-n`/`-z` subexpressions inside negated and compound bracket tests
- update `S019` to catch those additional grep-output-in-test shapes and align truthy span anchoring with ShellCheck
- record the remaining `S019` corpus mismatches as reviewed divergences when the current ShellCheck oracle classifies them under other warnings or skips them in harness/project-closure cases

## Why
`S019` was missing grep-output checks in negated and compound simple-test forms, and several corpus diffs were only span mismatches against ShellCheck. After fixing the rule and the supporting fact surface, the remaining corpus deltas are oracle-only cases rather than implementation bugs.

## Validation
- `cargo test -p shuck-linter grep_output_in_test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S019`