### PR TITLE
Fix X022 builtin option conformance

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/portability/X022.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X022.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
+read -p prompt name
+printf -v out '%s\n' foo
+export -fn greet
+trap -p EXIT
 wait -n
-wait -pn x
-wait -f -n %1
-wait -x
-wait -1
+ulimit -n
+type -P printf

--- a/crates/shuck-linter/resources/test/fixtures/portability/X022.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X022.sh
@@ -2,6 +2,7 @@
 read -p prompt name
 printf -v out '%s\n' foo
 export -fn greet
+command export -fn greet
 trap -p EXIT
 wait -n
 ulimit -n

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13660,14 +13660,23 @@ fn first_nonportable_sh_builtin_option_span(
             .and_then(|declaration| {
                 matches!(declaration.kind, command::DeclarationKind::Export).then(|| ())
             })
-            .and_then(|_| {
-                let operands = normalized
-                    .declaration
-                    .as_ref()
-                    .expect("checked export declaration")
-                    .operands;
-                first_nonportable_sh_export_option_span(operands, source)
-            }),
+            .map_or_else(
+                || {
+                    first_nonportable_sh_option_span_in_words(
+                        normalized.body_args(),
+                        source,
+                        ShBuiltinOptionPolicy::AllowOnly("p"),
+                    )
+                },
+                |_| {
+                    let operands = normalized
+                        .declaration
+                        .as_ref()
+                        .expect("checked export declaration")
+                        .operands;
+                    first_nonportable_sh_export_option_span(operands, source)
+                },
+            ),
         "ulimit" => first_nonportable_sh_option_span_in_words(
             normalized.body_args(),
             source,
@@ -17446,6 +17455,7 @@ printf -v out '%s' foo
 printf -- -v out
 export -p
 export -fn foo
+command export -fn foo
 trap -p EXIT
 trap -- -p EXIT
 wait -n
@@ -17477,6 +17487,7 @@ type -P printf
                         "-p",
                         "-\"$mode\"",
                         "-v",
+                        "-fn",
                         "-fn",
                         "-p",
                         "-n",

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2125,6 +2125,7 @@ pub struct CommandOptionFacts<'a> {
     expr: Option<ExprCommandFacts>,
     exit: Option<ExitCommandFacts<'a>>,
     sudo_family: Option<SudoFamilyCommandFacts>,
+    nonportable_sh_builtin_option_span: Option<Span>,
     file_operand_words: Box<[&'a Word]>,
 }
 
@@ -2215,6 +2216,10 @@ impl<'a> CommandOptionFacts<'a> {
 
     pub fn sudo_family(&self) -> Option<&SudoFamilyCommandFacts> {
         self.sudo_family.as_ref()
+    }
+
+    pub fn nonportable_sh_builtin_option_span(&self) -> Option<Span> {
+        self.nonportable_sh_builtin_option_span
     }
 
     pub fn file_operand_words(&self) -> &[&'a Word] {
@@ -2308,6 +2313,10 @@ impl<'a> CommandOptionFacts<'a> {
                         .expect("sudo-family wrapper should preserve its invoker"),
                 }
             }),
+            nonportable_sh_builtin_option_span: first_nonportable_sh_builtin_option_span(
+                normalized,
+                source,
+            ),
             file_operand_words: same_command_file_operand_words(
                 normalized.effective_or_literal_name(),
                 normalized.body_args(),
@@ -13630,6 +13639,129 @@ fn option_takes_argument(flag: char) -> bool {
     matches!(flag, 'a' | 'd' | 'i' | 'n' | 'N' | 'p' | 't' | 'u')
 }
 
+#[derive(Debug, Clone, Copy)]
+enum ShBuiltinOptionPolicy {
+    Any,
+    AllowOnly(&'static str),
+}
+
+fn first_nonportable_sh_builtin_option_span(
+    normalized: &NormalizedCommand<'_>,
+    source: &str,
+) -> Option<Span> {
+    match normalized.effective_name.as_deref()? {
+        "read" => first_nonportable_sh_option_span_in_words(
+            normalized.body_args(),
+            source,
+            ShBuiltinOptionPolicy::AllowOnly("r"),
+        ),
+        "export" => normalized.declaration.as_ref().and_then(|declaration| {
+            matches!(declaration.kind, command::DeclarationKind::Export).then(|| ())
+        }).and_then(|_| {
+            let operands = normalized
+                .declaration
+                .as_ref()
+                .expect("checked export declaration")
+                .operands;
+            first_nonportable_sh_export_option_span(operands, source)
+        }),
+        "ulimit" => first_nonportable_sh_option_span_in_words(
+            normalized.body_args(),
+            source,
+            ShBuiltinOptionPolicy::AllowOnly("f"),
+        ),
+        "printf" | "trap" | "type" | "wait" => first_nonportable_sh_option_span_in_words(
+            normalized.body_args(),
+            source,
+            ShBuiltinOptionPolicy::Any,
+        ),
+        _ => None,
+    }
+}
+
+fn first_nonportable_sh_export_option_span(
+    operands: &[DeclOperand],
+    source: &str,
+) -> Option<Span> {
+    for operand in operands {
+        match operand {
+            DeclOperand::Flag(word) => {
+                let Some(text) = static_word_text(word, source) else {
+                    return None;
+                };
+
+                if text == "--" {
+                    return None;
+                }
+
+                if !text.starts_with('-') || text == "-" {
+                    return None;
+                }
+
+                if sh_builtin_option_word_is_portable(
+                    text.as_str(),
+                    ShBuiltinOptionPolicy::AllowOnly("p"),
+                ) {
+                    continue;
+                }
+
+                return Some(word.span);
+            }
+            DeclOperand::Dynamic(word) => {
+                return word_starts_with_literal_dash(word, source).then_some(word.span);
+            }
+            DeclOperand::Name(_) | DeclOperand::Assignment(_) => return None,
+        }
+    }
+
+    None
+}
+
+fn first_nonportable_sh_option_span_in_words(
+    args: &[&Word],
+    source: &str,
+    policy: ShBuiltinOptionPolicy,
+) -> Option<Span> {
+    for word in args {
+        let Some(text) = static_word_text(word, source) else {
+            return word_starts_with_literal_dash(word, source).then_some(word.span);
+        };
+
+        if text == "--" {
+            return None;
+        }
+
+        if !text.starts_with('-') || text == "-" {
+            return None;
+        }
+
+        if sh_builtin_option_word_is_portable(text.as_str(), policy) {
+            continue;
+        }
+
+        return Some(word.span);
+    }
+
+    None
+}
+
+fn sh_builtin_option_word_is_portable(text: &str, policy: ShBuiltinOptionPolicy) -> bool {
+    let Some(flags) = text.strip_prefix('-') else {
+        return false;
+    };
+
+    if flags.is_empty() {
+        return false;
+    }
+
+    match policy {
+        ShBuiltinOptionPolicy::Any => false,
+        ShBuiltinOptionPolicy::AllowOnly(allowed_flags) => flags
+            .chars()
+            .all(|flag| allowed_flags.contains(flag)),
+    }
+}
+
 fn printf_format_word<'a>(args: &[&'a Word], source: &str) -> Option<&'a Word> {
     let mut index = 0usize;
 
@@ -17302,6 +17434,50 @@ find . -execdir sh -ec 'mv {} \"$target\"' \\;
         assert_eq!(
             read.options().read().map(|read| read.uses_raw_input),
             Some(false)
+        );
+    }
+
+    #[test]
+    fn summarizes_first_nonportable_sh_builtin_option_words() {
+        let source = "\
+#!/bin/sh
+read -r name
+read -p prompt name
+read -\"$mode\" name
+printf -v out '%s' foo
+printf -- -v out
+export -p
+export -fn foo
+trap -p EXIT
+trap -- -p EXIT
+wait -n
+wait -p jobid -n
+ulimit -f
+ulimit -n
+type -P printf
+";
+
+        with_facts_dialect(
+            source,
+            None,
+            ParseShellDialect::Bash,
+            ShellDialect::Sh,
+            |_, facts| {
+                let spans = facts
+                    .commands()
+                    .iter()
+                    .filter_map(|fact| {
+                        fact.options()
+                            .nonportable_sh_builtin_option_span()
+                            .map(|span| span.slice(source))
+                    })
+                    .collect::<Vec<_>>();
+
+                assert_eq!(
+                    spans,
+                    vec!["-p", "-\"$mode\"", "-v", "-fn", "-p", "-n", "-p", "-n", "-P"]
+                );
+            },
         );
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2314,8 +2314,7 @@ impl<'a> CommandOptionFacts<'a> {
                 }
             }),
             nonportable_sh_builtin_option_span: first_nonportable_sh_builtin_option_span(
-                normalized,
-                source,
+                normalized, source,
             ),
             file_operand_words: same_command_file_operand_words(
                 normalized.effective_or_literal_name(),
@@ -13655,16 +13654,20 @@ fn first_nonportable_sh_builtin_option_span(
             source,
             ShBuiltinOptionPolicy::AllowOnly("r"),
         ),
-        "export" => normalized.declaration.as_ref().and_then(|declaration| {
-            matches!(declaration.kind, command::DeclarationKind::Export).then(|| ())
-        }).and_then(|_| {
-            let operands = normalized
-                .declaration
-                .as_ref()
-                .expect("checked export declaration")
-                .operands;
-            first_nonportable_sh_export_option_span(operands, source)
-        }),
+        "export" => normalized
+            .declaration
+            .as_ref()
+            .and_then(|declaration| {
+                matches!(declaration.kind, command::DeclarationKind::Export).then(|| ())
+            })
+            .and_then(|_| {
+                let operands = normalized
+                    .declaration
+                    .as_ref()
+                    .expect("checked export declaration")
+                    .operands;
+                first_nonportable_sh_export_option_span(operands, source)
+            }),
         "ulimit" => first_nonportable_sh_option_span_in_words(
             normalized.body_args(),
             source,
@@ -13679,16 +13682,11 @@ fn first_nonportable_sh_builtin_option_span(
     }
 }
 
-fn first_nonportable_sh_export_option_span(
-    operands: &[DeclOperand],
-    source: &str,
-) -> Option<Span> {
+fn first_nonportable_sh_export_option_span(operands: &[DeclOperand], source: &str) -> Option<Span> {
     for operand in operands {
         match operand {
             DeclOperand::Flag(word) => {
-                let Some(text) = static_word_text(word, source) else {
-                    return None;
-                };
+                let text = static_word_text(word, source)?;
 
                 if text == "--" {
                     return None;
@@ -13756,9 +13754,9 @@ fn sh_builtin_option_word_is_portable(text: &str, policy: ShBuiltinOptionPolicy)
 
     match policy {
         ShBuiltinOptionPolicy::Any => false,
-        ShBuiltinOptionPolicy::AllowOnly(allowed_flags) => flags
-            .chars()
-            .all(|flag| allowed_flags.contains(flag)),
+        ShBuiltinOptionPolicy::AllowOnly(allowed_flags) => {
+            flags.chars().all(|flag| allowed_flags.contains(flag))
+        }
     }
 }
 
@@ -17475,7 +17473,17 @@ type -P printf
 
                 assert_eq!(
                     spans,
-                    vec!["-p", "-\"$mode\"", "-v", "-fn", "-p", "-n", "-p", "-n", "-P"]
+                    vec![
+                        "-p",
+                        "-\"$mode\"",
+                        "-v",
+                        "-fn",
+                        "-p",
+                        "-n",
+                        "-p",
+                        "-n",
+                        "-P"
+                    ]
                 );
             },
         );

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X022_X022.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X022_X022.sh.snap
@@ -1,39 +1,45 @@
 ---
 source: crates/shuck-linter/src/rules/portability/mod.rs
-assertion_line: 98
+assertion_line: 175
 ---
-X022 wait options are not portable in `sh` scripts
+X022 this builtin option is not portable in `sh` scripts
  --> <source>:2:6
   |
-2 | wait -n
+2 | read -p prompt name
   |
 
-X022 wait options are not portable in `sh` scripts
- --> <source>:3:6
+X022 this builtin option is not portable in `sh` scripts
+ --> <source>:3:8
   |
-3 | wait -pn x
-  |
-
-X022 wait options are not portable in `sh` scripts
- --> <source>:4:6
-  |
-4 | wait -f -n %1
+3 | printf -v out '%s\n' foo
   |
 
-X022 wait options are not portable in `sh` scripts
- --> <source>:4:9
+X022 this builtin option is not portable in `sh` scripts
+ --> <source>:4:8
   |
-4 | wait -f -n %1
+4 | export -fn greet
   |
 
-X022 wait options are not portable in `sh` scripts
+X022 this builtin option is not portable in `sh` scripts
  --> <source>:5:6
   |
-5 | wait -x
+5 | trap -p EXIT
   |
 
-X022 wait options are not portable in `sh` scripts
+X022 this builtin option is not portable in `sh` scripts
  --> <source>:6:6
   |
-6 | wait -1
+6 | wait -n
+  |
+
+X022 this builtin option is not portable in `sh` scripts
+ --> <source>:7:8
+  |
+7 | ulimit -n
+  |
+
+X022 this builtin option is not portable in `sh` scripts
+ --> <source>:8:6
+  |
+8 | type -P printf
   |

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X022_X022.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X022_X022.sh.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shuck-linter/src/rules/portability/mod.rs
-assertion_line: 175
 ---
 X022 this builtin option is not portable in `sh` scripts
  --> <source>:2:6
@@ -21,25 +20,31 @@ X022 this builtin option is not portable in `sh` scripts
   |
 
 X022 this builtin option is not portable in `sh` scripts
- --> <source>:5:6
+ --> <source>:5:16
   |
-5 | trap -p EXIT
+5 | command export -fn greet
   |
 
 X022 this builtin option is not portable in `sh` scripts
  --> <source>:6:6
   |
-6 | wait -n
+6 | trap -p EXIT
   |
 
 X022 this builtin option is not portable in `sh` scripts
- --> <source>:7:8
+ --> <source>:7:6
   |
-7 | ulimit -n
+7 | wait -n
   |
 
 X022 this builtin option is not portable in `sh` scripts
- --> <source>:8:6
+ --> <source>:8:8
   |
-8 | type -P printf
+8 | ulimit -n
+  |
+
+X022 this builtin option is not portable in `sh` scripts
+ --> <source>:9:6
+  |
+9 | type -P printf
   |

--- a/crates/shuck-linter/src/rules/portability/wait_option.rs
+++ b/crates/shuck-linter/src/rules/portability/wait_option.rs
@@ -41,6 +41,7 @@ read -p prompt name
 read -\"$mode\" name
 printf -v out '%s' foo
 export -fn greet
+command export -fn greet
 trap -p EXIT
 wait -n
 ulimit -n
@@ -48,13 +49,23 @@ type -P printf
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::WaitOption));
 
-        assert_eq!(diagnostics.len(), 8);
+        assert_eq!(diagnostics.len(), 9);
         assert_eq!(
             diagnostics
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-p", "-\"$mode\"", "-v", "-fn", "-p", "-n", "-n", "-P"]
+            vec![
+                "-p",
+                "-\"$mode\"",
+                "-v",
+                "-fn",
+                "-fn",
+                "-p",
+                "-n",
+                "-n",
+                "-P"
+            ]
         );
     }
 

