### PR TITLE
Fix K003 eval-on-array detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1185,6 +1185,7 @@ pub struct WordFact<'a> {
     array_assignment_split_scalar_expansion_spans: Box<[Span]>,
     array_expansion_spans: Box<[Span]>,
     all_elements_array_expansion_spans: Box<[Span]>,
+    direct_all_elements_array_expansion_spans: Box<[Span]>,
     unquoted_all_elements_array_expansion_spans: Box<[Span]>,
     unquoted_array_expansion_spans: Box<[Span]>,
     command_substitution_spans: Box<[Span]>,
@@ -1303,6 +1304,10 @@ impl<'a> WordFact<'a> {
 
     pub fn all_elements_array_expansion_spans(&self) -> &[Span] {
         &self.all_elements_array_expansion_spans
+    }
+
+    pub fn direct_all_elements_array_expansion_spans(&self) -> &[Span] {
+        &self.direct_all_elements_array_expansion_spans
     }
 
     pub fn unquoted_all_elements_array_expansion_spans(&self) -> &[Span] {
@@ -11988,6 +11993,9 @@ impl<'a> WordFactCollector<'a> {
                 self.source,
             )
             .into_boxed_slice(),
+            direct_all_elements_array_expansion_spans:
+                span::direct_all_elements_array_expansion_part_spans(word_ref, self.source)
+                    .into_boxed_slice(),
             unquoted_all_elements_array_expansion_spans:
                 span::unquoted_all_elements_array_expansion_part_spans(word_ref, self.source)
                     .into_boxed_slice(),
@@ -25388,6 +25396,15 @@ if [[ x == *${shims[@]}* ]]; then :; fi
                     .collect::<Vec<_>>(),
                 vec!["${shims[@]}"]
             );
+            assert_eq!(
+                fact.direct_all_elements_array_expansion_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${shims[@]}"],
+                "parts: {:?}",
+                fact.word().parts
+            );
         });
     }
 
