### PR TITLE
Avoid duplicate X032 report for printf -v

### DIFF
--- a/crates/shuck-linter/src/rules/portability/printf_q_format_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/printf_q_format_in_sh.rs
@@ -22,6 +22,7 @@ pub fn printf_q_format_in_sh(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("printf"))
+        .filter(|fact| fact.options().nonportable_sh_builtin_option_span().is_none())
         .filter_map(|fact| {
             let printf = fact.options().printf()?;
             printf
@@ -65,6 +66,17 @@ printf '%%q\\n' foo
         let source = "\
 #!/bin/bash
 printf '%q\\n' foo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::PrintfQFormatInSh));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_q_formats_when_printf_v_is_already_nonportable() {
+        let source = "\
+#!/bin/sh
+printf -v out '%q\\n' foo
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::PrintfQFormatInSh));
 

--- a/crates/shuck-linter/src/rules/portability/printf_q_format_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/printf_q_format_in_sh.rs
@@ -22,7 +22,11 @@ pub fn printf_q_format_in_sh(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("printf"))
-        .filter(|fact| fact.options().nonportable_sh_builtin_option_span().is_none())
+        .filter(|fact| {
+            fact.options()
+                .nonportable_sh_builtin_option_span()
+                .is_none()
+        })
         .filter_map(|fact| {
             let printf = fact.options().printf()?;
             printf


### PR DESCRIPTION
## Summary
- avoid reporting X032 for `printf` commands that already use a nonportable builtin option such as `-v`
- add a regression test for `printf -v out '%q\n' foo` in `sh` mode

## Why
ShellCheck reports the nonportable `printf -v` form as `SC3045` in POSIX sh and does not also emit `SC3050` for the `%q` format on that same command. Shuck was double-reporting the command, which produced a large-corpus false positive for X032.

## Testing
- `cargo test -p shuck-linter printf_q_format_in_sh`
- `cargo test -p shuck-linter wait_option -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X032` (X032 implementation diffs cleared; the run still reports an unrelated existing sudo-family harness panic)