--- a/crates/shuck-linter/src/rules/portability/wait_option.rs
+++ b/crates/shuck-linter/src/rules/portability/wait_option.rs
@@ -8,7 +8,7 @@ impl Violation for WaitOption {
     }
 
     fn message(&self) -> String {
-        "wait options are not portable in `sh` scripts".to_owned()
+        "this builtin option is not portable in `sh` scripts".to_owned()
     }
 }
 
@@ -21,13 +21,7 @@ pub fn wait_option(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter(|fact| fact.effective_name_is("wait"))
-        .flat_map(|fact| {
-            fact.options()
-                .wait()
-                .into_iter()
-                .flat_map(|wait| wait.option_spans().iter().copied())
-        })
+        .filter_map(|fact| fact.options().nonportable_sh_builtin_option_span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || WaitOption);
@@ -39,31 +33,36 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_wait_options_in_sh() {
+    fn reports_nonportable_builtin_options_in_sh() {
         let source = "\
 #!/bin/sh
+read -r name
+read -p prompt name
+read -\"$mode\" name
+printf -v out '%s' foo
+export -fn greet
+trap -p EXIT
 wait -n
-wait -pn x
-wait -f -n %1
-wait -x
-wait -1
+ulimit -n
+type -P printf
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::WaitOption));
 
-        assert_eq!(diagnostics.len(), 6);
+        assert_eq!(diagnostics.len(), 8);
         assert_eq!(
             diagnostics
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-n", "-pn", "-f", "-n", "-x", "-1"]
+            vec!["-p", "-\"$mode\"", "-v", "-fn", "-p", "-n", "-n", "-P"]
         );
     }
 
     #[test]
