### PR TITLE
Fix C097/C123 conformance regressions

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -31,10 +31,6 @@ pub(crate) fn file_entry_contract(
 }
 
 fn providers() -> &'static [AmbientContractProvider] {
-    void_packages_providers()
-}
-
-fn void_packages_providers() -> &'static [AmbientContractProvider] {
     &[
         AmbientContractProvider {
             matches: matches_void_packages_build_style_contract,

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -31,7 +31,6 @@ use shuck_semantic::{
     BindingAttributes, BindingId, BindingKind, ScopeId, SemanticModel, ZshOptionState,
 };
 use std::borrow::Cow;
-
 use self::{
     command_flow::{
         build_case_item_facts, build_for_header_facts, build_list_facts, build_pipeline_facts,
@@ -63,6 +62,24 @@ use crate::rules::common::{
         classify_contextual_operand, classify_word, static_word_text,
     },
 };
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::{
+    ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,
+    ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem, ArrayKind, Assignment, AssignmentValue,
+    BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext, BraceSyntaxKind,
+    BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command, CommandSubstitutionSyntax,
+    CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclClause,
+    DeclOperand, File, ForCommand, FunctionDef, IfCommand, Name, ParameterExpansion,
+    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position, Redirect, RedirectKind,
+    SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript,
+    VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment,
+    ZshQualifiedGlob,
+};
+use shuck_indexer::Indexer;
+use shuck_semantic::{
+    BindingAttributes, BindingId, BindingKind, ScopeId, SemanticModel, ZshOptionState,
+};
+use std::borrow::Cow;
 
 pub use self::conditional_portability::ConditionalPortabilityFacts;
 pub(crate) use self::escape_scan::EscapeScanSourceKind;
@@ -15694,6 +15711,9 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
         match text.as_str() {
             "-o" | "+o" => {
                 let enable = text.starts_with('-');
+                if text.starts_with('+') {
+                    resets_positional_parameters = true;
+                }
                 let Some(name_word) = args.get(index + 1) else {
                     break;
                 };
@@ -15722,6 +15742,9 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
         };
         if flags.is_empty() {
             break;
+        }
+        if text.starts_with('+') {
+            resets_positional_parameters = true;
         }
 
         if flags.chars().any(|flag| flag == 'e') {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13,24 +13,6 @@ mod escape_scan;
 mod presence;
 mod surface;
 
-use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{
-    ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,
-    ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem, ArrayKind, Assignment, AssignmentValue,
-    BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext, BraceSyntaxKind,
-    BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command, CommandSubstitutionSyntax,
-    CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclClause,
-    DeclOperand, File, ForCommand, FunctionDef, IfCommand, Name, ParameterExpansion,
-    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position, Redirect, RedirectKind,
-    SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript,
-    TextRange, VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionTarget,
-    ZshGlobSegment, ZshQualifiedGlob,
-};
-use shuck_indexer::Indexer;
-use shuck_semantic::{
-    BindingAttributes, BindingId, BindingKind, ScopeId, SemanticModel, ZshOptionState,
-};
-use std::borrow::Cow;
 use self::{
     command_flow::{
         build_case_item_facts, build_for_header_facts, build_list_facts, build_pipeline_facts,
@@ -62,6 +44,24 @@ use crate::rules::common::{
         classify_contextual_operand, classify_word, static_word_text,
     },
 };
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::{
+    ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,
+    ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem, ArrayKind, Assignment, AssignmentValue,
+    BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext, BraceSyntaxKind,
+    BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command, CommandSubstitutionSyntax,
+    CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclClause,
+    DeclOperand, File, ForCommand, FunctionDef, IfCommand, Name, ParameterExpansion,
+    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position, Redirect, RedirectKind,
+    SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript,
+    TextRange, VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionTarget,
+    ZshGlobSegment, ZshQualifiedGlob,
+};
+use shuck_indexer::Indexer;
+use shuck_semantic::{
+    BindingAttributes, BindingId, BindingKind, ScopeId, SemanticModel, ZshOptionState,
+};
+use std::borrow::Cow;
 
 pub use self::conditional_portability::ConditionalPortabilityFacts;
 pub(crate) use self::escape_scan::EscapeScanSourceKind;

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -62,24 +62,6 @@ use crate::rules::common::{
         classify_contextual_operand, classify_word, static_word_text,
     },
 };
-use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{
-    ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,
-    ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem, ArrayKind, Assignment, AssignmentValue,
-    BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext, BraceSyntaxKind,
-    BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command, CommandSubstitutionSyntax,
-    CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclClause,
-    DeclOperand, File, ForCommand, FunctionDef, IfCommand, Name, ParameterExpansion,
-    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position, Redirect, RedirectKind,
-    SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript,
-    VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment,
-    ZshQualifiedGlob,
-};
-use shuck_indexer::Indexer;
-use shuck_semantic::{
-    BindingAttributes, BindingId, BindingKind, ScopeId, SemanticModel, ZshOptionState,
-};
-use std::borrow::Cow;
 
 pub use self::conditional_portability::ConditionalPortabilityFacts;
 pub(crate) use self::escape_scan::EscapeScanSourceKind;

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -215,6 +215,24 @@ greet
     }
 
     #[test]
+    fn ignores_functions_after_bare_set_plus_o() {
+        let source = "\
+#!/bin/sh
+greet() {
+  set +o
+  printf '%s\n' \"$1\"
+}
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn still_reports_functions_after_set_minus_option_toggle() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -197,6 +197,46 @@ greet
     }
 
     #[test]
+    fn ignores_functions_after_set_plus_option_toggle() {
+        let source = "\
+#!/bin/sh
+greet() {
+  set +x
+  printf '%s\n' \"$1\"
+}
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn still_reports_functions_after_set_minus_option_toggle() {
+        let source = "\
+#!/bin/sh
+greet() {
+  set -x
+  printf '%s\n' \"$1\"
+}
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "greet() {\n  set -x\n  printf '%s\n' \"$1\"\n}"
+        );
+    }
+
+    #[test]
     fn reports_functions_that_use_variadic_positional_parameters() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -277,6 +277,24 @@ greet
     }
 
     #[test]
+    fn ignores_zero_argument_call_sites_after_bare_set_plus_o() {
+        let source = "\
+#!/bin/sh
+greet() {
+  set +o
+  printf '%s\n' \"$2\"
+}
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn still_reports_zero_argument_call_sites_after_set_minus_option_toggle() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -259,6 +259,44 @@ greet
     }
 
     #[test]
+    fn ignores_zero_argument_call_sites_after_set_plus_option_toggle() {
+        let source = "\
+#!/bin/sh
+greet() {
+  set +x
+  printf '%s\n' \"$2\"
+}
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn still_reports_zero_argument_call_sites_after_set_minus_option_toggle() {
+        let source = "\
+#!/bin/sh
+greet() {
+  set -x
+  printf '%s\n' \"$2\"
+}
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 7);
+    }
+
+    #[test]
     fn same_name_functions_in_different_scopes_do_not_mask_each_other() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1351,6 +1351,10 @@ impl<'a> Lexer<'a> {
                     }
                     return Some(LexedToken::fd(TokenKind::RedirectFdAppend, fd));
                 }
+                (Some('>'), Some('|')) => {
+                    self.consume_ascii_chars(3);
+                    return Some(LexedToken::fd(TokenKind::Clobber, fd));
+                }
                 (Some('>'), Some('&')) => {
                     self.consume_ascii_chars(3);
 
@@ -5032,7 +5036,7 @@ EOF
 
     #[test]
     fn test_redirects() {
-        let mut lexer = Lexer::new("a > b >> c >>| d 2>>| e < f << g <<< h &>> i <> j");
+        let mut lexer = Lexer::new("a > b >> c >>| d 2>>| e 2>| f < g << h <<< i &>> j <> k");
 
         assert_next_token(&mut lexer, TokenKind::Word, Some("a"));
         assert_next_token(&mut lexer, TokenKind::RedirectOut, None);
@@ -5043,16 +5047,21 @@ EOF
         assert_next_token(&mut lexer, TokenKind::Word, Some("d"));
         assert_next_token(&mut lexer, TokenKind::RedirectFdAppend, None);
         assert_next_token(&mut lexer, TokenKind::Word, Some("e"));
-        assert_next_token(&mut lexer, TokenKind::RedirectIn, None);
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::Clobber);
+        assert_eq!(token.fd_value(), Some(2));
+        assert_eq!(token_text(&token, lexer.input), None);
         assert_next_token(&mut lexer, TokenKind::Word, Some("f"));
-        assert_next_token(&mut lexer, TokenKind::HereDoc, None);
+        assert_next_token(&mut lexer, TokenKind::RedirectIn, None);
         assert_next_token(&mut lexer, TokenKind::Word, Some("g"));
-        assert_next_token(&mut lexer, TokenKind::HereString, None);
+        assert_next_token(&mut lexer, TokenKind::HereDoc, None);
         assert_next_token(&mut lexer, TokenKind::Word, Some("h"));
-        assert_next_token(&mut lexer, TokenKind::RedirectBothAppend, None);
+        assert_next_token(&mut lexer, TokenKind::HereString, None);
         assert_next_token(&mut lexer, TokenKind::Word, Some("i"));
-        assert_next_token(&mut lexer, TokenKind::RedirectReadWrite, None);
+        assert_next_token(&mut lexer, TokenKind::RedirectBothAppend, None);
         assert_next_token(&mut lexer, TokenKind::Word, Some("j"));
+        assert_next_token(&mut lexer, TokenKind::RedirectReadWrite, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("k"));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/redirects.rs
+++ b/crates/shuck-parser/src/parser/redirects.rs
@@ -131,10 +131,15 @@ impl<'a> Parser<'a> {
                 } else {
                     RedirectKind::Output
                 };
+                let fd = if fd_var.is_some() {
+                    None
+                } else {
+                    self.current_fd_value()
+                };
                 self.advance();
                 if let Some(target) = self.maybe_expect_word(strict)? {
                     redirects.push(Redirect {
-                        fd: None,
+                        fd,
                         fd_var,
                         fd_var_span,
                         kind,

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -6593,6 +6593,12 @@ fn test_zsh_if_condition_brace_group_keeps_closing_brace_out_of_arguments() {
 }
 
 #[test]
+fn test_parse_case_arm_with_fd_clobber_redirect() {
+    let source = "case $# in\n  0) shellspec_yield 2>|\"$SHELLSPEC_LEAK_FILE\" ;;\n  *) shellspec_yield \"$@\" 2>|\"$SHELLSPEC_LEAK_FILE\" ;;\nesac\n";
+    Parser::new(source).parse().unwrap();
+}
+
+#[test]
 fn test_zsh_always_and_background_operators_preserve_surface_forms() {
     let source = "\
 { print body; } always { print cleanup; }

--- a/crates/shuck/tests/testdata/corpus-metadata/c123.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c123.yaml
@@ -30,12 +30,6 @@ reviewed_divergences:
       - directive-handling
       - project-closure
     reason: "This bash.d helper is sourced into a larger shell environment, and the remaining `pull` invocation depends on project-closure plus directive-handling context that Shuck does not reconstruct for C123. The standalone local warning is therefore kept as a reviewed closure-side divergence."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__tests__test_all.sh"
-    labels:
-      - project-closure
-      - test-harness
-    reason: "This corpus case is a test harness that sources loader state before it exercises `test_explode`, so the remaining zero-argument helper call depends on project-closure and harness setup outside the file-local view. Shuck's standalone warning is reviewed rather than treated as a live C123 conformance bug."
   - side: shellcheck-only
     path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
     line: 33
@@ -68,12 +62,6 @@ reviewed_divergences:
       - project-closure
       - test-harness
     reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__lib__core__dsl.sh"
-    labels:
-      - directive-handling
-      - helper-library
-    reason: "This ShellSpec DSL file is sourced as helper-library code, and the remaining `shellspec_yield` site relies on the library's ambient execution contract rather than a normal script argv flow. Shuck still reports the local zero-argument helper call from its standalone view, so this helper-library difference is reviewed."
   - side: shuck-only
     path_suffix: "scop__bash-completion__completions-core__ssh.bash"
     labels:


### PR DESCRIPTION
## Summary
- treat `set +...` option toggles as positional resets for `C097`/`C123` parity
- remove the overly broad Kalua-specific `explode` workaround and cover the real behavior with regression tests
- fix explicit-fd clobber redirect parsing for ShellSpec-style `2>|...` cases and drop the stale reviewed-divergence entries

## Why
The previous corpus fix path was too broad: modeling the imported `explode` helper as a positional reset made one Kalua fixture pass, but it also suppressed real warnings that the oracle still reports. Black-box checks against the pinned `shellcheck` showed the real parity signal is `set +...` inside the function body. Separately, a ShellSpec fixture exposed a parser bug around explicit-fd clobber redirects.

## Impact
This restores full large-corpus parity for `C097`/`C123` without recording new reviewed divergences, and it keeps ShellSpec-style helpers parseable.

## Validation
- `cargo test -p shuck-linter`
- `cargo test -p shuck-parser`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C097,C123 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=100 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
