### PR TITLE
Add binding origin metadata for safe-value analysis

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -3246,7 +3246,12 @@ impl<'a> LinterFactsBuilder<'a> {
                 elif_condition_command_ids.insert(id);
             }
 
-            collect_binding_values(visit.command, self.semantic, &mut binding_values);
+            collect_binding_values(
+                visit.command,
+                self.semantic,
+                self.source,
+                &mut binding_values,
+            );
             collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
             collect_comma_array_assignment_spans(
                 visit.command,
@@ -15668,13 +15673,28 @@ fn trap_action_word<'a>(command: &'a Command, source: &str) -> Option<&'a Word> 
 fn collect_binding_values<'a>(
     command: &'a Command,
     semantic: &SemanticModel,
+    source: &str,
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
 ) {
-    for assignment in query::command_assignments(command) {
+    let assignments = match command {
+        Command::Simple(simple) if simple.name.span.slice(source).is_empty() => &simple.assignments,
+        Command::Builtin(_) | Command::Decl(_) => query::command_assignments(command),
+        Command::Simple(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => &[],
+    };
+
+    for assignment in assignments {
         let AssignmentValue::Scalar(word) = &assignment.value else {
             continue;
         };
-        if let Some(binding_id) = binding_value_id_for_name(semantic, &assignment.target.name, assignment.target.name_span) {
+        if let Some(binding_id) = binding_value_id_for_name(
+            semantic,
+            &assignment.target.name,
+            assignment.target.name_span,
+        ) {
             binding_values.insert(binding_id, BindingValueFact::scalar(word));
         }
     }
@@ -15686,7 +15706,11 @@ fn collect_binding_values<'a>(
         let AssignmentValue::Scalar(word) = &assignment.value else {
             continue;
         };
-        if let Some(binding_id) = binding_value_id_for_name(semantic, &assignment.target.name, assignment.target.name_span) {
+        if let Some(binding_id) = binding_value_id_for_name(
+            semantic,
+            &assignment.target.name,
+            assignment.target.name_span,
+        ) {
             binding_values.insert(binding_id, BindingValueFact::scalar(word));
         }
     }
@@ -15741,7 +15765,9 @@ fn binding_value_id_for_name(
     name: &Name,
     span: Span,
 ) -> Option<BindingId> {
-    semantic.visible_binding(name, span).map(|binding| binding.id)
+    semantic
+        .visible_binding(name, span)
+        .map(|binding| binding.id)
 }
 
 fn annotate_conditional_assignment_shortcuts<'a>(
@@ -16771,7 +16797,8 @@ done
 
     #[test]
     fn marks_conditional_assignment_shortcuts_on_binding_values() {
-        let source = "#!/bin/bash\ntrue && w='-w' || w=''\nif true; then flag='-f'; else flag=''; fi\n";
+        let source =
+            "#!/bin/bash\ntrue && w='-w' || w=''\nif true; then flag='-f'; else flag=''; fi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -16783,7 +16810,8 @@ done
             .iter()
             .copied()
             .map(|binding_id| {
-                facts.binding_value(binding_id)
+                facts
+                    .binding_value(binding_id)
                     .expect("expected w binding value fact")
                     .conditional_assignment_shortcut()
             })
@@ -16795,12 +16823,38 @@ done
             .iter()
             .copied()
             .map(|binding_id| {
-                facts.binding_value(binding_id)
+                facts
+                    .binding_value(binding_id)
                     .expect("expected flag binding value fact")
                     .conditional_assignment_shortcut()
             })
             .collect::<Vec<_>>();
         assert_eq!(flag_bindings, vec![false, false]);
+    }
+
+    #[test]
+    fn ignores_command_prefix_assignments_when_indexing_binding_values() {
+        let source = "\
+#!/bin/bash
+foo=stable
+foo=ephemeral tool
+printf '%s\\n' \"$foo\"
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let foo_bindings = semantic.bindings_for(&Name::from("foo"));
+        assert_eq!(foo_bindings.len(), 1);
+        assert_eq!(
+            facts
+                .binding_value(foo_bindings[0])
+                .and_then(|value| value.scalar_word())
+                .map(|word| word.span.slice(source)),
+            Some("stable")
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -15690,7 +15690,7 @@ fn collect_binding_values<'a>(
         let AssignmentValue::Scalar(word) = &assignment.value else {
             continue;
         };
-        if let Some(binding_id) = binding_value_id_for_name(
+        if let Some(binding_id) = binding_value_definition_id_for_name(
             semantic,
             &assignment.target.name,
             assignment.target.name_span,
@@ -15706,7 +15706,7 @@ fn collect_binding_values<'a>(
         let AssignmentValue::Scalar(word) = &assignment.value else {
             continue;
         };
-        if let Some(binding_id) = binding_value_id_for_name(
+        if let Some(binding_id) = binding_value_definition_id_for_name(
             semantic,
             &assignment.target.name,
             assignment.target.name_span,
@@ -15723,7 +15723,8 @@ fn collect_binding_values<'a>(
             let values = words.iter().collect::<Vec<_>>().into_boxed_slice();
             for target in &command.targets {
                 if let Some(name) = &target.name
-                    && let Some(binding_id) = binding_value_id_for_name(semantic, name, target.span)
+                    && let Some(binding_id) =
+                        binding_value_definition_id_for_name(semantic, name, target.span)
                 {
                     binding_values.insert(
                         binding_id,
@@ -15733,9 +15734,11 @@ fn collect_binding_values<'a>(
             }
         }
         Command::Compound(CompoundCommand::Foreach(command)) => {
-            if let Some(binding_id) =
-                binding_value_id_for_name(semantic, &command.variable, command.variable_span)
-            {
+            if let Some(binding_id) = binding_value_definition_id_for_name(
+                semantic,
+                &command.variable,
+                command.variable_span,
+            ) {
                 binding_values.insert(
                     binding_id,
                     BindingValueFact::from_loop_words(
@@ -15745,9 +15748,11 @@ fn collect_binding_values<'a>(
             }
         }
         Command::Compound(CompoundCommand::Select(command)) => {
-            if let Some(binding_id) =
-                binding_value_id_for_name(semantic, &command.variable, command.variable_span)
-            {
+            if let Some(binding_id) = binding_value_definition_id_for_name(
+                semantic,
+                &command.variable,
+                command.variable_span,
+            ) {
                 binding_values.insert(
                     binding_id,
                     BindingValueFact::from_loop_words(
@@ -15760,7 +15765,20 @@ fn collect_binding_values<'a>(
     }
 }
 
-fn binding_value_id_for_name(
+fn binding_value_definition_id_for_name(
+    semantic: &SemanticModel,
+    name: &Name,
+    span: Span,
+) -> Option<BindingId> {
+    semantic
+        .bindings_for(name)
+        .iter()
+        .rev()
+        .copied()
+        .find(|binding_id| semantic.binding(*binding_id).span == span)
+}
+
+fn binding_value_visible_id_for_name(
     semantic: &SemanticModel,
     name: &Name,
     span: Span,
@@ -15785,7 +15803,8 @@ fn annotate_conditional_assignment_shortcuts<'a>(
             let Some(span) = segment.assignment_span() else {
                 continue;
             };
-            let Some(binding_id) = binding_value_id_for_name(semantic, &Name::from(target), span)
+            let Some(binding_id) =
+                binding_value_visible_id_for_name(semantic, &Name::from(target), span)
             else {
                 continue;
             };
@@ -16129,7 +16148,7 @@ mod tests {
     use shuck_ast::{BinaryOp, CommandSubstitutionSyntax, ConditionalBinaryOp, Name};
     use shuck_indexer::Indexer;
     use shuck_parser::parser::{Parser, ShellDialect as ParseShellDialect};
-    use shuck_semantic::SemanticModel;
+    use shuck_semantic::{BindingAttributes, SemanticModel};
 
     use super::{
         CommandId, ConditionalNodeFact, ConditionalOperatorFamily, GrepPatternSourceKind,
@@ -16854,6 +16873,58 @@ printf '%s\\n' \"$foo\"
                 .and_then(|value| value.scalar_word())
                 .map(|word| word.span.slice(source)),
             Some("stable")
+        );
+    }
+
+    #[test]
+    fn declaration_assignment_values_attach_to_the_declared_binding() {
+        let source = "\
+#!/bin/bash
+f() {
+  (
+    value=shadow
+    local value=chosen
+    printf '%s\\n' \"$value\"
+  )
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let shadow_binding = semantic
+            .bindings_for(&Name::from("value"))
+            .iter()
+            .copied()
+            .find(|binding_id| semantic.binding(*binding_id).attributes.is_empty())
+            .expect("expected subshell shadow binding");
+        let local_binding = semantic
+            .bindings_for(&Name::from("value"))
+            .iter()
+            .copied()
+            .find(|binding_id| {
+                semantic
+                    .binding(*binding_id)
+                    .attributes
+                    .contains(BindingAttributes::LOCAL)
+            })
+            .expect("expected local declaration binding");
+
+        assert_eq!(
+            facts
+                .binding_value(shadow_binding)
+                .and_then(|value| value.scalar_word())
+                .map(|word| word.span.slice(source)),
+            Some("shadow")
+        );
+        assert_eq!(
+            facts
+                .binding_value(local_binding)
+                .and_then(|value| value.scalar_word())
+                .map(|word| word.span.slice(source)),
+            Some("chosen")
         );
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1687,6 +1687,56 @@ pub enum MixedShortCircuitKind {
 }
 
 #[derive(Debug, Clone)]
+pub struct BindingValueFact<'a> {
+    kind: BindingValueKind<'a>,
+    conditional_assignment_shortcut: bool,
+}
+
+#[derive(Debug, Clone)]
+enum BindingValueKind<'a> {
+    Scalar(&'a Word),
+    Loop(Box<[&'a Word]>),
+}
+
+impl<'a> BindingValueFact<'a> {
+    fn scalar(word: &'a Word) -> Self {
+        Self {
+            kind: BindingValueKind::Scalar(word),
+            conditional_assignment_shortcut: false,
+        }
+    }
+
+    fn from_loop_words(words: Box<[&'a Word]>) -> Self {
+        Self {
+            kind: BindingValueKind::Loop(words),
+            conditional_assignment_shortcut: false,
+        }
+    }
+
+    pub fn scalar_word(&self) -> Option<&'a Word> {
+        match &self.kind {
+            BindingValueKind::Scalar(word) => Some(*word),
+            BindingValueKind::Loop(_) => None,
+        }
+    }
+
+    pub fn loop_words(&self) -> Option<&[&'a Word]> {
+        match &self.kind {
+            BindingValueKind::Scalar(_) => None,
+            BindingValueKind::Loop(words) => Some(words.as_ref()),
+        }
+    }
+
+    pub fn conditional_assignment_shortcut(&self) -> bool {
+        self.conditional_assignment_shortcut
+    }
+
+    fn mark_conditional_assignment_shortcut(&mut self) {
+        self.conditional_assignment_shortcut = true;
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct ListFact<'a> {
     key: FactSpan,
     command: &'a BinaryCommand,
@@ -2546,8 +2596,7 @@ pub struct LinterFacts<'a> {
     command_ids_by_span: CommandLookupIndex,
     if_condition_command_ids: FxHashSet<CommandId>,
     elif_condition_command_ids: FxHashSet<CommandId>,
-    scalar_bindings: FxHashMap<FactSpan, &'a Word>,
-    loop_bindings: FxHashMap<FactSpan, Box<[&'a Word]>>,
+    binding_values: FxHashMap<BindingId, BindingValueFact<'a>>,
     broken_assoc_key_spans: Vec<Span>,
     comma_array_assignment_spans: Vec<Span>,
     ifs_literal_backslash_assignment_value_spans: Vec<Span>,
@@ -2711,22 +2760,12 @@ impl<'a> LinterFacts<'a> {
         command_id_for_command(command, &self.command_ids_by_span)
     }
 
-    pub fn scalar_binding_value(&self, span: Span) -> Option<&'a Word> {
-        self.scalar_bindings.get(&FactSpan::new(span)).copied()
+    pub fn binding_value(&self, binding_id: BindingId) -> Option<&BindingValueFact<'a>> {
+        self.binding_values.get(&binding_id)
     }
 
-    pub(crate) fn scalar_binding_values(&self) -> &FxHashMap<FactSpan, &'a Word> {
-        &self.scalar_bindings
-    }
-
-    pub fn loop_binding_values(&self, span: Span) -> Option<&[&'a Word]> {
-        self.loop_bindings
-            .get(&FactSpan::new(span))
-            .map(Box::as_ref)
-    }
-
-    pub(crate) fn loop_binding_value_sets(&self) -> &FxHashMap<FactSpan, Box<[&'a Word]>> {
-        &self.loop_bindings
+    pub(crate) fn binding_values(&self) -> &FxHashMap<BindingId, BindingValueFact<'a>> {
+        &self.binding_values
     }
 
     pub fn broken_assoc_key_spans(&self) -> &[Span] {
@@ -3162,8 +3201,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut command_ids_by_span = CommandLookupIndex::default();
         let mut if_condition_command_ids = FxHashSet::default();
         let mut elif_condition_command_ids = FxHashSet::default();
-        let mut scalar_bindings = FxHashMap::default();
-        let mut loop_bindings = FxHashMap::default();
+        let mut binding_values = FxHashMap::default();
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
         let mut ifs_literal_backslash_assignment_value_spans = Vec::new();
@@ -3208,7 +3246,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 elif_condition_command_ids.insert(id);
             }
 
-            collect_scalar_bindings(visit.command, &mut scalar_bindings, &mut loop_bindings);
+            collect_binding_values(visit.command, self.semantic, &mut binding_values);
             collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
             collect_comma_array_assignment_spans(
                 visit.command,
@@ -3445,6 +3483,7 @@ impl<'a> LinterFactsBuilder<'a> {
             fact.scope_read_source_words = words;
         }
         let lists = build_list_facts(&commands, &command_ids_by_span, self.source);
+        annotate_conditional_assignment_shortcuts(self.semantic, &lists, &mut binding_values);
         let statement_facts =
             build_statement_facts(&commands, &command_ids_by_span, &self.file.body);
         let single_test_subshell_spans =
@@ -3553,8 +3592,7 @@ impl<'a> LinterFactsBuilder<'a> {
             command_ids_by_span,
             if_condition_command_ids,
             elif_condition_command_ids,
-            scalar_bindings,
-            loop_bindings,
+            binding_values,
             broken_assoc_key_spans,
             comma_array_assignment_spans,
             ifs_literal_backslash_assignment_value_spans,
@@ -15627,16 +15665,18 @@ fn trap_action_word<'a>(command: &'a Command, source: &str) -> Option<&'a Word> 
     Some(action)
 }
 
-fn collect_scalar_bindings<'a>(
+fn collect_binding_values<'a>(
     command: &'a Command,
-    scalar_bindings: &mut FxHashMap<FactSpan, &'a Word>,
-    loop_bindings: &mut FxHashMap<FactSpan, Box<[&'a Word]>>,
+    semantic: &SemanticModel,
+    binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
 ) {
     for assignment in query::command_assignments(command) {
         let AssignmentValue::Scalar(word) = &assignment.value else {
             continue;
         };
-        scalar_bindings.insert(FactSpan::new(assignment.target.name_span), word);
+        if let Some(binding_id) = binding_value_id_for_name(semantic, &assignment.target.name, assignment.target.name_span) {
+            binding_values.insert(binding_id, BindingValueFact::scalar(word));
+        }
     }
 
     for operand in query::declaration_operands(command) {
@@ -15646,7 +15686,9 @@ fn collect_scalar_bindings<'a>(
         let AssignmentValue::Scalar(word) = &assignment.value else {
             continue;
         };
-        scalar_bindings.insert(FactSpan::new(assignment.target.name_span), word);
+        if let Some(binding_id) = binding_value_id_for_name(semantic, &assignment.target.name, assignment.target.name_span) {
+            binding_values.insert(binding_id, BindingValueFact::scalar(word));
+        }
     }
 
     match command {
@@ -15656,18 +15698,75 @@ fn collect_scalar_bindings<'a>(
             };
             let values = words.iter().collect::<Vec<_>>().into_boxed_slice();
             for target in &command.targets {
-                if target.name.is_some() {
-                    loop_bindings.insert(FactSpan::new(target.span), values.clone());
+                if let Some(name) = &target.name
+                    && let Some(binding_id) = binding_value_id_for_name(semantic, name, target.span)
+                {
+                    binding_values.insert(
+                        binding_id,
+                        BindingValueFact::from_loop_words(values.clone()),
+                    );
                 }
             }
         }
         Command::Compound(CompoundCommand::Foreach(command)) => {
-            loop_bindings.insert(
-                FactSpan::new(command.variable_span),
-                command.words.iter().collect::<Vec<_>>().into_boxed_slice(),
-            );
+            if let Some(binding_id) =
+                binding_value_id_for_name(semantic, &command.variable, command.variable_span)
+            {
+                binding_values.insert(
+                    binding_id,
+                    BindingValueFact::from_loop_words(
+                        command.words.iter().collect::<Vec<_>>().into_boxed_slice(),
+                    ),
+                );
+            }
+        }
+        Command::Compound(CompoundCommand::Select(command)) => {
+            if let Some(binding_id) =
+                binding_value_id_for_name(semantic, &command.variable, command.variable_span)
+            {
+                binding_values.insert(
+                    binding_id,
+                    BindingValueFact::from_loop_words(
+                        command.words.iter().collect::<Vec<_>>().into_boxed_slice(),
+                    ),
+                );
+            }
         }
         _ => {}
+    }
+}
+
+fn binding_value_id_for_name(
+    semantic: &SemanticModel,
+    name: &Name,
+    span: Span,
+) -> Option<BindingId> {
+    semantic.visible_binding(name, span).map(|binding| binding.id)
+}
+
+fn annotate_conditional_assignment_shortcuts<'a>(
+    semantic: &SemanticModel,
+    lists: &[ListFact<'a>],
+    binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
+) {
+    for list in lists.iter().filter(|list| {
+        list.mixed_short_circuit_kind() == Some(MixedShortCircuitKind::AssignmentTernary)
+    }) {
+        for segment in list.segments() {
+            let Some(target) = segment.assignment_target() else {
+                continue;
+            };
+            let Some(span) = segment.assignment_span() else {
+                continue;
+            };
+            let Some(binding_id) = binding_value_id_for_name(semantic, &Name::from(target), span)
+            else {
+                continue;
+            };
+            if let Some(binding_value) = binding_values.get_mut(&binding_id) {
+                binding_value.mark_conditional_assignment_shortcut();
+            }
+        }
     }
 }
 
@@ -16001,7 +16100,7 @@ fn compound_span(command: &CompoundCommand) -> Span {
 mod tests {
     use std::path::Path;
 
-    use shuck_ast::{BinaryOp, CommandSubstitutionSyntax, ConditionalBinaryOp};
+    use shuck_ast::{BinaryOp, CommandSubstitutionSyntax, ConditionalBinaryOp, Name};
     use shuck_indexer::Indexer;
     use shuck_parser::parser::{Parser, ShellDialect as ParseShellDialect};
     use shuck_semantic::SemanticModel;
@@ -16601,34 +16700,38 @@ done
 
     #[test]
     fn indexes_scalar_bindings_from_assignments_and_declarations() {
-        let source = "#!/bin/bash\nfoo=1 printf '%s\\n' \"$foo\"\nexport bar=2\n";
+        let source = "#!/bin/bash\nfoo=1\nprintf '%s\\n' \"$foo\"\nexport bar=2\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
-        let first_binding_span = match &output.file.body[0].command {
-            shuck_ast::Command::Simple(command) => command.assignments[0].target.name_span,
+        match &output.file.body[0].command {
+            shuck_ast::Command::Simple(_) => {}
             _ => panic!("expected simple command"),
         };
+        let first_binding_id = semantic.bindings_for(&Name::from("foo"))[0];
         assert_eq!(
             facts
-                .scalar_binding_value(first_binding_span)
+                .binding_value(first_binding_id)
+                .and_then(|value| value.scalar_word())
                 .map(|word| word.span.slice(source)),
             Some("1")
         );
 
-        let second_binding_span = match &output.file.body[1].command {
+        match &output.file.body[2].command {
             shuck_ast::Command::Decl(command) => match &command.operands[0] {
-                shuck_ast::DeclOperand::Assignment(assignment) => assignment.target.name_span,
+                shuck_ast::DeclOperand::Assignment(_) => {}
                 _ => panic!("expected declaration assignment"),
             },
             _ => panic!("expected declaration command"),
         };
+        let second_binding_id = semantic.bindings_for(&Name::from("bar"))[0];
         assert_eq!(
             facts
-                .scalar_binding_value(second_binding_span)
+                .binding_value(second_binding_id)
+                .and_then(|value| value.scalar_word())
                 .map(|word| word.span.slice(source)),
             Some("2")
         );
@@ -16649,16 +16752,55 @@ done
             }
             _ => panic!("expected for command"),
         };
+        let loop_binding_id = semantic
+            .visible_binding(&Name::from("i"), loop_binding_span)
+            .expect("expected i loop binding")
+            .id;
 
         assert_eq!(
             facts
-                .loop_binding_values(loop_binding_span)
+                .binding_value(loop_binding_id)
+                .and_then(|value| value.loop_words())
                 .expect("expected loop binding values")
                 .iter()
                 .map(|word| word.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["16", "32", "64"]
         );
+    }
+
+    #[test]
+    fn marks_conditional_assignment_shortcuts_on_binding_values() {
+        let source = "#!/bin/bash\ntrue && w='-w' || w=''\nif true; then flag='-f'; else flag=''; fi\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let shortcut_bindings = semantic
+            .bindings_for(&Name::from("w"))
+            .iter()
+            .copied()
+            .map(|binding_id| {
+                facts.binding_value(binding_id)
+                    .expect("expected w binding value fact")
+                    .conditional_assignment_shortcut()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(shortcut_bindings, vec![true, true]);
+
+        let flag_bindings = semantic
+            .bindings_for(&Name::from("flag"))
+            .iter()
+            .copied()
+            .map(|binding_id| {
+                facts.binding_value(binding_id)
+                    .expect("expected flag binding value fact")
+                    .conditional_assignment_shortcut()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(flag_bindings, vec![false, false]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -4,7 +4,9 @@ use shuck_ast::{
     RedirectKind, SourceText, Span, VarRef, Word, WordPart, WordPartNode,
 };
 use shuck_semantic::{
-    BindingAttributes, BindingKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
+    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, ContractCertainty,
+    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel,
+    UninitializedCertainty,
 };
 use shuck_semantic::{BindingId, BlockId, ReferenceId, ReferenceKind};
 
@@ -65,8 +67,6 @@ pub struct SafeValueIndex<'a> {
     analysis: &'a SemanticAnalysis<'a>,
     facts: &'a LinterFacts<'a>,
     source: &'a str,
-    scalar_bindings: FxHashMap<FactSpan, &'a Word>,
-    loop_bindings: FxHashMap<FactSpan, Box<[&'a Word]>>,
     maybe_uninitialized_refs: FxHashSet<FactSpan>,
     memo: FxHashMap<(FactSpan, SafeValueQuery), bool>,
     visiting: FxHashSet<(FactSpan, SafeValueQuery)>,
@@ -91,8 +91,6 @@ impl<'a> SafeValueIndex<'a> {
             analysis,
             facts,
             source,
-            scalar_bindings: facts.scalar_binding_values().clone(),
-            loop_bindings: facts.loop_binding_value_sets().clone(),
             maybe_uninitialized_refs,
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
@@ -212,13 +210,13 @@ impl<'a> SafeValueIndex<'a> {
 
     fn binding_is_safe(&mut self, binding_id: BindingId, query: SafeValueQuery) -> bool {
         let binding = self.semantic.binding(binding_id);
+        let binding_key = FactSpan::new(binding.span);
         if binding.attributes.contains(BindingAttributes::INTEGER)
             || matches!(binding.kind, BindingKind::ArithmeticAssignment)
         {
             return true;
         }
 
-        let binding_key = FactSpan::new(binding.span);
         let key = (binding_key, query);
         if let Some(result) = self.memo.get(&key) {
             return *result;
@@ -227,16 +225,46 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let result = if let Some(word) = self.scalar_bindings.get(&binding_key).copied() {
-            self.word_is_safe(word, query)
-        } else if let Some(words) = self.loop_bindings.get(&binding_key) {
-            let words = words.to_vec();
-            !words.is_empty()
-                && words.into_iter().all(|word| {
-                    !word_contains_special_parameter_slice(word) && self.word_is_safe(word, query)
+        let result = match &binding.origin {
+            BindingOrigin::Assignment {
+                value:
+                    AssignmentValueOrigin::PlainScalarAccess
+                    | AssignmentValueOrigin::StaticLiteral,
+                ..
+            } => {
+                let scalar_word = self
+                    .facts
+                    .binding_value(binding_id)
+                    .filter(|value| !value.conditional_assignment_shortcut())
+                    .and_then(|value| value.scalar_word());
+                scalar_word.is_some_and(|word| self.word_is_safe(word, query))
+            }
+            BindingOrigin::LoopVariable {
+                items: LoopValueOrigin::StaticWords,
+                ..
+            } => {
+                let words = self
+                    .facts
+                    .binding_value(binding_id)
+                    .and_then(|value| value.loop_words())
+                    .map(|words| words.to_vec());
+                words.is_some_and(|words| {
+                    !words.is_empty()
+                        && words.into_iter().all(|word| {
+                            !word_contains_special_parameter_slice(word)
+                                && self.word_is_safe(word, query)
+                        })
                 })
-        } else {
-            false
+            }
+            BindingOrigin::Assignment { .. }
+            | BindingOrigin::LoopVariable { .. }
+            | BindingOrigin::ParameterDefaultAssignment { .. }
+            | BindingOrigin::Imported { .. }
+            | BindingOrigin::FunctionDefinition { .. }
+            | BindingOrigin::BuiltinTarget { .. }
+            | BindingOrigin::ArithmeticAssignment { .. }
+            | BindingOrigin::Declaration { .. }
+            | BindingOrigin::Nameref { .. } => false,
         };
 
         self.visiting.remove(&key);
@@ -293,8 +321,129 @@ impl<'a> SafeValueIndex<'a> {
                 bindings = expanded;
             }
         }
+        if bindings.is_empty() {
+            bindings = self.called_helper_bindings_for_name(name, at);
+        }
 
         bindings
+    }
+
+    fn called_helper_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
+        let scope = self.semantic.scope_at(at.start.offset);
+        let mut seen = FxHashSet::default();
+        let mut bindings =
+            self.called_helper_bindings_before(name, scope, at.start.offset, &mut seen);
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.dedup();
+        bindings
+    }
+
+    fn called_helper_bindings_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+        seen: &mut FxHashSet<(ScopeId, usize)>,
+    ) -> Vec<BindingId> {
+        if !seen.insert((scope, offset)) {
+            return Vec::new();
+        }
+
+        let mut bindings = self
+            .helper_bindings_called_in_scope_before(name, scope, offset)
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        let Some(function_kind) = self.named_function_kind(scope) else {
+            return bindings;
+        };
+
+        for function_name in function_kind.static_names() {
+            for site in self.semantic.call_sites_for(function_name) {
+                if site.scope == scope {
+                    continue;
+                }
+                bindings.extend(self.called_helper_bindings_before(
+                    name,
+                    site.scope,
+                    site.span.start.offset,
+                    seen,
+                ));
+            }
+        }
+
+        bindings
+    }
+
+    fn helper_bindings_called_in_scope_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Vec<BindingId> {
+        let mut bindings = Vec::new();
+
+        for callee_scope in self.helper_scopes_definitely_providing_name(name) {
+            let Some(function_kind) = self.named_function_kind(callee_scope) else {
+                continue;
+            };
+
+            let called_before = function_kind.static_names().iter().any(|function_name| {
+                self.semantic.call_sites_for(function_name).iter().any(|site| {
+                    site.scope == scope && site.span.start.offset < offset
+                })
+            });
+            if !called_before {
+                continue;
+            }
+
+            bindings.extend(
+                self.semantic
+                    .bindings_for(name)
+                    .iter()
+                    .copied()
+                    .filter(|binding_id| {
+                        let binding = self.semantic.binding(*binding_id);
+                        binding.scope == callee_scope
+                            && !binding.attributes.contains(BindingAttributes::LOCAL)
+                    }),
+            );
+        }
+
+        bindings
+    }
+
+    fn helper_scopes_definitely_providing_name(&self, name: &Name) -> Vec<ScopeId> {
+        self.semantic
+            .scopes()
+            .iter()
+            .filter_map(|scope| {
+                matches!(scope.kind, ScopeKind::Function(_)).then_some(scope.id)
+            })
+            .filter(|scope| {
+                self.analysis
+                    .summarize_scope_provided_bindings(*scope)
+                    .iter()
+                    .any(|binding| {
+                        binding.name == *name
+                            && binding.certainty == ContractCertainty::Definite
+                    })
+            })
+            .collect()
+    }
+
+    fn named_function_kind(
+        &self,
+        scope: ScopeId,
+    ) -> Option<&shuck_semantic::FunctionScopeKind> {
+        match &self.semantic.scope(scope).kind {
+            ScopeKind::Function(function) if !function.static_names().is_empty() => Some(function),
+            ScopeKind::File
+            | ScopeKind::Function(_)
+            | ScopeKind::Subshell
+            | ScopeKind::CommandSubstitution
+            | ScopeKind::Pipeline => None,
+        }
     }
 
     fn binding_dominates_reference(&self, binding_id: BindingId, name: &Name, at: Span) -> bool {
@@ -332,7 +481,6 @@ impl<'a> SafeValueIndex<'a> {
 
         true
     }
-
     fn reference_id_for_name_at(&self, name: &Name, at: Span) -> Option<ReferenceId> {
         self.semantic
             .references()
@@ -579,10 +727,13 @@ fn special_parameter_slice_reference(reference: &VarRef) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use shuck_ast::Command;
+    use shuck_ast::{Command, Name};
     use shuck_indexer::Indexer;
     use shuck_parser::parser::Parser;
-    use shuck_semantic::SemanticModel;
+    use shuck_semantic::{
+        ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind,
+        SemanticBuildOptions, SemanticModel,
+    };
 
     use super::{SafeValueIndex, SafeValueQuery};
     use crate::LinterFacts;
@@ -830,6 +981,160 @@ f() {
     }
 
     #[test]
+    fn plain_access_bindings_stay_safe_but_parameter_operations_do_not_propagate() {
+        let source = "\
+#!/bin/bash
+base=Foobar
+copy=$base
+mixed=$base-1.0
+lower=${base,}
+trimmed=${base#Foo}
+count=${#base}
+printf '%s\\n' $copy $mixed $lower $trimmed $count
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let Command::Simple(command) = &output.file.body[6].command else {
+            panic!("expected simple command");
+        };
+
+        assert!(safe_values.word_is_safe(&command.args[1], SafeValueQuery::Argv));
+        assert!(safe_values.word_is_safe(&command.args[2], SafeValueQuery::Argv));
+        assert!(!safe_values.word_is_safe(&command.args[3], SafeValueQuery::Argv));
+        assert!(!safe_values.word_is_safe(&command.args[4], SafeValueQuery::Argv));
+        assert!(!safe_values.word_is_safe(&command.args[5], SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn loop_bindings_from_expanded_words_do_not_propagate() {
+        let source = "\
+#!/bin/bash
+name=neverball
+for i in $name prefix$name; do
+  printf '%s\\n' $i $i.png
+done
+for size in 16 32; do
+  printf '%s\\n' $size ${size}x${size}!
+done
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let unsafe_words = facts
+            .word_facts()
+            .iter()
+            .filter(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && matches!(fact.span().slice(source), "$i" | "$i.png")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(unsafe_words.len(), 2, "expected unsafe loop-body words");
+        assert!(unsafe_words
+            .iter()
+            .all(|fact| !safe_values.word_is_safe(fact.word(), SafeValueQuery::Argv)));
+
+        let safe_words = facts
+            .word_facts()
+            .iter()
+            .filter(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && matches!(fact.span().slice(source), "$size" | "${size}x${size}!")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(safe_words.len(), 2, "expected safe literal-loop words");
+        assert!(safe_words
+            .iter()
+            .all(|fact| safe_values.word_is_safe(fact.word(), SafeValueQuery::Argv)));
+    }
+
+    #[test]
+    fn assignment_ternary_bindings_do_not_propagate_safe_values() {
+        let source = "\
+#!/bin/bash
+true && w='-w' || w=''
+if true; then
+  flag='-w'
+else
+  flag=''
+fi
+iptables $w -t nat -N chain
+iptables $flag -t nat -N chain
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let short_circuit_word = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$w"
+            })
+            .expect("expected short-circuit command argument");
+        let if_else_word = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$flag"
+            })
+            .expect("expected if/else command argument");
+
+        assert!(!safe_values.word_is_safe(short_circuit_word.word(), SafeValueQuery::Argv));
+        assert!(safe_values.word_is_safe(if_else_word.word(), SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn nested_guarded_assignment_ternaries_stay_unsafe() {
+        let source = "\
+#!/bin/bash
+f() {
+  [ \"$1\" = iptables ] && {
+    true && w='-w' || w=''
+  }
+  [ \"$1\" = ip6tables ] && {
+    true && w='-w' || w=''
+  }
+  iptables $w -t nat -N chain
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$w"
+            })
+            .expect("expected guarded function command argument");
+
+        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+    }
+
+    #[test]
     fn unconditional_safe_overwrites_stay_safe() {
         let source = "\
 #!/bin/bash
@@ -939,4 +1244,105 @@ value=\"$(free ${humanreadable} | awk '{print $2}')\"
 
         assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
     }
+
+    #[test]
+    fn helper_initialized_option_flags_stay_safe_across_top_level_call_sequences() {
+        let source = "\
+#!/bin/bash
+fn_select_compression() {
+  if command -v zstd >/dev/null 2>&1; then
+    compressflag=--zstd
+  elif command -v pigz >/dev/null 2>&1; then
+    compressflag=--use-compress-program=pigz
+  elif command -v gzip >/dev/null 2>&1; then
+    compressflag=--gzip
+  else
+    compressflag=
+  fi
+}
+
+fn_backup_check_lockfile() { :; }
+fn_backup_create_lockfile() { :; }
+fn_backup_init() { :; }
+fn_backup_stop_server() { :; }
+fn_backup_dir() { :; }
+
+fn_backup_compression() {
+  if [ -n \"${compressflag}\" ]; then
+    tar ${compressflag} -hcf out.tar ./.
+  else
+    tar -hcf out.tar ./.
+  fi
+}
+
+fn_select_compression
+fn_backup_check_lockfile
+fn_backup_create_lockfile
+fn_backup_init
+fn_backup_stop_server
+fn_backup_dir
+fn_backup_compression
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${compressflag}"
+            })
+            .expect("expected helper-provided command argument fact");
+
+        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn imported_bindings_stay_unsafe_without_known_values() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' $pkgname
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build_with_options(
+            &output.file,
+            source,
+            &indexer,
+            SemanticBuildOptions {
+                file_entry_contract: Some(FileContract {
+                    required_reads: Vec::new(),
+                    provided_bindings: vec![ProvidedBinding::new(
+                        Name::from("pkgname"),
+                        ProvidedBindingKind::Variable,
+                        ContractCertainty::Definite,
+                    )],
+                    provided_functions: Vec::new(),
+                }),
+                ..SemanticBuildOptions::default()
+            },
+        );
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$pkgname"
+            })
+            .expect("expected imported command argument fact");
+
+        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+    }
+
 }

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -329,8 +329,7 @@ impl<'a> SafeValueIndex<'a> {
     fn called_helper_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
         let scope = self.semantic.scope_at(at.start.offset);
         let mut seen = FxHashSet::default();
-        let mut bindings =
-            self.called_helper_bindings_before(name, scope, at.start.offset, &mut seen);
+        let mut bindings = self.called_helper_bindings_before(name, scope, at, &mut seen);
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         bindings.dedup();
         bindings
@@ -340,15 +339,15 @@ impl<'a> SafeValueIndex<'a> {
         &self,
         name: &Name,
         scope: ScopeId,
-        offset: usize,
-        seen: &mut FxHashSet<(ScopeId, usize)>,
+        at: Span,
+        seen: &mut FxHashSet<(ScopeId, usize, usize)>,
     ) -> Vec<BindingId> {
-        if !seen.insert((scope, offset)) {
+        if !seen.insert((scope, at.start.offset, at.end.offset)) {
             return Vec::new();
         }
 
         let mut bindings = self
-            .helper_bindings_called_in_scope_before(name, scope, offset)
+            .helper_bindings_called_in_scope_before(name, scope, at)
             .into_iter()
             .collect::<FxHashSet<_>>();
 
@@ -357,7 +356,7 @@ impl<'a> SafeValueIndex<'a> {
             bindings.extend(caller_bindings);
         }
 
-        seen.remove(&(scope, offset));
+        seen.remove(&(scope, at.start.offset, at.end.offset));
         bindings.into_iter().collect()
     }
 
@@ -365,7 +364,7 @@ impl<'a> SafeValueIndex<'a> {
         &self,
         name: &Name,
         scope: ScopeId,
-        seen: &mut FxHashSet<(ScopeId, usize)>,
+        seen: &mut FxHashSet<(ScopeId, usize, usize)>,
     ) -> Option<FxHashSet<BindingId>> {
         let function_kind = self.named_function_kind(scope)?;
         let mut caller_sites = Vec::new();
@@ -382,27 +381,28 @@ impl<'a> SafeValueIndex<'a> {
             }
         }
 
-        let mut shared = None::<FxHashSet<BindingId>>;
+        let mut saw_caller = false;
+        let mut union = FxHashSet::default();
         for site in caller_sites {
+            saw_caller = true;
             let branch = self
-                .called_helper_bindings_before(name, site.scope, site.span.start.offset, seen)
+                .called_helper_bindings_before(name, site.scope, site.span, seen)
                 .into_iter()
                 .collect::<FxHashSet<_>>();
-
-            match &mut shared {
-                Some(shared) => shared.retain(|binding_id| branch.contains(binding_id)),
-                None => shared = Some(branch),
+            if branch.is_empty() {
+                return Some(FxHashSet::default());
             }
+            union.extend(branch);
         }
 
-        shared
+        saw_caller.then_some(union)
     }
 
     fn helper_bindings_called_in_scope_before(
         &self,
         name: &Name,
         scope: ScopeId,
-        offset: usize,
+        at: Span,
     ) -> Vec<BindingId> {
         let mut bindings = Vec::new();
 
@@ -415,7 +415,9 @@ impl<'a> SafeValueIndex<'a> {
                 self.semantic
                     .call_sites_for(function_name)
                     .iter()
-                    .any(|site| site.scope == scope && site.span.start.offset < offset)
+                    .any(|site| {
+                        site.scope == scope && self.call_site_dominates_use(site.span, name, at)
+                    })
             });
             if !called_before {
                 continue;
@@ -431,6 +433,34 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         bindings
+    }
+
+    fn call_site_dominates_use(&self, call_span: Span, name: &Name, at: Span) -> bool {
+        if call_span.start.offset >= at.start.offset {
+            return false;
+        }
+        let _ = name;
+
+        !self.facts.commands().iter().any(|fact| {
+            let outer = fact.span();
+            outer.start.offset < call_span.start.offset
+                && call_span.end.offset <= outer.end.offset
+                && outer.end.offset <= at.start.offset
+                && match fact.command() {
+                    shuck_ast::Command::Binary(_) => true,
+                    shuck_ast::Command::Compound(compound) => !matches!(
+                        compound,
+                        shuck_ast::CompoundCommand::BraceGroup(_)
+                            | shuck_ast::CompoundCommand::Arithmetic(_)
+                            | shuck_ast::CompoundCommand::Time(_)
+                    ),
+                    shuck_ast::Command::Simple(_)
+                    | shuck_ast::Command::Builtin(_)
+                    | shuck_ast::Command::Decl(_)
+                    | shuck_ast::Command::Function(_)
+                    | shuck_ast::Command::AnonymousFunction(_) => false,
+                }
+        })
     }
 
     fn helper_scopes_definitely_providing_name(&self, name: &Name) -> Vec<ScopeId> {
@@ -1363,6 +1393,90 @@ unsafe_path
             .expect("expected shared helper-derived command argument fact");
 
         assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn helper_calls_inside_conditionals_do_not_count_as_definite_initializers() {
+        let source = "\
+#!/bin/bash
+init_flag() {
+  flag=-n
+}
+
+render() {
+  if [ \"$1\" = yes ]; then
+    init_flag
+  fi
+  printf '%s\\n' ${flag}
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${flag}"
+            })
+            .expect("expected conditionally helper-initialized argument fact");
+
+        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn helper_initialized_bindings_stay_safe_when_all_callers_provide_distinct_values() {
+        let source = "\
+#!/bin/bash
+init_flag_a() {
+  flag=-a
+}
+
+init_flag_b() {
+  flag=-b
+}
+
+render() {
+  printf '%s\\n' ${flag}
+}
+
+safe_path_a() {
+  init_flag_a
+  render
+}
+
+safe_path_b() {
+  init_flag_b
+  render
+}
+
+safe_path_a
+safe_path_b
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${flag}"
+            })
+            .expect("expected multi-caller helper-derived argument fact");
+
+        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -5,8 +5,7 @@ use shuck_ast::{
 };
 use shuck_semantic::{
     AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, ContractCertainty,
-    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel,
-    UninitializedCertainty,
+    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
 };
 use shuck_semantic::{BindingId, BlockId, ReferenceId, ReferenceKind};
 
@@ -228,8 +227,7 @@ impl<'a> SafeValueIndex<'a> {
         let result = match &binding.origin {
             BindingOrigin::Assignment {
                 value:
-                    AssignmentValueOrigin::PlainScalarAccess
-                    | AssignmentValueOrigin::StaticLiteral,
+                    AssignmentValueOrigin::PlainScalarAccess | AssignmentValueOrigin::StaticLiteral,
                 ..
             } => {
                 let scalar_word = self
@@ -352,27 +350,52 @@ impl<'a> SafeValueIndex<'a> {
         let mut bindings = self
             .helper_bindings_called_in_scope_before(name, scope, offset)
             .into_iter()
-            .collect::<Vec<_>>();
+            .collect::<FxHashSet<_>>();
 
-        let Some(function_kind) = self.named_function_kind(scope) else {
-            return bindings;
-        };
+        if let Some(caller_bindings) = self.helper_bindings_reaching_all_callers(name, scope, seen)
+        {
+            bindings.extend(caller_bindings);
+        }
+
+        seen.remove(&(scope, offset));
+        bindings.into_iter().collect()
+    }
+
+    fn helper_bindings_reaching_all_callers(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        seen: &mut FxHashSet<(ScopeId, usize)>,
+    ) -> Option<FxHashSet<BindingId>> {
+        let function_kind = self.named_function_kind(scope)?;
+        let mut caller_sites = Vec::new();
+        let mut seen_sites = FxHashSet::default();
 
         for function_name in function_kind.static_names() {
             for site in self.semantic.call_sites_for(function_name) {
                 if site.scope == scope {
                     continue;
                 }
-                bindings.extend(self.called_helper_bindings_before(
-                    name,
-                    site.scope,
-                    site.span.start.offset,
-                    seen,
-                ));
+                if seen_sites.insert((site.scope, site.span.start.offset, site.span.end.offset)) {
+                    caller_sites.push(site.clone());
+                }
             }
         }
 
-        bindings
+        let mut shared = None::<FxHashSet<BindingId>>;
+        for site in caller_sites {
+            let branch = self
+                .called_helper_bindings_before(name, site.scope, site.span.start.offset, seen)
+                .into_iter()
+                .collect::<FxHashSet<_>>();
+
+            match &mut shared {
+                Some(shared) => shared.retain(|binding_id| branch.contains(binding_id)),
+                None => shared = Some(branch),
+            }
+        }
+
+        shared
     }
 
     fn helper_bindings_called_in_scope_before(
@@ -389,25 +412,22 @@ impl<'a> SafeValueIndex<'a> {
             };
 
             let called_before = function_kind.static_names().iter().any(|function_name| {
-                self.semantic.call_sites_for(function_name).iter().any(|site| {
-                    site.scope == scope && site.span.start.offset < offset
-                })
+                self.semantic
+                    .call_sites_for(function_name)
+                    .iter()
+                    .any(|site| site.scope == scope && site.span.start.offset < offset)
             });
             if !called_before {
                 continue;
             }
 
-            bindings.extend(
-                self.semantic
-                    .bindings_for(name)
-                    .iter()
-                    .copied()
-                    .filter(|binding_id| {
-                        let binding = self.semantic.binding(*binding_id);
-                        binding.scope == callee_scope
-                            && !binding.attributes.contains(BindingAttributes::LOCAL)
-                    }),
-            );
+            bindings.extend(self.semantic.bindings_for(name).iter().copied().filter(
+                |binding_id| {
+                    let binding = self.semantic.binding(*binding_id);
+                    binding.scope == callee_scope
+                        && !binding.attributes.contains(BindingAttributes::LOCAL)
+                },
+            ));
         }
 
         bindings
@@ -417,25 +437,19 @@ impl<'a> SafeValueIndex<'a> {
         self.semantic
             .scopes()
             .iter()
-            .filter_map(|scope| {
-                matches!(scope.kind, ScopeKind::Function(_)).then_some(scope.id)
-            })
+            .filter_map(|scope| matches!(scope.kind, ScopeKind::Function(_)).then_some(scope.id))
             .filter(|scope| {
                 self.analysis
                     .summarize_scope_provided_bindings(*scope)
                     .iter()
                     .any(|binding| {
-                        binding.name == *name
-                            && binding.certainty == ContractCertainty::Definite
+                        binding.name == *name && binding.certainty == ContractCertainty::Definite
                     })
             })
             .collect()
     }
 
-    fn named_function_kind(
-        &self,
-        scope: ScopeId,
-    ) -> Option<&shuck_semantic::FunctionScopeKind> {
+    fn named_function_kind(&self, scope: ScopeId) -> Option<&shuck_semantic::FunctionScopeKind> {
         match &self.semantic.scope(scope).kind {
             ScopeKind::Function(function) if !function.static_names().is_empty() => Some(function),
             ScopeKind::File
@@ -1040,9 +1054,11 @@ done
             })
             .collect::<Vec<_>>();
         assert_eq!(unsafe_words.len(), 2, "expected unsafe loop-body words");
-        assert!(unsafe_words
-            .iter()
-            .all(|fact| !safe_values.word_is_safe(fact.word(), SafeValueQuery::Argv)));
+        assert!(
+            unsafe_words
+                .iter()
+                .all(|fact| !safe_values.word_is_safe(fact.word(), SafeValueQuery::Argv))
+        );
 
         let safe_words = facts
             .word_facts()
@@ -1053,9 +1069,11 @@ done
             })
             .collect::<Vec<_>>();
         assert_eq!(safe_words.len(), 2, "expected safe literal-loop words");
-        assert!(safe_words
-            .iter()
-            .all(|fact| safe_values.word_is_safe(fact.word(), SafeValueQuery::Argv)));
+        assert!(
+            safe_words
+                .iter()
+                .all(|fact| safe_values.word_is_safe(fact.word(), SafeValueQuery::Argv))
+        );
     }
 
     #[test]
@@ -1304,6 +1322,50 @@ fn_backup_compression
     }
 
     #[test]
+    fn helper_initialized_bindings_do_not_leak_across_distinct_callers() {
+        let source = "\
+#!/bin/bash
+init_flag() {
+  flag=-n
+}
+
+render() {
+  printf '%s\\n' ${flag}
+}
+
+safe_path() {
+  init_flag
+  render
+}
+
+unsafe_path() {
+  render
+}
+
+safe_path
+unsafe_path
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${flag}"
+            })
+            .expect("expected shared helper-derived command argument fact");
+
+        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+    }
+
+    #[test]
     fn imported_bindings_stay_unsafe_without_known_values() {
         let source = "\
 #!/bin/bash
@@ -1344,5 +1406,4 @@ printf '%s\\n' $pkgname
 
         assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
     }
-
 }

--- a/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
@@ -38,7 +38,7 @@ pub fn append_to_array_as_string(checker: &mut Checker) {
                 return None;
             }
 
-            let value = checker.facts().scalar_binding_value(binding.span)?;
+            let value = checker.facts().binding_value(binding.id)?.scalar_word()?;
             leading_literal_word_prefix(value, source)
                 .starts_with(' ')
                 .then_some(binding.span)

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -30,7 +30,7 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
                 return None;
             }
 
-            let value = checker.facts().scalar_binding_value(binding.span)?;
+            let value = checker.facts().binding_value(binding.id)?.scalar_word()?;
             let value_fact = checker.facts().word_fact(value.span, context)?;
             if !uses_array_to_scalar_conversion_pattern(checker, binding, value_fact) {
                 return None;

--- a/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
@@ -19,8 +19,9 @@ impl Violation for QuotedArraySlice {
 pub fn quoted_array_slice(checker: &mut Checker) {
     let scalar_assignment_value_spans = checker
         .facts()
-        .scalar_binding_values()
+        .binding_values()
         .values()
+        .filter_map(|binding_value| binding_value.scalar_word())
         .map(|word| FactSpan::new(word.span))
         .collect::<FxHashSet<_>>();
 

--- a/crates/shuck-linter/src/rules/correctness/variable_as_command_name.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_as_command_name.rs
@@ -86,7 +86,7 @@ fn unsafe_shell_quoting_bindings(
         .iter()
         .filter_map(|binding| {
             let context = binding_assignment_context(binding.kind)?;
-            let word = checker.facts().scalar_binding_value(binding.span)?;
+            let word = checker.facts().binding_value(binding.id)?.scalar_word()?;
             Some((binding.id, word.span, context))
         })
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -904,6 +904,66 @@ unsafe_path
     }
 
     #[test]
+    fn reports_helper_bindings_when_initializers_are_guarded_by_conditionals() {
+        let source = "\
+#!/bin/bash
+init_flag() {
+  flag=-n
+}
+
+render() {
+  if [ \"$1\" = yes ]; then
+    init_flag
+  fi
+  printf '%s\\n' ${flag}
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${flag}"]
+        );
+    }
+
+    #[test]
+    fn skips_helper_initialized_bindings_when_all_callers_provide_distinct_values() {
+        let source = "\
+#!/bin/bash
+init_flag_a() {
+  flag=-a
+}
+
+init_flag_b() {
+  flag=-b
+}
+
+render() {
+  printf '%s\\n' ${flag}
+}
+
+safe_path_a() {
+  init_flag_a
+  render
+}
+
+safe_path_b() {
+  init_flag_b
+  render
+}
+
+safe_path_a
+safe_path_b
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_ambient_contract_bindings_without_known_values() {
         let path = Path::new("/tmp/void-packages/common/build-style/example.sh");
         let source = "\

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -869,6 +869,41 @@ fn_backup_compression
     }
 
     #[test]
+    fn reports_helper_initialized_bindings_when_other_callers_skip_the_helper() {
+        let source = "\
+#!/bin/bash
+init_flag() {
+  flag=-n
+}
+
+render() {
+  printf '%s\\n' ${flag}
+}
+
+safe_path() {
+  init_flag
+  render
+}
+
+unsafe_path() {
+  render
+}
+
+safe_path
+unsafe_path
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${flag}"]
+        );
+    }
+
+    #[test]
     fn reports_ambient_contract_bindings_without_known_values() {
         let path = Path::new("/tmp/void-packages/common/build-style/example.sh");
         let source = "\

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -267,6 +267,78 @@ printf '%s\\n' ${name@U}
     }
 
     #[test]
+    fn reports_bindings_derived_from_parameter_operations() {
+        let source = "\
+#!/bin/bash
+PRGNAM=Fennel
+SRCNAM=${PRGNAM,}
+release=1.0.0
+VERSION=${release:-fallback}
+rm -rf $SRCNAM-$VERSION
+printf '%s\\n' ${PRGNAM,} ${release:-fallback}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$SRCNAM", "$VERSION"]
+        );
+    }
+
+    #[test]
+    fn reports_bindings_from_short_circuit_assignment_ternaries() {
+        let source = "\
+#!/bin/bash
+check() { return 0; }
+check && w='-w' || w=''
+if check; then
+  flag='-w'
+else
+  flag=''
+fi
+iptables $w -t nat -N chain
+iptables $flag -t nat -N chain
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$w"]
+        );
+    }
+
+    #[test]
+    fn reports_nested_guarded_short_circuit_assignment_ternaries() {
+        let source = "\
+#!/bin/bash
+f() {
+  [ \"$1\" = iptables ] && {
+    true && w='-w' || w=''
+  }
+  [ \"$1\" = ip6tables ] && {
+    true && w='-w' || w=''
+  }
+  iptables $w -t nat -N chain
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$w"]
+        );
+    }
+
+    #[test]
     fn skips_colon_assign_default_expansions_but_keeps_regular_argument_cases() {
         let source = "\
 #!/bin/bash
@@ -558,6 +630,27 @@ done
     }
 
     #[test]
+    fn reports_loop_variables_derived_from_expanded_values() {
+        let source = "\
+#!/bin/bash
+PRGNAM=neverball
+BONUS=neverputt
+for i in $PRGNAM $BONUS; do
+  install -D ${i}.desktop /tmp/$i.png
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${i}", "$i"]
+        );
+    }
+
+    #[test]
     fn reports_loop_variables_derived_from_at_slices() {
         let source = "\
 #!/bin/bash
@@ -733,7 +826,125 @@ value=\"$(free ${humanreadable} | awk '{print $2}')\"
     }
 
     #[test]
-    fn skips_safe_indirect_and_transformed_bindings() {
+    fn skips_safe_helper_initialized_option_flags_after_intermediate_calls() {
+        let source = "\
+#!/bin/bash
+fn_select_compression() {
+  if command -v zstd >/dev/null 2>&1; then
+    compressflag=--zstd
+  elif command -v pigz >/dev/null 2>&1; then
+    compressflag=--use-compress-program=pigz
+  elif command -v gzip >/dev/null 2>&1; then
+    compressflag=--gzip
+  else
+    compressflag=
+  fi
+}
+
+fn_backup_check_lockfile() { :; }
+fn_backup_create_lockfile() { :; }
+fn_backup_init() { :; }
+fn_backup_stop_server() { :; }
+fn_backup_dir() { :; }
+
+fn_backup_compression() {
+  if [ -n \"${compressflag}\" ]; then
+    tar ${compressflag} -hcf out.tar ./.
+  else
+    tar -hcf out.tar ./.
+  fi
+}
+
+fn_select_compression
+fn_backup_check_lockfile
+fn_backup_create_lockfile
+fn_backup_init
+fn_backup_stop_server
+fn_backup_dir
+fn_backup_compression
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_ambient_contract_bindings_without_known_values() {
+        let path = Path::new("/tmp/void-packages/common/build-style/example.sh");
+        let source = "\
+#!/bin/sh
+helper() {
+  printf '%s\\n' $wrksrc $pkgname
+}
+";
+        let diagnostics = test_snippet_at_path(
+            path,
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$wrksrc", "$pkgname"]
+        );
+    }
+
+    #[test]
+    fn skips_static_suffix_bindings_in_slackbuild_subshell_paths() {
+        let path = Path::new("/tmp/example.SlackBuild");
+        let source = "\
+#!/bin/bash
+if [ \"$ARCH\" = \"i386\" ]; then
+  MULTILIB=\"NO\"
+  LIBDIRSUFFIX=\"\"
+elif [ \"$ARCH\" = \"i486\" ]; then
+  MULTILIB=\"NO\"
+  LIBDIRSUFFIX=\"\"
+elif [ \"$ARCH\" = \"i586\" ]; then
+  MULTILIB=\"NO\"
+  LIBDIRSUFFIX=\"\"
+elif [ \"$ARCH\" = \"i686\" ]; then
+  MULTILIB=\"NO\"
+  LIBDIRSUFFIX=\"\"
+elif [ \"$ARCH\" = \"x86_64\" ]; then
+  MULTILIB=\"YES\"
+  LIBDIRSUFFIX=\"64\"
+elif [ \"$ARCH\" = \"armv7hl\" ]; then
+  MULTILIB=\"NO\"
+  LIBDIRSUFFIX=\"\"
+elif [ \"$ARCH\" = \"s390\" ]; then
+  MULTILIB=\"NO\"
+  LIBDIRSUFFIX=\"\"
+else
+  MULTILIB=\"NO\"
+  LIBDIRSUFFIX=\"\"
+fi
+
+if [ ${MULTILIB} = \"YES\" ]; then
+  printf '%s\\n' multilib
+fi
+
+(
+  ./configure \
+    --libdir=/usr/lib${LIBDIRSUFFIX} \
+    --with-python-dir=/lib${LIBDIRSUFFIX}/python2.7/site-packages \
+    --with-java-home=/usr/lib${LIBDIRSUFFIX}/jvm/jre
+)
+";
+        let diagnostics = test_snippet_at_path(
+            path,
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn keeps_safe_indirect_bindings_but_reports_parameter_operator_results() {
         let source = "\
 #!/bin/bash
 base=abc
@@ -745,7 +956,13 @@ printf '%s\\n' ${!name} $upper $quoted
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$upper", "$quoted"]
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -17,10 +17,73 @@ pub struct Binding {
     pub id: BindingId,
     pub name: Name,
     pub kind: BindingKind,
+    pub origin: BindingOrigin,
     pub scope: ScopeId,
     pub span: Span,
     pub references: Vec<ReferenceId>,
     pub attributes: BindingAttributes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingOrigin {
+    Assignment {
+        definition_span: Span,
+        value: AssignmentValueOrigin,
+    },
+    LoopVariable {
+        definition_span: Span,
+        items: LoopValueOrigin,
+    },
+    ParameterDefaultAssignment {
+        definition_span: Span,
+    },
+    Imported {
+        definition_span: Span,
+    },
+    FunctionDefinition {
+        definition_span: Span,
+    },
+    BuiltinTarget {
+        definition_span: Span,
+        kind: BuiltinBindingTargetKind,
+    },
+    ArithmeticAssignment {
+        definition_span: Span,
+    },
+    Declaration {
+        definition_span: Span,
+    },
+    Nameref {
+        definition_span: Span,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssignmentValueOrigin {
+    PlainScalarAccess,
+    StaticLiteral,
+    ParameterOperator,
+    Transformation,
+    IndirectExpansion,
+    CommandOrProcessSubstitution,
+    MixedDynamic,
+    ArrayOrCompound,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoopValueOrigin {
+    StaticWords,
+    ExpandedWords,
+    ImplicitArgv,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltinBindingTargetKind {
+    Read,
+    Mapfile,
+    Printf,
+    Getopts,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -11,7 +11,10 @@ use shuck_ast::{
 use shuck_indexer::Indexer;
 use shuck_parser::{ShellProfile, ZshEmulationMode};
 
-use crate::binding::{Binding, BindingAttributes, BindingKind};
+use crate::binding::{
+    AssignmentValueOrigin, Binding, BindingAttributes, BindingKind, BindingOrigin,
+    BuiltinBindingTargetKind, LoopValueOrigin,
+};
 use crate::call_graph::{CallGraph, CallSite, OverwrittenFunction};
 use crate::cfg::{
     FlowContext, IsolatedRegion, RecordedCaseArm, RecordedCommand, RecordedCommandId,
@@ -614,6 +617,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                             BindingKind::LoopVariable,
                             self.current_scope(),
                             target.span,
+                            BindingOrigin::LoopVariable {
+                                definition_span: target.span,
+                                items: loop_binding_origin_for_words(command.words.as_deref()),
+                            },
                             BindingAttributes::empty(),
                         );
                     }
@@ -656,6 +663,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     BindingKind::LoopVariable,
                     self.current_scope(),
                     command.variable_span,
+                    BindingOrigin::LoopVariable {
+                        definition_span: command.variable_span,
+                        items: loop_binding_origin_for_words(Some(&command.words)),
+                    },
                     BindingAttributes::empty(),
                 );
 
@@ -789,6 +800,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     BindingKind::LoopVariable,
                     self.current_scope(),
                     command.variable_span,
+                    BindingOrigin::LoopVariable {
+                        definition_span: command.variable_span,
+                        items: loop_binding_origin_for_words(Some(&command.words)),
+                    },
                     BindingAttributes::empty(),
                 );
 
@@ -910,6 +925,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 BindingKind::FunctionDefinition,
                 parent_scope,
                 span,
+                BindingOrigin::FunctionDefinition {
+                    definition_span: span,
+                },
                 BindingAttributes::empty(),
             );
             self.recorded_program
@@ -1003,6 +1021,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             kind,
             scope,
             assignment.target.name_span,
+            binding_origin_for_assignment(assignment),
             attributes,
         );
         if let Some(hint) = indirect_target_hint(assignment, self.source) {
@@ -2080,6 +2099,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     BindingKind::ArithmeticAssignment,
                     self.current_scope(),
                     expr.span,
+                    BindingOrigin::ArithmeticAssignment {
+                        definition_span: expr.span,
+                    },
                     BindingAttributes::empty(),
                 );
             }
@@ -2092,6 +2114,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     BindingKind::ArithmeticAssignment,
                     self.current_scope(),
                     span,
+                    BindingOrigin::ArithmeticAssignment {
+                        definition_span: span,
+                    },
                     BindingAttributes::ARRAY,
                 );
             }
@@ -2123,6 +2148,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             BindingKind::ArithmeticAssignment,
             self.current_scope(),
             name_span,
+            BindingOrigin::ArithmeticAssignment {
+                definition_span: name_span,
+            },
             attributes,
         );
     }
@@ -2155,6 +2183,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         BindingKind::ReadTarget,
                         self.current_scope(),
                         span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Read,
+                        },
                         BindingAttributes::empty(),
                     );
                 }
@@ -2178,6 +2210,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         BindingKind::MapfileTarget,
                         self.current_scope(),
                         span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Mapfile,
+                        },
                         BindingAttributes::empty(),
                     );
                 }
@@ -2189,6 +2225,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         BindingKind::PrintfTarget,
                         self.current_scope(),
                         span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Printf,
+                        },
                         BindingAttributes::empty(),
                     );
                 }
@@ -2200,6 +2240,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         BindingKind::GetoptsTarget,
                         self.current_scope(),
                         span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Getopts,
+                        },
                         BindingAttributes::empty(),
                     );
                 }
@@ -2320,7 +2364,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         } else {
             BindingKind::Declaration(builtin)
         };
-        self.add_binding(name, kind, scope, span, attributes);
+        let origin = if matches!(kind, BindingKind::Nameref) {
+            BindingOrigin::Nameref {
+                definition_span: span,
+            }
+        } else {
+            BindingOrigin::Declaration {
+                definition_span: span,
+            }
+        };
+        self.add_binding(name, kind, scope, span, origin, attributes);
     }
 
     fn add_binding(
@@ -2329,6 +2382,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         kind: BindingKind,
         scope: ScopeId,
         span: Span,
+        origin: BindingOrigin,
         attributes: BindingAttributes,
     ) -> BindingId {
         let id = BindingId(self.bindings.len() as u32);
@@ -2336,6 +2390,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             id,
             name: name.clone(),
             kind,
+            origin,
             scope,
             span,
             references: Vec::new(),
@@ -2423,6 +2478,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             BindingKind::ParameterDefaultAssignment,
             self.current_scope(),
             reference.span,
+            BindingOrigin::ParameterDefaultAssignment {
+                definition_span: reference.span,
+            },
             BindingAttributes::empty(),
         );
     }
@@ -3418,6 +3476,195 @@ fn single_literal_word(word: &Word) -> Option<&str> {
             _ => None,
         },
         _ => None,
+    }
+}
+
+fn binding_origin_for_assignment(assignment: &Assignment) -> BindingOrigin {
+    let value = if assignment.target.subscript.is_some() {
+        AssignmentValueOrigin::ArrayOrCompound
+    } else {
+        match &assignment.value {
+            AssignmentValue::Scalar(word) => assignment_value_origin_for_word(word),
+            AssignmentValue::Compound(_) => AssignmentValueOrigin::ArrayOrCompound,
+        }
+    };
+
+    BindingOrigin::Assignment {
+        definition_span: assignment.target.name_span,
+        value,
+    }
+}
+
+fn loop_binding_origin_for_words(words: Option<&[Word]>) -> LoopValueOrigin {
+    let Some(words) = words else {
+        return LoopValueOrigin::ImplicitArgv;
+    };
+
+    if words.iter().all(word_is_static_binding_literal) {
+        LoopValueOrigin::StaticWords
+    } else {
+        LoopValueOrigin::ExpandedWords
+    }
+}
+
+fn assignment_value_origin_for_word(word: &Word) -> AssignmentValueOrigin {
+    if !word.brace_syntax.is_empty() {
+        return AssignmentValueOrigin::MixedDynamic;
+    }
+    if word_is_static_binding_literal(word) {
+        return AssignmentValueOrigin::StaticLiteral;
+    }
+
+    let mut scan = AssignmentWordOriginScan::default();
+    scan_assignment_word_parts(&word.parts, &mut scan);
+
+    if scan.category_count() == 0 {
+        return AssignmentValueOrigin::PlainScalarAccess;
+    }
+    if scan.mixed_dynamic || scan.category_count() > 1 {
+        return AssignmentValueOrigin::MixedDynamic;
+    }
+
+    scan.primary_origin().unwrap_or(AssignmentValueOrigin::Unknown)
+}
+
+#[derive(Debug, Default)]
+struct AssignmentWordOriginScan {
+    parameter_operator: bool,
+    transformation: bool,
+    indirect_expansion: bool,
+    command_or_process_substitution: bool,
+    array_or_compound: bool,
+    mixed_dynamic: bool,
+}
+
+impl AssignmentWordOriginScan {
+    fn category_count(&self) -> usize {
+        [
+            self.parameter_operator,
+            self.transformation,
+            self.indirect_expansion,
+            self.command_or_process_substitution,
+            self.array_or_compound,
+            self.mixed_dynamic,
+        ]
+        .into_iter()
+        .filter(|flag| *flag)
+        .count()
+    }
+
+    fn primary_origin(&self) -> Option<AssignmentValueOrigin> {
+        if self.parameter_operator {
+            Some(AssignmentValueOrigin::ParameterOperator)
+        } else if self.transformation {
+            Some(AssignmentValueOrigin::Transformation)
+        } else if self.indirect_expansion {
+            Some(AssignmentValueOrigin::IndirectExpansion)
+        } else if self.command_or_process_substitution {
+            Some(AssignmentValueOrigin::CommandOrProcessSubstitution)
+        } else if self.array_or_compound {
+            Some(AssignmentValueOrigin::ArrayOrCompound)
+        } else if self.mixed_dynamic {
+            Some(AssignmentValueOrigin::MixedDynamic)
+        } else {
+            None
+        }
+    }
+}
+
+fn word_is_static_binding_literal(word: &Word) -> bool {
+    word.brace_syntax.is_empty()
+        && word
+            .parts
+            .iter()
+            .all(|part| binding_literal_part_is_static(&part.kind))
+}
+
+fn binding_literal_part_is_static(part: &WordPart) -> bool {
+    match part {
+        WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
+        WordPart::DoubleQuoted { parts, .. } => parts
+            .iter()
+            .all(|part| binding_literal_part_is_static(&part.kind)),
+        WordPart::ZshQualifiedGlob(_)
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::Parameter(_)
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn scan_assignment_word_parts(parts: &[WordPartNode], scan: &mut AssignmentWordOriginScan) {
+    for part in parts {
+        scan_assignment_word_part(&part.kind, scan);
+    }
+}
+
+fn scan_assignment_word_part(part: &WordPart, scan: &mut AssignmentWordOriginScan) {
+    match part {
+        WordPart::Literal(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::ArithmeticExpansion { .. } => {}
+        WordPart::DoubleQuoted { parts, .. } => scan_assignment_word_parts(parts, scan),
+        WordPart::Parameter(parameter) => scan_parameter_word_part(parameter, scan),
+        WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {
+            scan.command_or_process_substitution = true;
+        }
+        WordPart::ParameterExpansion { reference, .. } => {
+            if reference.has_array_selector() {
+                scan.array_or_compound = true;
+            } else {
+                scan.parameter_operator = true;
+            }
+        }
+        WordPart::Length(_) | WordPart::Substring { .. } => scan.parameter_operator = true,
+        WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::ArraySlice { .. } => scan.array_or_compound = true,
+        WordPart::IndirectExpansion { .. } | WordPart::PrefixMatch { .. } => {
+            scan.indirect_expansion = true;
+        }
+        WordPart::Transformation { .. } => scan.transformation = true,
+        WordPart::ZshQualifiedGlob(_) => scan.mixed_dynamic = true,
+    }
+}
+
+fn scan_parameter_word_part(parameter: &ParameterExpansion, scan: &mut AssignmentWordOriginScan) {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
+            if reference.has_array_selector() {
+                scan.array_or_compound = true;
+            }
+        }
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { .. })
+        | ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation { .. })
+        | ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Slice { .. }) => {
+            scan.parameter_operator = true;
+        }
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Indices { .. }) => {
+            scan.array_or_compound = true;
+        }
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Indirect { .. })
+        | ParameterExpansionSyntax::Bourne(BourneParameterExpansion::PrefixMatch { .. }) => {
+            scan.indirect_expansion = true;
+        }
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Transformation { .. }) => {
+            scan.transformation = true;
+        }
+        ParameterExpansionSyntax::Zsh(_) => scan.mixed_dynamic = true,
     }
 }
 

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -3525,7 +3525,8 @@ fn assignment_value_origin_for_word(word: &Word) -> AssignmentValueOrigin {
         return AssignmentValueOrigin::MixedDynamic;
     }
 
-    scan.primary_origin().unwrap_or(AssignmentValueOrigin::Unknown)
+    scan.primary_origin()
+        .unwrap_or(AssignmentValueOrigin::Unknown)
 }
 
 #[derive(Debug, Default)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -882,6 +882,11 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    #[doc(hidden)]
+    pub fn block_ids_for_span(&self, span: Span) -> &[BlockId] {
+        self.cfg().block_ids_for_span(span)
+    }
+
     fn exact_variable_dataflow(&self) -> &ExactVariableDataflow {
         self.exact_variable_dataflow.get_or_init(|| {
             let cfg = self.cfg();

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -12,7 +12,10 @@ mod source_closure;
 mod source_ref;
 mod zsh_options;
 
-pub use binding::{Binding, BindingAttributes, BindingId, BindingKind};
+pub use binding::{
+    AssignmentValueOrigin, Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin,
+    BuiltinBindingTargetKind, LoopValueOrigin,
+};
 pub use call_graph::{CallGraph, CallSite, OverwrittenFunction};
 pub use cfg::{BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext};
 pub use contract::{
@@ -415,6 +418,10 @@ impl SemanticModel {
         &self.scopes
     }
 
+    pub fn scope(&self, id: ScopeId) -> &Scope {
+        &self.scopes[id.index()]
+    }
+
     pub fn bindings(&self) -> &[Binding] {
         &self.bindings
     }
@@ -609,6 +616,9 @@ impl SemanticModel {
             id,
             name: provided.name.clone(),
             kind: BindingKind::Imported,
+            origin: BindingOrigin::Imported {
+                definition_span: span,
+            },
             scope,
             span,
             references: Vec::new(),
@@ -1028,7 +1038,8 @@ impl<'model> SemanticAnalysis<'model> {
             .as_slice()
     }
 
-    pub(crate) fn summarize_scope_provided_bindings(&self, scope: ScopeId) -> Vec<ProvidedBinding> {
+    #[doc(hidden)]
+    pub fn summarize_scope_provided_bindings(&self, scope: ScopeId) -> Vec<ProvidedBinding> {
         let cfg = self.cfg();
         let exact = self.exact_variable_dataflow();
         let context = self.model.dataflow_context(cfg);
@@ -1637,6 +1648,12 @@ mod tests {
         names
     }
 
+    fn binding_for_name<'a>(model: &'a SemanticModel, name: &str) -> &'a Binding {
+        let ids = model.bindings_for(&Name::from(name));
+        assert_eq!(ids.len(), 1, "expected one binding for {name}, got {ids:?}");
+        model.binding(ids[0])
+    }
+
     fn block_with_reference(cfg: &ControlFlowGraph, reference: ReferenceId) -> BlockId {
         cfg.blocks()
             .iter()
@@ -1954,6 +1971,177 @@ done
             assert_eq!(binding.kind, BindingKind::LoopVariable);
             assert_eq!(binding.name, name);
         }
+    }
+
+    #[test]
+    fn classifies_assignment_and_function_binding_origins() {
+        let source = "\
+literal=plain
+copy=$literal
+fallback=${literal:-alt}
+lower=${literal,}
+quoted=${literal@Q}
+name=literal
+indirect=${!name}
+build() { :; }
+";
+        let model = model(source);
+
+        assert!(matches!(
+            binding_for_name(&model, "literal").origin,
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::StaticLiteral,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "copy").origin,
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::PlainScalarAccess,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "fallback").origin,
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::ParameterOperator,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "lower").origin,
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::ParameterOperator,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "quoted").origin,
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::Transformation,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "indirect").origin,
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::IndirectExpansion,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "build").origin,
+            BindingOrigin::FunctionDefinition { .. }
+        ));
+    }
+
+    #[test]
+    fn classifies_loop_and_parameter_default_origins() {
+        let source = "\
+for size in 16 32; do
+  :
+done
+name=world
+for item in $name; do
+  :
+done
+for arg; do
+  :
+done
+: \"${created:=default}\"
+";
+        let model = model(source);
+
+        assert!(matches!(
+            binding_for_name(&model, "size").origin,
+            BindingOrigin::LoopVariable {
+                items: LoopValueOrigin::StaticWords,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "item").origin,
+            BindingOrigin::LoopVariable {
+                items: LoopValueOrigin::ExpandedWords,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "arg").origin,
+            BindingOrigin::LoopVariable {
+                items: LoopValueOrigin::ImplicitArgv,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "created").origin,
+            BindingOrigin::ParameterDefaultAssignment { .. }
+        ));
+    }
+
+    #[test]
+    fn classifies_builtin_target_and_imported_origins() {
+        let source = "\
+read reply
+mapfile lines
+printf -v rendered '%s' hi
+while getopts 'a' opt; do
+  :
+done
+printf '%s\\n' \"$pkgname\"
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build_with_options(
+            &output.file,
+            source,
+            &indexer,
+            SemanticBuildOptions {
+                file_entry_contract: Some(FileContract {
+                    required_reads: Vec::new(),
+                    provided_bindings: vec![ProvidedBinding::new(
+                        Name::from("pkgname"),
+                        ProvidedBindingKind::Variable,
+                        ContractCertainty::Definite,
+                    )],
+                    provided_functions: Vec::new(),
+                }),
+                ..SemanticBuildOptions::default()
+            },
+        );
+
+        assert!(matches!(
+            binding_for_name(&model, "reply").origin,
+            BindingOrigin::BuiltinTarget {
+                kind: BuiltinBindingTargetKind::Read,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "lines").origin,
+            BindingOrigin::BuiltinTarget {
+                kind: BuiltinBindingTargetKind::Mapfile,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "rendered").origin,
+            BindingOrigin::BuiltinTarget {
+                kind: BuiltinBindingTargetKind::Printf,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "opt").origin,
+            BindingOrigin::BuiltinTarget {
+                kind: BuiltinBindingTargetKind::Getopts,
+                ..
+            }
+        ));
+        assert!(matches!(
+            binding_for_name(&model, "pkgname").origin,
+            BindingOrigin::Imported { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add first-class `BindingOrigin` metadata to semantic bindings
- key linter binding-value facts by `BindingId` instead of span joins
- move `safe_value` and related consumers onto semantic origin plus `BindingId` facts

## Why
`S001` had accumulated a lot of span-based propagation heuristics in `safe_value`. This refactor makes binding provenance explicit in `shuck-semantic` and threads binding values through `LinterFacts` by `BindingId`, so future flow-sensitive fixes can reason about how a binding was produced instead of reconstructing that from spans.

## Impact
- semantic bindings now carry assignment / loop / imported / builtin-target origin metadata
- linter facts now expose binding values and conditional short-circuit assignment state by `BindingId`
- `safe_value`, `unquoted_expansion`, and the other binding-value consumers use the new substrate

## Caveat
This change is structurally neutral but not yet a conformance win for `S001` by itself.

- last stable targeted `S001` result before this refactor path: `blocking=518`
- stable targeted `S001` result with this refactor state: `blocking=519`
- full all-rules corpus totals stayed flat

I am opening this for review because it establishes the provenance model cleanly, but I would not merge it without agreement that the substrate is worth keeping even before the next `S001` payoff lands.

## Validation
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter safe_value -- --nocapture`
- `cargo test -p shuck-linter unquoted_expansion -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_KEEP_GOING=1`

## Corpus totals
Before:
- `blocking=3328`
- `implementation_diffs=3328`

After:
- `blocking=3328`
- `implementation_diffs=3328`
