### PR TITLE
Fix S029 literal brace conformance

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7316,6 +7316,13 @@ fn raw_literal_brace_spans_without_exclusions(
         }
 
         if matches!(ch, '{' | '}') {
+            if mode == RawLiteralBraceScanMode::UnmatchedOnly
+                && brace_at_command_start(text, index, ch)
+            {
+                index += ch_len;
+                continue;
+            }
+
             let absolute_offset = scan_start + index;
             let position = container_span
                 .start
@@ -7337,6 +7344,51 @@ fn raw_literal_brace_spans_without_exclusions(
     }
 
     spans
+}
+
+fn brace_at_command_start(text: &str, index: usize, ch: char) -> bool {
+    match ch {
+        '{' => opening_brace_starts_shell_group(text, index),
+        '}' => closing_brace_ends_shell_group(text, index),
+        _ => false,
+    }
+}
+
+fn opening_brace_starts_shell_group(text: &str, index: usize) -> bool {
+    let Some(next) = text[index + '{'.len_utf8()..].chars().next() else {
+        return false;
+    };
+    if !next.is_whitespace() {
+        return false;
+    }
+
+    let prefix = text[..index].trim_end_matches(|candidate| matches!(candidate, ' ' | '\t'));
+    let Some(last) = prefix.chars().next_back() else {
+        return true;
+    };
+
+    match last {
+        '\n' | '&' | '|' | '(' | ')' => true,
+        ';' => prefix.chars().rev().nth(1) != Some('\\'),
+        'o' => prefix.ends_with("do"),
+        'n' => prefix.ends_with("then"),
+        'e' => prefix.ends_with("else"),
+        'f' => prefix.ends_with("elif"),
+        _ => false,
+    }
+}
+
+fn closing_brace_ends_shell_group(text: &str, index: usize) -> bool {
+    let prefix = text[..index].trim_end_matches(|candidate| matches!(candidate, ' ' | '\t'));
+    let Some(last) = prefix.chars().next_back() else {
+        return true;
+    };
+
+    match last {
+        '\n' | '&' | '|' | '(' => true,
+        ';' => prefix.chars().rev().nth(1) != Some('\\'),
+        _ => false,
+    }
 }
 
 fn unmatched_command_substitution_brace_spans(

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7190,6 +7190,7 @@ fn raw_literal_brace_spans(
     relevant_excluded.sort_unstable_by_key(|&(start, end)| (start, end));
 
     let mut spans = Vec::new();
+    let mut unmatched_opens = Vec::new();
     let mut cursor = scan_start;
     for (start, end) in relevant_excluded {
         if start > cursor {
@@ -7199,6 +7200,7 @@ fn raw_literal_brace_spans(
                 start,
                 source,
                 mode,
+                &mut unmatched_opens,
             ));
         }
         cursor = cursor.max(end);
@@ -7211,7 +7213,12 @@ fn raw_literal_brace_spans(
             scan_end,
             source,
             mode,
+            &mut unmatched_opens,
         ));
+    }
+
+    if mode == RawLiteralBraceScanMode::UnmatchedOnly {
+        spans.extend(unmatched_opens);
     }
 
     spans
