### PR TITLE
Fix C003 source classification

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C002.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C002.sh
@@ -8,6 +8,9 @@ lib=./lib.sh
 # Invalid: a variable plus a static suffix is still dynamic.
 . "$lib".generated
 
+# Invalid: a current-user home shortcut still expands at runtime.
+. ~/.bashrc
+
 # Valid: literal paths are analyzable.
 . "./lib.sh"
 

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C003.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C003.sh
@@ -10,6 +10,9 @@
 # Invalid: a quoted current-user tilde stays literal, so this is still C003.
 . "~/.bashrc"
 
+# Invalid: an escaped current-user tilde also stays literal.
+. \~/.bashrc
+
 # Valid: a helper that exists next to the script is available to the analysis.
 . ./c003_helper.sh
 

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C003.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C003.sh
@@ -7,6 +7,9 @@
 # shellcheck source=missing-directed.sh
 . "$generated_helper"
 
+# Invalid: a quoted current-user tilde stays literal, so this is still C003.
+. "~/.bashrc"
+
 # Valid: a helper that exists next to the script is available to the analysis.
 . ./c003_helper.sh
 

--- a/crates/shuck-linter/src/rules/correctness/dynamic_source_path.rs
+++ b/crates/shuck-linter/src/rules/correctness/dynamic_source_path.rs
@@ -1,4 +1,4 @@
-use shuck_semantic::SourceRefKind;
+use shuck_semantic::{SourceRefDiagnosticClass, SourceRefKind};
 
 use crate::{Checker, Rule, Violation};
 
