### PR TITLE
Fix conformance deltas across 36 lint rules

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C111.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C111.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 set -- a b
 
-# Invalid: positional @ expansion in string comparisons.
+# Invalid: positional @ expansion used as a [ ] or test operand.
+if [ -z "$@" ]; then :; fi
+if test -n "${@:-fallback}"; then :; fi
+if [ -d "$@" ]; then :; fi
 if [ "_$@" = "_--version" ]; then :; fi
 if [ "$@" = "--version" ]; then :; fi
-if [ "${@:-fallback}" = "--version" ]; then :; fi
+if [ -n foo -a "${@:-lhs}" = "${@:-rhs}" ]; then :; fi
+if [ -d "$@" -o "${@:-fallback}" = "x" ]; then :; fi
 
-# Valid: non-positional and double-bracket comparisons.
+# Valid: truthy tests, non-positional uses, and double-bracket comparisons.
+if [ "$@" ]; then :; fi
 if [ "_$*" = "_--version" ]; then :; fi
+if [ -d "${arr[@]}" ]; then :; fi
 if [ "_${arr[@]}" = "_x" ]; then :; fi
 if [[ "_$@" == "_--version" ]]; then :; fi
 if [[ "\$@" == "x" ]]; then :; fi

--- a/crates/shuck-linter/resources/test/fixtures/portability/X081.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X081.sh
@@ -8,3 +8,6 @@ echo "${*%dBm*}"
 
 # Should not trigger: longest suffix removal on $@ is outside this rule
 echo "${@%%dBm*}"
+
+# Should not trigger: long prefix removal on $@ is outside this rule
+echo "${@##*.}"

--- a/crates/shuck-linter/resources/test/fixtures/style/S016.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S016.sh
@@ -21,5 +21,16 @@ pipeline=$(echo piped | tr a-z A-Z)
 # Should not trigger: substitutions without echo are fine.
 printf_subst=$(printf '%s\n' value)
 
+# Should not trigger: a single nested command substitution belongs to a different warning family.
+nested_only=$(echo $(basename "$path" .txt))
+quoted_nested_only=$(echo "$(basename "$path" .txt)")
+
+# Should not trigger: echo can still matter when a dynamic prefix can collapse into a dash-led first argument.
+dynamic_dash=$(echo ${prefix}-suffix)
+quoted_dynamic_dash=$(echo "${prefix}-suffix")
+
+# Should not trigger: echo feeding another command in a pipeline is not the final substitution body.
+pipeline_cut=$(echo "$line" | cut -d' ' -f2-)
+
 # Should not trigger: echo outside command substitution is covered elsewhere.
 echo "$(date)"

--- a/crates/shuck-linter/resources/test/fixtures/style/S056.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S056.sh
@@ -1,4 +1,12 @@
-#!/bin/sh
+#!/bin/bash
+alias home=$HOME
+alias icloud="cd '$HOME'"
 alias printf=$(command -v printf)
-alias a=$(command -v printf) b=$(command -v cat)
+alias math="$((1+2))"
+alias list=${arr[@]}
+alias proc=<(printf hi)
+alias brace={a,b}
 alias plain=printf
+alias literal='$(command -v printf)'
+alias param='${HOME}'
+alias brace_lit='{a,b}'

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5392,29 +5392,30 @@ fn word_parts_contain_echo_backslash_escape(
     source: &str,
     in_double_quotes: bool,
 ) -> bool {
-    parts.iter().any(|part| match &part.kind {
-        WordPart::Literal(text) => {
-            let core_text = if in_double_quotes {
-                text.as_str(source, part.span)
-            } else {
-                part.span.slice(source)
-            };
-
-            text_contains_echo_backslash_escape(core_text, echo_escape_is_core_family)
-                || (in_double_quotes
-                    && text_contains_echo_backslash_escape(
-                        text.as_str(source, part.span),
-                        echo_escape_is_quote_like,
-                    ))
-        }
-        WordPart::SingleQuoted { value, .. } => {
-            text_contains_echo_backslash_escape(value.slice(source), echo_escape_is_core_family)
-        }
-        WordPart::DoubleQuoted { parts, .. } => {
-            word_parts_contain_echo_backslash_escape(parts, source, true)
-        }
-        _ => false,
-    })
+    parts
+        .iter()
+        .enumerate()
+        .any(|(index, part)| match &part.kind {
+            WordPart::Literal(text) => {
+                let core_text = if in_double_quotes {
+                    text.as_str(source, part.span)
+                } else {
+                    part.span.slice(source)
+                };
+                let rendered_text = text.as_str(source, part.span);
+                text_contains_echo_backslash_escape(core_text, echo_escape_is_core_family)
+                    || text_contains_echo_backslash_escape(rendered_text, echo_escape_is_quote_like)
+                    || text_contains_echo_double_backslash(rendered_text)
+                    || literal_backslash_touches_double_quoted_fragment(parts, index, rendered_text)
+            }
+            WordPart::SingleQuoted { value, .. } => {
+                text_contains_echo_backslash_escape(value.slice(source), echo_escape_is_core_family)
+            }
+            WordPart::DoubleQuoted { parts, .. } => {
+                word_parts_contain_echo_backslash_escape(parts, source, true)
+            }
+            _ => false,
+        })
 }
 
 fn echo_escape_is_core_family(byte: u8) -> bool {
@@ -5426,6 +5427,47 @@ fn echo_escape_is_core_family(byte: u8) -> bool {
 
 fn echo_escape_is_quote_like(byte: u8) -> bool {
     matches!(byte, b'`' | b'\'')
+}
+
+fn literal_backslash_touches_double_quoted_fragment(
+    parts: &[WordPartNode],
+    index: usize,
+    rendered_text: &str,
+) -> bool {
+    (rendered_text.ends_with('\\')
+        && parts
+            .get(index + 1)
+            .is_some_and(|part| matches!(part.kind, WordPart::DoubleQuoted { .. })))
+        || (rendered_text.starts_with('\\')
+            && index
+                .checked_sub(1)
+                .and_then(|prev| parts.get(prev))
+                .is_some_and(|part| matches!(part.kind, WordPart::DoubleQuoted { .. })))
+}
+
+fn text_contains_echo_double_backslash(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b'\\' {
+            index += 1;
+            continue;
+        }
+
+        let run_start = index;
+        while index < bytes.len() && bytes[index] == b'\\' {
+            index += 1;
+        }
+
+        if index.saturating_sub(run_start) >= 2
+            && bytes.get(index).is_some_and(|next| *next != b'"')
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn text_contains_echo_backslash_escape(text: &str, is_sensitive: fn(u8) -> bool) -> bool {
@@ -20326,6 +20368,59 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
                 .collect::<Vec<_>>(),
             vec!["a-z", "A-Z"]
         );
+    }
+
+    #[test]
+    fn tracks_quote_like_echo_escapes_inside_double_quotes_from_syntax_text() {
+        let source = "#!/bin/bash\necho \"  echo Remember to run \\\\\\`updatedb\\\\'.\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert_eq!(
+            facts
+                .echo_backslash_escape_word_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"  echo Remember to run \\\\\\`updatedb\\\\'.\""]
+        );
+    }
+
+    #[test]
+    fn tracks_echo_backslash_double_quote_escape_shapes() {
+        let source = "#!/bin/bash\necho -DLATEX=\\\\\"$(which latex)\\\\\"\necho \"  .TargetPath = \\\"\\\\\\\\host.lan\\\\Data\\\"\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert_eq!(
+            facts
+                .echo_backslash_escape_word_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "-DLATEX=\\\\\"$(which latex)\\\\\"",
+                "\"  .TargetPath = \\\"\\\\\\\\host.lan\\\\Data\\\"\""
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_json_like_backslash_quote_wrappers_around_variables() {
+        let source = "#!/bin/bash\necho \"LABEL com.dokku.docker-image-labeler/alternate-tags=[\\\\\\\"$DOCKER_IMAGE\\\\\\\"]\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(facts.echo_backslash_escape_word_spans().is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -287,6 +287,10 @@ impl<'a> SimpleTestFact<'a> {
             .collect()
     }
 
+    pub fn operator_expression_operand_words(&'a self, source: &str) -> Vec<&'a Word> {
+        simple_test_operator_expression_operand_words(self, source)
+    }
+
     pub fn string_unary_expression_words(&'a self, source: &str) -> Vec<(&'a Word, &'a Word)> {
         simple_test_expressions(self, source)
             .into_iter()
@@ -385,6 +389,89 @@ fn simple_test_expressions<'a>(
     }
 
     expressions
+}
+
+fn simple_test_operator_expression_operand_words<'a>(
+    simple_test: &'a SimpleTestFact<'a>,
+    source: &str,
+) -> Vec<&'a Word> {
+    let operands = simple_test.effective_operands();
+    let mut expression_operands = Vec::new();
+    let mut segment_start = 0;
+
+    for index in 0..=operands.len() {
+        let is_connector = index < operands.len()
+            && simple_test_effective_operand_text(simple_test, index, source)
+                .as_deref()
+                .is_some_and(simple_test_is_logical_connector);
+        let splits_segment = is_connector
+            && simple_test_segment_is_expression(simple_test, segment_start, index, source);
+        if !splits_segment && index != operands.len() {
+            continue;
+        }
+
+        collect_simple_test_operator_expression_operand_words(
+            simple_test,
+            segment_start,
+            index,
+            source,
+            &mut expression_operands,
+        );
+
+        segment_start = index + 1;
+    }
+
+    expression_operands
+}
+
+fn collect_simple_test_operator_expression_operand_words<'a>(
+    simple_test: &'a SimpleTestFact<'a>,
+    start: usize,
+    end: usize,
+    source: &str,
+    expression_operands: &mut Vec<&'a Word>,
+) {
+    if start >= end {
+        return;
+    }
+
+    let segment = &simple_test.effective_operands()[start..end];
+    let mut expression_start = 0;
+    while expression_start + 1 < segment.len()
+        && simple_test_effective_operand_text(simple_test, start + expression_start, source)
+            .as_deref()
+            == Some("!")
+    {
+        expression_start += 1;
+    }
+
+    let expression = &segment[expression_start..];
+    match expression {
+        [operator, operand]
+            if simple_test_effective_operand_text(
+                simple_test,
+                start + expression_start,
+                source,
+            )
+            .as_deref()
+            .is_some_and(simple_test_is_unary_operator) =>
+        {
+            expression_operands.push(operand);
+        }
+        [left, operator, right]
+            if simple_test_effective_operand_text(
+                simple_test,
+                start + expression_start + 1,
+                source,
+            )
+            .as_deref()
+            .is_some_and(simple_test_is_nonlogical_binary_operator) =>
+        {
+            expression_operands.push(left);
+            expression_operands.push(right);
+        }
+        [..] => {}
+    }
 }
 
 fn simple_test_segment_is_expression(
@@ -23146,6 +23233,88 @@ test
                     })
                     .collect::<Vec<_>>(),
                 vec![("-z".to_owned(), "baz".to_owned())]
