### PR TITLE
Fix S011 corpus parity

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -20691,6 +20691,23 @@ test
     }
 
     #[test]
+    fn skips_compound_operator_spans_for_quoted_negation_before_grouped_subexpressions() {
+        let source = "\
+#!/bin/sh
+[ '(' '!' '(' -f \"$left\" -o -f \"$right\" ')' ')' ]
+";
+
+        with_facts(source, None, |_, facts| {
+            let test = facts
+                .structural_commands()
+                .find_map(|fact| fact.simple_test())
+                .expect("expected grouped simple test fact");
+
+            assert!(test.compound_operator_spans(source).is_empty());
+        });
+    }
+
+    #[test]
     fn records_glued_closing_bracket_operand_spans_for_unary_tests() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -262,47 +262,13 @@ impl<'a> SimpleTestFact<'a> {
     }
 
     pub fn compound_operator_spans(&self, source: &str) -> Vec<Span> {
-        match self.effective_shape {
-            SimpleTestShape::Binary => {
-                return self
-                    .effective_operator_word()
-                    .into_iter()
-                    .filter(|word| {
-                        self.effective_operand_class(1)
-                            .is_some_and(|class| class.is_fixed_literal())
-                            && classify_word(word, source).quote == WordQuote::Unquoted
-                    })
-                    .filter_map(|word| {
-                        static_word_text(word, source)
-                            .is_some_and(|text| matches!(text.as_str(), "-a" | "-o"))
-                            .then_some(word.span)
-                    })
-                    .collect();
-            }
-            SimpleTestShape::Other => {}
-            SimpleTestShape::Empty | SimpleTestShape::Truthy | SimpleTestShape::Unary => {
-                return Vec::new();
-            }
-        }
+        let Some((end, spans)) = simple_test_parse_logical_expression(self, 0, source) else {
+            return Vec::new();
+        };
 
-        self.effective_operands()
-            .iter()
-            .enumerate()
-            .filter(|(index, _word)| {
-                self.effective_operand_class(*index)
-                    .is_some_and(|class| class.is_fixed_literal())
-            })
-            .map(|(_index, word)| (word, classify_word(word, source)))
-            .filter_map(|(word, classification)| {
-                (classification.quote == WordQuote::Unquoted)
-                    .then_some(word)
-                    .and_then(|word| {
-                        static_word_text(word, source)
-                            .is_some_and(|text| matches!(text.as_str(), "-a" | "-o"))
-                            .then_some(word.span)
-                    })
-            })
-            .collect()
+        (end == self.effective_operands().len())
+            .then_some(spans)
+            .unwrap_or_default()
     }
 
     pub fn truthy_expression_words(&'a self, source: &str) -> Vec<&'a Word> {
@@ -522,6 +488,17 @@ fn simple_test_effective_operand_text(
     static_word_text(word, source)
 }
 
+fn simple_test_effective_unquoted_operand_text(
+    simple_test: &SimpleTestFact<'_>,
+    index: usize,
+    source: &str,
+) -> Option<String> {
+    let word = simple_test.effective_operands().get(index).copied()?;
+    (classify_word(word, source).quote == WordQuote::Unquoted)
+        .then(|| simple_test_effective_operand_text(simple_test, index, source))
+        .flatten()
+}
+
 fn simple_test_is_logical_connector(text: &str) -> bool {
     matches!(text, "-a" | "-o")
 }
@@ -532,6 +509,99 @@ fn simple_test_is_string_unary_operator(text: &str) -> bool {
 
 fn simple_test_is_string_binary_operator(text: &str) -> bool {
     matches!(text, "=" | "==" | "!=" | "<" | ">")
+}
+
+fn simple_test_parse_logical_expression(
+    simple_test: &SimpleTestFact<'_>,
+    start: usize,
+    source: &str,
+) -> Option<(usize, Vec<Span>)> {
+    let (mut index, mut spans) = simple_test_parse_logical_term(simple_test, start, source)?;
+
+    loop {
+        let Some(connector_span) = simple_test_logical_connector_span(simple_test, index, source)
+        else {
+            break;
+        };
+        let (next_index, next_spans) =
+            simple_test_parse_logical_term(simple_test, index + 1, source)?;
+        spans.push(connector_span);
+        spans.extend(next_spans);
+        index = next_index;
+    }
+
+    Some((index, spans))
+}
+
+fn simple_test_parse_logical_term(
+    simple_test: &SimpleTestFact<'_>,
+    start: usize,
+    source: &str,
+) -> Option<(usize, Vec<Span>)> {
+    let mut index = start;
+
+    while index + 1 < simple_test.effective_operands().len()
+        && simple_test_effective_unquoted_operand_text(simple_test, index, source).as_deref()
+            == Some("!")
+    {
+        index += 1;
+    }
+
+    simple_test_parse_logical_primary(simple_test, index, source)
+}
+
+fn simple_test_parse_logical_primary(
+    simple_test: &SimpleTestFact<'_>,
+    index: usize,
+    source: &str,
+) -> Option<(usize, Vec<Span>)> {
+    if simple_test_effective_operand_text(simple_test, index, source).as_deref() == Some("(") {
+        if let Some((end, spans)) =
+            simple_test_parse_logical_expression(simple_test, index + 1, source)
+        {
+            if simple_test_effective_operand_text(simple_test, end, source).as_deref() == Some(")")
+            {
+                return Some((end + 1, spans));
+            }
+        }
+    }
+
+    if simple_test_effective_operand_text(simple_test, index, source)
+        .as_deref()
+        .is_some_and(simple_test_is_unary_operator)
+        && simple_test.effective_operands().get(index + 1).is_some()
+    {
+        return Some((index + 2, Vec::new()));
+    }
+
+    if simple_test_effective_operand_text(simple_test, index + 1, source)
+        .as_deref()
+        .is_some_and(simple_test_is_nonlogical_binary_operator)
+        && simple_test.effective_operands().get(index + 2).is_some()
+    {
+        return Some((index + 3, Vec::new()));
+    }
+
+    simple_test
+        .effective_operands()
+        .get(index)
+        .map(|_| (index + 1, Vec::new()))
+}
+
+fn simple_test_logical_connector_span(
+    simple_test: &SimpleTestFact<'_>,
+    index: usize,
+    source: &str,
+) -> Option<Span> {
+    let word = simple_test.effective_operands().get(index).copied()?;
+    simple_test_effective_unquoted_operand_text(simple_test, index, source)
+        .as_deref()
+        .is_some_and(simple_test_is_logical_connector)
+        .then_some(word.span)
+}
+
+fn simple_test_is_nonlogical_binary_operator(text: &str) -> bool {
+    simple_test_is_binary_operator(text) && !simple_test_is_logical_connector(text)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -20543,6 +20613,57 @@ test
                     .collect::<Vec<_>>(),
                 vec![("-z".to_owned(), "baz".to_owned())]
             );
+        });
+    }
+
+    #[test]
+    fn collects_compound_operator_spans_for_grouped_bracket_tests() {
+        let source = "\
+#!/bin/sh
+[ ! '(' -f \"$left\" -o -f \"$right\" ')' ]
+[ \"$a\" = 1 -a \\( \"$b\" = 2 -o \"$c\" = 3 \\) ]
+";
+
+        with_facts(source, None, |_, facts| {
+            let tests = facts
+                .structural_commands()
+                .filter_map(|fact| fact.simple_test())
+                .collect::<Vec<_>>();
+
+            assert_eq!(tests.len(), 2);
+            assert_eq!(
+                tests[0]
+                    .compound_operator_spans(source)
+                    .into_iter()
+                    .map(|span| span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["-o".to_owned()]
+            );
+            assert_eq!(
+                tests[1]
+                    .compound_operator_spans(source)
+                    .into_iter()
+                    .map(|span| span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["-a".to_owned(), "-o".to_owned()]
+            );
+        });
+    }
+
+    #[test]
+    fn skips_compound_operator_spans_for_malformed_grouped_bracket_tests() {
+        let source = "\
+#!/bin/sh
+[ -n \"${TMPDIR-}\" -a '(' '(' -d \"${TMPDIR-}\" -a -w \"${TMPDIR-}\" ')' -o '!' '(' -d /tmp -a -w /tmp ')' ')' ]
+";
+
+        with_facts(source, None, |_, facts| {
+            let test = facts
+                .structural_commands()
+                .find_map(|fact| fact.simple_test())
+                .expect("expected malformed simple test fact");
+
+            assert!(test.compound_operator_spans(source).is_empty());
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -505,6 +505,22 @@ fn simple_test_is_logical_connector(text: &str) -> bool {
     matches!(text, "-a" | "-o")
 }
 
+fn simple_test_is_logical_negation(
+    simple_test: &SimpleTestFact<'_>,
+    index: usize,
+    source: &str,
+) -> bool {
+    if simple_test_effective_unquoted_operand_text(simple_test, index, source).as_deref()
+        == Some("!")
+    {
+        return true;
+    }
+
+    simple_test_effective_operand_text(simple_test, index, source).as_deref() == Some("!")
+        && simple_test_effective_operand_text(simple_test, index + 1, source).as_deref()
+            != Some("(")
+}
+
 fn simple_test_is_string_unary_operator(text: &str) -> bool {
     matches!(text, "-n" | "-z")
 }
@@ -543,8 +559,7 @@ fn simple_test_parse_logical_term(
     let mut index = start;
 
     while index + 1 < simple_test.effective_operands().len()
-        && simple_test_effective_unquoted_operand_text(simple_test, index, source).as_deref()
-            == Some("!")
+        && simple_test_is_logical_negation(simple_test, index, source)
     {
         index += 1;
     }
@@ -20620,6 +20635,7 @@ test
         let source = "\
 #!/bin/sh
 [ ! '(' -f \"$left\" -o -f \"$right\" ')' ]
+[ '(' '!' -f \"$quoted_left\" -o -f \"$quoted_right\" ')' ]
 [ \"$a\" = 1 -a \\( \"$b\" = 2 -o \"$c\" = 3 \\) ]
 ";
 
@@ -20629,7 +20645,7 @@ test
                 .filter_map(|fact| fact.simple_test())
                 .collect::<Vec<_>>();
 
-            assert_eq!(tests.len(), 2);
+            assert_eq!(tests.len(), 3);
             assert_eq!(
                 tests[0]
                     .compound_operator_spans(source)
@@ -20640,6 +20656,14 @@ test
             );
             assert_eq!(
                 tests[1]
+                    .compound_operator_spans(source)
+                    .into_iter()
+                    .map(|span| span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["-o".to_owned()]
+            );
+            assert_eq!(
+                tests[2]
                     .compound_operator_spans(source)
                     .into_iter()
                     .map(|span| span.slice(source).to_owned())

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -266,9 +266,11 @@ impl<'a> SimpleTestFact<'a> {
             return Vec::new();
         };
 
-        (end == self.effective_operands().len())
-            .then_some(spans)
-            .unwrap_or_default()
+        if end == self.effective_operands().len() {
+            spans
+        } else {
+            Vec::new()
+        }
     }
 
     pub fn truthy_expression_words(&'a self, source: &str) -> Vec<&'a Word> {
@@ -555,15 +557,12 @@ fn simple_test_parse_logical_primary(
     index: usize,
     source: &str,
 ) -> Option<(usize, Vec<Span>)> {
-    if simple_test_effective_operand_text(simple_test, index, source).as_deref() == Some("(") {
-        if let Some((end, spans)) =
+    if simple_test_effective_operand_text(simple_test, index, source).as_deref() == Some("(")
+        && let Some((end, spans)) =
             simple_test_parse_logical_expression(simple_test, index + 1, source)
-        {
-            if simple_test_effective_operand_text(simple_test, end, source).as_deref() == Some(")")
-            {
-                return Some((end + 1, spans));
-            }
-        }
+        && simple_test_effective_operand_text(simple_test, end, source).as_deref() == Some(")")
+    {
+        return Some((end + 1, spans));
     }
 
     if simple_test_effective_operand_text(simple_test, index, source)

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3268,6 +3268,35 @@ f() {
     }
 
     #[test]
+    fn compound_test_operator_suppressed_by_shellcheck_disable_all() {
+        let source = "\
+#!/bin/bash
+# shellcheck disable=all
+[ \"$a\" = 1 -a \"$b\" = 2 ]
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let directives = parse_directives(
+            source,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        let suppressions = SuppressionIndex::new(
+            &directives,
+            &output.file,
+            first_statement_line(&output.file).unwrap_or(u32::MAX),
+        );
+        let diagnostics = lint_file(
+            &output.file,
+            source,
+            &indexer,
+            &LinterSettings::for_rule(Rule::CompoundTestOperator),
+            Some(&suppressions),
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn local_in_sh_suppressed_by_shellcheck_directive() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/compound_test_operator.rs
+++ b/crates/shuck-linter/src/rules/style/compound_test_operator.rs
@@ -131,4 +131,18 @@ test \"$a\" = 1 -a \"$b\" = 2
             vec!["-a"]
         );
     }
+
+    #[test]
+    fn ignores_quoted_negation_before_grouped_subexpressions() {
+        let source = "\
+#!/bin/sh
+[ '(' '!' '(' -f \"$left\" -o -f \"$right\" ')' ')' ]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CompoundTestOperator),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/style/compound_test_operator.rs
+++ b/crates/shuck-linter/src/rules/style/compound_test_operator.rs
@@ -94,6 +94,7 @@ test \"$a\" = 1 -a \"$b\" = 2
         let source = "\
 #!/bin/sh
 [ ! '(' -f \"$left\" -o -f \"$right\" ')' ]
+[ '(' '!' -f \"$quoted_left\" -o -f \"$quoted_right\" ')' ]
 [ \"$a\" = 1 -a \\( \"$b\" = 2 -o \"$c\" = 3 \\) ]
 ";
         let diagnostics = test_snippet(
@@ -106,7 +107,7 @@ test \"$a\" = 1 -a \"$b\" = 2
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-o", "-a", "-o"]
+            vec!["-o", "-o", "-a", "-o"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/compound_test_operator.rs
+++ b/crates/shuck-linter/src/rules/style/compound_test_operator.rs
@@ -15,14 +15,6 @@ impl Violation for CompoundTestOperator {
 }
 
 pub fn compound_test_operator(checker: &mut Checker) {
-    if !checker
-        .facts()
-        .abort_like_bracket_test_spans(checker.source())
-        .is_empty()
-    {
-        return;
-    }
-
     let source = checker.source();
     let spans = checker
         .facts()
@@ -98,7 +90,28 @@ test \"$a\" = 1 -a \"$b\" = 2
     }
 
     #[test]
-    fn ignores_simple_tests_when_the_file_has_malformed_bracket_tests() {
+    fn reports_grouped_compound_test_operators_in_brackets() {
+        let source = "\
+#!/bin/sh
+[ ! '(' -f \"$left\" -o -f \"$right\" ')' ]
+[ \"$a\" = 1 -a \\( \"$b\" = 2 -o \"$c\" = 3 \\) ]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CompoundTestOperator),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-o", "-a", "-o"]
+        );
+    }
+
+    #[test]
+    fn ignores_malformed_grouped_tests_without_hiding_valid_ones() {
         let source = "\
 #!/bin/sh
 [ \"$cross\" -a \"$nocross\" ]
@@ -109,6 +122,12 @@ test \"$a\" = 1 -a \"$b\" = 2
             &LinterSettings::for_rule(Rule::CompoundTestOperator),
         );
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-a"]
+        );
     }
 }

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -160,7 +160,11 @@ fn parse_shellcheck_directive(
                 if code.is_empty() {
                     continue;
                 }
-                codes.extend(shellcheck_map.resolve_all(code));
+                if code.eq_ignore_ascii_case("all") {
+                    codes.extend(Rule::iter());
+                } else {
+                    codes.extend(shellcheck_map.resolve_all(code));
+                }
             }
         }
     }
@@ -279,6 +283,17 @@ value=1 # shellcheck disable=SC2034
             directives[0].codes,
             vec![Rule::UnquotedExpansion, Rule::UnusedAssignment]
         );
+    }
+
+    #[test]
+    fn parses_shellcheck_disable_all() {
+        let directives = directives("# shellcheck disable=all\n");
+
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].source, SuppressionSource::ShellCheck);
+        assert_eq!(directives[0].codes.len(), Rule::COUNT);
+        assert!(directives[0].codes.contains(&Rule::CompoundTestOperator));
+        assert!(directives[0].codes.contains(&Rule::UnquotedExpansion));
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -567,6 +567,21 @@ echo $foo
     }
 
     #[test]
+    fn promotes_shellcheck_disable_all_before_the_first_statement_to_file_scope() {
+        let source = "\
+#!/bin/bash
+# shellcheck disable=all
+
+[ \"$a\" = 1 -a \"$b\" = 2 ]
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::CompoundTestOperator, 4));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
     fn scopes_shellcheck_disable_to_the_next_multiline_command() {
         let source = "\
 echo ready

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1449,7 +1449,7 @@ fn filter_shellcheck_run(
 
     run.diagnostics
         .retain(|diag| shellcheck_filter_codes.contains(&diag.code));
-    run.parse_aborted = shellcheck_parse_aborted(&run.diagnostics);
+    run.parse_aborted |= shellcheck_parse_aborted(&run.diagnostics);
     run
 }
 
@@ -3757,7 +3757,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(codes, vec![2034, 2086]);
-        assert!(!filtered.parse_aborted);
+        assert!(filtered.parse_aborted);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- teach S011 fact collection to parse grouped `[` expressions so logical connectors inside grouped tests are reported without hiding valid diagnostics behind malformed ones
- honor `# shellcheck disable=all` in Shuck suppression handling
- preserve ShellCheck parse-abort state when large-corpus filtering drops unmapped diagnostics

## Why
The remaining S011 corpus gaps were not metadata-only exceptions. They came from a mix of grouped-test fact collection, `disable=all` suppression handling, and a harness bug that lost parse-abort state after rule filtering. This fixes those behaviors directly so the rule can pass the corpus run without skips.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S011`
- `make test`