-    fn ignores_wait_options_in_bash() {
+    fn ignores_builtin_options_in_bash() {
         let source = "\
 #!/bin/bash
+read -p prompt name
 wait -n
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::WaitOption));
@@ -72,10 +71,16 @@ wait -n
     }
 
     #[test]
-    fn ignores_wait_after_double_dash() {
+    fn ignores_operands_after_double_dash() {
         let source = "\
 #!/bin/sh
+read -- -p name
+printf -- -v out
+export -- -f greet
+trap -- -p EXIT
 wait -- -n
+ulimit -- -n
+type -- -P printf
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::WaitOption));
 
@@ -83,39 +88,46 @@ wait -- -n
     }
 
     #[test]
-    fn reports_options_after_wait_p_argument() {
+    fn reports_only_the_first_nonportable_option_word_per_command() {
         let source = "\
 #!/bin/sh
+read -r -p prompt -n 1 name
 wait -p jobid -n
+ulimit -H -n 1
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::WaitOption));
 
-        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics.len(), 3);
         assert_eq!(
             diagnostics
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-p", "-n"]
+            vec!["-p", "-p", "-H"]
         );
     }
 
     #[test]
-    fn reports_attached_wait_p_argument_without_skipping_later_options() {
+    fn reports_combined_and_dynamic_option_words() {
         let source = "\
 #!/bin/sh
-wait -pjob -n
-wait -pfn -f
+read -rp prompt name
+wait -fpn job
+printf -\"$mode\" '%s' foo
+trap -lp EXIT
+export -pn greet
+ulimit -HSn 1
+type -ap printf
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::WaitOption));
 
