### PR TITLE
Fix S008 compatibility for @ expansions

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -968,6 +968,7 @@ pub struct WordFact<'a> {
     unquoted_scalar_expansion_spans: Box<[Span]>,
     array_expansion_spans: Box<[Span]>,
     all_elements_array_expansion_spans: Box<[Span]>,
+    unquoted_all_elements_array_expansion_spans: Box<[Span]>,
     unquoted_array_expansion_spans: Box<[Span]>,
     command_substitution_spans: Box<[Span]>,
     unquoted_command_substitution_spans: Box<[Span]>,
@@ -1065,6 +1066,10 @@ impl<'a> WordFact<'a> {
 
     pub fn all_elements_array_expansion_spans(&self) -> &[Span] {
         &self.all_elements_array_expansion_spans
+    }
+
+    pub fn unquoted_all_elements_array_expansion_spans(&self) -> &[Span] {
+        &self.unquoted_all_elements_array_expansion_spans
     }
 
     pub fn unquoted_array_expansion_spans(&self) -> &[Span] {
@@ -10241,6 +10246,9 @@ impl<'a> WordFactCollector<'a> {
                 self.source,
             )
             .into_boxed_slice(),
+            unquoted_all_elements_array_expansion_spans:
+                span::unquoted_all_elements_array_expansion_part_spans(word_ref, self.source)
+                    .into_boxed_slice(),
             unquoted_array_expansion_spans: span::unquoted_array_expansion_part_spans(
                 word_ref,
                 self.source,
@@ -21164,6 +21172,40 @@ eval \"conda_shim() { case \\\"\\${1##*/}\\\" in ${shims[@]} *) return 1;; esac 
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["${shims[@]}"]
+            );
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_for_unquoted_all_elements_array_expansions() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' $@ ${@:2} ${items[@]} ${items[@]:1} ${!items[@]} ${items[@]/#/#} ${items[@]@Q} ${items[@]:-fallback} ${items[@]:+fallback} \"$@\" \"${items[@]}\" $* ${items[*]} ${1+\"$@\"}
+";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .flat_map(|fact| {
+                    fact.unquoted_all_elements_array_expansion_spans()
+                        .iter()
+                        .map(|span| span.slice(source).to_owned())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                spans,
+                vec![
+                    "$@",
+                    "${@:2}",
+                    "${items[@]}",
+                    "${items[@]:1}",
+                    "${!items[@]}",
+                    "${items[@]/#/#}",
+                    "${items[@]@Q}",
+                    "${items[@]:-fallback}"
+                ]
             );
         });
     }

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -96,6 +96,12 @@ pub fn all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec
     spans
 }
 
+pub fn unquoted_all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_unquoted_all_elements_array_expansion_spans(&word.parts, false, source, &mut spans);
+    spans
+}
+
 pub fn word_all_elements_array_slice_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_all_elements_array_slice_spans(&word.parts, false, false, &mut spans);
@@ -758,6 +764,26 @@ fn collect_all_elements_array_expansion_spans(
                 }
             }
             WordPart::Variable(name) if name.as_str() == "*" => {}
+            _ => {}
+        }
+    }
+}
+
+fn collect_unquoted_all_elements_array_expansion_spans(
+    parts: &[WordPartNode],
+    quoted: bool,
+    _source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPart::SingleQuoted { .. } => {}
+            WordPart::DoubleQuoted { parts, .. } => {
+                collect_unquoted_all_elements_array_expansion_spans(parts, true, _source, spans)
+            }
+            _ if !quoted && part_uses_unquoted_all_elements_array_expansion(&part.kind) => {
+                spans.push(part.span)
+            }
             _ => {}
         }
     }
@@ -2056,6 +2082,20 @@ fn part_uses_positional_at_splat(part: &WordPart) -> bool {
     }
 }
 