+            );
+        });
+    }
+
+    #[test]
+    fn simple_test_fact_tracks_operator_expression_operands() {
+        let source = "\
+#!/bin/sh
+[ foo ]
+[ -d dir ]
+[ lhs -eq rhs ]
+[ -d one -o two = three ]
+[ ! -e four -a five -nt six ]
+";
+
+        with_facts(source, None, |_, facts| {
+            let commands = facts
+                .structural_commands()
+                .map(|fact| (fact.span().slice(source).trim_end().to_owned(), fact))
+                .collect::<Vec<_>>();
+
+            let truthy = commands
+                .iter()
+                .find(|(text, _)| text == "[ foo ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected truthy test fact");
+            assert!(truthy.operator_expression_operand_words(source).is_empty());
+
+            let unary = commands
+                .iter()
+                .find(|(text, _)| text == "[ -d dir ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected unary test fact");
+            assert_eq!(
+                unary
+                    .operator_expression_operand_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["dir"]
+            );
+
+            let binary = commands
+                .iter()
+                .find(|(text, _)| text == "[ lhs -eq rhs ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected binary test fact");
+            assert_eq!(
+                binary
+                    .operator_expression_operand_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["lhs", "rhs"]
+            );
+
+            let compound = commands
+                .iter()
+                .find(|(text, _)| text == "[ -d one -o two = three ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected compound test fact");
+            assert_eq!(
+                compound
+                    .operator_expression_operand_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["one", "two", "three"]
+            );
+
+            let negated_compound = commands
+                .iter()
+                .find(|(text, _)| text == "[ ! -e four -a five -nt six ]")
+                .and_then(|(_, fact)| fact.simple_test())
+                .expect("expected negated compound test fact");
+            assert_eq!(
+                negated_compound
+                    .operator_expression_operand_words(source)
+                    .into_iter()
+                    .map(|word| word.span.slice(source).to_owned())
+                    .collect::<Vec<_>>(),
+                vec!["four", "five", "six"]
             );
         });
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -8926,31 +8926,39 @@ fn find_operator_span(expression_span: Span, source: &str, operator: &str, first
 
 fn double_paren_grouping_anchor(span: Span, source: &str) -> Option<Span> {
     let text = span.slice(source);
-    let body_start = if let Some(stripped) = text.strip_prefix("((") {
-        (text.len() - stripped.len()) + stripped.find(|char: char| !char.is_whitespace())?
+    let anchor_start = if let Some(stripped) = text.strip_prefix("((") {
+        let body_start =
+            (text.len() - stripped.len()) + stripped.find(|char: char| !char.is_whitespace())?;
+        let body = &text[body_start..];
+        let has_grouping_operator =
+            body.contains("||") || body.contains("&&") || body.contains('|') || body.contains(';');
+        if !has_grouping_operator {
+            return None;
+        }
+        span.start
     } else if text.starts_with('(')
         && span.start.offset > 0
         && source.as_bytes().get(span.start.offset - 1) == Some(&b'(')
     {
         let stripped = text.strip_prefix('(')?;
-        (text.len() - stripped.len()) + stripped.find(|char: char| !char.is_whitespace())?
+        let body_start =
+            (text.len() - stripped.len()) + stripped.find(|char: char| !char.is_whitespace())?;
+        let body = &text[body_start..];
+        let has_grouping_operator =
+            body.contains("||") || body.contains("&&") || body.contains('|') || body.contains(';');
+        if !has_grouping_operator {
+            return None;
+        }
+        Position {
+            line: span.start.line,
+            column: span.start.column - 1,
+            offset: span.start.offset - 1,
+        }
     } else {
         return None;
     };
 
-    let body = &text[body_start..];
-    let has_grouping_operator =
-        body.contains("||") || body.contains("&&") || body.contains('|') || body.contains(';');
-    if !has_grouping_operator {
-        return None;
-    }
-
-    let command_offset = body.find(|char: char| char == '_' || char.is_ascii_alphabetic())?;
-    let command_start = span.start.advanced_by(&text[..body_start + command_offset]);
-    let head = &body[command_offset..];
-    let first_char_len = head.chars().next()?.len_utf8();
-    let command_end = command_start.advanced_by(&head[..first_char_len]);
-    Some(Span::from_positions(command_start, command_end))
+    Some(Span::at(anchor_start))
 }
 
 fn has_header_shellcheck_shell_directive(source: &str) -> bool {
@@ -24262,14 +24270,20 @@ then \"install\" later
 ";
 
         with_facts(source, None, |_, facts| {
-            assert_eq!(
-                facts
-                    .double_paren_grouping_spans()
-                    .iter()
-                    .map(|span| span.slice(source))
-                    .collect::<Vec<_>>(),
-                vec!["p"]
-            );
+            let anchors = facts
+                .double_paren_grouping_spans()
+                .iter()
+                .map(|span| {
+                    (
+                        span.start.line,
+                        span.start.column,
+                        span.end.line,
+                        span.end.column,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(anchors, vec![(2, 1, 2, 1)]);
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -16438,7 +16438,6 @@ fn grep_pattern_has_glob_style_star_confusion(pattern: &str) -> bool {
     if pattern.starts_with('^')
         || ends_with_unescaped_dollar(bytes)
         || bytes.contains(&b'[')
-        || bytes.contains(&b'\\')
         || bytes.contains(&b'+')
     {
         return false;
@@ -16450,6 +16449,11 @@ fn grep_pattern_has_glob_style_star_confusion(pattern: &str) -> bool {
 
     let mut index = 0usize;
     while let Some(star_index) = next_unescaped_star_index(bytes, index) {
+        if bytes.get(star_index + 1) == Some(&b'\\') {
+            index = star_index + 1;
+            continue;
+        }
+
         let Some(previous) = previous_unescaped_byte(bytes, star_index) else {
             index = star_index + 1;
             continue;
@@ -16457,7 +16461,7 @@ fn grep_pattern_has_glob_style_star_confusion(pattern: &str) -> bool {
 
         if matches!(
             previous,
-            b'.' | b']' | b')' | b'*' | b'?' | b'|' | b'$' | b'{' | b'('
+            b'.' | b']' | b')' | b'*' | b'?' | b'|' | b'$' | b'{' | b'(' | b'\\'
         ) || previous.is_ascii_whitespace()
         {
             index = star_index + 1;
@@ -21414,6 +21418,7 @@ grep --regexp='*start' data.txt
 #!/bin/bash
 grep start* data.txt
 grep 'foo*bar' data.txt
+grep 'foo\\*bar*' data.txt
 grep '^#* OPTIONS #*$' data.txt
 grep -Eo 'https?://[[:alnum:]./?&!$#%@*;:+~_=-]+' data.txt
 grep '^root:[:!*]' data.txt
@@ -21445,6 +21450,7 @@ grep 'foo*bar+' data.txt
             vec![
                 ("start*", true),
                 ("'foo*bar'", true),
+                ("'foo\\*bar*'", true),
                 ("'^#* OPTIONS #*$'", false),
                 ("'https?://[[:alnum:]./?&!$#%@*;:+~_=-]+'", false),
                 ("'^root:[:!*]'", false),

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1089,6 +1089,7 @@ pub struct WordFact<'a> {
     runtime_literal: RuntimeLiteralAnalysis,
     operand_class: Option<TestOperandClass>,
     static_text: Option<Box<str>>,
+    starts_with_extglob: bool,
     has_literal_affixes: bool,
     contains_shell_quoting_literals: bool,
     active_expansion_spans: Box<[Span]>,
@@ -1172,6 +1173,10 @@ impl<'a> WordFact<'a> {
 
     pub fn static_text(&self) -> Option<&str> {
         self.static_text.as_deref()
+    }
+
+    pub fn starts_with_extglob(&self) -> bool {
+        self.starts_with_extglob
     }
 
     pub fn has_literal_affixes(&self) -> bool {
@@ -11660,10 +11665,12 @@ impl<'a> WordFactCollector<'a> {
             | WordFactContext::CaseSubject
             | WordFactContext::ArithmeticCommand => None,
         };
+        let starts_with_extglob = span::word_starts_with_extglob(word_ref, self.source);
         let index = self.facts.len();
         self.facts.push(WordFact {
             key,
             static_text: static_word_text(word_ref, self.source).map(String::into_boxed_str),
+            starts_with_extglob,
             has_literal_affixes: word_has_literal_affixes(word_ref),
             contains_shell_quoting_literals: word_contains_shell_quoting_literals(
                 word_ref,

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -23525,6 +23525,25 @@ for entry in $(find . -type f); do :; done
     }
 
     #[test]
+    fn builds_loop_header_find_substitution_detection_for_find_exec_forms() {
+        let source = "\
+#!/bin/bash
+for entry in $(find . -type f -exec grep -Pl '\\r$' {} \\;); do :; done
+for entry in $(command find . -type f -exec basename {} \\;); do :; done
+";
+
+        with_facts(source, None, |_, facts| {
+            let first = facts.for_headers()[0].words();
+            assert!(first[0].has_unquoted_command_substitution());
+            assert!(first[0].contains_find_substitution());
+
+            let second = facts.for_headers()[1].words();
+            assert!(second[0].has_unquoted_command_substitution());
+            assert!(second[0].contains_find_substitution());
+        });
+    }
+
+    #[test]
     fn zsh_for_headers_only_track_iteration_words() {
         let source = "\
 #!/usr/bin/env zsh

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -17207,7 +17207,6 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
 
         if text == "-print0" {
             has_print0 = true;
-            has_formatted_output_action = true;
         }
 
         if is_find_group_open_token(text.as_str()) {
@@ -20753,7 +20752,7 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
     }
 
     #[test]
-    fn tracks_find_formatted_output_actions() {
+    fn tracks_find_print0_without_treating_it_as_formatted_output() {
         let source = "\
 #!/bin/bash
 find . -print0 | xargs rm
@@ -20774,7 +20773,8 @@ find . -print | xargs rm
             .collect::<Vec<_>>();
 
         assert_eq!(find_facts.len(), 3);
-        assert!(find_facts[0].has_formatted_output_action());
+        assert!(find_facts[0].has_print0);
+        assert!(!find_facts[0].has_formatted_output_action());
         assert!(find_facts[1].has_formatted_output_action());
         assert!(!find_facts[2].has_formatted_output_action());
     }
@@ -25687,7 +25687,7 @@ arr=(\"$(printf '%s\\n' \"$x\")\")
                     .iter()
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
-                vec!["$x"]
+                Vec::<&str>::new()
             );
         });
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2699,12 +2699,12 @@ impl<'a> CommandOptionFacts<'a> {
             unset: normalized
                 .effective_name_is("unset")
                 .then(|| parse_unset_command(normalized.body_args(), source)),
-            find: normalized
-                .effective_name_is("find")
-                .then(|| {
+            find: (normalized.effective_name_is("find")
+                || normalized.literal_name.as_deref() == Some("find"))
+            .then(|| {
                     let args = find_command_args(command, normalized, source);
                     parse_find_command(args.as_slice(), source)
-                }),
+            }),
             find_exec: (normalized.has_wrapper(WrapperKind::FindExec)
                 || normalized.has_wrapper(WrapperKind::FindExecDir))
             .then(|| FindExecCommandFacts {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1086,6 +1086,7 @@ pub struct WordFact<'a> {
     static_text: Option<Box<str>>,
     has_literal_affixes: bool,
     contains_shell_quoting_literals: bool,
+    active_expansion_spans: Box<[Span]>,
     scalar_expansion_spans: Box<[Span]>,
     unquoted_scalar_expansion_spans: Box<[Span]>,
     array_assignment_split_scalar_expansion_spans: Box<[Span]>,
@@ -1174,6 +1175,10 @@ impl<'a> WordFact<'a> {
 
     pub fn contains_shell_quoting_literals(&self) -> bool {
         self.contains_shell_quoting_literals
+    }
+
+    pub fn active_expansion_spans(&self) -> &[Span] {
+        &self.active_expansion_spans
     }
 
     pub fn scalar_expansion_spans(&self) -> &[Span] {
@@ -11456,6 +11461,8 @@ impl<'a> WordFactCollector<'a> {
                 word_ref,
                 self.source,
             ),
+            active_expansion_spans: span::active_expansion_spans_in_source(word_ref, self.source)
+                .into_boxed_slice(),
             scalar_expansion_spans: span::scalar_expansion_part_spans(word_ref, self.source)
                 .into_boxed_slice(),
             unquoted_scalar_expansion_spans: span::unquoted_scalar_expansion_part_spans(

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2701,7 +2701,10 @@ impl<'a> CommandOptionFacts<'a> {
                 .then(|| parse_unset_command(normalized.body_args(), source)),
             find: normalized
                 .effective_name_is("find")
-                .then(|| parse_find_command(normalized.body_args(), source)),
+                .then(|| {
+                    let args = find_command_args(command, normalized, source);
+                    parse_find_command(args.as_slice(), source)
+                }),
             find_exec: (normalized.has_wrapper(WrapperKind::FindExec)
                 || normalized.has_wrapper(WrapperKind::FindExecDir))
             .then(|| FindExecCommandFacts {
@@ -16938,6 +16941,20 @@ fn is_find_exec_semicolon_terminator(word: &Word, source: &str) -> bool {
     }
 }
 
+fn find_command_args<'a>(
+    command: &'a Command,
+    normalized: &NormalizedCommand<'a>,
+    source: &'a str,
+) -> Vec<&'a Word> {
+    if normalized.literal_name.as_deref() == Some("find")
+        && let Command::Simple(command) = command
+    {
+        return simple_command_body_words(command, source).skip(1).collect();
+    }
+
+    normalized.body_args().to_vec()
+}
+
 fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
     let mut has_print0 = false;
     let mut has_formatted_output_action = false;
@@ -16984,7 +17001,7 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
                 group_stack
                     .last_mut()
                     .expect("group stack retains the root frame")
-                    .incorporate_group(child, &mut or_without_grouping_spans);
+                    .incorporate_group(child);
             }
             continue;
         }
@@ -17091,12 +17108,11 @@ struct FindGroupState {
     current_branch_has_explicit_and: bool,
     has_any_predicate: bool,
     has_any_action: bool,
-    first_action_span_for_parent: Option<Span>,
 }
 
 impl FindGroupState {
     fn current_branch_can_bind_action(&self) -> bool {
-        !self.current_branch_has_explicit_and && (self.current_branch_has_predicate || self.saw_or)
+        !self.current_branch_has_explicit_and && self.current_branch_has_predicate
     }
 
     fn note_or(&mut self) {
@@ -17123,25 +17139,13 @@ impl FindGroupState {
             spans.push(span);
         }
 
-        if reportable
-            && self.first_action_span_for_parent.is_none()
-            && self.current_branch_can_bind_action()
-        {
-            self.first_action_span_for_parent = Some(span);
-        }
-
         self.saw_action_before_current_branch = true;
         self.has_any_action = true;
     }
 
-    fn incorporate_group(&mut self, child: Self, spans: &mut Vec<Span>) {
+    fn incorporate_group(&mut self, child: Self) {
         if child.has_any_predicate {
             self.note_predicate();
-        }
-
-        if let Some(span) = child.first_action_span_for_parent {
-            self.note_action(span, true, spans);
-            return;
         }
 
         if child.has_any_action {
@@ -20937,6 +20941,32 @@ unset -v \"${!prefix_@}\" x${!prefix_*} \"${!name}\" \"${!arr[@]}\"
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
         assert_eq!(find_or_without_grouping_spans, vec!["-print"]);
+    }
+
+    #[test]
+    fn tracks_find_exec_or_branches_without_action_only_false_positives() {
+        let source = "\
+#!/bin/bash
+find . -name a -o -name b -exec rm -f {} \\;
+find . -name a -o -name b -o -name c -exec cp {} out \\;
+find . \\( -name a -o \\( -name b -exec rm -f {} \\; \\) \\) -print
+find . -type l -o -print
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let find_or_without_grouping_spans = facts
+            .commands()
+            .iter()
+            .filter_map(|fact| fact.options().find())
+            .flat_map(|find| find.or_without_grouping_spans().iter().copied())
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(find_or_without_grouping_spans, vec!["-exec", "-exec"]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1817,6 +1817,7 @@ pub struct ListSegmentFact {
     kind: ListSegmentKind,
     assignment_target: Option<Box<str>>,
     assignment_span: Option<Span>,
+    assignment_is_declaration: bool,
 }
 
 impl ListSegmentFact {
@@ -1838,6 +1839,10 @@ impl ListSegmentFact {
 
     pub fn assignment_span(&self) -> Option<Span> {
         self.assignment_span
+    }
+
+    pub fn assignment_is_declaration(&self) -> bool {
+        self.assignment_is_declaration
     }
 }
 
@@ -23308,6 +23313,14 @@ true && declare -x flag=1
                     .collect::<Vec<_>>(),
                 vec![None, Some("out"), Some("out")]
             );
+            assert_eq!(
+                ternary
+                    .segments()
+                    .iter()
+                    .map(|segment| segment.assignment_is_declaration())
+                    .collect::<Vec<_>>(),
+                vec![false, true, true]
+            );
 
             let shortcut = &facts.lists()[1];
             assert_eq!(
@@ -23322,6 +23335,7 @@ true && declare -x flag=1
                 ]
             );
             assert_eq!(shortcut.segments()[1].assignment_target(), Some("flag"));
+            assert!(shortcut.segments()[1].assignment_is_declaration());
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -10956,6 +10956,7 @@ fn extend_surface_fragment_facts(target: &mut SurfaceFragmentFacts, source: Surf
 
 struct WordFactCollector<'a> {
     source: &'a str,
+    semantic: &'a SemanticModel,
     command_id: CommandId,
     nested_word_command: bool,
     surface_command_name: Option<Box<str>>,
@@ -10981,6 +10982,7 @@ impl<'a> WordFactCollector<'a> {
     ) -> Self {
         Self {
             source,
+            semantic,
             command_id,
             nested_word_command,
             surface_command_name: normalized
@@ -11360,6 +11362,10 @@ impl<'a> WordFactCollector<'a> {
             match operand {
                 DeclOperand::Name(reference) => {
                     self.surface.record_var_ref_subscript(reference);
+                    let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
+                        Some(&reference.name),
+                        reference.subscript.as_ref(),
+                    );
                     query::visit_var_ref_subscript_words_with_source(
                         reference,
                         self.source,
@@ -11368,6 +11374,9 @@ impl<'a> WordFactCollector<'a> {
                                 word,
                                 SurfaceScanContext::new(None, self.nested_word_command),
                             );
+                            if indexed_semantics {
+                                self.collect_array_index_arithmetic_spans(word);
+                            }
                             self.push_owned_word(
                                 word.clone(),
                                 WordFactContext::Expansion(
@@ -11397,11 +11406,18 @@ impl<'a> WordFactCollector<'a> {
         let surface_context = SurfaceScanContext::new(None, self.nested_word_command)
             .with_assignment_target(assignment.target.name.as_str());
         self.surface.record_var_ref_subscript(&assignment.target);
+        let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
+            Some(&assignment.target.name),
+            assignment.target.subscript.as_ref(),
+        );
         query::visit_var_ref_subscript_words_with_source(
             &assignment.target,
             self.source,
             &mut |word| {
                 self.surface.collect_word(word, surface_context);
+                if indexed_semantics {
+                    self.collect_array_index_arithmetic_spans(word);
+                }
                 self.push_owned_word(
                     word.clone(),
                     context,
@@ -11827,17 +11843,6 @@ impl<'a> WordFactCollector<'a> {
         context: WordFactContext,
         host_kind: WordFactHostKind,
     ) {
-        if matches!(
-            host_kind,
-            WordFactHostKind::AssignmentTargetSubscript
-                | WordFactHostKind::DeclarationNameSubscript
-                | WordFactHostKind::ArrayKeySubscript
-                | WordFactHostKind::ConditionalVarRefSubscript
-        ) {
-            self.arithmetic
-                .array_index_arithmetic_spans
-                .extend(span::arithmetic_expansion_part_spans(word));
-        }
         if host_kind == WordFactHostKind::Direct
             && matches!(
                 context,
@@ -11868,6 +11873,37 @@ impl<'a> WordFactCollector<'a> {
                 &mut self.arithmetic.arithmetic_command_substitution_spans,
             );
         }
+    }
+
+    fn subscript_uses_index_arithmetic_semantics(
+        &self,
+        owner_name: Option<&Name>,
+        subscript: Option<&Subscript>,
+    ) -> bool {
+        let Some(subscript) = subscript else {
+            return false;
+        };
+        if subscript.selector().is_some() {
+            return false;
+        }
+        if matches!(
+            subscript.interpretation,
+            shuck_ast::SubscriptInterpretation::Associative
+        ) {
+            return false;
+        }
+
+        !owner_name.is_some_and(|name| {
+            self.semantic
+                .visible_binding(name, subscript.span())
+                .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+        })
+    }
+
+    fn collect_array_index_arithmetic_spans(&mut self, word: &Word) {
+        self.arithmetic
+            .array_index_arithmetic_spans
+            .extend(span::arithmetic_expansion_part_spans(word));
     }
 }
 
@@ -24696,6 +24732,32 @@ case x in *[!a-zA-Z0-9._/+\\-]*) continue ;; esac
 
         assert!(facts.is_subscript_index_reference(idx_reference.span));
         assert!(!facts.is_subscript_index_reference(free_reference.span));
+    }
+
+    #[test]
+    fn collects_array_index_arithmetic_spans_only_for_indexed_lvalues() {
+        let source = "\
+#!/bin/bash
+arr[$((indexed+1))]=x
+declare named[$((declared+1))]=y
+declare -A map
+map[$((assoc+1))]=z
+map[temp_$((mixed+1))]=q
+map=([$((compound+1))]=w)
+printf '%s\\n' \"${arr[$((read+1))]}\"
+[[ -v arr[$((check+1))] ]]
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .array_index_arithmetic_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["$((indexed+1))", "$((declared+1))"]
+            );
+        });
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -22011,6 +22011,13 @@ expanded=$(echo $foo)
 quoted=$(echo \"$foo\")
 var_suffix=$(echo foo$foo)
 command_subst=$(echo foo $(date))
+nested_only=$(echo $(basename \"$f\" .fuzz))
+quoted_nested_only=$(echo \"$(basename \"$f\" .fuzz)\")
+multiple_nested=$(echo $(date) $(pwd))
+dynamic_dash=$(echo ${foo}-bar)
+quoted_dynamic_dash=$(echo \"${foo}-bar\")
+command_subst_dash=$(echo $(date)-bar)
+pipeline_cut=$(echo \"$line\" | cut -d' ' -f2-)
 option_like=$(echo -en \"\\001\")
 glob_like=$(echo O*)
 brace_like=$(echo {a,b})
@@ -22034,9 +22041,57 @@ brace_like=$(echo {a,b})
             assert_eq!(substitutions.get("$(echo \"$foo\")"), Some(&true));
             assert_eq!(substitutions.get("$(echo foo$foo)"), Some(&true));
             assert_eq!(substitutions.get("$(echo foo $(date))"), Some(&true));
+            assert_eq!(
+                substitutions.get("$(echo $(basename \"$f\" .fuzz))"),
+                Some(&false)
+            );
+            assert_eq!(
+                substitutions.get("$(echo \"$(basename \"$f\" .fuzz)\")"),
+                Some(&false)
+            );
+            assert_eq!(substitutions.get("$(echo $(date) $(pwd))"), Some(&true));
+            assert_eq!(substitutions.get("$(echo ${foo}-bar)"), Some(&false));
+            assert_eq!(substitutions.get("$(echo \"${foo}-bar\")"), Some(&false));
+            assert_eq!(substitutions.get("$(echo $(date)-bar)"), Some(&false));
+            assert_eq!(
+                substitutions.get("$(echo \"$line\" | cut -d' ' -f2-)"),
+                Some(&false)
+            );
             assert_eq!(substitutions.get("$(echo -en \"\\001\")"), Some(&false));
             assert_eq!(substitutions.get("$(echo O*)"), Some(&false));
             assert_eq!(substitutions.get("$(echo {a,b})"), Some(&false));
+        });
+    }
+
+    #[test]
+    fn keeps_bash_pipeline_substitution_facts_false_in_pattern_and_array_contexts() {
+        let source = "\
+#!/bin/bash
+if [[ \"${currencyCodes[*]}\" == *\"$(echo \"${@}\" | tr -d '[:space:]')\"* ]]; then :; fi
+CANDIDATES+=(\"$(echo \"$line\" | cut -d' ' -f2-)\")
+";
+
+        with_facts(source, None, |_, facts| {
+            let substitutions = facts
+                .commands()
+                .iter()
+                .flat_map(|fact| fact.substitution_facts().iter().copied())
+                .filter(|fact| fact.span().slice(source).contains("$(echo"))
+                .map(|fact| {
+                    (
+                        fact.span().slice(source).to_owned(),
+                        fact.body_contains_echo(),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                substitutions,
+                vec![
+                    ("$(echo \"${@}\" | tr -d '[:space:]')".to_owned(), false,),
+                    ("$(echo \"$line\" | cut -d' ' -f2-)".to_owned(), false),
+                ]
+            );
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2938,6 +2938,7 @@ pub struct LinterFacts<'a> {
     array_assignment_split_word_indices: Vec<usize>,
     brace_variable_before_bracket_spans: Vec<Span>,
     function_headers: Vec<FunctionHeaderFact<'a>>,
+    function_in_alias_spans: Vec<Span>,
     function_body_without_braces_spans: Vec<Span>,
     function_parameter_fallback_spans: Vec<Span>,
     redundant_return_status_spans: Vec<Span>,
@@ -3206,6 +3207,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn function_headers(&self) -> &[FunctionHeaderFact<'a>] {
         &self.function_headers
+    }
+
+    pub fn function_in_alias_spans(&self) -> &[Span] {
+        &self.function_in_alias_spans
     }
 
     pub fn function_body_without_braces_spans(&self) -> &[Span] {
@@ -3818,6 +3823,7 @@ impl<'a> LinterFactsBuilder<'a> {
         sort_and_dedup_spans(&mut condition_status_capture_spans);
         sort_and_dedup_spans(&mut condition_command_substitution_spans);
         sort_and_dedup_spans(&mut case_pattern_expansion_spans);
+        let function_in_alias_spans = build_function_in_alias_spans(&commands, self.source);
         let function_parameter_fallback_spans = build_function_parameter_fallback_spans(
             &commands,
             &structural_command_ids,
@@ -3977,6 +3983,7 @@ impl<'a> LinterFactsBuilder<'a> {
             array_assignment_split_word_indices,
             brace_variable_before_bracket_spans,
             function_headers,
+            function_in_alias_spans,
             function_body_without_braces_spans,
             function_parameter_fallback_spans,
             redundant_return_status_spans,
@@ -4063,6 +4070,182 @@ fn build_brace_variable_before_bracket_spans(words: &[WordFact<'_>], source: &st
         .collect::<Vec<_>>();
     sort_and_dedup_spans(&mut spans);
     spans
+}
+
+fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+    let mut spans = commands
+        .iter()
+        .filter(|fact| fact.effective_name_is("alias"))
+        .flat_map(|fact| function_in_alias_spans_for_command(fact, source))
+        .collect::<Vec<_>>();
+    sort_and_dedup_spans(&mut spans);
+    spans
+}
+
+fn function_in_alias_spans_for_command(command: &CommandFact<'_>, source: &str) -> Vec<Span> {
+    let body_args = command.body_args();
+    let mut spans = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(word) = body_args.get(index).copied() {
+        let Some(text) = static_word_text(word, source) else {
+            index += 1;
+            continue;
+        };
+        if !text.contains('=') {
+            index += 1;
+            continue;
+        }
+
+        let mut last_word = word;
+        let mut definition_len = 1usize;
+        while last_word.span.slice(source).ends_with('=')
+            && let Some(next_word) = body_args.get(index + definition_len).copied()
+            && last_word.span.end.offset == next_word.span.start.offset
+        {
+            last_word = next_word;
+            definition_len += 1;
+        }
+
+        let definition_words = &body_args[index..index + definition_len];
+        if let Some(span) = function_in_alias_definition_span(definition_words, source) {
+            spans.push(span);
+        }
+
+        index += definition_len;
+    }
+
+    spans
+}
+
+fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Span> {
+    let definition = static_alias_definition_text(words, source)?;
+    let (_, value) = definition.split_once('=')?;
+    let end = words.last()?.span.end;
+    contains_function_definition(value).then(|| Span::from_positions(words[0].span.start, end))
+}
+
+fn static_alias_definition_text(words: &[&Word], source: &str) -> Option<String> {
+    let mut text = String::new();
+    for word in words {
+        text.push_str(&static_word_text(word, source)?);
+    }
+    Some(text)
+}
+
+fn contains_function_definition(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if starts_with_keyword(value, index, "function")
+            && precedes_definition_start(value, index)
+            && is_definition_after_function_keyword(value, index + "function".len())
+        {
+            return true;
+        }
+        if is_identifier_start(bytes[index])
+            && precedes_definition_start(value, index)
+            && is_definition_after_name(value, index, bytes.len())
+        {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
+fn starts_with_keyword(text: &str, index: usize, keyword: &str) -> bool {
+    let tail = &text[index..];
+    if !tail.starts_with(keyword) {
+        return false;
+    }
+    let before_ok = index == 0 || !is_identifier_char(text.as_bytes()[index - 1]);
+    let after_index = index + keyword.len();
+    let after_ok = after_index >= text.len() || !is_identifier_char(text.as_bytes()[after_index]);
+    before_ok && after_ok
+}
+
+fn precedes_definition_start(text: &str, index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+
+    let bytes = text.as_bytes();
+    let mut cursor = index;
+    while cursor > 0 && bytes[cursor - 1].is_ascii_whitespace() {
+        cursor -= 1;
+    }
+
+    cursor == 0 || matches!(bytes[cursor - 1], b';' | b'|' | b'&' | b'(' | b'{' | b'\n')
+}
+
+fn is_definition_after_function_keyword(text: &str, mut index: usize) -> bool {
+    let bytes = text.as_bytes();
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+
+    let Some(end) = parse_identifier(text, index) else {
+        return false;
+    };
+    is_definition_suffix(text, end, false)
+}
+
+fn is_definition_after_name(text: &str, index: usize, len: usize) -> bool {
+    let Some(end) = parse_identifier(text, index) else {
+        return false;
+    };
+    if end >= len {
+        return false;
+    }
+    is_definition_suffix(text, end, true)
+}
+
+fn is_definition_suffix(text: &str, mut index: usize, require_parens: bool) -> bool {
+    let bytes = text.as_bytes();
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+
+    let has_parens = bytes
+        .get(index..)
+        .is_some_and(|rest| rest.starts_with(b"()"));
+    if require_parens && !has_parens {
+        return false;
+    }
+
+    if has_parens {
+        index += 2;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+    }
+
+    bytes.get(index) == Some(&b'{')
+}
+
+fn parse_identifier(text: &str, index: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let first = bytes.get(index).copied()?;
+    if !is_identifier_start(first) {
+        return None;
+    }
+    let mut end = index + 1;
+    while let Some(byte) = bytes.get(end) {
+        if !is_identifier_char(*byte) {
+            break;
+        }
+        end += 1;
+    }
+    Some(end)
+}
+
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn is_identifier_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
@@ -25390,6 +25573,31 @@ $cmd[0] arg
                 .collect::<Vec<_>>();
 
             assert_eq!(spans, vec![(2, 7), (6, 1)]);
+        });
+    }
+
+    #[test]
+    fn builds_function_in_alias_spans_from_static_alias_definitions() {
+        let source = "\
+#!/bin/sh
+alias gtl='gtl(){ git tag --sort=-v:refname -n -l \"${1}*\" }; noglob gtl'
+alias hello='function hello { echo hi; }'
+alias positional='${1+\"$@\"}'
+alias runtime=$BAR
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .function_in_alias_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec![
+                    "gtl='gtl(){ git tag --sort=-v:refname -n -l \"${1}*\" }; noglob gtl'",
+                    "hello='function hello { echo hi; }'",
+                ]
+            );
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2364,10 +2364,19 @@ impl FunctionPositionalParameterFacts {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExprStringHelperKind {
+    Length,
+    Index,
+    Match,
+    Substr,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ExprCommandFacts {
     pub uses_arithmetic_operator: bool,
-    uses_substr_string_form: bool,
+    string_helper_kind: Option<ExprStringHelperKind>,
+    string_helper_span: Option<Span>,
 }
 
 impl ExprCommandFacts {
@@ -2375,8 +2384,16 @@ impl ExprCommandFacts {
         self.uses_arithmetic_operator
     }
 
+    pub fn string_helper_kind(self) -> Option<ExprStringHelperKind> {
+        self.string_helper_kind
+    }
+
+    pub fn string_helper_span(self) -> Option<Span> {
+        self.string_helper_span
+    }
+
     pub fn uses_substr_string_form(self) -> bool {
-        self.uses_substr_string_form
+        self.string_helper_kind == Some(ExprStringHelperKind::Substr)
     }
 }
 
@@ -17548,9 +17565,13 @@ fn xargs_long_option_requires_separate_argument(option: &str) -> bool {
 }
 
 fn parse_expr_command(args: &[&Word], source: &str) -> Option<ExprCommandFacts> {
+    let (string_helper_kind, string_helper_span) = expr_string_helper(args, source)
+        .map_or((None, None), |(kind, span)| (Some(kind), Some(span)));
+
     Some(ExprCommandFacts {
         uses_arithmetic_operator: !expr_uses_string_form(args, source),
-        uses_substr_string_form: expr_uses_substr_string_form(args, source),
+        string_helper_kind,
+        string_helper_span,
     })
 }
 
@@ -17567,11 +17588,17 @@ fn expr_uses_string_form(args: &[&Word], source: &str) -> bool {
         .is_some_and(|text| matches!(text, ":" | "=" | "!=" | "<" | ">" | "<=" | ">=" | "=="))
 }
 
-fn expr_uses_substr_string_form(args: &[&Word], source: &str) -> bool {
-    args.first()
-        .and_then(|word| static_word_text(word, source))
-        .as_deref()
-        == Some("substr")
+fn expr_string_helper(args: &[&Word], source: &str) -> Option<(ExprStringHelperKind, Span)> {
+    let word = args.first()?;
+    let kind = match static_word_text(word, source).as_deref() {
+        Some("length") => ExprStringHelperKind::Length,
+        Some("index") => ExprStringHelperKind::Index,
+        Some("match") => ExprStringHelperKind::Match,
+        Some("substr") => ExprStringHelperKind::Substr,
+        _ => return None,
+    };
+
+    Some((kind, word.span))
 }
 
 fn parse_exit_command<'a>(command: &'a Command, source: &str) -> Option<ExitCommandFacts<'a>> {
@@ -18164,9 +18191,9 @@ mod tests {
     use shuck_semantic::{BindingAttributes, SemanticModel};
 
     use super::{
-        CommandId, ConditionalNodeFact, ConditionalOperatorFamily, GrepPatternSourceKind,
-        LinterFacts, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax,
-        SubstitutionHostKind, SudoFamilyInvoker, WordFactHostKind,
+        CommandId, ConditionalNodeFact, ConditionalOperatorFamily, ExprStringHelperKind,
+        GrepPatternSourceKind, LinterFacts, SimpleTestOperatorFamily, SimpleTestShape,
+        SimpleTestSyntax, SubstitutionHostKind, SudoFamilyInvoker, WordFactHostKind,
     };
     use crate::facts::PositionalParameterFragmentKind;
     use crate::rules::common::command::WrapperKind;
@@ -20141,6 +20168,68 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
                 .map(|word| word.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["a-z", "A-Z"]
+        );
+    }
+
+    #[test]
+    fn tracks_expr_string_helper_kinds_and_spans() {
+        let source = "\
+#!/bin/sh
+expr length \"$mode\"
+expr index \"$mode\" w
+expr match \"$mode\" 'w'
+expr substr \"$mode\" 1 1
+expr \"$a\" = \"$b\"
+expr 1 + 2
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let exprs = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("expr"))
+            .filter_map(|fact| fact.options().expr())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            exprs
+                .iter()
+                .map(|expr| expr.string_helper_kind())
+                .collect::<Vec<_>>(),
+            vec![
+                Some(ExprStringHelperKind::Length),
+                Some(ExprStringHelperKind::Index),
+                Some(ExprStringHelperKind::Match),
+                Some(ExprStringHelperKind::Substr),
+                None,
+                None,
+            ]
+        );
+        assert_eq!(
+            exprs
+                .iter()
+                .map(|expr| expr.string_helper_span().map(|span| span.slice(source)))
+                .collect::<Vec<_>>(),
+            vec![
+                Some("length"),
+                Some("index"),
+                Some("match"),
+                Some("substr"),
+                None,
+                None,
+            ]
+        );
+        assert!(exprs[3].uses_substr_string_form());
+        assert_eq!(
+            exprs
+                .iter()
+                .map(|expr| expr.uses_arithmetic_operator())
+                .collect::<Vec<_>>(),
+            vec![false, false, false, false, false, true]
         );
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2105,11 +2105,16 @@ impl SshCommandFacts {
 #[derive(Debug, Clone)]
 pub struct FindCommandFacts {
     pub has_print0: bool,
+    has_formatted_output_action: bool,
     or_without_grouping_spans: Box<[Span]>,
     glob_pattern_operand_spans: Box<[Span]>,
 }
 
 impl FindCommandFacts {
+    pub fn has_formatted_output_action(&self) -> bool {
+        self.has_formatted_output_action
+    }
+
     pub fn or_without_grouping_spans(&self) -> &[Span] {
         &self.or_without_grouping_spans
     }
@@ -16737,6 +16742,7 @@ fn is_find_exec_semicolon_terminator(word: &Word, source: &str) -> bool {
 
 fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
     let mut has_print0 = false;
+    let mut has_formatted_output_action = false;
     let mut or_without_grouping_spans = Vec::new();
     let mut glob_pattern_operand_spans = Vec::new();
     let mut group_stack = vec![FindGroupState::default()];
@@ -16767,6 +16773,7 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
 
         if text == "-print0" {
             has_print0 = true;
+            has_formatted_output_action = true;
         }
 
         if is_find_group_open_token(text.as_str()) {
@@ -16799,6 +16806,9 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
         }
 
         if is_find_branch_action_token(text.as_str()) {
+            if matches!(text.as_str(), "-fprint0" | "-printf" | "-fprintf") {
+                has_formatted_output_action = true;
+            }
             state.note_action(
                 word.span,
                 is_find_reportable_action_token(text.as_str()),
@@ -16816,6 +16826,7 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
 
     FindCommandFacts {
         has_print0,
+        has_formatted_output_action,
         or_without_grouping_spans: or_without_grouping_spans.into_boxed_slice(),
         glob_pattern_operand_spans: glob_pattern_operand_spans.into_boxed_slice(),
     }
@@ -20259,6 +20270,33 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
                 .collect::<Vec<_>>(),
             vec!["a-z", "A-Z"]
         );
+    }
+
+    #[test]
+    fn tracks_find_formatted_output_actions() {
+        let source = "\
+#!/bin/bash
+find . -print0 | xargs rm
+find . -printf '%h\\n' | xargs mv -t dest
+find . -print | xargs rm
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let find_facts = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("find"))
+            .filter_map(|fact| fact.options().find())
+            .collect::<Vec<_>>();
+
+        assert_eq!(find_facts.len(), 3);
+        assert!(find_facts[0].has_formatted_output_action());
+        assert!(find_facts[1].has_formatted_output_action());
+        assert!(!find_facts[2].has_formatted_output_action());
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2218,6 +2218,7 @@ pub struct GrepPatternFact<'a> {
     static_text: Option<Box<str>>,
     source_kind: GrepPatternSourceKind,
     starts_with_glob_style_star: bool,
+    has_glob_style_star_confusion: bool,
 }
 
 impl<'a> GrepPatternFact<'a> {
@@ -2239,6 +2240,10 @@ impl<'a> GrepPatternFact<'a> {
 
     pub fn starts_with_glob_style_star(&self) -> bool {
         self.starts_with_glob_style_star
+    }
+
+    pub fn has_glob_style_star_confusion(&self) -> bool {
+        self.has_glob_style_star_confusion
     }
 }
 
@@ -15762,12 +15767,16 @@ fn grep_prefixed_pattern_fact<'a>(
     let starts_with_glob_style_star = static_text
         .as_deref()
         .is_some_and(|text| text.starts_with('*') || text == "^*");
+    let has_glob_style_star_confusion = static_text
+        .as_deref()
+        .is_some_and(grep_pattern_has_glob_style_star_confusion);
 
     GrepPatternFact {
         word,
         static_text,
         source_kind,
         starts_with_glob_style_star,
+        has_glob_style_star_confusion,
     }
 }
 
@@ -15855,7 +15864,89 @@ fn push_cooked_double_quoted_literal_text(text: &str, out: &mut String) {
         }
     }
 }
+fn grep_pattern_has_glob_style_star_confusion(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
 
+    if pattern.starts_with('^')
+        || ends_with_unescaped_dollar(bytes)
+        || bytes.contains(&b'[')
+        || bytes.contains(&b'\\')
+        || bytes.contains(&b'+')
+    {
+        return false;
+    }
+
+    if first_unescaped_star_index(bytes).is_some_and(|index| index == 0) {
+        return false;
+    }
+
+    let mut index = 0usize;
+    while let Some(star_index) = next_unescaped_star_index(bytes, index) {
+        let Some(previous) = previous_unescaped_byte(bytes, star_index) else {
+            index = star_index + 1;
+            continue;
+        };
+
+        if matches!(
+            previous,
+            b'.' | b']' | b')' | b'*' | b'?' | b'|' | b'$' | b'{' | b'('
+        ) || previous.is_ascii_whitespace()
+        {
+            index = star_index + 1;
+            continue;
+        }
+
+        return true;
+    }
+
+    false
+}
+
+fn first_unescaped_star_index(bytes: &[u8]) -> Option<usize> {
+    next_unescaped_star_index(bytes, 0)
+}
+
+fn next_unescaped_star_index(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut index = start;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+        if bytes[index] == b'*' {
+            return Some(index);
+        }
+        index += 1;
+    }
+    None
+}
+
+fn previous_unescaped_byte(bytes: &[u8], index: usize) -> Option<u8> {
+    let mut candidate = index;
+    while candidate > 0 {
+        candidate -= 1;
+        if !is_escaped(bytes, candidate) {
+            return Some(bytes[candidate]);
+        }
+    }
+    None
+}
+
+fn ends_with_unescaped_dollar(bytes: &[u8]) -> bool {
+    bytes
+        .last()
+        .is_some_and(|byte| *byte == b'$' && !is_escaped(bytes, bytes.len() - 1))
+}
+
+fn is_escaped(bytes: &[u8], index: usize) -> bool {
+    let mut backslashes = 0usize;
+    let mut cursor = index;
+    while cursor > 0 && bytes[cursor - 1] == b'\\' {
+        backslashes += 1;
+        cursor -= 1;
+    }
+    backslashes % 2 == 1
+}
 fn grep_option_takes_argument(flag: char) -> bool {
     matches!(flag, 'A' | 'B' | 'C' | 'D' | 'd' | 'e' | 'f' | 'm')
 }
@@ -20522,6 +20613,52 @@ grep --regexp='*start' data.txt
                 ("'^*'", Some("^*"), true),
                 ("'^*foo'", Some("^*foo"), false),
                 ("--regexp='*start'", Some("*start"), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn grep_pattern_facts_track_glob_style_star_confusion() {
+        let source = "\
+#!/bin/bash
+grep start* data.txt
+grep 'foo*bar' data.txt
+grep '^#* OPTIONS #*$' data.txt
+grep -Eo 'https?://[[:alnum:]./?&!$#%@*;:+~_=-]+' data.txt
+grep '^root:[:!*]' data.txt
+grep -e 'Swarm:*\\sactive\\s*' data.txt
+grep 'foo*bar+' data.txt
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let grep_patterns = facts
+            .commands()
+            .iter()
+            .filter(|fact| fact.effective_name_is("grep"))
+            .filter_map(|fact| fact.options().grep())
+            .flat_map(|grep| grep.patterns().iter())
+            .map(|pattern| {
+                (
+                    pattern.span().slice(source),
+                    pattern.has_glob_style_star_confusion(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            grep_patterns,
+            vec![
+                ("start*", true),
+                ("'foo*bar'", true),
+                ("'^#* OPTIONS #*$'", false),
+                ("'https?://[[:alnum:]./?&!$#%@*;:+~_=-]+'", false),
+                ("'^root:[:!*]'", false),
+                ("'Swarm:*\\sactive\\s*'", false),
+                ("'foo*bar+'", false),
             ]
         );
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2702,8 +2702,8 @@ impl<'a> CommandOptionFacts<'a> {
             find: (normalized.effective_name_is("find")
                 || normalized.literal_name.as_deref() == Some("find"))
             .then(|| {
-                    let args = find_command_args(command, normalized, source);
-                    parse_find_command(args.as_slice(), source)
+                let args = find_command_args(command, normalized, source);
+                parse_find_command(args.as_slice(), source)
             }),
             find_exec: (normalized.has_wrapper(WrapperKind::FindExec)
                 || normalized.has_wrapper(WrapperKind::FindExecDir))
@@ -11697,21 +11697,6 @@ impl<'a> WordFactCollector<'a> {
     }
 
     fn collect_case_pattern_expansion_spans(&mut self, pattern: &Pattern) {
-        if pattern
-            .parts
-            .iter()
-            .any(|part| matches!(part.kind, PatternPart::Group { .. }))
-        {
-            for part in &pattern.parts {
-                if let PatternPart::Group { patterns, .. } = &part.kind {
-                    for nested in patterns {
-                        self.collect_case_pattern_expansion_spans(nested);
-                    }
-                }
-            }
-            return;
-        }
-
         let expanded_word_spans = pattern
             .parts
             .iter()
@@ -11732,6 +11717,13 @@ impl<'a> WordFactCollector<'a> {
             .collect::<Vec<_>>();
 
         if expanded_word_spans.is_empty() {
+            for part in &pattern.parts {
+                if let PatternPart::Group { patterns, .. } = &part.kind {
+                    for nested in patterns {
+                        self.collect_case_pattern_expansion_spans(nested);
+                    }
+                }
+            }
             return;
         }
 
@@ -25123,6 +25115,7 @@ case $value in
   x$pat) : ;;
   \"$quoted\") : ;;
   \"$left\"$right) : ;;
+  x$left@(foo|bar)) : ;;
   @($nested|\"$ignored\")) : ;;
 esac
 ";
@@ -25134,7 +25127,7 @@ esac
                     .iter()
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
-                vec!["x$pat", "\"$left\"$right", "$nested"]
+                vec!["x$pat", "\"$left\"$right", "x$left@(foo|bar)", "$nested"]
             );
         });
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -24200,6 +24200,20 @@ echo 'hello ‘world’'
     }
 
     #[test]
+    fn ignores_unicode_smart_quotes_in_heredoc_payloads() {
+        let source = "\
+#!/bin/sh
+cat <<EOF
+q { quotes: \"“\" \"”\" \"‘\" \"’\"; }
+EOF
+";
+
+        with_facts(source, None, |_, facts| {
+            assert!(facts.unicode_smart_quote_spans().is_empty());
+        });
+    }
+
+    #[test]
     fn traces_case_pattern_spans_for_escaped_char_classes() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -52,14 +52,14 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,
     ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem, ArrayKind, Assignment, AssignmentValue,
-    BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext, BraceSyntaxKind,
-    BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command, CommandSubstitutionSyntax,
-    CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclClause,
-    DeclOperand, File, ForCommand, FunctionDef, IfCommand, Name, ParameterExpansion,
-    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position, Redirect, RedirectKind,
-    SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript,
-    TextRange, VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionTarget,
-    ZshGlobSegment, ZshQualifiedGlob,
+    BackgroundOperator, BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext,
+    BraceSyntaxKind, BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command,
+    CommandSubstitutionSyntax, CompoundCommand, ConditionalBinaryOp, ConditionalExpr,
+    ConditionalUnaryOp, DeclClause, DeclOperand, File, ForCommand, FunctionDef, IfCommand, Name,
+    ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position,
+    Redirect, RedirectKind, SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq,
+    StmtTerminator, Subscript, TextRange, VarRef, WhileCommand, Word, WordPart, WordPartNode,
+    ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob,
 };
 use shuck_indexer::Indexer;
 use shuck_semantic::{
@@ -2845,6 +2845,7 @@ pub struct LinterFacts<'a> {
     pipelines: Vec<PipelineFact<'a>>,
     lists: Vec<ListFact<'a>>,
     statement_facts: Vec<StatementFact>,
+    background_semicolon_spans: Vec<Span>,
     single_test_subshell_spans: Vec<Span>,
     subshell_test_group_spans: Vec<Span>,
     indented_shebang_span: Option<Span>,
@@ -3148,6 +3149,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn statement_facts(&self) -> &[StatementFact] {
         &self.statement_facts
+    }
+
+    pub fn background_semicolon_spans(&self) -> &[Span] {
+        &self.background_semicolon_spans
     }
 
     pub fn single_test_subshell_spans(&self) -> &[Span] {
@@ -3728,6 +3733,8 @@ impl<'a> LinterFactsBuilder<'a> {
         annotate_conditional_assignment_shortcuts(self.semantic, &lists, &mut binding_values);
         let statement_facts =
             build_statement_facts(&commands, &command_ids_by_span, &self.file.body);
+        let background_semicolon_spans =
+            build_background_semicolon_spans(&commands, &case_items, self.source);
         let single_test_subshell_spans =
             build_single_test_subshell_spans(&commands, &command_ids_by_span, self.source);
         let subshell_test_group_spans =
@@ -3877,6 +3884,7 @@ impl<'a> LinterFactsBuilder<'a> {
             pipelines,
             lists,
             statement_facts,
+            background_semicolon_spans,
             single_test_subshell_spans,
             subshell_test_group_spans,
             indented_shebang_span: shebang_header_facts.indented_shebang_span,
@@ -5662,6 +5670,56 @@ fn position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
         position.advance(ch);
     }
     Some(position)
+}
+
+fn build_background_semicolon_spans(
+    commands: &[CommandFact<'_>],
+    case_items: &[CaseItemFact<'_>],
+    source: &str,
+) -> Vec<Span> {
+    let case_terminator_starts = case_items
+        .iter()
+        .filter_map(CaseItemFact::terminator_span)
+        .map(|span| span.start.offset)
+        .collect::<FxHashSet<_>>();
+    let mut spans = commands
+        .iter()
+        .filter_map(|command| background_semicolon_span(command, &case_terminator_starts, source))
+        .collect::<Vec<_>>();
+    sort_and_dedup_spans(&mut spans);
+    spans
+}
+
+fn background_semicolon_span(
+    command: &CommandFact<'_>,
+    case_terminator_starts: &FxHashSet<usize>,
+    source: &str,
+) -> Option<Span> {
+    if command.stmt().terminator != Some(StmtTerminator::Background(BackgroundOperator::Plain)) {
+        return None;
+    }
+
+    let terminator_span = command.stmt().terminator_span?;
+    if terminator_span.slice(source) != "&" {
+        return None;
+    }
+
+    let semicolon_offset = source[terminator_span.end.offset..]
+        .char_indices()
+        .find_map(|(relative, ch)| match ch {
+            ' ' | '\t' | '\r' => None,
+            '\n' | '#' => Some(None),
+            ';' => Some(Some(terminator_span.end.offset + relative)),
+            _ => Some(None),
+        })??;
+
+    if case_terminator_starts.contains(&semicolon_offset) {
+        return None;
+    }
+
+    let start = position_at_offset(source, semicolon_offset)?;
+    let end = position_at_offset(source, semicolon_offset + 1)?;
+    Some(Span::from_positions(start, end))
 }
 
 fn build_plus_equals_assignment_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
@@ -18227,6 +18285,38 @@ mod tests {
             ShellDialect::Bash,
             visit,
         );
+    }
+
+    #[test]
+    fn background_semicolon_facts_report_plain_semicolons() {
+        let source = "#!/bin/bash\necho x &;\necho y & ;\n";
+
+        with_facts(source, None, |_, facts| {
+            let spans = facts.background_semicolon_spans();
+
+            assert_eq!(spans.len(), 2);
+            assert_eq!(spans[0].slice(source), ";");
+            assert_eq!(spans[0].start.line, 2);
+            assert_eq!(spans[1].slice(source), ";");
+            assert_eq!(spans[1].start.line, 3);
+        });
+    }
+
+    #[test]
+    fn background_semicolon_facts_ignore_case_item_terminators() {
+        let source = "\
+#!/bin/bash
+case ${1-} in
+  break) printf '%s\\n' ok &;;
+  spaced) printf '%s\\n' ok & ;;
+  fallthrough) printf '%s\\n' ok & ;&
+  continue) printf '%s\\n' ok & ;;&
+esac
+";
+
+        with_facts(source, None, |_, facts| {
+            assert!(facts.background_semicolon_spans().is_empty());
+        });
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5682,7 +5682,11 @@ fn word_parts_contain_echo_backslash_escape(
                 };
                 let rendered_text = text.as_str(source, part.span);
                 text_contains_echo_backslash_escape(core_text, echo_escape_is_core_family)
-                    || text_contains_echo_backslash_escape(rendered_text, echo_escape_is_quote_like)
+                    || (in_double_quotes
+                        && text_contains_echo_backslash_escape(
+                            rendered_text,
+                            echo_escape_is_quote_like,
+                        ))
                     || text_contains_echo_double_backslash(rendered_text)
                     || literal_backslash_touches_double_quoted_fragment(parts, index, rendered_text)
             }
@@ -5921,24 +5925,18 @@ fn heredoc_end_space_span(
     strip_tabs: bool,
     source: &str,
 ) -> Option<Span> {
-    let mut line_start_offset = body_span.start.offset;
-    for raw_line in body_span.slice(source).split_inclusive('\n') {
-        let (candidate_line, tab_prefix_len) = normalized_heredoc_line(raw_line, strip_tabs);
-        let Some(trailing) = candidate_line.strip_prefix(delimiter) else {
-            line_start_offset += raw_line.len();
-            continue;
-        };
-        if trailing.is_empty() || !trailing.chars().all(|ch| matches!(ch, ' ' | '\t')) {
-            line_start_offset += raw_line.len();
-            continue;
-        }
-
-        let trailing_start_offset = line_start_offset + tab_prefix_len + delimiter.len();
-        let start = position_at_offset(source, trailing_start_offset)?;
-        return Some(Span::from_positions(start, start));
+    let line_start_offset = body_span.end.offset;
+    let remainder = source.get(line_start_offset..)?;
+    let raw_line = remainder.split_inclusive('\n').next().unwrap_or(remainder);
+    let (candidate_line, tab_prefix_len) = normalized_heredoc_line(raw_line, strip_tabs);
+    let trailing = candidate_line.strip_prefix(delimiter)?;
+    if trailing.is_empty() || !trailing.chars().all(|ch| matches!(ch, ' ' | '\t')) {
+        return None;
     }
 
-    None
+    let trailing_start_offset = line_start_offset + tab_prefix_len + delimiter.len();
+    let start = position_at_offset(source, trailing_start_offset)?;
+    Some(Span::from_positions(start, start))
 }
 
 fn spaced_tabstrip_close_spans(body_span: Span, delimiter: &str, source: &str) -> Vec<Span> {
@@ -11035,7 +11033,11 @@ fn build_word_facts_for_command<'a>(
     collector.finish()
 }
 
-fn collect_array_assignment_nested_scalar_expansion_spans(word: &Word, source: &str) -> Vec<Span> {
+fn collect_array_assignment_nested_scalar_expansion_spans(
+    word: &Word,
+    source: &str,
+    semantic: &SemanticModel,
+) -> Vec<Span> {
     let mut spans = Vec::new();
 
     query::walk_commands_in_word(
@@ -11047,6 +11049,7 @@ fn collect_array_assignment_nested_scalar_expansion_spans(word: &Word, source: &
             let normalized = command::normalize_command(visit.command, source);
             let mut collector = WordFactCollector {
                 source,
+                semantic,
                 command_id: CommandId::new(0),
                 nested_word_command: context.nested_word_command,
                 surface_command_name: normalized
@@ -11058,6 +11061,7 @@ fn collect_array_assignment_nested_scalar_expansion_spans(word: &Word, source: &
                 array_assignment_split_word_indices: Vec::new(),
                 seen: FxHashSet::default(),
                 compound_assignment_value_word_spans: FxHashSet::default(),
+                case_pattern_expansion_spans: Vec::new(),
                 pattern_literal_spans: Vec::new(),
                 pattern_charclass_spans: Vec::new(),
                 arithmetic: ArithmeticFactSummary::default(),
@@ -11627,12 +11631,18 @@ impl<'a> WordFactCollector<'a> {
                                 let fact = &mut self.facts[index];
                                 let mut split_sensitive_spans =
                                     fact.unquoted_scalar_expansion_spans().to_vec();
-                                split_sensitive_spans.extend(
-                                    collect_array_assignment_nested_scalar_expansion_spans(
-                                        word,
-                                        self.source,
-                                    ),
-                                );
+                                if !word_fact_is_double_quoted_command_substitution_only(
+                                    fact,
+                                    self.source,
+                                ) {
+                                    split_sensitive_spans.extend(
+                                        collect_array_assignment_nested_scalar_expansion_spans(
+                                            word,
+                                            self.source,
+                                            self.semantic,
+                                        ),
+                                    );
+                                }
                                 sort_and_dedup_spans(&mut split_sensitive_spans);
                                 fact.array_assignment_split_scalar_expansion_spans =
                                     split_sensitive_spans.into_boxed_slice();

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -9076,7 +9076,9 @@ fn collect_terminal_command_substitution_spans_in_command(
 ) {
     match command {
         Command::Simple(command) => {
-            if command_name_is_plain_command_substitution(&command.name, source) {
+            if command.args.is_empty()
+                && command_name_is_plain_command_substitution(&command.name, source)
+            {
                 spans.push(command.name.span);
             }
         }
@@ -19033,8 +19035,14 @@ fi
 if $(printf one); then
   :
 fi
+if $(command -v printf) --version >/dev/null 2>&1; then
+  :
+fi
 while $(printf two); do
   :
+done
+until $(command -v printf) --help >/dev/null 2>&1; do
+  break
 done
 ";
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2823,6 +2823,7 @@ pub struct LinterFacts<'a> {
     select_headers: Vec<SelectHeaderFact<'a>>,
     case_items: Vec<CaseItemFact<'a>>,
     case_pattern_shadows: Vec<CasePatternShadowFact>,
+    case_pattern_expansion_spans: Vec<Span>,
     getopts_cases: Vec<GetoptsCaseFact>,
     pipelines: Vec<PipelineFact<'a>>,
     lists: Vec<ListFact<'a>>,
@@ -3110,6 +3111,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn case_pattern_shadows(&self) -> &[CasePatternShadowFact] {
         &self.case_pattern_shadows
+    }
+
+    pub fn case_pattern_expansion_spans(&self) -> &[Span] {
+        &self.case_pattern_expansion_spans
     }
 
     pub fn getopts_cases(&self) -> &[GetoptsCaseFact] {
@@ -3419,6 +3424,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut compound_assignment_value_word_spans = FxHashSet::default();
         let mut array_assignment_split_word_indices = Vec::new();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
+        let mut case_pattern_expansion_spans = Vec::new();
         let mut pattern_literal_spans = Vec::new();
         let mut pattern_charclass_spans = Vec::new();
         let mut arithmetic_summary = ArithmeticFactSummary::default();
@@ -3501,6 +3507,7 @@ impl<'a> LinterFactsBuilder<'a> {
                     .map(|index| word_index_offset + *index),
             );
             words.extend(collected_words.facts);
+            case_pattern_expansion_spans.extend(collected_words.case_pattern_expansion_spans);
             pattern_literal_spans.extend(collected_words.pattern_literal_spans);
             pattern_charclass_spans.extend(collected_words.pattern_charclass_spans);
             arithmetic_summary
@@ -3683,6 +3690,7 @@ impl<'a> LinterFactsBuilder<'a> {
             build_function_header_facts(self.semantic, &functions, &commands, self.source);
         sort_and_dedup_spans(&mut condition_status_capture_spans);
         sort_and_dedup_spans(&mut condition_command_substitution_spans);
+        sort_and_dedup_spans(&mut case_pattern_expansion_spans);
         let function_parameter_fallback_spans = build_function_parameter_fallback_spans(
             &commands,
             &structural_command_ids,
@@ -3847,6 +3855,7 @@ impl<'a> LinterFactsBuilder<'a> {
             select_headers,
             case_items,
             case_pattern_shadows,
+            case_pattern_expansion_spans,
             getopts_cases,
             pipelines,
             lists,
@@ -10650,6 +10659,7 @@ struct CollectedWordFacts<'a> {
     facts: Vec<WordFact<'a>>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
     array_assignment_split_word_indices: Vec<usize>,
+    case_pattern_expansion_spans: Vec<Span>,
     pattern_literal_spans: Vec<Span>,
     pattern_charclass_spans: Vec<Span>,
     arithmetic: ArithmeticFactSummary,
@@ -10718,6 +10728,7 @@ struct WordFactCollector<'a> {
     array_assignment_split_word_indices: Vec<usize>,
     seen: FxHashSet<(FactSpan, WordFactContext, WordFactHostKind)>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
+    case_pattern_expansion_spans: Vec<Span>,
     pattern_literal_spans: Vec<Span>,
     pattern_charclass_spans: Vec<Span>,
     arithmetic: ArithmeticFactSummary,
@@ -10749,6 +10760,7 @@ impl<'a> WordFactCollector<'a> {
             array_assignment_split_word_indices: Vec::new(),
             seen: FxHashSet::default(),
             compound_assignment_value_word_spans: FxHashSet::default(),
+            case_pattern_expansion_spans: Vec::new(),
             pattern_literal_spans: Vec::new(),
             pattern_charclass_spans: Vec::new(),
             arithmetic: ArithmeticFactSummary::default(),
@@ -10761,6 +10773,7 @@ impl<'a> WordFactCollector<'a> {
             facts: self.facts,
             compound_assignment_value_word_spans: self.compound_assignment_value_word_spans,
             array_assignment_split_word_indices: self.array_assignment_split_word_indices,
+            case_pattern_expansion_spans: self.case_pattern_expansion_spans,
             pattern_literal_spans: self.pattern_literal_spans,
             pattern_charclass_spans: self.pattern_charclass_spans,
             arithmetic: self.arithmetic,
@@ -10831,6 +10844,7 @@ impl<'a> WordFactCollector<'a> {
                                 pattern,
                                 surface_context.with_pattern_charclass_scan(),
                             );
+                            self.collect_case_pattern_expansion_spans(pattern);
                             self.collect_pattern_context_words(
                                 pattern,
                                 WordFactContext::Expansion(ExpansionContext::CasePattern),
@@ -11244,6 +11258,53 @@ impl<'a> WordFactCollector<'a> {
                 PatternPart::AnyString | PatternPart::AnyChar => {}
                 PatternPart::Literal(_) | PatternPart::CharClass(_) => {}
             }
+        }
+    }
+
+    fn collect_case_pattern_expansion_spans(&mut self, pattern: &Pattern) {
+        if pattern
+            .parts
+            .iter()
+            .any(|part| matches!(part.kind, PatternPart::Group { .. }))
+        {
+            for part in &pattern.parts {
+                if let PatternPart::Group { patterns, .. } = &part.kind {
+                    for nested in patterns {
+                        self.collect_case_pattern_expansion_spans(nested);
+                    }
+                }
+            }
+            return;
+        }
+
+        let expanded_word_spans = pattern
+            .parts
+            .iter()
+            .filter_map(|part| match &part.kind {
+                PatternPart::Word(word) => {
+                    let analysis =
+                        analyze_word(word, self.source, self.command_zsh_options.as_ref());
+                    (analysis.literalness == WordLiteralness::Expanded
+                        && analysis.quote != WordQuote::FullyQuoted)
+                        .then_some(word.span)
+                }
+                PatternPart::Literal(_)
+                | PatternPart::AnyString
+                | PatternPart::AnyChar
+                | PatternPart::CharClass(_)
+                | PatternPart::Group { .. } => None,
+            })
+            .collect::<Vec<_>>();
+
+        if expanded_word_spans.is_empty() {
+            return;
+        }
+
+        if pattern.parts.len() > 1 {
+            self.case_pattern_expansion_spans.push(pattern.span);
+        } else {
+            self.case_pattern_expansion_spans
+                .extend(expanded_word_spans);
         }
     }
 
@@ -24171,6 +24232,30 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["${items[@]}"]
+            );
+        });
+    }
+
+    #[test]
+    fn builds_case_pattern_expansion_spans_for_mixed_and_quoted_patterns() {
+        let source = "\
+#!/bin/sh
+case $value in
+  x$pat) : ;;
+  \"$quoted\") : ;;
+  \"$left\"$right) : ;;
+  @($nested|\"$ignored\")) : ;;
+esac
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .case_pattern_expansion_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["x$pat", "\"$left\"$right", "$nested"]
             );
         });
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5648,20 +5648,24 @@ fn heredoc_end_space_span(
     strip_tabs: bool,
     source: &str,
 ) -> Option<Span> {
-    let line_start_offset = body_span.end.offset;
-    let remainder = source.get(line_start_offset..)?;
-    let raw_line = remainder.split_inclusive('\n').next().unwrap_or(remainder);
-    let (candidate_line, tab_prefix_len) = normalized_heredoc_line(raw_line, strip_tabs);
-    let trailing = candidate_line.strip_prefix(delimiter)?;
-    if trailing.is_empty() || !trailing.chars().all(|ch| matches!(ch, ' ' | '\t')) {
-        return None;
+    let mut line_start_offset = body_span.start.offset;
+    for raw_line in body_span.slice(source).split_inclusive('\n') {
+        let (candidate_line, tab_prefix_len) = normalized_heredoc_line(raw_line, strip_tabs);
+        let Some(trailing) = candidate_line.strip_prefix(delimiter) else {
+            line_start_offset += raw_line.len();
+            continue;
+        };
+        if trailing.is_empty() || !trailing.chars().all(|ch| matches!(ch, ' ' | '\t')) {
+            line_start_offset += raw_line.len();
+            continue;
+        }
+
+        let trailing_start_offset = line_start_offset + tab_prefix_len + delimiter.len();
+        let start = position_at_offset(source, trailing_start_offset)?;
+        return Some(Span::from_positions(start, start));
     }
 
-    let trailing_start_offset = line_start_offset + tab_prefix_len + delimiter.len();
-    let trailing_end_offset = trailing_start_offset + trailing.len();
-    let start = position_at_offset(source, trailing_start_offset)?;
-    let end = position_at_offset(source, trailing_end_offset)?;
-    Some(Span::from_positions(start, end))
+    None
 }
 
 fn spaced_tabstrip_close_spans(body_span: Span, delimiter: &str, source: &str) -> Vec<Span> {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -12368,12 +12368,55 @@ fn build_getopts_case_match(command: &CaseCommand, source: &str) -> GetoptsCaseM
         )
         .collect::<Vec<_>>();
     GetoptsCaseMatch {
-        case_span: command.span,
+        case_span: trim_trailing_case_span(command.span, source),
         handled_case_labels: labels,
         invalid_case_pattern_spans,
         has_fallback_pattern,
         has_unknown_coverage,
     }
+}
+
+fn trim_trailing_case_span(span: Span, source: &str) -> Span {
+    let text = span.slice(source);
+    let mut line_start = 0;
+    let mut last_code_end = 0;
+
+    for line in text.split_inclusive('\n') {
+        let line_end = line_start + line.len();
+        let line_without_newline = line.trim_end_matches(['\r', '\n']);
+        let line_without_comment =
+            trim_case_line_comment(line_without_newline).trim_end_matches([' ', '\t']);
+
+        if !line_without_comment
+            .trim_start_matches([' ', '\t'])
+            .is_empty()
+        {
+            last_code_end = line_start + line_without_comment.len();
+        }
+
+        line_start = line_end;
+    }
+
+    if last_code_end == 0 {
+        return span;
+    }
+
+    Span::from_positions(span.start, span.start.advanced_by(&text[..last_code_end]))
+}
+
+fn trim_case_line_comment(line: &str) -> &str {
+    for (index, ch) in line.char_indices() {
+        if ch == '#'
+            && line[..index]
+                .chars()
+                .next_back()
+                .is_none_or(char::is_whitespace)
+        {
+            return &line[..index];
+        }
+    }
+
+    line
 }
 
 enum GetoptsCasePatternKind {
@@ -19035,7 +19078,7 @@ done
             };
 
             assert_eq!(
-                case.case_span().slice(source).trim_end(),
+                case.case_span().slice(source),
                 "case \"$opt\" in\n    a)\n      ;;\n    b)\n      echo \"$(printf body)\"\n      ;;\n  esac"
             );
             assert_eq!(

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -923,11 +923,16 @@ impl SuspectClosingQuoteFragmentFact {
 #[derive(Debug, Clone, Copy)]
 pub struct BacktickFragmentFact {
     span: Span,
+    empty: bool,
 }
 
 impl BacktickFragmentFact {
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.empty
     }
 }
 
@@ -24876,6 +24881,25 @@ printf '%s\\n' ${name%$suffix} `printf backtick`
                     .map(|fragment| fragment.span().slice(source))
                     .collect::<Vec<_>>(),
                 vec!["`printf backtick`"]
+            );
+        });
+    }
+
+    #[test]
+    fn backtick_fragments_remember_when_the_substitution_body_is_empty() {
+        let source = "\
+#!/bin/sh
+echo \"Resolve the conflict and run ``${PROGRAM} --continue`` plus `date`.\"
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .backtick_fragments()
+                    .iter()
+                    .map(|fragment| (fragment.span().slice(source), fragment.is_empty()))
+                    .collect::<Vec<_>>(),
+                vec![("``", true), ("``", true), ("`date`", false)]
             );
         });
     }

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -1707,6 +1707,9 @@ fn collect_list_stmt_segment_facts<'a>(
         .map(|info| info.target)
         .map(str::to_owned)
         .map(String::into_boxed_str);
+    let assignment_is_declaration = assignment_info
+        .as_ref()
+        .is_some_and(|info| info.is_declaration);
 
     segments.push(ListSegmentFact {
         command_id: id,
@@ -1714,6 +1717,7 @@ fn collect_list_stmt_segment_facts<'a>(
         kind: list_segment_kind(fact),
         assignment_target,
         assignment_span: assignment_info.map(|info| info.span),
+        assignment_is_declaration,
     });
     Some(())
 }
@@ -1742,6 +1746,7 @@ fn list_segment_assignment_target<'a>(fact: &'a CommandFact<'a>) -> Option<&'a s
 struct ListSegmentAssignmentInfo<'a> {
     target: &'a str,
     span: Span,
+    is_declaration: bool,
 }
 
 fn list_segment_assignment_info<'a>(
@@ -1766,6 +1771,7 @@ fn single_assignment_info<'a>(
     (assignments.len() == 1).then(|| ListSegmentAssignmentInfo {
         target: assignments[0].target.name.as_str(),
         span: assignments[0].span,
+        is_declaration: false,
     })
 }
 
@@ -1793,6 +1799,7 @@ fn declaration_assignment_info<'a>(
     assignment.map(|assignment| ListSegmentAssignmentInfo {
         target: assignment.target.name.as_str(),
         span: assignment.span,
+        is_declaration: true,
     })
 }
 

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -459,34 +459,122 @@ fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
 }
 
 fn substitution_body_contains_echo(body: &StmtSeq, source: &str) -> bool {
-    let mut visits = query::iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: false,
-        },
-    );
-    let Some(visit) = visits.next() else {
+    let [stmt] = body.stmts.as_slice() else {
         return false;
     };
-    if visits.next().is_some() {
+
+    if !matches!(
+        stmt.command,
+        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_)
+    ) {
         return false;
     }
 
-    let normalized = command::normalize_command(visit.command, source);
+    let normalized = command::normalize_command(&stmt.command, source);
     if !normalized.effective_name_is("echo") {
         return false;
     }
 
-    if normalized.body_args().first().is_some_and(|word| {
+    let body_args = normalized.body_args();
+    if body_args.first().is_some_and(|word| {
         static_word_text(word, source).is_some_and(|text| text.starts_with('-'))
     }) {
         return false;
     }
 
-    normalized
-        .body_args()
+    if body_args
+        .first()
+        .is_some_and(|word| word_has_leading_dynamic_dash_literal(word, source))
+    {
+        return false;
+    }
+
+    if matches!(body_args, [word] if word_is_command_substitution_only(word)) {
+        return false;
+    }
+
+    body_args
         .iter()
         .all(|word| !word_contains_unquoted_glob_or_brace(word, source))
+}
+
+fn word_is_command_substitution_only(word: &Word) -> bool {
+    match word.parts.as_slice() {
+        [
+            WordPartNode {
+                kind: WordPart::CommandSubstitution { .. },
+                ..
+            },
+        ] => true,
+        [
+            WordPartNode {
+                kind: WordPart::DoubleQuoted { parts, .. },
+                ..
+            },
+        ] => matches!(
+            parts.as_slice(),
+            [WordPartNode {
+                kind: WordPart::CommandSubstitution { .. },
+                ..
+            }]
+        ),
+        _ => false,
+    }
+}
+
+fn word_has_leading_dynamic_dash_literal(word: &Word, source: &str) -> bool {
+    let mut saw_dynamic = false;
+    leading_dynamic_dash_literal_in_parts(&word.parts, source, &mut saw_dynamic).unwrap_or(false)
+}
+
+fn leading_dynamic_dash_literal_in_parts(
+    parts: &[WordPartNode],
+    source: &str,
+    saw_dynamic: &mut bool,
+) -> Option<bool> {
+    for part in parts {
+        match &part.kind {
+            WordPart::Literal(text) => {
+                let text = text.as_str(source, part.span);
+                if !text.is_empty() {
+                    return Some(*saw_dynamic && text.starts_with('-'));
+                }
+            }
+            WordPart::SingleQuoted { value, .. } => {
+                let text = value.slice(source);
+                if !text.is_empty() {
+                    return Some(*saw_dynamic && text.starts_with('-'));
+                }
+            }
+            WordPart::DoubleQuoted { parts, .. } => {
+                if let Some(result) =
+                    leading_dynamic_dash_literal_in_parts(parts, source, saw_dynamic)
+                {
+                    return Some(result);
+                }
+            }
+            WordPart::Variable(_)
+            | WordPart::Parameter(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. }
+            | WordPart::ZshQualifiedGlob(_) => {
+                *saw_dynamic = true;
+            }
+        }
+    }
+
+    None
 }
 
 fn substitution_body_contains_ls<'a>(

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -2184,7 +2184,7 @@ fn substitution_body_is_find<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
-    matches!(body.as_slice(), [stmt] if stmt_effective_name_is(stmt, "find", commands, command_ids_by_span))
+    matches!(body.as_slice(), [stmt] if stmt_invokes_find(stmt, commands, command_ids_by_span))
 }
 
 fn substitution_body_is_pgrep_lookup<'a>(
@@ -2219,15 +2219,24 @@ fn substitution_body_is_simple_command_named<'a>(
     matches!(body.as_slice(), [stmt] if stmt_literal_name_is(stmt, name, commands, command_ids_by_span))
 }
 
-fn stmt_effective_name_is<'a>(
+fn stmt_invokes_find<'a>(
     stmt: &'a Stmt,
-    name: &str,
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
     command_fact_for_stmt(stmt, commands, command_ids_by_span)
-        .map(|fact| fact.effective_name_is(name))
-        .unwrap_or(false)
+        .is_some_and(command_fact_invokes_find)
+}
+
+fn command_fact_invokes_find(fact: &CommandFact<'_>) -> bool {
+    command_name_matches_basename(fact.literal_name(), "find")
+        || command_name_matches_basename(fact.effective_name(), "find")
+        || fact.has_wrapper(WrapperKind::FindExec)
+        || fact.has_wrapper(WrapperKind::FindExecDir)
+}
+
+fn command_name_matches_basename(name: Option<&str>, expected: &str) -> bool {
+    name.is_some_and(|name| name == expected || name.rsplit('/').next() == Some(expected))
 }
 
 fn stmt_literal_name_is<'a>(

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1863,7 +1863,7 @@ mod tests {
 
     #[test]
     fn detects_positional_parameter_operator_in_parsed_arithmetic_shell_word() {
-        let source = "#!/bin/sh\necho \"$(( value + $1suffix ))\"\n";
+        let source = "#!/bin/sh\necho \"$(( value + prefix$1 ))\"\n";
         let output = Parser::new(source).parse().unwrap();
         let command = output.file.body.stmts.first().expect("expected command");
         let Command::Simple(command) = &command.command else {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1139,13 +1139,13 @@ fn collect_positional_parameter_operator_spans_in_arithmetic(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    if expression_ast.is_some_and(|expression_ast| {
-        arithmetic_expr_has_positional_parameter_operator(expression_ast, source)
-    }) {
-        spans.push(Span::from_positions(
-            expansion_span.start,
-            expansion_span.start,
-        ));
+    if let Some(expression_ast) = expression_ast {
+        if arithmetic_expr_has_positional_parameter_operator(expression_ast, source) {
+            spans.push(Span::from_positions(
+                expansion_span.start,
+                expansion_span.start,
+            ));
+        }
         return;
     }
 
@@ -1166,6 +1166,25 @@ fn collect_positional_parameter_operator_spans_in_arithmetic(
                     let Some(token_end) = positional_parameter_token_end(text, index) else {
                         continue;
                     };
+
+                    let immediate_prev = text[..index].chars().next_back();
+                    let immediate_next = text[token_end..].chars().next();
+                    let same_word_prefix =
+                        immediate_prev.is_some_and(|ch| !raw_arithmetic_word_boundary(ch));
+                    let same_word_suffix =
+                        immediate_next.is_some_and(|ch| !raw_arithmetic_word_boundary(ch));
+
+                    if same_word_prefix || same_word_suffix {
+                        if same_word_prefix {
+                            let word_start = raw_arithmetic_word_start(text, index);
+                            let prefix = &text[word_start..index];
+                            if prefix_starts_with_identifier_like_text(prefix) {
+                                should_report = true;
+                                break;
+                            }
+                        }
+                        continue;
+                    }
 
                     let prev = text[..index].chars().rev().find(|ch| !ch.is_whitespace());
                     let next = text[token_end..].chars().find(|ch| !ch.is_whitespace());
@@ -1202,6 +1221,43 @@ fn collect_positional_parameter_operator_spans_in_arithmetic(
     }
 }
 
+fn raw_arithmetic_word_start(text: &str, end: usize) -> usize {
+    let mut start = end;
+
+    while let Some((index, ch)) = text[..start].char_indices().next_back() {
+        if raw_arithmetic_word_boundary(ch) {
+            break;
+        }
+        start = index;
+    }
+
+    start
+}
+
+fn raw_arithmetic_word_boundary(ch: char) -> bool {
+    ch.is_whitespace()
+        || matches!(
+            ch,
+            '+' | '-'
+                | '*'
+                | '/'
+                | '%'
+                | '&'
+                | '|'
+                | '^'
+                | '?'
+                | ':'
+                | '<'
+                | '>'
+                | '='
+                | '!'
+                | '~'
+                | ','
+                | '('
+                | '['
+        )
+}
+
 fn arithmetic_expr_has_positional_parameter_operator(
     expression: &ArithmeticExprNode,
     source: &str,
@@ -1218,7 +1274,7 @@ fn arithmetic_expr_has_positional_parameter_operator(
 fn word_has_unquoted_positional_parameter_operator_neighbors(word: &Word, source: &str) -> bool {
     word.parts.iter().enumerate().any(|(index, part)| {
         part_is_unquoted_positional_parameter(&part.kind)
-            && positional_parameter_part_has_operator_neighbor(word, index, source)
+            && positional_parameter_part_has_identifier_like_prefix(word, index, source)
     })
 }
 
@@ -1257,7 +1313,7 @@ fn name_is_positional_parameter(name: &Name) -> bool {
     !name.as_str().is_empty() && name.as_str().bytes().all(|byte| byte.is_ascii_digit())
 }
 
-fn positional_parameter_part_has_operator_neighbor(
+fn positional_parameter_part_has_identifier_like_prefix(
     word: &Word,
     index: usize,
     source: &str,
@@ -1267,11 +1323,15 @@ fn positional_parameter_part_has_operator_neighbor(
     };
 
     let prefix = &source[word.span.start.offset..part.span.start.offset];
-    let suffix = &source[part.span.end.offset..word.span.end.offset];
-    let prev = prefix.chars().rev().find(|ch| !ch.is_whitespace());
-    let next = suffix.chars().find(|ch| !ch.is_whitespace());
+    prefix_starts_with_identifier_like_text(prefix)
+}
 
-    prev.is_some_and(is_left_operand_neighbor) || next.is_some_and(is_right_operand_neighbor)
+fn prefix_starts_with_identifier_like_text(prefix: &str) -> bool {
+    let Some(first_non_whitespace) = prefix.chars().find(|ch| !ch.is_whitespace()) else {
+        return false;
+    };
+
+    first_non_whitespace == '_' || first_non_whitespace.is_ascii_alphabetic()
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -1768,8 +1828,8 @@ mod tests {
     }
 
     #[test]
-    fn detects_operator_like_neighbors_around_positional_parameters_in_arithmetic_words() {
-        for text in ["$1$2", "$1suffix", "prefix$1", "${1}x"] {
+    fn detects_identifier_led_prefixes_before_positional_parameters_in_arithmetic_words() {
+        for text in ["prefix$1", "a${1}", "foo${bar}$1"] {
             let word = Parser::parse_word_string(text);
             assert!(
                 word_has_unquoted_positional_parameter_operator_neighbors(&word, text),
@@ -1779,8 +1839,20 @@ mod tests {
     }
 
     #[test]
-    fn ignores_non_operator_neighbors_around_positional_parameters_in_arithmetic_words() {
-        for text in ["$1", "${1}", "\"$1\"", "'$1'", "16#$1"] {
+    fn ignores_suffixes_and_non_identifier_prefixes_around_positional_parameters() {
+        for text in [
+            "$1",
+            "${1}",
+            "$1suffix",
+            "${1}suffix",
+            "\"$1\"",
+            "'$1'",
+            "16#$1",
+            "0x$1",
+            "0x${1}${2}",
+            "1a$1",
+            "${base}$1",
+        ] {
             let word = Parser::parse_word_string(text);
             assert!(
                 !word_has_unquoted_positional_parameter_operator_neighbors(&word, text),

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -438,15 +438,16 @@ impl<'a> SurfaceFragmentSink<'a> {
                 }
                 WordPart::CommandSubstitution {
                     syntax: CommandSubstitutionSyntax::Backtick,
-                    body: _,
+                    body,
                     ..
                 } => {
                     if self.opening_backtick_is_escaped(part.span) {
                         continue;
                     }
-                    self.facts
-                        .backticks
-                        .push(BacktickFragmentFact { span: part.span });
+                    self.facts.backticks.push(BacktickFragmentFact {
+                        span: part.span,
+                        empty: body.is_empty(),
+                    });
                 }
                 WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
                 WordPart::Parameter(parameter) => {
@@ -609,14 +610,16 @@ impl<'a> SurfaceFragmentSink<'a> {
                 HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
                 HeredocBodyPart::CommandSubstitution {
                     syntax: CommandSubstitutionSyntax::Backtick,
+                    body,
                     ..
                 } => {
                     if self.opening_backtick_is_escaped(part.span) {
                         continue;
                     }
-                    self.facts
-                        .backticks
-                        .push(BacktickFragmentFact { span: part.span });
+                    self.facts.backticks.push(BacktickFragmentFact {
+                        span: part.span,
+                        empty: body.is_empty(),
+                    });
                 }
                 HeredocBodyPart::CommandSubstitution { .. } => {}
                 HeredocBodyPart::ArithmeticExpansion {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -243,11 +243,6 @@ impl<'a> SurfaceFragmentSink<'a> {
         context: SurfaceScanContext<'_>,
     ) {
         self.collect_single_quoted_fragments_in_heredoc_body_parts(&body.parts, context);
-        collect_unicode_smart_quote_spans_in_heredoc_body_parts(
-            &body.parts,
-            self.source,
-            &mut self.facts.unicode_smart_quote_spans,
-        );
         self.collect_heredoc_body_parts(&body.parts, context);
     }
 
@@ -1729,26 +1724,6 @@ fn collect_unicode_smart_quote_spans_in_word_parts(
                 collect_unicode_smart_quote_spans_in_word_parts(parts, source, true, spans)
             }
             _ => {}
-        }
-    }
-}
-
-fn collect_unicode_smart_quote_spans_in_heredoc_body_parts(
-    parts: &[HeredocBodyPartNode],
-    source: &str,
-    spans: &mut Vec<Span>,
-) {
-    for part in parts {
-        if let HeredocBodyPart::Literal(text) = &part.kind {
-            let literal = text.as_str(source, part.span);
-            for (offset, char) in literal.char_indices() {
-                if !is_unicode_smart_quote(char) {
-                    continue;
-                }
-                let start = part.span.start.advanced_by(&literal[..offset]);
-                let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
-                spans.push(Span::from_positions(start, end));
-            }
         }
     }
 }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -64,6 +64,7 @@ pub use rules::common::span::{
     word_standalone_literal_backslash_span, word_suspicious_bracket_glob_spans,
     word_unbraced_variable_before_bracket_spans, word_unquoted_assign_default_spans,
     word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
+    word_unquoted_glob_pattern_spans_outside_brace_expansion,
     word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_parameter_spans,
     word_unquoted_star_splat_spans, word_unquoted_word_between_single_quoted_segments_spans,
     word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1743,6 +1743,26 @@ f
     }
 
     #[test]
+    fn guarded_source_inside_function_in_sh_is_flagged_by_x080() {
+        let diagnostics = lint(
+            "#!/bin/sh\nf() {\n  [ -r ./helpers.sh ] && source ./helpers.sh\n}\n",
+            &LinterSettings::for_rule(Rule::SourceInsideFunctionInSh),
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::SourceInsideFunctionInSh);
+    }
+
+    #[test]
+    fn source_inside_function_command_substitution_in_sh_is_flagged_by_x080() {
+        let diagnostics = lint(
+            "#!/bin/sh\nf() {\n  version=$(source ./helpers.sh && echo \"$name\")\n}\n",
+            &LinterSettings::for_rule(Rule::SourceInsideFunctionInSh),
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::SourceInsideFunctionInSh);
+    }
+
+    #[test]
     fn top_level_source_is_not_flagged_by_x080() {
         let diagnostics = lint(
             "#!/bin/sh\nsource ./helpers.sh\n",

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -244,6 +244,33 @@ pub fn word_unquoted_glob_pattern_spans(word: &Word, source: &str) -> Vec<Span> 
     spans
 }
 
+pub fn word_unquoted_glob_pattern_spans_outside_brace_expansion(
+    word: &Word,
+    source: &str,
+) -> Vec<Span> {
+    let active_brace_spans = word
+        .brace_syntax()
+        .iter()
+        .copied()
+        .filter(|brace| brace.expands())
+        .map(|brace| brace.span)
+        .collect::<Vec<_>>();
+
+    if active_brace_spans.is_empty() {
+        return word_unquoted_glob_pattern_spans(word, source);
+    }
+
+    word_unquoted_glob_pattern_spans(word, source)
+        .into_iter()
+        .filter(|glob_span| {
+            !active_brace_spans.iter().any(|brace_span| {
+                brace_span.start.offset <= glob_span.start.offset
+                    && glob_span.end.offset <= brace_span.end.offset
+            })
+        })
+        .collect()
+}
+
 pub fn word_suspicious_bracket_glob_spans(word: &Word, source: &str) -> Vec<Span> {
     word_unquoted_glob_pattern_spans(word, source)
         .into_iter()
@@ -2846,6 +2873,7 @@ mod tests {
         word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
         word_suspicious_bracket_glob_spans, word_unquoted_assign_default_spans,
         word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
+        word_unquoted_glob_pattern_spans_outside_brace_expansion,
         word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_splat_spans,
         word_unquoted_word_between_single_quoted_segments_spans,
     };
@@ -3099,6 +3127,40 @@ mod tests {
         assert!(
             word_unquoted_glob_pattern_spans(&command.args[2], source).is_empty(),
             "parameter longest-prefix operator tails should not be reported as pathname globs"
+        );
+    }
+
+    #[test]
+    fn word_unquoted_glob_pattern_spans_outside_brace_expansion_ignore_brace_local_globs() {
+        let source = "\
+echo $DIR/{1..3}*.txt \
+$DIR/setjmp-aarch64/{setjmp.S,private-*.h} \
+$PKG/usr/man/{ja/,}*/*-8.?.?.gz
+";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        assert_eq!(
+            word_unquoted_glob_pattern_spans_outside_brace_expansion(&command.args[0], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*"]
+        );
+        assert!(
+            word_unquoted_glob_pattern_spans_outside_brace_expansion(&command.args[1], source)
+                .is_empty(),
+            "globs nested inside brace alternatives should stay excluded"
+        );
+        assert_eq!(
+            word_unquoted_glob_pattern_spans_outside_brace_expansion(&command.args[2], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*", "*", "?", "?"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -567,6 +567,21 @@ pub fn word_extglob_span(word: &Word, source: &str) -> Option<Span> {
     })
 }
 
+pub fn word_starts_with_extglob(word: &Word, source: &str) -> bool {
+    if word_has_only_literal_parts(&word.parts) {
+        return matches!(
+            find_extglob_bounds(word.span.slice(source).as_bytes()),
+            Some((0, _))
+        );
+    }
+
+    let Some((surface, _)) = word_surface_bytes(word, source) else {
+        return false;
+    };
+
+    matches!(find_extglob_bounds(&surface), Some((0, _)))
+}
+
 pub fn word_exactly_one_extglob_span(word: &Word, source: &str) -> Option<Span> {
     word_exactly_one_extglob_span_from_literal_parts(&word.parts, source).or_else(|| {
         if word_has_only_literal_parts(&word.parts) {
@@ -2871,9 +2886,9 @@ mod tests {
         word_nested_dynamic_double_quote_spans, word_positional_at_splat_span_in_source,
         word_positional_at_splat_spans, word_quoted_all_elements_array_slice_spans,
         word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
-        word_suspicious_bracket_glob_spans, word_unquoted_assign_default_spans,
-        word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
-        word_unquoted_glob_pattern_spans_outside_brace_expansion,
+        word_starts_with_extglob, word_suspicious_bracket_glob_spans,
+        word_unquoted_assign_default_spans, word_unquoted_escaped_pipe_or_brace_spans_in_source,
+        word_unquoted_glob_pattern_spans, word_unquoted_glob_pattern_spans_outside_brace_expansion,
         word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_splat_spans,
         word_unquoted_word_between_single_quoted_segments_spans,
     };
@@ -3013,6 +3028,19 @@ mod tests {
         };
 
         assert!(word_exactly_one_extglob_span(&command.args[0], source).is_none());
+    }
+
+    #[test]
+    fn word_starts_with_extglob_distinguishes_leading_and_trailing_groups() {
+        let source = "printf '%s\\n' ?(*.txt) *.@(jpg|png)\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        assert!(word_starts_with_extglob(&command.args[1], source));
+        assert!(!word_starts_with_extglob(&command.args[2], source));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -148,6 +148,23 @@ pub fn expansion_part_spans(word: &Word) -> Vec<Span> {
     spans
 }
 
+pub fn active_expansion_spans_in_source(word: &Word, source: &str) -> Vec<Span> {
+    let mut spans = expansion_part_spans(word)
+        .into_iter()
+        .map(|span| normalize_command_substitution_span(span, source))
+        .collect::<Vec<_>>();
+    spans.extend(
+        word.brace_syntax()
+            .iter()
+            .copied()
+            .filter(|brace| brace.expands())
+            .map(|brace| brace.span),
+    );
+    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup();
+    spans
+}
+
 pub fn scalar_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_scalar_expansion_spans(&word.parts, false, false, &mut spans);

--- a/crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
+++ b/crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
@@ -1,7 +1,6 @@
-use crate::{
-    Checker, Rule, SimpleTestOperatorFamily, SimpleTestShape, Violation,
-    word_positional_at_splat_span_in_source,
-};
+use shuck_ast::Span;
+
+use crate::{Checker, Rule, Violation, word_positional_at_splat_span_in_source};
 
 pub struct AtSignInStringCompare;
 
@@ -11,37 +10,28 @@ impl Violation for AtSignInStringCompare {
     }
 
     fn message(&self) -> String {
-        "positional-parameter at-splats fold arguments in string comparisons".to_owned()
+        "positional-parameter at-splats fold arguments when used as test operands".to_owned()
     }
 }
 
 pub fn at_sign_in_string_compare(checker: &mut Checker) {
+    let source = checker.source();
     let spans = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| fact.simple_test())
-        .filter_map(|simple_test| simple_test_span(simple_test, checker.source()))
+        .flat_map(|simple_test| simple_test_spans(simple_test, source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || AtSignInStringCompare);
 }
 
-fn simple_test_span(fact: &crate::SimpleTestFact<'_>, source: &str) -> Option<shuck_ast::Span> {
-    if fact.shape() != SimpleTestShape::Binary
-        || fact.operator_family() != SimpleTestOperatorFamily::StringBinary
-    {
-        return None;
-    }
-
-    fact.operands()
-        .first()
-        .and_then(|word| word_positional_at_splat_span_in_source(word, source))
-        .or_else(|| {
-            fact.operands()
-                .get(2)
-                .and_then(|word| word_positional_at_splat_span_in_source(word, source))
-        })
+fn simple_test_spans(fact: &crate::SimpleTestFact<'_>, source: &str) -> Vec<Span> {
+    fact.operator_expression_operand_words(source)
+        .into_iter()
+        .filter_map(|word| word_positional_at_splat_span_in_source(word, source).map(|_| word.span))
+        .collect()
 }
 
 #[cfg(test)]
@@ -50,12 +40,17 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_positional_at_splats_in_string_comparisons() {
+    fn reports_positional_at_splats_in_test_operands() {
         let source = "\
 #!/bin/bash
+if [ -z \"$@\" ]; then :; fi
+if test -n \"${@:-fallback}\"; then :; fi
+if [ -d \"$@\" ]; then :; fi
 if [ \"_$@\" = \"_--version\" ]; then :; fi
 if [ \"$@\" = \"--version\" ]; then :; fi
-if [ \"${@:-fallback}\" = \"--version\" ]; then :; fi
+if [ ! \"$@\" = \"x\" ]; then :; fi
+if [ -n foo -a \"${@:-lhs}\" = \"${@:-rhs}\" ]; then :; fi
+if [ -d \"$@\" -o \"${@:-fallback}\" = \"x\" ]; then :; fi
 ";
         let diagnostics = test_snippet(
             source,
@@ -67,18 +62,32 @@ if [ \"${@:-fallback}\" = \"--version\" ]; then :; fi
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$@", "$@", "${@:-fallback}"]
+            vec![
+                "\"$@\"",
+                "\"${@:-fallback}\"",
+                "\"$@\"",
+                "\"_$@\"",
+                "\"$@\"",
+                "\"$@\"",
+                "\"${@:-lhs}\"",
+                "\"${@:-rhs}\"",
+                "\"$@\"",
+                "\"${@:-fallback}\"",
+            ]
         );
     }
 
     #[test]
-    fn ignores_non_positional_double_bracket_and_escaped_comparisons() {
+    fn ignores_non_positional_truthy_double_bracket_and_escaped_tests() {
         let source = "\
 #!/bin/bash
+if [ \"$@\" ]; then :; fi
+if test \"${@:-fallback}\"; then :; fi
 if [ \"_${arr[@]}\" = \"_x\" ]; then :; fi
 if [ \"_${arr[@]:1}\" = \"_x\" ]; then :; fi
 if [ \"\\$@\" = \"x\" ]; then :; fi
 if [[ \"_$@\" == \"_x\" ]]; then :; fi
+if [ ! \"\\$@\" = \"x\" ]; then :; fi
 if [ \"_$*\" = \"_--version\" ]; then :; fi
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{Checker, Rule, Violation};
 
 pub struct CasePatternVar;
 
@@ -13,16 +13,10 @@ impl Violation for CasePatternVar {
 }
 
 pub fn case_pattern_var(checker: &mut Checker) {
-    let spans = checker
-        .facts()
-        .expansion_word_facts(ExpansionContext::CasePattern)
-        .filter(|fact| fact.classification().is_expanded())
-        .map(|fact| fact.span())
-        .collect::<Vec<_>>();
-
-    for span in spans {
-        checker.report(CasePatternVar, span);
-    }
+    checker.report_all(
+        checker.facts().case_pattern_expansion_spans().to_vec(),
+        || CasePatternVar,
+    );
 }
 
 #[cfg(test)]
@@ -49,12 +43,47 @@ esac
             vec!["$pat", "$(printf '%s' bar)"]
         );
     }
+
     #[test]
     fn ignores_case_patterns_built_from_quoted_literal_fragments() {
         let source = "#!/bin/bash\ncase $value in foo\"bar\"'baz') : ;; esac\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CasePatternVar));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_fully_quoted_case_pattern_expansions() {
+        let source = "\
+#!/bin/sh
+case $value in
+  \"$pat\") : ;;
+  x\"$quoted\") : ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CasePatternVar));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn anchors_mixed_case_patterns_to_the_full_pattern_span() {
+        let source = "\
+#!/bin/sh
+case $value in
+  x$pat) : ;;
+  \"$left\"$right) : ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CasePatternVar));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["x$pat", "\"$left\"$right"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
@@ -73,6 +73,7 @@ esac
 case $value in
   x$pat) : ;;
   \"$left\"$right) : ;;
+  x$left@(foo|bar)) : ;;
 esac
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CasePatternVar));
@@ -82,7 +83,7 @@ esac
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["x$pat", "\"$left\"$right"]
+            vec!["x$pat", "\"$left\"$right", "x$left@(foo|bar)"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
+++ b/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
@@ -1,6 +1,7 @@
 use crate::facts::{ListFact, ListSegmentKind, MixedShortCircuitKind};
 use crate::{Checker, Rule, Violation};
 use shuck_ast::BinaryOp;
+use std::cmp::Reverse;
 
 pub struct ChainedTestBranches;
 
@@ -15,15 +16,44 @@ impl Violation for ChainedTestBranches {
 }
 
 pub fn chained_test_branches(checker: &mut Checker) {
-    let spans = checker
+    let mut lists = checker
         .facts()
         .lists()
         .iter()
         .filter(|list| matches_mixed_short_circuit(checker, list))
-        .filter_map(|list| list.mixed_short_circuit_span())
         .collect::<Vec<_>>();
 
+    lists.sort_by_key(|list| {
+        (
+            list.span().start.offset,
+            Reverse(list.span().end.offset - list.span().start.offset),
+        )
+    });
+
+    let mut reported_lists = Vec::new();
+    let mut spans = Vec::new();
+
+    for list in lists {
+        if reported_lists
+            .iter()
+            .any(|reported| span_strictly_contains(*reported, list.span()))
+        {
+            continue;
+        }
+
+        reported_lists.push(list.span());
+        if let Some(span) = list.mixed_short_circuit_span() {
+            spans.push(span);
+        }
+    }
+
     checker.report_all_dedup(spans, || ChainedTestBranches);
+}
+
+fn span_strictly_contains(outer: shuck_ast::Span, inner: shuck_ast::Span) -> bool {
+    outer.start.offset <= inner.start.offset
+        && inner.end.offset <= outer.end.offset
+        && (outer.start.offset < inner.start.offset || inner.end.offset < outer.end.offset)
 }
 
 fn matches_mixed_short_circuit(checker: &Checker<'_>, list: &ListFact<'_>) -> bool {
@@ -109,7 +139,7 @@ fn matches_exempt_fallback_branch(checker: &Checker<'_>, list: &ListFact<'_>) ->
     };
 
     if last_segment.kind() == ListSegmentKind::AssignmentOnly {
-        return true;
+        return !last_segment.assignment_is_declaration();
     }
 
     matches!(
@@ -226,6 +256,7 @@ test -d x && chmod 755 y || echo fail
     fn ignores_when_only_the_fallback_is_an_assignment_or_list_runs_in_condition_position() {
         let source = "\
 [ -n \"$x\" ] && run_task || fallback=1
+[ \"$hidden\" ] && return 0 || len=${_width%,*}
 if [ ! -d \"$cache_dir\" ] && ! mkdir -p -- \"$cache_dir\" || [ ! -w \"$cache_dir\" ]; then
   :
 fi
@@ -248,5 +279,34 @@ check && log_ok || log_fail
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "&&");
         assert_eq!(diagnostics[1].span.slice(source), "&&");
+    }
+
+    #[test]
+    fn reports_return_guards_that_fall_back_to_declaration_assignments() {
+        let source = "\
+init_guard() {
+  [[ ${FLAG:-} -eq 1 ]] && return || readonly FLAG=1
+}
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::ChainedTestBranches));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "&&");
+    }
+
+    #[test]
+    fn suppresses_nested_lists_when_an_outer_chain_is_already_reported() {
+        let source = "\
+check && {
+  nested && log_ok || log_fail
+} || cleanup
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::ChainedTestBranches));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.slice(source), "&&");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
@@ -33,7 +33,7 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 3);
+        assert_eq!(diagnostics[0].span.start.column, 1);
     }
 
     #[test]
@@ -41,6 +41,18 @@ mod tests {
         let source = "\
 #!/bin/sh
 (( i += 1 ))
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::DoubleParenGrouping));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_grouped_bash_arithmetic_expressions() {
+        let source = "\
+#!/bin/bash
+if ((threads>(cpu_height-3)*3 && tty_width>=200)); then :; fi
 ";
         let diagnostics =
             test_snippet(source, &LinterSettings::for_rule(Rule::DoubleParenGrouping));

--- a/crates/shuck-linter/src/rules/correctness/export_with_positional_params.rs
+++ b/crates/shuck-linter/src/rules/correctness/export_with_positional_params.rs
@@ -64,7 +64,8 @@ export -- \"$@\"
         let source = "\
 #!/bin/bash
 arr=(a b)
-export \"prefix$@suffix\" \"$*\" \"${arr[@]}\" \"$1\" foo
+name=HOME
+export \"$name\" ${name} \"prefix$@suffix\" \"$*\" \"${arr[@]}\" \"$1\" foo
 export target=\"$@\"
 local \"$@\"
 ";

--- a/crates/shuck-linter/src/rules/correctness/expr_substr_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/expr_substr_in_test.rs
@@ -1,10 +1,4 @@
-use shuck_ast::Span;
-
-use crate::{
-    Checker, CommandSubstitutionKind, ConditionalNodeFact, ConditionalOperatorFamily,
-    ExpansionContext, Rule, SimpleTestOperatorFamily, SimpleTestShape, SubstitutionFact, Violation,
-    WordClassification, WordFactContext,
-};
+use crate::{Checker, Rule, Violation};
 
 pub struct ExprSubstrInTest;
 
@@ -14,167 +8,23 @@ impl Violation for ExprSubstrInTest {
     }
 
     fn message(&self) -> String {
-        "this test uses `expr substr` instead of shell substring expansion".to_owned()
+        "this uses an `expr` string helper instead of shell string operations".to_owned()
     }
 }
 
 pub fn expr_substr_in_test(checker: &mut Checker) {
-    let expr_substr_spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter(|fact| {
-            fact.effective_name_is("expr")
-                && fact
-                    .options()
-                    .expr()
-                    .is_some_and(|expr| expr.uses_substr_string_form())
-        })
-        .map(|fact| fact.span())
-        .collect::<Vec<_>>();
-
-    let substitutions = checker
-        .facts()
-        .commands()
-        .iter()
-        .flat_map(|fact| fact.substitution_facts().iter())
-        .collect::<Vec<_>>();
-
     let spans = checker
         .facts()
         .commands()
         .iter()
-        .flat_map(|fact| {
-            let mut spans = Vec::new();
-            if let Some(simple_test) = fact.simple_test()
-                && let Some(span) = simple_test_expr_substr_span(
-                    checker,
-                    simple_test,
-                    &substitutions,
-                    &expr_substr_spans,
-                )
-            {
-                spans.push(span);
-            }
-            if let Some(conditional) = fact.conditional() {
-                spans.extend(conditional_expr_substr_spans(
-                    conditional,
-                    &substitutions,
-                    &expr_substr_spans,
-                ));
-            }
-            spans
+        .filter_map(|fact| {
+            fact.options()
+                .expr()
+                .and_then(|expr| expr.string_helper_span())
         })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ExprSubstrInTest);
-}
-
-fn simple_test_expr_substr_span(
-    checker: &Checker<'_>,
-    simple_test: &crate::SimpleTestFact<'_>,
-    substitutions: &[&SubstitutionFact],
-    expr_substr_spans: &[Span],
-) -> Option<Span> {
-    if simple_test.effective_shape() != SimpleTestShape::Binary
-        || simple_test.effective_operator_family() != SimpleTestOperatorFamily::StringBinary
-    {
-        return None;
-    }
-
-    simple_test.effective_operands().iter().find_map(|word| {
-        test_operand_contains_expr_substr(checker, word, substitutions, expr_substr_spans)
-    })
-}
-
-fn conditional_expr_substr_spans(
-    conditional: &crate::ConditionalFact<'_>,
-    substitutions: &[&SubstitutionFact],
-    expr_substr_spans: &[Span],
-) -> Vec<Span> {
-    conditional
-        .nodes()
-        .iter()
-        .filter_map(|node| match node {
-            ConditionalNodeFact::Binary(binary)
-                if binary.operator_family() == ConditionalOperatorFamily::StringBinary =>
-            {
-                conditional_operand_contains_expr_substr(
-                    binary.left().word(),
-                    binary.left().word_classification(),
-                    substitutions,
-                    expr_substr_spans,
-                )
-                .or_else(|| {
-                    conditional_operand_contains_expr_substr(
-                        binary.right().word(),
-                        binary.right().word_classification(),
-                        substitutions,
-                        expr_substr_spans,
-                    )
-                })
-            }
-            _ => None,
-        })
-        .collect()
-}
-
-fn test_operand_contains_expr_substr(
-    checker: &Checker<'_>,
-    word: &shuck_ast::Word,
-    substitutions: &[&SubstitutionFact],
-    expr_substr_spans: &[Span],
-) -> Option<Span> {
-    checker
-        .facts()
-        .word_fact(
-            word.span,
-            WordFactContext::Expansion(ExpansionContext::CommandArgument),
-        )
-        .filter(|fact| fact.classification().has_plain_command_substitution())
-        .and_then(|_| {
-            command_substitution_contains_expr_substr(word.span, substitutions, expr_substr_spans)
-        })
-}
-
-fn conditional_operand_contains_expr_substr(
-    word: Option<&shuck_ast::Word>,
-    classification: Option<WordClassification>,
-    substitutions: &[&SubstitutionFact],
-    expr_substr_spans: &[Span],
-) -> Option<Span> {
-    let word = word?;
-    let classification = classification?;
-    if !classification.has_plain_command_substitution() {
-        return None;
-    }
-
-    command_substitution_contains_expr_substr(word.span, substitutions, expr_substr_spans)
-}
-
-fn command_substitution_contains_expr_substr(
-    word_span: Span,
-    substitutions: &[&SubstitutionFact],
-    expr_substr_spans: &[Span],
-) -> Option<Span> {
-    substitutions
-        .iter()
-        .copied()
-        .filter(|substitution| {
-            substitution.kind() == CommandSubstitutionKind::Command
-                && substitution.host_word_span() == word_span
-        })
-        .find_map(|substitution| {
-            expr_substr_spans
-                .iter()
-                .copied()
-                .find(|expr_span| span_contains(substitution.span(), *expr_span))
-                .map(|_| substitution.span())
-        })
-}
-
-fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
 }
 
 #[cfg(test)]
@@ -183,12 +33,13 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_expr_substr_inside_test_comparisons() {
+    fn reports_expr_string_helpers_in_multiple_contexts() {
         let source = "\
 #!/bin/sh
-# shellcheck disable=2046
-if test \"$(expr substr $(uname -s) 1 5)\" = \"Linux\"; then echo linux; fi
-if [[ \"$(expr substr $(uname -s) 1 5)\" == \"Linux\" ]]; then echo linux; fi
+x=$(expr length \"$mode\")
+if ! expr index \"$mode\" 'w' >/dev/null; then echo r; fi
+if test \"`expr substr $(uname -s) 1 5`\" = \"Linux\"; then echo linux; fi
+expr match \"$mode\" 'w'
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ExprSubstrInTest));
 
@@ -197,19 +48,17 @@ if [[ \"$(expr substr $(uname -s) 1 5)\" == \"Linux\" ]]; then echo linux; fi
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec![
-                "$(expr substr $(uname -s) 1 5)",
-                "$(expr substr $(uname -s) 1 5)"
-            ]
+            vec!["length", "index", "substr", "match"]
         );
     }
 
     #[test]
-    fn ignores_non_substr_expr_and_non_test_contexts() {
+    fn ignores_expr_arithmetic_and_non_helper_string_forms() {
         let source = "\
 #!/bin/sh
 x=$(expr 1 + 2)
-test \"$x\" = \"Linux\"
+expr \"$a\" = \"$b\"
+expr \"$a\" : '.*'
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ExprSubstrInTest));
 

--- a/crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
@@ -17,7 +17,6 @@ pub fn find_or_without_grouping(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter(|fact| fact.effective_name_is("find"))
         .filter_map(|fact| fact.options().find())
         .flat_map(|find| find.or_without_grouping_spans().iter().copied())
         .collect::<Vec<_>>();
@@ -43,15 +42,14 @@ mod tests {
     }
 
     #[test]
-    fn reports_ungrouped_or_when_right_branch_is_action_only() {
+    fn ignores_when_right_branch_is_action_only() {
         let source = "find . -name a -o -print\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),
         );
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "-print");
+        assert!(diagnostics.is_empty());
     }
 
     #[test]
@@ -79,6 +77,30 @@ mod tests {
     }
 
     #[test]
+    fn reports_ungrouped_or_when_find_exec_branch_has_a_predicate() {
+        let source = "find . -name a -o -name b -exec rm -f {} \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "-exec");
+    }
+
+    #[test]
+    fn reports_ungrouped_or_across_multiple_exec_branches() {
+        let source = "find . -name a -o -name b -o -name c -exec rm -f {} \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "-exec");
+    }
+
+    #[test]
     fn ignores_grouped_or_and_explicit_and() {
         let source = "\
 find . \\( -name a -o -name b \\) -exec rm -f {} \\;
@@ -95,6 +117,17 @@ find . -name a -o -name b -a -exec rm -f {} \\;
     #[test]
     fn ignores_when_an_earlier_branch_already_has_an_action() {
         let source = "find . -name a -print -o -name b -print\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_actions_inside_grouped_right_branches() {
+        let source = "find . \\( -name a -o \\( -name b -exec rm -f {} \\; \\) \\) -print\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),

--- a/crates/shuck-linter/src/rules/correctness/find_output_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_loop.rs
@@ -43,6 +43,18 @@ mod tests {
     }
 
     #[test]
+    fn reports_find_exec_substitutions_in_for_loops() {
+        let source = "for item in $(find . -type f -exec grep -Pl '\\r$' {} \\;); do :; done\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FindOutputLoop));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "$(find . -type f -exec grep -Pl '\\r$' {} \\;)"
+        );
+    }
+
+    #[test]
     fn ignores_non_find_substitutions() {
         let source = "for item in $(command printf '%s\\n' hi); do :; done\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FindOutputLoop));

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -40,6 +40,14 @@ fn unsafe_find_to_xargs_spans(checker: &Checker<'_>, pipeline: &PipelineFact<'_>
                 return None;
             }
 
+            if left
+                .options()
+                .find()
+                .is_some_and(|find| find.has_formatted_output_action())
+            {
+                return None;
+            }
+
             if left.options().find().is_some_and(|find| find.has_print0)
                 && right
                     .options()
@@ -107,5 +115,30 @@ command find . -type f | xargs rm
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.slice(source), "find . -type f");
+    }
+
+    #[test]
+    fn reports_parallel_xargs_without_null_delimiters() {
+        let source = "\
+find \"$dir\" \\( -type f -o -type l \\) -and -not -path \"$dir/plugins/*\" | xargs -I % -P10 bash -c '. /tmp/lib.sh && foo %'
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FindOutputToXargs));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "find \"$dir\" \\( -type f -o -type l \\) -and -not -path \"$dir/plugins/*\""
+        );
+    }
+
+    #[test]
+    fn ignores_find_printf_output_actions() {
+        let source = "\
+find plugins/ -maxdepth 2 -name '__init__.py' -printf '%h\\n' | xargs mv -t \"$dest\"
+find \"$pkg\" -print0 | xargs rm
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FindOutputToXargs));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -132,13 +132,15 @@ find \"$dir\" \\( -type f -o -type l \\) -and -not -path \"$dir/plugins/*\" | xa
     }
 
     #[test]
-    fn ignores_find_printf_output_actions() {
+    fn ignores_find_printf_output_actions_but_reports_print0_without_null_xargs() {
         let source = "\
 find plugins/ -maxdepth 2 -name '__init__.py' -printf '%h\\n' | xargs mv -t \"$dest\"
 find \"$pkg\" -print0 | xargs rm
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FindOutputToXargs));
 
-        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.slice(source), "find \"$pkg\" -print0");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/getopts_option_not_in_case.rs
+++ b/crates/shuck-linter/src/rules/correctness/getopts_option_not_in_case.rs
@@ -346,4 +346,47 @@ done
             "getopts option -b is not handled by this case statement"
         );
     }
+
+    #[test]
+    fn anchors_reports_to_the_case_statement_without_the_following_newline() {
+        let source = "\
+while getopts 'ab' opt; do
+  case \"$opt\" in
+    a) : ;;
+  esac
+  printf '%s\\n' \"$opt\"
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GetoptsOptionNotInCase),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "case \"$opt\" in\n    a) : ;;\n  esac"
+        );
+    }
+
+    #[test]
+    fn excludes_trailing_inline_comments_from_the_case_anchor() {
+        let source = "\
+while getopts 'ab' opt; do
+  case \"$opt\" in
+    a) : ;;
+  esac # trailing comment
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GetoptsOptionNotInCase),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "case \"$opt\" in\n    a) : ;;\n  esac"
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -41,6 +41,7 @@ mod tests {
 grep start* out.txt
 grep \"start*\" out.txt
 grep 'foo*bar' out.txt
+grep 'foo\\*bar*' out.txt
 grep foo*bar out.txt
 grep -efoo* out.txt
 grep --regexp start* out.txt
@@ -64,6 +65,7 @@ grep -E \"foo*bar\" out.txt
                 "start*",
                 "\"start*\"",
                 "'foo*bar'",
+                "'foo\\*bar*'",
                 "foo*bar",
                 "-efoo*",
                 "start*",

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -21,85 +21,12 @@ pub fn glob_in_grep_pattern(checker: &mut Checker) {
         .filter_map(|fact| fact.options().grep())
         .filter(|grep| !grep.uses_fixed_strings)
         .flat_map(|grep| grep.patterns().iter())
-        .filter(|pattern| {
-            pattern
-                .static_text()
-                .filter(|text| !text.starts_with('*'))
-                .is_some_and(has_glob_style_star_confusion)
-        })
+        .filter(|pattern| !pattern.starts_with_glob_style_star())
+        .filter(|pattern| pattern.has_glob_style_star_confusion())
         .map(|pattern| pattern.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || GlobInGrepPattern);
-}
-
-fn has_glob_style_star_confusion(pattern: &str) -> bool {
-    let bytes = pattern.as_bytes();
-
-    if first_unescaped_star_index(bytes).is_some_and(|index| index == 0) {
-        return false;
-    }
-
-    let mut index = 0usize;
-    while let Some(star_index) = next_unescaped_star_index(bytes, index) {
-        let Some(previous) = previous_unescaped_byte(bytes, star_index) else {
-            index = star_index + 1;
-            continue;
-        };
-
-        if matches!(
-            previous,
-            b'.' | b']' | b')' | b'*' | b'+' | b'?' | b'|' | b'^' | b'$' | b'{' | b'(' | b'\\'
-        ) || previous.is_ascii_whitespace()
-        {
-            index = star_index + 1;
-            continue;
-        }
-
-        return true;
-    }
-
-    false
-}
-
-fn first_unescaped_star_index(bytes: &[u8]) -> Option<usize> {
-    next_unescaped_star_index(bytes, 0)
-}
-
-fn next_unescaped_star_index(bytes: &[u8], start: usize) -> Option<usize> {
-    let mut index = start;
-    while index < bytes.len() {
-        if bytes[index] == b'\\' {
-            index = (index + 2).min(bytes.len());
-            continue;
-        }
-        if bytes[index] == b'*' {
-            return Some(index);
-        }
-        index += 1;
-    }
-    None
-}
-
-fn previous_unescaped_byte(bytes: &[u8], index: usize) -> Option<u8> {
-    let mut candidate = index;
-    while candidate > 0 {
-        candidate -= 1;
-        if !is_escaped(bytes, candidate) {
-            return Some(bytes[candidate]);
-        }
-    }
-    None
-}
-
-fn is_escaped(bytes: &[u8], index: usize) -> bool {
-    let mut backslashes = 0usize;
-    let mut cursor = index;
-    while cursor > 0 && bytes[cursor - 1] == b'\\' {
-        backslashes += 1;
-        cursor -= 1;
-    }
-    backslashes % 2 == 1
 }
 
 #[cfg(test)]
@@ -167,6 +94,12 @@ grep --regexp='*start' out.txt
 grep item\\\\* out.txt
 grep '^ *#' out.txt
 grep '\"name\": *\"$x\"' out.txt
+grep '^#* OPTIONS #*$' out.txt
+grep -Eo 'https?://[[:alnum:]./?&!$#%@*;:+~_=-]+' out.txt
+grep '^root:[:!*]' out.txt
+grep -e 'Swarm:*\\sactive\\s*' out.txt
+grep 'foo*bar+' out.txt
+grep '^foo*bar$' out.txt
 grep -F foo*bar out.txt
 grep -F \"foo*bar\" out.txt
 grep --fixed-strings foo*bar out.txt

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Checker, ExpansionContext, Rule, Violation, WordFact, word_has_unquoted_brace_expansion,
-    word_unquoted_glob_pattern_spans,
+    Checker, ExpansionContext, Rule, Violation, WordFact,
+    word_unquoted_glob_pattern_spans_outside_brace_expansion,
 };
 use shuck_ast::Span;
 
@@ -21,8 +21,10 @@ pub fn glob_with_expansion_in_loop(checker: &mut Checker) {
     let spans = checker
         .facts()
         .expansion_word_facts(ExpansionContext::ForList)
-        .filter(|fact| !word_has_unquoted_brace_expansion(fact.word(), source))
-        .filter(|fact| !word_unquoted_glob_pattern_spans(fact.word(), source).is_empty())
+        .filter(|fact| {
+            !word_unquoted_glob_pattern_spans_outside_brace_expansion(fact.word(), source)
+                .is_empty()
+        })
         .flat_map(unquoted_expansion_prefix_spans)
         .collect::<Vec<_>>();
 
@@ -53,6 +55,10 @@ mod tests {
 for i in $CWD/file.*pattern*; do :; done
 for i in ${CWD}/file.*pattern*; do :; done
 for i in $(pwd)/file.*pattern*; do :; done
+for i in $DIR/{1..3}*.txt; do :; done
+for i in $dir/{exec,grom,ecs}.{rom,bin,int}*; do :; done
+for i in $PKG/usr/man/{ja/,}*/*-8.?.?.gz; do :; done
+for file in $BINARY_SAMPLES_V2/{linux,windows}/*_DWARF*/*; do :; done
 ";
         let diagnostics = test_snippet(
             source,
@@ -64,7 +70,15 @@ for i in $(pwd)/file.*pattern*; do :; done
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$CWD", "${CWD}", "$(pwd)"]
+            vec![
+                "$CWD",
+                "${CWD}",
+                "$(pwd)",
+                "$DIR",
+                "$dir",
+                "$PKG",
+                "$BINARY_SAMPLES_V2",
+            ]
         );
     }
 
@@ -76,7 +90,6 @@ for i in \"$CWD\"/file.*pattern*; do :; done
 for i in file.*pattern*; do :; done
 for i in \"$CWD\"/*.txt; do :; done
 for i in $CWD/file.txt; do :; done
-for i in $DIR/{1..3}*.txt; do :; done
 for i in $DIR/setjmp-aarch64/{setjmp.S,private-*.h}; do :; done
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
@@ -79,6 +79,8 @@ $(false) && echo x
 if foo; then :; fi
 if \"$(printf '%s' foo)\"; then :; fi
 if [[ \"$pm\" == apt ]] && \"$(printf '%s' missing)\" != installed; then :; fi
+if $(command -v rvm) -v > /dev/null 2>&1; then :; fi
+if $(tc-getSTRIP) --enable-deterministic-archives |& grep -q aarch; then :; fi
 if command $(false); then :; fi
 if env FOO=1 $(false); then :; fi
 if `printf '%s' ok`; then :; fi

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -42,6 +42,9 @@ fn reportable_glob_span(checker: &Checker<'_>, fact: &crate::facts::WordFact<'_>
     if !matches!(prefix, '*' | '?') {
         return None;
     }
+    if fact.starts_with_extglob() {
+        return None;
+    }
 
     if fact.operand_class()?.is_fixed_literal() {
         return None;
@@ -112,6 +115,29 @@ set -- *
             test_snippet(source, &LinterSettings::for_rule(Rule::LeadingGlobArgument));
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_leading_extglob_patterns() {
+        let source = "\
+shopt -s extglob
+rm ?(*.txt)
+rm *(@.txt)
+rm *.@(jpg|png)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Bash),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
@@ -60,10 +60,10 @@ echo \"$(( x ? $1 : y ))\"
     }
 
     #[test]
-    fn reports_concatenated_positional_parameters_in_valid_arithmetic_words() {
+    fn reports_identifier_prefixed_positional_parameters_in_arithmetic_words() {
         let source = "\
 #!/bin/sh
-echo \"$(( value + $1suffix ))\"
+echo \"$(( value + prefix$1 ))\"
 ";
         let diagnostics = test_snippet(
             source,
@@ -77,12 +77,13 @@ echo \"$(( value + $1suffix ))\"
     }
 
     #[test]
-    fn ignores_non_positional_parameter_expansions_in_arithmetic() {
+    fn ignores_suffix_only_and_expansion_led_arithmetic_words() {
         let source = "\
 #!/bin/sh
-echo \"$(( $_value ))\"
-echo \"$(( ${name} ))\"
-echo \"$(( ${#1} ))\"
+base=8#
+echo \"$(( $1suffix ))\"
+echo \"$(( ${1}suffix ))\"
+echo \"$(( ${base}$1 ))\"
 ";
         let diagnostics = test_snippet(
             source,
@@ -96,7 +97,25 @@ echo \"$(( ${#1} ))\"
     fn ignores_base_prefixed_literals_that_use_positional_parameters() {
         let source = "\
 #!/bin/sh
+echo \"$(( 0x$1 ))\"
+echo \"$(( 0x${1}${2} ^ 0x200 ))\"
 echo \"$(( 16#$1 ))\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PositionalParamAsOperator),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_other_non_positional_parameter_expansions_in_arithmetic() {
+        let source = "\
+#!/bin/sh
+echo \"$(( $_value ))\"
+echo \"$(( ${name} ))\"
+echo \"$(( ${#1} ))\"
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
@@ -33,29 +33,33 @@ fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact<'_
         .filter(|(_, operator)| operator.op() == BinaryOp::Pipe)
         .flat_map(|(segment, _)| {
             let fact = checker.facts().command(segment.command_id());
-            fact.redirect_facts()
+            let redirects = fact.redirect_facts();
+            if has_explicit_output_dup_redirect(redirects, checker.source()) {
+                return Vec::new();
+            }
+
+            redirects
                 .iter()
-                .enumerate()
-                .filter_map(|(index, redirect)| {
-                    stdout_redirect_span_before_pipe(redirect).filter(|_| {
-                        !has_prior_stderr_to_stdout_dup(&fact.redirect_facts()[..index])
-                    })
-                })
+                .filter_map(|redirect| stdout_redirect_span_before_pipe(redirect, checker.source()))
+                .collect::<Vec<_>>()
         })
         .collect()
 }
 
-fn has_prior_stderr_to_stdout_dup(redirects: &[crate::RedirectFact<'_>]) -> bool {
+fn has_explicit_output_dup_redirect(redirects: &[crate::RedirectFact<'_>], source: &str) -> bool {
     redirects.iter().any(|redirect| {
         redirect.redirect().kind == RedirectKind::DupOutput
-            && redirect.redirect().fd == Some(2)
             && redirect
                 .analysis()
-                .is_some_and(|analysis| analysis.numeric_descriptor_target == Some(1))
+                .is_some_and(|analysis| analysis.numeric_descriptor_target.is_some())
+            && redirect.redirect().span.slice(source).contains(">&")
     })
 }
 
-fn stdout_redirect_span_before_pipe(redirect: &crate::RedirectFact<'_>) -> Option<Span> {
+fn stdout_redirect_span_before_pipe(
+    redirect: &crate::RedirectFact<'_>,
+    source: &str,
+) -> Option<Span> {
     let data = redirect.redirect();
     if data.fd.unwrap_or(1) != 1 {
         return None;
@@ -71,7 +75,31 @@ fn stdout_redirect_span_before_pipe(redirect: &crate::RedirectFact<'_>) -> Optio
         return None;
     }
 
-    redirect.analysis()?.is_file_target().then_some(data.span)
+    redirect
+        .analysis()?
+        .is_file_target()
+        .then(|| redirect_operator_span(redirect, source))
+        .flatten()
+}
+
+fn redirect_operator_span(redirect: &crate::RedirectFact<'_>, source: &str) -> Option<Span> {
+    let target_span = redirect.target_span()?;
+    let operator_slice =
+        source.get(redirect.redirect().span.start.offset..target_span.start.offset)?;
+    let operator_start = operator_slice.find('>')?;
+    let operator_end = operator_slice.rfind(|ch: char| !ch.is_whitespace())? + 1;
+    let operator_start_pos = redirect
+        .redirect()
+        .span
+        .start
+        .advanced_by(&operator_slice[..operator_start]);
+    let operator_end_pos = redirect
+        .redirect()
+        .span
+        .start
+        .advanced_by(&operator_slice[..operator_end]);
+
+    Some(Span::from_positions(operator_start_pos, operator_end_pos))
 }
 
 #[cfg(test)]
@@ -86,8 +114,9 @@ mod tests {
 cmd >/dev/null | next
 cmd >out | next
 left | mid >/dev/null | right
-cmd >out | next |& logger
-cmd |& next >/dev/null | logger
+cmd >>out | next
+cmd >|out | next
+cmd 1>out | next
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RedirectBeforePipe));
 
@@ -96,23 +125,44 @@ cmd |& next >/dev/null | logger
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec![">/dev/null", ">out", ">/dev/null", ">out", ">/dev/null"]
+            vec![">", ">", ">", ">>", ">|", ">"]
         );
     }
 
     #[test]
-    fn ignores_stderr_only_descriptor_dups_and_pipeall() {
+    fn ignores_commands_with_descriptor_dups_and_pipeall() {
         let source = "\
 #!/bin/sh
 2>/dev/null | next
 cmd | next >/dev/null
 cmd >/dev/null |& next
 cmd 1>&2 | next
+cmd >out 1>&2 | next
+cmd >out 2>&1 | next
 cmd 2>&1 1>/dev/null | next
+cmd >out 3>&1 | next
 cmd <>file | next
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RedirectBeforePipe));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn still_reports_bash_both_redirects_without_explicit_dups() {
+        let source = "\
+#!/bin/bash
+cmd &>out | next
+cmd &>>out | next
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RedirectBeforePipe));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![">", ">>"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
@@ -33,26 +33,26 @@ fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact<'_
         .filter(|(_, operator)| operator.op() == BinaryOp::Pipe)
         .flat_map(|(segment, _)| {
             let fact = checker.facts().command(segment.command_id());
-            let redirects = fact.redirect_facts();
-            if has_explicit_output_dup_redirect(redirects, checker.source()) {
-                return Vec::new();
-            }
-
-            redirects
+            fact.redirect_facts()
                 .iter()
-                .filter_map(|redirect| stdout_redirect_span_before_pipe(redirect, checker.source()))
+                .enumerate()
+                .filter_map(|(index, redirect)| {
+                    stdout_redirect_span_before_pipe(redirect, checker.source()).filter(|_| {
+                        !has_prior_stderr_to_stdout_dup(&fact.redirect_facts()[..index])
+                    })
+                })
                 .collect::<Vec<_>>()
         })
         .collect()
 }
 
-fn has_explicit_output_dup_redirect(redirects: &[crate::RedirectFact<'_>], source: &str) -> bool {
+fn has_prior_stderr_to_stdout_dup(redirects: &[crate::RedirectFact<'_>]) -> bool {
     redirects.iter().any(|redirect| {
         redirect.redirect().kind == RedirectKind::DupOutput
+            && redirect.redirect().fd == Some(2)
             && redirect
                 .analysis()
-                .is_some_and(|analysis| analysis.numeric_descriptor_target.is_some())
-            && redirect.redirect().span.slice(source).contains(">&")
+                .is_some_and(|analysis| analysis.numeric_descriptor_target == Some(1))
     })
 }
 
@@ -130,17 +130,14 @@ cmd 1>out | next
     }
 
     #[test]
-    fn ignores_commands_with_descriptor_dups_and_pipeall() {
+    fn ignores_stderr_only_descriptor_dups_and_pipeall() {
         let source = "\
 #!/bin/sh
 2>/dev/null | next
 cmd | next >/dev/null
 cmd >/dev/null |& next
 cmd 1>&2 | next
-cmd >out 1>&2 | next
-cmd >out 2>&1 | next
 cmd 2>&1 1>/dev/null | next
-cmd >out 3>&1 | next
 cmd <>file | next
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RedirectBeforePipe));
@@ -163,6 +160,25 @@ cmd &>>out | next
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec![">", ">>"]
+        );
+    }
+
+    #[test]
+    fn reports_output_redirects_with_late_or_unrelated_dup_redirects() {
+        let source = "\
+#!/bin/sh
+cmd >out 1>&2 | next
+cmd >out 2>&1 | next
+cmd >out 3>&1 | next
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RedirectBeforePipe));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![">", ">", ">"]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C071_C071.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C071_C071.sh.snap
@@ -3,7 +3,7 @@ source: crates/shuck-linter/src/rules/correctness/mod.rs
 assertion_line: 102
 ---
 C071 double parentheses are used to group commands instead of arithmetic
- --> <source>:3:3
+ --> <source>:3:1
   |
 3 | ((ps aux | grep foo) || kill "$pid") 2>/dev/null
   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C111_C111.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C111_C111.sh.snap
@@ -1,20 +1,57 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 286
 ---
-C111 positional-parameter at-splats fold arguments in string comparisons
- --> <source>:5:8
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:5:9
   |
-5 | if [ "_$@" = "_--version" ]; then :; fi
-  |
-
-C111 positional-parameter at-splats fold arguments in string comparisons
- --> <source>:6:7
-  |
-6 | if [ "$@" = "--version" ]; then :; fi
+5 | if [ -z "$@" ]; then :; fi
   |
 
-C111 positional-parameter at-splats fold arguments in string comparisons
- --> <source>:7:7
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:6:12
   |
-7 | if [ "${@:-fallback}" = "--version" ]; then :; fi
+6 | if test -n "${@:-fallback}"; then :; fi
   |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:7:9
+  |
+7 | if [ -d "$@" ]; then :; fi
+  |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:8:6
+  |
+8 | if [ "_$@" = "_--version" ]; then :; fi
+  |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:9:6
+  |
+9 | if [ "$@" = "--version" ]; then :; fi
+  |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+  --> <source>:10:16
+   |
+10 | if [ -n foo -a "${@:-lhs}" = "${@:-rhs}" ]; then :; fi
+   |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+  --> <source>:10:30
+   |
+10 | if [ -n foo -a "${@:-lhs}" = "${@:-rhs}" ]; then :; fi
+   |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+  --> <source>:11:9
+   |
+11 | if [ -d "$@" -o "${@:-fallback}" = "x" ]; then :; fi
+   |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+  --> <source>:11:17
+   |
+11 | if [ -d "$@" -o "${@:-fallback}" = "x" ]; then :; fi
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C114_C114.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C114_C114.sh.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 286
 ---
 C114 quote expansion prefixes when combining them with loop globs
  --> <source>:2:10
@@ -17,4 +18,10 @@ C114 quote expansion prefixes when combining them with loop globs
  --> <source>:4:10
   |
 4 | for i in $(pwd)/file.*pattern*; do :; done
+  |
+
+C114 quote expansion prefixes when combining them with loop globs
+ --> <source>:9:10
+  |
+9 | for i in $DIR/{1..3}*.txt; do :; done
   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C120_C120.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C120_C120.sh.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
 ---
-C120 this test uses `expr substr` instead of shell substring expansion
- --> <source>:3:10
+C120 this uses an `expr` string helper instead of shell string operations
+ --> <source>:3:17
   |
 3 | if test "$(expr substr $(uname -s) 1 5)" = "Linux"; then echo linux; fi
   |

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashSet;
 use shuck_ast::RedirectKind;
 
 use crate::{Checker, RedirectFact, Rule, Violation};
@@ -15,9 +16,23 @@ impl Violation for StderrBeforeStdoutRedirect {
 }
 
 pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
+    let pipeline_producer_command_ids = checker
+        .facts()
+        .pipelines()
+        .iter()
+        .flat_map(|pipeline| {
+            pipeline
+                .segments()
+                .split_last()
+                .into_iter()
+                .flat_map(|(_, producers)| producers.iter().map(|segment| segment.command_id()))
+        })
+        .collect::<FxHashSet<_>>();
+
     let spans = checker
         .facts()
         .structural_commands()
+        .filter(|fact| !pipeline_producer_command_ids.contains(&fact.id()))
         .flat_map(|fact| {
             let redirects = fact.redirect_facts();
             redirects
@@ -76,5 +91,21 @@ out=$(bar 2>&1 >/dev/null)
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn ignores_pipeline_producers_but_keeps_pipeline_tail_reports() {
+        let source = "\
+#!/bin/sh
+foo 2>&1 >/dev/null | sed 's/x/y/'
+echo ok | foo 2>&1 >/dev/null
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 3);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/template_brace_in_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/template_brace_in_command.rs
@@ -74,4 +74,20 @@ echo hi > \"{{name}}\"
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_other_malformed_command_name_shapes_without_template_braces() {
+        let source = "\
+#!/bin/sh
+\"ERROR: missing arg\"
+amoeba=\"\" [ \"${AMOEBA:-yes}\" = \"yes\" ] && amoeba=1
++++ diff header
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::TemplateBraceInCommand),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/trap_string_expansion.rs
+++ b/crates/shuck-linter/src/rules/correctness/trap_string_expansion.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{Checker, ExpansionContext, Rule, Violation, WordQuote};
 
 pub struct TrapStringExpansion;
 
@@ -16,6 +16,7 @@ pub fn trap_string_expansion(checker: &mut Checker) {
     let spans = checker
         .facts()
         .expansion_word_facts(ExpansionContext::TrapAction)
+        .filter(|fact| fact.classification().quote == WordQuote::FullyQuoted)
         .flat_map(|fact| fact.double_quoted_expansion_spans().iter().copied())
         .collect::<Vec<_>>();
 
@@ -54,17 +55,15 @@ mod tests {
     }
 
     #[test]
-    fn reports_expansions_inside_mixed_quoted_trap_words() {
-        let source = "trap foo\"$x\"bar\"$(date)\" EXIT\n";
+    fn ignores_mixed_quoted_trap_words() {
+        let source = "\
+trap foo\"$x\"bar EXIT
+trap \"$x\"\"$y\" EXIT
+trap 'result=$?; '\"delete_container $container msg\"' || : ; exit $result' EXIT
+";
         let diagnostics =
             test_snippet(source, &LinterSettings::for_rule(Rule::TrapStringExpansion));
 
-        assert_eq!(
-            diagnostics
-                .iter()
-                .map(|diagnostic| diagnostic.span.slice(source))
-                .collect::<Vec<_>>(),
-            vec!["$x", "$(date)"]
-        );
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
@@ -1,6 +1,6 @@
-use shuck_ast::Span;
+use shuck_ast::{ConditionalUnaryOp, Span};
 
-use crate::{Checker, ConditionalNodeFact, Rule, SimpleTestShape, Violation};
+use crate::{Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, Violation};
 
 pub struct TruthyLiteralTest;
 
@@ -15,44 +15,81 @@ impl Violation for TruthyLiteralTest {
 }
 
 pub fn truthy_literal_test(checker: &mut Checker) {
+    let source = checker.source();
     let spans = checker
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| {
-            if let Some(simple_test) = fact.simple_test()
-                && simple_test_matches(simple_test)
-            {
-                return simple_test_report_span(simple_test);
+        .flat_map(|fact| {
+            let mut spans = Vec::new();
+            if let Some(simple_test) = fact.simple_test() {
+                spans.extend(simple_test_report_spans(simple_test, source));
             }
-
-            fact.conditional().and_then(conditional_report_span)
+            if let Some(conditional) = fact.conditional() {
+                spans.extend(conditional_report_spans(conditional));
+            }
+            spans
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || TruthyLiteralTest);
+    checker.report_all_dedup(spans, || TruthyLiteralTest);
 }
 
-fn simple_test_matches(fact: &crate::SimpleTestFact<'_>) -> bool {
-    fact.shape() == SimpleTestShape::Truthy
-        && fact
-            .truthy_operand_class()
-            .is_some_and(|class| class.is_fixed_literal())
+fn simple_test_report_spans(fact: &crate::SimpleTestFact<'_>, source: &str) -> Vec<Span> {
+    fact.truthy_expression_words(source)
+        .into_iter()
+        .filter_map(|word| {
+            fact.effective_operands()
+                .iter()
+                .position(|operand| operand.span == word.span)
+                .and_then(|index| fact.effective_operand_class(index))
+                .is_some_and(|class| class.is_fixed_literal())
+                .then_some(word.span)
+        })
+        .collect()
 }
 
-fn simple_test_report_span(fact: &crate::SimpleTestFact<'_>) -> Option<Span> {
-    (fact.shape() == SimpleTestShape::Truthy)
-        .then(|| fact.operands().first().map(|word| word.span))
-        .flatten()
-}
+fn conditional_report_spans(fact: &crate::ConditionalFact<'_>) -> Vec<Span> {
+    let excluded_operand_spans = fact
+        .nodes()
+        .iter()
+        .flat_map(|node| match node {
+            ConditionalNodeFact::Unary(unary) if unary.op() != ConditionalUnaryOp::Not => unary
+                .operand()
+                .word()
+                .map(|word| vec![word.span])
+                .unwrap_or_default(),
+            ConditionalNodeFact::Binary(binary)
+                if binary.operator_family() != ConditionalOperatorFamily::Logical =>
+            {
+                [binary.left().word(), binary.right().word()]
+                    .into_iter()
+                    .flatten()
+                    .map(|word| word.span)
+                    .collect::<Vec<_>>()
+            }
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => Vec::new(),
+        })
+        .collect::<Vec<_>>();
 
-fn conditional_report_span(fact: &crate::ConditionalFact<'_>) -> Option<Span> {
-    match fact.root() {
-        ConditionalNodeFact::BareWord(word) if word.operand().class().is_fixed_literal() => {
-            word.operand().word().map(|word| word.span)
-        }
-        _ => None,
-    }
+    fact.nodes()
+        .iter()
+        .filter_map(|node| match node {
+            ConditionalNodeFact::BareWord(word)
+                if word.operand().class().is_fixed_literal()
+                    && word
+                        .operand()
+                        .word()
+                        .is_some_and(|operand| !excluded_operand_spans.contains(&operand.span)) =>
+            {
+                word.operand().word().map(|operand| operand.span)
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -112,6 +149,45 @@ test foo
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "\"\"");
+    }
+
+    #[test]
+    fn reports_truthy_terms_inside_simple_test_logical_chains() {
+        let source = "\
+#!/bin/sh
+[ \"$mode\" = yes -o foo ]
+[ bar -a \"$mode\" = yes ]
+[ \"$mode\" = yes -o \"$other\" = no ]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TruthyLiteralTest));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["foo", "bar"]
+        );
+    }
+
+    #[test]
+    fn reports_truthy_literals_inside_negated_and_logical_conditionals() {
+        let source = "\
+#!/bin/bash
+[[ ! foo ]]
+[[ \"$mode\" == yes || bar ]]
+[[ ! -n baz ]]
+[[ foo == bar ]]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TruthyLiteralTest));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["foo", "bar"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
@@ -56,4 +56,20 @@ echo 'hello ‘world’'
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_unicode_smart_quotes_inside_heredoc_payloads() {
+        let source = "\
+#!/bin/sh
+cat <<EOF
+q { quotes: \"“\" \"”\" \"‘\" \"’\"; }
+EOF
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnicodeQuoteInString),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
@@ -26,8 +26,7 @@ pub fn unicode_single_quote_in_single_quotes(checker: &mut Checker) {
                 }
 
                 let start = fragment.span().start.advanced_by(&text[..offset]);
-                let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
-                Some(shuck_ast::Span::from_positions(start, end))
+                Some(shuck_ast::Span::from_positions(start, start))
             })
         })
         .collect::<Vec<_>>();
@@ -55,9 +54,20 @@ echo \"hello ‘world’\"
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.slice(source))
+                .map(|diagnostic| {
+                    (
+                        diagnostic.span.start.line,
+                        diagnostic.span.start.column,
+                        diagnostic.span.end.line,
+                        diagnostic.span.end.column,
+                        source[diagnostic.span.start.offset..]
+                            .chars()
+                            .next()
+                            .unwrap(),
+                    )
+                })
                 .collect::<Vec<_>>(),
-            vec!["‘", "’"]
+            vec![(2, 13, 2, 13, '‘'), (2, 19, 2, 19, '’')]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
@@ -57,18 +57,17 @@ fn combined_ampersand_redirect_span(redirect: &RedirectFact<'_>, source: &str) -
     }
     let operator_text = &source[redirect_start..target_start];
     let operator_offset = operator_text.find(">&")?;
+    if !operator_text[..operator_offset]
+        .chars()
+        .all(char::is_whitespace)
+    {
+        return None;
+    }
     if !operator_text[operator_offset..].starts_with(">&") {
         return None;
     }
 
-    let operator_start = redirect_data
-        .span
-        .start
-        .advanced_by(&operator_text[..operator_offset]);
-    Some(Span::from_positions(
-        operator_start,
-        operator_start.advanced_by(">&"),
-    ))
+    Some(redirect_data.span)
 }
 
 #[cfg(test)]
@@ -82,25 +81,26 @@ mod tests {
 #!/bin/sh
 echo test >& /dev/null
 echo test >&+1
-echo test 1>&/tmp/log
 ";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::AmpersandRedirectInSh),
         );
 
-        assert_eq!(diagnostics.len(), 3);
-        assert_eq!(diagnostics[0].span.slice(source), ">&");
-        assert_eq!(diagnostics[1].span.slice(source), ">&");
-        assert_eq!(diagnostics[2].span.slice(source), ">&");
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), ">& /dev/null");
+        assert_eq!(diagnostics[1].span.slice(source), ">&+1");
     }
 
     #[test]
-    fn ignores_descriptor_duplication_and_close_forms() {
+    fn ignores_descriptor_duplication_close_and_explicit_fd_forms() {
         let source = "\
 #!/bin/sh
 echo test >&2
 echo test 1>&2
+echo test 1>&+1
+echo test 1>&/tmp/log
+echo test 2>&/tmp/log
 echo test >&\"2\"
 echo test 1>&\"2\"
 echo test >&-

--- a/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
@@ -47,11 +47,16 @@ echo 'It'\''s just quote plumbing'
 echo "  echo You may need to get \\\`FluidR3_GM.sf2\\' from somewhere"
 echo "sed -e 's|^\\(CertStore=\\).*|\\1X|g'"
 echo "prefix $VAR \\0 suffix"
+echo -DLATEX=\\"$(which latex)\\"
+echo "  .TargetPath = \"\\\\host.lan\\Data\""
 echo -e "\n"
 echo -n -e "\n"
 echo -n "$flag" -e \x41
 echo \c
 echo \u1234
+echo -n "\"${shortname}\""
+echo "include \"$TERMUX_PREFIX/share/nano/*nanorc\""
+echo "  .TargetPath = \"\\host.lan\\Data\""
 command echo \n
 builtin echo \n
 printf '%s\n' \n
@@ -78,6 +83,8 @@ printf '%s\n' \n
                 "\"  echo You may need to get \\\\\\`FluidR3_GM.sf2\\\\' from somewhere\"",
                 "\"sed -e 's|^\\\\(CertStore=\\\\).*|\\\\1X|g'\"",
                 "\"prefix $VAR \\\\0 suffix\"",
+                "-DLATEX=\\\\\"$(which latex)\\\\\"",
+                "\"  .TargetPath = \\\"\\\\\\\\host.lan\\\\Data\\\"\"",
                 "\\x41",
             ]
         );

--- a/crates/shuck-linter/src/rules/portability/pipefail_option.rs
+++ b/crates/shuck-linter/src/rules/portability/pipefail_option.rs
@@ -86,6 +86,17 @@ set -o pipefail
     }
 
     #[test]
+    fn ignores_other_set_o_names_in_sh() {
+        let source = "\
+#!/bin/sh
+set -o posix
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::PipefailOption));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_positional_pipefail_after_double_dash() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/portability/star_glob_removal_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/star_glob_removal_in_sh.rs
@@ -36,7 +36,7 @@ mod tests {
     fn anchors_only_on_star_longest_suffix_removal() {
         let source = "\
 #!/bin/sh
-printf '%s\n' \"${*%%dBm*}\" \"${*%dBm*}\" \"${@%%dBm*}\" \"${name%%dBm*}\"
+printf '%s\n' \"${*%%dBm*}\" \"${*%dBm*}\" \"${@%%dBm*}\" \"${@##*.}\" \"${name%%dBm*}\"
 ";
         let diagnostics =
             test_snippet(source, &LinterSettings::for_rule(Rule::StarGlobRemovalInSh));

--- a/crates/shuck-linter/src/rules/style/ampersand_semicolon.rs
+++ b/crates/shuck-linter/src/rules/style/ampersand_semicolon.rs
@@ -1,5 +1,3 @@
-use shuck_ast::{BackgroundOperator, Span, StmtTerminator};
-
 use crate::{Checker, Rule, Violation};
 
 pub struct AmpersandSemicolon;
@@ -15,53 +13,10 @@ impl Violation for AmpersandSemicolon {
 }
 
 pub fn ampersand_semicolon(checker: &mut Checker) {
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|command| ampersand_semicolon_span(command, checker.source()))
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || AmpersandSemicolon);
-}
-
-fn ampersand_semicolon_span(command: &crate::CommandFact<'_>, source: &str) -> Option<Span> {
-    if command.stmt().terminator != Some(StmtTerminator::Background(BackgroundOperator::Plain)) {
-        return None;
-    }
-    let terminator_span = command.stmt().terminator_span?;
-    if terminator_span.slice(source) != "&" {
-        return None;
-    }
-
-    let mut semicolon_offset = None;
-    for (relative, ch) in source[terminator_span.end.offset..].char_indices() {
-        if matches!(ch, ' ' | '\t' | '\r') {
-            continue;
-        }
-        if ch == '\n' || ch == '#' {
-            return None;
-        }
-        if ch == ';' {
-            semicolon_offset = Some(terminator_span.end.offset + relative);
-        }
-        break;
-    }
-    let semicolon_offset = semicolon_offset?;
-    let start = position_at_offset(source, semicolon_offset)?;
-    let end = start.advanced_by(";");
-    Some(Span::from_positions(start, end))
-}
-
-fn position_at_offset(source: &str, target_offset: usize) -> Option<shuck_ast::Position> {
-    if target_offset > source.len() {
-        return None;
-    }
-    let mut position = shuck_ast::Position::new();
-    for ch in source[..target_offset].chars() {
-        position.advance(ch);
-    }
-    Some(position)
+    checker.report_all_dedup(
+        checker.facts().background_semicolon_spans().to_vec(),
+        || AmpersandSemicolon,
+    );
 }
 
 #[cfg(test)]
@@ -84,6 +39,22 @@ mod tests {
     #[test]
     fn ignores_background_without_semicolon() {
         let source = "#!/bin/sh\necho x &\nwait\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AmpersandSemicolon));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_case_item_terminators_after_background() {
+        let source = "\
+#!/bin/bash
+case ${1-} in
+  break) printf '%s\\n' ok &;;
+  spaced) printf '%s\\n' ok & ;;
+  fallthrough) printf '%s\\n' ok & ;&
+  continue) printf '%s\\n' ok & ;;&
+esac
+";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AmpersandSemicolon));
 
         assert!(diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/style/array_index_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/array_index_arithmetic.rs
@@ -41,8 +41,8 @@ mod tests {
     }
 
     #[test]
-    fn reports_arithmetic_expansions_inside_array_keys() {
-        let source = "#!/bin/bash\ndeclare -A map=([foo[$((1+1))]]=x)\n";
+    fn reports_arithmetic_expansions_inside_declaration_subscripts() {
+        let source = "#!/bin/bash\ndeclare arr[$((1+1))]=x\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::ArrayIndexArithmetic),
@@ -54,6 +54,25 @@ mod tests {
     #[test]
     fn ignores_plain_arithmetic_subscripts_without_expansion() {
         let source = "#!/bin/bash\narr[1+1]=x\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayIndexArithmetic),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_associative_and_non_lvalue_subscript_contexts() {
+        let source = "\
+#!/bin/bash
+declare -A map
+map[$((assoc+1))]=x
+map[temp_$((mixed+1))]=y
+map=([$((compound+1))]=z)
+printf '%s\\n' \"${map[$((read+1))]}\"
+[[ -v map[$((check+1))] ]]
+";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::ArrayIndexArithmetic),

--- a/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
+++ b/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
@@ -35,7 +35,7 @@ fn let_command_span(source: &str, fact: &crate::facts::CommandFact<'_>) -> Optio
     let mut end = fact
         .body_args()
         .last()
-        .map_or(name.span.end, |word| word.span.end);
+        .map_or(name.span.end, |word| let_argument_end(source, word));
 
     let tail = source.get(end.offset..)?;
     let mut padding_end = end;
@@ -55,6 +55,17 @@ fn let_command_span(source: &str, fact: &crate::facts::CommandFact<'_>) -> Optio
     Some(Span::from_positions(name.span.start, end))
 }
 
+fn let_argument_end(source: &str, word: &shuck_ast::Word) -> shuck_ast::Position {
+    if word.is_fully_quoted() {
+        let text = word.span.slice(source);
+        if let Some(trimmed) = text.strip_suffix('"').or_else(|| text.strip_suffix('\'')) {
+            return word.span.start.advanced_by(trimmed);
+        }
+    }
+
+    word.span.end
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
@@ -69,6 +80,17 @@ mod tests {
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.start.column, 1);
         assert_eq!(diagnostics[0].span.end.column, 7);
+    }
+
+    #[test]
+    fn anchors_quoted_let_builtin_before_closing_quote() {
+        let source = "#!/usr/bin/env bash\nlet \"number %= RANGE\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AvoidLetBuiltin));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.end.column, 21);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/command_output_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/command_output_array_split.rs
@@ -24,7 +24,9 @@ pub fn command_output_array_split(checker: &mut Checker) {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
+    use std::path::Path;
+
+    use crate::test::{test_snippet, test_snippet_at_path};
     use crate::{LinterSettings, Rule};
 
     #[test]
@@ -70,5 +72,86 @@ declare -A map=([k]=$(printf '%s\\n' assoc))
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_command_output_array_split_in_nb_theme_validation_flow() {
+        let source = r#"#!/usr/bin/env bash
+set -o noglob
+IFS=$'\n\t'
+
+validate_theme() {
+  if ! _bat --command-exists
+  then
+    printf "bat required\n"
+  elif [[ -z "${1:-}" ]]
+  then
+    return 1
+  else
+    local _theme_list=
+    _theme_list=($(_bat --list-themes --color never))
+
+    local __theme=
+    for __theme in "${_theme_list[@]}"
+    do
+      if [[ "$1" == "${__theme:-}" ]]
+      then
+        return 0
+      fi
+    done
+  fi
+}
+"#;
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/scripts/xwmx__nb__nb"),
+            source,
+            &LinterSettings::for_rule(Rule::CommandOutputArraySplit),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(_bat --list-themes --color never)"]
+        );
+    }
+
+    #[test]
+    fn keeps_s018_before_following_extglob_parameter_pattern_condition() {
+        let source = r#"#!/usr/bin/env bash
+shopt -s extglob
+check() {
+  local _theme_list=
+  _theme_list=($(printf '%s\n' 'Solarized (dark)' base16))
+  local __theme=
+  for __theme in "${_theme_list[@]}"
+  do
+    if [[ "${2}" =~ \( ]]
+    then
+      if [[ "${2}" == "${__theme:-}" ]]
+      then
+        return 0
+      fi
+    elif [[ "${2}" =~ ^${__theme%% (*} ]]
+    then
+      return 0
+    fi
+  done
+}
+"#;
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/scripts/xwmx__nb__nb"),
+            source,
+            &LinterSettings::for_rule(Rule::CommandOutputArraySplit),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(printf '%s\\n' 'Solarized (dark)' base16)"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/command_substitution_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/command_substitution_in_alias.rs
@@ -8,38 +8,59 @@ impl Violation for CommandSubstitutionInAlias {
     }
 
     fn message(&self) -> String {
-        "avoid command substitutions in alias definitions".to_owned()
+        "avoid expansions in alias definitions".to_owned()
     }
 }
 
 pub fn command_substitution_in_alias(checker: &mut Checker) {
     let source = checker.source();
-    let alias_definition_spans = checker
+    let word_facts = checker.facts().word_facts();
+    let spans = checker
         .facts()
         .commands()
         .iter()
-        .filter(|fact| {
-            fact.effective_name_is("alias")
-                && fact
-                    .body_args()
-                    .iter()
-                    .any(|word| word.span.slice(source).contains('='))
-        })
+        .filter(|fact| fact.effective_name_is("alias"))
         .flat_map(|fact| {
-            fact.body_args()
-                .iter()
-                .filter(|word| word.span.slice(source).contains('='))
-                .map(|word| word.span)
-        })
-        .collect::<Vec<_>>();
+            let body_args = fact.body_args();
+            let mut definition_spans = Vec::new();
+            let mut index = 0usize;
 
-    let spans = checker
-        .facts()
-        .word_facts()
-        .iter()
-        .filter(|fact| fact.expansion_context() == Some(ExpansionContext::CommandArgument))
-        .filter(|fact| alias_definition_spans.contains(&fact.span()))
-        .flat_map(|fact| fact.command_substitution_spans().iter().copied())
+            while let Some(word) = body_args.get(index).copied() {
+                let text = word.span.slice(source);
+                if !text.contains('=') {
+                    index += 1;
+                    continue;
+                }
+
+                let mut definition_len = 1usize;
+                let mut last_word = word;
+                while last_word.span.slice(source).ends_with('=')
+                    && let Some(next_word) = body_args.get(index + definition_len).copied()
+                    && last_word.span.end.offset == next_word.span.start.offset
+                {
+                    last_word = next_word;
+                    definition_len += 1;
+                }
+
+                let first_expansion = body_args[index..index + definition_len]
+                    .iter()
+                    .filter_map(|candidate| {
+                        word_facts.iter().find(|fact| {
+                            fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                                && fact.span() == candidate.span
+                        })
+                    })
+                    .flat_map(|fact| fact.active_expansion_spans().iter().copied())
+                    .min_by_key(|span| (span.start.offset, span.end.offset));
+                if let Some(first_expansion) = first_expansion {
+                    definition_spans.push(first_expansion);
+                }
+
+                index += definition_len;
+            }
+
+            definition_spans
+        })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || CommandSubstitutionInAlias);
@@ -51,11 +72,16 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_command_substitutions_inside_alias_definitions() {
+    fn reports_active_expansions_inside_alias_definitions() {
         let source = "\
-#!/bin/sh
+#!/bin/bash
+alias home=$HOME
+alias icloud=\"cd '$HOME'\"
 alias printf=$(command -v printf)
-alias a=$(command -v printf) b=$(command -v cat)
+alias math=\"$((1+2))\"
+alias list=${arr[@]}
+alias proc=<(printf hi)
+alias brace={a,b}
 alias plain=printf
 ";
         let diagnostics = test_snippet(
@@ -69,20 +95,27 @@ alias plain=printf
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec![
+                "$HOME",
+                "$HOME",
                 "$(command -v printf)",
-                "$(command -v printf)",
-                "$(command -v cat)"
+                "$((1+2))",
+                "${arr[@]}",
+                "<(printf hi)",
+                "{a,b}",
             ]
         );
     }
 
     #[test]
-    fn ignores_aliases_without_command_substitutions() {
+    fn ignores_aliases_without_active_expansions() {
         let source = "\
-#!/bin/sh
+#!/bin/bash
 alias printf=printf
-alias foo=$BAR
 alias plain='$(command -v printf)'
+alias param='${HOME}'
+alias brace='{a,b}'
+alias ansi=$'\\n'
+alias tilde=~
 \\alias \"${1-}\" >/dev/null 2>&1
 alias -p
 ";
@@ -107,5 +140,26 @@ FOO=$(date) BAR=$(uname) alias ll='ls -l'
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_only_the_first_active_expansion_per_alias_definition() {
+        let source = "\
+#!/bin/bash
+alias \"$a=$b\"
+alias \"${method}\"=\"lwp-request -m '${method}'\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CommandSubstitutionInAlias),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$a", "${method}"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
 
 pub struct FunctionInAlias;
 
@@ -13,137 +13,8 @@ impl Violation for FunctionInAlias {
 }
 
 pub fn function_in_alias(checker: &mut Checker) {
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter(|fact| fact.effective_name_is("alias"))
-        .flat_map(|fact| {
-            fact.body_args().iter().filter_map(move |word| {
-                let text = static_word_text(word, source)?;
-                let (_, value) = text.split_once('=')?;
-                contains_function_definition(value).then_some(word.span)
-            })
-        })
-        .collect::<Vec<_>>();
-
+    let spans = checker.facts().function_in_alias_spans().to_vec();
     checker.report_all_dedup(spans, || FunctionInAlias);
-}
-
-fn contains_function_definition(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    let mut index = 0;
-    while index < bytes.len() {
-        if starts_with_keyword(value, index, "function")
-            && precedes_definition_start(value, index)
-            && is_definition_after_function_keyword(value, index + "function".len())
-        {
-            return true;
-        }
-        if is_identifier_start(bytes[index])
-            && precedes_definition_start(value, index)
-            && is_definition_after_name(value, index, bytes.len())
-        {
-            return true;
-        }
-        index += 1;
-    }
-    false
-}
-
-fn starts_with_keyword(text: &str, index: usize, keyword: &str) -> bool {
-    let tail = &text[index..];
-    if !tail.starts_with(keyword) {
-        return false;
-    }
-    let before_ok = index == 0 || !is_identifier_char(text.as_bytes()[index - 1]);
-    let after_index = index + keyword.len();
-    let after_ok = after_index >= text.len() || !is_identifier_char(text.as_bytes()[after_index]);
-    before_ok && after_ok
-}
-
-fn precedes_definition_start(text: &str, index: usize) -> bool {
-    if index == 0 {
-        return true;
-    }
-
-    let bytes = text.as_bytes();
-    let mut cursor = index;
-    while cursor > 0 && bytes[cursor - 1].is_ascii_whitespace() {
-        cursor -= 1;
-    }
-
-    cursor == 0 || matches!(bytes[cursor - 1], b';' | b'|' | b'&' | b'(' | b'{' | b'\n')
-}
-
-fn is_definition_after_function_keyword(text: &str, mut index: usize) -> bool {
-    let bytes = text.as_bytes();
-    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-        index += 1;
-    }
-
-    let Some(end) = parse_identifier(text, index) else {
-        return false;
-    };
-    is_definition_suffix(text, end, false)
-}
-
-fn is_definition_after_name(text: &str, index: usize, len: usize) -> bool {
-    let Some(end) = parse_identifier(text, index) else {
-        return false;
-    };
-    if end >= len {
-        return false;
-    }
-    is_definition_suffix(text, end, true)
-}
-
-fn is_definition_suffix(text: &str, mut index: usize, require_parens: bool) -> bool {
-    let bytes = text.as_bytes();
-    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-        index += 1;
-    }
-
-    let has_parens = bytes
-        .get(index..)
-        .is_some_and(|rest| rest.starts_with(b"()"));
-    if require_parens && !has_parens {
-        return false;
-    }
-
-    if has_parens {
-        index += 2;
-        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-            index += 1;
-        }
-    }
-
-    bytes.get(index) == Some(&b'{')
-}
-
-fn parse_identifier(text: &str, index: usize) -> Option<usize> {
-    let bytes = text.as_bytes();
-    let first = bytes.get(index).copied()?;
-    if !is_identifier_start(first) {
-        return None;
-    }
-    let mut end = index + 1;
-    while let Some(byte) = bytes.get(end) {
-        if !is_identifier_char(*byte) {
-            break;
-        }
-        end += 1;
-    }
-    Some(end)
-}
-
-fn is_identifier_start(byte: u8) -> bool {
-    byte.is_ascii_alphabetic() || byte == b'_'
-}
-
-fn is_identifier_char(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 #[cfg(test)]
@@ -181,6 +52,7 @@ alias bar='$(printf hi)'
 alias baz='noglob gtl'
 alias brace='echo {a,b}'
 alias not_fn='helper { echo hi; }'
+alias positional='${1+\"$@\"}'
 alias -p
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));

--- a/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
+++ b/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
@@ -36,7 +36,9 @@ EOF
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 4);
         assert_eq!(diagnostics[0].span.start.column, 4);
-        assert_eq!(diagnostics[0].span.slice(source), " ");
+        assert_eq!(diagnostics[0].span.end.line, 4);
+        assert_eq!(diagnostics[0].span.end.column, 4);
+        assert_eq!(diagnostics[0].span.slice(source), "");
     }
 
     #[test]
@@ -46,7 +48,9 @@ EOF
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.slice(source), "\t");
+        assert_eq!(diagnostics[0].span.start.column, 4);
+        assert_eq!(diagnostics[0].span.end.column, 4);
+        assert_eq!(diagnostics[0].span.slice(source), "");
     }
 
     #[test]
@@ -61,7 +65,22 @@ cat <<-EOF
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.slice(source), " ");
+        assert_eq!(diagnostics[0].span.start.column, 5);
+        assert_eq!(diagnostics[0].span.end.column, 5);
+        assert_eq!(diagnostics[0].span.slice(source), "");
+    }
+
+    #[test]
+    fn anchors_at_the_first_trailing_whitespace_character() {
+        let source = "#!/bin/sh\ncat <<EOF\nok\nEOF  \t\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::HeredocEndSpace));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.column, 4);
+        assert_eq!(diagnostics[0].span.end.line, 4);
+        assert_eq!(diagnostics[0].span.end.column, 4);
+        assert_eq!(diagnostics[0].span.slice(source), "");
     }
 
     #[test]
@@ -91,6 +110,8 @@ EOF
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.slice(source), " ");
+        assert_eq!(diagnostics[0].span.start.column, 4);
+        assert_eq!(diagnostics[0].span.end.column, 4);
+        assert_eq!(diagnostics[0].span.slice(source), "");
     }
 }

--- a/crates/shuck-linter/src/rules/style/legacy_backticks.rs
+++ b/crates/shuck-linter/src/rules/style/legacy_backticks.rs
@@ -17,6 +17,7 @@ pub fn legacy_backticks(checker: &mut Checker) {
         .facts()
         .backtick_fragments()
         .iter()
+        .filter(|fragment| !fragment.is_empty())
         .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
 
@@ -63,6 +64,130 @@ mod tests {
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["`pyenv-commands --sh`"]
+        );
+    }
+
+    #[test]
+    fn ignores_empty_backtick_markup_inside_double_quotes() {
+        let source = "echo \"Resolve the conflict and run ``${PROGRAM} --continue``.\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LegacyBackticks));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_backticks_inside_multiline_double_quotes_after_line_continuation() {
+        let source = "\
+ECHO=echo
+$ECHO \"\\
+*** ERROR
+`cat lockfile 2>/dev/null`
+\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LegacyBackticks));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["`cat lockfile 2>/dev/null`"]
+        );
+    }
+
+    #[test]
+    fn reports_backticks_after_a_quoted_heredoc_help_block() {
+        let source = "\
+cat <<\\_ACEOF
+Use `configure' or `make' to build this project.
+_ACEOF
+x=`pwd`
+y=`uname`
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LegacyBackticks));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["`pwd`", "`uname`"]
+        );
+    }
+
+    #[test]
+    fn reports_multiple_backtick_assignments_with_single_quoted_sed_scripts() {
+        let source = "\
+ac_dir_suffix=/`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`
+ac_top_builddir_sub=`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LegacyBackticks));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`",
+                "`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`",
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_backticks_inside_recursive_help_loop() {
+        let source = "\
+if test \"$ac_init_help\" = \"recursive\"; then
+  for ac_dir in : $ac_subdirs_all; do test \"x$ac_dir\" = x: && continue
+    test -d \"$ac_dir\" ||
+      { cd \"$srcdir\" && ac_pwd=`pwd` && srcdir=. && test -d \"$ac_dir\"; } ||
+      continue
+    case \"$ac_dir\" in
+    *)
+      ac_dir_suffix=/`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`
+      ac_top_builddir_sub=`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`
+      ;;
+    esac
+  done
+fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LegacyBackticks));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "`pwd`",
+                "`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`",
+                "`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`",
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_sed_backticks_after_quoted_heredoc_backticks() {
+        let source = "\
+cat <<\\_ACEOF
+Use these variables to override the choices made by `configure' or to help
+it to find libraries and programs with nonstandard names/locations.
+_ACEOF
+ac_dir_suffix=/`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`
+ac_top_builddir_sub=`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LegacyBackticks));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`",
+                "`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`",
+            ]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S056_S056.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S056_S056.sh.snap
@@ -1,21 +1,45 @@
 ---
 source: crates/shuck-linter/src/rules/style/mod.rs
-assertion_line: 98
+assertion_line: 177
 ---
-S056 avoid command substitutions in alias definitions
- --> <source>:2:14
+S056 avoid expansions in alias definitions
+ --> <source>:2:12
   |
-2 | alias printf=$(command -v printf)
-  |
-
-S056 avoid command substitutions in alias definitions
- --> <source>:3:9
-  |
-3 | alias a=$(command -v printf) b=$(command -v cat)
+2 | alias home=$HOME
   |
 
-S056 avoid command substitutions in alias definitions
- --> <source>:3:32
+S056 avoid expansions in alias definitions
+ --> <source>:3:19
   |
-3 | alias a=$(command -v printf) b=$(command -v cat)
+3 | alias icloud="cd '$HOME'"
+  |
+
+S056 avoid expansions in alias definitions
+ --> <source>:4:14
+  |
+4 | alias printf=$(command -v printf)
+  |
+
+S056 avoid expansions in alias definitions
+ --> <source>:5:13
+  |
+5 | alias math="$((1+2))"
+  |
+
+S056 avoid expansions in alias definitions
+ --> <source>:6:12
+  |
+6 | alias list=${arr[@]}
+  |
+
+S056 avoid expansions in alias definitions
+ --> <source>:7:12
+  |
+7 | alias proc=<(printf hi)
+  |
+
+S056 avoid expansions in alias definitions
+ --> <source>:8:13
+  |
+8 | alias brace={a,b}
   |

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -606,6 +606,16 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn suspicious_double_paren_is_command_style(
+        &mut self,
+        checkpoint: &ParserCheckpoint<'a>,
+    ) -> bool {
+        self.restore(checkpoint.clone());
+        let parses_as_arithmetic = self.parse_arithmetic_command().is_ok();
+        self.restore(checkpoint.clone());
+        !parses_as_arithmetic
+    }
+
     fn looks_like_command_style_double_paren(&mut self) -> bool {
         if self.current_token_kind != Some(TokenKind::DoubleLeftParen) {
             return false;
@@ -643,8 +653,7 @@ impl<'a> Parser<'a> {
                 }
                 Some(TokenKind::RightParen) => {
                     if paren_depth == 0 {
-                        self.restore(checkpoint);
-                        return true;
+                        return self.suspicious_double_paren_is_command_style(&checkpoint);
                     }
                     paren_depth -= 1;
                     previous_top_level_operand = false;
@@ -666,8 +675,7 @@ impl<'a> Parser<'a> {
                             .is_some_and(Self::is_operand_like_double_paren_token) =>
                 {
                     if previous_top_level_operand {
-                        self.restore(checkpoint);
-                        return true;
+                        return self.suspicious_double_paren_is_command_style(&checkpoint);
                     }
                     previous_top_level_operand = true;
                     self.advance();

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -3410,8 +3410,10 @@ impl<'a> Parser<'a> {
                 '\'' if !in_double => in_single = !in_single,
                 '"' if !in_single => in_double = !in_double,
                 '`' if !in_single => in_backtick = !in_backtick,
-                '(' if !in_single && !in_double => paren_depth += 1,
-                ')' if !in_single && !in_double && paren_depth > 0 => paren_depth -= 1,
+                '(' if !in_single && !in_double && brace_depth == 0 => paren_depth += 1,
+                ')' if !in_single && !in_double && brace_depth == 0 && paren_depth > 0 => {
+                    paren_depth -= 1
+                }
                 '{' if !in_single && !in_double => brace_depth += 1,
                 '}' if !in_single && !in_double && brace_depth > 0 => brace_depth -= 1,
                 '[' if !in_single && !in_double => bracket_depth += 1,

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -4654,6 +4654,32 @@ mod tests {
     }
 
     #[test]
+    fn test_double_quoted_token_preserves_inner_quoted_command_substitution_pipeline() {
+        let source = r#""$(echo "$line" | cut -d' ' -f2-)""#;
+        let mut lexer = Lexer::new(source);
+
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::QuotedWord);
+        assert_eq!(
+            token.word_text(),
+            Some(r#"$(echo "$line" | cut -d' ' -f2-)"#)
+        );
+    }
+
+    #[test]
+    fn test_double_quoted_token_preserves_braced_param_pipeline_substitution() {
+        let source = r#""$(echo "${@}" | tr -d '[:space:]')""#;
+        let mut lexer = Lexer::new(source);
+
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::QuotedWord);
+        assert_eq!(
+            token.word_text(),
+            Some(r#"$(echo "${@}" | tr -d '[:space:]')"#)
+        );
+    }
+
+    #[test]
     fn test_mixed_word_keeps_segment_kinds() {
         let source = r#"foo"bar"'baz'"#;
         let mut lexer = Lexer::new(source);
@@ -4909,6 +4935,26 @@ mod tests {
     #[test]
     fn test_scan_command_substitution_body_len_handles_backticks_with_right_parens_at_eof() {
         let source = "printf %s `echo foo)`; printf %s ok)";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert_eq!(body, source);
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_inner_quotes_in_pipeline_at_eof() {
+        let source = "echo \"$line\" | cut -d' ' -f2-)";
+
+        let consumed = scan_command_substitution_body_len(source).expect("expected match");
+        let body = &source[..consumed];
+
+        assert_eq!(body, source);
+    }
+
+    #[test]
+    fn test_scan_command_substitution_body_len_handles_braced_params_in_pipeline_at_eof() {
+        let source = "echo \"${@}\" | tr -d '[:space:]')";
 
         let consumed = scan_command_substitution_body_len(source).expect("expected match");
         let body = &source[..consumed];

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -5632,6 +5632,106 @@ EOF
     }
 
     #[test]
+    fn test_quoted_heredoc_preserves_following_backtick_word_spans() {
+        let source = "\
+cat <<\\_ACEOF
+Use these variables to override the choices made by `configure' or to help
+it to find libraries and programs with nonstandard names/locations.
+_ACEOF
+ac_dir_suffix=/`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`
+ac_top_builddir_sub=`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`
+";
+        let mut lexer = Lexer::new(source);
+
+        assert_next_token_with_comments(&mut lexer, TokenKind::Word, Some("cat"));
+        assert_next_token_with_comments(&mut lexer, TokenKind::HereDoc, None);
+        let delimiter = lexer.next_lexed_token_with_comments().unwrap();
+        assert_eq!(delimiter.kind, TokenKind::Word);
+        assert_eq!(delimiter.span.slice(source), "\\_ACEOF");
+
+        let heredoc = lexer.read_heredoc("_ACEOF", false);
+        assert_eq!(
+            heredoc.content,
+            "Use these variables to override the choices made by `configure' or to help\nit to find libraries and programs with nonstandard names/locations.\n"
+        );
+
+        assert_next_token_with_comments(&mut lexer, TokenKind::Newline, None);
+
+        let first = lexer.next_lexed_token_with_comments().unwrap();
+        assert_eq!(first.kind, TokenKind::Word);
+        assert_eq!(
+            first.span.slice(source),
+            "ac_dir_suffix=/`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`"
+        );
+        let first_segments = first
+            .word()
+            .unwrap()
+            .segments()
+            .map(|segment| {
+                (
+                    segment.kind(),
+                    segment.as_str().to_string(),
+                    segment.span().map(|span| span.slice(source).to_string()),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            first_segments,
+            vec![
+                (
+                    LexedWordSegmentKind::Plain,
+                    "ac_dir_suffix=/".to_string(),
+                    Some("ac_dir_suffix=/".to_string()),
+                ),
+                (
+                    LexedWordSegmentKind::Plain,
+                    "`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`".to_string(),
+                    Some("`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`".to_string()),
+                ),
+            ]
+        );
+
+        assert_next_token_with_comments(&mut lexer, TokenKind::Newline, None);
+
+        let second = lexer.next_lexed_token_with_comments().unwrap();
+        assert_eq!(second.kind, TokenKind::Word);
+        assert_eq!(
+            second.span.slice(source),
+            "ac_top_builddir_sub=`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`"
+        );
+        let second_segments = second
+            .word()
+            .unwrap()
+            .segments()
+            .map(|segment| {
+                (
+                    segment.kind(),
+                    segment.as_str().to_string(),
+                    segment.span().map(|span| span.slice(source).to_string()),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            second_segments,
+            vec![
+                (
+                    LexedWordSegmentKind::Plain,
+                    "ac_top_builddir_sub=".to_string(),
+                    Some("ac_top_builddir_sub=".to_string()),
+                ),
+                (
+                    LexedWordSegmentKind::Plain,
+                    "`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`".to_string(),
+                    Some(
+                        "`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`"
+                            .to_string(),
+                    ),
+                ),
+            ]
+        );
+    }
+
+    #[test]
     fn test_heredoc_with_unicode_content() {
         // Heredoc containing multi-byte characters; spans must be on char boundaries
         let source = "cat <<EOF\n# 你好\ncafé\nEOF\n";

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2918,7 +2918,8 @@ impl<'a> Parser<'a> {
     fn decode_word_from_token(&mut self, token: &LexedToken<'_>, span: Span) -> Option<Word> {
         let word = token.word()?;
 
-        if !token.flags.is_synthetic()
+        if word.single_segment().is_none()
+            && !token.flags.is_synthetic()
             && let Some(source_text) = token.source_slice(self.input)
         {
             return Some(self.parse_word_with_context(source_text, span, span.start, true));
@@ -2943,7 +2944,14 @@ impl<'a> Parser<'a> {
             } else {
                 raw_text
             };
-            let decode_text = if source_backed && !self.source_matches(content_span, text) {
+            let decode_text = if source_backed
+                && !self.source_matches(content_span, text)
+                && matches!(
+                    segment.kind(),
+                    LexedWordSegmentKind::DoubleQuoted | LexedWordSegmentKind::DollarDoubleQuoted
+                )
+                && !text.contains("$(")
+            {
                 content_span.slice(self.input)
             } else {
                 text
@@ -2967,7 +2975,7 @@ impl<'a> Parser<'a> {
                 )),
                 LexedWordSegmentKind::Plain if Self::word_text_needs_parse(text) => Some(
                     self.decode_word_text_preserving_quotes_if_needed_with_escape_mode(
-                        decode_text,
+                        text,
                         span,
                         content_span.start,
                         source_backed,

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2918,6 +2918,12 @@ impl<'a> Parser<'a> {
     fn decode_word_from_token(&mut self, token: &LexedToken<'_>, span: Span) -> Option<Word> {
         let word = token.word()?;
 
+        if !token.flags.is_synthetic()
+            && let Some(source_text) = token.source_slice(self.input)
+        {
+            return Some(self.parse_word_with_context(source_text, span, span.start, true));
+        }
+
         if let Some(segment) = word.single_segment() {
             let content_span = Self::segment_content_span(segment, span);
             let wrapper_span = Self::segment_wrapper_span(segment, span);
@@ -2937,7 +2943,13 @@ impl<'a> Parser<'a> {
             } else {
                 raw_text
             };
-            let preserve_escaped_expansion_literals = source_backed;
+            let decode_text = if source_backed && !self.source_matches(content_span, text) {
+                content_span.slice(self.input)
+            } else {
+                text
+            };
+            let preserve_escaped_expansion_literals =
+                source_backed && self.source_matches(content_span, decode_text);
 
             return match segment.kind() {
                 LexedWordSegmentKind::SingleQuoted => Some(self.word_with_parts(
@@ -2955,7 +2967,7 @@ impl<'a> Parser<'a> {
                 )),
                 LexedWordSegmentKind::Plain if Self::word_text_needs_parse(text) => Some(
                     self.decode_word_text_preserving_quotes_if_needed_with_escape_mode(
-                        text,
+                        decode_text,
                         span,
                         content_span.start,
                         source_backed,
@@ -2966,7 +2978,7 @@ impl<'a> Parser<'a> {
                     if Self::word_text_needs_parse(text) =>
                 {
                     let inner = self.decode_quoted_segment_text(
-                        text,
+                        decode_text,
                         content_span,
                         content_span.start,
                         source_backed,
@@ -3363,12 +3375,21 @@ impl<'a> Parser<'a> {
 
     fn current_static_token_text(&self) -> Option<(String, bool)> {
         let token = self.current_token.as_ref()?;
-        let text = token.word_string()?;
+        let raw_text = token.word_string()?;
+        let text_had_escape_markers = raw_text.contains('\x00');
+        let text = if text_had_escape_markers {
+            raw_text.replace('\x00', "")
+        } else {
+            raw_text
+        };
 
         match token.kind {
             TokenKind::LiteralWord => Some((text, true)),
             TokenKind::QuotedWord if !Self::word_text_needs_parse(&text) => Some((text, true)),
-            TokenKind::Word if !Self::word_text_needs_parse(&text) => Some((text, false)),
+            TokenKind::Word if !Self::word_text_needs_parse(&text) => Some((
+                text,
+                token.flags.has_cooked_text() || text_had_escape_markers,
+            )),
             _ => None,
         }
     }

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3199,6 +3199,27 @@ fn test_parse_conditional_regex_rhs_with_double_left_paren_groups() {
 }
 
 #[test]
+fn test_parse_conditional_regex_rhs_keeps_parameter_pattern_with_literal_paren() {
+    let input = "[[ \"${2}\" =~ ^${__theme%% (*} ]]\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    assert_eq!(binary.op, ConditionalBinaryOp::RegexMatch);
+
+    let ConditionalExpr::Regex(word) = binary.right.as_ref() else {
+        panic!("expected regex rhs");
+    };
+    assert_eq!(word.render(input), "^${__theme%% (*}");
+}
+
+#[test]
 fn test_parse_conditional_regex_allows_left_brace_operand() {
     let input = "[[ { =~ \"{\" ]]\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -1090,6 +1090,25 @@ fn test_parse_arithmetic_command_with_nested_parens_before_outer_close() {
 }
 
 #[test]
+fn test_parse_arithmetic_command_with_grouped_term_before_logical_and() {
+    let input = "((threads>(cpu_height-3)*3 && tty_width>=200))\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let (compound, redirects) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Arithmetic(command) = compound else {
+        panic!("expected arithmetic compound command");
+    };
+
+    assert!(redirects.is_empty());
+    assert_eq!(command.left_paren_span.slice(input), "((");
+    assert_eq!(command.right_paren_span.slice(input), "))");
+    assert_eq!(
+        command.expr_span.unwrap().slice(input),
+        "threads>(cpu_height-3)*3 && tty_width>=200"
+    );
+}
+
+#[test]
 fn test_parse_arithmetic_command_with_nested_double_parens_and_grouping() {
     let input = "(( x = ((1 + 2) * (3 - 4)) ))\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3717,6 +3717,40 @@ fn test_parse_declare_array_preserves_quoted_command_substitution_elements() {
 }
 
 #[test]
+fn test_parse_array_append_preserves_pipeline_command_substitution_span() {
+    let input = "CANDIDATES+=(\"$(echo \"$line\" | cut -d' ' -f2-)\")\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let assignment = match &script.body[0].command {
+        AstCommand::Simple(command) => &command.assignments[0],
+        AstCommand::Decl(command) => match &command.operands[0] {
+            DeclOperand::Assignment(assignment) => assignment,
+            operand => panic!("expected assignment operand, got {operand:#?}"),
+        },
+        command => panic!("expected assignment command, got {command:#?}"),
+    };
+    let AssignmentValue::Compound(array) = &assignment.value else {
+        panic!("expected compound array assignment");
+    };
+    let ArrayElem::Sequential(word) = &array.elements[0] else {
+        panic!("expected sequential array element");
+    };
+
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double-quoted array element");
+    };
+    let WordPart::CommandSubstitution { body, .. } = &parts[0].kind else {
+        panic!("expected command substitution");
+    };
+
+    assert_eq!(
+        parts[0].span.slice(input),
+        "$(echo \"$line\" | cut -d' ' -f2-)"
+    );
+    assert!(matches!(&body[0].command, AstCommand::Binary(_)));
+}
+
+#[test]
 fn test_parse_declare_array_preserves_separator_comment_in_quoted_command_substitution() {
     let input = "f() {\n\tlocal -a parts=(\n\t\t\"$(printf '%s' x;# comment with ) and ,\n\t\tprintf '%s' y\n\t\t)\"\n\t)\n}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1661,6 +1661,28 @@ fn test_escaped_backticks_inside_double_quotes_stay_literal() {
 }
 
 #[test]
+fn test_escaped_backticks_after_escaped_backslashes_inside_double_quotes_stay_literal() {
+    let input = "echo \"  echo Remember to run \\\\\\`updatedb\\\\'.\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    assert_eq!(word.render(input), "  echo Remember to run \\`updatedb\\'.");
+
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double-quoted word");
+    };
+    assert!(
+        !parts
+            .iter()
+            .any(|part| matches!(part.kind, WordPart::CommandSubstitution { .. }))
+    );
+}
+
+#[test]
 fn test_process_substitution_like_text_inside_double_quotes_stays_literal() {
     let input = "echo \"<(printf hi)\" \" >(printf bye)\"\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1418,6 +1418,101 @@ fn test_backtick_command_substitution_inside_double_quotes_preserves_syntax_form
 }
 
 #[test]
+fn test_backtick_command_substitution_inside_multiline_double_quotes_preserves_syntax_form() {
+    let input = "echo \"\\\n*** ERROR\n`cat lockfile 2>/dev/null`\n\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    let WordPart::DoubleQuoted { parts, dollar } = &word.parts[0].kind else {
+        panic!("expected double-quoted word");
+    };
+    assert!(!dollar);
+
+    let slices: Vec<&str> = parts.iter().map(|part| part.span.slice(input)).collect();
+    assert_eq!(
+        slices,
+        vec!["\\\n*** ERROR\n", "`cat lockfile 2>/dev/null`", "\n"]
+    );
+
+    let WordPart::CommandSubstitution {
+        body: commands,
+        syntax,
+    } = &parts[1].kind
+    else {
+        panic!("expected command substitution");
+    };
+    assert_eq!(*syntax, CommandSubstitutionSyntax::Backtick);
+
+    let inner = expect_simple(&commands[0]);
+    assert_eq!(inner.name.render(input), "cat");
+    assert_eq!(inner.args[0].render(input), "lockfile");
+    assert_eq!(commands[0].redirects[0].fd, Some(2));
+    assert_eq!(
+        redirect_word_target(&commands[0].redirects[0]).render(input),
+        "/dev/null"
+    );
+}
+
+#[test]
+fn test_backtick_assignments_after_quoted_heredoc_preserve_each_substitution() {
+    let input = "\
+cat <<\\_ACEOF
+Use these variables to override the choices made by `configure' or to help
+it to find libraries and programs with nonstandard names/locations.
+_ACEOF
+ac_dir_suffix=/`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`
+ac_top_builddir_sub=`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`
+";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    assert_eq!(script.body.len(), 3, "{:#?}", script.body);
+
+    let AstCommand::Simple(first) = &script.body[1].command else {
+        panic!("expected simple command, got {:#?}", script.body[1].command);
+    };
+    let AssignmentValue::Scalar(first_value) = &first.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+    assert_eq!(
+        first_value
+            .parts
+            .iter()
+            .map(|part| part.span.slice(input))
+            .collect::<Vec<_>>(),
+        vec!["/", "`$as_echo \"$ac_dir\" | sed 's|^\\.[\\\\/]||'`"]
+    );
+    let WordPart::CommandSubstitution { syntax, body } = &first_value.parts[1].kind else {
+        panic!("expected backtick substitution");
+    };
+    assert_eq!(*syntax, CommandSubstitutionSyntax::Backtick);
+    assert!(!body.is_empty());
+
+    let AstCommand::Simple(second) = &script.body[2].command else {
+        panic!("expected simple command, got {:#?}", script.body[2].command);
+    };
+    let AssignmentValue::Scalar(second_value) = &second.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+    assert_eq!(
+        second_value
+            .parts
+            .iter()
+            .map(|part| part.span.slice(input))
+            .collect::<Vec<_>>(),
+        vec!["`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||'`"]
+    );
+    let WordPart::CommandSubstitution { syntax, body } = &second_value.parts[0].kind else {
+        panic!("expected backtick substitution");
+    };
+    assert_eq!(*syntax, CommandSubstitutionSyntax::Backtick);
+    assert!(!body.is_empty());
+}
+
+#[test]
 fn test_dollar_paren_command_substitution_inside_double_quotes_preserves_nested_quoted_argument() {
     let input = "echo \"$(cmd \"$arg\")\"\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3188,6 +3188,7 @@ impl<'a> Parser<'a> {
                             // double quotes, so nested decoding must not
                             // reactivate dollar-quote parsing here.
                             parse_dollar_quotes: false,
+                            preserve_escaped_expansion_literals: source_backed,
                             parse_process_substitutions: false,
                             ..DecodeWordPartsOptions::default()
                         },
@@ -5144,6 +5145,7 @@ impl<'a> Parser<'a> {
                 // Double-quoted segment contents treat `$'...'` and `$"..."`
                 // as literal text, not nested quote forms.
                 parse_dollar_quotes: false,
+                preserve_escaped_expansion_literals: source_backed,
                 parse_process_substitutions: false,
                 ..DecodeWordPartsOptions::default()
             },

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3052,6 +3052,71 @@ impl<'a> Parser<'a> {
                         continue;
                     }
 
+                    if c == '$' && source_backed {
+                        let relative_offset = cursor.offset.saturating_sub(base.offset);
+                        let remaining = &s[relative_offset..];
+
+                        if chars.peek() == Some(&'(')
+                            && !remaining['('.len_utf8()..].starts_with('(')
+                            && let Some(consumed) = lexer::scan_command_substitution_body_len(
+                                &remaining['('.len_utf8()..],
+                            )
+                        {
+                            if let Some(content) = content.as_mut() {
+                                content.push('$');
+                                content.push_str(&remaining[..'('.len_utf8() + consumed]);
+                            }
+                            for _ in remaining[..'('.len_utf8() + consumed].chars() {
+                                Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                            }
+                            content_end = cursor;
+                            continue;
+                        }
+
+                        if chars.peek() == Some(&'{')
+                            && let Some(consumed) = Self::scan_array_parameter_expansion_len(
+                                &remaining['{'.len_utf8()..],
+                            )
+                        {
+                            if let Some(content) = content.as_mut() {
+                                content.push('$');
+                                content.push_str(&remaining[..'{'.len_utf8() + consumed]);
+                            }
+                            for _ in remaining[..'{'.len_utf8() + consumed].chars() {
+                                Self::next_word_char_unwrap(&mut chars, &mut cursor);
+                            }
+                            content_end = cursor;
+                            continue;
+                        }
+                    }
+
+                    if c == '`' {
+                        if let Some(content) = content.as_mut() {
+                            content.push('`');
+                        }
+                        while let Some(nested) = Self::next_word_char(&mut chars, &mut cursor) {
+                            if let Some(content) = content.as_mut() {
+                                content.push(nested);
+                            }
+                            content_end = cursor;
+                            if nested == '\\' {
+                                if let Some(escaped) =
+                                    Self::next_word_char(&mut chars, &mut cursor)
+                                {
+                                    if let Some(content) = content.as_mut() {
+                                        content.push(escaped);
+                                    }
+                                    content_end = cursor;
+                                }
+                                continue;
+                            }
+                            if nested == '`' {
+                                break;
+                            }
+                        }
+                        continue;
+                    }
+
                     if c == '\\' {
                         if let Some(content) = content.as_mut() {
                             content.push(c);

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -5182,7 +5182,13 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
     ) -> Word {
-        self.decode_word_text_preserving_quotes_if_needed(s, span, base, source_backed)
+        let (text, source_backed) = if source_backed && !self.source_matches(span, s) {
+            (span.slice(self.input), true)
+        } else {
+            (s, source_backed)
+        };
+
+        self.decode_word_text_preserving_quotes_if_needed(text, span, base, source_backed)
     }
 
     fn arithmetic_expansion_word_part(

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3100,8 +3100,7 @@ impl<'a> Parser<'a> {
                             }
                             content_end = cursor;
                             if nested == '\\' {
-                                if let Some(escaped) =
-                                    Self::next_word_char(&mut chars, &mut cursor)
+                                if let Some(escaped) = Self::next_word_char(&mut chars, &mut cursor)
                                 {
                                     if let Some(content) = content.as_mut() {
                                         content.push(escaped);

--- a/crates/shuck/tests/testdata/corpus-metadata/c007.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c007.yaml
@@ -1,0 +1,21 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__libjenkins.sh"
+    line: 216
+    end_line: 216
+    reason: "This helper still pipes raw `find` paths into `xargs`; inline `-P10` only adds parallelism and does not change how whitespace or newlines split path records. The pinned oracle stays silent on this specific inline-parallel form, so the standalone Shuck warning is recorded as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__libjenkins.sh"
+    line: 426
+    end_line: 426
+    reason: "This helper still pipes raw `find` paths into `xargs`; inline `-P10` only adds parallelism and does not change how whitespace or newlines split path records. The pinned oracle stays silent on this specific inline-parallel form, so the standalone Shuck warning is recorded as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "bitnami__containers__bitnami__jenkins__2__debian-12__rootfs__opt__bitnami__scripts__libjenkins.sh"
+    line: 479
+    end_line: 479
+    reason: "This helper still pipes raw `find` paths into `xargs`; inline `-P10` only adds parallelism and does not change how whitespace or newlines split path records. The pinned oracle stays silent on this specific inline-parallel form, so the standalone Shuck warning is recorded as a reviewed divergence."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__python__python3-numpydoc__python3-numpydoc.SlackBuild"
+    line: 74
+    end_line: 74
+    reason: "This pipeline feeds `xargs -0` from `find ... -print1`, but that token still does not establish a null-delimited handoff. Shuck keeps the unsafe find-to-xargs warning on the malformed option shape even though the pinned oracle stays silent here."

--- a/crates/shuck/tests/testdata/corpus-metadata/c010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c010.yaml
@@ -1,5 +1,29 @@
 reviewed_divergences:
   - side: shuck-only
+    path_suffix: "scop__bash-completion__completions-core__7z.bash"
+    line: 95
+    labels:
+      - shell-collapse
+    reason: "This bash-completion helper intentionally falls back from the write-mode archive matcher to the broader archive matcher when the first completion pass returns no candidates. Shuck keeps the mixed short-circuit warning, while the pinned oracle stays silent in this shell-collapsed helper."
+  - side: shuck-only
+    path_suffix: "scop__bash-completion__completions-core__hostname.bash"
+    line: 20
+    labels:
+      - shell-collapse
+    reason: "This bash-completion helper intentionally falls back from help-option completions to the general usage completions when the first generator returns no matches. Shuck keeps the mixed short-circuit warning, while the pinned oracle stays silent in this shell-collapsed helper."
+  - side: shuck-only
+    path_suffix: "scop__bash-completion__completions-core__mussh.bash"
+    line: 37
+    labels:
+      - shell-collapse
+    reason: "This bash-completion helper intentionally falls back from `user@host` completion to the known-host list when the first generator yields no candidates. Shuck keeps the mixed short-circuit warning, while the pinned oracle stays silent in this shell-collapsed helper."
+  - side: shuck-only
+    path_suffix: "scop__bash-completion__completions-core__rcs.bash"
+    line: 35
+    labels:
+      - shell-collapse
+    reason: "This bash-completion helper intentionally falls back from file matches to directory suggestions when the first completion pass returns nothing. Shuck keeps the mixed short-circuit warning, while the pinned oracle stays silent in this shell-collapsed helper."
+  - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     labels:
       - helper-library

--- a/crates/shuck/tests/testdata/corpus-metadata/c020.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c020.yaml
@@ -1,0 +1,13 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__helper__fixture__bin__script.sh"
+    line: 5
+    column: 6
+    end_column: 8
+    reason: "This shellspec helper deliberately calls `test \"\"` so the harness can exercise the false exit-status path. Shuck keeps warning on plain literal `test` invocations, while the current oracle does not surface the C020 comparison target for that helper."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__helper__fixture__test_when_run_source"
+    line: 3
+    column: 6
+    end_column: 11
+    reason: "This shellspec source-helper uses `test dummy` as a fixed-status probe during harness setup. Shuck still treats that plain literal `test` call as a constant condition, but the current oracle does not emit the mapped comparison warning there."

--- a/crates/shuck/tests/testdata/corpus-metadata/c061.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c061.yaml
@@ -3,3 +3,31 @@ reviewed_divergences:
     path_suffix: "termux__termux-packages__packages__openssl__add-trusted-certificate"
     line: 12
     reason: "C061 is scoped to `{{...}}` template placeholders in command position. This ShellCheck hit is a different malformed command-name shape without template braces, so it stays reviewed narrowly."
+  - side: shellcheck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__lib__docker.sh"
+    line: 158
+    reason: "This helper tries to execute a quoted error string after a missing-argument guard. The oracle classifies that malformed quoted command name under SC2288, but C061 is intentionally limited to `{{...}}` template placeholders in command position."
+  - side: shellcheck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__lib__docker.sh"
+    line: 162
+    reason: "This helper tries to execute a quoted error string after a missing-argument guard. The oracle classifies that malformed quoted command name under SC2288, but C061 is intentionally limited to `{{...}}` template placeholders in command position."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__academic__lammps__lammps.SlackBuild"
+    line: 99
+    reason: "This package script is missing a command separator between an assignment and a following test, so the oracle reads the stray `[` as part of a malformed command name. C061 stays scoped to template-brace command placeholders instead of covering every SC2288 command-shape parse issue."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__mads__example_shell_scripts.sh"
+    line: 16
+    reason: "This file is a unified diff fragment rather than live shell code, and the oracle treats the `+++` hunk marker as a malformed command name. C061 only covers `{{...}}` placeholders in executable command position, so this SC2288 spillover is reviewed narrowly."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__mads__example_shell_scripts.sh"
+    line: 23
+    reason: "This file is a unified diff fragment rather than live shell code, and the oracle treats the `+++` hunk marker as a malformed command name. C061 only covers `{{...}}` placeholders in executable command position, so this SC2288 spillover is reviewed narrowly."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__development__mads__example_shell_scripts.sh"
+    line: 25
+    reason: "This file is a unified diff fragment rather than live shell code, and the oracle treats the `+++` hunk marker as a malformed command name. C061 only covers `{{...}}` placeholders in executable command position, so this SC2288 spillover is reviewed narrowly."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__varnish__rc.varnishd"
+    line: 50
+    reason: "This startup script tries to execute a quoted error sentence when the pid file is stale. The oracle classifies that malformed quoted command name under SC2288, but C061 remains intentionally scoped to `{{...}}` template placeholders."

--- a/crates/shuck/tests/testdata/corpus-metadata/c092.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c092.yaml
@@ -41,17 +41,24 @@ reviewed_divergences:
     column: 1
     end_column: 57
     reason: "This standalone harness probe runs `$()` in command position and then inspects `$?`; it is outside C092's condition-only scope even though the pinned oracle still reports its broader SC2091 warning here."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__scripts__setup-termux-glibc.sh"
-    line: 10
-    end_line: 10
+  - side: shellcheck-only
+    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
+    line: 99
+    end_line: 99
     column: 5
+    end_column: 17
+    reason: "This helper function executes `$()` as a standalone command in an ordinary branch body rather than using it as an `if`, `while`, or `until` condition. C092 stays scoped to condition commands only."
+  - side: shellcheck-only
+    path_suffix: "basecamp__omarchy__bin__omarchy-reinstall-configs"
+    line: 16
+    end_line: 16
+    column: 1
+    end_column: 46
+    reason: "This script runs the command substitution in plain command position during setup, not as a condition command. The broader SC2091 family still reports it, but C092 intentionally does not."
+  - side: shellcheck-only
+    path_suffix: "tmux-plugins__tpm__scripts__helpers__tmux_echo_functions.sh"
+    line: 2
+    end_line: 2
+    column: 2
     end_column: 44
-    reason: "This `if $(pacman-conf ...)` branch still treats command substitution output as the command name for the condition. Shuck keeps warning even though the pinned oracle stays silent on this project-closure fixture."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__chroot.sh"
-    line: 50
-    end_line: 50
-    column: 8
-    end_column: 68
-    reason: "This condition executes the stdout from `$(${XBPS_INSTALL_CMD} ...)` as a command, so the command-substitution misuse is still present. Shuck keeps the warning despite the pinned oracle's silence on this project-closure fixture."
+    reason: "This function body executes `$()` directly as a helper command outside any condition form, so it falls outside C092's condition-focused scope even though the pinned oracle still buckets it under SC2091."

--- a/crates/shuck/tests/testdata/corpus-metadata/c105.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c105.yaml
@@ -13,3 +13,51 @@ reviewed_divergences:
       - directive-handling
       - project-closure
     reason: "C105 is intentionally scoped to positional-parameter @ splats, while the oracle's SC2163 check also flags exporting values through general variable expansion."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 1166
+    labels:
+      - project-closure
+    reason: "The script validates that ac_envvar holds a shell variable name, assigns through that name, and then exports it via expansion. C105 stays focused on positional-parameter @ splats rather than indirect name export."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__misc__stardict__stardict-wayland"
+    line: 4
+    reason: "C105 is intentionally scoped to positional-parameter @ splats, while the oracle's SC2163 check also flags exporting the result of a general variable expansion."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__main__compat-pvgrub__update-pvgrub"
+    line: 40
+    labels:
+      - project-closure
+    reason: "blkid -o export emits KEY=value records, so exporting the expanded result is a different pattern from C105's positional-parameter @ splat check."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__main__compat-pvgrub__update-pvgrub"
+    line: 48
+    labels:
+      - project-closure
+    reason: "blkid -o export emits KEY=value records, so exporting the expanded result is a different pattern from C105's positional-parameter @ splat check."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__main__syslinux__update-extlinux"
+    line: 63
+    labels:
+      - project-closure
+    reason: "blkid -o export emits KEY=value records, so exporting the expanded result is a different pattern from C105's positional-parameter @ splat check."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__main__syslinux__update-extlinux"
+    line: 71
+    labels:
+      - project-closure
+    reason: "blkid -o export emits KEY=value records, so exporting the expanded result is a different pattern from C105's positional-parameter @ splat check."
+  - side: shellcheck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__start-utils"
+    line: 218
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "The function receives a variable name, assigns through that name with eval, and exports it via expansion. That indirect-name pattern is outside C105's positional-parameter @ splat scope."
+  - side: shellcheck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__start-utils"
+    line: 228
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "The function receives a variable name, assigns through that name with eval, and exports it via expansion. That indirect-name pattern is outside C105's positional-parameter @ splat scope."

--- a/crates/shuck/tests/testdata/corpus-metadata/s056.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s056.yaml
@@ -1,7 +1,0 @@
-reviewed_divergences:
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__rvm"
-    line: 189
-    labels:
-      - project-closure
-    reason: "The authored S056 rule only targets command substitutions inside alias definitions, while this fixture uses parameter expansion in an alias assignment. ShellCheck reports SC2139 here, but shuck intentionally leaves plain expansion-only aliases alone."

--- a/crates/shuck/tests/testdata/corpus-metadata/s057.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s057.yaml
@@ -1,0 +1,28 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh"
+    line: 52
+    end_line: 52
+    column: 7
+    end_column: 53
+    labels:
+      - project-closure
+    reason: "This alias value defines a helper function before sourcing another script, so it remains an S057 hit even though the oracle does not surface a matching comparison record for that profile helper."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 22
+    end_line: 22
+    column: 12
+    end_column: 30
+    labels:
+      - project-closure
+    reason: "This zsh bootstrap alias rewrites positional-parameter forwarding, but it does not define a function inside the alias value, so it falls outside S057's independently authored scope."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    line: 93
+    end_line: 93
+    column: 12
+    end_column: 30
+    labels:
+      - shell-collapse
+    reason: "This zsh bootstrap alias rewrites positional-parameter forwarding, but it does not define a function inside the alias value, so it falls outside S057's independently authored scope."

--- a/crates/shuck/tests/testdata/corpus-metadata/x021.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x021.yaml
@@ -1,0 +1,28 @@
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 27
+    end_line: 27
+    column: 12
+    end_column: 17
+    labels:
+      - project-closure
+    reason: "X021 is scoped to the non-POSIX `pipefail` toggle. This autoconf helper is using `set -o posix`, and the current SC3040 oracle groups that different option under the same compatibility code during project-closure comparison."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__desktop__gdm__wayland-session"
+    line: 17
+    end_line: 17
+    column: 12
+    end_column: 17
+    labels:
+      - project-closure
+    reason: "X021 is scoped to the non-POSIX `pipefail` toggle. This login helper flips `set +o posix`, and the current SC3040 oracle groups that different option under the same compatibility code during project-closure comparison."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    line: 96
+    end_line: 96
+    column: 50
+    end_column: 55
+    labels:
+      - shell-collapse
+    reason: "X021 is scoped to the non-POSIX `pipefail` toggle. This libtool helper is using `set -o posix`, and the current SC3040 oracle groups that different option under the same compatibility code when the corpus collapses the shell mode."

--- a/crates/shuck/tests/testdata/corpus-metadata/x031.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x031.yaml
@@ -35,3 +35,29 @@ reviewed_divergences:
       - project-closure
       - shell-collapse
     reason: "This fixture is an Oh My Zsh startup script. In the shell-collapse comparison path it gets treated like portable `sh`, but these `source` commands belong to Zsh-specific startup loading rather than the POSIX portability target for X031."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__misc__cwiid__rc.cwiid.new"
+    line: 39
+    reason: "This helper uses `source` inside a function body. Shuck classifies function-local `source` under X080, while the current ShellCheck oracle still reports the generic X031 portability code here."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__firewalld__rc.firewalld"
+    line: 6
+    reason: "This helper uses `source` inside a function body. Shuck classifies function-local `source` under X080, while the current ShellCheck oracle still reports the generic X031 portability code here."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    line: 3360
+    reason: "This generated helper uses `source` inside a function body, nested in command substitution. Shuck classifies function-local `source` under X080, while the current ShellCheck oracle still reports the generic X031 portability code here."
+  - side: shellcheck-only
+    path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
+    line: 164
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "This fixture is a bash gitstatus plugin that only shows up through the shell-collapse portability comparison path. The generic POSIX-sh X031 comparison target is not the right match for this function-local `source` call."
+  - side: shellcheck-only
+    path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
+    line: 206
+    labels:
+      - project-closure
+      - shell-collapse
+    reason: "This fixture is a bash gitstatus plugin that only shows up through the shell-collapse portability comparison path. The generic POSIX-sh X031 comparison target is not the right match for this function-local `source` call."

--- a/crates/shuck/tests/testdata/corpus-metadata/x081.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x081.yaml
@@ -1,0 +1,13 @@
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__office__smoffice2018__presentations18"
+    line: 3
+    reason: "X081 is intentionally limited to longest-suffix trimming on `$*`. This package helper uses long-prefix trimming on `$@`, which the current SC3058 oracle groups into the same bucket even though it is a different positional-parameter string operation."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__office__smoffice2021__presentations21"
+    line: 3
+    reason: "X081 is intentionally limited to longest-suffix trimming on `$*`. This package helper uses long-prefix trimming on `$@`, which the current SC3058 oracle groups into the same bucket even though it is a different positional-parameter string operation."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__office__smoffice2024__presentations24"
+    line: 3
+    reason: "X081 is intentionally limited to longest-suffix trimming on `$*`. This package helper uses long-prefix trimming on `$@`, which the current SC3058 oracle groups into the same bucket even though it is a different positional-parameter string operation."

--- a/docs/rules/C008.yaml
+++ b/docs/rules/C008.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: Expanding variables inside a trap body resolves them when the trap is set instead of when it runs.
-rationale: Keep trap commands quoted so the values are evaluated at signal time rather than at definition time.
+description: Expansions inside a double-quoted trap body resolve when the trap is set instead of when it runs.
+rationale: Use single-quoted trap commands when you need values to be evaluated at signal time rather than at definition time.
 source:
   shell_checks_rule: rules/SH-042.yaml
   shell_checks_example: examples/042.sh

--- a/docs/rules/C071.yaml
+++ b/docs/rules/C071.yaml
@@ -3,7 +3,7 @@ legacy_name: double-paren-grouping
 new_category: Correctness
 new_code: C071
 runtime_kind: ast
-shellcheck_code: SC2283
+shellcheck_code: SC1105
 shells:
   - sh
   - bash

--- a/docs/rules/C111.yaml
+++ b/docs/rules/C111.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: "Quoting `$@` inside a string comparison folds all arguments together."
-rationale: Use a loop or check individual parameters.
+description: "Quoting `$@` as a `[ ... ]` or `test` operand folds all arguments together."
+rationale: Use a loop or inspect the arguments one at a time instead.
 source:
   shell_checks_rule: rules/SH-249.yaml
   shell_checks_example: examples/249.sh
@@ -20,4 +20,6 @@ examples:
     code: |
       #!/bin/sh
       # shellcheck disable=2145
+      if [ -z "$@" ]; then echo missing; fi
+      if [ -d "$@" ]; then echo found; fi
       if [ "_$@" = "_--version" ]; then echo v1; fi

--- a/docs/rules/C120.yaml
+++ b/docs/rules/C120.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: "The `expr substr` command is used inside a test expression."
-rationale: Use shell parameter expansion for substring extraction.
+description: "An `expr` string helper is used instead of shell string operations."
+rationale: Prefer shell builtins or parameter expansion over `expr` string helpers.
 source:
   shell_checks_rule: rules/SH-287.yaml
   shell_checks_example: examples/287.sh

--- a/docs/rules/S056.yaml
+++ b/docs/rules/S056.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: A command substitution is used inside an alias definition.
-rationale: Define a function instead or expand the path before aliasing.
+description: An alias definition contains an expansion that resolves while the alias is being declared.
+rationale: Escape the expansion or move the logic into a function so it is evaluated when the alias is used.
 source:
   shell_checks_rule: rules/SH-233.yaml
   shell_checks_example: examples/233.sh
@@ -18,6 +18,5 @@ examples:
   - kind: invalid
     source: shell-checks/examples/233.sh
     code: |
-      #!/bin/sh
-      # shellcheck disable=2034,2046
-      alias printf=$(command -v printf)
+      #!/bin/bash
+      alias icloud="cd '$HOME'"


### PR DESCRIPTION
## Summary
This branch resolves conformance and anchoring gaps across 36 rules, keeping the work split into one commit per rule for easier review.

Affected rules:
- Correctness: `C007`, `C008`, `C010`, `C012`, `C013`, `C020`, `C048`, `C061`, `C070`, `C071`, `C072`, `C080`, `C085`, `C092`, `C103`, `C105`, `C111`, `C114`, `C119`, `C120`, `C134`, `C137`
- Style: `S005`, `S016`, `S018`, `S022`, `S030`, `S034`, `S056`, `S057`, `S074`
- Portability: `X021`, `X030`, `X031`, `X063`, `X081`

The fixes include a mix of parser, fact-builder, rule-filter, fixture, and corpus-metadata updates. Several rule implementations were simplified to consume better `LinterFacts` instead of carrying structural discovery locally, and the remaining intentional oracle differences were documented with focused corpus metadata where appropriate.

## Why
The branch was built as a targeted sweep to reduce large-corpus diffs rule by rule while preserving the linter architecture contract. In a number of cases the underlying issue was not the rule predicate itself, but missing or inaccurate parser/fact information for spans, pipeline context, alias definitions, heredoc handling, glob detection, and similar structural details.

## Impact
This improves compatibility coverage for the listed rules, reduces false positives and anchoring drift, and leaves reviewed divergences recorded explicitly instead of rediscovering the same oracle mismatches later.

## Validation
- Ran targeted large-corpus validation for each rule with `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=<rule>`
- Ran `make check` for each rule-fix pass before accepting it
- Performed local QA on the returned diffs and reran focused rule tests before committing each change