### PR TITLE
Fix S076 corpus blockers

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -18165,6 +18165,7 @@ fn detect_sudo_family_invoker(
         // even when there is no statically known inner command.
         .take_while(|word| scan_all_words || word.span.start.offset < body_start)
         .filter_map(|word| static_word_text(word, source))
+        .map(|word| word.strip_prefix('\\').map_or(word.clone(), str::to_owned))
         .filter_map(|word| match word.as_str() {
             "sudo" => Some(SudoFamilyInvoker::Sudo),
             "doas" => Some(SudoFamilyInvoker::Doas),
@@ -22248,6 +22249,27 @@ set 'foo' bar
         assert_eq!(
             invokers,
             vec![SudoFamilyInvoker::Sudo, SudoFamilyInvoker::Run0]
+        );
+    }
+
+    #[test]
+    fn resolves_sudo_family_invokers_when_wrapper_names_are_escaped() {
+        let source = "#!/bin/bash\n\\command \\doas tee out.txt\n\\command \\sudo tee out.txt\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let invokers = facts
+            .commands()
+            .iter()
+            .filter_map(|fact| fact.options().sudo_family().map(|sudo| sudo.invoker))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            invokers,
+            vec![SudoFamilyInvoker::Doas, SudoFamilyInvoker::Sudo]
         );
     }
 

--- a/crates/shuck/tests/testdata/corpus-metadata/s076.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s076.yaml
@@ -28,6 +28,13 @@ reviewed_divergences:
     end_column: 47
     reason: "S076 intentionally warns when a quoted fragment is spliced into a constructed export-assignment word, even though current ShellCheck leaves this dynamic assignment-name form unreported."
   - side: shuck-only
+    path_suffix: "scripts/termux__termux-packages__packages__golang__build.sh"
+    line: 46
+    column: 26
+    end_line: 46
+    end_column: 44
+    reason: "This Termux install path joins a quoted root, a bare slash, and a brace expansion in one argument. Shuck keeps that mixed-fragment readability warning, while the project-closure oracle for this file only reports the portability-side brace expansion."
+  - side: shuck-only
     path_suffix: "scripts/termux__termux-packages__scripts__updates__api__termux_github_api_get_tag.sh"
     line: 48
     column: 7


### PR DESCRIPTION
## Summary
- normalize escaped sudo-family wrapper names before inferring the invoker in linter facts
- add a regression test covering escaped `\command \doas` and `\command \sudo` wrappers
- record the remaining Termux `S076` project-closure mismatch as a reviewed divergence in the corpus metadata

## Why
The targeted `S076` large-corpus run still had two blockers:
- a harness panic when escaped sudo-family wrappers preserved the wrapper marker but the invoker detector failed to recognize the escaped command name
- a remaining `project-closure` oracle mismatch on the Termux golang fixture that direct ShellCheck does not report as `SC2140`

## Impact
This keeps the `S076` compatibility run stable and documents the remaining oracle-only mismatch without changing the rule's intended behavior.

## Validation
- `cargo test -p shuck-linter resolves_sudo_family_invokers_when_wrapper_names_are_escaped`
- `cargo test -p shuck-linter mixed_quote_word -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S076`