### PR TITLE
Align S007 printf format handling with ShellCheck

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1793,6 +1793,7 @@ impl SedCommandFacts {
 #[derive(Debug, Clone, Copy)]
 pub struct PrintfCommandFacts<'a> {
     pub format_word: Option<&'a Word>,
+    pub format_word_has_literal_percent: bool,
     pub uses_q_format: bool,
 }
 
@@ -2323,6 +2324,8 @@ impl<'a> CommandOptionFacts<'a> {
             printf: normalized.effective_name_is("printf").then(|| {
                 let format_word = printf_format_word(normalized.body_args(), source);
                 PrintfCommandFacts {
+                    format_word_has_literal_percent: format_word
+                        .is_some_and(|word| printf_format_word_has_literal_percent(word, source)),
                     uses_q_format: format_word
                         .is_some_and(|word| printf_uses_q_format(word, source)),
                     format_word,
@@ -14461,6 +14464,40 @@ fn printf_format_word<'a>(args: &[&'a Word], source: &str) -> Option<&'a Word> {
     args.get(index).copied()
 }
 
+fn printf_format_word_has_literal_percent(word: &Word, source: &str) -> bool {
+    word_parts_have_literal_percent(&word.parts, source)
+}
+
+fn word_parts_have_literal_percent(parts: &[WordPartNode], source: &str) -> bool {
+    parts
+        .iter()
+        .any(|part| word_part_has_literal_percent(part, source))
+}
+
+fn word_part_has_literal_percent(part: &WordPartNode, source: &str) -> bool {
+    match &part.kind {
+        WordPart::Literal(text) => text.as_str(source, part.span).contains('%'),
+        WordPart::ZshQualifiedGlob(_) => part.span.slice(source).contains('%'),
+        WordPart::SingleQuoted { value, .. } => value.slice(source).contains('%'),
+        WordPart::DoubleQuoted { parts, .. } => word_parts_have_literal_percent(parts, source),
+        WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::Parameter(_)
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
 fn printf_uses_q_format(word: &Word, source: &str) -> bool {
     let Some(text) = static_word_text(word, source) else {
         return false;
@@ -17415,6 +17452,12 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
             Some("\"$fmt\"")
         );
         assert!(
+            printf
+                .options()
+                .printf()
+                .is_some_and(|printf| !printf.format_word_has_literal_percent)
+        );
+        assert!(
             !printf
                 .options()
                 .printf()
@@ -17454,6 +17497,7 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
             .and_then(|fact| fact.options().printf())
             .expect("expected star-width q printf facts");
         assert!(star_q_printf.uses_q_format);
+        assert!(star_q_printf.format_word_has_literal_percent);
 
         let unset = facts
             .commands()
@@ -17644,6 +17688,47 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
             .and_then(|fact| fact.options().sudo_family())
             .expect("expected sudo-family facts");
         assert_eq!(doas.invoker, SudoFamilyInvoker::Doas);
+    }
+
+    #[test]
+    fn tracks_printf_formats_with_and_without_literal_percents() {
+        let source = "printf \"$fmt\" value\nprintf \"${left}${right}\" value\nprintf \"${fmt:-%s}\" value\nprintf \"$(echo %s)\" value\nprintf \"pre$foo\" value\nprintf \"%${width}s\\n\" value\nprintf \"${color}%s${reset}\" value\nprintf \"$fmt%s\" value\nprintf '%s\\n' value\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let printfs = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("printf"))
+            .filter_map(|fact| fact.options().printf())
+            .map(|printf| {
+                (
+                    printf
+                        .format_word
+                        .map(|word| word.span.slice(source))
+                        .expect("expected format word"),
+                    printf.format_word_has_literal_percent,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            printfs,
+            vec![
+                ("\"$fmt\"", false),
+                ("\"${left}${right}\"", false),
+                ("\"${fmt:-%s}\"", false),
+                ("\"$(echo %s)\"", false),
+                ("\"pre$foo\"", false),
+                ("\"%${width}s\\n\"", true),
+                ("\"${color}%s${reset}\"", true),
+                ("\"$fmt%s\"", true),
+                ("'%s\\n'", true),
+            ]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/printf_format_variable.rs
+++ b/crates/shuck-linter/src/rules/style/printf_format_variable.rs
@@ -18,9 +18,10 @@ pub fn printf_format_variable(checker: &mut Checker) {
         .commands()
         .iter()
         .filter_map(|fact| {
-            fact.options()
-                .printf()
-                .and_then(|printf| printf.format_word)
+            let printf = fact.options().printf()?;
+            (!printf.format_word_has_literal_percent)
+                .then_some(printf.format_word)
+                .flatten()
         })
         .filter_map(|word| {
             checker
@@ -42,8 +43,8 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_runtime_supplied_formats_and_skips_fixed_literals() {
-        let source = "printf '%s\\n' value\nprintf \"$fmt\" value\nprintf \"$(echo %s)\" value\n";
+    fn reports_dynamic_formats_without_literal_percents_and_skips_percent_templates() {
+        let source = "printf '%s\\n' value\nprintf \"$fmt\" value\nprintf \"$(echo %s)\" value\nprintf \"${left}${right}\" value\nprintf \"pre$foo\" value\nprintf \"%${span}s\\n\" value\nprintf \"${color}%s${reset}\" value\nprintf \"$fmt%s\" value\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::PrintfFormatVariable),
@@ -54,7 +55,7 @@ mod tests {
                 .iter()
                 .map(|diagnostic| diagnostic.span.start.line)
                 .collect::<Vec<_>>(),
-            vec![2, 3]
+            vec![2, 3, 4, 5]
         );
     }
 

--- a/crates/shuck/tests/testdata/corpus-metadata/s007.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s007.yaml
@@ -95,6 +95,17 @@ reviewed_divergences:
     path_suffix: "rvm__rvm__scripts__functions__utility_logging"
     reason: "This helper script is treated as a reviewed S007 divergence in the corpus comparison."
   - side: shuck-only
+    path_suffix: "oh-my-fish__oh-my-fish__bin__install"
+    labels:
+      - project-closure
+    reason: "This project-closure Fish installer is treated as a reviewed S007 divergence in the corpus comparison."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "This shell-collapse wrapper is treated as a reviewed S007 divergence in the corpus comparison."
+  - side: shuck-only
     path_suffix: "sstephenson__bats__libexec__bats-format-tap-stream"
     labels:
       - helper-library


### PR DESCRIPTION
## Summary
- align `S007` with the current `SC2059` boundary for dynamic `printf` format strings
- add `printf` fact coverage for literal-percent detection and extend the focused rule tests
- record the remaining project-closure and shell-collapse comparison quirks for `S007`

## Root Cause
`S007` was treating any non-literal `printf` format word as a violation. That over-reported on percent-template forms that ShellCheck accepts and left the corpus comparison depending on a few known wrapper-collapse quirks.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S007`
