### PR TITLE
Fix C076 commented continuation diagnostics

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -6519,8 +6519,7 @@ fn build_commented_continuation_comment_spans(source: &str, indexer: &Indexer) -
                 return None;
             }
             let comment_text = &source[comment_start..line_end];
-            let trimmed_comment_text =
-                comment_text.trim_end_matches(|ch| matches!(ch, ' ' | '\t' | '\r'));
+            let trimmed_comment_text = comment_text.trim_end_matches([' ', '\t', '\r']);
             if !trimmed_comment_text.ends_with('\\') {
                 return None;
             }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -6508,40 +6508,33 @@ fn build_commented_continuation_comment_spans(source: &str, indexer: &Indexer) -
         .iter()
         .filter_map(|&line_start_offset| {
             let line = line_index.line_number(line_start_offset);
-            let previous_line = line.checked_sub(1)?;
-            let previous_line_text = line_index.line_range(previous_line, source)?.slice(source);
-            if continued_comment_line_is_safe(previous_line_text) {
-                return None;
-            }
             let comment = comment_index
                 .comments_on_line(line)
                 .iter()
                 .find(|comment| comment.is_own_line)?;
             let line_start = usize::from(line_index.line_start(line)?);
+            let line_end = usize::from(line_index.line_range(line, source)?.end());
             let comment_start = usize::from(comment.range.start());
-            if comment_start < line_start || comment_start > source.len() {
+            if comment_start < line_start || comment_start >= line_end || line_end > source.len() {
                 return None;
             }
+            let comment_text = &source[comment_start..line_end];
+            let trimmed_comment_text =
+                comment_text.trim_end_matches(|ch| matches!(ch, ' ' | '\t' | '\r'));
+            if !trimmed_comment_text.ends_with('\\') {
+                return None;
+            }
+            let caret_offset = comment_start + trimmed_comment_text.len();
 
             let line_start_position = Position {
                 line,
                 column: 1,
                 offset: line_start,
             };
-            let start = line_start_position.advanced_by(&source[line_start..comment_start]);
-            let end = start.advanced_by("#");
-            Some(Span::from_positions(start, end))
+            let caret = line_start_position.advanced_by(&source[line_start..caret_offset]);
+            Some(Span::at(caret))
         })
         .collect()
-}
-
-fn continued_comment_line_is_safe(previous_line_text: &str) -> bool {
-    let text = previous_line_text
-        .trim_end()
-        .strip_suffix('\\')
-        .unwrap_or(previous_line_text.trim_end())
-        .trim_end();
-    matches!(text.chars().last(), Some('|')) || text.ends_with("&&") || text.ends_with("||")
 }
 
 fn build_trailing_directive_comment_spans(source: &str, indexer: &Indexer) -> Vec<Span> {
@@ -16513,6 +16506,32 @@ mod tests {
             ShellDialect::Bash,
             visit,
         );
+    }
+
+    #[test]
+    fn commented_continuation_facts_ignore_plain_comment_only_lines() {
+        let source = "#!/bin/sh\necho hello \\\n  #world\n  foo\n";
+
+        with_facts(source, None, |_, facts| {
+            assert!(facts.commented_continuation_comment_spans().is_empty());
+        });
+    }
+
+    #[test]
+    fn commented_continuation_facts_anchor_at_comment_backslash() {
+        let source = "#!/bin/sh\necho hello \\\n  #world \\\n  foo\n";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts.commented_continuation_comment_spans();
+            assert_eq!(spans.len(), 1);
+            assert_eq!(spans[0].start.line, 3);
+            assert_eq!(spans[0].start.column, 11);
+            assert_eq!(spans[0].start, spans[0].end);
+            assert_eq!(
+                &source[spans[0].start.offset - 1..spans[0].start.offset],
+                "\\"
+            );
+        });
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
@@ -37,8 +37,12 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 3);
-        assert_eq!(diagnostics[0].span.slice(source), "#");
+        assert_eq!(diagnostics[0].span.start.column, 11);
+        assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
+        assert_eq!(
+            &source[diagnostics[0].span.start.offset - 1..diagnostics[0].span.start.offset],
+            "\\"
+        );
     }
 
     #[test]
@@ -64,15 +68,14 @@ mod tests {
     }
 
     #[test]
-    fn reports_comment_line_without_its_own_backslash() {
+    fn ignores_comment_line_without_its_own_backslash() {
         let source = "#!/bin/bash\necho hello \\\n  #world\n  foo\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::CommentedContinuationLine),
         );
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C076_C076.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C076_C076.sh.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 132
 ---
 C076 line continuation is followed by a comment-only line
- --> <source>:3:3
+ --> <source>:3:11
   |
 3 |   #world \
   |


### PR DESCRIPTION
## Summary
- only report C076 when the comment-only continuation line itself ends with a trailing backslash
- anchor the diagnostic on that trailing backslash so the span matches the SC1143 point location
- add fact-layer coverage for the plain comment and trailing-backslash cases, and update the C076 snapshot

## Root cause
The C076 fact builder treated any own-line comment after a continued line as a violation and reported the `#` position. The oracle only reports SC1143 when the comment text itself ends with a misleading backslash.

## Impact
This removes the C076 false positives from the large corpus SlackBuild and helper-script fixtures while keeping the real misleading-comment-backslash case covered.

## Validation
- `cargo test -p shuck-linter commented_continuation -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C076`