### PR TITLE
Fix S023 escape classification

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -3599,6 +3599,7 @@ impl<'a> LinterFactsBuilder<'a> {
             unicode_smart_quote_spans,
             pattern_exactly_one_extglob_spans: surface_pattern_exactly_one_extglob_spans,
             pattern_charclass_spans: surface_pattern_charclass_spans,
+            parameter_pattern_spans,
             nested_pattern_charclass_spans,
             nested_parameter_expansions,
             indirect_expansions,
@@ -3628,6 +3629,7 @@ impl<'a> LinterFactsBuilder<'a> {
             &words,
             &pattern_literal_spans,
             &pattern_charclass_spans,
+            &parameter_pattern_spans,
             &single_quoted,
             &backticks,
             EscapeScanContext {
@@ -10268,6 +10270,9 @@ fn extend_surface_fragment_facts(target: &mut SurfaceFragmentFacts, source: Surf
     target
         .pattern_charclass_spans
         .extend(source.pattern_charclass_spans);
+    target
+        .parameter_pattern_spans
+        .extend(source.parameter_pattern_spans);
     target
         .nested_pattern_charclass_spans
         .extend(source.nested_pattern_charclass_spans);

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -20,7 +20,9 @@ use self::{
         build_subshell_test_group_spans, build_substitution_facts,
     },
     conditional_portability::build_conditional_portability_facts,
-    escape_scan::{EscapeScanContext, EscapeScanMatch, build_escape_scan_matches},
+    escape_scan::{
+        EscapeScanContext, EscapeScanInputs, EscapeScanMatch, build_escape_scan_matches,
+    },
     presence::build_presence_tested_names,
     surface::{
         SurfaceFragmentFacts, SurfaceFragmentSink, SurfaceScanContext,
@@ -3627,11 +3629,13 @@ impl<'a> LinterFactsBuilder<'a> {
         let escape_scan_matches = build_escape_scan_matches(
             &commands,
             &words,
-            &pattern_literal_spans,
-            &pattern_charclass_spans,
-            &parameter_pattern_spans,
-            &single_quoted,
-            &backticks,
+            EscapeScanInputs {
+                pattern_literal_spans: &pattern_literal_spans,
+                pattern_charclass_spans: &pattern_charclass_spans,
+                parameter_pattern_spans: &parameter_pattern_spans,
+                single_quoted_fragments: &single_quoted,
+                backtick_fragments: &backticks,
+            },
             EscapeScanContext {
                 source: self.source,
                 file_context: self._file_context,

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -21,6 +21,7 @@ pub(crate) enum EscapeScanSourceKind {
     DynamicPathCommandName,
     PatternLiteral,
     PatternCharClass,
+    ParameterPatternCharClass,
     SingleLiteralAssignmentWord,
     BacktickFragment,
 }
@@ -31,6 +32,8 @@ pub(crate) struct EscapeScanMatch {
     escaped_byte: u8,
     source_kind: EscapeScanSourceKind,
     grep_style_argument: bool,
+    tr_operand_argument: bool,
+    #[cfg_attr(not(test), allow(dead_code))]
     host_contains_single_quoted_fragment: bool,
     inside_single_quoted_fragment: bool,
 }
@@ -52,6 +55,11 @@ impl EscapeScanMatch {
         self.grep_style_argument
     }
 
+    pub(crate) fn is_tr_operand_argument(self) -> bool {
+        self.tr_operand_argument
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn host_contains_single_quoted_fragment(self) -> bool {
         self.host_contains_single_quoted_fragment
     }
@@ -66,6 +74,7 @@ pub(super) fn build_escape_scan_matches(
     words: &[WordFact<'_>],
     pattern_literal_spans: &[Span],
     pattern_charclass_spans: &[Span],
+    parameter_pattern_spans: &[Span],
     single_quoted_fragments: &[SingleQuotedFragmentFact],
     backtick_fragments: &[BacktickFragmentFact],
     context: EscapeScanContext<'_>,
@@ -81,6 +90,7 @@ pub(super) fn build_escape_scan_matches(
         .filter(|fact| is_relevant_word_context(fact.expansion_context()))
     {
         let grep_style_argument = is_grep_style_argument(commands, fact);
+        let tr_operand_argument = is_tr_operand_argument(commands, fact);
         if is_regex_like_context(fact.expansion_context()) {
             continue;
         }
@@ -97,6 +107,7 @@ pub(super) fn build_escape_scan_matches(
                 context.source,
                 EscapeScanSourceKind::WordLiteralPart,
                 grep_style_argument,
+                tr_operand_argument,
                 host_contains_single_quoted_fragment,
                 single_quoted_fragments,
             );
@@ -117,6 +128,7 @@ pub(super) fn build_escape_scan_matches(
             context.source,
             EscapeScanSourceKind::SingleLiteralAssignmentWord,
             is_grep_style_argument(commands, fact),
+            is_tr_operand_argument(commands, fact),
             span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments),
             single_quoted_fragments,
         );
@@ -129,6 +141,7 @@ pub(super) fn build_escape_scan_matches(
         )
     }) {
         let grep_style_argument = is_grep_style_argument(commands, fact);
+        let tr_operand_argument = is_tr_operand_argument(commands, fact);
         if is_regex_like_context(fact.expansion_context()) {
             continue;
         }
@@ -143,6 +156,7 @@ pub(super) fn build_escape_scan_matches(
                 context.source,
                 EscapeScanSourceKind::RedirectLiteralSegment,
                 grep_style_argument,
+                tr_operand_argument,
                 host_contains_single_quoted_fragment,
                 single_quoted_fragments,
             );
@@ -163,6 +177,7 @@ pub(super) fn build_escape_scan_matches(
             context.source,
             EscapeScanSourceKind::DynamicPathCommandName,
             false,
+            false,
             span_contains_single_quoted_fragment(span, single_quoted_fragments),
             single_quoted_fragments,
         );
@@ -175,17 +190,24 @@ pub(super) fn build_escape_scan_matches(
             context.source,
             EscapeScanSourceKind::PatternLiteral,
             false,
+            false,
             span_contains_single_quoted_fragment(*span, single_quoted_fragments),
             single_quoted_fragments,
         );
     }
 
     for span in pattern_charclass_spans {
+        let source_kind = if span_within_any(*span, parameter_pattern_spans) {
+            EscapeScanSourceKind::ParameterPatternCharClass
+        } else {
+            EscapeScanSourceKind::PatternCharClass
+        };
         append_escape_scan_matches(
             &mut matches,
             *span,
             context.source,
-            EscapeScanSourceKind::PatternCharClass,
+            source_kind,
+            false,
             false,
             span_contains_single_quoted_fragment(*span, single_quoted_fragments),
             single_quoted_fragments,
@@ -198,6 +220,7 @@ pub(super) fn build_escape_scan_matches(
             fragment.span(),
             context.source,
             EscapeScanSourceKind::BacktickFragment,
+            false,
             false,
             span_contains_single_quoted_fragment(fragment.span(), single_quoted_fragments),
             single_quoted_fragments,
@@ -213,6 +236,7 @@ fn append_escape_scan_matches(
     source: &str,
     source_kind: EscapeScanSourceKind,
     grep_style_argument: bool,
+    tr_operand_argument: bool,
     host_contains_single_quoted_fragment: bool,
     single_quoted_fragments: &[SingleQuotedFragmentFact],
 ) {
@@ -283,6 +307,7 @@ fn append_escape_scan_matches(
             escaped_byte,
             source_kind,
             grep_style_argument,
+            tr_operand_argument,
             host_contains_single_quoted_fragment,
             inside_single_quoted_fragment: span_within_single_quoted_fragment(
                 report_span,
@@ -336,8 +361,14 @@ fn span_within_single_quoted_fragment(span: Span, fragments: &[SingleQuotedFragm
     fragments.iter().any(|fragment| {
         let fragment_span = fragment.span();
         span.start.offset >= fragment_span.start.offset
-            && span.end.offset <= fragment_span.end.offset
+            && span.end.offset < fragment_span.end.offset
     })
+}
+
+fn span_within_any(span: Span, hosts: &[Span]) -> bool {
+    hosts
+        .iter()
+        .any(|host| span.start.offset >= host.start.offset && span.end.offset <= host.end.offset)
 }
 
 fn is_grep_style_argument(commands: &[CommandFact<'_>], fact: &WordFact<'_>) -> bool {
@@ -356,6 +387,21 @@ fn is_grep_style_argument(commands: &[CommandFact<'_>], fact: &WordFact<'_>) -> 
     command
         .effective_or_literal_name()
         .is_some_and(|name| name.contains("grep"))
+}
+
+fn is_tr_operand_argument(commands: &[CommandFact<'_>], fact: &WordFact<'_>) -> bool {
+    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
+        return false;
+    }
+
+    commands[fact.command_id().index()]
+        .options()
+        .tr()
+        .is_some_and(|tr| {
+            tr.operand_words()
+                .iter()
+                .any(|word| word.span == fact.span())
+        })
 }
 
 #[cfg(test)]
@@ -442,7 +488,7 @@ case x in [a\-z]) : ;; esac
     }
 
     #[test]
-    fn records_single_quote_metadata_for_nested_command_words() {
+    fn keeps_adjacent_escapes_outside_single_quoted_fragments() {
         let source = r#"#!/bin/bash
 echo "$(printf prefix'quoted'\n)"
 "#;
@@ -463,7 +509,7 @@ echo "$(printf prefix'quoted'\n)"
                     })
                     .expect("expected nested command word match");
 
-                assert!(nested_match.inside_single_quoted_fragment());
+                assert!(!nested_match.inside_single_quoted_fragment());
             },
         );
     }
@@ -502,6 +548,84 @@ echo foo\tbar
                     })
                     .expect("expected ordinary argument match");
                 assert!(!echo_match.is_grep_style_argument());
+            },
+        );
+    }
+
+    #[test]
+    fn marks_tr_operands_without_dropping_the_match() {
+        let source = r#"#!/bin/bash
+printf '%s\n' "$value" | tr \. _
+echo foo\.bar
+"#;
+
+        with_matches(
+            source,
+            None,
+            ParseShellDialect::Bash,
+            ShellDialect::Bash,
+            |matches| {
+                let tr_match = matches
+                    .iter()
+                    .copied()
+                    .find(|escape| {
+                        escape.escaped_byte() == b'.'
+                            && escape.span().start.line == 2
+                            && escape.source_kind() == EscapeScanSourceKind::WordLiteralPart
+                    })
+                    .expect("expected tr operand match");
+                assert!(tr_match.is_tr_operand_argument());
+
+                let echo_match = matches
+                    .iter()
+                    .copied()
+                    .find(|escape| {
+                        escape.escaped_byte() == b'.'
+                            && escape.span().start.line == 3
+                            && escape.source_kind() == EscapeScanSourceKind::WordLiteralPart
+                    })
+                    .expect("expected ordinary word match");
+                assert!(!echo_match.is_tr_operand_argument());
+            },
+        );
+    }
+
+    #[test]
+    fn distinguishes_parameter_expansion_char_classes() {
+        let source = r#"#!/bin/bash
+case "$x" in [a\-z]) : ;; esac
+name="${name//[^a-zA-Z0-9_\-]/}"
+"#;
+
+        with_matches(
+            source,
+            None,
+            ParseShellDialect::Bash,
+            ShellDialect::Bash,
+            |matches| {
+                let conditional_match = matches
+                    .iter()
+                    .copied()
+                    .find(|escape| {
+                        escape.escaped_byte() == b'-'
+                            && escape.span().start.line == 2
+                            && escape.source_kind() == EscapeScanSourceKind::PatternCharClass
+                    })
+                    .expect("expected case-pattern char class match");
+
+                let parameter_match = matches
+                    .iter()
+                    .copied()
+                    .find(|escape| {
+                        escape.escaped_byte() == b'-'
+                            && escape.span().start.line == 3
+                            && escape.source_kind()
+                                == EscapeScanSourceKind::ParameterPatternCharClass
+                    })
+                    .expect("expected parameter-pattern char class match");
+
+                assert_eq!(conditional_match.escaped_byte(), b'-');
+                assert_eq!(parameter_match.escaped_byte(), b'-');
             },
         );
     }

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -14,6 +14,14 @@ pub(super) struct EscapeScanContext<'a> {
     pub(super) file_context: &'a FileContext,
 }
 
+pub(super) struct EscapeScanInputs<'a> {
+    pub(super) pattern_literal_spans: &'a [Span],
+    pub(super) pattern_charclass_spans: &'a [Span],
+    pub(super) parameter_pattern_spans: &'a [Span],
+    pub(super) single_quoted_fragments: &'a [SingleQuotedFragmentFact],
+    pub(super) backtick_fragments: &'a [BacktickFragmentFact],
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EscapeScanSourceKind {
     WordLiteralPart,
@@ -69,14 +77,18 @@ impl EscapeScanMatch {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct EscapeScanMatchContext {
+    source_kind: EscapeScanSourceKind,
+    grep_style_argument: bool,
+    tr_operand_argument: bool,
+    host_contains_single_quoted_fragment: bool,
+}
+
 pub(super) fn build_escape_scan_matches(
     commands: &[CommandFact<'_>],
     words: &[WordFact<'_>],
-    pattern_literal_spans: &[Span],
-    pattern_charclass_spans: &[Span],
-    parameter_pattern_spans: &[Span],
-    single_quoted_fragments: &[SingleQuotedFragmentFact],
-    backtick_fragments: &[BacktickFragmentFact],
+    inputs: EscapeScanInputs<'_>,
     context: EscapeScanContext<'_>,
 ) -> Vec<EscapeScanMatch> {
     if context.file_context.has_tag(FileContextTag::PatchFile) {
@@ -96,7 +108,7 @@ pub(super) fn build_escape_scan_matches(
         }
 
         let host_contains_single_quoted_fragment =
-            span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments);
+            span_contains_single_quoted_fragment(fact.span(), inputs.single_quoted_fragments);
 
         for span in
             word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), context.source)
@@ -105,11 +117,13 @@ pub(super) fn build_escape_scan_matches(
                 &mut matches,
                 span,
                 context.source,
-                EscapeScanSourceKind::WordLiteralPart,
-                grep_style_argument,
-                tr_operand_argument,
-                host_contains_single_quoted_fragment,
-                single_quoted_fragments,
+                EscapeScanMatchContext {
+                    source_kind: EscapeScanSourceKind::WordLiteralPart,
+                    grep_style_argument,
+                    tr_operand_argument,
+                    host_contains_single_quoted_fragment,
+                },
+                inputs.single_quoted_fragments,
             );
         }
     }
@@ -126,11 +140,16 @@ pub(super) fn build_escape_scan_matches(
             &mut matches,
             fact.span(),
             context.source,
-            EscapeScanSourceKind::SingleLiteralAssignmentWord,
-            is_grep_style_argument(commands, fact),
-            is_tr_operand_argument(commands, fact),
-            span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments),
-            single_quoted_fragments,
+            EscapeScanMatchContext {
+                source_kind: EscapeScanSourceKind::SingleLiteralAssignmentWord,
+                grep_style_argument: is_grep_style_argument(commands, fact),
+                tr_operand_argument: is_tr_operand_argument(commands, fact),
+                host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
+                    fact.span(),
+                    inputs.single_quoted_fragments,
+                ),
+            },
+            inputs.single_quoted_fragments,
         );
     }
 
@@ -147,18 +166,20 @@ pub(super) fn build_escape_scan_matches(
         }
 
         let host_contains_single_quoted_fragment =
-            span_contains_single_quoted_fragment(fact.span(), single_quoted_fragments);
+            span_contains_single_quoted_fragment(fact.span(), inputs.single_quoted_fragments);
 
         for span in word_literal_scan_segments_excluding_expansions(fact.word(), context.source) {
             append_escape_scan_matches(
                 &mut matches,
                 span,
                 context.source,
-                EscapeScanSourceKind::RedirectLiteralSegment,
-                grep_style_argument,
-                tr_operand_argument,
-                host_contains_single_quoted_fragment,
-                single_quoted_fragments,
+                EscapeScanMatchContext {
+                    source_kind: EscapeScanSourceKind::RedirectLiteralSegment,
+                    grep_style_argument,
+                    tr_operand_argument,
+                    host_contains_single_quoted_fragment,
+                },
+                inputs.single_quoted_fragments,
             );
         }
     }
@@ -175,29 +196,39 @@ pub(super) fn build_escape_scan_matches(
             &mut matches,
             span,
             context.source,
-            EscapeScanSourceKind::DynamicPathCommandName,
-            false,
-            false,
-            span_contains_single_quoted_fragment(span, single_quoted_fragments),
-            single_quoted_fragments,
+            EscapeScanMatchContext {
+                source_kind: EscapeScanSourceKind::DynamicPathCommandName,
+                grep_style_argument: false,
+                tr_operand_argument: false,
+                host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
+                    span,
+                    inputs.single_quoted_fragments,
+                ),
+            },
+            inputs.single_quoted_fragments,
         );
     }
 
-    for span in pattern_literal_spans {
+    for span in inputs.pattern_literal_spans {
         append_escape_scan_matches(
             &mut matches,
             *span,
             context.source,
-            EscapeScanSourceKind::PatternLiteral,
-            false,
-            false,
-            span_contains_single_quoted_fragment(*span, single_quoted_fragments),
-            single_quoted_fragments,
+            EscapeScanMatchContext {
+                source_kind: EscapeScanSourceKind::PatternLiteral,
+                grep_style_argument: false,
+                tr_operand_argument: false,
+                host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
+                    *span,
+                    inputs.single_quoted_fragments,
+                ),
+            },
+            inputs.single_quoted_fragments,
         );
     }
 
-    for span in pattern_charclass_spans {
-        let source_kind = if span_within_any(*span, parameter_pattern_spans) {
+    for span in inputs.pattern_charclass_spans {
+        let source_kind = if span_within_any(*span, inputs.parameter_pattern_spans) {
             EscapeScanSourceKind::ParameterPatternCharClass
         } else {
             EscapeScanSourceKind::PatternCharClass
@@ -206,24 +237,34 @@ pub(super) fn build_escape_scan_matches(
             &mut matches,
             *span,
             context.source,
-            source_kind,
-            false,
-            false,
-            span_contains_single_quoted_fragment(*span, single_quoted_fragments),
-            single_quoted_fragments,
+            EscapeScanMatchContext {
+                source_kind,
+                grep_style_argument: false,
+                tr_operand_argument: false,
+                host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
+                    *span,
+                    inputs.single_quoted_fragments,
+                ),
+            },
+            inputs.single_quoted_fragments,
         );
     }
 
-    for fragment in backtick_fragments {
+    for fragment in inputs.backtick_fragments {
         append_escape_scan_matches(
             &mut matches,
             fragment.span(),
             context.source,
-            EscapeScanSourceKind::BacktickFragment,
-            false,
-            false,
-            span_contains_single_quoted_fragment(fragment.span(), single_quoted_fragments),
-            single_quoted_fragments,
+            EscapeScanMatchContext {
+                source_kind: EscapeScanSourceKind::BacktickFragment,
+                grep_style_argument: false,
+                tr_operand_argument: false,
+                host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
+                    fragment.span(),
+                    inputs.single_quoted_fragments,
+                ),
+            },
+            inputs.single_quoted_fragments,
         );
     }
 
@@ -234,10 +275,7 @@ fn append_escape_scan_matches(
     matches: &mut Vec<EscapeScanMatch>,
     scan_span: Span,
     source: &str,
-    source_kind: EscapeScanSourceKind,
-    grep_style_argument: bool,
-    tr_operand_argument: bool,
-    host_contains_single_quoted_fragment: bool,
+    match_context: EscapeScanMatchContext,
     single_quoted_fragments: &[SingleQuotedFragmentFact],
 ) {
     let text = scan_span.slice(source);
@@ -305,10 +343,11 @@ fn append_escape_scan_matches(
         matches.push(EscapeScanMatch {
             span: report_span,
             escaped_byte,
-            source_kind,
-            grep_style_argument,
-            tr_operand_argument,
-            host_contains_single_quoted_fragment,
+            source_kind: match_context.source_kind,
+            grep_style_argument: match_context.grep_style_argument,
+            tr_operand_argument: match_context.tr_operand_argument,
+            host_contains_single_quoted_fragment: match_context
+                .host_contains_single_quoted_fragment,
             inside_single_quoted_fragment: span_within_single_quoted_fragment(
                 report_span,
                 single_quoted_fragments,

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -181,12 +181,7 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     fn record_parameter_pattern(&mut self, span: Span) {
-        if self
-            .facts
-            .parameter_pattern_spans
-            .iter()
-            .any(|recorded| *recorded == span)
-        {
+        if self.facts.parameter_pattern_spans.contains(&span) {
             return;
         }
         self.facts.parameter_pattern_spans.push(span);

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -14,6 +14,7 @@ pub(super) struct SurfaceFragmentFacts {
     pub(super) unicode_smart_quote_spans: Vec<Span>,
     pub(super) pattern_exactly_one_extglob_spans: Vec<Span>,
     pub(super) pattern_charclass_spans: Vec<Span>,
+    pub(super) parameter_pattern_spans: Vec<Span>,
     pub(super) nested_pattern_charclass_spans: Vec<Span>,
     pub(super) nested_parameter_expansions: Vec<NestedParameterExpansionFragmentFact>,
     pub(super) indirect_expansions: Vec<IndirectExpansionFragmentFact>,
@@ -177,6 +178,18 @@ impl<'a> SurfaceFragmentSink<'a> {
         self.facts
             .replacement_expansions
             .push(ReplacementExpansionFragmentFact { span });
+    }
+
+    fn record_parameter_pattern(&mut self, span: Span) {
+        if self
+            .facts
+            .parameter_pattern_spans
+            .iter()
+            .any(|recorded| *recorded == span)
+        {
+            return;
+        }
+        self.facts.parameter_pattern_spans.push(span);
     }
 
     fn record_star_glob_removal(&mut self, span: Span) {
@@ -867,6 +880,7 @@ impl<'a> SurfaceFragmentSink<'a> {
             | ParameterOp::RemovePrefixLong { pattern }
             | ParameterOp::RemoveSuffixShort { pattern }
             | ParameterOp::RemoveSuffixLong { pattern } => {
+                self.record_parameter_pattern(pattern.span);
                 self.collect_pattern(pattern, context.with_pattern_charclass_scan())
             }
             ParameterOp::ReplaceFirst {
@@ -879,6 +893,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 replacement,
                 ..
             } => {
+                self.record_parameter_pattern(pattern.span);
                 self.collect_pattern(pattern, context.with_pattern_charclass_scan());
                 self.collect_fragment_word(
                     operator.replacement_word_ast(),

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -22,15 +22,20 @@ pub fn escaped_underscore(checker: &mut Checker) {
         .filter(|escape| match escape.source_kind() {
             EscapeScanSourceKind::WordLiteralPart
             | EscapeScanSourceKind::RedirectLiteralSegment => {
-                !escape.host_contains_single_quoted_fragment()
+                !escape.inside_single_quoted_fragment()
             }
             EscapeScanSourceKind::DynamicPathCommandName
             | EscapeScanSourceKind::PatternLiteral
             | EscapeScanSourceKind::PatternCharClass => true,
+            EscapeScanSourceKind::ParameterPatternCharClass => false,
             EscapeScanSourceKind::SingleLiteralAssignmentWord
             | EscapeScanSourceKind::BacktickFragment => false,
         })
-        .filter(|escape| !escape.is_grep_style_argument())
+        .filter(|escape| {
+            !escape.is_grep_style_argument()
+                && !(escape.is_tr_operand_argument()
+                    && matches!(escape.escaped_byte(), b'.' | b'*' | b'?'))
+        })
         .filter(|escape| match escape.source_kind() {
             EscapeScanSourceKind::PatternCharClass => escape.escaped_byte() == b'-',
             _ => is_regular_plain_word_escape_target(escape.escaped_byte()),
@@ -46,6 +51,7 @@ fn is_regular_plain_word_escape_target(byte: u8) -> bool {
         byte,
         b' ' | b'\t'
             | b'\n'
+            | b'.'
             | b'@'
             | b'#'
             | b'$'
@@ -186,5 +192,63 @@ grep foo\\_bar file
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn keeps_tr_operands_out_of_the_sc1001_family() {
+        let source = "\
+#!/bin/bash
+srcnam=$(tr \\. _ <<<${PRGNAM#python3-*})
+src_ver=$(echo $VERSION | tr -d \\.)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_parameter_expansion_char_classes() {
+        let source = "\
+#!/bin/bash
+name=\"${name//[^a-zA-Z0-9_\\-]/}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_literal_dot_escapes() {
+        let source = "\
+#!/bin/bash
+echo foo\\.bar
+echo gem5-$gem5_isa\\.$VARIANT
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_escapes_adjacent_to_expansions() {
+        let source = "\
+#!/bin/bash
+echo $VERSION\\_$(echo x)
+echo ${host}\\:443
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
+
+        assert_eq!(diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn reports_escapes_outside_single_quoted_fragments() {
+        let source = "\
+#!/bin/bash
+echo 'prefix'\\:suffix
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EscapedUnderscore));
+
+        assert_eq!(diagnostics.len(), 1);
     }
 }

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -32,8 +32,8 @@ pub fn escaped_underscore(checker: &mut Checker) {
             | EscapeScanSourceKind::BacktickFragment => false,
         })
         .filter(|escape| {
-            !escape.is_grep_style_argument()
-                && !(escape.is_tr_operand_argument()
+            !(escape.is_grep_style_argument()
+                || escape.is_tr_operand_argument()
                     && matches!(escape.escaped_byte(), b'.' | b'*' | b'?'))
         })
         .filter(|escape| match escape.source_kind() {

--- a/crates/shuck-linter/src/rules/style/literal_control_escape.rs
+++ b/crates/shuck-linter/src/rules/style/literal_control_escape.rs
@@ -27,6 +27,7 @@ pub fn literal_control_escape(checker: &mut Checker) {
                     | EscapeScanSourceKind::DynamicPathCommandName
                     | EscapeScanSourceKind::PatternLiteral
                     | EscapeScanSourceKind::PatternCharClass
+                    | EscapeScanSourceKind::ParameterPatternCharClass
                     | EscapeScanSourceKind::SingleLiteralAssignmentWord
                     | EscapeScanSourceKind::BacktickFragment
             )
@@ -100,5 +101,19 @@ fi
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_control_escapes_in_parameter_pattern_char_classes() {
+        let source = "\
+#!/bin/bash
+name=\"${name//[a\\t]/x}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralControlEscape),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- refine S023 escape scanning so `tr` operands and parameter-expansion char classes are classified separately from ordinary plain words
- report escapes only when they are actually outside single-quoted fragments, and stop flagging literal dot escapes that ShellCheck treats as intentional
- add regression coverage for mixed-quote boundaries, expansion-adjacent escapes, `tr` operands, parameter patterns, and dot escapes

## Root cause
S023 was treating several utility operands and pattern contexts as generic plain words. That produced false positives in cases like `tr \\. _`, `find -name \\*.po`, and parameter-expansion character classes. At the same time, the single-quote suppression logic operated at the host-word level, so mixed-quote words could hide escapes that still lived outside the quoted fragment.

## Impact
This brings S023 back into line with the ShellCheck oracle across the targeted large corpus run while keeping the rule architecture fact-driven.

## Validation
- `cargo test -p shuck-linter escaped_underscore -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S023`