### PR TITLE
Fix C018 loop-control rule split

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/continue_outside_loop_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/continue_outside_loop_in_function.rs
@@ -61,6 +61,24 @@ f() {
     }
 
     #[test]
+    fn ignores_continue_inside_function_subshells() {
+        let source = "\
+#!/bin/sh
+f() {
+\t(
+\t\tcontinue
+\t)
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ContinueOutsideLoopInFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_top_level_continue() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
@@ -53,14 +53,18 @@ pub(crate) fn loop_control_violations(
                     ScopeKind::Function(_)
                 )
             });
+            let in_subshell = checker
+                .semantic()
+                .flow_context_at(command_span)
+                .map(|context| context.in_subshell)
+                .unwrap_or(false);
             if inside_function_only && !inside_function {
                 return false;
             }
-            if !inside_function_only
-                && inside_function
-                && *keyword == "continue"
-                && checker.is_rule_enabled(Rule::ContinueOutsideLoopInFunction)
-            {
+            if inside_function_only && in_subshell {
+                return false;
+            }
+            if !inside_function_only && inside_function && *keyword == "continue" && !in_subshell {
                 return false;
             }
             checker
@@ -118,11 +122,29 @@ done
     }
 
     #[test]
-    fn reports_continue_inside_functions_when_the_specific_rule_is_disabled() {
+    fn ignores_continue_inside_functions() {
         let source = "\
 #!/bin/sh
 f() {
 \tcontinue
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LoopControlOutsideLoop),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_continue_inside_function_subshells() {
+        let source = "\
+#!/bin/sh
+f() {
+\t(
+\t\tcontinue
+\t)
 }
 ";
         let diagnostics = test_snippet(

--- a/docs/rules/C126.yaml
+++ b/docs/rules/C126.yaml
@@ -3,6 +3,7 @@ legacy_name: continue-outside-loop-in-func
 new_category: Correctness
 new_code: C126
 runtime_kind: ast
+shellcheck_code: SC2104
 shells:
   - sh
   - bash

--- a/docs/rules/shellcheck-mapping-audit.md
+++ b/docs/rules/shellcheck-mapping-audit.md
@@ -25,7 +25,7 @@ Important context:
 | `C034` | `SC1046` | Keep paired with `C035` on `SC1047`; both examples currently emit both codes. |
 | `C053` | `SC2283` | `C071` currently claims `SC2283`, but its example now emits `SC1105`. |
 | `C089` | `SC2078` | `C020` currently claims `SC2078`, but its example now emits `SC2161`. |
-| `C126` | `SC2104` | `C018` currently claims `SC2104`, but its example now emits `SC2105`. |
+| `X052` | `SC2112` | `X004` currently claims `SC2112`, but its example now emits `SC2113`. |
 | `X053` | `SC2277` | `X048` currently claims `SC2277`, but its example now emits `SC1085`. |
 
 ## Rewrite Or Manual Review


### PR DESCRIPTION
## Summary
- split `continue` ownership between `C018` and `C126` so plain function-scoped `continue` stays with `C126`
- keep function-local subshell loop control under `C018` to match ShellCheck's `SC2105` behavior
- add the missing `SC2104` mapping for `C126` and remove the resolved mapping-audit note

## Why
The rule pair was over-reporting one function-scoped `continue` shape under `C018`, and once that was narrowed it exposed the complementary subshell case that still belongs to `C018`. The fix makes the split match the oracle boundary used in the corpus comparison.

## Validation
- `cargo test -p shuck-linter loop_control_outside_loop`
- `cargo test -p shuck-linter continue_outside_loop_in_function`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C018`

## Notes
The rule-scoped large-corpus rerun finished with `implementation_diffs=0` for `C018`. The command still exits nonzero because of an existing unrelated harness failure in `rvm__rvm__scripts__functions__support` caused by `crates/shuck-linter/src/facts.rs` panicking in the sudo-family wrapper path.
