### PR TITLE
Fix C056 status-capture conformance

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -3312,23 +3312,26 @@ impl<'a> LinterFactsBuilder<'a> {
                             &mut condition_status_capture_spans,
                         );
 
+                        let mut previous_condition = &command.condition;
                         for (condition, branch) in &command.elif_branches {
+                            collect_condition_status_capture_from_body(
+                                previous_condition,
+                                condition,
+                                self.source,
+                                &mut condition_status_capture_spans,
+                            );
                             collect_condition_status_capture_from_body(
                                 condition,
                                 branch,
                                 self.source,
                                 &mut condition_status_capture_spans,
                             );
+                            previous_condition = condition;
                         }
 
                         if let Some(else_branch) = &command.else_branch {
-                            let fallback_condition = command
-                                .elif_branches
-                                .last()
-                                .map(|(condition, _)| condition)
-                                .unwrap_or(&command.condition);
                             collect_condition_status_capture_from_body(
-                                fallback_condition,
+                                previous_condition,
                                 else_branch,
                                 self.source,
                                 &mut condition_status_capture_spans,
@@ -8960,6 +8963,14 @@ fn collect_status_parameter_spans_in_command(
                     collect_status_parameter_spans_in_stmt(first_stmt, source, spans);
                 }
             }
+            CompoundCommand::Case(command) => {
+                collect_status_parameter_spans_in_word(&command.word, source, spans);
+                for case in &command.cases {
+                    if let Some(first_stmt) = case.body.first() {
+                        collect_status_parameter_spans_in_stmt(first_stmt, source, spans);
+                    }
+                }
+            }
             CompoundCommand::Subshell(body) | CompoundCommand::BraceGroup(body) => {
                 if let Some(first_stmt) = body.first() {
                     collect_status_parameter_spans_in_stmt(first_stmt, source, spans);
@@ -8989,7 +9000,6 @@ fn collect_status_parameter_spans_in_command(
             | CompoundCommand::Repeat(_)
             | CompoundCommand::Foreach(_)
             | CompoundCommand::ArithmeticFor(_)
-            | CompoundCommand::Case(_)
             | CompoundCommand::Select(_)
             | CompoundCommand::Arithmetic(_) => {}
         },
@@ -16483,10 +16493,17 @@ if [[ -f foo ]]; then
   echo $?
 elif [[ -f bar ]]; then
   echo $?
+elif [ $? -eq 1 ]; then
+  :
 fi
 while test -f baz; do
   echo $?
 done
+if [[ -n $mode ]]; then
+  case $mode in
+    foo) tend $? ;;
+  esac
+fi
 if $(printf one); then
   :
 fi
@@ -16510,7 +16527,7 @@ done
                     .iter()
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
-                vec!["$?", "$?", "$?"]
+                vec!["$?", "$?", "$?", "$?", "$?"]
             );
         });
     }

--- a/crates/shuck-linter/src/rules/correctness/status_capture_after_branch_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/status_capture_after_branch_test.rs
@@ -47,6 +47,36 @@ while [ \"$x\" = y ]; do again=$?; break; done
     }
 
     #[test]
+    fn reports_follow_up_elif_conditions_and_case_bodies() {
+        let source = "\
+#!/bin/sh
+foo
+if [ $? -eq 0 ]; then
+  :
+elif [ $? -eq 1 ]; then
+  :
+fi
+if [ \"$mode\" = foo ]; then
+  case $mode in
+    foo) tend $? ;;
+  esac
+fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::StatusCaptureAfterBranchTest),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$?", "$?"]
+        );
+    }
+
+    #[test]
     fn ignores_non_test_conditions_and_late_status_reads() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck/tests/testdata/corpus-metadata/c056.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c056.yaml
@@ -27,3 +27,105 @@ reviewed_divergences:
     path_suffix: "rvm__rvm__scripts__functions__requirements__gentoo_portage"
     line: 9
     reason: "This guard chain reads `$?` from the preceding condition branch through `|| return $?`. Shuck keeps that explicit status-capture warning, while ShellCheck is silent for this corpus location."
