### PR TITLE
Fix C015 sudo redirection compatibility

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C015.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C015.sh
@@ -6,14 +6,24 @@ sudo echo hi > out.txt
 # Invalid: appending has the same problem
 sudo printf '%s\n' ok >> log.txt
 
+# Invalid: stdin redirections still happen before sudo elevates
+sudo cat < input.txt
+
+# Invalid: tee only makes the write privileged; input redirects still happen locally
+sudo tee /tmp/out.txt < input.txt >/dev/null
+
 # Valid: move the redirection into the elevated shell
 sudo sh -c 'echo hi > out.txt'
 
 # Valid: the tee handoff performs the privileged write
 printf '%s\n' hi | sudo tee /tmp/out.txt >/dev/null
 
+# Valid: explicit file descriptors stay outside this compatibility rule
+sudo printf '%s\n' ok 1> out.txt 2>> err.log 0< input.txt
+
 # Valid: /dev/null sinks should stay quiet
 sudo -u "$user" printf '%s\n' ok 2>/dev/null
+sudo cat < /dev/null
 
 # Valid: here-strings are not output file redirects
 sudo scutil <<< "ComputerName: example"

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -807,6 +807,7 @@ impl<'a> ConditionalFact<'a> {
 #[derive(Debug, Clone)]
 pub struct RedirectFact<'a> {
     redirect: &'a Redirect,
+    operator_span: Span,
     target_span: Option<Span>,
     analysis: Option<RedirectTargetAnalysis>,
 }