@@ -16,9 +16,12 @@ impl Violation for DynamicSourcePath {
 
 pub fn dynamic_source_path(checker: &mut Checker) {
     for source_ref in checker.semantic().source_refs() {
+        if matches!(source_ref.kind, SourceRefKind::DirectiveDevNull) {
+            continue;
+        }
         if matches!(
-            source_ref.kind,
-            SourceRefKind::Dynamic | SourceRefKind::SingleVariableStaticTail { .. }
+            source_ref.diagnostic_class,
+            SourceRefDiagnosticClass::DynamicPath
         ) {
             checker.report(DynamicSourcePath, source_ref.path_span);
         }

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C002_C002.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C002_C002.sh.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 286
 ---
 C002 source path is built at runtime
  --> <source>:6:3
@@ -12,3 +13,9 @@ C002 source path is built at runtime
   |
 9 | . "$lib".generated
   |
+
+C002 source path is built at runtime
+  --> <source>:12:3
+   |
+12 | . ~/.bashrc
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C003_C003.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C003_C003.sh.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 76
 ---
 C003 sourced file is not available to this analysis
  --> <source>:4:3
@@ -13,3 +12,9 @@ C003 sourced file is not available to this analysis
   |
 8 | . "$generated_helper"
   |
+
+C003 sourced file is not available to this analysis
+  --> <source>:11:3
+   |
+11 | . "~/.bashrc"
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C003_C003.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C003_C003.sh.snap
@@ -18,3 +18,9 @@ C003 sourced file is not available to this analysis
    |
 11 | . "~/.bashrc"
    |
+
+C003 sourced file is not available to this analysis
+  --> <source>:14:3
+   |
+14 | . \~/.bashrc
+   |

--- a/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
+++ b/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
@@ -1,4 +1,4 @@
-use shuck_semantic::{SourceRefKind, SourceRefResolution};
+use shuck_semantic::{SourceRefDiagnosticClass, SourceRefKind};
 
 use crate::{Checker, Rule, Violation};
 
@@ -20,18 +20,15 @@ pub fn untracked_source_file(checker: &mut Checker) {
             continue;
         }
 
-        let report = match (&source_ref.kind, source_ref.resolution) {
-            (SourceRefKind::DirectiveDevNull, _) => false,
-            (_, SourceRefResolution::Resolved) => true,
-            (SourceRefKind::Literal(_) | SourceRefKind::Directive(_), _) => true,
-            _ => false,
-        };
-
-        if !report {
+        if matches!(source_ref.kind, SourceRefKind::DirectiveDevNull) {
             continue;
         }
-
-        checker.report(UntrackedSourceFile, source_ref.path_span);
+        if matches!(
+            source_ref.diagnostic_class,
+            SourceRefDiagnosticClass::UntrackedFile
+        ) {
+            checker.report(UntrackedSourceFile, source_ref.path_span);
+        }
     }
 }
 
@@ -109,6 +106,156 @@ mod tests {
             &main,
             source,
             &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_current_user_tilde_sources_that_belong_to_c002() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "#!/bin/sh\n. ~/.bashrc\n";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_single_variable_path_tail_without_a_resolver() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "#!/bin/sh\n. \"$CRASHDIR/starts/start_legacy.sh\"\n";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"$CRASHDIR/starts/start_legacy.sh\""
+        );
+    }
+
+    #[test]
+    fn reports_bash_source_dir_templates_that_belong_to_c003() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "#!/bin/bash\n. \"$(dirname \"${BASH_SOURCE[0]}\")/helper.sh\"\n";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"$(dirname \"${BASH_SOURCE[0]}\")/helper.sh\""
+        );
+    }
+
+    #[test]
+    fn reports_parameter_expansion_roots_with_static_path_tails() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "#!/bin/sh\n. ${BUILD_ROOT}/sh/functions.sh\n";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "${BUILD_ROOT}/sh/functions.sh"
+        );
+    }
+
+    #[test]
+    fn reports_negated_parameter_expansion_roots_with_static_path_tails() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "\
+#!/bin/sh
+if [ ! -f ${BUILD_ROOT}/sh/functions.sh ]; then
+  exit 1
+elif ! . ${BUILD_ROOT}/sh/functions.sh; then
+  exit 1
+fi
+";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "${BUILD_ROOT}/sh/functions.sh"
+        );
+    }
+
+    #[test]
+    fn ignores_single_variable_leaf_tail_that_belongs_to_c002() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "#!/bin/sh\n. \"$helper\".generated\n";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_resolved_multi_dynamic_templates_that_belong_to_c002() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("tests/main.sh");
+        let helper = temp.path().join("src/helper.sh");
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::create_dir_all(helper.parent().unwrap()).unwrap();
+        let source = "#!/bin/sh\nload() { . \"$ROOT/src/$1\"; }\nload helper.sh\n";
+        fs::write(&main, source).unwrap();
+        fs::write(&helper, "echo helper\n").unwrap();
+
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+
+        let main_path = main.clone();
+        let helper_path = helper.clone();
+        let resolver = move |source_path: &Path, _candidate: &str| {
+            if source_path == main_path.as_path() {
+                vec![helper_path.clone()]
+            } else {
+                Vec::new()
+            }
+        };
+
+        let diagnostics = lint_file_at_path_with_resolver(
+            &output.file,
+            source,
+            &indexer,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+            None,
+            Some(&main),
+            Some(&resolver),
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");

--- a/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
+++ b/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
@@ -143,6 +143,22 @@ mod tests {
     }
 
     #[test]
+    fn reports_escaped_current_user_tilde_sources_as_untracked_files() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "#!/bin/sh\n. \\~/.bashrc\n";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "\\~/.bashrc");
+    }
+
+    #[test]
     fn reports_single_variable_path_tail_without_a_resolver() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
+++ b/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
@@ -127,6 +127,22 @@ mod tests {
     }
 
     #[test]
+    fn reports_quoted_current_user_tilde_sources_as_untracked_files() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "#!/bin/sh\n. \"~/.bashrc\"\n";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "\"~/.bashrc\"");
+    }
+
+    #[test]
     fn reports_single_variable_path_tail_without_a_resolver() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
+++ b/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
@@ -216,6 +216,25 @@ mod tests {
     }
 
     #[test]
+    fn reports_quoted_parameter_expansion_roots_with_static_path_tails() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "#!/bin/sh\n. \"${BUILD_ROOT}/sh/functions.sh\"\n";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"${BUILD_ROOT}/sh/functions.sh\""
+        );
+    }
+
+    #[test]
     fn reports_negated_parameter_expansion_roots_with_static_path_tails() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -3415,10 +3415,33 @@ fn classify_source_ref_diagnostic_class(
     kind: &SourceRefKind,
 ) -> SourceRefDiagnosticClass {
     match kind {
+        SourceRefKind::Literal(path) if literal_uses_current_user_home_tilde(word, source, path) => {
+            SourceRefDiagnosticClass::DynamicPath
+        }
         SourceRefKind::Dynamic if dynamic_root_with_slash_tail(word, source) => {
             SourceRefDiagnosticClass::UntrackedFile
         }
         _ => default_diagnostic_class(kind),
+    }
+}
+
+fn literal_uses_current_user_home_tilde(word: &Word, source: &str, path: &str) -> bool {
+    if !path.starts_with("~/") {
+        return false;
+    }
+
+    let Some((first, tail)) = word.parts.split_first() else {
+        return false;
+    };
+
+    match &first.kind {
+        WordPart::Literal(text) => {
+            let text = text.as_str(source, first.span);
+            text.starts_with("~/")
+                || (text == "~"
+                    && static_parts_text(tail, source).is_some_and(|tail| tail.starts_with('/')))
+        }
+        _ => false,
     }
 }
 

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -26,7 +26,10 @@ use crate::declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 use crate::reference::{Reference, ReferenceKind};
 use crate::runtime::RuntimePrelude;
 use crate::source_closure::source_path_template;