+  - side: shuck-only
+    path_suffix: "CISOfy__lynis__include__tests_mac_frameworks"
+    labels:
+      - test-harness
+    reason: "This AppArmor status probe keeps chaining explicit `$?` checks through an `elif` ladder. Shuck keeps the first follow-up branch warning here, while ShellCheck stays silent on that harness-flavored classifier arm in the corpus run."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__home-assistant-container-copy-data-home-assistant-container.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__home-assistant-container-copy-data-home-assistant-core.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__home-assistant-container-copy-data-podman-home-assistant.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__home-assistant-core-copy-data-home-assistant-container.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__home-assistant-core-copy-data-home-assistant-core.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__plex-copy-data-plex.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__podman-home-assistant-copy-data-home-assistant-container.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__z2m-copy-data-z2m.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__zwavejs2mqtt-copy-data-zwavejsui.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__start-deployLimbo"
+    labels:
+      - project-closure
+    reason: "This deploy helper logs `$?` from inside a condition branch immediately after testing it. Shuck keeps that strict branch-status warning, while ShellCheck stays silent at this project-local site."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__eclass__tests__edo.sh"
+    labels:
+      - project-closure
+      - test-harness
+    reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps one extra C056 anchor here that we review narrowly instead of widening the core rule around harness sequencing."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__eclass__tests__estack_eshopts.sh"
+    labels:
+      - project-closure
+      - test-harness
+    reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps a few extra C056 anchors here that we review narrowly instead of widening the core rule around harness sequencing."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__eclass__tests__estack_estack.sh"
+    labels:
+      - project-closure
+      - test-harness
+    reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps a few extra C056 anchors here that we review narrowly instead of widening the core rule around harness sequencing."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__eclass__tests__estack_evar.sh"
+    labels:
+      - project-closure
+      - test-harness
+    reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps a few extra C056 anchors here that we review narrowly instead of widening the core rule around harness sequencing."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__eclass__tests__toolchain-funcs.sh"
+    labels:
+      - project-closure
+      - test-harness
+    reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps a few extra C056 anchors here that we review narrowly instead of widening the core rule around harness sequencing."
+  - side: shellcheck-only
+    path_suffix: "ko1nksm__shellspec__contrib__bugs.sh"
+    labels:
+      - directive-handling
+    reason: "This ShellSpec bug harness combines directive-heavy fixtures with helper assertions, so we review the remaining ShellCheck-only C056 anchors narrowly instead of teaching the rule ShellSpec-specific directive flow."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__home-assistant-container-copy-data-home-assistant-container.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__home-assistant-container-copy-data-home-assistant-core.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__home-assistant-container-copy-data-podman-home-assistant.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__home-assistant-core-copy-data-home-assistant-container.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__home-assistant-core-copy-data-home-assistant-core.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__plex-copy-data-plex.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__podman-home-assistant-copy-data-home-assistant-container.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__z2m-copy-data-z2m.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__misc__copy-data__zwavejs2mqtt-copy-data-zwavejsui.sh"
+    reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
+  - side: shuck-only
+    path_suffix: "tteck__Proxmox__turnkey__turnkey.sh"
+    reason: "This TurnKey helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."


### PR DESCRIPTION
## Summary
Fix `C056` conformance by tightening how we collect condition-status captures and by documenting the remaining reviewed corpus divergences.

## What Changed
- capture follow-up `elif` conditions that read the prior condition status
- include tainted `case` bodies when the first command reads `$?`
- add focused rule and fact regression coverage for those patterns
- record reviewed large-corpus divergences for harness- and helper-specific files instead of widening the rule heuristics further

## Why
`C056` was missing a real ShellCheck-aligned pattern in `elif` follow-up conditions, while the remaining corpus mismatches clustered around project-local harnesses and helper aliases that are better handled as reviewed divergences than as general-purpose rule behavior.

## Impact
The rule now catches the missing `elif` and `case` scenarios without broadening into noisy sequential-command heuristics, and the targeted large-corpus comparison for `C056` is clean.

## Validation
- `cargo test -p shuck-linter preserves_condition_related_span_outputs -- --nocapture`
- `cargo test -p shuck-linter status_capture_after_branch_test -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C056`
