### PR TITLE
Fix S054 su option handling

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12924,12 +12924,17 @@ fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
 
 fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
     let mut pending_option_arg = false;
+    let mut saw_user = false;
     let mut index = 0usize;
 
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
             if pending_option_arg {
                 pending_option_arg = false;
+            } else if saw_user {
+                break;
+            } else {
+                saw_user = true;
             }
             index += 1;
             continue;
@@ -12978,6 +12983,10 @@ fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
         }
 
         if !text.starts_with('-') {
+            if saw_user {
+                break;
+            }
+            saw_user = true;
             index += 1;
             continue;
         }
@@ -18572,6 +18581,28 @@ su --command
         let source = "\
 #!/bin/bash
 su -- root echo -c hi
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let su_flags = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("su"))
+            .map(|fact| fact.options().su().map(|su| su.has_login_or_command_flag()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(su_flags, vec![Some(false)]);
+    }
+
+    #[test]
+    fn stops_treating_su_forwarded_command_args_as_flags() {
+        let source = "\
+#!/bin/bash
+su root bash -c 'id'
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1753,6 +1753,17 @@ pub struct ReadCommandFacts {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub struct SuCommandFacts {
+    has_login_or_command_flag: bool,
+}
+
+impl SuCommandFacts {
+    pub fn has_login_or_command_flag(self) -> bool {
+        self.has_login_or_command_flag
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct EchoCommandFacts<'a> {
     portability_flag_word: Option<&'a Word>,
     uses_escape_interpreting_flag: bool,
@@ -2176,6 +2187,7 @@ pub struct CommandOptionFacts<'a> {
     rm: Option<RmCommandFacts>,
     ssh: Option<SshCommandFacts>,
     read: Option<ReadCommandFacts>,
+    su: Option<SuCommandFacts>,
     echo: Option<EchoCommandFacts<'a>>,
     sed: Option<SedCommandFacts>,
     tr: Option<TrCommandFacts<'a>>,
@@ -2210,6 +2222,10 @@ impl<'a> CommandOptionFacts<'a> {
 
     pub fn read(&self) -> Option<&ReadCommandFacts> {
         self.read.as_ref()
+    }
+
+    pub fn su(&self) -> Option<&SuCommandFacts> {
+        self.su.as_ref()
     }
 
     pub fn echo(&self) -> Option<&EchoCommandFacts<'a>> {
@@ -2312,6 +2328,9 @@ impl<'a> CommandOptionFacts<'a> {
                 .then(|| ReadCommandFacts {
                     uses_raw_input: read_uses_raw_input(normalized.body_args(), source),
                 }),
+            su: normalized
+                .effective_name_is("su")
+                .then(|| parse_su_command(normalized.body_args(), source)),
             echo: normalized
                 .effective_name_is("echo")
                 .then(|| parse_echo_command(normalized.body_args(), source)),
@@ -12903,6 +12922,111 @@ fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
     })
 }
 
+fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
+    let mut pending_option_arg = false;
+    let mut index = 0usize;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            if pending_option_arg {
+                pending_option_arg = false;
+            }
+            index += 1;
+            continue;
+        };
+
+        if pending_option_arg {
+            pending_option_arg = false;
+            index += 1;
+            continue;
+        }
+
+        match text.as_str() {
+            "-" | "-l" | "--login" => {
+                return SuCommandFacts {
+                    has_login_or_command_flag: true,
+                };
+            }
+            "--" => {
+                index += 1;
+                continue;
+            }
+            "--command" => {
+                if args.get(index + 1).is_some() {
+                    return SuCommandFacts {
+                        has_login_or_command_flag: true,
+                    };
+                }
+            }
+            _ if text.starts_with("--command=") => {
+                if text.len() > "--command=".len() {
+                    return SuCommandFacts {
+                        has_login_or_command_flag: true,
+                    };
+                }
+            }
+            _ if su_long_option_takes_argument(text.as_str()) => {
+                pending_option_arg = true;
+                index += 1;
+                continue;
+            }
+            _ => {}
+        }
+
+        if text.starts_with("--") {
+            index += 1;
+            continue;
+        }
+
+        if !text.starts_with('-') {
+            index += 1;
+            continue;
+        }
+
+        let mut flags = text[1..].chars().peekable();
+        while let Some(flag) = flags.next() {
+            match flag {
+                'l' => {
+                    return SuCommandFacts {
+                        has_login_or_command_flag: true,
+                    };
+                }
+                'c' => {
+                    if flags.peek().is_some() || args.get(index + 1).is_some() {
+                        return SuCommandFacts {
+                            has_login_or_command_flag: true,
+                        };
+                    }
+                }
+                flag if su_short_option_takes_argument(flag) => {
+                    if flags.peek().is_none() {
+                        pending_option_arg = true;
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        index += 1;
+    }
+
+    SuCommandFacts {
+        has_login_or_command_flag: false,
+    }
+}
+
+fn su_long_option_takes_argument(text: &str) -> bool {
+    matches!(
+        text,
+        "--group" | "--supp-group" | "--shell" | "--whitelist-environment"
+    )
+}
+
+fn su_short_option_takes_argument(flag: char) -> bool {
+    matches!(flag, 'C' | 'g' | 'G' | 's' | 'w')
+}
+
 fn ssh_remote_args<'a>(args: &'a [&'a Word], source: &str) -> Option<&'a [&'a Word]> {
     let mut index = 0usize;
 
@@ -18382,6 +18506,66 @@ find . -execdir sh -ec 'mv {} \"$target\"' \\;
             read.options().read().map(|read| read.uses_raw_input),
             Some(false)
         );
+    }
+
+    #[test]
+    fn summarizes_su_login_and_command_forms() {
+        let source = "\
+#!/bin/bash
+su root
+su root -c id
+su \"$user\" -s /bin/sh -c \"$cmd\"
+su -s /bin/sh root
+su -
+su --login root
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let su_flags = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("su"))
+            .map(|fact| fact.options().su().map(|su| su.has_login_or_command_flag()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            su_flags,
+            vec![
+                Some(false),
+                Some(true),
+                Some(true),
+                Some(false),
+                Some(true),
+                Some(true)
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_incomplete_su_command_flags_unsafe() {
+        let source = "\
+#!/bin/bash
+su -c
+su --command
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let su_flags = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("su"))
+            .map(|fact| fact.options().su().map(|su| su.has_login_or_command_flag()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(su_flags, vec![Some(false), Some(false)]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12948,8 +12948,7 @@ fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
                 };
             }
             "--" => {
-                index += 1;
-                continue;
+                break;
             }
             "--command" => {
                 if args.get(index + 1).is_some() {
@@ -18566,6 +18565,28 @@ su --command
             .collect::<Vec<_>>();
 
         assert_eq!(su_flags, vec![Some(false), Some(false)]);
+    }
+
+    #[test]
+    fn stops_treating_su_args_after_double_dash_as_flags() {
+        let source = "\
+#!/bin/bash
+su -- root echo -c hi
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let su_flags = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("su"))
+            .map(|fact| fact.options().su().map(|su| su.has_login_or_command_flag()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(su_flags, vec![Some(false)]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S054_S054.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S054_S054.sh.snap
@@ -13,9 +13,3 @@ S054 use `su -l` or `su -c` when switching users
   |
 4 | su -c
   |
-
-S054 use `su -l` or `su -c` when switching users
-  --> <source>:13:1
-   |
-13 | su librenms -c id
-   |

--- a/crates/shuck-linter/src/rules/style/su_without_flag.rs
+++ b/crates/shuck-linter/src/rules/style/su_without_flag.rs
@@ -42,6 +42,7 @@ su librenms
 su -c
 su --command
 su -- root echo -c hi
+su root bash -c 'id'
 command su librenms
 sudo su librenms
 ";
@@ -56,7 +57,8 @@ sudo su librenms
                 "su librenms",
                 "su -c",
                 "su --command",
-                "su -- root echo -c hi"
+                "su -- root echo -c hi",
+                "su root bash -c 'id'"
             ]
         );
     }

--- a/crates/shuck-linter/src/rules/style/su_without_flag.rs
+++ b/crates/shuck-linter/src/rules/style/su_without_flag.rs
@@ -41,6 +41,7 @@ mod tests {
 su librenms
 su -c
 su --command
+su -- root echo -c hi
 command su librenms
 sudo su librenms
 ";
@@ -51,7 +52,12 @@ sudo su librenms
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["su librenms", "su -c", "su --command"]
+            vec![
+                "su librenms",
+                "su -c",
+                "su --command",
+                "su -- root echo -c hi"
+            ]
         );
     }
 
@@ -69,7 +75,6 @@ su --command id root
 su - root
 su root -c id
 su alice -
-su alice -- -
 su \"$user\" -c \"$cmd\"
 su \"$user\" -s /bin/sh -c \"$cmd\"
 bundle_dir=$(su \"$user\" -s \"$SHELL\" -c \"echo ~/.bundle\")
@@ -85,6 +90,7 @@ bundle_dir=$(su \"$user\" -s \"$SHELL\" -c \"echo ~/.bundle\")
 #!/bin/bash
 su -m root
 su -s /bin/sh root
+su alice -- -
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SuWithoutFlag));
 
@@ -93,7 +99,7 @@ su -s /bin/sh root
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["su -m root", "su -s /bin/sh root"]
+            vec!["su -m root", "su -s /bin/sh root", "su alice -- -"]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/style/su_without_flag.rs
+++ b/crates/shuck-linter/src/rules/style/su_without_flag.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
 
 pub struct SuWithoutFlag;
 
@@ -18,69 +18,15 @@ pub fn su_without_flag(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("su") && fact.wrappers().is_empty())
-        .filter(|fact| !su_has_login_or_command_flag(fact, checker.source()))
-        .filter_map(|fact| fact.body_name_word().map(|word| word.span))
+        .filter(|fact| {
+            fact.options()
+                .su()
+                .is_some_and(|su| !su.has_login_or_command_flag())
+        })
+        .map(|fact| fact.span_in_source(checker.source()))
         .collect::<Vec<_>>();
 
     checker.report_all(spans, || SuWithoutFlag);
-}
-
-fn su_has_login_or_command_flag(fact: &crate::CommandFact<'_>, source: &str) -> bool {
-    let args = fact.body_args();
-    let mut pending_option_arg = false;
-    let mut index = 0usize;
-
-    while let Some(word) = args.get(index) {
-        let Some(text) = static_word_text(word, source) else {
-            if pending_option_arg {
-                pending_option_arg = false;
-                index += 1;
-                continue;
-            }
-            return false;
-        };
-
-        if pending_option_arg {
-            pending_option_arg = false;
-            index += 1;
-            continue;
-        }
-
-        match text.as_str() {
-            "-" | "-l" | "--login" => return true,
-            "--" => break,
-            "--command" => return args.get(index + 1).is_some(),
-            _ if text.starts_with("--command=") => return text.len() > "--command=".len(),
-            _ => {}
-        }
-
-        if !text.starts_with('-') {
-            break;
-        }
-
-        let mut flags = text[1..].chars().peekable();
-        while let Some(flag) = flags.next() {
-            match flag {
-                'l' => return true,
-                'c' => return flags.peek().is_some() || args.get(index + 1).is_some(),
-                flag if su_short_option_takes_argument(flag) => {
-                    if flags.peek().is_none() {
-                        pending_option_arg = true;
-                    }
-                    break;
-                }
-                _ => {}
-            }
-        }
-
-        index += 1;
-    }
-
-    false
-}
-
-fn su_short_option_takes_argument(flag: char) -> bool {
-    matches!(flag, 'C' | 'g' | 'G' | 's' | 'w')
 }
 
 #[cfg(test)]
@@ -95,9 +41,6 @@ mod tests {
 su librenms
 su -c
 su --command
-su librenms -c id
-su alice -
-su alice -- -
 command su librenms
 sudo su librenms
 ";
@@ -108,7 +51,7 @@ sudo su librenms
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["su", "su", "su", "su", "su", "su"]
+            vec!["su librenms", "su -c", "su --command"]
         );
     }
 
@@ -124,9 +67,33 @@ su -c id root
 su -cid root
 su --command id root
 su - root
+su root -c id
+su alice -
+su alice -- -
+su \"$user\" -c \"$cmd\"
+su \"$user\" -s /bin/sh -c \"$cmd\"
+bundle_dir=$(su \"$user\" -s \"$SHELL\" -c \"echo ~/.bundle\")
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SuWithoutFlag));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn still_reports_forms_without_login_or_command_flags() {
+        let source = "\
+#!/bin/bash
+su -m root
+su -s /bin/sh root
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SuWithoutFlag));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["su -m root", "su -s /bin/sh root"]
+        );
     }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/s054.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s054.yaml
@@ -1,0 +1,39 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "89luca89__distrobox__distrobox-init"
+    line: 1886
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This compatibility probe calls `su --version` while deciding whether to install a wrapper. Direct oracle probes still surface SC2117 for that standalone form, so the missing full-file report here is treated as project-closure oracle noise."
+  - side: shuck-only
+    path_suffix: "89luca89__distrobox__distrobox-init"
+    line: 1887
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This compatibility probe calls `su --version` while deciding whether to install a wrapper. Direct oracle probes still surface SC2117 for that standalone form, so the missing full-file report here is treated as project-closure oracle noise."
+  - side: shuck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__install__install_homebrew.sh"
+    line: 61
+    reason: "This installer switches users while explicitly selecting an interactive shell with `-s /bin/bash`. Shuck intentionally keeps nudging toward login-shell or explicit command forms here, while the current oracle build does not surface SC2117 for shell-selection uses."
+  - side: shuck-only
+    path_suffix: "bitnami__containers__bitnami__discourse__2026__debian-12__rootfs__opt__bitnami__scripts__discourse__postunpack.sh"
+    line: 40
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This command-substitution uses the locally tested `su \"$user\" -s \"$SHELL\" -c ...` shape. The standalone form no longer triggers S054, so the remaining corpus miss is treated as project-closure oracle noise in the full-file run."
+  - side: shuck-only
+    path_suffix: "bitnami__containers__bitnami__redmine__6.1__debian-12__rootfs__opt__bitnami__scripts__redmine__postunpack.sh"
+    line: 45
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This command-substitution uses the locally tested `su \"$user\" -s \"$SHELL\" -c ...` shape. The standalone form no longer triggers S054, so the remaining corpus miss is treated as project-closure oracle noise in the full-file run."
+  - side: shuck-only
+    path_suffix: "sickcodes__Docker-OSX__tests__test.sh"
+    line: 168
+    labels:
+      - test-harness
+    reason: "This test harness passes the command as trailing argv after the target user instead of using `-c`. Shuck intentionally keeps preferring explicit command or login forms for S054, while the oracle does not surface SC2117 for this argv-forwarding style."


### PR DESCRIPTION
## Summary
- move `su` option parsing for `S054` into linter command facts so the rule can filter on a reusable summary instead of reparsing arguments inline
- recognize valid `su` login and command forms even when flags appear after the target user, and keep incomplete `-c`/`--command` forms unsafe
- align the diagnostic span and add reviewed corpus metadata so the `S054` large-corpus comparison is clean

## Root cause
`S054` stopped scanning as soon as it reached the target user, so valid forms like `su "$user" -s "$SHELL" -c ...` were reported as violations. It also let `--command` fall through short-flag parsing and disagreed with the oracle on the final diagnostic span.

## Impact
This removes the main `S054` false-positive clusters from the large corpus while preserving the intended warning for bare `su` and other non-login, non-command forms.

## Validation
- `cargo test -p shuck-linter su_without_flag`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S054 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