-use crate::source_ref::{SourceRef, SourceRefKind, SourceRefResolution};
+use crate::source_ref::{
+    SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution,
+    default_diagnostic_class,
+};
 use crate::{
     BindingId, FunctionScopeKind, IndirectTargetHint, ReferenceId, Scope, ScopeId, ScopeKind,
     SourceDirectiveOverride, SpanKey, TraversalObserver,
@@ -2251,9 +2254,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
             "source" | "." => {
                 if let Some(argument) = command.args.first() {
+                    let source_span = self.command_stack.last().copied().unwrap_or(command.span);
+                    let kind = self.classify_source_ref(command.span.line(), argument);
                     self.source_refs.push(SourceRef {
-                        kind: self.classify_source_ref(command.span.line(), argument),
-                        span: command.span,
+                        diagnostic_class: classify_source_ref_diagnostic_class(
+                            argument,
+                            self.source,
+                            &kind,
+                        ),
+                        kind,
+                        span: source_span,
                         path_span: argument.span,
                         resolution: SourceRefResolution::Unchecked,
                         explicitly_provided: false,
@@ -3397,6 +3407,49 @@ fn classify_dynamic_source_word(word: &Word, source: &str) -> SourceRefKind {
     }
 
     SourceRefKind::Dynamic
+}
+
+fn classify_source_ref_diagnostic_class(
+    word: &Word,
+    source: &str,
+    kind: &SourceRefKind,
+) -> SourceRefDiagnosticClass {
+    match kind {
+        SourceRefKind::Dynamic if dynamic_root_with_slash_tail(word, source) => {
+            SourceRefDiagnosticClass::UntrackedFile
+        }
+        _ => default_diagnostic_class(kind),
+    }
+}
+
+fn dynamic_root_with_slash_tail(word: &Word, source: &str) -> bool {
+    let Some((root, tail)) = word.parts.split_first() else {
+        return false;
+    };
+
+    root_word_part_is_dynamic_root(&root.kind)
+        && !tail.is_empty()
+        && static_parts_text(tail, source).is_some_and(|text| text.starts_with('/'))
+}
+
+fn root_word_part_is_dynamic_root(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(_) | WordPart::ArrayAccess(_) => true,
+        WordPart::Parameter(parameter) => matches!(
+            parameter.syntax,
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { .. })
+        ),
+        WordPart::DoubleQuoted { parts, .. } => matches!(
+            parts.as_slice(),
+            [part] if root_word_part_is_dynamic_root(&part.kind)
+        ),
+        _ => false,
+    }
+}
+
+fn static_parts_text(parts: &[WordPartNode], source: &str) -> Option<String> {
+    let mut result = String::new();
+    collect_static_word_text(parts, source, &mut result).then_some(result)
 }
 
 fn parse_source_directives(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -3452,9 +3452,20 @@ fn dynamic_root_with_slash_tail(word: &Word, source: &str) -> bool {
         return false;
     };
 
-    root_word_part_is_dynamic_root(&root.kind)
-        && !tail.is_empty()
-        && static_parts_text(tail, source).is_some_and(|text| text.starts_with('/'))
+    match &root.kind {
+        WordPart::DoubleQuoted { parts, .. } => {
+            let Some((inner_root, inner_tail)) = parts.split_first() else {
+                return false;
+            };
+
+            root_word_part_is_dynamic_root(&inner_root.kind)
+                && static_tail_text_starts_with_slash(inner_tail, tail, source)
+        }
+        _ => {
+            root_word_part_is_dynamic_root(&root.kind)
+                && static_tail_text_starts_with_slash(tail, &[], source)
+        }
+    }
 }
 
 fn root_word_part_is_dynamic_root(part: &WordPart) -> bool {
@@ -3464,10 +3475,6 @@ fn root_word_part_is_dynamic_root(part: &WordPart) -> bool {
             parameter.syntax,
             ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { .. })
         ),
-        WordPart::DoubleQuoted { parts, .. } => matches!(
-            parts.as_slice(),
-            [part] if root_word_part_is_dynamic_root(&part.kind)
-        ),
         _ => false,
     }
 }
