### PR TITLE
Fix P004 overlap with P003

### DIFF
--- a/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
+++ b/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
@@ -13,7 +13,14 @@ impl Violation for SubshellTestGroup {
 }
 
 pub fn subshell_test_group(checker: &mut Checker) {
-    let spans = checker.facts().subshell_test_group_spans().to_vec();
+    let single_test_spans = checker.facts().single_test_subshell_spans();
+    let spans = checker
+        .facts()
+        .subshell_test_group_spans()
+        .iter()
+        .copied()
+        .filter(|span| !single_test_spans.contains(span))
+        .collect::<Vec<_>>();
     checker.report_all_dedup(spans, || SubshellTestGroup);
 }
 
@@ -30,6 +37,7 @@ a=1
 b=jpg
 if [ -n \"$a\" ] && ( [ \"$b\" = jpeg ] || [ \"$b\" = jpg ] ); then echo ok; fi
 if ! ( [ \"$b\" = jpeg ] || [ \"$b\" = jpg ] ); then echo ok; fi
+if ( [ \"$b\" = jpeg ] || [ \"$b\" = jpg ] ); then echo ok; fi
 ( { [ \"$b\" = jpeg ] || [ \"$b\" = jpg ]; } )
 ( [ \"$b\" = jpeg ] ; [ \"$b\" = jpg ] )
 ( cd /tmp || exit 1


### PR DESCRIPTION
## Summary
- prevent `P004` from reporting spans that are already covered by `P003`
- add a regression case for a whole-condition grouped test wrapped in a subshell

## Root cause
`P004` treated grouped test conditions wrapped in a subshell as its own reportable shape even when the entire condition already matched `P003`'s single-condition subshell rule. That produced a misleading second diagnostic suggesting braces for code that should instead just drop the subshell.

## Impact
This keeps the performance rules from double-reporting the same construct and fixes the remaining `P004` large-corpus blocker.

## Validation
- `cargo test -p shuck-linter single_test_subshell -- --nocapture`
- `cargo test -p shuck-linter subshell_test_group -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=P004`