-        assert_eq!(diagnostics.len(), 4);
+        assert_eq!(diagnostics.len(), 7);
         assert_eq!(
             diagnostics
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-pjob", "-n", "-pfn", "-f"]
+            vec!["-rp", "-fpn", "-\"$mode\"", "-lp", "-pn", "-HSn", "-ap"]
         );
     }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/x022.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x022.yaml
@@ -3,3 +3,14 @@ reviewed_divergences:
     path_suffix: "termux__termux-packages__scripts__build__termux_get_repo_files.sh"
     line: 88
     reason: "This Termux build helper uses Bash arrays and `[[ ... ]]` conditionals in a file without a concrete shell header. Shuck still reaches the `wait -n` site through its collapsed-shell path, while the current ShellCheck oracle leaves that Bash-specific helper unclassified for X022."
+  - side: shuck-only
+    path_suffix: "oh-my-fish__oh-my-fish__bin__install"
+    labels:
+      - project-closure
+    reason: "This installer is a fish script with fish-specific `read -g` and `read -l` flag usage. Shuck can still see those helper paths through project-closure analysis, but they are outside the POSIX sh portability target for X022."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh"
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "This upgrade helper belongs to a zsh codebase and uses zsh-specific syntax such as `[[ ... ]]` patterns alongside `read -k`. X022 intentionally stays scoped to files Shuck actually treats as sh or dash instead of collapsing that helper to POSIX sh."

