### PR TITLE
Split SC1087 handling into S077

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/style/S077.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S077.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Should trigger: adjacent bracket text after an unbraced variable.
+printf '%s\n' "$name[0]"
+
+# Should trigger: bracket expressions after an unbraced variable in a pattern.
+pattern="^$key[[:space:]]*$"
+
+# Should trigger: literal prefixes do not change the ambiguity.
+entry=game$game[0]
+
+# Should trigger: command names are still ordinary words here.
+$cmd[0] arg
+
+# Should not trigger: braces make the boundary explicit.
+printf '%s\n' "${name}[0]"
+
+# Should not trigger: quote boundaries break the adjacency.
+printf '%s\n' "$name""[0]" "$name"'[0]'
+
+# Should not trigger: escaped brackets stay literal.
+printf '%s\n' "$name\[0]"
+
+# Should not trigger: positional parameters are not part of this rule.
+printf '%s\n' "$1[0]"

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -540,6 +540,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::MixedQuoteWord) {
             rules::style::mixed_quote_word::mixed_quote_word(self);
         }
+        if self.is_rule_enabled(Rule::BraceVariableBeforeBracket) {
+            rules::style::brace_variable_before_bracket::brace_variable_before_bracket(self);
+        }
         if self.is_rule_enabled(Rule::UnquotedPipeInEcho) {
             rules::correctness::unquoted_pipe_in_echo::unquoted_pipe_in_echo(self);
         }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -34,7 +34,9 @@ use crate::rules::common::expansion::{
     SubstitutionOutputIntent, WordExpansionKind, WordLiteralness, WordSubstitutionShape,
     analyze_literal_runtime, analyze_redirect_target, analyze_word,
 };