+fn part_uses_unquoted_all_elements_array_expansion(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => name.as_str() == "@",
+        WordPart::ArrayAccess(reference) | WordPart::ArrayIndices(reference) => {
+            var_ref_uses_all_elements_at_splat(reference)
+        }
+        WordPart::ArraySlice { reference, .. } => var_ref_uses_all_elements_at_splat(reference),
+        WordPart::Parameter(parameter) => {
+            parameter_uses_unquoted_all_elements_array_expansion(parameter)
+        }
+        _ => false,
+    }
+}
+
 fn part_is_pure_positional_at_splat(part: &WordPart) -> bool {
     match part {
         WordPart::Variable(name) => name.as_str() == "@",
@@ -2109,6 +2149,32 @@ fn parameter_uses_all_elements_array_slice(parameter: &ParameterExpansion) -> bo
         BourneParameterExpansion::Slice { reference, .. }
             if var_ref_uses_all_elements_at_splat(reference)
     )
+}
+
+fn parameter_uses_unquoted_all_elements_array_expansion(parameter: &ParameterExpansion) -> bool {
+    let ParameterExpansionSyntax::Bourne(syntax) = &parameter.syntax else {
+        return false;
+    };
+
+    match syntax {
+        BourneParameterExpansion::Access { reference }
+        | BourneParameterExpansion::Indices { reference }
+        | BourneParameterExpansion::Slice { reference, .. } => {
+            var_ref_uses_all_elements_at_splat(reference)
+        }
+        BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            ..
+        } => {
+            !matches!(operator, ParameterOp::UseReplacement)
+                && var_ref_uses_all_elements_at_splat(reference)
+        }
+        BourneParameterExpansion::Transformation { reference, .. } => {
+            var_ref_uses_all_elements_at_splat(reference)
+        }
+        _ => false,
+    }
 }
 
 fn parameter_is_unindexed_bash_source(parameter: &ParameterExpansion) -> bool {
@@ -2474,6 +2540,7 @@ mod tests {
     use super::{
         all_elements_array_expansion_part_spans, array_expansion_part_spans,
         command_substitution_part_spans, find_extglob_bounds, scalar_expansion_part_spans,
+        unquoted_all_elements_array_expansion_part_spans,
         unquoted_command_substitution_part_spans_in_source, unquoted_scalar_expansion_part_spans,
         word_all_elements_array_slice_span_in_source, word_all_elements_array_slice_spans,
         word_caret_negated_bracket_spans, word_double_quoted_scalar_only_expansion_spans,
@@ -2843,6 +2910,87 @@ printf '%s\\n' ${#arr[@]} ${!arr[@]} ${name:-safe[@]} ${arr[@]}
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${arr[@]}"]
+        );
+    }
+
+    #[test]
+    fn unquoted_all_elements_array_expansion_spans_only_return_unquoted_at_style_parts() {
+        let source = "printf '%s\\n' $@ $* \"$@\" \"$*\" ${arr[@]} ${arr[*]} ${arr[@]:1:2} ${arr[*]:1:2} ${!arr[@]} ${arr[@]/#/#} ${arr[@]@Q} ${arr[@]:-fallback} ${arr[@]:+fallback} ${1+\"$@\"}\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        assert_eq!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[1], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$@"]
+        );
+        assert!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[2], source).is_empty()
+        );
+        assert!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[3], source).is_empty()
+        );
+        assert!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[4], source).is_empty()
+        );
+        assert_eq!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[5], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${arr[@]}"]
+        );
+        assert!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[6], source).is_empty()
+        );
+        assert_eq!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[7], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${arr[@]:1:2}"]
+        );
+        assert!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[8], source).is_empty()
+        );
+        assert_eq!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[9], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${!arr[@]}"]
+        );
+        assert_eq!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[10], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${arr[@]/#/#}"]
+        );
+        assert_eq!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[11], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${arr[@]@Q}"]
+        );
+        assert_eq!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[12], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${arr[@]:-fallback}"]
+        );
+        assert!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[13], source).is_empty()
+        );
+        assert!(
+            unquoted_all_elements_array_expansion_part_spans(&command.args[14], source).is_empty()
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S008_S008.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S008_S008.sh.snap
@@ -6,9 +6,3 @@ S008 quote array expansions to preserve element boundaries
   |
 4 | printf '%s\n' ${arr[@]}
   |
-
-S008 quote array expansions to preserve element boundaries
- --> <source>:5:15
-  |
-5 | printf '%s\n' ${arr[*]}
-  |

--- a/crates/shuck-linter/src/rules/style/unquoted_array_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_expansion.rs
@@ -14,14 +14,19 @@ impl Violation for UnquotedArrayExpansion {
 
 pub fn unquoted_array_expansion(checker: &mut Checker) {
     let spans = [
+        ExpansionContext::CommandName,
         ExpansionContext::CommandArgument,
+        ExpansionContext::HereString,
         ExpansionContext::ForList,
         ExpansionContext::SelectList,
     ]
     .into_iter()
     .flat_map(|context| checker.facts().expansion_word_facts(context))
-    .filter(|fact| fact.analysis().array_valued && fact.analysis().can_expand_to_multiple_fields)
-    .flat_map(|fact| fact.unquoted_array_expansion_spans().iter().copied())
+    .flat_map(|fact| {
+        fact.unquoted_all_elements_array_expansion_spans()
+            .iter()
+            .copied()
+    })
     .collect::<Vec<_>>();
 
     for span in spans {
@@ -50,31 +55,38 @@ printf '%s\\n' prefix${arr[@]}suffix ${arr[0]} ${names[*]}
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["${arr[@]}", "${names[*]}"]
+            vec!["${arr[@]}"]
         );
     }
 
     #[test]
-    fn ignores_non_argument_array_contexts() {
+    fn ignores_redirect_targets_but_reports_here_strings() {
         let source = "\
 #!/bin/bash
 arr=(a b)
 printf '%s\\n' ok >${paths[@]}
 cat <<< ${items[@]}
+cat <<< ${items[@]:+fallback}
 ";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::UnquotedArrayExpansion),
         );
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${items[@]}"]
+        );
     }
 
     #[test]
     fn ignores_array_values_that_stay_single_field_when_quoted() {
         let source = "\
 #!/bin/bash
-printf '%s\\n' \"${names[*]}\" \"${arr[0]}\"
+printf '%s\\n' \"${names[*]}\" \"${arr[0]}\" \"$@\" \"${@:2}\" \"${items[@]}\" \"${items[@]:1}\"
 ";
         let diagnostics = test_snippet(
             source,
@@ -111,10 +123,10 @@ done
     }
 
     #[test]
-    fn reports_positional_parameter_expansions() {
+    fn reports_at_style_positional_parameter_expansions_only() {
         let source = "\
 #!/bin/bash
-printf '%s\\n' $@ $*
+printf '%s\\n' $@ ${@:2} $*
 ";
         let diagnostics = test_snippet(
             source,
@@ -126,7 +138,55 @@ printf '%s\\n' $@ $*
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$@", "$*"]
+            vec!["$@", "${@:2}"]
+        );
+    }
+
+    #[test]
+    fn reports_command_name_and_array_slice_at_expansions() {
+        let source = "\
+#!/bin/bash
+arr=(a b c)
+${arr[@]:0:1} --flag
+printf '%s\\n' ${arr[@]:1} ${arr[*]:1} ${!arr[@]} ${arr[@]/#/#} ${arr[@]@Q} ${arr[@]:-fallback} ${arr[@]:+fallback}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedArrayExpansion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "${arr[@]:0:1}",
+                "${arr[@]:1}",
+                "${!arr[@]}",
+                "${arr[@]/#/#}",
+                "${arr[@]@Q}",
+                "${arr[@]:-fallback}",
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_star_splats_that_have_their_own_rule() {
+        let source = "\
+#!/bin/bash
+arr=(a b c)
+${arr[*]:0:1} --flag
+printf '%s\\n' $* ${arr[*]} ${arr[*]:1}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedArrayExpansion),
+        );
+
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics: {diagnostics:#?}"
         );
     }
 }


### PR DESCRIPTION
## What changed
- narrow S008 to unquoted all-elements `@` expansions instead of the broader array-expansion bucket
- add fact and span helpers for unquoted `@`-style expansions so the rule can distinguish `@` from `*`
- cover command-name, here-string, slice, index-list, rewrite, and transform forms that ShellCheck treats as SC2068-compatible
- update the S008 snapshot to reflect that `${arr[*]}` belongs to the separate star-splat rule

## Why
S008 was mixing two different behaviors:
- it missed several ShellCheck-compatible `@` forms such as slices, index lists, here-strings, and element-wise rewrites
- it also over-reported `*` forms and `:+` wrapper patterns that should not be flagged by S008

The fix moves that distinction into the fact/span layer so the rule stays a cheap filter over the right structural data.

## Impact
- S008 now matches ShellCheck compatibility for the targeted corpus run
- `${arr[*]}` and related star-splat cases stay with their dedicated rule instead of being double-classified under S008
- the rule now reports the missing unquoted `@` expansion shapes without broadening unrelated contexts

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S008`