@@ -25411,6 +25428,43 @@ eval \"conda_shim() { case \\\"\\${1##*/}\\\" in ${shims[@]} *) return 1;; esac 
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["${shims[@]}"]
+            );
+            assert_eq!(
+                fact.direct_all_elements_array_expansion_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${shims[@]}"],
+                "parts: {:?}",
+                fact.word().parts
+            );
+        });
+    }
+
+    #[test]
+    fn direct_all_elements_word_facts_ignore_nested_positional_forwarding_idioms() {
+        let source = "\
+#!/bin/sh
+eval shellspec_join SHELLSPEC_EXPECTATION '\" \"' The ${1+'\"$@\"'}
+";
+
+        with_facts(source, None, |_, facts| {
+            let fact = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source).contains("${1+'\"$@\"'}"))
+                .expect("expected eval argument fact");
+
+            assert_eq!(
+                fact.all_elements_array_expansion_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["$@"]
+            );
+            assert!(
+                fact.direct_all_elements_array_expansion_spans().is_empty(),
+                "parts: {:?}",
+                fact.word().parts
             );
         });
     }

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -1078,6 +1078,13 @@ fn normalize_nested_direct_all_elements_array_expansion_span(
     span: Span,
     source: &str,
 ) -> Option<Span> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum QuoteState {
+        None,
+        Single,
+        Double,
+    }
+
     let text = span.slice(source);
     if !text.contains('$') {
         return None;
@@ -1087,10 +1094,44 @@ fn normalize_nested_direct_all_elements_array_expansion_span(
     let bytes = text.as_bytes();
     let mut index = 0usize;
     let mut nested_braced_depth = 0usize;
+    let mut quote_state = QuoteState::None;
 
     while index < bytes.len() {
         let absolute_start = base_offset + index;
         let byte = bytes[index];
+
+        match quote_state {
+            QuoteState::Single if nested_braced_depth > 0 => {
+                if byte == b'\'' {
+                    quote_state = QuoteState::None;
+                }
+                index += 1;
+                continue;
+            }
+            QuoteState::Double if nested_braced_depth > 0 => {
+                if byte == b'\\' {
+                    index += usize::from(index + 1 < bytes.len()) + 1;
+                    continue;
+                }
+                if byte == b'"' {
+                    quote_state = QuoteState::None;
+                }
+                index += 1;
+                continue;
+            }
+            QuoteState::None if nested_braced_depth > 0 && byte == b'\'' => {
+                quote_state = QuoteState::Single;
+                index += 1;
+                continue;
+            }
+            QuoteState::None if nested_braced_depth > 0 && byte == b'"' => {
+                quote_state = QuoteState::Double;
+                index += 1;
+                continue;
+            }
+            QuoteState::None => {}
+            QuoteState::Single | QuoteState::Double => {}
+        }
 
         if byte == b'\\' {
             if index + 2 < bytes.len() && bytes[index + 1] == b'$' && bytes[index + 2] == b'{' {
@@ -3765,6 +3806,26 @@ printf '%s\\n' \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${
     fn word_has_direct_all_elements_array_expansion_ignores_escaped_parameter_nesting() {
         let source = "\
 printf '%s\\n' \"\\${1+'\\\"$@\\\"'}\" \"$@\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        let matches = command
+            .args
+            .iter()
+            .skip(1)
+            .map(|word| word_has_direct_all_elements_array_expansion_in_source(word, source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(matches, vec![false, true]);
+    }
+
+    #[test]
+    fn word_has_direct_all_elements_array_expansion_ignores_quoted_braces_in_escaped_text() {
+        let source = "\
+printf '%s\\n' \"\\${1+'} \\\"$@\\\"'}\" \"$@\"\n";
         let output = Parser::new(source).parse().unwrap();
         let command = &output.file.body[0].command;
         let shuck_ast::Command::Simple(command) = command else {

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -935,7 +935,9 @@ fn collect_direct_all_elements_array_expansion_spans(
                 collect_direct_all_elements_array_expansion_spans(parts, source, spans)
             }
             _ if part_uses_direct_all_elements_array_expansion(&part.kind) => {
-                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                if let Some(span) =
+                    normalize_direct_all_elements_array_expansion_span(part.span, source)
+                {
                     spans.push(span);
                 }
             }
@@ -1029,6 +1031,49 @@ fn normalize_all_elements_array_expansion_span(span: Span, source: &str) -> Opti
     widen_all_elements_array_expansion_span(span, source)
 }
 
+fn normalize_direct_all_elements_array_expansion_span(span: Span, source: &str) -> Option<Span> {
+    let text = span.slice(source);
+    if !span_is_escaped(span, source)
+        && (text == "$@" || candidate_is_direct_all_elements_array_expansion(text))
+    {
+        return Some(span);
+    }
+
+    let base_offset = span.start.offset;
+    let mut search_from = 0usize;
+
+    while let Some(found) = text[search_from..].find('$') {
+        let relative_start = search_from + found;
+        let absolute_start = base_offset + relative_start;
+        if absolute_start > 0 && source.as_bytes()[absolute_start - 1] == b'\\' {
+            search_from = relative_start + 1;
+            continue;
+        }
+
+        let start = position_at_offset(source, absolute_start)?;
+        let remainder = &source[absolute_start..];
+
+        if remainder.starts_with("$@") {
+            let end = position_at_offset(source, absolute_start + "$@".len())?;
+            return Some(Span::from_positions(start, end));
+        }
+
+        if remainder.starts_with("${")
+            && let Some(relative_end) = remainder.find('}')
+        {
+            let candidate = &remainder[..=relative_end];
+            if candidate_is_direct_all_elements_array_expansion(candidate) {
+                let end = position_at_offset(source, absolute_start + candidate.len())?;
+                return Some(Span::from_positions(start, end));
+            }
+        }
+
+        search_from = relative_start + 1;
+    }
+
+    widen_direct_all_elements_array_expansion_span(span, source)
+}
+
 fn normalize_nested_direct_all_elements_array_expansion_span(
     span: Span,
     source: &str,
@@ -1083,7 +1128,7 @@ fn normalize_nested_direct_all_elements_array_expansion_span(
                 && let Some(relative_end) = remainder.find('}')
             {
                 let candidate = &remainder[..=relative_end];
-                if candidate_is_all_elements_array_expansion(candidate) {
+                if candidate_is_direct_all_elements_array_expansion(candidate) {
                     let start = position_at_offset(source, absolute_start)?;
                     let end = position_at_offset(source, absolute_start + candidate.len())?;
                     return Some(Span::from_positions(start, end));
@@ -1257,6 +1302,29 @@ fn widen_all_elements_array_expansion_span(span: Span, source: &str) -> Option<S
     Some(Span::from_positions(start, end))
 }
 
+fn widen_direct_all_elements_array_expansion_span(span: Span, source: &str) -> Option<Span> {
+    let text = span.slice(source);
+    if !text.contains("[@]") {
+        return None;
+    }
+
+    let start_offset = span.start.offset.checked_sub(2)?;
+    if source.as_bytes().get(start_offset..span.start.offset)? != b"${" {
+        return None;
+    }
+
+    let start = position_at_offset(source, start_offset)?;
+    let remainder = &source[start_offset..];
+    let relative_end = remainder.find('}')?;
+    let candidate = &remainder[..=relative_end];
+    if !candidate_is_direct_all_elements_array_expansion(candidate) {
+        return None;
+    }
+
+    let end = position_at_offset(source, start_offset + candidate.len())?;
+    Some(Span::from_positions(start, end))
+}
+
 fn candidate_is_all_elements_array_expansion(candidate: &str) -> bool {
     let Some(inner) = candidate
         .strip_prefix("${")
@@ -1284,6 +1352,43 @@ fn candidate_is_all_elements_array_expansion(candidate: &str) -> bool {
     }
 
     inner[index..].starts_with("[@]")
+}
+
+fn candidate_is_direct_all_elements_array_expansion(candidate: &str) -> bool {
+    let Some(inner) = candidate
+        .strip_prefix("${")
+        .and_then(|text| text.strip_suffix('}'))
+    else {
+        return false;
+    };
+
+    let suffix = if let Some(stripped) = inner.strip_prefix('@') {
+        stripped
+    } else {
+        let Some(first) = inner.as_bytes().first().copied() else {
+            return false;
+        };
+        if !is_name_start(first) {
+            return false;
+        }
+
+        let bytes = inner.as_bytes();
+        let mut index = 1usize;
+        while index < bytes.len() && is_name_continue(bytes[index]) {
+            index += 1;
+        }
+
+        let Some(stripped) = inner[index..].strip_prefix("[@]") else {
+            return false;
+        };
+        stripped
+    };
+
+    if suffix.starts_with('+') || suffix.starts_with(":+") {
+        return false;
+    }
+
+    true
 }
 
 fn position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
@@ -3630,7 +3735,7 @@ printf '%s\\n' \"${@:2}\" \"x${@:2}y\" \"${arr[@]:1}\" \"${arr[@]:1:2}\" ${@:2} 
     #[test]
     fn word_has_direct_all_elements_array_expansion_ignores_nested_or_scalar_operator_uses() {
         let source = "\
-printf '%s\\n' \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${target=\"$@\"}\" \"$(echo \"$@\")\" \"${arr[*]}\"\n";
+printf '%s\\n' \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${@:+ok}\" \"${arr[@]:+ok}\" \"${target=\"$@\"}\" \"$(echo \"$@\")\" \"${arr[*]}\"\n";
         let output = Parser::new(source).parse().unwrap();
         let command = &output.file.body[0].command;
         let shuck_ast::Command::Simple(command) = command else {
@@ -3644,7 +3749,10 @@ printf '%s\\n' \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${
             .map(|word| word_has_direct_all_elements_array_expansion_in_source(word, source))
             .collect::<Vec<_>>();
 
-        assert_eq!(matches, vec![true, true, true, true, false, false, false]);
+        assert_eq!(
+            matches,
+            vec![true, true, true, true, false, false, false, false, false]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -96,6 +96,12 @@ pub fn all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec
     spans
 }
 
+pub fn direct_all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_direct_all_elements_array_expansion_spans(&word.parts, source, &mut spans);
+    spans
+}
+
 pub fn unquoted_all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_unquoted_all_elements_array_expansion_spans(&word.parts, false, source, &mut spans);
@@ -119,9 +125,7 @@ pub fn word_has_quoted_all_elements_array_slice(word: &Word) -> bool {
 }
 
 pub fn word_has_direct_all_elements_array_expansion_in_source(word: &Word, source: &str) -> bool {
-    let mut spans = Vec::new();
-    collect_direct_all_elements_array_expansion_spans(&word.parts, source, &mut spans);
-    !spans.is_empty()
+    !direct_all_elements_array_expansion_part_spans(word, source).is_empty()
 }
 
 pub fn word_all_elements_array_slice_span_in_source(word: &Word, source: &str) -> Option<Span> {
@@ -930,10 +934,21 @@ fn collect_direct_all_elements_array_expansion_spans(
             WordPart::DoubleQuoted { parts, .. } => {
                 collect_direct_all_elements_array_expansion_spans(parts, source, spans)
             }
-            _ if part_uses_direct_all_elements_array_expansion(&part.kind)
-                && !span_is_escaped(part.span, source) =>
+            _ if part_uses_direct_all_elements_array_expansion(&part.kind) => {
+                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                    spans.push(span);
+                }
+            }
+            WordPart::Parameter(parameter)
+                if parameter_might_use_all_elements_array_expansion(
+                    parameter, part.span, source,
+                ) =>
             {
-                spans.push(part.span)
+                if let Some(span) =
+                    normalize_nested_braced_all_elements_array_expansion_span(part.span, source)
+                {
+                    spans.push(span);
+                }
             }
             _ => {}
         }
@@ -1012,6 +1027,43 @@ fn normalize_all_elements_array_expansion_span(span: Span, source: &str) -> Opti
     }
 
     widen_all_elements_array_expansion_span(span, source)
+}
+
+fn normalize_nested_braced_all_elements_array_expansion_span(
+    span: Span,
+    source: &str,
+) -> Option<Span> {
+    let text = span.slice(source);
+    if !text.contains("${") {
+        return None;
+    }
+
+    let base_offset = span.start.offset;
+    let mut search_from = 0usize;
+
+    while let Some(found) = text[search_from..].find("${") {
+        let relative_start = search_from + found;
+        let absolute_start = base_offset + relative_start;
+        if absolute_start > 0 && source.as_bytes()[absolute_start - 1] == b'\\' {
+            search_from = relative_start + 2;
+            continue;
+        }
+
+        let remainder = &source[absolute_start..];
+        let Some(relative_end) = remainder.find('}') else {
+            break;
+        };
+        let candidate = &remainder[..=relative_end];
+        if candidate_is_all_elements_array_expansion(candidate) {
+            let start = position_at_offset(source, absolute_start)?;
+            let end = position_at_offset(source, absolute_start + candidate.len())?;
+            return Some(Span::from_positions(start, end));
+        }
+
+        search_from = relative_start + 2;
+    }
+
+    None
 }
 
 fn normalize_command_substitution_span(span: Span, source: &str) -> Span {

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -945,7 +945,7 @@ fn collect_direct_all_elements_array_expansion_spans(
                 ) =>
             {
                 if let Some(span) =
-                    normalize_nested_braced_all_elements_array_expansion_span(part.span, source)
+                    normalize_nested_direct_all_elements_array_expansion_span(part.span, source)
                 {
                     spans.push(span);
                 }
@@ -1029,38 +1029,73 @@ fn normalize_all_elements_array_expansion_span(span: Span, source: &str) -> Opti
     widen_all_elements_array_expansion_span(span, source)
 }
 
-fn normalize_nested_braced_all_elements_array_expansion_span(
+fn normalize_nested_direct_all_elements_array_expansion_span(
     span: Span,
     source: &str,
 ) -> Option<Span> {
     let text = span.slice(source);
-    if !text.contains("${") {
+    if !text.contains('$') {
         return None;
     }
 
     let base_offset = span.start.offset;
-    let mut search_from = 0usize;
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+    let mut nested_braced_depth = 0usize;
 
-    while let Some(found) = text[search_from..].find("${") {
-        let relative_start = search_from + found;
-        let absolute_start = base_offset + relative_start;
+    while index < bytes.len() {
+        let absolute_start = base_offset + index;
+        let byte = bytes[index];
+
+        if byte == b'\\' {
+            index += usize::from(index + 1 < bytes.len()) + 1;
+            continue;
+        }
+
+        if byte == b'}' && nested_braced_depth > 0 {
+            nested_braced_depth -= 1;
+            index += 1;
+            continue;
+        }
+
+        if byte != b'$' {
+            if byte == b'{' && nested_braced_depth > 0 {
+                nested_braced_depth += 1;
+            }
+            index += 1;
+            continue;
+        }
+
         if absolute_start > 0 && source.as_bytes()[absolute_start - 1] == b'\\' {
-            search_from = relative_start + 2;
+            index += 1;
             continue;
         }
 
         let remainder = &source[absolute_start..];
-        let Some(relative_end) = remainder.find('}') else {
-            break;
-        };
-        let candidate = &remainder[..=relative_end];
-        if candidate_is_all_elements_array_expansion(candidate) {
+        if nested_braced_depth == 0 && remainder.starts_with("$@") {
             let start = position_at_offset(source, absolute_start)?;
-            let end = position_at_offset(source, absolute_start + candidate.len())?;
+            let end = position_at_offset(source, absolute_start + "$@".len())?;
             return Some(Span::from_positions(start, end));
         }
 
-        search_from = relative_start + 2;
+        if remainder.starts_with("${") {
+            if nested_braced_depth == 0
+                && let Some(relative_end) = remainder.find('}')
+            {
+                let candidate = &remainder[..=relative_end];
+                if candidate_is_all_elements_array_expansion(candidate) {
+                    let start = position_at_offset(source, absolute_start)?;
+                    let end = position_at_offset(source, absolute_start + candidate.len())?;
+                    return Some(Span::from_positions(start, end));
+                }
+            }
+
+            nested_braced_depth += 1;
+            index += 2;
+            continue;
+        }
+
+        index += 1;
     }
 
     None

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -1093,6 +1093,12 @@ fn normalize_nested_direct_all_elements_array_expansion_span(
         let byte = bytes[index];
 
         if byte == b'\\' {
+            if index + 2 < bytes.len() && bytes[index + 1] == b'$' && bytes[index + 2] == b'{' {
+                nested_braced_depth += 1;
+                index += 3;
+                continue;
+            }
+
             index += usize::from(index + 1 < bytes.len()) + 1;
             continue;
         }
@@ -3753,6 +3759,26 @@ printf '%s\\n' \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${
             matches,
             vec![true, true, true, true, false, false, false, false, false]
         );
+    }
+
+    #[test]
+    fn word_has_direct_all_elements_array_expansion_ignores_escaped_parameter_nesting() {
+        let source = "\
+printf '%s\\n' \"\\${1+'\\\"$@\\\"'}\" \"$@\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        let matches = command
+            .args
+            .iter()
+            .skip(1)
+            .map(|word| word_has_direct_all_elements_array_expansion_in_source(word, source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(matches, vec![false, true]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/security/eval_on_array.rs
+++ b/crates/shuck-linter/src/rules/security/eval_on_array.rs
@@ -112,6 +112,18 @@ eval shellspec_join SHELLSPEC_EXPECTATION '\" \"' The ${1+'\"$@\"'}
     }
 
     #[test]
+    fn ignores_replacement_forms_that_do_not_expand_the_positional_splat_itself() {
+        let source = "\
+#!/bin/bash
+eval \"${@:+ok}\"
+eval \"${args[@]:+ok}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EvalOnArray));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_direct_positional_splats_after_escaped_parameter_text_in_eval_strings() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/security/eval_on_array.rs
+++ b/crates/shuck-linter/src/rules/security/eval_on_array.rs
@@ -110,4 +110,16 @@ eval shellspec_join SHELLSPEC_EXPECTATION '\" \"' The ${1+'\"$@\"'}
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
+
+    #[test]
+    fn reports_direct_positional_splats_after_escaped_parameter_text_in_eval_strings() {
+        let source = "\
+#!/bin/bash
+eval \"echo \\${1##*/} $@\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EvalOnArray));
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        assert_eq!(diagnostics[0].span.slice(source), "$@");
+    }
 }

--- a/crates/shuck-linter/src/rules/security/eval_on_array.rs
+++ b/crates/shuck-linter/src/rules/security/eval_on_array.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext};
+use crate::{Checker, ExpansionContext, Rule, Violation};
 
 pub struct EvalOnArray;
 
@@ -13,18 +13,27 @@ impl Violation for EvalOnArray {
 }
 
 pub fn eval_on_array(checker: &mut Checker) {
+    let command_arg_facts = checker
+        .facts()
+        .expansion_word_facts(ExpansionContext::CommandArgument)
+        .collect::<Vec<_>>();
+
     let spans = checker
         .facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("eval"))
-        .flat_map(|fact| fact.body_args())
-        .filter_map(|word| {
-            checker.facts().word_fact(
-                word.span,
-                WordFactContext::Expansion(ExpansionContext::CommandArgument),
-            )
+        .flat_map(|command| command.body_args())
+        .flat_map(|word| {
+            command_arg_facts
+                .iter()
+                .copied()
+                .filter(move |fact| fact.span() == word.span)
+                .flat_map(|fact| {
+                    fact.direct_all_elements_array_expansion_spans()
+                        .iter()
+                        .copied()
+                })
         })
-        .flat_map(|fact| fact.all_elements_array_expansion_spans().iter().copied())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || EvalOnArray);
@@ -85,6 +94,17 @@ eval command sudo \\\"\\${sudo_args[@]}\\\" $(printf '%s\\n' env=1) \\\"\\$@\\\"
         let source = "\
 #!/bin/bash
 eval \"${name:-safe[@]}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EvalOnArray));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_posix_forwarding_idioms_that_only_embed_quoted_positional_params() {
+        let source = "\
+#!/bin/sh
+eval shellspec_join SHELLSPEC_EXPECTATION '\" \"' The ${1+'\"$@\"'}
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EvalOnArray));
 

--- a/crates/shuck-linter/src/rules/security/eval_on_array.rs
+++ b/crates/shuck-linter/src/rules/security/eval_on_array.rs
@@ -135,6 +135,17 @@ eval \"\\${1+'\\\"$@\\\"'}\"
     }
 
     #[test]
+    fn ignores_quoted_braces_inside_escaped_parameter_text() {
+        let source = "\
+#!/bin/bash
+eval \"\\${1+'} \\\"$@\\\"'}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EvalOnArray));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_direct_positional_splats_after_escaped_parameter_text_in_eval_strings() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/security/eval_on_array.rs
+++ b/crates/shuck-linter/src/rules/security/eval_on_array.rs
@@ -124,6 +124,17 @@ eval \"${args[@]:+ok}\"
     }
 
     #[test]
+    fn ignores_nested_positional_splats_inside_escaped_parameter_text() {
+        let source = "\
+#!/bin/bash
+eval \"\\${1+'\\\"$@\\\"'}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EvalOnArray));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_direct_positional_splats_after_escaped_parameter_text_in_eval_strings() {
         let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- narrow K003 to direct all-elements expansions passed to `eval`
- add a dedicated direct-expansion word fact and source-backed span recovery for parser-misaligned quoted eval strings
- keep POSIX forwarding idioms like `${1+'"$@"'}` from being flagged as eval-on-array hazards

## Root Cause
K003 was using a broad all-elements expansion helper that also recovered nested `$@` text inside helper-library forwarding idioms. That caused false positives across shellspec helper files during the large-corpus compatibility run.

## Impact
This keeps K003 aligned with ShellCheck for the shellspec helper-library cases without weakening legitimate detections like direct `eval "$@"` and quoted `eval "${arr[@]}"` patterns.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=K003`
