### PR TITLE
Broaden C112 coverage for [[ ]] array expansions

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C111.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C111.sh
@@ -5,9 +5,9 @@ set -- a b
 if [ "_$@" = "_--version" ]; then :; fi
 if [ "$@" = "--version" ]; then :; fi
 if [ "${@:-fallback}" = "--version" ]; then :; fi
-if [[ "_$@" == "_--version" ]]; then :; fi
 
-# Valid: non-positional comparisons.
+# Valid: non-positional and double-bracket comparisons.
 if [ "_$*" = "_--version" ]; then :; fi
 if [ "_${arr[@]}" = "_x" ]; then :; fi
+if [[ "_$@" == "_--version" ]]; then :; fi
 if [[ "\$@" == "x" ]]; then :; fi

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C112.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C112.sh
@@ -2,16 +2,19 @@
 
 # shellcheck disable=2034,2154
 
-# Invalid: all-elements array slices in [[ string comparisons ]].
+# Invalid: all-elements array expansions in [[ ... ]] tests.
+set -- a b
+arr=(x y)
 if [[ "${sel[@]:0:4}" == "HELP" ]]; then :; fi
-if [[ "x${@:2}y" == "x" ]]; then :; fi
+if [[ -n "$@" ]]; then :; fi
+if [[ x == *${arr[@]}* ]]; then :; fi
+if [[ "${@: -1}" == "mM" || "${@:-1}" == "Mm" ]]; then :; fi
+if [[ " ${arr[@]} " =~ " x " ]]; then :; fi
+if [[ "${arr[@]}" ]]; then :; fi
 
-# Valid: non-slice and star-selector forms.
-if [[ "${sel[@]}" == "HELP" ]]; then :; fi
+# Valid: star-selector forms, escaped text, and single-bracket tests.
 if [[ "${sel[*]:1}" == "HELP" ]]; then :; fi
-
-# Valid: escaped slice marker.
 if [[ "\${sel[@]:1}" == "HELP" ]]; then :; fi
-
-# Valid: single-bracket comparisons are out of scope for C112.
+if [[ x == ${sel[*]}* ]]; then :; fi
+if [[ "\$@" ]]; then :; fi
 if [ "${sel[@]:1}" = "HELP" ]; then :; fi

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -10245,9 +10245,15 @@ impl<'a> WordFactCollector<'a> {
                     WordFactHostKind::Direct,
                 );
             }
