### PR TITLE
Fix S010 readonly declaration parity

### DIFF
--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -1,4 +1,5 @@
 use shuck_ast::AssignmentValue;
+use shuck_semantic::ScopeKind;
 
 use crate::{
     Checker, DeclarationKind, ExpansionContext, Rule, Violation, WordFactContext,
@@ -23,9 +24,15 @@ pub fn export_command_substitution(checker: &mut Checker) {
     let findings = checker
         .facts()
         .structural_commands()
-        .filter_map(|fact| fact.declaration())
-        .filter(|declaration| {
-            matches_s010_declaration_kind(&declaration.kind) && !declaration.readonly_flag
+        .filter_map(|fact| {
+            let declaration = fact.declaration()?;
+            should_report_s010_declaration(
+                checker,
+                &declaration.kind,
+                declaration.readonly_flag,
+                fact.span(),
+            )
+            .then_some(declaration)
         })
         .flat_map(|declaration| declaration.assignment_operands.iter().copied())
         .filter_map(|assignment| {
@@ -64,6 +71,33 @@ fn matches_s010_declaration_kind(kind: &DeclarationKind) -> bool {
     ) || matches!(kind, DeclarationKind::Other(name) if name == "readonly")
 }
 
+fn should_report_s010_declaration(
+    checker: &Checker,
+    kind: &DeclarationKind,
+    readonly_flag: bool,
+    span: shuck_ast::Span,
+) -> bool {
+    if !matches_s010_declaration_kind(kind) {
+        return false;
+    }
+
+    if !readonly_flag || matches!(kind, DeclarationKind::Export) {
+        return true;
+    }
+
+    if matches!(kind, DeclarationKind::Other(name) if name == "readonly") {
+        return true;
+    }
+
+    let scope = checker.semantic().scope_at(span.start.offset);
+    let inside_function = checker
+        .semantic()
+        .ancestor_scopes(scope)
+        .any(|scope| matches!(checker.semantic().scope_kind(scope), ScopeKind::Function(_)));
+
+    !inside_function
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
@@ -94,12 +128,13 @@ demo() {
     }
 
     #[test]
-    fn ignores_readonly_declaration_assignments() {
+    fn ignores_function_local_readonly_modifier_declaration_assignments() {
         let source = "\
 #!/bin/bash
 demo() {
   local -r temp=\"$(date)\"
   declare -r other=$(date)
+  typeset -r home=$(pwd)
 }
 ";
         let diagnostics = test_snippet(
@@ -127,6 +162,27 @@ readonly temp=\"$(mktemp)\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["temp"]
+        );
+    }
+
+    #[test]
+    fn reports_top_level_readonly_declare_variants() {
+        let source = "\
+#!/bin/bash
+declare -r archive_dir_create=\"$(mktemp -dt archive_dir_create.XXXXXX)\"
+typeset -r n_version=\"$(./bin/n --version)\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["archive_dir_create", "n_version"]
         );
     }
 

--- a/crates/shuck/tests/testdata/corpus-metadata/s010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s010.yaml
@@ -66,3 +66,32 @@ reviewed_divergences:
       - helper-library
       - project-closure
     reason: "ShellCheck aborts on earlier syntax errors in this helper, so the later declaration-assignment warnings are not stable comparison targets."
+  - side: shuck-only
+    path_suffix: "alpinelinux__aports__community__dnscrypt-proxy__dnscrypt-proxy.setup"
+    line: 53
+    reason: "The pinned ShellCheck run aborts on a malformed test later in this setup script and never surfaces SC2155 for these sanitized export assignments. Shuck still reports the declaration-assignment combination on the live sites."
+  - side: shuck-only
+    path_suffix: "alpinelinux__aports__community__dnscrypt-proxy__dnscrypt-proxy.setup"
+    line: 86
+    reason: "The pinned ShellCheck run aborts on a malformed test later in this setup script and never surfaces SC2155 for these sanitized export assignments. Shuck still reports the declaration-assignment combination on the live sites."
+  - side: shuck-only
+    path_suffix: "alpinelinux__aports__community__dnscrypt-proxy__dnscrypt-proxy.setup"
+    line: 112
+    reason: "The pinned ShellCheck run aborts on a malformed test later in this setup script and never surfaces SC2155 for these sanitized export assignments. Shuck still reports the declaration-assignment combination on the live sites."
+  - side: shuck-only
+    path_suffix: "alpinelinux__aports__community__dnscrypt-proxy__dnscrypt-proxy.setup"
+    line: 258
+    reason: "The pinned ShellCheck run aborts on a malformed test later in this setup script and never surfaces SC2155 for these sanitized export assignments. Shuck still reports the declaration-assignment combination on the live sites."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
+    line: 69
+    labels:
+      - project-closure
+    reason: "This CGI helper is compared through a project-closure path, and the pinned ShellCheck run does not surface SC2155 for the `local mult_list` aggregation in that closure context. Shuck still reports the declaration-assignment combination on the helper itself."
+  - side: shuck-only
+    path_suffix: "paulirish__dotfiles__.git-completion.bash"
+    labels:
+      - directive-handling
+      - helper-library
+      - shell-collapse
+    reason: "This Git completion helper carries a file-wide `shellcheck disable=all`, so the pinned oracle stays silent on SC2155 throughout the shell-collapsed helper-library copy. Shuck still reports the live declaration assignments there."


### PR DESCRIPTION
## What changed
- narrowed `S010` so readonly-modified declaration assignments only report where ShellCheck also reports them
- kept top-level `readonly`, `declare -r`, and `typeset -r` cases covered
- added targeted tests for function-local vs top-level readonly behavior
- recorded the remaining reviewed `S010` corpus divergences that come from parse-abort, project-closure, and file-wide ShellCheck suppression contexts

## Why
`S010` was out of parity with the ShellCheck oracle around readonly declarations. The rule treated readonly handling too broadly, which missed some top-level cases and, when widened naively, overreported function-local helper patterns that ShellCheck intentionally leaves alone.

## Impact
This keeps `S010` aligned with the current oracle behavior while preserving the project’s clean-room metadata for known comparison artifacts.

## Root cause
The rule only tracked whether a declaration had a readonly modifier, but it did not distinguish between top-level readonly declarations and function-local readonly declarations. That scope difference is significant for `SC2155` parity.

## Validation
- `cargo test -p shuck-linter export_command_substitution`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S010`
- `make test`
- `cargo fmt --check`
