### PR TITLE
Fix C123 corpus conformance

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1393,7 +1393,7 @@ impl GetoptsCaseFact {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct FunctionHeaderFact<'a> {
     function: &'a FunctionDef,
     binding_id: Option<BindingId>,
@@ -1418,8 +1418,8 @@ impl<'a> FunctionHeaderFact<'a> {
         self.scope_id
     }
 
-    pub fn call_arity(&self) -> FunctionCallArityFacts {
-        self.call_arity
+    pub fn call_arity(&self) -> &FunctionCallArityFacts {
+        &self.call_arity
     }
 
     pub fn function_span_in_source(&self, source: &str) -> Span {
@@ -1447,37 +1447,45 @@ impl<'a> FunctionHeaderFact<'a> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct FunctionCallArityFacts {
     call_count: usize,
     min_arg_count: usize,
     max_arg_count: usize,
+    zero_arg_call_spans: Vec<Span>,
 }
 
 impl FunctionCallArityFacts {
-    pub fn call_count(self) -> usize {
+    pub fn call_count(&self) -> usize {
         self.call_count
     }
 
-    pub fn min_arg_count(self) -> Option<usize> {
+    pub fn min_arg_count(&self) -> Option<usize> {
         (self.call_count != 0).then_some(self.min_arg_count)
     }
 
-    pub fn max_arg_count(self) -> Option<usize> {
+    pub fn max_arg_count(&self) -> Option<usize> {
         (self.call_count != 0).then_some(self.max_arg_count)
     }
 
-    pub fn called_only_without_args(self) -> bool {
+    pub fn called_only_without_args(&self) -> bool {
         self.call_count != 0 && self.max_arg_count == 0
     }
 
-    fn record_call(&mut self, arg_count: usize) {
+    pub fn zero_arg_call_spans(&self) -> &[Span] {
+        &self.zero_arg_call_spans
+    }
+
+    fn record_call(&mut self, arg_count: usize, span: Span) {
         if self.call_count == 0 {
             self.min_arg_count = arg_count;
             self.max_arg_count = arg_count;
         } else {
             self.min_arg_count = self.min_arg_count.min(arg_count);
             self.max_arg_count = self.max_arg_count.max(arg_count);
+        }
+        if arg_count == 0 {
+            self.zero_arg_call_spans.push(span);
         }
         self.call_count += 1;
     }
@@ -3348,7 +3356,8 @@ impl<'a> LinterFactsBuilder<'a> {
         }
 
         let presence_tested_names = build_presence_tested_names(&commands, self.source);
-        let function_headers = build_function_header_facts(self.semantic, &functions);
+        let function_headers =
+            build_function_header_facts(self.semantic, &functions, &commands, self.source);
         sort_and_dedup_spans(&mut condition_status_capture_spans);
         sort_and_dedup_spans(&mut condition_command_substitution_spans);
         let function_parameter_fallback_spans = build_function_parameter_fallback_spans(
@@ -3356,8 +3365,6 @@ impl<'a> LinterFactsBuilder<'a> {
             &structural_command_ids,
             self.source,
         );
-        let function_positional_parameter_facts =
-            build_function_positional_parameter_facts(self.semantic, &commands);
         let for_headers = build_for_header_facts(&commands, &command_ids_by_span, self.source);
         let select_headers =
             build_select_header_facts(&commands, &command_ids_by_span, self.source);
@@ -3421,6 +3428,11 @@ impl<'a> LinterFactsBuilder<'a> {
             star_glob_removals,
             subscript_spans,
         } = surface_fragments;
+        let function_positional_parameter_facts = build_function_positional_parameter_facts(
+            self.semantic,
+            &commands,
+            &positional_parameters,
+        );
         let double_paren_grouping_spans = build_double_paren_grouping_spans(&commands, self.source);
         let arithmetic_for_update_operator_spans =
             build_arithmetic_for_update_operator_spans(&commands, self.source);
@@ -5304,8 +5316,11 @@ fn collect_base_prefix_spans_in_text(span: Span, source: &str, spans: &mut Vec<S
 fn build_function_header_facts<'a>(
     semantic: &SemanticModel,
     functions: &[&'a FunctionDef],
+    commands: &[CommandFact<'a>],
+    source: &str,
 ) -> Vec<FunctionHeaderFact<'a>> {
-    let call_arity_by_binding = build_function_call_arity_facts(semantic, functions);
+    let call_arity_by_binding =
+        build_function_call_arity_facts(semantic, functions, commands, source);
     functions
         .iter()
         .copied()
@@ -5314,7 +5329,7 @@ fn build_function_header_facts<'a>(
             let scope_id = binding_id
                 .and_then(|binding_id| function_header_scope_id(semantic, function, binding_id));
             let call_arity = binding_id
-                .and_then(|binding_id| call_arity_by_binding.get(&binding_id).copied())
+                .and_then(|binding_id| call_arity_by_binding.get(&binding_id).cloned())
                 .unwrap_or_default();
 
             FunctionHeaderFact {
@@ -5373,9 +5388,11 @@ fn function_parameter_fallback_span(pair: &[&CommandFact<'_>], source: &str) -> 
     let start = first.span().start.advanced_by(&text[..relative]);
     Some(Span::from_positions(start, start.advanced_by("(")))
 }
-fn build_function_call_arity_facts(
+fn build_function_call_arity_facts<'a>(
     semantic: &SemanticModel,
     functions: &[&FunctionDef],
+    commands: &[CommandFact<'a>],
+    source: &str,
 ) -> FxHashMap<BindingId, FunctionCallArityFacts> {
     let mut facts = FxHashMap::<BindingId, FunctionCallArityFacts>::default();
     let mut seen_names = FxHashSet::default();
@@ -5388,19 +5405,56 @@ fn build_function_call_arity_facts(
             continue;
         }
 
-        for site in semantic.call_sites_for(name) {
-            let Some(binding_id) = visible_function_binding_for_call_site(semantic, name, site)
-            else {
+        for command in commands {
+            if command.effective_or_literal_name() != Some(name.as_str()) {
+                continue;
+            }
+            let Some(name_word) = command.body_name_word() else {
+                continue;
+            };
+            let Some(binding_id) = visible_function_binding_for_call_offset(
+                semantic,
+                name,
+                name_word.span.start.offset,
+            ) else {
                 continue;
             };
             facts
                 .entry(binding_id)
                 .or_default()
-                .record_call(site.arg_count);
+                .record_call(function_call_arg_count(command, source), name_word.span);
         }
     }
 
     facts
+}
+
+fn function_call_arg_count(command: &CommandFact<'_>, source: &str) -> usize {
+    let arg_count = command.body_args().len();
+    if arg_count != 0 || !command.redirects().is_empty() || !command.is_nested_word_command() {
+        return arg_count;
+    }
+
+    let Some(name_word) = command.body_name_word() else {
+        return 0;
+    };
+    let stmt_span = trim_trailing_whitespace_span(command.stmt().span, source);
+    let tail = if stmt_span.end.offset > name_word.span.end.offset {
+        trim_shell_layout_prefix(&source[name_word.span.end.offset..stmt_span.end.offset])
+    } else {
+        trim_shell_layout_prefix(&source[name_word.span.end.offset..])
+    };
+    if tail.is_empty() {
+        return 0;
+    }
+    if matches!(
+        tail.as_bytes().first(),
+        Some(b')' | b';' | b'|' | b'&' | b'<' | b'>' | b'#')
+    ) {
+        return 0;
+    }
+
+    1
 }
 
 fn function_header_binding_id(
@@ -5434,12 +5488,11 @@ fn function_header_scope_id(
     })
 }
 
-fn visible_function_binding_for_call_site(
+fn visible_function_binding_for_call_offset(
     semantic: &SemanticModel,
     name: &Name,
-    site: &shuck_semantic::CallSite,
+    site_offset: usize,
 ) -> Option<BindingId> {
-    let site_offset = site.span.start.offset;
     let scopes = semantic
         .ancestor_scopes(semantic.scope_at(site_offset))
         .collect::<Vec<_>>();
@@ -5639,6 +5692,7 @@ fn stmt_is_terminal_status_propagating_command(stmt: &Stmt) -> bool {
 fn build_function_positional_parameter_facts(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
+    positional_parameter_fragments: &[PositionalParameterFragmentFact],
 ) -> FxHashMap<ScopeId, FunctionPositionalParameterFacts> {
     let mut facts: FxHashMap<ScopeId, FunctionPositionalParameterFacts> = FxHashMap::default();
     let mut local_reset_offsets_by_scope: FxHashMap<ScopeId, Vec<usize>> = FxHashMap::default();
@@ -5705,6 +5759,25 @@ fn build_function_positional_parameter_facts(
         let entry = facts.entry(scope).or_default();
         entry.required_arg_count = entry.required_arg_count.max(index);
         entry.uses_unprotected_positional_parameters = true;
+    }
+
+    for fragment in positional_parameter_fragments {
+        if reference_has_local_positional_reset(
+            semantic,
+            fragment.span().start.offset,
+            &local_reset_offsets_by_scope,
+        ) {
+            continue;
+        }
+
+        let Some(scope) = enclosing_function_scope(semantic, fragment.span().start.offset) else {
+            continue;
+        };
+
+        facts
+            .entry(scope)
+            .or_default()
+            .uses_unprotected_positional_parameters = true;
     }
 
     for command in commands {
@@ -14507,6 +14580,7 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
 
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
+            resets_positional_parameters = true;
             break;
         };
 
@@ -15624,6 +15698,40 @@ mod tests {
             assert_eq!(header.call_arity().call_count(), 2);
             assert_eq!(header.call_arity().min_arg_count(), Some(0));
             assert_eq!(header.call_arity().max_arg_count(), Some(1));
+            assert_eq!(header.call_arity().zero_arg_call_spans().len(), 1);
+            assert_eq!(
+                header.call_arity().zero_arg_call_spans()[0].slice(source),
+                "greet"
+            );
+        });
+    }
+
+    #[test]
+    fn function_header_fact_tracks_call_arity_inside_parameter_expansion_defaults() {
+        let source = "\
+#!/usr/bin/env bash
+GetBuildVersion() {
+  local build_revision=\"${1}\"
+  printf '%s\n' \"$build_revision\"
+}
+BUILD_VERSION=\"${BUILD_VERSION:-\"$(GetBuildVersion \"${BUILD_REVISION}\")\"}\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let header = facts
+                .function_headers()
+                .iter()
+                .find(|header| {
+                    header
+                        .static_name_entry()
+                        .is_some_and(|(name, _)| name == "GetBuildVersion")
+                })
+                .expect("expected GetBuildVersion header fact");
+
+            assert_eq!(header.call_arity().call_count(), 1);
+            assert_eq!(header.call_arity().min_arg_count(), Some(1));
+            assert_eq!(header.call_arity().max_arg_count(), Some(1));
+            assert!(header.call_arity().zero_arg_call_spans().is_empty());
         });
     }
 
@@ -19545,7 +19653,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
                     .iter()
                     .map(|fragment| fragment.span().slice(source))
                     .collect::<Vec<_>>(),
-                vec!["$10", "$10"]
+                vec!["$10", "$10", "${@:1}", "${*:1:2}"]
             );
             assert_eq!(
                 facts

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -808,6 +808,7 @@ pub enum PositionalParameterFragmentKind {
 pub struct PositionalParameterFragmentFact {
     span: Span,
     kind: PositionalParameterFragmentKind,
+    guarded: bool,
 }
 
 impl PositionalParameterFragmentFact {
@@ -821,6 +822,10 @@ impl PositionalParameterFragmentFact {
 
     pub fn is_above_nine(&self) -> bool {
         self.kind == PositionalParameterFragmentKind::AboveNine
+    }
+
+    pub fn is_guarded(&self) -> bool {
+        self.guarded
     }
 }
 
@@ -5779,6 +5784,10 @@ fn build_function_positional_parameter_facts(
     }
 
     for fragment in positional_parameter_fragments {
+        if fragment.is_guarded() {
+            continue;
+        }
+
         if reference_has_local_positional_reset(
             semantic,
             fragment.span().start.offset,
@@ -19696,6 +19705,7 @@ echo $\"Usage: $0 {start|stop}\"
 printf '%s\n' \"${!name}\" \"${!arr[*]}\"
 printf '%s\n' \"${arr[0]}\" \"${arr[@]}\" \"${arr[*]}\" \"${#arr[0]}\" \"${#arr[@]}\" \"${arr[0]%x}\" \"${arr[0]:2}\" \"${arr[0]//x/y}\" \"${arr[0]:-fallback}\" \"${!arr[0]}\"
 printf '%s\n' \"${name:2}\" \"${1:1}\" \"${name::2}\" \"${@:1}\" \"${*:1:2}\" \"${arr[@]:1}\" \"${arr[0]:1}\"
+printf '%s\n' \"${@:-fallback}\" \"${name:-$10}\"
 printf '%s\n' \"${name^}\" \"${name^^pattern}\" \"${name,}\" \"${arr[0]^^}\" \"${arr[@],,}\" \"${!name^^}\" \"${name//x/y}\"
 printf '%s\n' \"${name/a/b}\" \"${name//a}\" \"${arr[0]//a/b}\" \"${arr[@]/a/b}\" \"${arr[*]//a}\" \"${!name//a/b}\"
 if [ \"$(dpkg-query -W -f '${db:Status-Status}\\n' package 2>/dev/null)\" != \"installed\" ]; then :; fi
@@ -19736,14 +19746,47 @@ if [[ \"$@\" =~ x ]]; then :; fi
                             fragment.span().slice(source),
                             fragment.kind(),
                             fragment.is_above_nine(),
+                            fragment.is_guarded(),
                         )
                     })
                     .collect::<Vec<_>>(),
                 vec![
-                    ("$10", PositionalParameterFragmentKind::AboveNine, true),
-                    ("$10", PositionalParameterFragmentKind::AboveNine, true),
-                    ("${@:1}", PositionalParameterFragmentKind::General, false),
-                    ("${*:1:2}", PositionalParameterFragmentKind::General, false),
+                    (
+                        "$10",
+                        PositionalParameterFragmentKind::AboveNine,
+                        true,
+                        false
+                    ),
+                    (
+                        "$10",
+                        PositionalParameterFragmentKind::AboveNine,
+                        true,
+                        false
+                    ),
+                    (
+                        "${@:1}",
+                        PositionalParameterFragmentKind::General,
+                        false,
+                        false
+                    ),
+                    (
+                        "${*:1:2}",
+                        PositionalParameterFragmentKind::General,
+                        false,
+                        false
+                    ),
+                    (
+                        "${@:-fallback}",
+                        PositionalParameterFragmentKind::General,
+                        false,
+                        true
+                    ),
+                    (
+                        "$10",
+                        PositionalParameterFragmentKind::AboveNine,
+                        true,
+                        true
+                    ),
                 ]
             );
             assert_eq!(

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5471,7 +5471,7 @@ fn function_call_arg_count(command: &CommandFact<'_>, source: &str) -> usize {
     }
     if matches!(
         tail.as_bytes().first(),
-        Some(b')' | b';' | b'|' | b'&' | b'<' | b'>' | b'#')
+        Some(b')' | b';' | b'|' | b'&' | b'<' | b'>' | b'#' | b'`')
     ) {
         return 0;
     }
@@ -15816,6 +15816,36 @@ greet
             assert_eq!(header.call_arity().call_count(), 2);
             assert_eq!(header.call_arity().min_arg_count(), Some(0));
             assert_eq!(header.call_arity().max_arg_count(), Some(1));
+            assert_eq!(header.call_arity().zero_arg_call_spans().len(), 1);
+            assert_eq!(
+                header.call_arity().zero_arg_call_spans()[0].slice(source),
+                "greet"
+            );
+        });
+    }
+
+    #[test]
+    fn function_header_fact_tracks_zero_arg_backtick_calls() {
+        let source = "\
+#!/bin/sh
+greet() { printf '%s\n' \"$1\"; }
+value=\"`greet`\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let header = facts
+                .function_headers()
+                .iter()
+                .find(|header| {
+                    header
+                        .static_name_entry()
+                        .is_some_and(|(name, _)| name == "greet")
+                })
+                .expect("expected greet header fact");
+
+            assert_eq!(header.call_arity().call_count(), 1);
+            assert_eq!(header.call_arity().min_arg_count(), Some(0));
+            assert_eq!(header.call_arity().max_arg_count(), Some(0));
             assert_eq!(header.call_arity().zero_arg_call_spans().len(), 1);
             assert_eq!(
                 header.call_arity().zero_arg_call_spans()[0].slice(source),

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -798,14 +798,29 @@ impl LegacyArithmeticFragmentFact {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PositionalParameterFragmentKind {
+    AboveNine,
+    General,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct PositionalParameterFragmentFact {
     span: Span,
+    kind: PositionalParameterFragmentKind,
 }
 
 impl PositionalParameterFragmentFact {
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    pub fn kind(&self) -> PositionalParameterFragmentKind {
+        self.kind
+    }
+
+    pub fn is_above_nine(&self) -> bool {
+        self.kind == PositionalParameterFragmentKind::AboveNine
     }
 }
 
@@ -15586,6 +15601,7 @@ mod tests {
         SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax, SubstitutionHostKind,
         SudoFamilyInvoker, WordFactHostKind,
     };
+    use crate::facts::PositionalParameterFragmentKind;
     use crate::rules::common::command::WrapperKind;
     use crate::rules::common::expansion::{ExpansionContext, SubstitutionOutputIntent};
     use crate::{ShellDialect, classify_file_context};
@@ -19715,9 +19731,20 @@ if [[ \"$@\" =~ x ]]; then :; fi
                 facts
                     .positional_parameter_fragments()
                     .iter()
-                    .map(|fragment| fragment.span().slice(source))
+                    .map(|fragment| {
+                        (
+                            fragment.span().slice(source),
+                            fragment.kind(),
+                            fragment.is_above_nine(),
+                        )
+                    })
                     .collect::<Vec<_>>(),
-                vec!["$10", "$10", "${@:1}", "${*:1:2}"]
+                vec![
+                    ("$10", PositionalParameterFragmentKind::AboveNine, true),
+                    ("$10", PositionalParameterFragmentKind::AboveNine, true),
+                    ("${@:1}", PositionalParameterFragmentKind::General, false),
+                    ("${*:1:2}", PositionalParameterFragmentKind::General, false),
+                ]
             );
             assert_eq!(
                 facts

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5406,7 +5406,7 @@ fn build_function_call_arity_facts<'a>(
         }
 
         for command in commands {
-            if command.effective_or_literal_name() != Some(name.as_str()) {
+            if command.literal_name() != Some(name.as_str()) {
                 continue;
             }
             let Some(name_word) = command.body_name_word() else {
@@ -15732,6 +15732,37 @@ BUILD_VERSION=\"${BUILD_VERSION:-\"$(GetBuildVersion \"${BUILD_REVISION}\")\"}\"
             assert_eq!(header.call_arity().min_arg_count(), Some(1));
             assert_eq!(header.call_arity().max_arg_count(), Some(1));
             assert!(header.call_arity().zero_arg_call_spans().is_empty());
+        });
+    }
+
+    #[test]
+    fn function_header_fact_ignores_wrapper_resolved_targets_for_call_arity() {
+        let source = "\
+#!/usr/bin/env bash
+greet() { printf '%s\n' \"$1\"; }
+command greet ok
+greet
+";
+
+        with_facts(source, None, |_, facts| {
+            let header = facts
+                .function_headers()
+                .iter()
+                .find(|header| {
+                    header
+                        .static_name_entry()
+                        .is_some_and(|(name, _)| name == "greet")
+                })
+                .expect("expected greet header fact");
+
+            assert_eq!(header.call_arity().call_count(), 1);
+            assert_eq!(header.call_arity().min_arg_count(), Some(0));
+            assert_eq!(header.call_arity().max_arg_count(), Some(0));
+            assert_eq!(header.call_arity().zero_arg_call_spans().len(), 1);
+            assert_eq!(
+                header.call_arity().zero_arg_call_spans()[0].slice(source),
+                "greet"
+            );
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5406,7 +5406,9 @@ fn build_function_call_arity_facts<'a>(
         }
 
         for command in commands {
-            if command.literal_name() != Some(name.as_str()) {
+            if !command.wrappers().is_empty()
+                || command.effective_or_literal_name() != Some(name.as_str())
+            {
                 continue;
             }
             let Some(name_word) = command.body_name_word() else {
@@ -15758,6 +15760,37 @@ greet
             assert_eq!(header.call_arity().call_count(), 1);
             assert_eq!(header.call_arity().min_arg_count(), Some(0));
             assert_eq!(header.call_arity().max_arg_count(), Some(0));
+            assert_eq!(header.call_arity().zero_arg_call_spans().len(), 1);
+            assert_eq!(
+                header.call_arity().zero_arg_call_spans()[0].slice(source),
+                "greet"
+            );
+        });
+    }
+
+    #[test]
+    fn function_header_fact_counts_quoted_static_calls_in_call_arity() {
+        let source = "\
+#!/usr/bin/env bash
+greet() { printf '%s\n' \"$1\"; }
+\"greet\" ok
+greet
+";
+
+        with_facts(source, None, |_, facts| {
+            let header = facts
+                .function_headers()
+                .iter()
+                .find(|header| {
+                    header
+                        .static_name_entry()
+                        .is_some_and(|(name, _)| name == "greet")
+                })
+                .expect("expected greet header fact");
+
+            assert_eq!(header.call_arity().call_count(), 2);
+            assert_eq!(header.call_arity().min_arg_count(), Some(0));
+            assert_eq!(header.call_arity().max_arg_count(), Some(1));
             assert_eq!(header.call_arity().zero_arg_call_spans().len(), 1);
             assert_eq!(
                 header.call_arity().zero_arg_call_spans()[0].slice(source),

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -19706,6 +19706,7 @@ printf '%s\n' \"${!name}\" \"${!arr[*]}\"
 printf '%s\n' \"${arr[0]}\" \"${arr[@]}\" \"${arr[*]}\" \"${#arr[0]}\" \"${#arr[@]}\" \"${arr[0]%x}\" \"${arr[0]:2}\" \"${arr[0]//x/y}\" \"${arr[0]:-fallback}\" \"${!arr[0]}\"
 printf '%s\n' \"${name:2}\" \"${1:1}\" \"${name::2}\" \"${@:1}\" \"${*:1:2}\" \"${arr[@]:1}\" \"${arr[0]:1}\"
 printf '%s\n' \"${@:-fallback}\" \"${name:-$10}\"
+printf '%s\n' \"${name:-${@}}\"
 printf '%s\n' \"${name^}\" \"${name^^pattern}\" \"${name,}\" \"${arr[0]^^}\" \"${arr[@],,}\" \"${!name^^}\" \"${name//x/y}\"
 printf '%s\n' \"${name/a/b}\" \"${name//a}\" \"${arr[0]//a/b}\" \"${arr[@]/a/b}\" \"${arr[*]//a}\" \"${!name//a/b}\"
 if [ \"$(dpkg-query -W -f '${db:Status-Status}\\n' package 2>/dev/null)\" != \"installed\" ]; then :; fi
@@ -19785,6 +19786,12 @@ if [[ \"$@\" =~ x ]]; then :; fi
                         "$10",
                         PositionalParameterFragmentKind::AboveNine,
                         true,
+                        true
+                    ),
+                    (
+                        "${@}",
+                        PositionalParameterFragmentKind::General,
+                        false,
                         true
                     ),
                 ]

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -743,7 +743,8 @@ impl<'a> SurfaceFragmentSink<'a> {
         span: Span,
         context: SurfaceScanContext<'_>,
     ) {
-        let guarded_reference = parameter_expansion_guards_unset_reference(parameter);
+        let guarded_reference = context.guarded_parameter_operand
+            || parameter_expansion_guards_unset_reference(parameter);
 
         self.record_special_positional_parameter(parameter, guarded_reference);
         if span.slice(self.source).starts_with("${##") {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -731,6 +731,12 @@ impl<'a> SurfaceFragmentSink<'a> {
         span: Span,
         context: SurfaceScanContext<'_>,
     ) {
+        self.record_special_positional_parameter(parameter);
+        if span.slice(self.source).starts_with("${##") {
+            self.facts
+                .positional_parameters
+                .push(PositionalParameterFragmentFact { span });
+        }
         if is_nested_parameter_expansion(parameter, self.source) {
             self.facts
                 .nested_parameter_expansions
@@ -794,6 +800,33 @@ impl<'a> SurfaceFragmentSink<'a> {
                 | BourneParameterExpansion::Slice { .. }
                 | BourneParameterExpansion::Transformation { .. } => {}
             }
+        }
+    }
+
+    fn record_special_positional_parameter(&mut self, parameter: &shuck_ast::ParameterExpansion) {
+        let reference = match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+                BourneParameterExpansion::Access { reference }
+                | BourneParameterExpansion::Length { reference }
+                | BourneParameterExpansion::Indices { reference }
+                | BourneParameterExpansion::Indirect { reference, .. }
+                | BourneParameterExpansion::Slice { reference, .. }
+                | BourneParameterExpansion::Operation { reference, .. }
+                | BourneParameterExpansion::Transformation { reference, .. } => Some(reference),
+                BourneParameterExpansion::PrefixMatch { .. } => None,
+            },
+            ParameterExpansionSyntax::Zsh(_) => None,
+        };
+
+        if let Some(reference) = reference
+            && reference.subscript.is_none()
+            && matches!(reference.name.as_str(), "@" | "*" | "#")
+        {
+            self.facts
+                .positional_parameters
+                .push(PositionalParameterFragmentFact {
+                    span: reference.span,
+                });
         }
     }
 

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -31,6 +31,7 @@ pub(super) struct SurfaceScanContext<'a> {
     assignment_target: Option<&'a str>,
     nested_word_command: bool,
     variable_set_operand: bool,
+    guarded_parameter_operand: bool,
     collect_open_double_quotes: bool,
     collect_pattern_charclasses: bool,
 }
@@ -56,6 +57,13 @@ impl<'a> SurfaceScanContext<'a> {
     pub(super) fn variable_set_operand(self) -> Self {
         Self {
             variable_set_operand: true,
+            ..self
+        }
+    }
+
+    pub(super) fn guarded_parameter_operand(self) -> Self {
+        Self {
+            guarded_parameter_operand: true,
             ..self
         }
     }
@@ -345,6 +353,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     .push(PositionalParameterFragmentFact {
                         span: part.span.merge(next_part.span),
                         kind: PositionalParameterFragmentKind::AboveNine,
+                        guarded: context.guarded_parameter_operand,
                     });
             }
 
@@ -578,6 +587,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     .push(PositionalParameterFragmentFact {
                         span: part.span.merge(next_part.span),
                         kind: PositionalParameterFragmentKind::AboveNine,
+                        guarded: context.guarded_parameter_operand,
                     });
             }
 
@@ -733,13 +743,16 @@ impl<'a> SurfaceFragmentSink<'a> {
         span: Span,
         context: SurfaceScanContext<'_>,
     ) {
-        self.record_special_positional_parameter(parameter);
+        let guarded_reference = parameter_expansion_guards_unset_reference(parameter);
+
+        self.record_special_positional_parameter(parameter, guarded_reference);
         if span.slice(self.source).starts_with("${##") {
             self.facts
                 .positional_parameters
                 .push(PositionalParameterFragmentFact {
                     span,
                     kind: PositionalParameterFragmentKind::General,
+                    guarded: guarded_reference,
                 });
         }
         if is_nested_parameter_expansion(parameter, self.source) {
@@ -808,7 +821,11 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    fn record_special_positional_parameter(&mut self, parameter: &shuck_ast::ParameterExpansion) {
+    fn record_special_positional_parameter(
+        &mut self,
+        parameter: &shuck_ast::ParameterExpansion,
+        guarded: bool,
+    ) {
         let reference = match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(syntax) => match syntax {
                 BourneParameterExpansion::Access { reference }
@@ -832,6 +849,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 .push(PositionalParameterFragmentFact {
                     span: reference.span,
                     kind: PositionalParameterFragmentKind::General,
+                    guarded,
                 });
         }
     }
@@ -871,7 +889,11 @@ impl<'a> SurfaceFragmentSink<'a> {
             | ParameterOp::AssignDefault
             | ParameterOp::UseReplacement
             | ParameterOp::Error => {
-                self.collect_fragment_word(operand_word_ast, operand, context);
+                self.collect_fragment_word(
+                    operand_word_ast,
+                    operand,
+                    context.guarded_parameter_operand(),
+                );
             }
             ParameterOp::UpperFirst
             | ParameterOp::UpperAll
@@ -936,6 +958,38 @@ fn heredoc_single_quote_is_escaped(text: &str, quote_offset: usize) -> bool {
     }
 
     !backslash_count.is_multiple_of(2)
+}
+
+fn parameter_expansion_guards_unset_reference(parameter: &shuck_ast::ParameterExpansion) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(
+            BourneParameterExpansion::Operation { operator, .. }
+            | BourneParameterExpansion::Indirect {
+                operator: Some(operator),
+                ..
+            },
+        ) => parameter_operator_guards_unset_reference(operator),
+        ParameterExpansionSyntax::Bourne(
+            BourneParameterExpansion::Access { .. }
+            | BourneParameterExpansion::Length { .. }
+            | BourneParameterExpansion::Indices { .. }
+            | BourneParameterExpansion::Indirect { operator: None, .. }
+            | BourneParameterExpansion::PrefixMatch { .. }
+            | BourneParameterExpansion::Slice { .. }
+            | BourneParameterExpansion::Transformation { .. },
+        )
+        | ParameterExpansionSyntax::Zsh(_) => false,
+    }
+}
+
+fn parameter_operator_guards_unset_reference(operator: &ParameterOp) -> bool {
+    matches!(
+        operator,
+        ParameterOp::UseDefault
+            | ParameterOp::AssignDefault
+            | ParameterOp::UseReplacement
+            | ParameterOp::Error
+    )
 }
 
 fn parameter_has_array_reference(parameter: &shuck_ast::ParameterExpansion) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -344,6 +344,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     .positional_parameters
                     .push(PositionalParameterFragmentFact {
                         span: part.span.merge(next_part.span),
+                        kind: PositionalParameterFragmentKind::AboveNine,
                     });
             }
 
@@ -576,6 +577,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     .positional_parameters
                     .push(PositionalParameterFragmentFact {
                         span: part.span.merge(next_part.span),
+                        kind: PositionalParameterFragmentKind::AboveNine,
                     });
             }
 
@@ -735,7 +737,10 @@ impl<'a> SurfaceFragmentSink<'a> {
         if span.slice(self.source).starts_with("${##") {
             self.facts
                 .positional_parameters
-                .push(PositionalParameterFragmentFact { span });
+                .push(PositionalParameterFragmentFact {
+                    span,
+                    kind: PositionalParameterFragmentKind::General,
+                });
         }
         if is_nested_parameter_expansion(parameter, self.source) {
             self.facts
@@ -826,6 +831,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 .positional_parameters
                 .push(PositionalParameterFragmentFact {
                     span: reference.span,
+                    kind: PositionalParameterFragmentKind::General,
                 });
         }
     }

--- a/crates/shuck-linter/src/rules/common/command.rs
+++ b/crates/shuck-linter/src/rules/common/command.rs
@@ -1,6 +1,6 @@
 use shuck_ast::{
     Assignment, BuiltinCommand, Command, DeclClause, DeclOperand, Redirect, SimpleCommand, Span,
-    Word, WordPart,
+    Word,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -520,14 +520,7 @@ fn builtin_span(command: &BuiltinCommand) -> Span {
 }
 
 fn static_word_text(word: &Word, source: &str) -> Option<String> {
-    let mut result = String::new();
-    for (part, span) in word.parts_with_spans() {
-        match part {
-            WordPart::Literal(text) => result.push_str(text.as_str(source, span)),
-            _ => return None,
-        }
-    }
-    Some(result)
+    super::word::static_word_text(word, source)
 }
 
 #[cfg(test)]
@@ -664,6 +657,41 @@ mod tests {
             assert_eq!(normalized.wrappers, vec![wrapper], "{source}");
             assert!(normalized.body_words.is_empty(), "{source}");
         }
+    }
+
+    #[test]
+    fn normalize_command_tracks_quoted_static_command_names() {
+        let source = "\"printf\" '%s\\n' hi\n";
+        let command = parse_first_command(source);
+        let normalized = normalize_command(&command, source);
+
+        assert_eq!(normalized.literal_name.as_deref(), Some("printf"));
+        assert_eq!(normalized.effective_name.as_deref(), Some("printf"));
+        assert!(normalized.wrappers.is_empty());
+        assert_eq!(normalized.body_words.len(), 3);
+        assert_eq!(
+            normalized
+                .body_name_word()
+                .map(|word| word.span.slice(source)),
+            Some("\"printf\"")
+        );
+    }
+
+    #[test]
+    fn normalize_command_preserves_wrapper_markers_for_quoted_targets() {
+        let source = "command \"printf\" '%s\\n' hi\n";
+        let command = parse_first_command(source);
+        let normalized = normalize_command(&command, source);
+
+        assert_eq!(normalized.literal_name.as_deref(), Some("command"));
+        assert_eq!(normalized.effective_name.as_deref(), Some("printf"));
+        assert_eq!(normalized.wrappers, vec![WrapperKind::Command]);
+        assert_eq!(
+            normalized
+                .body_name_word()
+                .map(|word| word.span.slice(source)),
+            Some("\"printf\"")
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -321,6 +321,25 @@ greet
     }
 
     #[test]
+    fn backtick_substitutions_still_count_as_zero_arg_calls() {
+        let source = "\
+#!/bin/sh
+greet() { printf '%s\n' \"$1\"; }
+value=\"`greet`\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "greet() { printf '%s\n' \"$1\"; }"
+        );
+    }
+
+    #[test]
     fn earlier_calls_in_same_scope_still_count_toward_mixed_arity() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -131,6 +131,21 @@ greet
     }
 
     #[test]
+    fn ignores_guarded_special_positional_parameters() {
+        let source = "\
+#!/bin/sh
+greet() { printf '%s\n' \"${@:-fallback}\"; }
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_functions_that_reset_positional_parameters() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -146,6 +146,21 @@ greet
     }
 
     #[test]
+    fn ignores_nested_guarded_special_positional_parameters() {
+        let source = "\
+#!/bin/sh
+greet() { printf '%s\n' \"${name:-${@}}\"; }
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_functions_that_reset_positional_parameters() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -186,6 +186,21 @@ greet
     }
 
     #[test]
+    fn ignores_nested_guarded_special_positional_parameters() {
+        let source = "\
+#!/bin/sh
+greet() { printf '%s\n' \"${name:-${@}}\"; }
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn later_redefinitions_do_not_inherit_argumented_calls_from_earlier_bindings() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -171,6 +171,21 @@ greet
     }
 
     #[test]
+    fn ignores_guarded_special_positional_parameters() {
+        let source = "\
+#!/bin/sh
+greet() { printf '%s\n' \"${@:-fallback}\"; }
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn later_redefinitions_do_not_inherit_argumented_calls_from_earlier_bindings() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -291,6 +291,24 @@ greet
     }
 
     #[test]
+    fn wrapper_resolved_targets_do_not_suppress_direct_zero_arg_reports() {
+        let source = "\
+#!/usr/bin/env bash
+greet() { echo \"$1 $2\"; }
+command greet ok yes
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 4);
+    }
+
+    #[test]
     fn nested_set_commands_still_count_as_positional_parameter_resets() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -40,19 +40,21 @@ pub fn function_references_unset_param(checker: &mut Checker) {
         let positional = checker
             .facts()
             .function_positional_parameter_facts(function_scope);
-        let required_arg_count = positional.required_arg_count();
-
-        if required_arg_count <= 1 || positional.resets_positional_parameters() {
+        if !positional.uses_positional_parameters() || positional.resets_positional_parameters() {
             continue;
         }
-        if !header.call_arity().called_only_without_args() {
+        let call_arity = header.call_arity();
+        if !call_arity.called_only_without_args() {
             continue;
         }
 
-        violations.push((
-            header.function_span_in_source(checker.source()),
-            name.to_string(),
-        ));
+        violations.extend(
+            call_arity
+                .zero_arg_call_spans()
+                .iter()
+                .copied()
+                .map(|span| (span, name.to_string())),
+        );
     }
 
     for (span, name) in violations {
@@ -66,7 +68,7 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_functions_called_with_too_few_arguments() {
+    fn reports_zero_argument_call_sites_for_functions_that_read_positional_parameters() {
         let source = "\
 #!/bin/sh
 greet() { echo \"$1 $2\"; }
@@ -78,10 +80,28 @@ greet
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].span.slice(source),
-            "greet() { echo \"$1 $2\"; }"
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn reports_each_zero_argument_call_site_when_all_calls_omit_arguments() {
+        let source = "\
+#!/bin/sh
+greet() { echo \"$1\"; }
+greet
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
         );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.slice(source), "greet");
+        assert_eq!(diagnostics[1].span.start.line, 4);
     }
 
     #[test]
@@ -116,18 +136,20 @@ greet
     }
 
     #[test]
-    fn ignores_functions_with_only_one_required_argument() {
+    fn reports_functions_that_read_special_positional_parameters() {
         let source = "\
 #!/bin/sh
-greet() { echo \"$1\"; }
-greet
+usage() { echo \"usage: ${##*/} <files>\"; }
+usage
 ";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
         );
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "usage");
+        assert_eq!(diagnostics[0].span.start.line, 3);
     }
 
     #[test]
@@ -163,10 +185,8 @@ greet
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].span.slice(source),
-            "greet() { echo \"$2\"; }"
-        );
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 5);
     }
 
     #[test]
@@ -186,7 +206,8 @@ wrapper
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "foo() { echo \"$2\"; }");
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
+        assert_eq!(diagnostics[0].span.start.line, 4);
     }
 
     #[test]
@@ -230,10 +251,8 @@ outer_with_args
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].span.slice(source),
-            "inner() { echo \"$1 $2\"; }"
-        );
+        assert_eq!(diagnostics[0].span.slice(source), "inner");
+        assert_eq!(diagnostics[0].span.start.line, 4);
     }
 
     #[test]
@@ -251,10 +270,8 @@ greet
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].span.slice(source),
-            "greet() {\n  printf '%s\n' \"$(printf '%s' \"$1 $2\")\"\n}"
-        );
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 6);
     }
 
     #[test]
@@ -309,10 +326,8 @@ greet
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].span.slice(source),
-            "greet() {\n  status=$(set -- hello world)\n  echo \"$2\"\n}"
-        );
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 6);
     }
 
     #[test]
@@ -353,9 +368,44 @@ greet
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].span.slice(source),
-            "greet() {\n  printf '%s\n' 'hello world' | while read -r first second; do\n    set -- \"$first\" \"$second\"\n  done\n  echo \"$2\"\n}"
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 9);
+    }
+
+    #[test]
+    fn ignores_dynamic_set_operands_that_reset_positional_parameters() {
+        let source = "\
+#!/bin/sh
+greet() {
+  line='hello world'
+  set $line
+  echo \"$2\"
+}
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
         );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_calls_with_arguments_inside_parameter_expansion_defaults() {
+        let source = "\
+#!/usr/bin/env bash
+GetBuildVersion() {
+  local build_revision=\"${1}\"
+  printf '%s\n' \"$build_revision\"
+}
+BUILD_VERSION=\"${BUILD_VERSION:-\"$(GetBuildVersion \"${BUILD_REVISION}\")\"}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -305,6 +305,22 @@ greet
     }
 
     #[test]
+    fn backtick_substitutions_still_count_as_zero_arg_calls() {
+        let source = "\
+#!/bin/sh
+greet() { printf '%s\n' \"$1 $2\"; }
+value=\"`greet`\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+    }
+
+    #[test]
     fn earlier_calls_in_same_scope_still_count_toward_mixed_arity() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -309,6 +309,22 @@ greet
     }
 
     #[test]
+    fn quoted_static_calls_with_arguments_still_suppress_zero_arg_reports() {
+        let source = "\
+#!/usr/bin/env bash
+greet() { echo \"$1 $2\"; }
+\"greet\" ok yes
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn nested_set_commands_still_count_as_positional_parameter_resets() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
@@ -17,6 +17,7 @@ pub fn positional_ten_braces(checker: &mut Checker) {
         .facts()
         .positional_parameter_fragments()
         .iter()
+        .filter(|fragment| fragment.is_above_nine())
         .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
 
@@ -41,5 +42,14 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["$10", "$10"]
         );
+    }
+
+    #[test]
+    fn ignores_special_positional_parameter_expansions() {
+        let source = "#!/usr/bin/env bash\nprintf '%s\\n' \"${@:1}\" \"${*:1:2}\"\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::PositionalTenBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C123_C123.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C123_C123.sh.snap
@@ -2,7 +2,7 @@
 source: crates/shuck-linter/src/rules/correctness/mod.rs
 ---
 C123 function `greet` is called with too few arguments
- --> <source>:2:1
+ --> <source>:3:1
   |
-2 | greet() { echo "$1 $2"; }
+3 | greet
   |

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -322,6 +322,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             let call_site = CallSite {
                 callee: callee.clone(),
                 span: command.span,
+                name_span: command.name.span,
                 scope,
                 arg_count: command.args.len(),
             };

--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -7,6 +7,7 @@ use crate::{BindingId, ScopeId};
 pub struct CallSite {
     pub callee: Name,
     pub span: Span,
+    pub name_span: Span,
     pub scope: ScopeId,
     pub arg_count: usize,
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/c123.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c123.yaml
@@ -1,0 +1,83 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__completion__available__salt.completion.bash"
+    labels:
+      - directive-handling
+      - helper-library
+    reason: "These bash-completion helpers are compared as sourced library code, and the remaining zero-argument `_salt_get_grains` calls run inside helper-library and directive-handling context rather than a standalone command-line entrypoint. Shuck's file-local call graph still reports the helper invocation sites, so this completion-library drift is reviewed instead of broadening C123 to trust incomplete closure state."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__completion__available__virtualbox.completion.bash"
+    labels:
+      - directive-handling
+      - helper-library
+    reason: "These VirtualBox completion helpers are sourced library code, and the pinned oracle's helper-library plus directive-handling path suppresses the local zero-argument helper invocations. Shuck still reports the in-file `__vboxmanage_list_vms` call sites from its standalone view, so this completion-helper divergence is reviewed."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__plugins__available__browser.plugin.bash"
+    labels:
+      - directive-handling
+      - helper-library
+    reason: "This browser plugin is evaluated as sourced helper code, where the plugin entrypoints rely on ambient shell state more than positional arguments. Shuck still sees the local `browser` helper call without that surrounding plugin context, so the remaining helper-library drift is reviewed."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__plugins__available__z_autoenv.plugin.bash"
+    labels:
+      - directive-handling
+      - helper-library
+      - project-closure
+    reason: "This autoenv plugin is compared through helper-library and project-closure context, and the remaining `autoenv_init` site is part of sourced plugin initialization rather than a self-contained script entrypoint. Shuck's local view still reports the zero-argument helper call, so this closure-dependent difference is reviewed."
+  - side: shuck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__.bash.d__git.sh"
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This bash.d helper is sourced into a larger shell environment, and the remaining `pull` invocation depends on project-closure plus directive-handling context that Shuck does not reconstruct for C123. The standalone local warning is therefore kept as a reviewed closure-side divergence."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__tests__test_all.sh"
+    labels:
+      - project-closure
+      - test-harness
+    reason: "This corpus case is a test harness that sources loader state before it exercises `test_explode`, so the remaining zero-argument helper call depends on project-closure and harness setup outside the file-local view. Shuck's standalone warning is reviewed rather than treated as a live C123 conformance bug."
+  - side: shellcheck-only
+    path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
+    line: 33
+    end_line: 33
+    labels:
+      - project-closure
+      - test-harness
+    reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
+  - side: shuck-only
+    path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
+    line: 33
+    end_line: 33
+    labels:
+      - project-closure
+      - test-harness
+    reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
+  - side: shellcheck-only
+    path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
+    line: 37
+    end_line: 37
+    labels:
+      - project-closure
+      - test-harness
+    reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
+  - side: shuck-only
+    path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
+    line: 37
+    end_line: 37
+    labels:
+      - project-closure
+      - test-harness
+    reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__lib__core__dsl.sh"
+    labels:
+      - directive-handling
+      - helper-library
+    reason: "This ShellSpec DSL file is sourced as helper-library code, and the remaining `shellspec_yield` site relies on the library's ambient execution contract rather than a normal script argv flow. Shuck still reports the local zero-argument helper call from its standalone view, so this helper-library difference is reviewed."
+  - side: shuck-only
+    path_suffix: "scop__bash-completion__completions-core__ssh.bash"
+    labels:
+      - directive-handling
+      - helper-library
+      - shell-collapse
+    reason: "This ssh completion helper is compared through helper-library and shell-collapse context, and the remaining `_comp_xfunc_scp_compgen_remote_files` call depends on sourced completion state outside the file-local argv model. Shuck's standalone helper warning is reviewed rather than treated as a live C123 gap."


### PR DESCRIPTION
## Summary
- report C123 on zero-argument call sites instead of function definitions
- tighten function call arity and positional-parameter fact gathering for nested/default-arm and special-parameter cases
- record reviewed C123 corpus divergences, including the postgres location-only span drift

## Testing
- cargo test -p shuck-linter function_references_unset_param
- cargo test -p shuck-linter function_header_fact_tracks_call_arity_inside_parameter_expansion_defaults
- cargo test -p shuck-linter builds_surface_fragment_facts_and_static_utility_names
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C123