### PR TITLE
Fix C098 false positives in corpus comparison

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -14997,13 +14997,15 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
     let mut index = 0usize;
 
     if args.len() >= 2
-        && let Some(first_text) = args.first().and_then(|word| static_word_text(word, source))
+        && let Some(first_word) = args.first().copied()
+        && classify_word(first_word, source).quote == WordQuote::Unquoted
+        && let Some(first_text) = static_word_text(first_word, source)
         && first_text != "--"
         && !first_text.starts_with('-')
         && !first_text.starts_with('+')
         && is_shell_variable_name(first_text.as_str())
     {
-        flags_without_prefix_spans.push(args[0].span);
+        flags_without_prefix_spans.push(first_word.span);
     }
 
     while let Some(word) = args.get(index) {
@@ -18438,6 +18440,34 @@ type -P printf
                 );
             },
         );
+    }
+
+    #[test]
+    fn set_command_flags_without_prefix_ignore_quoted_literals() {
+        let source = "\
+set foo bar
+set \"foo\" bar
+set f\"oo\" bar
+set 'foo' bar
+";
+
+        with_facts(source, None, |_, facts| {
+            let set_without_prefix_spans = facts
+                .commands()
+                .iter()
+                .filter(|fact| fact.effective_name_is("set"))
+                .filter_map(|fact| fact.options().set())
+                .flat_map(|set| set.flags_without_prefix_spans().iter().copied())
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                set_without_prefix_spans
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["foo"]
+            );
+        });
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
+++ b/crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
@@ -15,7 +15,11 @@ impl Violation for SetFlagsWithoutDashes {
 pub fn set_flags_without_dashes(checker: &mut Checker) {
     if !matches!(
         checker.shell(),
-        ShellDialect::Sh | ShellDialect::Bash | ShellDialect::Dash | ShellDialect::Ksh
+        ShellDialect::Unknown
+            | ShellDialect::Sh
+            | ShellDialect::Bash
+            | ShellDialect::Dash
+            | ShellDialect::Ksh
     ) {
         return;
     }
@@ -76,7 +80,7 @@ set n-aliases.conf n-env.conf
     }
 
     #[test]
-    fn ignores_quoted_literals_and_unsupported_shells() {
+    fn ignores_quoted_literals_but_keeps_unknown_shells_enabled() {
         let source = "\
 set \"required\" \"$1\"
 set f\"oo\" bar
@@ -94,11 +98,29 @@ set OFFLINE_PATH \"$PWD\"
             vec!["OFFLINE_PATH"]
         );
 
+        let unknown_source = "set foo bar\n";
         let unknown_shell_diagnostics = test_snippet(
-            source,
+            unknown_source,
             &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes)
                 .with_shell(ShellDialect::Unknown),
         );
-        assert!(unknown_shell_diagnostics.is_empty());
+        assert_eq!(
+            unknown_shell_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(unknown_source))
+                .collect::<Vec<_>>(),
+            vec!["foo"]
+        );
+    }
+
+    #[test]
+    fn ignores_unsupported_known_shells() {
+        let source = "set foo bar\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
+++ b/crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct SetFlagsWithoutDashes;
 
@@ -13,6 +13,13 @@ impl Violation for SetFlagsWithoutDashes {
 }
 
 pub fn set_flags_without_dashes(checker: &mut Checker) {
+    if !matches!(
+        checker.shell(),
+        ShellDialect::Sh | ShellDialect::Bash | ShellDialect::Dash | ShellDialect::Ksh
+    ) {
+        return;
+    }
+
     let spans = checker
         .facts()
         .commands()
@@ -28,7 +35,7 @@ pub fn set_flags_without_dashes(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_set_flags_without_prefix() {
@@ -38,7 +45,7 @@ set foo bar
 ";
         let diagnostics = test_snippet(
             source,
-            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes),
+            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes).with_shell(ShellDialect::Bash),
         );
 
         assert_eq!(diagnostics.len(), 2);
@@ -62,9 +69,36 @@ set n-aliases.conf n-env.conf
 ";
         let diagnostics = test_snippet(
             source,
-            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes),
+            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes).with_shell(ShellDialect::Bash),
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_quoted_literals_and_unsupported_shells() {
+        let source = "\
+set \"required\" \"$1\"
+set f\"oo\" bar
+set OFFLINE_PATH \"$PWD\"
+";
+        let bash_diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes).with_shell(ShellDialect::Bash),
+        );
+        assert_eq!(
+            bash_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["OFFLINE_PATH"]
+        );
+
+        let unknown_shell_diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes)
+                .with_shell(ShellDialect::Unknown),
+        );
+        assert!(unknown_shell_diagnostics.is_empty());
     }
 }

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -2386,17 +2386,16 @@ fn resolve_shell(path: &Path, src: &[u8]) -> String {
         return "zsh".into();
     }
 
