### PR TITLE
Fix S065 x-prefix detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -310,7 +310,8 @@ impl<'a> SimpleTestFact<'a> {
             .into_iter()
             .filter_map(|expression| match expression {
                 SimpleTestExpression::Truthy(word) => Some(word),
-                SimpleTestExpression::StringUnary { .. } => None,
+                SimpleTestExpression::StringUnary { .. }
+                | SimpleTestExpression::StringBinary { .. } => None,
             })
             .collect()
     }
@@ -322,7 +323,24 @@ impl<'a> SimpleTestFact<'a> {
                 SimpleTestExpression::StringUnary { operator, operand } => {
                     Some((operator, operand))
                 }
-                SimpleTestExpression::Truthy(_) => None,
+                SimpleTestExpression::Truthy(_) | SimpleTestExpression::StringBinary { .. } => None,
+            })
+            .collect()
+    }
+
+    pub fn string_binary_expression_words(
+        &'a self,
+        source: &str,
+    ) -> Vec<(&'a Word, &'a Word, &'a Word)> {
+        simple_test_expressions(self, source)
+            .into_iter()
+            .filter_map(|expression| match expression {
+                SimpleTestExpression::StringBinary {
+                    left,
+                    operator,
+                    right,
+                } => Some((left, operator, right)),
+                SimpleTestExpression::Truthy(_) | SimpleTestExpression::StringUnary { .. } => None,
             })
             .collect()
     }
@@ -359,6 +377,11 @@ enum SimpleTestExpression<'a> {
     StringUnary {
         operator: &'a Word,
         operand: &'a Word,
+    },
+    StringBinary {
+        left: &'a Word,
+        operator: &'a Word,
+        right: &'a Word,
     },
 }
 
@@ -466,6 +489,21 @@ fn parse_simple_test_expression_segment<'a>(
         {
             Some(SimpleTestExpression::StringUnary { operator, operand })
         }
+        [left, operator, right]
+            if simple_test_effective_operand_text(
+                simple_test,
+                start + expression_start + 1,
+                source,
+            )
+            .as_deref()
+            .is_some_and(simple_test_is_string_binary_operator) =>
+        {
+            Some(SimpleTestExpression::StringBinary {
+                left,
+                operator,
+                right,
+            })
+        }
         [] | [_, _, ..] => None,
     }
 }