@@ -814,6 +815,10 @@ pub struct RedirectFact<'a> {
 impl<'a> RedirectFact<'a> {
     pub fn redirect(&self) -> &'a Redirect {
         self.redirect
+    }
+
+    pub fn operator_span(&self) -> Span {
+        self.operator_span
     }
 
     pub fn target_span(&self) -> Option<Span> {
@@ -10325,11 +10330,44 @@ fn build_redirect_facts<'a>(
         .iter()
         .map(|redirect| RedirectFact {
             redirect,
+            operator_span: redirect_operator_span(redirect),
             target_span: redirect.word_target().map(|word| word.span),
             analysis: analyze_redirect_target(redirect, source, zsh_options),
         })
         .collect::<Vec<_>>()
         .into_boxed_slice()
+}
+
+fn redirect_operator_span(redirect: &Redirect) -> Span {
+    let operator_start = redirect
+        .fd_var_span
+        .map(|span| span.end)
+        .or_else(|| {
+            redirect
+                .fd
+                .filter(|fd| *fd >= 0)
+                .map(|fd| redirect.span.start.advanced_by(&fd.to_string()))
+        })
+        .unwrap_or(redirect.span.start);
+    let operator_end = operator_start.advanced_by(redirect_operator_text(redirect.kind));
+
+    Span::from_positions(operator_start, operator_end)
+}
+
+fn redirect_operator_text(kind: RedirectKind) -> &'static str {
+    match kind {
+        RedirectKind::Output => ">",
+        RedirectKind::Clobber => ">|",
+        RedirectKind::Append => ">>",
+        RedirectKind::Input => "<",
+        RedirectKind::ReadWrite => "<>",
+        RedirectKind::HereDoc => "<<",
+        RedirectKind::HereDocStrip => "<<-",
+        RedirectKind::HereString => "<<<",
+        RedirectKind::DupOutput => ">&",
+        RedirectKind::DupInput => "<&",
+        RedirectKind::OutputBoth => "&>",
+    }
 }
 
 fn effective_command_zsh_options(
@@ -20940,6 +20978,7 @@ rm -rf $PKG/opt/$PRGNAM/bin
             assert_eq!(redirects.len(), 3);
 
             let descriptor_dup = &redirects[0];
+            assert_eq!(descriptor_dup.operator_span().slice(source), ">&");
             assert!(
                 descriptor_dup
                     .analysis()
@@ -20953,6 +20992,7 @@ rm -rf $PKG/opt/$PRGNAM/bin
             );
 
             let dev_null = &redirects[1];
+            assert_eq!(dev_null.operator_span().slice(source), ">");
             assert_eq!(
                 dev_null.target_span().map(|span| span.slice(source)),
                 Some("/dev/null")
@@ -20964,6 +21004,7 @@ rm -rf $PKG/opt/$PRGNAM/bin
             );
 
             let arithmetic = &redirects[2];
+            assert_eq!(arithmetic.operator_span().slice(source), ">>");
             assert_eq!(
                 arithmetic.target_span().map(|span| span.slice(source)),
                 Some("\"$((i++))\"")

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C015_C015.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C015_C015.sh.snap
@@ -1,14 +1,27 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 286
 ---
 C015 redirections on `sudo` still run in the current shell
- --> <source>:4:16
+ --> <source>:4:14
   |
 4 | sudo echo hi > out.txt
   |
 
 C015 redirections on `sudo` still run in the current shell
- --> <source>:7:26
+ --> <source>:7:23
   |
 7 | sudo printf '%s\n' ok >> log.txt
   |
+
+C015 redirections on `sudo` still run in the current shell
+  --> <source>:10:10
+   |
+10 | sudo cat < input.txt
+   |
+
+C015 redirections on `sudo` still run in the current shell
+  --> <source>:13:23
+   |
+13 | sudo tee /tmp/out.txt < input.txt >/dev/null
+   |

--- a/crates/shuck-linter/src/rules/correctness/sudo_redirection_order.rs
+++ b/crates/shuck-linter/src/rules/correctness/sudo_redirection_order.rs
@@ -72,10 +72,13 @@ fn operator_slices(source: &str) -> Vec<&str> {
     use crate::test::test_snippet;
     use crate::{LinterSettings, Rule};
 
-    test_snippet(source, &LinterSettings::for_rule(Rule::SudoRedirectionOrder))
-        .iter()
-        .map(|diagnostic| diagnostic.span.slice(source))
-        .collect()
+    test_snippet(
+        source,
+        &LinterSettings::for_rule(Rule::SudoRedirectionOrder),
+    )
+    .iter()
+    .map(|diagnostic| diagnostic.span.slice(source))
+    .collect()
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/sudo_redirection_order.rs
+++ b/crates/shuck-linter/src/rules/correctness/sudo_redirection_order.rs
@@ -1,4 +1,4 @@
-use shuck_ast::RedirectKind;
+use shuck_ast::{Redirect, RedirectKind, Span};
 
 use crate::{Checker, Rule, Violation, WrapperKind};
 
@@ -22,15 +22,13 @@ pub fn sudo_redirection_order(checker: &mut Checker) {
         .filter(|fact| {
             fact.has_wrapper(WrapperKind::SudoFamily) && fact.options().sudo_family().is_some()
         })
-        .filter(|fact| !fact.effective_name_is("tee"))
         .flat_map(|fact| {
             fact.redirect_facts().iter().filter_map(|redirect| {
-                (redirects_output_to_file(redirect.redirect().kind)
+                (is_hazardous_sudo_redirect(redirect.redirect())
                     && !redirect
                         .analysis()
                         .is_some_and(|analysis| analysis.is_definitely_dev_null()))
-                .then(|| redirect.target_span())
-                .flatten()
+                .then_some(sudo_redirect_span(redirect.redirect()))
             })
         })
         .collect::<Vec<_>>();
@@ -38,48 +36,90 @@ pub fn sudo_redirection_order(checker: &mut Checker) {
     checker.report_all_dedup(spans, || SudoRedirectionOrder);
 }
 
-fn redirects_output_to_file(kind: RedirectKind) -> bool {
+fn is_hazardous_sudo_redirect(redirect: &Redirect) -> bool {
+    if redirect.fd.is_some() || redirect.fd_var.is_some() {
+        return false;
+    }
+
     matches!(
-        kind,
-        RedirectKind::Output
-            | RedirectKind::Clobber
+        redirect.kind,
+        RedirectKind::Input
+            | RedirectKind::Output
             | RedirectKind::Append
-            | RedirectKind::ReadWrite
             | RedirectKind::OutputBoth
     )
 }
 
+fn sudo_redirect_span(redirect: &Redirect) -> Span {
+    let start = match redirect.kind {
+        RedirectKind::OutputBoth => redirect.span.start.advanced_by("&"),
+        _ => redirect.span.start,
+    };
+    let end = match redirect.kind {
+        RedirectKind::Append => start.advanced_by(">>"),
+        _ => start.advanced_by(">"),
+    };
+
+    if redirect.kind == RedirectKind::Input {
+        return Span::from_positions(start, start.advanced_by("<"));
+    }
+
+    Span::from_positions(start, end)
+}
+
+#[cfg(test)]
+fn operator_slices(source: &str) -> Vec<&str> {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    test_snippet(source, &LinterSettings::for_rule(Rule::SudoRedirectionOrder))
+        .iter()
+        .map(|diagnostic| diagnostic.span.slice(source))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
+    use super::operator_slices;
     use crate::test::test_snippet;
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_each_hazardous_redirect_target() {
-        let source = "#!/bin/bash\nsudo printf '%s\\n' ok > out.txt 2>> err.log\n";
-        let diagnostics = test_snippet(
-            source,
-            &LinterSettings::for_rule(Rule::SudoRedirectionOrder),
-        );
-
-        assert_eq!(
-            diagnostics
-                .iter()
-                .map(|diagnostic| diagnostic.span.slice(source))
-                .collect::<Vec<_>>(),
-            vec!["out.txt", "err.log"]
-        );
+    fn reports_default_output_and_input_redirect_operators() {
+        let source = "\
+#!/bin/bash
+sudo printf '%s\\n' ok > out.txt >> log.txt < input.txt
+";
+        assert_eq!(operator_slices(source), vec![">", ">>", "<"]);
     }
 
     #[test]
-    fn handles_doas_and_run0_like_sudo() {
-        let source = "#!/bin/bash\ndoas printf '%s\\n' ok > out.txt\nrun0 tee out.txt >/dev/null\n";
+    fn reports_tee_input_redirects_but_skips_dev_null_sink() {
+        let source = "\
+#!/bin/bash
+sudo tee /tmp/out < input.txt >/dev/null
+";
+        assert_eq!(operator_slices(source), vec!["<"]);
+    }
+
+    #[test]
+    fn skips_explicit_file_descriptors_and_dev_null_input() {
+        let source = "\
+#!/bin/bash
+sudo printf '%s\\n' ok 1> out.txt 2>> err.txt 0< input.txt
+sudo cat < /dev/null
+";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::SudoRedirectionOrder),
         );
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "out.txt");
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_bash_output_both_on_the_output_operator() {
+        let source = "#!/bin/bash\nsudo cat &> out.txt\n";
+        assert_eq!(operator_slices(source), vec![">"]);
     }
 }

--- a/docs/rules/C015.yaml
+++ b/docs/rules/C015.yaml
@@ -10,7 +10,7 @@ shells:
   - dash
   - ksh
 description: A redirection attached to sudo still happens in the current shell before privilege escalation.
-rationale: Move the write operation into the privileged command itself or use a helper such as tee.
+rationale: Move the redirection into the privileged command itself, or pipe data through a helper such as tee when only the write needs elevation.
 source:
   shell_checks_rule: rules/SH-060.yaml
   shell_checks_example: examples/060.sh


### PR DESCRIPTION
## Summary
- align C015 with the observed SC2024 behavior for plain `sudo` redirect operators, including input redirects and `&>`
- anchor C015 diagnostics on the redirect operator and expose reusable redirect operator spans in linter facts
- expand the C015 fixture, snapshot, and rule docs to cover tee/input cases and explicit-fd exclusions

## Root Cause
C015 was only checking a subset of output redirects, skipped `tee` entirely, and reported the redirect target span instead of the operator span. That left several large-corpus SC2024 cases uncovered and produced location-only diffs where Shuck did report.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C015`