@@ -3475,6 +3482,17 @@ fn root_word_part_is_dynamic_root(part: &WordPart) -> bool {
 fn static_parts_text(parts: &[WordPartNode], source: &str) -> Option<String> {
     let mut result = String::new();
     collect_static_word_text(parts, source, &mut result).then_some(result)
+}
+
+fn static_tail_text_starts_with_slash(
+    parts: &[WordPartNode],
+    trailing: &[WordPartNode],
+    source: &str,
+) -> bool {
+    let mut result = String::new();
+    collect_static_word_text(parts, source, &mut result)
+        && collect_static_word_text(trailing, source, &mut result)
+        && result.starts_with('/')
 }
 
 fn parse_source_directives(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -3437,8 +3437,8 @@ fn literal_uses_current_user_home_tilde(word: &Word, source: &str, path: &str) -
     };
 
     match &first.kind {
-        WordPart::Literal(text) => {
-            let text = text.as_str(source, first.span);
+        WordPart::Literal(_) => {
+            let text = first.span.slice(source);
             text.starts_with("~/")
                 || (text == "~"
                     && static_parts_text(tail, source).is_some_and(|tail| tail.starts_with('/')))

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -3415,7 +3415,9 @@ fn classify_source_ref_diagnostic_class(
     kind: &SourceRefKind,
 ) -> SourceRefDiagnosticClass {
     match kind {
-        SourceRefKind::Literal(path) if literal_uses_current_user_home_tilde(word, source, path) => {
+        SourceRefKind::Literal(path)
+            if literal_uses_current_user_home_tilde(word, source, path) =>
+        {
             SourceRefDiagnosticClass::DynamicPath
         }
         SourceRefKind::Dynamic if dynamic_root_with_slash_tail(word, source) => {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -30,7 +30,7 @@ pub use declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 pub use reference::{Reference, ReferenceId, ReferenceKind};
 pub use scope::{FunctionScopeKind, Scope, ScopeId, ScopeKind};
 pub use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionState};
-pub use source_ref::{SourceRef, SourceRefKind, SourceRefResolution};
+pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Command, File, Name, Span};
@@ -713,11 +713,13 @@ impl SemanticModel {
         imported_bindings: Vec<ImportedBindingContractSite>,
         source_ref_resolutions: Vec<SourceRefResolution>,
         source_ref_explicitness: Vec<bool>,
+        source_ref_diagnostic_classes: Vec<SourceRefDiagnosticClass>,
     ) {
         if synthetic_reads.is_empty()
             && imported_bindings.is_empty()
             && source_ref_resolutions.is_empty()
             && source_ref_explicitness.is_empty()
+            && source_ref_diagnostic_classes.is_empty()
         {
             return;
         }
@@ -744,6 +746,16 @@ impl SemanticModel {
                 .zip(source_ref_explicitness.into_iter())
             {
                 source_ref.explicitly_provided = explicitly_provided;
+            }
+        }
+        if !source_ref_diagnostic_classes.is_empty() {
+            debug_assert_eq!(source_ref_diagnostic_classes.len(), self.source_refs.len());
+            for (source_ref, diagnostic_class) in self
+                .source_refs
+                .iter_mut()
+                .zip(source_ref_diagnostic_classes.into_iter())
+            {
+                source_ref.diagnostic_class = diagnostic_class;
             }
         }
 
@@ -1229,20 +1241,26 @@ fn build_semantic_model(
         model.apply_file_entry_contract(contract, file);
     }
     if let Some(source_path) = options.source_path {
-        let (synthetic_reads, imported_bindings, source_ref_resolutions, source_ref_explicitness) =
-            source_closure::collect_source_closure_contracts(
-                &model,
-                file,
-                source,
-                source_path,
-                options.source_path_resolver,
-                options.analyzed_paths,
-            );
+        let (
+            synthetic_reads,
+            imported_bindings,
+            source_ref_resolutions,
+            source_ref_explicitness,
+            source_ref_diagnostic_classes,
+        ) = source_closure::collect_source_closure_contracts(
+            &model,
+            file,
+            source,
+            source_path,
+            options.source_path_resolver,
+            options.analyzed_paths,
+        );
         model.apply_source_contracts(
             synthetic_reads,
             imported_bindings,
             source_ref_resolutions,
             source_ref_explicitness,
+            source_ref_diagnostic_classes,
         );
     }
     model

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -13,8 +13,8 @@ use shuck_parser::parser::Parser;
 use crate::{
     Binding, BindingId, BindingKind, ContractCertainty, FileContract, FunctionContract,
     FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel,
-    SourcePathResolver, SourceRefKind, SourceRefResolution, SpanKey, SyntheticRead,
-    build_semantic_model_base,
+    SourcePathResolver, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution, SpanKey,
+    SyntheticRead, build_semantic_model_base,
 };
 
 #[derive(Debug, Clone)]
@@ -24,6 +24,7 @@ struct SourceClosureContracts {
     imported_functions: Vec<ImportedFunctionContractSite>,
     source_ref_resolutions: Vec<SourceRefResolution>,
     source_ref_explicitness: Vec<bool>,
+    source_ref_diagnostic_classes: Vec<SourceRefDiagnosticClass>,
 }
 
 type SourceClosureContractResult = (
@@ -31,6 +32,7 @@ type SourceClosureContractResult = (
     Vec<ImportedBindingContractSite>,
     Vec<SourceRefResolution>,
     Vec<bool>,
+    Vec<SourceRefDiagnosticClass>,
 );
 
 #[derive(Clone, Copy)]
@@ -83,6 +85,7 @@ pub(crate) fn collect_source_closure_contracts(
         contracts.imported_bindings,
         contracts.source_ref_resolutions,
         contracts.source_ref_explicitness,
+        contracts.source_ref_diagnostic_classes,
     )
 }
 
@@ -102,12 +105,14 @@ fn collect_source_closure_contracts_with_cache(
     let mut imported_functions = Vec::new();
     let mut source_ref_resolutions = Vec::new();
     let mut source_ref_explicitness = Vec::new();
+    let mut source_ref_diagnostic_classes = Vec::new();
 
     for source_ref in model.source_refs() {
         let scope = model.scope_at(source_ref.span.start.offset);
+        let template = facts.source_templates.get(&SpanKey::new(source_ref.span));
         let candidates = source_candidates(
             &source_ref.kind,
-            facts.source_templates.get(&SpanKey::new(source_ref.span)),
+            template,
             call_args_by_scope.get(&scope).map(Vec::as_slice),
             source_path,
         );
@@ -116,6 +121,8 @@ fn collect_source_closure_contracts_with_cache(
             merge_contracts_for_candidates(source_path, candidates, summaries, active, context);
         source_ref_resolutions.push(classify_source_ref_resolution(&source_ref.kind, resolved));
         source_ref_explicitness.push(explicit);
+        source_ref_diagnostic_classes
+            .push(classify_source_ref_diagnostic_class(source_ref, template));
         for provided in contract.provided_bindings.iter().cloned() {
             imported_bindings.push(ImportedBindingContractSite {
                 scope,
@@ -183,6 +190,7 @@ fn collect_source_closure_contracts_with_cache(
         imported_functions,
         source_ref_resolutions,
         source_ref_explicitness,
+        source_ref_diagnostic_classes,
     }
 }
 
@@ -236,6 +244,32 @@ fn classify_source_ref_resolution(kind: &SourceRefKind, resolved: bool) -> Sourc
             }
         }
     }
+}
+
+fn classify_source_ref_diagnostic_class(
+    source_ref: &crate::SourceRef,
+    template: Option<&SourcePathTemplate>,
+) -> SourceRefDiagnosticClass {
+    match source_ref.kind {
+        SourceRefKind::Dynamic if template_is_untracked_file(template) => {
+            SourceRefDiagnosticClass::UntrackedFile
+        }
+        _ => source_ref.diagnostic_class,
+    }
+}
+
+fn template_is_untracked_file(template: Option<&SourcePathTemplate>) -> bool {
+    let Some(SourcePathTemplate::Interpolated(parts)) = template else {
+        return false;
+    };
+
+    matches!(
+        parts.as_slice(),
+        [TemplatePart::Literal(path)] if path.contains('/')
+    ) || matches!(
+        parts.as_slice(),
+        [TemplatePart::SourceDir, TemplatePart::Literal(tail)] if tail.starts_with('/')
+    )
 }
 
 fn dedup_synthetic_reads(reads: Vec<SyntheticRead>) -> Vec<SyntheticRead> {
@@ -1076,6 +1110,7 @@ fn summarize_helper_uncached(
         collected.imported_bindings.clone(),
         collected.source_ref_resolutions.clone(),
         collected.source_ref_explicitness.clone(),
+        collected.source_ref_diagnostic_classes.clone(),
     );
     let analysis = semantic.analysis();
 

--- a/crates/shuck-semantic/src/source_ref.rs
+++ b/crates/shuck-semantic/src/source_ref.rs
@@ -1,5 +1,11 @@
 use shuck_ast::{Name, Span};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceRefDiagnosticClass {
+    DynamicPath,
+    UntrackedFile,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceRef {
     pub kind: SourceRefKind,
@@ -7,6 +13,7 @@ pub struct SourceRef {
     pub path_span: Span,
     pub resolution: SourceRefResolution,
     pub explicitly_provided: bool,
+    pub diagnostic_class: SourceRefDiagnosticClass,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,4 +30,31 @@ pub enum SourceRefResolution {
     Unchecked,
     Resolved,
     Unresolved,
+}
+
+pub(crate) fn default_diagnostic_class(kind: &SourceRefKind) -> SourceRefDiagnosticClass {
+    match kind {
+        SourceRefKind::DirectiveDevNull | SourceRefKind::Directive(_) => {
+            SourceRefDiagnosticClass::UntrackedFile
+        }
+        SourceRefKind::Literal(path) => {
+            if uses_current_user_home_tilde(path) {
+                SourceRefDiagnosticClass::DynamicPath
+            } else {
+                SourceRefDiagnosticClass::UntrackedFile
+            }
+        }
+        SourceRefKind::Dynamic => SourceRefDiagnosticClass::DynamicPath,
+        SourceRefKind::SingleVariableStaticTail { tail, .. } => {
+            if tail.starts_with('/') {
+                SourceRefDiagnosticClass::UntrackedFile
+            } else {
+                SourceRefDiagnosticClass::DynamicPath
+            }
+        }
+    }
+}
+
+fn uses_current_user_home_tilde(path: &str) -> bool {
+    path.starts_with("~/")
 }

--- a/crates/shuck-semantic/src/source_ref.rs
+++ b/crates/shuck-semantic/src/source_ref.rs
@@ -37,13 +37,7 @@ pub(crate) fn default_diagnostic_class(kind: &SourceRefKind) -> SourceRefDiagnos
         SourceRefKind::DirectiveDevNull | SourceRefKind::Directive(_) => {
             SourceRefDiagnosticClass::UntrackedFile
         }
-        SourceRefKind::Literal(path) => {
-            if uses_current_user_home_tilde(path) {
-                SourceRefDiagnosticClass::DynamicPath
-            } else {
-                SourceRefDiagnosticClass::UntrackedFile
-            }
-        }
+        SourceRefKind::Literal(_) => SourceRefDiagnosticClass::UntrackedFile,
         SourceRefKind::Dynamic => SourceRefDiagnosticClass::DynamicPath,
         SourceRefKind::SingleVariableStaticTail { tail, .. } => {
             if tail.starts_with('/') {
@@ -53,8 +47,4 @@ pub(crate) fn default_diagnostic_class(kind: &SourceRefKind) -> SourceRefDiagnos
             }
         }
     }
-}
-
-fn uses_current_user_home_tilde(path: &str) -> bool {
-    path.starts_with("~/")
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/c003.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c003.yaml
@@ -61,3 +61,59 @@ reviewed_divergences:
     path_suffix: "romkatv__powerlevel10k__gitstatus__install"
     line: 158
     reason: "This installer sources `build.info` from a dynamic gitstatus directory, and standalone ShellCheck 0.11.0 still emits SC1091 for that shape. The large-corpus oracle stays silent on this full-file fixture, so we record it as a narrow reviewed divergence instead of weakening C003."
+  - side: shuck-only
+    path_suffix: "dylanaraps__neofetch__neofetch"
+    line: 2591
+    labels:
+      - project-closure
+    reason: "This macOS probe re-sources a cached GPU detail file under a runtime cache directory rather than a checked project input. ShellCheck stays silent on that user-cache helper path in the full fixture, while Shuck keeps the sourced dependency visible."
+  - side: shuck-only
+    path_suffix: "dylanaraps__neofetch__neofetch"
+    line: 4783
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This config loader conditionally sources a user config file under `XDG_CONFIG_HOME`, which lives outside the analyzed project inputs. ShellCheck stays silent on that full-file user-config path, while Shuck keeps the sourced dependency visible."
+  - side: shuck-only
+    path_suffix: "dylanaraps__neofetch__neofetch"
+    line: 4787
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This config loader conditionally sources a user config file under `XDG_CONFIG_HOME`, which lives outside the analyzed project inputs. ShellCheck stays silent on that full-file user-config path, while Shuck keeps the sourced dependency visible."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__rvmrc"
+    line: 3
+    labels:
+      - project-closure
+    reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__rvmrc"
+    line: 4
+    labels:
+      - project-closure
+    reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__rvmrc"
+    line: 5
+    labels:
+      - project-closure
+    reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__rvmrc"
+    line: 6
+    labels:
+      - project-closure
+    reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__rvmrc"
+    line: 7
+    labels:
+      - project-closure
+    reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__rvmrc"
+    line: 8
+    labels:
+      - project-closure
+    reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."

--- a/crates/shuck/tests/testdata/corpus-metadata/c003.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c003.yaml
@@ -31,3 +31,33 @@ reviewed_divergences:
     path_suffix: "void-linux__void-packages__srcpkgs__m1n1__files__kernel.d__m1n1.post-install"
     line: 12
     reason: "This post-install hook only sources a host-side defaults file when a runtime root directory variable points at it. We review that deployment-specific path convention instead of widening C003 around installer-root heuristics."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
+    line: 2
+    reason: "This CGI helper bootstraps through an absolute `/tmp/loader` path that depends on host-local setup outside the checked project tree. We keep the missing-loader dependency visible in Shuck rather than trusting a corpus-specific temporary file."
+  - side: shuck-only
+    path_suffix: "dylanaraps__pure-bash-bible__test.sh"
+    line: 233
+    reason: "This test harness generates `readme_code` earlier in the same script before sourcing it. ShellCheck stays silent on that ephemeral test artifact, while Shuck keeps the not-provided helper dependency visible."
+  - side: shuck-only
+    path_suffix: "leebaird__discover__passive.sh"
+    line: 254
+    reason: "This helper activates a virtualenv that is created by the preceding `uv sync` workflow rather than being part of the checked inputs. ShellCheck treats that generated environment file as outside its missing-input warning path, while Shuck keeps the dependency visible."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
+    line: 71
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "This shell-collapsed Oh My Zsh entrypoint loads internal helpers through the repo-root `$ZSH/...` library path. The current oracle run stays silent on those shell-collapse library loads, while Shuck keeps the not-provided helper dependencies visible."
+  - side: shuck-only
+    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
+    line: 125
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "This shell-collapsed Oh My Zsh entrypoint loads internal helpers through the repo-root `$ZSH/...` library path. The current oracle run stays silent on those shell-collapse library loads, while Shuck keeps the not-provided helper dependencies visible."
+  - side: shuck-only
+    path_suffix: "romkatv__powerlevel10k__gitstatus__install"
+    line: 158
+    reason: "This installer sources `build.info` from a dynamic gitstatus directory, and standalone ShellCheck 0.11.0 still emits SC1091 for that shape. The large-corpus oracle stays silent on this full-file fixture, so we record it as a narrow reviewed divergence instead of weakening C003."


### PR DESCRIPTION
## Summary
- split source refs into semantic diagnostic classes so runtime-built paths stay in `C002` while missing helper inputs stay in `C003`
- classify variable-root path templates like `${BUILD_ROOT}/sh/functions.sh` as untracked sourced files instead of generic dynamic paths
- add focused regressions and reviewed divergences for the remaining large-corpus edge cases

## Root Cause
`C003` was relying too heavily on coarse source-ref kind and resolution state. That blurred together dynamic path construction, missing helper inputs, and some source-template shapes, which left false positives in `C002` and a false negative for the openrc-style `${VAR}/...` source path.

## Testing
- `cargo test -p shuck-linter correctness::tests -- --nocapture`
- `cargo test -p shuck-semantic source_ -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C003`
