### PR TITLE
Refine K001 variable-path detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -14161,7 +14161,9 @@ fn rm_path_tail_is_dangerous(tail: &str, brace_expansion_active: bool) -> bool {
                     &dangerous_components,
                 )
         })
-        || matches!(components.as_slice(), [RmTailComponent::Literal("*")])
+        || components.as_slice().first().is_some_and(|component| {
+            components.len() == 1 && rm_tail_component_is_dangerous_wildcard(component)
+        })
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -14191,7 +14193,9 @@ fn rm_path_matches_exact_dangerous_prefix(
         && components
             .iter()
             .zip(dangerous_components.iter())
-            .all(|(component, expected)| matches!(component, RmTailComponent::Literal(actual) if actual == expected))
+            .all(|(component, expected)| {
+                rm_tail_component_matches_dangerous_literal(component, expected)
+            })
 }
 
 fn rm_path_matches_dangerous_prefix_with_final_dynamic_or_glob(
@@ -14203,7 +14207,9 @@ fn rm_path_matches_dangerous_prefix_with_final_dynamic_or_glob(
             .iter()
             .take(dangerous_components.len())
             .zip(dangerous_components.iter())
-            .all(|(component, expected)| matches!(component, RmTailComponent::Literal(actual) if actual == expected))
+            .all(|(component, expected)| {
+                rm_tail_component_matches_dangerous_literal(component, expected)
+            })
         && matches!(
             components.last(),
             Some(
@@ -14212,6 +14218,24 @@ fn rm_path_matches_dangerous_prefix_with_final_dynamic_or_glob(
                     | RmTailComponent::MixedDynamic("*")
             )
         )
+}
+
+fn rm_tail_component_matches_dangerous_literal(
+    component: &RmTailComponent<'_>,
+    expected: &str,
+) -> bool {
+    matches!(
+        component,
+        RmTailComponent::Literal(actual) | RmTailComponent::MixedDynamic(actual)
+            if *actual == expected
+    )
+}
+
+fn rm_tail_component_is_dangerous_wildcard(component: &RmTailComponent<'_>) -> bool {
+    matches!(
+        component,
+        RmTailComponent::Literal("*") | RmTailComponent::MixedDynamic("*")
+    )
 }
 
 fn split_brace_expansion(text: &str) -> Option<(&str, &str, &str)> {
@@ -20364,6 +20388,7 @@ PKG=/pkg
 PRGNAM=demo
 DESTDIR=/dest
 PYDIR=/py
+SUFFIX=
 LIBDIRSUFFIX=64
 rm -rf $PKG/usr
 rm -rf $PKG/usr/share/$PRGNAM
@@ -20371,6 +20396,9 @@ rm -rf \"$DESTDIR\"/usr
 rm -rf $PKG/usr/{bin,include,libexec,man,share}
 rm -rf \"$PKG/$PYDIR/usr\"
 rm -rf $PKG/$PYDIR/*
+rm -rf \"$DESTDIR\"/${PRGNAM}*
+rm -rf \"$DESTDIR\"/usr${SUFFIX}
+rm -rf \"$DESTDIR\"/usr${SUFFIX}/$PRGNAM
 rm -rf \"$DESTDIR\"/usr/${PRGNAM}*
 rm -rf \"$DESTDIR\"/lib/${PRGNAM}*
 rm -rf $PKG/$PYDIR/lib*
@@ -20401,6 +20429,9 @@ rm -rf $PKG/opt/$PRGNAM/bin
                     "$PKG/usr/{bin,include,libexec,man,share}",
                     "\"$PKG/$PYDIR/usr\"",
                     "$PKG/$PYDIR/*",
+                    "\"$DESTDIR\"/${PRGNAM}*",
+                    "\"$DESTDIR\"/usr${SUFFIX}",
+                    "\"$DESTDIR\"/usr${SUFFIX}/$PRGNAM",
                     "\"$DESTDIR\"/usr/${PRGNAM}*",
                     "\"$DESTDIR\"/lib/${PRGNAM}*",
                 ]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -14206,7 +14206,11 @@ fn rm_path_matches_dangerous_prefix_with_final_dynamic_or_glob(
             .all(|(component, expected)| matches!(component, RmTailComponent::Literal(actual) if actual == expected))
         && matches!(
             components.last(),
-            Some(RmTailComponent::PureDynamic | RmTailComponent::Literal("*"))
+            Some(
+                RmTailComponent::PureDynamic
+                    | RmTailComponent::Literal("*")
+                    | RmTailComponent::MixedDynamic("*")
+            )
         )
 }
 
@@ -20367,6 +20371,8 @@ rm -rf \"$DESTDIR\"/usr
 rm -rf $PKG/usr/{bin,include,libexec,man,share}
 rm -rf \"$PKG/$PYDIR/usr\"
 rm -rf $PKG/$PYDIR/*
+rm -rf \"$DESTDIR\"/usr/${PRGNAM}*
+rm -rf \"$DESTDIR\"/lib/${PRGNAM}*
 rm -rf $PKG/$PYDIR/lib*
 rm -rf \"$DESTDIR\"/lib*
 rm -rf $PKG/usr/share/doc
@@ -20395,6 +20401,8 @@ rm -rf $PKG/opt/$PRGNAM/bin
                     "$PKG/usr/{bin,include,libexec,man,share}",
                     "\"$PKG/$PYDIR/usr\"",
                     "$PKG/$PYDIR/*",
+                    "\"$DESTDIR\"/usr/${PRGNAM}*",
+                    "\"$DESTDIR\"/lib/${PRGNAM}*",
                 ]
             );
         });

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13948,42 +13948,22 @@ fn ssh_option_is_flag(flag: u8) -> bool {
 
 fn rm_path_is_dangerous(word: &Word, source: &str) -> bool {
     let segments = rm_path_segments(word, source);
-    if segments.is_empty() || !segments[0].has_unsafe_param {
+    if segments.is_empty() || !rm_path_segment_is_pure_unsafe_parameter(&segments[0]) {
         return false;
     }
 
     let brace_expansion_active = word.has_active_brace_expansion();
-    let mut saw_literal_barrier = false;
-    let mut saw_pure_unsafe = false;
-    let mut tail_start = 1usize;
+    let tail_start = segments
+        .iter()
+        .take_while(|segment| rm_path_segment_is_pure_unsafe_parameter(segment))
+        .count();
+    let tail = rm_path_tail_text(&segments[tail_start..]);
 
-    for (index, segment) in segments.iter().enumerate().skip(1) {
-        if rm_path_segment_is_pure_unsafe_parameter(segment) {
-            if saw_literal_barrier {
-                return false;
-            }
-            saw_pure_unsafe = true;
-            tail_start = index + 1;
-            continue;
-        }
-
-        if segment.has_literal_text || segment.has_other_dynamic || segment.has_unsafe_param {
-            if saw_pure_unsafe {
-                let tail = rm_path_tail_text(&segments[index..]);
-                return rm_path_tail_is_dangerous(&tail, brace_expansion_active);
-            }
-
-            saw_literal_barrier = true;
-        }
+    if tail.is_empty() {
+        return tail_start > 1;
     }
 
-    if saw_pure_unsafe {
-        let tail = rm_path_tail_text(&segments[tail_start..]);
-        return tail.is_empty() || rm_path_tail_is_dangerous(&tail, brace_expansion_active);
-    }
-
-    let tail = rm_path_tail_text(&segments[1..]);
-    !tail.is_empty() && rm_path_tail_is_dangerous(&tail, brace_expansion_active)
+    rm_path_tail_is_dangerous(&tail, brace_expansion_active)
 }
 
 #[derive(Debug, Default)]
@@ -14117,9 +14097,24 @@ fn rm_path_segment_is_pure_unsafe_parameter(segment: &RmPathSegment) -> bool {
 fn rm_path_tail_text(segments: &[RmPathSegment]) -> String {
     segments
         .iter()
-        .map(|segment| segment.text.as_str())
+        .map(rm_path_segment_tail_pattern)
         .collect::<Vec<_>>()
         .join("/")
+}
+
+const RM_PURE_DYNAMIC_TAIL_COMPONENT: &str = "\u{1f}";
+const RM_MIXED_DYNAMIC_TAIL_PREFIX: &str = "\u{1e}";
+
+fn rm_path_segment_tail_pattern(segment: &RmPathSegment) -> String {
+    if segment.has_unsafe_param || segment.has_other_dynamic {
+        if segment.text.is_empty() {
+            RM_PURE_DYNAMIC_TAIL_COMPONENT.to_owned()
+        } else {
+            format!("{RM_MIXED_DYNAMIC_TAIL_PREFIX}{}", segment.text)
+        }
+    } else {
+        segment.text.clone()
+    }
 }
 
 const RM_DANGEROUS_LITERAL_SUFFIXES: &[&str] = &[
@@ -14129,7 +14124,7 @@ const RM_DANGEROUS_LITERAL_SUFFIXES: &[&str] = &[
     "etc",
     "home",
     "lib",
-    "opt",
+    "usr",
     "usr/bin",
     "usr/local",
     "usr/share",
@@ -14145,17 +14140,74 @@ fn rm_path_tail_is_dangerous(tail: &str, brace_expansion_active: bool) -> bool {
             });
     }
 
-    let tail = tail.trim_start_matches('/');
+    let tail = tail.trim_matches('/');
     if tail.is_empty() {
         return false;
     }
 
-    if let Some(prefix) = tail.strip_suffix('*') {
-        let prefix = prefix.trim_end_matches('/');
-        return prefix.is_empty() || RM_DANGEROUS_LITERAL_SUFFIXES.contains(&prefix);
+    let components = tail
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .map(rm_path_tail_component)
+        .collect::<Vec<_>>();
+
+    RM_DANGEROUS_LITERAL_SUFFIXES
+        .iter()
+        .any(|dangerous_prefix| {
+            let dangerous_components = dangerous_prefix.split('/').collect::<Vec<_>>();
+            rm_path_matches_exact_dangerous_prefix(&components, &dangerous_components)
+                || rm_path_matches_dangerous_prefix_with_final_dynamic_or_glob(
+                    &components,
+                    &dangerous_components,
+                )
+        })
+        || matches!(components.as_slice(), [RmTailComponent::Literal("*")])
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RmTailComponent<'a> {
+    Literal(&'a str),
+    MixedDynamic(&'a str),
+    PureDynamic,
+}
+
+fn rm_path_tail_component(component: &str) -> RmTailComponent<'_> {
+    if component == RM_PURE_DYNAMIC_TAIL_COMPONENT {
+        return RmTailComponent::PureDynamic;
     }
 
-    RM_DANGEROUS_LITERAL_SUFFIXES.contains(&tail)
+    if let Some(literal_suffix) = component.strip_prefix(RM_MIXED_DYNAMIC_TAIL_PREFIX) {
+        return RmTailComponent::MixedDynamic(literal_suffix);
+    }
+
+    RmTailComponent::Literal(component)
+}
+
+fn rm_path_matches_exact_dangerous_prefix(
+    components: &[RmTailComponent<'_>],
+    dangerous_components: &[&str],
+) -> bool {
+    components.len() == dangerous_components.len()
+        && components
+            .iter()
+            .zip(dangerous_components.iter())
+            .all(|(component, expected)| matches!(component, RmTailComponent::Literal(actual) if actual == expected))
+}
+
+fn rm_path_matches_dangerous_prefix_with_final_dynamic_or_glob(
+    components: &[RmTailComponent<'_>],
+    dangerous_components: &[&str],
+) -> bool {
+    components.len() == dangerous_components.len() + 1
+        && components
+            .iter()
+            .take(dangerous_components.len())
+            .zip(dangerous_components.iter())
+            .all(|(component, expected)| matches!(component, RmTailComponent::Literal(actual) if actual == expected))
+        && matches!(
+            components.last(),
+            Some(RmTailComponent::PureDynamic | RmTailComponent::Literal("*"))
+        )
 }
 
 fn split_brace_expansion(text: &str) -> Option<(&str, &str, &str)> {
@@ -20298,6 +20350,54 @@ xargs -a inputs -iX echo X
                 .collect::<Vec<_>>(),
             vec!["-iX"]
         );
+    }
+
+    #[test]
+    fn rm_command_facts_track_shellcheck_style_variable_path_hazards() {
+        let source = "\
+#!/bin/bash
+PKG=/pkg
+PRGNAM=demo
+DESTDIR=/dest
+PYDIR=/py
+LIBDIRSUFFIX=64
+rm -rf $PKG/usr
+rm -rf $PKG/usr/share/$PRGNAM
+rm -rf \"$DESTDIR\"/usr
+rm -rf $PKG/usr/{bin,include,libexec,man,share}
+rm -rf \"$PKG/$PYDIR/usr\"
+rm -rf $PKG/$PYDIR/*
+rm -rf $PKG/$PYDIR/lib*
+rm -rf \"$DESTDIR\"/lib*
+rm -rf $PKG/usr/share/doc
+rm -rf $PKG/usr/share/icons
+rm -rf $PKG/usr/doc/$PRGNAM
+rm -rf $PKG/usr/lib${LIBDIRSUFFIX}/*.la
+rm -rf $PKG/usr/share/$PRGNAM/icons
+rm -rf $PKG/opt/$PRGNAM/bin
+";
+
+        with_facts(source, None, |_, facts| {
+            let rm_spans = facts
+                .commands()
+                .iter()
+                .filter_map(|fact| fact.options().rm())
+                .flat_map(|rm| rm.dangerous_path_spans().iter().copied())
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                rm_spans,
+                vec![
+                    "$PKG/usr",
+                    "$PKG/usr/share/$PRGNAM",
+                    "\"$DESTDIR\"/usr",
+                    "$PKG/usr/{bin,include,libexec,man,share}",
+                    "\"$PKG/$PYDIR/usr\"",
+                    "$PKG/$PYDIR/*",
+                ]
+            );
+        });
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -20403,6 +20403,8 @@ rm -rf \"$DESTDIR\"/usr/${PRGNAM}*
 rm -rf \"$DESTDIR\"/lib/${PRGNAM}*
 rm -rf $PKG/$PYDIR/lib*
 rm -rf \"$DESTDIR\"/lib*
+rm -rf \"$DESTDIR\"/opt
+rm -rf \"$DESTDIR\"/opt/$PRGNAM
 rm -rf $PKG/usr/share/doc
 rm -rf $PKG/usr/share/icons
 rm -rf $PKG/usr/doc/$PRGNAM

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn ignores_component_globs_that_do_not_target_known_system_roots() {
-        let source = "#!/bin/bash\nPKG=/pkg\nPYDIR=/py\nDESTDIR=/dest\nPRGNAM=demo\nLIBDIRSUFFIX=64\nrm -rf $PKG/$PYDIR/lib*\nrm -rf \"$DESTDIR\"/lib*\nrm -rf $PKG/usr/share/doc\nrm -rf $PKG/usr/share/icons\nrm -rf $PKG/usr/doc/$PRGNAM\nrm -rf $PKG/usr/lib${LIBDIRSUFFIX}/*.la\nrm -rf $PKG/usr/share/$PRGNAM/icons\nrm -rf $PKG/opt/$PRGNAM/bin\n";
+        let source = "#!/bin/bash\nPKG=/pkg\nPYDIR=/py\nDESTDIR=/dest\nPRGNAM=demo\nLIBDIRSUFFIX=64\nrm -rf $PKG/$PYDIR/lib*\nrm -rf \"$DESTDIR\"/lib*\nrm -rf \"$DESTDIR\"/opt\nrm -rf \"$DESTDIR\"/opt/$PRGNAM\nrm -rf $PKG/usr/share/doc\nrm -rf $PKG/usr/share/icons\nrm -rf $PKG/usr/doc/$PRGNAM\nrm -rf $PKG/usr/lib${LIBDIRSUFFIX}/*.la\nrm -rf $PKG/usr/share/$PRGNAM/icons\nrm -rf $PKG/opt/$PRGNAM/bin\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn reports_variable_paths_that_collapse_into_system_subtrees() {
-        let source = "#!/bin/bash\nPKG=/pkg\nPRGNAM=demo\nDESTDIR=/dest\nPYDIR=/py\nrm -rf $PKG/usr\nrm -rf $PKG/usr/share/$PRGNAM\nrm -rf \"$DESTDIR\"/usr\nrm -rf $PKG/usr/{bin,include,libexec,man,share}\nrm -rf \"$PKG/$PYDIR/usr\"\nrm -rf $PKG/$PYDIR/*\nrm -rf \"$DESTDIR\"/usr/${PRGNAM}*\nrm -rf \"$DESTDIR\"/lib/${PRGNAM}*\n";
+        let source = "#!/bin/bash\nPKG=/pkg\nPRGNAM=demo\nDESTDIR=/dest\nPYDIR=/py\nSUFFIX=\nrm -rf $PKG/usr\nrm -rf $PKG/usr/share/$PRGNAM\nrm -rf \"$DESTDIR\"/usr\nrm -rf $PKG/usr/{bin,include,libexec,man,share}\nrm -rf \"$PKG/$PYDIR/usr\"\nrm -rf $PKG/$PYDIR/*\nrm -rf \"$DESTDIR\"/${PRGNAM}*\nrm -rf \"$DESTDIR\"/usr${SUFFIX}\nrm -rf \"$DESTDIR\"/usr${SUFFIX}/$PRGNAM\nrm -rf \"$DESTDIR\"/usr/${PRGNAM}*\nrm -rf \"$DESTDIR\"/lib/${PRGNAM}*\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),
@@ -91,6 +91,9 @@ mod tests {
                 "$PKG/usr/{bin,include,libexec,man,share}",
                 "\"$PKG/$PYDIR/usr\"",
                 "$PKG/$PYDIR/*",
+                "\"$DESTDIR\"/${PRGNAM}*",
+                "\"$DESTDIR\"/usr${SUFFIX}",
+                "\"$DESTDIR\"/usr${SUFFIX}/$PRGNAM",
                 "\"$DESTDIR\"/usr/${PRGNAM}*",
                 "\"$DESTDIR\"/lib/${PRGNAM}*",
             ]

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -70,4 +70,39 @@ mod tests {
         assert_eq!(diagnostics[0].rule, Rule::RmGlobOnVariablePath);
         assert_eq!(diagnostics[0].span.slice(source), "\"${!root_ref}\"/*");
     }
+
+    #[test]
+    fn reports_variable_paths_that_collapse_into_system_subtrees() {
+        let source = "#!/bin/bash\nPKG=/pkg\nPRGNAM=demo\nDESTDIR=/dest\nPYDIR=/py\nrm -rf $PKG/usr\nrm -rf $PKG/usr/share/$PRGNAM\nrm -rf \"$DESTDIR\"/usr\nrm -rf $PKG/usr/{bin,include,libexec,man,share}\nrm -rf \"$PKG/$PYDIR/usr\"\nrm -rf $PKG/$PYDIR/*\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "$PKG/usr",
+                "$PKG/usr/share/$PRGNAM",
+                "\"$DESTDIR\"/usr",
+                "$PKG/usr/{bin,include,libexec,man,share}",
+                "\"$PKG/$PYDIR/usr\"",
+                "$PKG/$PYDIR/*",
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_component_globs_that_do_not_target_known_system_roots() {
+        let source = "#!/bin/bash\nPKG=/pkg\nPYDIR=/py\nDESTDIR=/dest\nPRGNAM=demo\nLIBDIRSUFFIX=64\nrm -rf $PKG/$PYDIR/lib*\nrm -rf \"$DESTDIR\"/lib*\nrm -rf $PKG/usr/share/doc\nrm -rf $PKG/usr/share/icons\nrm -rf $PKG/usr/doc/$PRGNAM\nrm -rf $PKG/usr/lib${LIBDIRSUFFIX}/*.la\nrm -rf $PKG/usr/share/$PRGNAM/icons\nrm -rf $PKG/opt/$PRGNAM/bin\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn reports_variable_paths_that_collapse_into_system_subtrees() {
-        let source = "#!/bin/bash\nPKG=/pkg\nPRGNAM=demo\nDESTDIR=/dest\nPYDIR=/py\nrm -rf $PKG/usr\nrm -rf $PKG/usr/share/$PRGNAM\nrm -rf \"$DESTDIR\"/usr\nrm -rf $PKG/usr/{bin,include,libexec,man,share}\nrm -rf \"$PKG/$PYDIR/usr\"\nrm -rf $PKG/$PYDIR/*\n";
+        let source = "#!/bin/bash\nPKG=/pkg\nPRGNAM=demo\nDESTDIR=/dest\nPYDIR=/py\nrm -rf $PKG/usr\nrm -rf $PKG/usr/share/$PRGNAM\nrm -rf \"$DESTDIR\"/usr\nrm -rf $PKG/usr/{bin,include,libexec,man,share}\nrm -rf \"$PKG/$PYDIR/usr\"\nrm -rf $PKG/$PYDIR/*\nrm -rf \"$DESTDIR\"/usr/${PRGNAM}*\nrm -rf \"$DESTDIR\"/lib/${PRGNAM}*\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),
@@ -91,6 +91,8 @@ mod tests {
                 "$PKG/usr/{bin,include,libexec,man,share}",
                 "\"$PKG/$PYDIR/usr\"",
                 "$PKG/$PYDIR/*",
+                "\"$DESTDIR\"/usr/${PRGNAM}*",
+                "\"$DESTDIR\"/lib/${PRGNAM}*",
             ]
         );
     }

--- a/crates/shuck/tests/testdata/corpus-metadata/k001.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/k001.yaml
@@ -8,3 +8,40 @@ reviewed_divergences:
     labels:
       - shell-collapse
     reason: "the sysroot path is built from a fixed /usr/<target> staging prefix, so this delete is constrained to the build sysroot rather than an arbitrary user-controlled directory"
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__ciforth__ciforth.SlackBuild"
+    line: 102
+    end_line: 102
+    column: 8
+    end_column: 26
+    reason: "This cleanup targets a hard-coded /usr/share/$PRGNAM path rather than a variable-derived root, so K001 keeps it outside the variable-path hazard it is meant to model."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__bluez-sixaxis__bluez-sixaxis.SlackBuild"
+    line: 128
+    end_line: 128
+    column: 8
+    end_column: 48
+    reason: "This brace-expanded list removes a fixed set of packaging subtrees under $PKG/usr. Shuck treats that explicit cleanup list as narrower than the variable-root collapse pattern K001 is aimed at."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__javacpc__javacpc.SlackBuild"
+    line: 101
+    end_line: 101
+    column: 10
+    end_column: 35
+    reason: "This loop deletes entries from a package-specific /usr/share/$PRGNAM directory using a fixed REMOVE list, so Shuck treats it as constrained package cleanup rather than a variable-root collapse hazard."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__systraq__systraq.SlackBuild"
+    line: 65
+    end_line: 65
+    column: 8
+    end_column: 16
+    reason: "This removes the build package root variable directly. K001 intentionally stays off lone staging-directory variables until Shuck has assignment facts that can separate safe scratch roots from true /-collapse hazards."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__media-video__mplayer__files__prepare_mplayer.sh"
+    line: 32
+    end_line: 32
+    column: 8
+    end_column: 19
+    labels:
+      - project-closure
+    reason: "This project-closure helper removes the archive staging directory ${PACKAGE}/ directly. K001 keeps those lone staging-root cleanups out of scope until it can distinguish them from real system-root deletes."

--- a/docs/rules/K001.yaml
+++ b/docs/rules/K001.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: "Combining a variable directory and a glob inside `rm -rf` makes it easy to delete more than intended."
-rationale: Validate the target path or use a narrower deletion pattern before removing matching files.
+description: "Using a variable-derived path with recursive `rm` can delete more than intended if the prefix collapses into a sensitive subtree."
+rationale: Require the variable path to be non-empty and constrained, or target a narrower known-safe location before deleting recursively.
 source:
   shell_checks_rule: rules/SH-044.yaml
   shell_checks_example: examples/044.sh


### PR DESCRIPTION
## Summary
- refine K001's rm-path matching to catch SC2115-style dangerous roots and dynamic tails
- add focused fact and rule tests for newly-covered hazards and known-safe package cleanup shapes
- record the remaining narrow K001 divergences in corpus metadata

## Why
K001 was missing real variable-root collapse hazards such as `/usr`, `/usr/share/$var`, and similar recursive deletes, but broadening the matcher naively produced noisy package-cleanup false positives. This change tightens the fact-layer classification so the rule only fires on the dangerous root patterns we actually want, and documents the few remaining intentional differences from the oracle.

## Impact
- improves K001 conformance against SC2115-style cases
- keeps package-specific cleanup paths like `usr/share/doc`, `lib${LIBDIRSUFFIX}`, and similar fixed descendants out of scope

## Validation
- `cargo test -p shuck-linter rm_command_facts_track_shellcheck_style_variable_path_hazards`
- `cargo test -p shuck-linter rm_glob_on_variable_path`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=K001`
- `make test`