-use crate::rules::common::span::expansion_part_spans;
+use crate::rules::common::span::{
+    expansion_part_spans, word_unbraced_variable_before_bracket_spans,
+};
 use crate::rules::common::{
     command::{self, NormalizedCommand, WrapperKind},
     query::{self, CommandSubstitutionKind, CommandVisit, CommandWalkOptions},
@@ -2759,6 +2761,7 @@ pub struct LinterFacts<'a> {
     word_index: FxHashMap<FactSpan, Vec<usize>>,
     unquoted_command_argument_use_offsets: FxHashMap<Name, Vec<usize>>,
     array_assignment_split_word_indices: Vec<usize>,
+    brace_variable_before_bracket_spans: Vec<Span>,
     function_headers: Vec<FunctionHeaderFact<'a>>,
     function_body_without_braces_spans: Vec<Span>,
     function_parameter_fallback_spans: Vec<Span>,
@@ -3018,6 +3021,10 @@ impl<'a> LinterFacts<'a> {
         self.array_assignment_split_word_indices
             .iter()
             .map(|&index| &self.words[index])
+    }
+
+    pub fn brace_variable_before_bracket_spans(&self) -> &[Span] {
+        &self.brace_variable_before_bracket_spans
     }
 
     pub fn function_headers(&self) -> &[FunctionHeaderFact<'a>] {
@@ -3752,6 +3759,8 @@ impl<'a> LinterFactsBuilder<'a> {
             build_bare_command_name_assignment_spans(&commands, &words, &word_index, self.source);
         let unquoted_command_argument_use_offsets =
             build_unquoted_command_argument_use_offsets(self.semantic, &words);
+        let brace_variable_before_bracket_spans =
+            build_brace_variable_before_bracket_spans(&words, self.source);
 
         LinterFacts {
             commands,
@@ -3772,6 +3781,7 @@ impl<'a> LinterFactsBuilder<'a> {
             word_index,
             unquoted_command_argument_use_offsets,
             array_assignment_split_word_indices,
+            brace_variable_before_bracket_spans,
             function_headers,
             function_body_without_braces_spans,
             function_parameter_fallback_spans,
@@ -3846,6 +3856,17 @@ impl<'a> LinterFactsBuilder<'a> {
             conditional_portability,
         }
     }
+}
+
+fn build_brace_variable_before_bracket_spans(words: &[WordFact<'_>], source: &str) -> Vec<Span> {
+    let mut spans = words
+        .iter()
+        .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
+        .filter(|fact| !fact.is_arithmetic_command())
+        .flat_map(|fact| word_unbraced_variable_before_bracket_spans(fact.word(), source))
+        .collect::<Vec<_>>();
+    sort_and_dedup_spans(&mut spans);
+    spans
 }
 
 fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
@@ -23160,6 +23181,28 @@ echo <(echo x # ${
                 .collect::<Vec<_>>();
 
             assert_eq!(spans, vec!["bar"]);
+        });
+    }
+
+    #[test]
+    fn builds_brace_variable_before_bracket_spans_from_direct_words() {
+        let source = "\
+#!/bin/bash
+echo \"$foo[0]\"
+echo \"${foo}[0]\"
+echo \"$foo\"\"[0]\"
+echo \"$foo\\[0]\"
+$cmd[0] arg
+";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts
+                .brace_variable_before_bracket_spans()
+                .iter()
+                .map(|span| (span.start.line, span.start.column))
+                .collect::<Vec<_>>();
+
+            assert_eq!(spans, vec![(2, 7), (6, 1)]);
         });
     }
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -61,7 +61,6 @@ pub use rules::common::span::{
     word_standalone_literal_backslash_span, word_unquoted_assign_default_spans,
     word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
     word_unbraced_variable_before_bracket_spans,
-    word_unquoted_literal_between_double_quoted_segments_spans,
     word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_parameter_spans,
     word_unquoted_star_splat_spans, word_unquoted_word_between_single_quoted_segments_spans,
     word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -60,6 +60,8 @@ pub use rules::common::span::{
     word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
     word_standalone_literal_backslash_span, word_unquoted_assign_default_spans,
     word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
+    word_unbraced_variable_before_bracket_spans,
+    word_unquoted_literal_between_double_quoted_segments_spans,
     word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_parameter_spans,
     word_unquoted_star_splat_spans, word_unquoted_word_between_single_quoted_segments_spans,
     word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -58,12 +58,12 @@ pub use rules::common::span::{
     word_nested_zsh_substitution_spans, word_positional_at_splat_span_in_source,
     word_positional_at_splat_spans, word_quoted_all_elements_array_slice_spans,
     word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
-    word_standalone_literal_backslash_span, word_unquoted_assign_default_spans,
-    word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
-    word_unbraced_variable_before_bracket_spans,
-    word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_parameter_spans,
-    word_unquoted_star_splat_spans, word_unquoted_word_between_single_quoted_segments_spans,
-    word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,
+    word_standalone_literal_backslash_span, word_unbraced_variable_before_bracket_spans,
+    word_unquoted_assign_default_spans, word_unquoted_escaped_pipe_or_brace_spans_in_source,
+    word_unquoted_glob_pattern_spans, word_unquoted_scalar_between_double_quoted_segments_spans,
+    word_unquoted_star_parameter_spans, word_unquoted_star_splat_spans,
+    word_unquoted_word_between_single_quoted_segments_spans, word_zsh_flag_modifier_spans,
+    word_zsh_nested_expansion_spans,
 };
 pub use rules::common::word::{
     TestOperandClass, WordClassification, conditional_binary_op_is_string_match,

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -623,6 +623,12 @@ declare_rules! {
     ("S070", Category::Style, Severity::Warning, DoubleQuoteNesting),
     ("S071", Category::Style, Severity::Warning, EnvPrefixCommandOnly),
     ("S076", Category::Style, Severity::Warning, MixedQuoteWord),
+    (
+        "S077",
+        Category::Style,
+        Severity::Warning,
+        BraceVariableBeforeBracket
+    ),
     ("S049", Category::Style, Severity::Warning, UnquotedTrRange),
     ("S046", Category::Style, Severity::Warning, LsPipedToXargs),
     ("S047", Category::Style, Severity::Warning, LsInSubstitution),
@@ -780,6 +786,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-306" => Some(Rule::DoubleQuoteNesting),
         "SH-309" => Some(Rule::EnvPrefixCommandOnly),
         "SH-350" => Some(Rule::MixedQuoteWord),
+        "SH-354" => Some(Rule::BraceVariableBeforeBracket),
         "SH-071" => Some(Rule::GrepOutputInTest),
         "SH-076" => Some(Rule::SingleIterationLoop),
         "SH-128" => Some(Rule::BareCommandNameAssignment),
@@ -1026,6 +1033,14 @@ mod tests {
         assert_eq!(code_to_rule("SH-309"), Some(Rule::EnvPrefixCommandOnly));
         assert_eq!(code_to_rule("S076"), Some(Rule::MixedQuoteWord));
         assert_eq!(code_to_rule("SH-350"), Some(Rule::MixedQuoteWord));
+        assert_eq!(
+            code_to_rule("S077"),
+            Some(Rule::BraceVariableBeforeBracket)
+        );
+        assert_eq!(
+            code_to_rule("SH-354"),
+            Some(Rule::BraceVariableBeforeBracket)
+        );
         assert_eq!(code_to_rule("S021"), Some(Rule::PositionalArgsInString));
         assert_eq!(code_to_rule("SH-077"), Some(Rule::PositionalArgsInString));
         assert_eq!(code_to_rule("S020"), Some(Rule::SingleIterationLoop));

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -1033,10 +1033,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-309"), Some(Rule::EnvPrefixCommandOnly));
         assert_eq!(code_to_rule("S076"), Some(Rule::MixedQuoteWord));
         assert_eq!(code_to_rule("SH-350"), Some(Rule::MixedQuoteWord));
-        assert_eq!(
-            code_to_rule("S077"),
-            Some(Rule::BraceVariableBeforeBracket)
-        );
+        assert_eq!(code_to_rule("S077"), Some(Rule::BraceVariableBeforeBracket));
         assert_eq!(
             code_to_rule("SH-354"),
             Some(Rule::BraceVariableBeforeBracket)

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -236,6 +236,13 @@ pub fn word_unquoted_escaped_pipe_or_brace_spans_in_source(word: &Word, source: 
     collect_unquoted_escaped_pipe_or_brace_spans(&word.parts, source, false, &mut spans);
     spans
 }
+
+pub fn word_unbraced_variable_before_bracket_spans(word: &Word, source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_unbraced_variable_before_bracket_spans(&word.parts, source, &mut spans);
+    spans
+}
+
 pub fn word_standalone_literal_backslash_span(word: &Word, source: &str) -> Option<Span> {
     let [part] = word.parts.as_slice() else {
         return None;
@@ -1595,6 +1602,80 @@ fn word_array_subscript_span_from_parts(parts: &[WordPartNode], source: &str) ->
     }
 
     None
+}
+
+fn collect_unbraced_variable_before_bracket_spans(
+    parts: &[WordPartNode],
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let mut pending_variable = None;
+
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts: inner, .. } => {
+                collect_unbraced_variable_before_bracket_spans(inner, source, spans);
+                pending_variable = None;
+            }
+            WordPart::SingleQuoted { .. }
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::ProcessSubstitution { .. } => {
+                pending_variable = None;
+            }
+            WordPart::Variable(name)
+                if is_named_shell_variable(name.as_str())
+                    && !variable_part_uses_braces(part, source) =>
+            {
+                pending_variable = Some(unbraced_variable_dollar_span(part, source));
+            }
+            WordPart::Literal(text) => {
+                if text.as_str(source, part.span).starts_with('[')
+                    && let Some(variable_span) = pending_variable
+                {
+                    spans.push(variable_span);
+                }
+                pending_variable = None;
+            }
+            WordPart::Variable(_)
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::Transformation { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ZshQualifiedGlob(_) => {
+                pending_variable = None;
+            }
+        }
+    }
+}
+
+fn is_named_shell_variable(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    let Some((&first, rest)) = bytes.split_first() else {
+        return false;
+    };
+
+    is_name_start(first) && rest.iter().copied().all(is_name_continue)
+}
+
+fn unbraced_variable_dollar_span(part: &WordPartNode, source: &str) -> Span {
+    let raw = part.span.slice(source);
+    let dollar_offset = raw.find('$').unwrap_or(0);
+    Span::at(part.span.start.advanced_by(&raw[..dollar_offset]))
+}
+
+fn variable_part_uses_braces(part: &WordPartNode, source: &str) -> bool {
+    let raw = part.span.slice(source);
+    raw.find('$')
+        .and_then(|offset| raw.as_bytes().get(offset + 1))
+        .is_some_and(|next| *next == b'{')
 }
 
 fn parameter_array_subscript_span(parameter: &ParameterExpansion) -> Option<Span> {

--- a/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+++ b/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Checker, Rule, Violation, WordFactHostKind, word_unbraced_variable_before_bracket_spans,
+    Checker, Rule, ShellDialect, Violation, WordFactHostKind,
+    word_unbraced_variable_before_bracket_spans,
 };
 
 pub struct BraceVariableBeforeBracket;
@@ -15,6 +16,10 @@ impl Violation for BraceVariableBeforeBracket {
 }
 
 pub fn brace_variable_before_bracket(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
     let source = checker.source();
     let spans = checker
         .facts()
@@ -31,7 +36,7 @@ pub fn brace_variable_before_bracket(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_unbraced_variables_before_bracket_text() {
@@ -105,5 +110,20 @@ sed_var() {
                 .collect::<Vec<_>>(),
             vec![(4, 33), (7, 14)]
         );
+    }
+
+    #[test]
+    fn ignores_zsh_array_subscripts() {
+        let source = "\
+#!/bin/zsh
+echo \"$foo[1]\"
+print $reply[2]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::BraceVariableBeforeBracket).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+++ b/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Checker, Rule, ShellDialect, Violation, WordFactHostKind,
-    word_unbraced_variable_before_bracket_spans,
-};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct BraceVariableBeforeBracket;
 
@@ -20,17 +17,13 @@ pub fn brace_variable_before_bracket(checker: &mut Checker) {
         return;
     }
 
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .word_facts()
-        .iter()
-        .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
-        .filter(|fact| !fact.is_arithmetic_command())
-        .flat_map(|fact| word_unbraced_variable_before_bracket_spans(fact.word(), source))
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || BraceVariableBeforeBracket);
+    checker.report_all_dedup(
+        checker
+            .facts()
+            .brace_variable_before_bracket_spans()
+            .to_vec(),
+        || BraceVariableBeforeBracket,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+++ b/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
@@ -121,7 +121,8 @@ print $reply[2]
 ";
         let diagnostics = test_snippet(
             source,
-            &LinterSettings::for_rule(Rule::BraceVariableBeforeBracket).with_shell(ShellDialect::Zsh),
+            &LinterSettings::for_rule(Rule::BraceVariableBeforeBracket)
+                .with_shell(ShellDialect::Zsh),
         );
 
         assert!(diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+++ b/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
@@ -1,0 +1,109 @@
+use crate::{
+    Checker, Rule, Violation, WordFactHostKind, word_unbraced_variable_before_bracket_spans,
+};
+
+pub struct BraceVariableBeforeBracket;
+
+impl Violation for BraceVariableBeforeBracket {
+    fn rule() -> Rule {
+        Rule::BraceVariableBeforeBracket
+    }
+
+    fn message(&self) -> String {
+        "brace variable expansions before adjacent `[` text".to_owned()
+    }
+}
+
+pub fn brace_variable_before_bracket(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .word_facts()
+        .iter()
+        .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
+        .filter(|fact| !fact.is_arithmetic_command())
+        .flat_map(|fact| word_unbraced_variable_before_bracket_spans(fact.word(), source))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || BraceVariableBeforeBracket);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_unbraced_variables_before_bracket_text() {
+        let source = "\
+#!/bin/sh
+echo \"$foo[0]\"
+echo \"$key[[:space:]]\"
+echo game$game[0]
+echo \"$foo[\"
+$cmd[0] arg
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::BraceVariableBeforeBracket),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .collect::<Vec<_>>(),
+            vec![(2, 7), (3, 7), (4, 10), (5, 7), (6, 1)]
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.span.start == diagnostic.span.end)
+        );
+    }
+
+    #[test]
+    fn ignores_braced_special_and_quote_split_forms() {
+        let source = "\
+#!/bin/sh
+echo \"${foo}[0]\"
+echo \"${foo}[[:space:]]\"
+echo \"$foo\"\"[0]\"
+echo \"$foo\"'[0]'
+echo \"$foo\\[0]\"
+echo \"$1[0]\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::BraceVariableBeforeBracket),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_corpus_style_regex_suffix_forms() {
+        let source = "\
+#!/bin/bash
+check() {
+  local cmd=\"$1\"
+  command git grep -E \"^[^#]*\\\\<$cmd[[:space:]]+\"
+}
+sed_var() {
+  sed -i \"/\\\\$symon['$1']/s|=.*|='$2';|\" setup.inc
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::BraceVariableBeforeBracket),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .collect::<Vec<_>>(),
+            vec![(4, 33), (7, 14)]
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -1,4 +1,5 @@
 pub mod ampersand_semicolon;
+pub mod brace_variable_before_bracket;
 pub mod arithmetic_score_line;
 pub mod array_index_arithmetic;
 pub mod avoid_let_builtin;
@@ -110,6 +111,7 @@ mod tests {
     #[test_case(Rule::DoubleQuoteNesting, Path::new("S070.sh"))]
     #[test_case(Rule::EnvPrefixCommandOnly, Path::new("S071.sh"))]
     #[test_case(Rule::MixedQuoteWord, Path::new("S076.sh"))]
+    #[test_case(Rule::BraceVariableBeforeBracket, Path::new("S077.sh"))]
     #[test_case(Rule::FunctionInAlias, Path::new("S057.sh"))]
     #[test_case(Rule::FunctionBodyWithoutBraces, Path::new("S041.sh"))]
     #[test_case(Rule::LocalDeclareCombined, Path::new("S066.sh"))]

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -1,11 +1,11 @@
 pub mod ampersand_semicolon;
-pub mod brace_variable_before_bracket;
 pub mod arithmetic_score_line;
 pub mod array_index_arithmetic;
 pub mod avoid_let_builtin;
 pub mod backslash_before_command;
 pub mod bare_command_name_assignment;
 pub mod bare_read;
+pub mod brace_variable_before_bracket;
 pub mod combine_appends;
 pub mod command_output_array_split;
 pub mod command_substitution_in_alias;

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S077_S077.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S077_S077.sh.snap
@@ -1,0 +1,27 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+assertion_line: 169
+---
+S077 brace variable expansions before adjacent `[` text
+ --> <source>:3:16
+  |
+3 | printf '%s\n' "$name[0]"
+  |
+
+S077 brace variable expansions before adjacent `[` text
+ --> <source>:6:11
+  |
+6 | pattern="^$key[[:space:]]*$"
+  |
+
+S077 brace variable expansions before adjacent `[` text
+ --> <source>:9:11
+  |
+9 | entry=game$game[0]
+  |
+
+S077 brace variable expansions before adjacent `[` text
+  --> <source>:12:1
+   |
+12 | $cmd[0] arg
+   |

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -124,6 +124,10 @@ mod tests {
         assert_eq!(map.resolve("SC2096"), Some(Rule::DuplicateShebangFlag));
         assert_eq!(map.resolve("SC2318"), Some(Rule::LocalCrossReference));
         assert_eq!(map.resolve("SC2260"), Some(Rule::RedirectBeforePipe));
+        assert_eq!(
+            map.resolve("SC1087"),
+            Some(Rule::BraceVariableBeforeBracket)
+        );
         assert_eq!(map.resolve("SC2317"), None);
         assert_eq!(map.resolve("SC7777"), None);
     }
@@ -181,6 +185,10 @@ mod tests {
         assert_eq!(map.code_for_rule(Rule::DuplicateShebangFlag), Some(2096));
         assert_eq!(map.code_for_rule(Rule::BashFileSlurp), Some(3034));
         assert_eq!(map.code_for_rule(Rule::LiteralControlEscape), Some(1012));
+        assert_eq!(
+            map.code_for_rule(Rule::BraceVariableBeforeBracket),
+            Some(1087)
+        );
         assert_eq!(map.code_for_rule(Rule::BackslashBeforeCommand), None);
         assert_eq!(
             map.code_for_rule(Rule::LeadingGlobInGrepPattern),

--- a/crates/shuck/tests/testdata/corpus-metadata/s077.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s077.yaml
@@ -1,0 +1,11 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
+    line: 827
+    end_line: 827
+    column: 16
+    end_column: 16
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This helper intentionally builds literal `NAME[@]` text for a later indirect expansion, so the adjacent bracket suffix is deliberate and warning here would be noisy."

--- a/crates/shuck/tests/testdata/corpus-metadata/x049.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x049.yaml
@@ -1,8 +1,0 @@
-reviewed_divergences:
-  - side: shellcheck-only
-    path_suffix: "pyenv__pyenv__libexec__pyenv-latest"
-    line: 63
-    end_line: 63
-    column: 18
-    end_column: 18
-    reason: "ShellCheck 0.11.0 reuses SC1087 for a parameter expansion followed by a bracket expression in this Bash regex. X049 only covers zsh `%{...%}` prompt escapes, so this corpus hit is outside the rule's scope."

--- a/docs/rules/S077.yaml
+++ b/docs/rules/S077.yaml
@@ -1,0 +1,23 @@
+legacy_code: SH-354
+legacy_name: brace-variable-before-bracket
+new_category: Style
+new_code: S077
+runtime_kind: ast
+shellcheck_code: SC1087
+shells:
+  - sh
+  - bash
+  - dash
+  - ksh
+description: An unbraced variable expansion is immediately followed by `[` text.
+rationale: Wrap the expansion in braces so the following bracket text is unambiguous.
+source:
+  shell_checks_rule: rules/SH-354.yaml
+  shell_checks_example: examples/354.sh
+examples:
+  - kind: invalid
+    source: shell-checks/examples/354.sh
+    code: |
+      #!/bin/sh
+      printf '%s\n' "$name[0]"
+      pattern="^$key[[:space:]]*$"

--- a/docs/rules/X049.yaml
+++ b/docs/rules/X049.yaml
@@ -3,7 +3,6 @@ legacy_name: zsh-prompt-bracket
 new_category: Portability
 new_code: X049
 runtime_kind: ast
-shellcheck_code: SC1087
 shells:
   - sh
   - bash

--- a/docs/rules/shellcheck-mapping-audit.md
+++ b/docs/rules/shellcheck-mapping-audit.md
@@ -34,7 +34,7 @@ Important context:
 | Rule | Current `SC` | Why it still needs help |
 | --- | --- | --- |
 | `X033` | `SC1027`, `SC1036` | The current example does not isolate a unique portability code. It looks closer to the `X046` extglob-in-test case than to a distinct `elif` portability rule. |
-| `X041` | `SC3010`, `SC1087`, `SC2203`, `SC2154` | `SC2203` is the only unique current code, but the example is too noisy to claim it confidently without a cleaner fixture. |
+| `X041` | `SC3010`, `SC2203`, `SC2154` | `SC2203` is the only unique current code, but the example is too noisy to claim it confidently without a cleaner fixture. |
 
 ## Suggested Next Pass
 


### PR DESCRIPTION
## Summary

This splits overloaded `SC1087` handling out of `X049` and gives it a dedicated style rule, `S077`.

## What changed

- add `S077` for unbraced variable expansions immediately followed by `[` text
- map `SC1087` to `S077` instead of `X049`
- keep `X049` focused on zsh prompt escape syntax rather than broader ShellCheck reuse cases
- add rule fixtures, snapshots, and large-corpus metadata for the one intentional reviewed divergence

## Why

`SC1087` was being reused by ShellCheck for patterns that are not zsh prompt escapes. Keeping that mapping on `X049` made the rule semantically wrong and forced corpus suppressions for unrelated cases.

The new split preserves the intended zsh-only meaning of `X049` while giving the bracket-suffix form a dedicated rule with cleaner conformance behavior.

## Impact

- `X049` now reports only the zsh prompt-escape portability issue it was designed for
- `SC1087` suppressions and compatibility now resolve through `S077`
- large-corpus compatibility for the split rule is clean except for one reviewed helper-library divergence in pyenv

## Validation

- `cargo test -p shuck-linter brace_variable_before_bracket -- --nocapture`
- `cargo test -p shuck-linter bracevariablebeforebracket_path_new_s077 --lib -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S077`
- `SHUCK_CACHE_DIR=/tmp/shuck-cache make test`
