### PR TITLE
Align X012 redirect span with ShellCheck

### DIFF
--- a/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{RedirectKind, Span};
+use shuck_ast::RedirectKind;
 
 use crate::{Checker, Rule, ShellDialect, Violation};
 
@@ -25,10 +25,7 @@ pub fn ampersand_redirection(checker: &mut Checker) {
         .iter()
         .flat_map(|fact| fact.redirect_facts().iter())
         .filter(|redirect| redirect.redirect().kind == RedirectKind::OutputBoth)
-        .map(|redirect| {
-            let span = redirect.redirect().span;
-            Span::from_positions(span.start, span.start.advanced_by("&>"))
-        })
+        .map(|redirect| redirect.redirect().span)
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || AmpersandRedirection);
@@ -44,14 +41,16 @@ mod tests {
         let source = "\
 #!/bin/sh
 : &>out
+echo ok &> /dev/null
 ";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::AmpersandRedirection),
         );
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "&>");
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "&>out");
+        assert_eq!(diagnostics[1].span.slice(source), "&> /dev/null");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This updates X012 to report the full `&>` redirect span instead of only the `&>` operator token.

## Why
The large-corpus X012 comparison was failing with location-only diffs because Shuck flagged the redirect operator while ShellCheck anchored the whole redirect expression, including the target.

## Root Cause
`AmpersandRedirection` narrowed the reported span to the first two characters of an `OutputBoth` redirect even though the parser and redirect facts already preserved the full redirect span.

## Impact
This brings X012's reported range into line with ShellCheck's SC3020 locations and removes the implementation diffs in the targeted corpus run.

## Validation
- `cargo test -p shuck-linter ampersand_redirection -- --nocapture`
- `cargo test -p shuck-linter portability::tests::rules -- --nocapture X012`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X012`