@@ -7223,6 +7230,7 @@ fn raw_literal_brace_spans_without_exclusions(
     scan_end: usize,
     source: &str,
     mode: RawLiteralBraceScanMode,
+    unmatched_opens: &mut Vec<Span>,
 ) -> Vec<Span> {
     let text = &source[scan_start..scan_end];
     if text.is_empty() {
@@ -7230,7 +7238,6 @@ fn raw_literal_brace_spans_without_exclusions(
     }
 
     let mut spans = Vec::new();
-    let mut unmatched_opens = Vec::new();
     let mut index = 0usize;
     let mut quote_state = None;
     let mut in_comment = false;
@@ -7329,10 +7336,6 @@ fn raw_literal_brace_spans_without_exclusions(
         index += ch_len;
     }
 
-    if mode == RawLiteralBraceScanMode::UnmatchedOnly {
-        spans.extend(unmatched_opens);
-    }
-
     spans
 }
 
@@ -7353,33 +7356,10 @@ fn unmatched_command_substitution_brace_spans(
             continue;
         };
 
-        let mut covered = commands
-            .iter()
-            .flat_map(|command| command.redirects())
-            .filter_map(|redirect| redirect.heredoc().map(|heredoc| heredoc.body.span))
-            .filter(|span| span.start.offset >= body_start && span.end.offset <= body_end)
-            .collect::<Vec<_>>();
-        covered.sort_by_key(|span| (span.start.offset, span.end.offset));
-
-        let mut cursor = body_start;
-        for span in covered {
-            if span.start.offset > cursor {
-                spans.extend(raw_literal_brace_spans(
-                    container_span,
-                    cursor,
-                    span.start.offset,
-                    source,
-                    RawLiteralBraceScanMode::UnmatchedOnly,
-                    heredoc_ranges,
-                ));
-            }
-            cursor = cursor.max(span.end.offset);
-        }
-
-        if body_end > cursor {
+        if body_end > body_start {
             spans.extend(raw_literal_brace_spans(
                 container_span,
-                cursor,
+                body_start,
                 body_end,
                 source,
                 RawLiteralBraceScanMode::UnmatchedOnly,

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7362,7 +7362,7 @@ fn opening_brace_starts_shell_group(text: &str, index: usize) -> bool {
         return false;
     }
 
-    let prefix = text[..index].trim_end_matches(|candidate| matches!(candidate, ' ' | '\t'));
+    let prefix = text[..index].trim_end_matches([' ', '\t']);
     let Some(last) = prefix.chars().next_back() else {
         return true;
     };
@@ -7379,7 +7379,7 @@ fn opening_brace_starts_shell_group(text: &str, index: usize) -> bool {
 }
 
 fn closing_brace_ends_shell_group(text: &str, index: usize) -> bool {
-    let prefix = text[..index].trim_end_matches(|candidate| matches!(candidate, ' ' | '\t'));
+    let prefix = text[..index].trim_end_matches([' ', '\t']);
     let Some(last) = prefix.chars().next_back() else {
         return true;
     };

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -23,8 +23,8 @@ use shuck_ast::{
     DeclOperand, File, ForCommand, FunctionDef, IfCommand, Name, ParameterExpansion,
     ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position, Redirect, RedirectKind,
     SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript,
-    VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment,
-    ZshQualifiedGlob,
+    TextRange, VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionTarget,
+    ZshGlobSegment, ZshQualifiedGlob,
 };
 use shuck_indexer::Indexer;
 use shuck_semantic::{
@@ -3548,7 +3548,12 @@ impl<'a> LinterFactsBuilder<'a> {
         let heredoc_summary =
             build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
-        let literal_brace_spans = build_literal_brace_spans(&words, &commands, self.source);
+        let literal_brace_spans = build_literal_brace_spans(
+            &words,
+            &commands,
+            self.source,
+            self._indexer.region_index().heredoc_ranges(),
+        );
         let SurfaceFragmentFacts {
             single_quoted,
             dollar_double_quoted,
@@ -6562,6 +6567,7 @@ fn build_literal_brace_spans(
     words: &[WordFact<'_>],
     commands: &[CommandFact<'_>],
     source: &str,
+    heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {
     let mut spans = Vec::new();
 
@@ -6572,37 +6578,59 @@ fn build_literal_brace_spans(
 
         let is_find_exec_placeholder_word = is_find_exec_placeholder_word(commands, fact, source);
         let is_xargs_replacement_word = is_xargs_replacement_word(commands, fact, source);
-        spans.extend(
-            fact.word()
-                .brace_syntax()
-                .iter()
-                .copied()
-                .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
-                .filter(|brace| {
-                    matches!(
-                        brace.kind,
-                        BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
-                    ) || brace_syntax_with_whitespace_is_literal(*brace, source)
-                })
-                .filter(|brace| {
-                    brace.span.slice(source) != "{}"
-                        && !brace_span_has_escaped_dollar_prefix(brace.span, source)
-                        && !is_find_exec_placeholder_word
-                        && !is_xargs_replacement_word
-                })
-                .flat_map(|brace| brace_character_spans(brace.span, source)),
-        );
+        let direct_spans = fact
+            .word()
+            .brace_syntax()
+            .iter()
+            .copied()
+            .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
+            .filter(|brace| {
+                matches!(
+                    brace.kind,
+                    BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
+                ) || brace_syntax_with_whitespace_is_literal(*brace, source)
+            })
+            .filter(|brace| {
+                brace.span.slice(source) != "{}"
+                    && !brace_span_has_escaped_dollar_prefix(brace.span, source)
+                    && !is_find_exec_placeholder_word
+                    && !is_xargs_replacement_word
+            })
+            .flat_map(|brace| brace_character_spans(brace.span, source))
+            .filter(|span| {
+                !span_inside_nested_escaped_parameter_template(fact.word(), *span, source)
+            })
+            .collect::<Vec<_>>();
+        spans.extend(direct_spans);
 
         if !is_find_exec_placeholder_word && !is_xargs_replacement_word {
-            spans.extend(unclassified_literal_brace_spans(fact.word(), source));
-            spans.extend(escaped_parameter_expansion_brace_edge_spans(
-                fact.word(),
-                source,
-            ));
+            let unclassified = unclassified_literal_brace_spans(fact.word(), source)
+                .into_iter()
+                .filter(|span| {
+                    !span_inside_nested_escaped_parameter_template(fact.word(), *span, source)
+                })
+                .collect::<Vec<_>>();
+            spans.extend(unclassified);
+            let escaped = escaped_parameter_expansion_brace_edge_spans(fact.word(), source)
+                .into_iter()
+                .filter(|span| {
+                    !span_inside_nested_escaped_parameter_template(fact.word(), *span, source)
+                })
+                .collect::<Vec<_>>();
+            spans.extend(escaped);
         }
     }
 
-    spans.extend(uncovered_command_brace_spans(commands, source));
+    spans.extend(uncovered_command_brace_spans(
+        commands,
+        source,
+        heredoc_ranges,
+    ));
+    spans.extend(unmatched_command_substitution_brace_spans(
+        commands,
+        source,
+        heredoc_ranges,
+    ));
     spans
 }
 
@@ -6828,9 +6856,13 @@ fn brace_character_spans(span: Span, source: &str) -> Vec<Span> {
     let text = span.slice(source);
     text.char_indices()
         .filter(|&(_, ch)| matches!(ch, '{' | '}'))
-        .map(|(offset, _)| {
+        .filter_map(|(offset, _)| {
+            let absolute_offset = span.start.offset + offset;
+            if has_odd_backslash_run_before(source, absolute_offset) {
+                return None;
+            }
             let position = span.start.advanced_by(&text[..offset]);
-            Span::from_positions(position, position)
+            Some(Span::from_positions(position, position))
         })
         .collect()
 }
@@ -7017,7 +7049,11 @@ fn unclassified_literal_brace_spans(word: &Word, source: &str) -> Vec<Span> {
     spans
 }
 
-fn uncovered_command_brace_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+fn uncovered_command_brace_spans(
+    commands: &[CommandFact<'_>],
+    source: &str,
+    heredoc_ranges: &[TextRange],
+) -> Vec<Span> {
     let mut spans = Vec::new();
 
     for command in commands {
@@ -7033,6 +7069,7 @@ fn uncovered_command_brace_spans(commands: &[CommandFact<'_>], source: &str) -> 
         covered.extend(simple.args.iter().map(|word| word.span));
         covered.extend(simple.assignments.iter().map(|assignment| assignment.span));
         covered.extend(command.redirects().iter().map(|redirect| redirect.span));
+        covered.extend(command.substitution_facts().iter().map(|fact| fact.span()));
         covered.extend(
             command
                 .redirects()
@@ -7044,6 +7081,12 @@ fn uncovered_command_brace_spans(commands: &[CommandFact<'_>], source: &str) -> 
                 .redirects()
                 .iter()
                 .filter_map(|redirect| redirect_fd_var_brace_span(redirect, source)),
+        );
+        covered.extend(
+            command
+                .redirects()
+                .iter()
+                .filter_map(|redirect| redirect.heredoc().map(|heredoc| heredoc.body.span)),
         );
         covered.extend(
             command
@@ -7061,22 +7104,26 @@ fn uncovered_command_brace_spans(commands: &[CommandFact<'_>], source: &str) -> 
         let mut cursor = command_span.start.offset;
         for span in covered {
             if span.start.offset > cursor {
-                spans.extend(raw_uncovered_brace_spans(
+                spans.extend(raw_literal_brace_spans(
                     command_span,
                     cursor,
                     span.start.offset,
                     source,
+                    RawLiteralBraceScanMode::All,
+                    heredoc_ranges,
                 ));
             }
             cursor = cursor.max(span.end.offset);
         }
 
         if command_span.end.offset > cursor {
-            spans.extend(raw_uncovered_brace_spans(
+            spans.extend(raw_literal_brace_spans(
                 command_span,
                 cursor,
                 command_span.end.offset,
                 source,
+                RawLiteralBraceScanMode::All,
+                heredoc_ranges,
             ));
         }
     }
@@ -7109,24 +7156,131 @@ fn redirect_fd_var_brace_span(redirect: &Redirect, source: &str) -> Option<Span>
     ))
 }
 
-fn raw_uncovered_brace_spans(
-    command_span: Span,
-    gap_start: usize,
-    gap_end: usize,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RawLiteralBraceScanMode {
+    All,
+    UnmatchedOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RawLiteralBraceQuoteState {
+    Single,
+    Double,
+}
+
+fn raw_literal_brace_spans(
+    container_span: Span,
+    scan_start: usize,
+    scan_end: usize,
     source: &str,
+    mode: RawLiteralBraceScanMode,
+    excluded_ranges: &[TextRange],
 ) -> Vec<Span> {
-    let text = &source[gap_start..gap_end];
+    let mut relevant_excluded = excluded_ranges
+        .iter()
+        .filter_map(|range| {
+            let start = usize::from(range.start());
+            let end = usize::from(range.end());
+            if end <= scan_start || start >= scan_end {
+                return None;
+            }
+            Some((start.max(scan_start), end.min(scan_end)))
+        })
+        .collect::<Vec<_>>();
+    relevant_excluded.sort_unstable_by_key(|&(start, end)| (start, end));
+
+    let mut spans = Vec::new();
+    let mut cursor = scan_start;
+    for (start, end) in relevant_excluded {
+        if start > cursor {
+            spans.extend(raw_literal_brace_spans_without_exclusions(
+                container_span,
+                cursor,
+                start,
+                source,
+                mode,
+            ));
+        }
+        cursor = cursor.max(end);
+    }
+
+    if scan_end > cursor {
+        spans.extend(raw_literal_brace_spans_without_exclusions(
+            container_span,
+            cursor,
+            scan_end,
+            source,
+            mode,
+        ));
+    }
+
+    spans
+}
+
+fn raw_literal_brace_spans_without_exclusions(
+    container_span: Span,
+    scan_start: usize,
+    scan_end: usize,
+    source: &str,
+    mode: RawLiteralBraceScanMode,
+) -> Vec<Span> {
+    let text = &source[scan_start..scan_end];
     if text.is_empty() {
         return Vec::new();
     }
 
     let mut spans = Vec::new();
+    let mut unmatched_opens = Vec::new();
     let mut index = 0usize;
+    let mut quote_state = None;
+    let mut in_comment = false;
+
     while index < text.len() {
         let Some(ch) = text[index..].chars().next() else {
             break;
         };
         let ch_len = ch.len_utf8();
+
+        if in_comment {
+            if ch == '\n' {
+                in_comment = false;
+            }
+            index += ch_len;
+            continue;
+        }
+
+        if let Some(state) = quote_state {
+            match state {
+                RawLiteralBraceQuoteState::Single => {
+                    if ch == '\'' {
+                        quote_state = None;
+                    }
+                    index += ch_len;
+                    continue;
+                }
+                RawLiteralBraceQuoteState::Double => {
+                    if ch == '\\' {
+                        index += ch_len;
+                        if let Some(escaped) = text[index..].chars().next() {
+                            index += escaped.len_utf8();
+                        }
+                        continue;
+                    }
+                    if ch == '"' {
+                        quote_state = None;
+                    }
+                    index += ch_len;
+                    continue;
+                }
+            }
+        }
+
+        if text[index..].starts_with("${")
+            && let Some(end_offset) = find_runtime_parameter_closing_brace(text, index)
+        {
+            index = end_offset;
+            continue;
+        }
 
         if ch == '\\' {
             index += ch_len;
@@ -7137,21 +7291,123 @@ fn raw_uncovered_brace_spans(
         }
 
         if ch == '#' {
-            break;
+            in_comment = true;
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '\'' {
+            quote_state = Some(RawLiteralBraceQuoteState::Single);
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '"' {
+            quote_state = Some(RawLiteralBraceQuoteState::Double);
+            index += ch_len;
+            continue;
         }
 
         if matches!(ch, '{' | '}') {
-            let absolute_offset = gap_start + index;
-            let position = command_span
+            let absolute_offset = scan_start + index;
+            let position = container_span
                 .start
-                .advanced_by(&source[command_span.start.offset..absolute_offset]);
-            spans.push(Span::from_positions(position, position));
+                .advanced_by(&source[container_span.start.offset..absolute_offset]);
+            let span = Span::from_positions(position, position);
+            match mode {
+                RawLiteralBraceScanMode::All => spans.push(span),
+                RawLiteralBraceScanMode::UnmatchedOnly => {
+                    if ch == '{' {
+                        unmatched_opens.push(span);
+                    } else if unmatched_opens.pop().is_none() {
+                        spans.push(span);
+                    }
+                }
+            }
         }
 
         index += ch_len;
     }
 
+    if mode == RawLiteralBraceScanMode::UnmatchedOnly {
+        spans.extend(unmatched_opens);
+    }
+
     spans
+}
+
+fn unmatched_command_substitution_brace_spans(
+    commands: &[CommandFact<'_>],
+    source: &str,
+    heredoc_ranges: &[TextRange],
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+
+    for substitution in commands
+        .iter()
+        .flat_map(|command| command.substitution_facts())
+    {
+        let Some((container_span, body_start, body_end)) =
+            command_substitution_body_offsets(substitution.span(), source)
+        else {
+            continue;
+        };
+
+        let mut covered = commands
+            .iter()
+            .flat_map(|command| command.redirects())
+            .filter_map(|redirect| redirect.heredoc().map(|heredoc| heredoc.body.span))
+            .filter(|span| span.start.offset >= body_start && span.end.offset <= body_end)
+            .collect::<Vec<_>>();
+        covered.sort_by_key(|span| (span.start.offset, span.end.offset));
+
+        let mut cursor = body_start;
+        for span in covered {
+            if span.start.offset > cursor {
+                spans.extend(raw_literal_brace_spans(
+                    container_span,
+                    cursor,
+                    span.start.offset,
+                    source,
+                    RawLiteralBraceScanMode::UnmatchedOnly,
+                    heredoc_ranges,
+                ));
+            }
+            cursor = cursor.max(span.end.offset);
+        }
+
+        if body_end > cursor {
+            spans.extend(raw_literal_brace_spans(
+                container_span,
+                cursor,
+                body_end,
+                source,
+                RawLiteralBraceScanMode::UnmatchedOnly,
+                heredoc_ranges,
+            ));
+        }
+    }
+
+    spans
+}
+
+fn command_substitution_body_offsets(span: Span, source: &str) -> Option<(Span, usize, usize)> {
+    let text = span.slice(source);
+    if text.starts_with("$(") && text.ends_with(')') && text.len() >= 3 {
+        return Some((
+            span,
+            span.start.offset + "$(".len(),
+            span.end.offset - ')'.len_utf8(),
+        ));
+    }
+    if text.starts_with('`') && text.ends_with('`') && text.len() >= 2 {
+        return Some((
+            span,
+            span.start.offset + '`'.len_utf8(),
+            span.end.offset - '`'.len_utf8(),
+        ));
+    }
+    None
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -7576,6 +7832,54 @@ fn brace_pair_matches_nonliteral_syntax(
             && brace.span.start.offset == absolute_open_offset
             && brace.span.end.offset == absolute_close_offset
     })
+}
+
+fn span_inside_nested_escaped_parameter_template(word: &Word, span: Span, source: &str) -> bool {
+    if span.start.offset < word.span.start.offset || span.start.offset >= word.span.end.offset {
+        return false;
+    }
+
+    let text = word.span.slice(source);
+    let relative_offset = span.start.offset - word.span.start.offset;
+    let mut index = 0usize;
+
+    while index < text.len() {
+        if text[index..].starts_with("\\${")
+            && let Some(end_offset) =
+                find_runtime_parameter_closing_brace(text, index + '\\'.len_utf8())
+        {
+            let body_start = index + "\\${".len();
+            let body_end = end_offset.saturating_sub('}'.len_utf8());
+            let has_nested_parameter =
+                body_start < body_end && text[body_start..body_end].contains("${");
+            let open_brace_offset = index + "\\$".len();
+            if has_nested_parameter
+                && relative_offset > open_brace_offset
+                && relative_offset < end_offset.saturating_sub('}'.len_utf8())
+            {
+                return true;
+            }
+            index = end_offset;
+            continue;
+        }
+
+        let Some(ch) = text[index..].chars().next() else {
+            break;
+        };
+        let ch_len = ch.len_utf8();
+
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
+            continue;
+        }
+
+        index += ch_len;
+    }
+
+    false
 }
 
 fn collect_raw_escaped_parameter_exclusions(

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -236,6 +236,23 @@ EOF
     }
 
     #[test]
+    fn reports_literal_closing_braces_inside_grouped_command_substitutions() {
+        let source = "\
+#!/bin/bash
+value=$(
+  {
+    cut -d} -f1
+  }
+)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.column, 11);
+    }
+
+    #[test]
     fn ignores_even_backslash_runs_before_parameter_expansions() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -207,6 +207,18 @@ echo [0-9a-f]{$HASHLEN}
     }
 
     #[test]
+    fn reports_lone_closing_braces_inside_command_substitutions() {
+        let source = "\
+#!/bin/bash
+value=$(cut -d} -f1)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.column, 15);
+    }
+
+    #[test]
     fn ignores_even_backslash_runs_before_parameter_expansions() {
         let source = "\
 #!/bin/bash
@@ -327,6 +339,33 @@ fi
 __rvm_find \"${rvm_bin_path:=$rvm_path/bin}\" -name \\*${ruby_at_gemset} -exec rm -rf '{}' \\;
 exec {IPC_FIFO_FD}<>\"$IPC_FIFO\"
 exec {IPC_FIFO_FD}>&-
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_escaped_double_brace_templates_in_sed_scripts() {
+        let source = "\
+#!/bin/bash
+sed -e s/\\{\\{DEVICE_MODEL\\}\\}/\"${DEVICE_MODEL}\"/g \\
+  -e s/\\{\\{KERNEL_ARGS\\}\\}/\"${KERNEL_ARGS:-}\"/g
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_parameter_expansions_inside_command_substitutions() {
+        let source = "\
+#!/bin/sh
+srcnam=$(tr \\. _ <<<${PRGNAM#python3-*})
+v=$(echo ${TERMUX_PKG_VERSION#*:} | cut -d . -f 1)
+if [ \"`echo ${x##*/} | awk '{ print toupper($1) }'`\" = \"`echo ${command} | awk '{ print toupper($1) }'`\" ]; then
+  :
+fi
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -219,6 +219,23 @@ value=$(cut -d} -f1)
     }
 
     #[test]
+    fn ignores_balanced_brace_groups_split_by_heredocs_in_command_substitutions() {
+        let source = "\
+#!/bin/bash
+value=$(
+  {
+    cat <<'EOF'
+literal text
+EOF
+  }
+)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_even_backslash_runs_before_parameter_expansions() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck/tests/testdata/corpus-metadata/s029.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s029.yaml
@@ -111,3 +111,171 @@ reviewed_divergences:
     column: 44
     end_column: 44
     reason: "This later configure probe keeps an escaped parameter template inside an `eval` cache check, and the remaining closing-brace hit is treated as project-closure corpus drift."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__community__pdns__pdns-backend-pgsql.post-upgrade"
+    line: 44
+    end_line: 44
+    column: 20
+    end_column: 20
+    reason: "This post-upgrade helper intentionally builds an escaped `\\${PG...}` template for later `eval` expansion. The remaining opening-brace anchor is tracked as a reviewed escaped-template divergence."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__community__pdns__pdns-backend-pgsql.post-upgrade"
+    line: 44
+    end_line: 44
+    column: 28
+    end_column: 28
+    reason: "This post-upgrade helper intentionally builds an escaped `\\${PG...}` template for later `eval` expansion. The remaining closing-brace anchor is tracked as a reviewed escaped-template divergence."
+  - side: shellcheck-only
+    path_suffix: "megastep__makeself__test__variabletest"
+    line: 15
+    end_line: 15
+    column: 55
+    end_column: 55
+    reason: "This harness fixture serializes a variable reference through an escaped nested template inside a project-closure test case, so the remaining opening-brace hit is reviewed as harness-specific divergence."
+  - side: shellcheck-only
+    path_suffix: "megastep__makeself__test__variabletest"
+    line: 15
+    end_line: 15
+    column: 60
+    end_column: 60
+    reason: "This harness fixture serializes a variable reference through an escaped nested template inside a project-closure test case, so the remaining closing-brace hit is reviewed as harness-specific divergence."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 15
+    end_line: 15
+    column: 41
+    end_column: 41
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 24
+    end_line: 24
+    column: 66
+    end_column: 66
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 33
+    end_line: 33
+    column: 50
+    end_column: 50
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 44
+    end_line: 44
+    column: 75
+    end_column: 75
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 53
+    end_line: 53
+    column: 90
+    end_column: 90
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 62
+    end_line: 62
+    column: 91
+    end_column: 91
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 74
+    end_line: 74
+    column: 106
+    end_column: 106
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 84
+    end_line: 84
+    column: 62
+    end_column: 62
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
+    line: 97
+    end_line: 97
+    column: 89
+    end_column: 89
+    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
+  - side: shuck-only
+    path_suffix: "scop__bash-completion__completions-core__tmux.bash"
+    line: 59
+    end_line: 59
+    column: 49
+    end_column: 49
+    reason: "This completion helper trims a literal `[`/`]` wrapper with `${words[i]#\"[\"}` and `${words[i + 1]%\"]\"}`. The surviving brace hit is reviewed as a shell-collapse helper-library mismatch rather than a live S029 bug."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 49
+    end_line: 49
+    column: 70
+    end_column: 70
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 50
+    end_line: 50
+    column: 59
+    end_column: 59
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 52
+    end_line: 52
+    column: 8
+    end_column: 8
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 53
+    end_line: 53
+    column: 8
+    end_column: 8
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 54
+    end_line: 54
+    column: 15
+    end_column: 15
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 55
+    end_line: 55
+    column: 15
+    end_column: 15
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 57
+    end_line: 57
+    column: 10
+    end_column: 10
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 58
+    end_line: 58
+    column: 9
+    end_column: 9
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 59
+    end_line: 59
+    column: 8
+    end_column: 8
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."
+  - side: shuck-only
+    path_suffix: "termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
+    line: 60
+    end_line: 60
+    column: 7
+    end_column: 7
+    reason: "This GraphQL request body is data inside a heredoc nested under command substitution. Shuck still surfaces these JSON braces as shell text in this nested-heredoc shape, so the bucket is reviewed as a known parser/index limitation."


### PR DESCRIPTION
## Summary
- refine S029 literal-brace fact collection around escaped brace templates, command substitutions, and real `${...}` parameter expansions
- add focused regression coverage for lone closing braces in `$(...)`, escaped `{{...}}`-style templates, and parameter expansions inside command substitutions
- document the remaining reviewed large-corpus divergence buckets in the S029 corpus metadata

## Why
The fallback brace scanning for S029 was still too eager in a few mixed shell/template cases, which produced mismatches against the oracle around escaped braces, nested escaped templates, and command-substitution contents.

## Impact
This reduces false positives in template-heavy scripts while preserving the cases we still intentionally track as reviewed harness/parser limitations.

## Validation
- `cargo test -p shuck-linter literal_braces`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S029`