### PR TITLE
Move S076 mixed-quote detection into linter facts

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4076,8 +4076,8 @@ fn mixed_quote_word_parts_inside_nested_shell_fragments(word: &Word, source: &st
     for part in &word.parts {
         nested.push(command_depth > 0 || parameter_depth > 0);
 
-        let text = part.span.slice(source);
-        let (command_delta, parameter_delta) = mixed_quote_shell_fragment_balance_delta(text);
+        let (command_delta, parameter_delta) =
+            mixed_quote_shell_fragment_balance_delta_for_part(part, source);
         command_depth += command_delta;
         parameter_depth += parameter_delta;
         command_depth = command_depth.max(0);
@@ -4087,7 +4087,30 @@ fn mixed_quote_word_parts_inside_nested_shell_fragments(word: &Word, source: &st
     nested
 }
 
-fn mixed_quote_shell_fragment_balance_delta(text: &str) -> (i32, i32) {
+fn mixed_quote_shell_fragment_balance_delta_for_part(
+    part: &WordPartNode,
+    source: &str,
+) -> (i32, i32) {
+    match &part.kind {
+        WordPart::CommandSubstitution {
+            syntax: CommandSubstitutionSyntax::Backtick,
+            ..
+        } => {
+            let text = part.span.slice(source);
+            let body = text
+                .strip_prefix('`')
+                .and_then(|text| text.strip_suffix('`'))
+                .unwrap_or(text);
+            mixed_quote_shell_fragment_balance_delta(body, true)
+        }
+        _ => mixed_quote_shell_fragment_balance_delta(part.span.slice(source), false),
+    }
+}
+
+fn mixed_quote_shell_fragment_balance_delta(
+    text: &str,
+    allow_top_level_command_comments: bool,
+) -> (i32, i32) {
     let mut command_delta = 0i32;
     let mut parameter_delta = 0i32;
     let mut chars = text.chars().peekable();
@@ -4131,7 +4154,13 @@ fn mixed_quote_shell_fragment_balance_delta(text: &str) -> (i32, i32) {
             continue;
         }
 
-        if ch == '#' && mixed_quote_shell_comment_can_start(command_delta, previous_char) {
+        if ch == '#'
+            && mixed_quote_shell_comment_can_start(
+                command_delta,
+                allow_top_level_command_comments,
+                previous_char,
+            )
+        {
             in_comment = true;
             continue;
         }
@@ -4166,8 +4195,12 @@ fn mixed_quote_shell_fragment_balance_delta(text: &str) -> (i32, i32) {
     (command_delta, parameter_delta)
 }
 
-fn mixed_quote_shell_comment_can_start(command_depth: i32, previous_char: Option<char>) -> bool {
-    command_depth > 0
+fn mixed_quote_shell_comment_can_start(
+    command_depth: i32,
+    allow_top_level_command_comments: bool,
+    previous_char: Option<char>,
+) -> bool {
+    (command_depth > 0 || allow_top_level_command_comments)
         && previous_char.is_none_or(|ch| {
             ch.is_ascii_whitespace() || matches!(ch, ';' | '|' | '&' | '(' | ')' | '<' | '>')
         })
@@ -22850,6 +22883,29 @@ printf '%s\\n' \"foo\"bar\"baz\" \"foo\"-\"bar\" \"foo\"$(printf '%s' x)\"bar\" 
 #!/bin/bash
 echo $(echo x # $(
  )\"foo\"bar\"baz\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .flat_map(|fact| {
+                    fact.unquoted_literal_between_double_quoted_segments_spans()
+                        .iter()
+                        .map(|span| span.slice(source).to_owned())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(spans, vec!["bar"]);
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_ignore_comment_text_in_backtick_fragment_scan() {
+        let source = "\
+#!/bin/bash
+echo `echo x # $(
+`\"foo\"bar\"baz\"
 ";
 
         with_facts(source, None, |_, facts| {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4000,10 +4000,10 @@ fn build_unquoted_literal_between_double_quoted_segments_spans(
         })
         .collect::<Vec<_>>();
 
-    if let Some(span) = mixed_quote_trailing_line_join_between_double_quotes_span(word, source) {
-        if !spans.contains(&span) {
-            spans.push(span);
-        }
+    if let Some(span) = mixed_quote_trailing_line_join_between_double_quotes_span(word, source)
+        && !spans.contains(&span)
+    {
+        spans.push(span);
     }
 
     spans
@@ -4092,10 +4092,23 @@ fn mixed_quote_shell_fragment_balance_delta(text: &str) -> (i32, i32) {
     let mut parameter_delta = 0i32;
     let mut chars = text.chars().peekable();
     let mut escaped = false;
+    let mut in_single_quotes = false;
 
     while let Some(ch) = chars.next() {
+        if in_single_quotes {
+            if ch == '\'' {
+                in_single_quotes = false;
+            }
+            continue;
+        }
+
         if escaped {
             escaped = false;
+            continue;
+        }
+
+        if ch == '\'' {
+            in_single_quotes = true;
             continue;
         }
 
@@ -22782,7 +22795,7 @@ printf '%s\\n' $@ ${@:2} ${items[@]} ${items[@]:1} ${!items[@]} ${items[@]/#/#} 
     fn builds_word_facts_for_unquoted_literals_between_reopened_double_quotes() {
         let source = "\
 #!/bin/bash
-printf '%s\\n' \"foo\"bar\"baz\" \"foo\"-\"bar\" \"foo\"$(printf '%s' x)\"bar\" \"$left\"-\"$right\" x=\"$(cmd \"a\".\"b\")\"
+printf '%s\\n' \"foo\"bar\"baz\" \"foo\"-\"bar\" \"foo\"$(printf '%s' x)\"bar\" \"$left\"-\"$right\" x=\"$(cmd \"a\".\"b\")\" '$('\"foo\"parenmid\"baz\" '${'\"foo\"bracemid\"baz\"
 ";
 
         with_facts(source, None, |_, facts| {
@@ -22797,7 +22810,7 @@ printf '%s\\n' \"foo\"bar\"baz\" \"foo\"-\"bar\" \"foo\"$(printf '%s' x)\"bar\" 
                 })
                 .collect::<Vec<_>>();
 
-            assert_eq!(spans, vec!["bar", "-", "."]);
+            assert_eq!(spans, vec!["bar", "-", "parenmid", "bracemid", "."]);
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -993,6 +993,7 @@ pub struct WordFact<'a> {
     command_substitution_spans: Box<[Span]>,
     unquoted_command_substitution_spans: Box<[Span]>,
     double_quoted_expansion_spans: Box<[Span]>,
+    unquoted_literal_between_double_quoted_segments_spans: Box<[Span]>,
 }
 
 impl<'a> WordFact<'a> {
@@ -1106,6 +1107,10 @@ impl<'a> WordFact<'a> {
 
     pub fn double_quoted_expansion_spans(&self) -> &[Span] {
         &self.double_quoted_expansion_spans
+    }
+
+    pub fn unquoted_literal_between_double_quoted_segments_spans(&self) -> &[Span] {
+        &self.unquoted_literal_between_double_quoted_segments_spans
     }
 }
 
@@ -3947,6 +3952,210 @@ fn word_fact_is_pure_quoted_dynamic(fact: &WordFact<'_>, source: &str) -> bool {
         || !span::word_quoted_all_elements_array_slice_spans(fact.word()).is_empty()
         || word_fact_is_double_quoted_command_substitution_only(fact, source)
         || word_fact_is_backtick_escaped_double_quoted_dynamic(fact, source)
+}
+
+fn build_unquoted_literal_between_double_quoted_segments_spans(
+    word: &Word,
+    source: &str,
+) -> Vec<Span> {
+    let nested_fragment_parts = mixed_quote_word_parts_inside_nested_shell_fragments(word, source);
+
+    let mut spans = word
+        .parts
+        .windows(3)
+        .enumerate()
+        .filter_map(|(window_index, window)| {
+            let [left, middle, right] = window else {
+                return None;
+            };
+            let WordPart::DoubleQuoted {
+                parts: left_inner, ..
+            } = &left.kind
+            else {
+                return None;
+            };
+            let WordPart::Literal(text) = &middle.kind else {
+                return None;
+            };
+            let WordPart::DoubleQuoted {
+                parts: right_inner, ..
+            } = &right.kind
+            else {
+                return None;
+            };
+
+            let neighbor_has_literal =
+                mixed_quote_double_quoted_parts_contain_literal_content(left_inner)
+                    || mixed_quote_double_quoted_parts_contain_literal_content(right_inner);
+            let middle_is_nested = nested_fragment_parts
+                .get(window_index + 1)
+                .copied()
+                .unwrap_or(false);
+            (neighbor_has_literal
+                && !middle_is_nested
+                && mixed_quote_literal_is_warnable_between_double_quotes(
+                    text.as_str(source, middle.span),
+                ))
+            .then_some(middle.span)
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(span) = mixed_quote_trailing_line_join_between_double_quotes_span(word, source) {
+        if !spans.contains(&span) {
+            spans.push(span);
+        }
+    }
+
+    spans
+}
+
+fn mixed_quote_double_quoted_parts_contain_literal_content(parts: &[WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
+        WordPart::DoubleQuoted { parts, .. } => {
+            mixed_quote_double_quoted_parts_contain_literal_content(parts)
+        }
+        WordPart::Variable(_)
+        | WordPart::Parameter(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. }
+        | WordPart::ZshQualifiedGlob(_) => false,
+    })
+}
+
+fn mixed_quote_literal_is_warnable_between_double_quotes(text: &str) -> bool {
+    if text.is_empty() {
+        return false;
+    }
+
+    if text == "\"" {
+        return true;
+    }
+
+    if matches!(text, "\\\n" | "\\\r\n") {
+        return true;
+    }
+
+    if text == "/,/" {
+        return true;
+    }
+
+    if text.chars().all(|ch| matches!(ch, '\\' | '"')) && text.contains('\\') {
+        return true;
+    }
+
+    if text.chars().any(|ch| ch.is_ascii_alphanumeric()) {
+        return !text.chars().any(char::is_whitespace);
+    }
+
+    if text.chars().all(|ch| ch == ':') {
+        return text.len() > 1;
+    }
+
+    text.chars().all(|ch| {
+        ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | '@' | '+' | '-' | '%' | ':')
+    })
+}
+
+fn mixed_quote_word_parts_inside_nested_shell_fragments(word: &Word, source: &str) -> Vec<bool> {
+    let mut command_depth = 0i32;
+    let mut parameter_depth = 0i32;
+    let mut nested = Vec::with_capacity(word.parts.len());
+
+    for part in &word.parts {
+        nested.push(command_depth > 0 || parameter_depth > 0);
+
+        let text = part.span.slice(source);
+        let (command_delta, parameter_delta) = mixed_quote_shell_fragment_balance_delta(text);
+        command_depth += command_delta;
+        parameter_depth += parameter_delta;
+        command_depth = command_depth.max(0);
+        parameter_depth = parameter_depth.max(0);
+    }
+
+    nested
+}
+
+fn mixed_quote_shell_fragment_balance_delta(text: &str) -> (i32, i32) {
+    let mut command_delta = 0i32;
+    let mut parameter_delta = 0i32;
+    let mut chars = text.chars().peekable();
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if ch == '$' {
+            match chars.peek().copied() {
+                Some('(') => {
+                    command_delta += 1;
+                    chars.next();
+                    continue;
+                }
+                Some('{') => {
+                    parameter_delta += 1;
+                    chars.next();
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        match ch {
+            ')' => command_delta -= 1,
+            '}' => parameter_delta -= 1,
+            _ => {}
+        }
+    }
+
+    (command_delta, parameter_delta)
+}
+
+fn mixed_quote_trailing_line_join_between_double_quotes_span(
+    word: &Word,
+    source: &str,
+) -> Option<Span> {
+    if !matches!(
+        word.parts.first().map(|part| &part.kind),
+        Some(WordPart::DoubleQuoted { .. })
+    ) {
+        return None;
+    }
+
+    let text = word.span.slice(source);
+    let (prefix, suffix) = if let Some(prefix) = text.strip_suffix("\\\n") {
+        (prefix, "\\\n")
+    } else if let Some(prefix) = text.strip_suffix("\\\r\n") {
+        (prefix, "\\\r\n")
+    } else {
+        return None;
+    };
+
+    if !source[word.span.end.offset..].starts_with('"') {
+        return None;
+    }
+
+    let start = word.span.start.advanced_by(prefix);
+    Some(Span::from_positions(start, start.advanced_by(suffix)))
 }
 
 fn build_bare_command_name_assignment_spans<'a>(
@@ -10787,6 +10996,9 @@ impl<'a> WordFactCollector<'a> {
                     .into_boxed_slice(),
             double_quoted_expansion_spans: double_quoted_expansion_part_spans(word_ref)
                 .into_boxed_slice(),
+            unquoted_literal_between_double_quoted_segments_spans:
+                build_unquoted_literal_between_double_quoted_segments_spans(word_ref, self.source)
+                    .into_boxed_slice(),
             word,
             command_id: self.command_id,
             nested_word_command: self.nested_word_command,
@@ -22563,6 +22775,29 @@ printf '%s\\n' $@ ${@:2} ${items[@]} ${items[@]:1} ${!items[@]} ${items[@]/#/#} 
                     "${items[@]:-fallback}"
                 ]
             );
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_for_unquoted_literals_between_reopened_double_quotes() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"foo\"bar\"baz\" \"foo\"-\"bar\" \"foo\"$(printf '%s' x)\"bar\" \"$left\"-\"$right\" x=\"$(cmd \"a\".\"b\")\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
+                .flat_map(|fact| {
+                    fact.unquoted_literal_between_double_quoted_segments_spans()
+                        .iter()
+                        .map(|span| span.slice(source).to_owned())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(spans, vec!["bar", "-", "."]);
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4116,6 +4116,7 @@ fn mixed_quote_shell_fragment_balance_delta(
     let mut chars = text.chars().peekable();
     let mut escaped = false;
     let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
     let mut in_comment = false;
     let mut previous_char = None;
 
@@ -4142,8 +4143,14 @@ fn mixed_quote_shell_fragment_balance_delta(
             continue;
         }
 
-        if ch == '\'' {
+        if ch == '\'' && !in_double_quotes {
             in_single_quotes = true;
+            previous_char = Some(ch);
+            continue;
+        }
+
+        if ch == '"' {
+            in_double_quotes = !in_double_quotes;
             previous_char = Some(ch);
             continue;
         }
@@ -4155,6 +4162,7 @@ fn mixed_quote_shell_fragment_balance_delta(
         }
 
         if ch == '#'
+            && !in_double_quotes
             && mixed_quote_shell_comment_can_start(
                 command_delta,
                 allow_top_level_command_comments,
@@ -22906,6 +22914,28 @@ echo $(echo x # $(
 #!/bin/bash
 echo `echo x # $(
 `\"foo\"bar\"baz\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .flat_map(|fact| {
+                    fact.unquoted_literal_between_double_quoted_segments_spans()
+                        .iter()
+                        .map(|span| span.slice(source).to_owned())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(spans, vec!["bar"]);
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_ignore_hashes_inside_nested_double_quotes() {
+        let source = "\
+#!/bin/bash
+echo $(printf \"%s\" \"x # $(printf y)\")\"foo\"bar\"baz\"
 ";
 
         with_facts(source, None, |_, facts| {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4103,6 +4103,9 @@ fn mixed_quote_shell_fragment_balance_delta_for_part(
                 .unwrap_or(text);
             mixed_quote_shell_fragment_balance_delta(body, true)
         }
+        WordPart::ProcessSubstitution { .. } => {
+            mixed_quote_shell_fragment_balance_delta(part.span.slice(source), true)
+        }
         _ => mixed_quote_shell_fragment_balance_delta(part.span.slice(source), false),
     }
 }
@@ -22936,6 +22939,29 @@ echo `echo x # $(
         let source = "\
 #!/bin/bash
 echo $(printf \"%s\" \"x # $(printf y)\")\"foo\"bar\"baz\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .flat_map(|fact| {
+                    fact.unquoted_literal_between_double_quoted_segments_spans()
+                        .iter()
+                        .map(|span| span.slice(source).to_owned())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(spans, vec!["bar"]);
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_ignore_comment_text_in_process_substitution_scan() {
+        let source = "\
+#!/bin/bash
+echo <(echo x # ${
+ )\"foo\"bar\"baz\"
 ";
 
         with_facts(source, None, |_, facts| {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -4093,27 +4093,46 @@ fn mixed_quote_shell_fragment_balance_delta(text: &str) -> (i32, i32) {
     let mut chars = text.chars().peekable();
     let mut escaped = false;
     let mut in_single_quotes = false;
+    let mut in_comment = false;
+    let mut previous_char = None;
 
     while let Some(ch) = chars.next() {
+        if in_comment {
+            if ch == '\n' {
+                in_comment = false;
+                previous_char = Some(ch);
+            }
+            continue;
+        }
+
         if in_single_quotes {
             if ch == '\'' {
                 in_single_quotes = false;
             }
+            previous_char = Some(ch);
             continue;
         }
 
         if escaped {
             escaped = false;
+            previous_char = Some(ch);
             continue;
         }
 
         if ch == '\'' {
             in_single_quotes = true;
+            previous_char = Some(ch);
             continue;
         }
 
         if ch == '\\' {
             escaped = true;
+            previous_char = Some(ch);
+            continue;
+        }
+
+        if ch == '#' && mixed_quote_shell_comment_can_start(command_delta, previous_char) {
+            in_comment = true;
             continue;
         }
 
@@ -4122,11 +4141,13 @@ fn mixed_quote_shell_fragment_balance_delta(text: &str) -> (i32, i32) {
                 Some('(') => {
                     command_delta += 1;
                     chars.next();
+                    previous_char = Some('(');
                     continue;
                 }
                 Some('{') => {
                     parameter_delta += 1;
                     chars.next();
+                    previous_char = Some('{');
                     continue;
                 }
                 _ => {}
@@ -4138,9 +4159,18 @@ fn mixed_quote_shell_fragment_balance_delta(text: &str) -> (i32, i32) {
             '}' => parameter_delta -= 1,
             _ => {}
         }
+
+        previous_char = Some(ch);
     }
 
     (command_delta, parameter_delta)
+}
+
+fn mixed_quote_shell_comment_can_start(command_depth: i32, previous_char: Option<char>) -> bool {
+    command_depth > 0
+        && previous_char.is_none_or(|ch| {
+            ch.is_ascii_whitespace() || matches!(ch, ';' | '|' | '&' | '(' | ')' | '<' | '>')
+        })
 }
 
 fn mixed_quote_trailing_line_join_between_double_quotes_span(
@@ -22811,6 +22841,29 @@ printf '%s\\n' \"foo\"bar\"baz\" \"foo\"-\"bar\" \"foo\"$(printf '%s' x)\"bar\" 
                 .collect::<Vec<_>>();
 
             assert_eq!(spans, vec!["bar", "-", "parenmid", "bracemid", "."]);
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_ignore_comment_text_in_nested_fragment_scan() {
+        let source = "\
+#!/bin/bash
+echo $(echo x # $(
+ )\"foo\"bar\"baz\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .flat_map(|fact| {
+                    fact.unquoted_literal_between_double_quoted_segments_spans()
+                        .iter()
+                        .map(|span| span.slice(source).to_owned())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(spans, vec!["bar"]);
         });
     }
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -60,7 +60,6 @@ pub use rules::common::span::{
     word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
     word_standalone_literal_backslash_span, word_unquoted_assign_default_spans,
     word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
-    word_unquoted_literal_between_double_quoted_segments_spans,
     word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_parameter_spans,
     word_unquoted_star_splat_spans, word_unquoted_word_between_single_quoted_segments_spans,
     word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -320,41 +320,6 @@ pub fn word_unquoted_word_between_single_quoted_segments_spans(
         .collect()
 }
 
-pub fn word_unquoted_literal_between_double_quoted_segments_spans(
-    word: &Word,
-    source: &str,
-) -> Vec<Span> {
-    word.parts
-        .windows(3)
-        .filter_map(|window| {
-            let [left, middle, right] = window else {
-                return None;
-            };
-            let WordPart::DoubleQuoted {
-                parts: left_inner, ..
-            } = &left.kind
-            else {
-                return None;
-            };
-            let WordPart::Literal(text) = &middle.kind else {
-                return None;
-            };
-            let WordPart::DoubleQuoted {
-                parts: right_inner, ..
-            } = &right.kind
-            else {
-                return None;
-            };
-
-            let neighbor_has_literal = double_quoted_parts_contain_literal_content(left_inner)
-                || double_quoted_parts_contain_literal_content(right_inner);
-            (neighbor_has_literal
-                && literal_is_warnable_between_double_quotes(text.as_str(source, middle.span)))
-            .then_some(middle.span)
-        })
-        .collect::<Vec<_>>()
-}
-
 pub fn word_unquoted_scalar_between_double_quoted_segments_spans(
     word: &Word,
     candidate_spans: &[Span],
@@ -1268,25 +1233,6 @@ fn collect_double_quoted_scalar_only_expansion_spans(
 
     true
 }
-
-fn literal_is_warnable_between_double_quotes(text: &str) -> bool {
-    if text.is_empty() {
-        return false;
-    }
-
-    if text.chars().any(|ch| ch.is_ascii_alphanumeric()) {
-        return !text.chars().any(char::is_whitespace);
-    }
-
-    if text.chars().all(|ch| ch == ':') {
-        return text.len() > 1;
-    }
-
-    text.chars().all(|ch| {
-        ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | '@' | '+' | '-' | '%' | ':')
-    })
-}
-
 fn literal_part_is_parameter_operator_tail(
     parts: &[WordPartNode],
     index: usize,
@@ -2490,29 +2436,6 @@ fn double_quoted_parts_contain_dynamic_content(parts: &[WordPartNode]) -> bool {
     })
 }
 
-fn double_quoted_parts_contain_literal_content(parts: &[WordPartNode]) -> bool {
-    parts.iter().any(|part| match &part.kind {
-        WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
-        WordPart::DoubleQuoted { parts, .. } => double_quoted_parts_contain_literal_content(parts),
-        WordPart::Variable(_)
-        | WordPart::Parameter(_)
-        | WordPart::CommandSubstitution { .. }
-        | WordPart::ArithmeticExpansion { .. }
-        | WordPart::ParameterExpansion { .. }
-        | WordPart::Length(_)
-        | WordPart::ArrayAccess(_)
-        | WordPart::ArrayLength(_)
-        | WordPart::ArrayIndices(_)
-        | WordPart::Substring { .. }
-        | WordPart::ArraySlice { .. }
-        | WordPart::IndirectExpansion { .. }
-        | WordPart::PrefixMatch { .. }
-        | WordPart::ProcessSubstitution { .. }
-        | WordPart::Transformation { .. }
-        | WordPart::ZshQualifiedGlob(_) => false,
-    })
-}
-
 fn neighbor_is_literal(part: Option<&WordPartNode>) -> bool {
     matches!(part.map(|part| &part.kind), Some(WordPart::Literal(_)))
 }
@@ -2621,7 +2544,6 @@ mod tests {
         word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
         word_unquoted_assign_default_spans, word_unquoted_escaped_pipe_or_brace_spans_in_source,
         word_unquoted_glob_pattern_spans,
-        word_unquoted_literal_between_double_quoted_segments_spans,
         word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_splat_spans,
         word_unquoted_word_between_single_quoted_segments_spans,
     };
@@ -3396,29 +3318,6 @@ printf '%s\\n' \"$a\" \"$a\"\"$b\" \"prefix$a\" \"$a$(printf '%s' x)\" $a \"$a\"
             .collect::<Vec<_>>();
 
         assert_eq!(spans, vec!["$a", "$a", "$b"]);
-    }
-
-    #[test]
-    fn word_unquoted_literal_between_double_quoted_segments_tracks_word_like_middle_parts() {
-        let source = "\
-printf '%s\\n' \"foo\"bar\"baz\" \"foo\"-\"bar\" \"foo\".\"bar\" \"foo\"::\"bar\" \"--sysroot=$tool\"/sysroot,\"-I${prefix}/include\" \"$left\"-\"$right\" \"foo\"?\"bar\" \"foo\"$(printf '%s' x)\"bar\"
-";
-        let output = Parser::new(source).parse().unwrap();
-        let command = &output.file.body[0].command;
-        let shuck_ast::Command::Simple(command) = command else {
-            panic!("expected simple command");
-        };
-
-        let spans = command
-            .args
-            .iter()
-            .flat_map(|word| {
-                word_unquoted_literal_between_double_quoted_segments_spans(word, source)
-            })
-            .map(|span| span.slice(source))
-            .collect::<Vec<_>>();
-
-        assert_eq!(spans, vec!["bar", "-", ".", "::", "/sysroot,"]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
+++ b/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
@@ -208,4 +208,22 @@ echo $(echo x # $(
             vec!["bar"]
         );
     }
+
+    #[test]
+    fn still_reports_reopened_quotes_after_comment_text_inside_backticks() {
+        let source = "\
+#!/bin/bash
+echo `echo x # $(
+`\"foo\"bar\"baz\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["bar"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
+++ b/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
@@ -173,4 +173,21 @@ this_dir=\\$(dirname \"\\$0\")
             vec!["\\$0"]
         );
     }
+
+    #[test]
+    fn still_reports_reopened_quotes_after_quoted_literal_fragment_prefixes() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' '$('\"foo\"parenmid\"baz\" '${'\"foo\"bracemid\"baz\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["parenmid", "bracemid"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
+++ b/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
@@ -226,4 +226,21 @@ echo `echo x # $(
             vec!["bar"]
         );
     }
+
+    #[test]
+    fn still_reports_reopened_quotes_after_hashes_inside_nested_double_quotes() {
+        let source = "\
+#!/bin/bash
+echo $(printf \"%s\" \"x # $(printf y)\")\"foo\"bar\"baz\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["bar"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
+++ b/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
@@ -243,4 +243,22 @@ echo $(printf \"%s\" \"x # $(printf y)\")\"foo\"bar\"baz\"
             vec!["bar"]
         );
     }
+
+    #[test]
+    fn still_reports_reopened_quotes_after_comment_text_inside_process_substitutions() {
+        let source = "\
+#!/bin/bash
+echo <(echo x # ${
+ )\"foo\"bar\"baz\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["bar"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
+++ b/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Checker, ExpansionContext, Rule, Violation,
-    word_unquoted_literal_between_double_quoted_segments_spans,
-};
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactHostKind};
 
 pub struct MixedQuoteWord;
 
@@ -16,7 +13,6 @@ impl Violation for MixedQuoteWord {
 }
 
 pub fn mixed_quote_word(checker: &mut Checker) {
-    let source = checker.source();
     let facts = checker.facts();
     let spans = [
         ExpansionContext::CommandName,
@@ -29,9 +25,11 @@ pub fn mixed_quote_word(checker: &mut Checker) {
     .into_iter()
     .flat_map(|context| facts.expansion_word_facts(context))
     .chain(facts.case_subject_facts())
-    .filter(|fact| !fact.is_nested_word_command())
+    .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
     .flat_map(|fact| {
-        word_unquoted_literal_between_double_quoted_segments_spans(fact.word(), source)
+        fact.unquoted_literal_between_double_quoted_segments_spans()
+            .iter()
+            .copied()
     })
     .collect::<Vec<_>>();
 
@@ -78,5 +76,101 @@ if [[ x =~ \"foo\"bar\"baz\" ]]; then :; fi
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_shellcheck_style_escaped_quote_separator_and_line_join_patterns() {
+        let source = "\
+#!/bin/bash
+echo -e \"\"\\\"\"CDKey\"\\\"\"=\"\\\"\"${CODE}\"\\\"\"\"
+escaped=x
+sed -i /\"${escaped}_START\"/,/\"${escaped}_END\"/d file
+x=\"$AWK '\"\\
+\" {x};\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\\\"", "\\\"", "\\\"", "\\\"", "/,/", "\\\n"]
+        );
+    }
+
+    #[test]
+    fn ignores_fully_quoted_nested_contexts_that_shellcheck_skips() {
+        let source = "\
+#!/bin/bash
+options+=(U \"${option_msgs[\"U\"]}\")
+result=\"$(regex \"#FFFFFF\" '^(#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3}))$')\"
+args+=(\"--latest\" \"$(is_boolean_yes \"$JENKINS_PLUGINS_LATEST\" && echo \"true\" || echo \"false\")\")
+x=\"${VALUE:-\"false\"}\"
+cmd=(dialog --menu \"Wireless ESSID: \\Zb$(iwgetid -r || echo \"none\")\\ZB\")
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert!(
+            diagnostics.is_empty(),
+            "{:?}",
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn still_reports_reopened_quotes_inside_nested_command_words() {
+        let source = "\
+#!/bin/bash
+x=\"$(cmd \"a\".\"b\")\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["."]
+        );
+    }
+
+    #[test]
+    fn still_reports_reopened_quotes_after_complete_command_substitutions() {
+        let source = "\
+#!/bin/bash
+echo \"$(cmd)\"x\"y\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["x"]
+        );
+    }
+
+    #[test]
+    fn reports_escaped_template_fragments_between_reopened_quotes() {
+        let source = "\
+#!/bin/bash
+echo \"#!/bin/bash
+this_dir=\\$(dirname \"\\$0\")
+\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\\$0"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
+++ b/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
@@ -190,4 +190,22 @@ printf '%s\\n' '$('\"foo\"parenmid\"baz\" '${'\"foo\"bracemid\"baz\"
             vec!["parenmid", "bracemid"]
         );
     }
+
+    #[test]
+    fn still_reports_reopened_quotes_after_comment_text_inside_command_substitutions() {
+        let source = "\
+#!/bin/bash
+echo $(echo x # $(
+ )\"foo\"bar\"baz\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MixedQuoteWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["bar"]
+        );
+    }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/s076.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s076.yaml
@@ -34,3 +34,31 @@ reviewed_divergences:
     end_line: 48
     end_column: 12
     reason: "S076 intentionally flags nested quoted fragments inside a GraphQL query string assembled in one shell word, while current ShellCheck skips this string-literal construction."
+  - side: shuck-only
+    path_suffix: "scripts/GameServerManagers__LinuxGSM__lgsm__modules__alert_gotify.sh"
+    line: 43
+    column: 70
+    end_line: 43
+    end_column: 77
+    reason: "This Gotify curl call deliberately glues a quoted URL prefix, a bare `?token=` query segment, and a quoted token into one argument. Shuck keeps that mixed-fragment readability warning, while current ShellCheck does not classify the query-string join."
+  - side: shuck-only
+    path_suffix: "scripts/HariSekhon__DevOps-Bash-tools__.bash.d__java.sh"
+    line: 65
+    column: 52
+    end_line: 65
+    end_column: 55
+    reason: "This Java home finder intentionally builds one glob pattern from a quoted base path, bare wildcard/version glue, and a quoted version fragment. Shuck keeps warning on that mixed glob-and-quote assembly even though current ShellCheck leaves the path pattern alone."
+  - side: shuck-only
+    path_suffix: "scripts/RetroPie__RetroPie-Setup__scriptmodules__supplementary__wifi.sh"
+    line: 273
+    column: 297
+    end_line: 273
+    end_column: 301
+    reason: "This dialog menu string embeds an inner `echo \"none\"` fallback inside a larger human-readable shell word. S076 still treats that nested reopened quote as a readability issue, while current ShellCheck skips the display-string form."
+  - side: shellcheck-only
+    path_suffix: "scripts/moovweb__gvm__examples__native__configure"
+    line: 5840
+    column: 45
+    end_line: 5841
+    end_column: 1
+    reason: "This generated configure fragment is compared through a project-closure path, and the remaining SC2140 on the line-continued awk program string is treated as an unreliable oracle-only result for that generated file."


### PR DESCRIPTION
## Summary
- move the S076 mixed-quote span detection into `LinterFacts` and expose it through `WordFact`
- keep `mixed_quote_word` as a cheap facts-only filter instead of parsing source text from the rule layer
- remove the now-stale `common/span` helper and add direct regression coverage for the cached fact path

## Why
S076 had picked up source-scanning logic outside the semantic/facts layer. This keeps the rule aligned with the repo architecture while preserving the expanded conformance behavior for escaped quotes, line joins, nested command words, and escaped template fragments.

## Impact
- keeps rule logic on the intended fact boundary
- preserves the reviewed large-corpus behavior for S076
- records the remaining reviewed divergences in the corpus metadata

## Validation
- `cargo fmt --all`
- `cargo test -p shuck-linter builds_word_facts_for_unquoted_literals_between_reopened_double_quotes`
- `cargo test -p shuck-linter mixed_quote_word`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S076`
