### PR TITLE
Fix C047 exit status detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2242,11 +2242,18 @@ pub struct ExitCommandFacts<'a> {
     pub status_word: Option<&'a Word>,
     pub is_numeric_literal: bool,
     status_is_static: bool,
+    status_has_literal_content: bool,
 }
 
 impl<'a> ExitCommandFacts<'a> {
     pub fn has_static_status(self) -> bool {
         self.status_is_static
+    }
+
+    pub fn has_invalid_status_argument(self) -> bool {
+        self.status_word.is_some()
+            && !self.is_numeric_literal
+            && (self.status_is_static || self.status_has_literal_content)
     }
 }
 
@@ -15748,16 +15755,46 @@ fn parse_exit_command<'a>(command: &'a Command, source: &str) -> Option<ExitComm
             status_word: None,
             is_numeric_literal: false,
             status_is_static: false,
+            status_has_literal_content: false,
         });
     };
     let status_text = static_word_text(status_word, source);
 
     Some(ExitCommandFacts {
         status_word: Some(status_word),
-        is_numeric_literal: status_text
-            .as_deref()
-            .is_some_and(|text| text.chars().all(|character| character.is_ascii_digit())),
+        is_numeric_literal: status_text.as_deref().is_some_and(|text| {
+            !text.is_empty() && text.chars().all(|character| character.is_ascii_digit())
+        }),
         status_is_static: status_text.is_some(),
+        status_has_literal_content: word_contains_literal_content(status_word, source),
+    })
+}
+
+fn word_contains_literal_content(word: &Word, source: &str) -> bool {
+    word_parts_contain_literal_content(&word.parts, source)
+}
+
+fn word_parts_contain_literal_content(parts: &[WordPartNode], source: &str) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Literal(text) => !text.as_str(source, part.span).is_empty(),
+        WordPart::SingleQuoted { value, .. } => !value.slice(source).is_empty(),
+        WordPart::DoubleQuoted { parts, .. } => word_parts_contain_literal_content(parts, source),
+        WordPart::Variable(_)
+        | WordPart::Parameter(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. }
+        | WordPart::ZshQualifiedGlob(_) => false,
     })
 }
 
@@ -18182,6 +18219,7 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
         );
         assert!(exit.has_static_status());
         assert!(!exit.is_numeric_literal);
+        assert!(exit.has_invalid_status_argument());
 
         let doas = facts
             .commands()
@@ -19180,6 +19218,53 @@ command run0 --version
         );
         assert!(exit.has_static_status());
         assert!(exit.is_numeric_literal);
+        assert!(!exit.has_invalid_status_argument());
+    }
+
+    #[test]
+    fn parses_mixed_and_pure_dynamic_exit_status_shapes() {
+        let source = "\
+#!/bin/bash
+code=3
+other=4
+exit \"message $code\"
+exit \"123$code\"
+exit \"$code\"
+exit \"${code}${other}\"
+exit \"$(printf '%s' 3)\"
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let exits = facts
+            .commands()
+            .iter()
+            .filter_map(|fact| fact.options().exit())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            exits
+                .iter()
+                .map(|exit| exit.status_word.map(|word| word.span.slice(source)))
+                .collect::<Vec<_>>(),
+            vec![
+                Some("\"message $code\""),
+                Some("\"123$code\""),
+                Some("\"$code\""),
+                Some("\"${code}${other}\""),
+                Some("\"$(printf '%s' 3)\""),
+            ]
+        );
+        assert_eq!(
+            exits
+                .iter()
+                .map(|exit| exit.has_invalid_status_argument())
+                .collect::<Vec<_>>(),
+            vec![true, true, false, false, false]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/invalid_exit_status.rs
+++ b/crates/shuck-linter/src/rules/correctness/invalid_exit_status.rs
@@ -18,7 +18,7 @@ pub fn invalid_exit_status(checker: &mut Checker) {
         .commands()
         .iter()
         .filter_map(|fact| fact.options().exit().copied())
-        .filter(|exit| exit.has_static_status() && !exit.is_numeric_literal)
+        .filter(|exit| exit.has_invalid_status_argument())
         .filter_map(|exit| exit.status_word.map(|word| word.span))
         .collect::<Vec<_>>();
 
@@ -37,5 +37,26 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "nope");
+    }
+
+    #[test]
+    fn reports_empty_and_mixed_literal_exit_values() {
+        let source = "\
+code=3
+exit \"\"
+exit \"123$code\"
+exit \"$code\"
+exit \"${code}$(printf 4)\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::InvalidExitStatus));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"\"", "\"123$code\""]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- teach exit command facts to distinguish pure dynamic status words from mixed literal-plus-expansion arguments
- flag empty and mixed literal exit values in C047 while still allowing pure dynamic statuses
- add regression coverage at both the fact and rule layers

## Root Cause
C047 only warned when the exit status argument was fully static and nonnumeric. Mixed words like `exit "message $code"` were being treated as dynamic and skipped even though they cannot produce a valid numeric exit status.

## Validation
- `cargo test -p shuck-linter exit_status -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C047`