-    if let Some(unsupported_shell) = unsupported_large_corpus_shebang_shell(&trimmed_first_line) {
-        return unsupported_shell.to_ascii_lowercase();
-    }
-
     match shuck_linter::ShellDialect::infer(source, Some(path)) {
         shuck_linter::ShellDialect::Bash => "bash".into(),
         shuck_linter::ShellDialect::Ksh | shuck_linter::ShellDialect::Mksh => "ksh".into(),
         shuck_linter::ShellDialect::Zsh => "zsh".into(),
-        shuck_linter::ShellDialect::Unknown
-        | shuck_linter::ShellDialect::Sh
-        | shuck_linter::ShellDialect::Dash => "sh".into(),
+        shuck_linter::ShellDialect::Sh | shuck_linter::ShellDialect::Dash => "sh".into(),
+        shuck_linter::ShellDialect::Unknown => {
+            unsupported_large_corpus_shebang_shell(&trimmed_first_line)
+                .map(|shell| shell.to_ascii_lowercase())
+                .unwrap_or_else(|| "sh".into())
+        }
     }
 }
 
@@ -3152,6 +3151,17 @@ mod tests {
     #[test]
     fn resolve_shell_csh_shebang_stays_unsupported() {
         assert_eq!(resolve_shell(Path::new("script"), b"#!/bin/csh\n"), "csh");
+    }
+
+    #[test]
+    fn resolve_shell_respects_shellcheck_header_over_unsupported_shebang() {
+        assert_eq!(
+            resolve_shell(
+                Path::new("script"),
+                b"#!/usr/bin/env fish\n# shellcheck shell=bash\necho hi\n",
+            ),
+            "bash"
+        );
     }
 
     #[test]

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -2022,7 +2022,11 @@ fn shell_supported_for_large_corpus(
 
     shellcheck_supported_shells
         .map(|supported| supported.contains_key(shell))
-        .unwrap_or(true)
+        .unwrap_or_else(|| default_supported_large_corpus_shell(shell))
+}
+
+fn default_supported_large_corpus_shell(shell: &str) -> bool {
+    matches!(shell, "sh" | "bash" | "dash" | "ksh")
 }
 
 fn effective_large_corpus_shell(fixture: &LargeCorpusFixture) -> &str {
@@ -3536,6 +3540,13 @@ mod tests {
         assert!(!shell_supported_for_large_corpus("zsh", Some(&supported)));
         assert!(shell_supported_for_large_corpus("sh", Some(&supported)));
         assert!(shell_supported_for_large_corpus("bash", Some(&supported)));
+    }
+
+    #[test]
+    fn unsupported_shebang_shells_are_skipped_without_shellcheck_metadata() {
+        assert!(!shell_supported_for_large_corpus("fish", None));
+        assert!(!shell_supported_for_large_corpus("csh", None));
+        assert!(shell_supported_for_large_corpus("sh", None));
     }
 
     #[test]

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -2382,6 +2382,10 @@ fn resolve_shell(path: &Path, src: &[u8]) -> String {
         return "zsh".into();
     }
 
+    if let Some(unsupported_shell) = unsupported_large_corpus_shebang_shell(&trimmed_first_line) {
+        return unsupported_shell.to_ascii_lowercase();
+    }
+
     match shuck_linter::ShellDialect::infer(source, Some(path)) {
         shuck_linter::ShellDialect::Bash => "bash".into(),
         shuck_linter::ShellDialect::Ksh | shuck_linter::ShellDialect::Mksh => "ksh".into(),
@@ -2389,6 +2393,22 @@ fn resolve_shell(path: &Path, src: &[u8]) -> String {
         shuck_linter::ShellDialect::Unknown
         | shuck_linter::ShellDialect::Sh
         | shuck_linter::ShellDialect::Dash => "sh".into(),
+    }
+}
+
+fn unsupported_large_corpus_shebang_shell(first_line: &str) -> Option<&str> {
+    let line = first_line.strip_prefix("#!")?.trim();
+    let mut parts = line.split_whitespace();
+    let first = parts.next()?;
+    let interpreter = if Path::new(first).file_name()?.to_str()? == "env" {
+        parts.find(|part| !part.starts_with('-'))?
+    } else {
+        Path::new(first).file_name()?.to_str()?
+    };
+
+    match interpreter.to_ascii_lowercase().as_str() {
+        "fish" | "csh" | "tcsh" => Some(interpreter),
+        _ => None,
     }
 }
 
@@ -3115,6 +3135,19 @@ mod tests {
     #[test]
     fn resolve_shell_zsh_shebang() {
         assert_eq!(resolve_shell(Path::new("script"), b"#!/bin/zsh\n"), "zsh");
+    }
+
+    #[test]
+    fn resolve_shell_fish_shebang_stays_unsupported() {
+        assert_eq!(
+            resolve_shell(Path::new("script"), b"#!/usr/bin/env fish\n"),
+            "fish"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_csh_shebang_stays_unsupported() {
+        assert_eq!(resolve_shell(Path::new("script"), b"#!/bin/csh\n"), "csh");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- limit C098's unprefixed `set` flag detection to unquoted first arguments
- restrict the rule to the shells listed in the rule metadata
- keep the large-corpus harness from collapsing explicit `fish` and `csh` shebangs into `sh`

## Root Cause
- the C098 fact builder treated any statically reconstructible first `set` argument as a missing-prefix candidate, even when shell syntax made it a quoted literal
- the large-corpus resolver mapped unsupported shebangs to `sh`, which let C098 run on files that ShellCheck skips entirely

## Validation
- `cargo test -p shuck-linter set_command_flags_without_prefix_ignore_quoted_literals`
- `cargo test -p shuck-linter set_flags_without_dashes`
- `cargo test -p shuck --test large_corpus resolve_shell_`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C098`