--- a/docs/rules/X022.yaml
+++ b/docs/rules/X022.yaml
@@ -7,8 +7,8 @@ shellcheck_code: SC3045
 shells:
   - sh
   - dash
-description: The script uses a wait option that portable sh does not provide.
-rationale: Avoid that wait flag in portable scripts, or require bash for the workflow.
+description: The script uses a shell builtin option that portable sh does not provide.
+rationale: Avoid shell builtin option forms that POSIX sh does not define, or require a shell that guarantees them.
 source:
   shell_checks_rule: rules/SH-030.yaml
   shell_checks_example: examples/030.sh
@@ -17,4 +17,8 @@ examples:
     source: shell-checks/examples/030.sh
     code: |
       #!/bin/sh
+      read -p "Name? " name
+      printf -v out '%s' "$name"
+      export -fn greet
+      trap -p EXIT
       wait -n


### PR DESCRIPTION
## Summary
- expand `X022` from wait-only handling to the broader `SC3045` builtin-option family via fact-layer detection
- update the `X022` fixture, snapshot, and rule docs to reflect the widened portability scope
- record reviewed large-corpus divergences for fish and zsh project-closure cases that should stay outside the POSIX `sh` target

## Why
`X022` only reported `wait` option usage, which left many `SC3045` portability cases uncovered in the large corpus. The underlying issue was that the rule had no reusable fact exposing the first non-portable builtin option word across the relevant POSIX-`sh` builtins.

## Impact
This brings `X022` into targeted corpus conformance for `SC3045` while keeping the rule implementation small and fact-driven.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X022`
- `cargo test --workspace`