@@ -490,6 +528,10 @@ fn simple_test_is_logical_connector(text: &str) -> bool {
 
 fn simple_test_is_string_unary_operator(text: &str) -> bool {
     matches!(text, "-n" | "-z")
+}
+
+fn simple_test_is_string_binary_operator(text: &str) -> bool {
+    matches!(text, "=" | "==" | "!=" | "<" | ">")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18757,7 +18799,7 @@ test
     }
 
     #[test]
-    fn simple_test_fact_tracks_truthy_and_string_unary_subexpressions() {
+    fn simple_test_fact_tracks_truthy_string_unary_and_string_binary_subexpressions() {
         let source = "\
 #!/bin/sh
 [ foo ]
@@ -18776,6 +18818,7 @@ test
 [ foo \"-o\" \"-z\" baz ]
 [ -f file -a ! -z baz ]
 [ lhs = rhs ]
+[ lhs = rhs -a -z baz ]
 ";
 
         with_facts(source, None, |_, facts| {
@@ -19051,6 +19094,53 @@ test
                 .expect("expected binary test fact");
             assert!(binary.truthy_expression_words(source).is_empty());
             assert!(binary.string_unary_expression_words(source).is_empty());
+            assert_eq!(
+                binary
+                    .string_binary_expression_words(source)
+                    .into_iter()
+                    .map(|(left, operator, right)| {
+                        (
+                            left.span.slice(source).to_owned(),
+                            operator.span.slice(source).to_owned(),
+                            right.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("lhs".to_owned(), "=".to_owned(), "rhs".to_owned())]
+            );
+
+            let binary_then_unary = commands
+                .iter()
+                .find(|(text, _)| text == "[ lhs = rhs -a -z baz ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected binary plus unary test fact");
+            assert_eq!(
+                binary_then_unary
+                    .string_binary_expression_words(source)
+                    .into_iter()
+                    .map(|(left, operator, right)| {
+                        (
+                            left.span.slice(source).to_owned(),
+                            operator.span.slice(source).to_owned(),
+                            right.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("lhs".to_owned(), "=".to_owned(), "rhs".to_owned())]
+            );
+            assert_eq!(
+                binary_then_unary
+                    .string_unary_expression_words(source)
+                    .into_iter()
+                    .map(|(operator, operand)| {
+                        (
+                            operator.span.slice(source).to_owned(),
+                            operand.span.slice(source).to_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                vec![("-z".to_owned(), "baz".to_owned())]
+            );
         });
     }
 

--- a/crates/shuck-linter/src/rules/style/x_prefix_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/x_prefix_in_test.rs
@@ -1,8 +1,8 @@
 use shuck_ast::Span;
 
 use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, SimpleTestOperatorFamily,
-    SimpleTestShape, SimpleTestSyntax, Violation, leading_literal_word_prefix,
+    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, SimpleTestSyntax, Violation,
+    leading_literal_word_prefix,
 };
 
 pub struct XPrefixInTest;
@@ -25,10 +25,8 @@ pub fn x_prefix_in_test(checker: &mut Checker) {
         .iter()
         .flat_map(|fact| {
             let mut spans = Vec::new();
-            if let Some(simple_test) = fact.simple_test()
-                && let Some(span) = simple_test_span(simple_test, source)
-            {
-                spans.push(span);
+            if let Some(simple_test) = fact.simple_test() {
+                spans.extend(simple_test_spans(simple_test, source));
             }
             if let Some(conditional) = fact.conditional() {
                 spans.extend(conditional_spans(conditional, source));
@@ -40,28 +38,21 @@ pub fn x_prefix_in_test(checker: &mut Checker) {
     checker.report_all_dedup(spans, || XPrefixInTest);
 }
 
-fn simple_test_span(simple_test: &crate::SimpleTestFact<'_>, source: &str) -> Option<Span> {
+fn simple_test_spans(simple_test: &crate::SimpleTestFact<'_>, source: &str) -> Vec<Span> {
     if simple_test.syntax() != SimpleTestSyntax::Test
         && simple_test.syntax() != SimpleTestSyntax::Bracket
     {
-        return None;
-    }
-    if simple_test.effective_shape() != SimpleTestShape::Binary
-        || simple_test.effective_operator_family() != SimpleTestOperatorFamily::StringBinary
-    {
-        return None;
+        return Vec::new();
     }
 
-    let operands = simple_test.effective_operands();
-    if operands.len() != 3 {
-        return None;
-    }
-
-    if word_has_x_prefix(operands[0], source) && word_has_x_prefix(operands[2], source) {
-        Some(operands[0].span)
-    } else {
-        None
-    }
+    simple_test
+        .string_binary_expression_words(source)
+        .into_iter()
+        .filter_map(|(left, _operator, right)| {
+            (word_has_x_prefix(left, source) && word_has_x_prefix(right, source))
+                .then_some(left.span)
+        })
+        .collect()
 }
 
 fn conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &str) -> Vec<Span> {
@@ -95,11 +86,15 @@ fn conditional_operand_has_x_prefix(
     operand
         .word()
         .map(|word| word_has_x_prefix(word, source))
-        .unwrap_or_else(|| operand.expression().span().slice(source).starts_with('x'))
+        .unwrap_or_else(|| has_legacy_x_prefix(operand.expression().span().slice(source)))
 }
 
 fn word_has_x_prefix(word: &shuck_ast::Word, source: &str) -> bool {
-    leading_literal_word_prefix(word, source).starts_with('x')
+    has_legacy_x_prefix(&leading_literal_word_prefix(word, source))
+}
+
+fn has_legacy_x_prefix(text: &str) -> bool {
+    matches!(text.as_bytes().first(), Some(b'x' | b'X'))
 }
 
 #[cfg(test)]
@@ -112,12 +107,15 @@ mod tests {
         let source = "\
 #!/bin/bash
 [ x = x ]
-[ x = xbar ]
-[ xfoo = xbar ]
-[ \"xfoo\" = \"x$browser\" ]
+[ X = Xbar ]
+[ \"Xfoo\" = \"X$browser\" ]
+[ X = \"X$browser\" ]
 test \"x$browser\" != \"x\"
-[[ x = xbar ]]
-[[ \"x$browser\" != \"x\" ]]
+[ \"X`id -u`\" = \"X0\" -a -z \"$RUN_AS_USER\" ]
+[ \"pkg-config --exists libffmpegthumbnailer\" -a \"x${VIDEO_THUMBNAILS}\" != \"xno\" ]
+[ X = X ]
+[[ X = Xbar ]]
+[[ \"X$browser\" != \"X\" ]]
 [ \"x$browser\" = \"x$other\" ]
 [ x = \"x$browser\" ]
 ";
@@ -130,12 +128,15 @@ test \"x$browser\" != \"x\"
                 .collect::<Vec<_>>(),
             vec![
                 "x",
-                "x",
-                "xfoo",
-                "\"xfoo\"",
+                "X",
+                "\"Xfoo\"",
+                "X",
                 "\"x$browser\"",
-                "x",
-                "\"x$browser\"",
+                "\"X`id -u`\"",
+                "\"x${VIDEO_THUMBNAILS}\"",
+                "X",
+                "X",
+                "\"X$browser\"",
                 "\"x$browser\"",
                 "x"
             ]
@@ -148,10 +149,14 @@ test \"x$browser\" != \"x\"
 #!/bin/bash
 [ \"x$browser\" = \"$other\" ]
 [ x = \"$browser\" ]
-[ xfoo = y ]
-[ \"x$browser\" = \"y\" ]
+[ \"X$browser\" = \"$other\" ]
+[ X = \"$browser\" ]
+[ Xfoo = y ]
+[ \"X$browser\" = \"Y\" ]
 [[ prefix$browser = prefix ]]
+[[ Prefix$browser = Prefix ]]
 [[ x = y ]]
+[[ X = Y ]]
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::XPrefixInTest));
 


### PR DESCRIPTION
## Summary
- teach `SimpleTestFact` to expose string-binary subexpressions so rules can inspect compound `[ ... -a ... ]` tests without re-parsing in the rule layer
- update `S065` to flag both lowercase and uppercase legacy `x`/`X` prefixes in simple tests and `[[ ... ]]` conditionals
- add focused fact and rule coverage for mixed-case prefixes and compound test expressions

## Why
`S065` only examined whole three-word binary tests and only treated lowercase `x` as the legacy prefix. That missed real corpus cases like `X"$var" = X` and comparisons embedded inside compound `[ ... -a ... ]` tests.

## Impact
This brings `S065` back into parity for the targeted corpus run and removes the rule's blocking implementation diffs.

## Validation
- `cargo test -p shuck-linter x_prefix_in_test`
- `cargo test -p shuck-linter simple_test_fact_tracks_truthy_string_unary_and_string_binary_subexpressions`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S065`