-            ConditionalExpr::Pattern(pattern) => self
-                .surface
-                .collect_pattern(pattern, surface_context.with_pattern_charclass_scan()),
+            ConditionalExpr::Pattern(pattern) => {
+                let pattern_context = surface_context.with_pattern_charclass_scan();
+                self.surface.collect_pattern(pattern, pattern_context);
+                self.collect_pattern_context_words(
+                    pattern,
+                    WordFactContext::Expansion(ExpansionContext::ConditionalPattern),
+                    WordFactHostKind::Direct,
+                );
+            }
             ConditionalExpr::VarRef(reference) => {
                 self.surface.record_var_ref_subscript(reference);
                 query::visit_var_ref_subscript_words_with_source(
@@ -22147,6 +22153,29 @@ eval \"${shims[@]}\"
                 vec!["${shims[@]}"],
                 "parts: {:?}",
                 fact.word().parts
+            );
+        });
+    }
+
+    #[test]
+    fn builds_word_facts_for_conditional_patterns() {
+        let source = "\
+#!/bin/bash
+if [[ x == *${shims[@]}* ]]; then :; fi
+";
+
+        with_facts(source, None, |_, facts| {
+            let fact = facts
+                .expansion_word_facts(ExpansionContext::ConditionalPattern)
+                .find(|fact| fact.span().slice(source) == "${shims[@]}")
+                .expect("expected conditional pattern word fact");
+
+            assert_eq!(
+                fact.all_elements_array_expansion_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${shims[@]}"]
             );
         });
     }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -44,14 +44,16 @@ pub use rules::common::expansion::{ExpansionContext, WordQuote};
 pub use rules::common::query::CommandSubstitutionKind;
 pub use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
 pub use rules::common::span::{
-    assignment_name_span, conditional_array_subscript_span, conditional_extglob_span,
-    double_quoted_scalar_affix_span, unescaped_backtick_command_substitution_span,
-    word_all_elements_array_slice_span_in_source, word_all_elements_array_slice_spans,
-    word_array_subscript_span, word_double_quoted_scalar_only_expansion_spans, word_extglob_span,
+    assignment_name_span, command_substitution_part_spans, conditional_array_subscript_span,
+    conditional_extglob_span, double_quoted_scalar_affix_span,
+    unescaped_backtick_command_substitution_span, word_all_elements_array_slice_span_in_source,
+    word_all_elements_array_slice_spans, word_array_subscript_span,
+    word_double_quoted_scalar_only_expansion_spans, word_extglob_span,
     word_folded_positional_at_splat_span, word_folded_positional_at_splat_span_in_source,
-    word_has_folded_positional_at_splat, word_has_quoted_all_elements_array_slice,
-    word_has_single_literal_part, word_has_unquoted_brace_expansion,
-    word_is_pure_positional_at_splat, word_literal_part_spans_excluding_parameter_operator_tails,
+    word_has_direct_all_elements_array_expansion_in_source, word_has_folded_positional_at_splat,
+    word_has_quoted_all_elements_array_slice, word_has_single_literal_part,
+    word_has_unquoted_brace_expansion, word_is_pure_positional_at_splat,
+    word_literal_part_spans_excluding_parameter_operator_tails,
     word_literal_scan_segments_excluding_expansions, word_nested_dynamic_double_quote_spans,
     word_nested_zsh_substitution_spans, word_positional_at_splat_span_in_source,
     word_positional_at_splat_spans, word_quoted_all_elements_array_slice_spans,

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -118,6 +118,12 @@ pub fn word_has_quoted_all_elements_array_slice(word: &Word) -> bool {
     !word_quoted_all_elements_array_slice_spans(word).is_empty()
 }
 
+pub fn word_has_direct_all_elements_array_expansion_in_source(word: &Word, source: &str) -> bool {
+    let mut spans = Vec::new();
+    collect_direct_all_elements_array_expansion_spans(&word.parts, source, &mut spans);
+    !spans.is_empty()
+}
+
 pub fn word_all_elements_array_slice_span_in_source(word: &Word, source: &str) -> Option<Span> {
     word_all_elements_array_slice_spans(word)
         .into_iter()
@@ -802,6 +808,27 @@ fn collect_all_elements_array_slice_spans(
                 collect_all_elements_array_slice_spans(parts, true, only_quoted, spans)
             }
             _ if (!only_quoted || quoted) && part_uses_all_elements_array_slice(&part.kind) => {
+                spans.push(part.span)
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_direct_all_elements_array_expansion_spans(
+    parts: &[WordPartNode],
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPart::SingleQuoted { .. } => {}
+            WordPart::DoubleQuoted { parts, .. } => {
+                collect_direct_all_elements_array_expansion_spans(parts, source, spans)
+            }
+            _ if part_uses_direct_all_elements_array_expansion(&part.kind)
+                && !span_is_escaped(part.span, source) =>
+            {
                 spans.push(part.span)
             }
             _ => {}
@@ -2096,6 +2123,20 @@ fn part_uses_unquoted_all_elements_array_expansion(part: &WordPart) -> bool {
     }
 }
 
+fn part_uses_direct_all_elements_array_expansion(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => name.as_str() == "@",
+        WordPart::ArrayAccess(reference) | WordPart::ArrayIndices(reference) => {
+            var_ref_uses_all_elements_at_splat(reference)
+        }
+        WordPart::ArraySlice { reference, .. } => var_ref_uses_all_elements_at_splat(reference),
+        WordPart::Parameter(parameter) => {
+            parameter_uses_direct_all_elements_array_expansion(parameter)
+        }
+        _ => false,
+    }
+}
+
 fn part_is_pure_positional_at_splat(part: &WordPart) -> bool {
     match part {
         WordPart::Variable(name) => name.as_str() == "@",
@@ -2152,6 +2193,32 @@ fn parameter_uses_all_elements_array_slice(parameter: &ParameterExpansion) -> bo
 }
 
 fn parameter_uses_unquoted_all_elements_array_expansion(parameter: &ParameterExpansion) -> bool {
+    let ParameterExpansionSyntax::Bourne(syntax) = &parameter.syntax else {
+        return false;
+    };
+
+    match syntax {
+        BourneParameterExpansion::Access { reference }
+        | BourneParameterExpansion::Indices { reference }
+        | BourneParameterExpansion::Slice { reference, .. } => {
+            var_ref_uses_all_elements_at_splat(reference)
+        }
+        BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            ..
+        } => {
+            !matches!(operator, ParameterOp::UseReplacement)
+                && var_ref_uses_all_elements_at_splat(reference)
+        }
+        BourneParameterExpansion::Transformation { reference, .. } => {
+            var_ref_uses_all_elements_at_splat(reference)
+        }
+        _ => false,
+    }
+}
+
+fn parameter_uses_direct_all_elements_array_expansion(parameter: &ParameterExpansion) -> bool {
     let ParameterExpansionSyntax::Bourne(syntax) = &parameter.syntax else {
         return false;
     };
@@ -2545,13 +2612,15 @@ mod tests {
         word_all_elements_array_slice_span_in_source, word_all_elements_array_slice_spans,
         word_caret_negated_bracket_spans, word_double_quoted_scalar_only_expansion_spans,
         word_exactly_one_extglob_span, word_folded_positional_at_splat_span,
-        word_folded_positional_at_splat_span_in_source, word_has_folded_positional_at_splat,
-        word_has_quoted_all_elements_array_slice, word_has_unquoted_brace_expansion,
-        word_is_pure_positional_at_splat, word_nested_dynamic_double_quote_spans,
-        word_positional_at_splat_span_in_source, word_positional_at_splat_spans,
-        word_quoted_all_elements_array_slice_spans, word_quoted_star_splat_spans,
-        word_quoted_unindexed_bash_source_span_in_source, word_unquoted_assign_default_spans,
-        word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
+        word_folded_positional_at_splat_span_in_source,
+        word_has_direct_all_elements_array_expansion_in_source,
+        word_has_folded_positional_at_splat, word_has_quoted_all_elements_array_slice,
+        word_has_unquoted_brace_expansion, word_is_pure_positional_at_splat,
+        word_nested_dynamic_double_quote_spans, word_positional_at_splat_span_in_source,
+        word_positional_at_splat_spans, word_quoted_all_elements_array_slice_spans,
+        word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
+        word_unquoted_assign_default_spans, word_unquoted_escaped_pipe_or_brace_spans_in_source,
+        word_unquoted_glob_pattern_spans,
         word_unquoted_literal_between_double_quoted_segments_spans,
         word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_splat_spans,
         word_unquoted_word_between_single_quoted_segments_spans,
@@ -3067,6 +3136,26 @@ printf '%s\\n' \"${@:2}\" \"x${@:2}y\" \"${arr[@]:1}\" \"${arr[@]:1:2}\" ${@:2} 
         );
         assert!(word_has_quoted_all_elements_array_slice(&command.args[1]));
         assert!(!word_has_quoted_all_elements_array_slice(&command.args[5]));
+    }
+
+    #[test]
+    fn word_has_direct_all_elements_array_expansion_ignores_nested_or_scalar_operator_uses() {
+        let source = "\
+printf '%s\\n' \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${target=\"$@\"}\" \"$(echo \"$@\")\" \"${arr[*]}\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        let matches = command
+            .args
+            .iter()
+            .skip(1)
+            .map(|word| word_has_direct_all_elements_array_expansion_in_source(word, source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(matches, vec![true, true, true, true, false, false, false]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
@@ -1,6 +1,9 @@
+use shuck_ast::Span;
+
 use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, Violation,
-    word_all_elements_array_slice_span_in_source,
+    Checker, ConditionalNodeFact, ConditionalOperatorFamily, ExpansionContext, Rule, Violation,
+    command_substitution_part_spans, word_has_direct_all_elements_array_expansion_in_source,
+    word_is_pure_positional_at_splat,
 };
 
 pub struct ArraySliceInComparison;
@@ -11,42 +14,82 @@ impl Violation for ArraySliceInComparison {
     }
 
     fn message(&self) -> String {
-        "array-slice expansions collapse when used in string comparisons".to_owned()
+        "all-elements array expansions collapse inside `[[ ... ]]` tests".to_owned()
     }
 }
 
 pub fn array_slice_in_comparison(checker: &mut Checker) {
+    let direct_operand_spans = [
+        ExpansionContext::StringTestOperand,
+        ExpansionContext::RegexOperand,
+    ]
+    .into_iter()
+    .flat_map(|context| checker.facts().expansion_word_facts(context))
+    .filter(|fact| !fact.is_nested_word_command())
+    .filter(|fact| {
+        word_has_direct_all_elements_array_expansion_in_source(fact.word(), checker.source())
+    })
+    .map(|fact| fact.span())
+    .collect::<Vec<_>>();
+
+    let risky_pattern_word_spans = checker
+        .facts()
+        .expansion_word_facts(ExpansionContext::ConditionalPattern)
+        .filter(|fact| !fact.is_nested_word_command())
+        .filter(|fact| command_substitution_part_spans(fact.word()).is_empty())
+        .filter(|fact| !word_is_pure_positional_at_splat(fact.word()))
+        .filter(|fact| {
+            word_has_direct_all_elements_array_expansion_in_source(fact.word(), checker.source())
+        })
+        .map(|fact| fact.span())
+        .collect::<Vec<_>>();
+
     let spans = checker
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| {
-            fact.conditional()
-                .and_then(|conditional| conditional_span(conditional.root(), checker.source()))
-        })
+        .filter_map(|fact| fact.conditional())
+        .flat_map(|conditional| conditional.nodes().iter())
+        .flat_map(|node| conditional_pattern_spans(node, &risky_pattern_word_spans))
+        .chain(direct_operand_spans)
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ArraySliceInComparison);
 }
 
-fn conditional_span(fact: &ConditionalNodeFact<'_>, source: &str) -> Option<shuck_ast::Span> {
-    let ConditionalNodeFact::Binary(binary) = fact else {
-        return None;
-    };
-    if binary.operator_family() != ConditionalOperatorFamily::StringBinary {
-        return None;
+fn conditional_pattern_spans(
+    fact: &ConditionalNodeFact<'_>,
+    risky_word_spans: &[Span],
+) -> Vec<Span> {
+    match fact {
+        ConditionalNodeFact::Binary(binary)
+            if binary.operator_family() != ConditionalOperatorFamily::Logical =>
+        {
+            [
+                pattern_span_if_risky(binary.left().expression().span(), risky_word_spans),
+                pattern_span_if_risky(binary.right().expression().span(), risky_word_spans),
+            ]
+            .into_iter()
+            .flatten()
+            .collect()
+        }
+        ConditionalNodeFact::BareWord(_)
+        | ConditionalNodeFact::Unary(_)
+        | ConditionalNodeFact::Binary(_)
+        | ConditionalNodeFact::Other(_) => Vec::new(),
     }
+}
 
-    binary
-        .left()
-        .word()
-        .and_then(|word| word_all_elements_array_slice_span_in_source(word, source))
-        .or_else(|| {
-            binary
-                .right()
-                .word()
-                .and_then(|word| word_all_elements_array_slice_span_in_source(word, source))
-        })
+fn pattern_span_if_risky(span: Span, risky_word_spans: &[Span]) -> Option<Span> {
+    risky_word_spans
+        .iter()
+        .copied()
+        .any(|word_span| span_contains(span, word_span))
+        .then_some(span)
+}
+
+fn span_contains(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
 }
 
 #[cfg(test)]
@@ -55,11 +98,17 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_array_slices_in_double_bracket_string_comparisons() {
+    fn reports_all_elements_array_expansions_in_double_bracket_tests() {
         let source = "\
 #!/bin/bash
+set -- a b
+arr=(x y)
 if [[ \"${sel[@]:0:4}\" == \"HELP\" ]]; then :; fi
-if [[ \"x${@:2}y\" == \"x\" ]]; then :; fi
+if [[ -n \"$@\" ]]; then :; fi
+if [[ x == *${arr[@]}* ]]; then :; fi
+if [[ \"${@: -1}\" == \"mM\" || \"${@:-1}\" == \"Mm\" ]]; then :; fi
+if [[ \" ${arr[@]} \" =~ \" x \" ]]; then :; fi
+if [[ \"${arr[@]}\" ]]; then :; fi
 ";
         let diagnostics = test_snippet(
             source,
@@ -71,17 +120,27 @@ if [[ \"x${@:2}y\" == \"x\" ]]; then :; fi
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["${sel[@]:0:4}", "${@:2}"]
+            vec![
+                "\"${sel[@]:0:4}\"",
+                "\"$@\"",
+                "*${arr[@]}*",
+                "\"${@: -1}\"",
+                "\"${@:-1}\"",
+                "\" ${arr[@]} \"",
+                "\"${arr[@]}\"",
+            ]
         );
     }
 
     #[test]
-    fn ignores_non_slice_or_non_conditional_comparisons() {
+    fn ignores_star_expansions_escaped_literals_and_single_bracket_tests() {
         let source = "\
 #!/bin/bash
-if [[ \"${sel[@]}\" == \"HELP\" ]]; then :; fi
 if [[ \"${sel[*]:1}\" == \"HELP\" ]]; then :; fi
 if [[ \"\\${sel[@]:1}\" == \"HELP\" ]]; then :; fi
+if [[ x == ${sel[*]}* ]]; then :; fi
+if [[ \"\\$@\" ]]; then :; fi
+if [[ -z ${packed=\"$@\"} ]]; then :; fi
 if [ \"${sel[@]:1}\" = \"HELP\" ]; then :; fi
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
+++ b/crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, SimpleTestOperatorFamily,
-    SimpleTestShape, Violation, word_positional_at_splat_span_in_source,
+    Checker, Rule, SimpleTestOperatorFamily, SimpleTestShape, Violation,
+    word_positional_at_splat_span_in_source,
 };
 
 pub struct AtSignInStringCompare;
@@ -20,16 +20,8 @@ pub fn at_sign_in_string_compare(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| {
-            if let Some(simple_test) = fact.simple_test()
-                && let Some(span) = simple_test_span(simple_test, checker.source())
-            {
-                return Some(span);
-            }
-
-            fact.conditional()
-                .and_then(|conditional| conditional_span(conditional.root(), checker.source()))
-        })
+        .filter_map(|fact| fact.simple_test())
+        .filter_map(|simple_test| simple_test_span(simple_test, checker.source()))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || AtSignInStringCompare);
@@ -52,26 +44,6 @@ fn simple_test_span(fact: &crate::SimpleTestFact<'_>, source: &str) -> Option<sh
         })
 }
 
-fn conditional_span(fact: &ConditionalNodeFact<'_>, source: &str) -> Option<shuck_ast::Span> {
-    let ConditionalNodeFact::Binary(binary) = fact else {
-        return None;
-    };
-    if binary.operator_family() != ConditionalOperatorFamily::StringBinary {
-        return None;
-    }
-
-    binary
-        .left()
-        .word()
-        .and_then(|word| word_positional_at_splat_span_in_source(word, source))
-        .or_else(|| {
-            binary
-                .right()
-                .word()
-                .and_then(|word| word_positional_at_splat_span_in_source(word, source))
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
@@ -84,7 +56,6 @@ mod tests {
 if [ \"_$@\" = \"_--version\" ]; then :; fi
 if [ \"$@\" = \"--version\" ]; then :; fi
 if [ \"${@:-fallback}\" = \"--version\" ]; then :; fi
-if [[ \"_$@\" == \"_--version\" ]]; then :; fi
 ";
         let diagnostics = test_snippet(
             source,
@@ -96,18 +67,18 @@ if [[ \"_$@\" == \"_--version\" ]]; then :; fi
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$@", "$@", "${@:-fallback}", "$@"]
+            vec!["$@", "$@", "${@:-fallback}"]
         );
     }
 
     #[test]
-    fn ignores_non_positional_or_escaped_comparisons() {
+    fn ignores_non_positional_double_bracket_and_escaped_comparisons() {
         let source = "\
 #!/bin/bash
 if [ \"_${arr[@]}\" = \"_x\" ]; then :; fi
 if [ \"_${arr[@]:1}\" = \"_x\" ]; then :; fi
 if [ \"\\$@\" = \"x\" ]; then :; fi
-if [[ \"\\$@\" == \"x\" ]]; then :; fi
+if [[ \"_$@\" == \"_x\" ]]; then :; fi
 if [ \"_$*\" = \"_--version\" ]; then :; fi
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C111_C111.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C111_C111.sh.snap
@@ -18,9 +18,3 @@ C111 positional-parameter at-splats fold arguments in string comparisons
   |
 7 | if [ "${@:-fallback}" = "--version" ]; then :; fi
   |
-
-C111 positional-parameter at-splats fold arguments in string comparisons
- --> <source>:8:9
-  |
-8 | if [[ "_$@" == "_--version" ]]; then :; fi
-  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C112_C112.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C112_C112.sh.snap
@@ -1,14 +1,44 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
 ---
-C112 array-slice expansions collapse when used in string comparisons
- --> <source>:6:8
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+ --> <source>:8:7
   |
-6 | if [[ "${sel[@]:0:4}" == "HELP" ]]; then :; fi
+8 | if [[ "${sel[@]:0:4}" == "HELP" ]]; then :; fi
   |
 
-C112 array-slice expansions collapse when used in string comparisons
- --> <source>:7:9
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+ --> <source>:9:10
   |
-7 | if [[ "x${@:2}y" == "x" ]]; then :; fi
+9 | if [[ -n "$@" ]]; then :; fi
   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:10:12
+   |
+10 | if [[ x == *${arr[@]}* ]]; then :; fi
+   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:11:7
+   |
+11 | if [[ "${@: -1}" == "mM" || "${@:-1}" == "Mm" ]]; then :; fi
+   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:11:29
+   |
+11 | if [[ "${@: -1}" == "mM" || "${@:-1}" == "Mm" ]]; then :; fi
+   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:12:7
+   |
+12 | if [[ " ${arr[@]} " =~ " x " ]]; then :; fi
+   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:13:7
+   |
+13 | if [[ "${arr[@]}" ]]; then :; fi
+   |

--- a/crates/shuck/tests/testdata/corpus-metadata/c112.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c112.yaml
@@ -1,7 +1,8 @@
 reviewed_divergences:
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__binscripts__rvm-installer"
-    line: 757
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 2543
     labels:
+      - helper-library
       - project-closure
-    reason: "C112 is intentionally scoped to all-elements array-slice forms in string comparisons, while this SC2199 finding is for a non-slice `${sources[@]}` operand."
+    reason: "This helper-library fixture folds `${PYTHON_CONFIGURE_OPTS_ARRAY[@]}` into a project-scoped `[[ ... ]]` operand, but the current ShellCheck 0.11.0 oracle emits no SC2199 finding for that source-closure path, so we treat it as a reviewed divergence rather than narrowing C112."

--- a/docs/rules/C112.yaml
+++ b/docs/rules/C112.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: An array slice is used in a string comparison.
-rationale: Compare individual elements or convert the slice to a string first.
+description: An all-elements array expansion is used inside a `[[ ... ]]` test.
+rationale: Compare individual elements or join the array deliberately before testing it.
 source:
   shell_checks_rule: rules/SH-250.yaml
   shell_checks_example: examples/250.sh
@@ -21,3 +21,7 @@ examples:
       #!/bin/bash
       # shellcheck disable=2154
       if [[ "${sel[@]:0:4}" == "HELP" ]]; then echo help; fi
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      if [[ -n "$@" ]]; then echo args; fi


### PR DESCRIPTION
## Summary

This broadens `C112` so it catches all-elements array expansions across the `[[ ... ]]` test shapes that ShellCheck maps to `SC2199`, not just top-level string-binary slice operands.

## What Changed

- broadened `C112` to cover direct string operands, regex operands, logical subexpressions, and conditional pattern operands in `[[ ... ]]`
- added fact collection for conditional pattern words so the rule can stay fact-driven instead of walking AST structure in the rule file
- added direct-array-expansion span helpers to distinguish real operand-level `[@]` expansions from nested or escaped cases
- narrowed `C111` so it stays focused on single-bracket positional-parameter comparisons and no longer overlaps the `[[ ... ]]` cases owned by `C112`
- updated `C111`/`C112` fixtures, snapshots, rule docs, and `C112` corpus metadata

## Why

`C112` was under-reporting many real `SC2199` cases because it only inspected the root binary string-comparison operands and only looked for array-slice forms. The missing coverage showed up in the targeted large-corpus run.

## Impact

Shuck now reports `C112` on the broader set of `[[ ... ]]` array-expansion patterns that collapse elements together at test time, while avoiding the false positives we hit from nested command substitutions and other non-direct operand shapes.

## Validation

- `cargo test -p shuck-linter word_has_direct_all_elements_array_expansion`
- `cargo test -p shuck-linter array_slice_in_comparison`
- `cargo test -p shuck-linter at_sign_in_string_compare`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C112`
