### PR TITLE
Fix C002 for escaped source builtins

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/dynamic_source_path.rs
+++ b/crates/shuck-linter/src/rules/correctness/dynamic_source_path.rs
@@ -27,3 +27,24 @@ pub fn dynamic_source_path(checker: &mut Checker) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn flags_escaped_source_builtins_with_dynamic_paths() {
+        let source = "\
+#!/bin/bash
+\\. \"$rvm_environments_path/$1\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DynamicSourcePath));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"$rvm_environments_path/$1\""
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/dynamic_source_path.rs
+++ b/crates/shuck-linter/src/rules/correctness/dynamic_source_path.rs
@@ -47,4 +47,18 @@ mod tests {
             "\"$rvm_environments_path/$1\""
         );
     }
+
+    #[test]
+    fn ignores_literal_leading_backslashes_in_other_command_names() {
+        for source in [
+            "#!/bin/bash\n\"\\\\.\" \"$rvm_environments_path/$1\"\n",
+            "#!/bin/bash\n'\\source' \"$rvm_environments_path/$1\"\n",
+            "#!/bin/bash\n\\\\. \"$rvm_environments_path/$1\"\n",
+        ] {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::DynamicSourcePath));
+
+            assert!(diagnostics.is_empty(), "{source}");
+        }
+    }
 }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -320,7 +320,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             &mut nested_regions,
         );
 
-        if let Some(name) = static_word_text(&command.name, self.source)
+        if let Some(name) = static_command_name_text(&command.name, self.source)
             && !name.is_empty()
         {
             let callee = Name::from(name.as_str());
@@ -3012,6 +3012,11 @@ fn named_target_word(word: &Word, source: &str) -> Option<(Name, Span)> {
     is_name(&text).then_some((Name::from(text), word.span))
 }
 
+fn static_command_name_text(word: &Word, source: &str) -> Option<String> {
+    static_word_text(word, source)
+        .map(|text| text.strip_prefix('\\').map_or(text.clone(), str::to_owned))
+}
+
 fn static_word_text(word: &Word, source: &str) -> Option<String> {
     let mut result = String::new();
     collect_static_word_text(&word.parts, source, &mut result).then_some(result)
@@ -3043,7 +3048,7 @@ fn recorded_simple_command_info(
     let words = std::iter::once(&command.name)
         .chain(command.args.iter())
         .collect::<Vec<_>>();
-    let mut static_callee = static_word_text(&command.name, source);
+    let mut static_callee = static_command_name_text(&command.name, source);
     let static_args = command
         .args
         .iter()
@@ -3057,7 +3062,9 @@ fn recorded_simple_command_info(
         .and_then(|word| source_path_template(word, source, bash_runtime_vars_enabled));
 
     if static_callee.as_deref() == Some("noglob") {
-        static_callee = words.get(1).and_then(|word| static_word_text(word, source));
+        static_callee = words
+            .get(1)
+            .and_then(|word| static_command_name_text(word, source));
     }
 
     let mut info = RecordedCommandInfo {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -3013,13 +3013,86 @@ fn named_target_word(word: &Word, source: &str) -> Option<(Name, Span)> {
 }
 
 fn static_command_name_text(word: &Word, source: &str) -> Option<String> {
-    static_word_text(word, source)
-        .map(|text| text.strip_prefix('\\').map_or(text.clone(), str::to_owned))
+    let mut result = String::new();
+    collect_static_command_name_parts(
+        &word.parts,
+        source,
+        StaticCommandNameContext::Unquoted,
+        &mut result,
+    )
+    .then_some(result)
 }
 
 fn static_word_text(word: &Word, source: &str) -> Option<String> {
     let mut result = String::new();
     collect_static_word_text(&word.parts, source, &mut result).then_some(result)
+}
+
+#[derive(Clone, Copy)]
+enum StaticCommandNameContext {
+    Unquoted,
+    DoubleQuoted,
+}
+
+fn collect_static_command_name_parts(
+    parts: &[WordPartNode],
+    source: &str,
+    context: StaticCommandNameContext,
+    out: &mut String,
+) -> bool {
+    for part in parts {
+        match &part.kind {
+            WordPart::Literal(text) => {
+                decode_static_command_literal(text.as_str(source, part.span), context, out);
+            }
+            WordPart::SingleQuoted { value, .. } => out.push_str(value.slice(source)),
+            WordPart::DoubleQuoted { parts, .. } => {
+                if !collect_static_command_name_parts(
+                    parts,
+                    source,
+                    StaticCommandNameContext::DoubleQuoted,
+                    out,
+                ) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+
+    true
+}
+
+fn decode_static_command_literal(text: &str, context: StaticCommandNameContext, out: &mut String) {
+    let mut chars = text.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+
+        let Some(next) = chars.next() else {
+            out.push('\\');
+            break;
+        };
+
+        match context {
+            StaticCommandNameContext::Unquoted => {
+                if next != '\n' {
+                    out.push(next);
+                }
+            }
+            StaticCommandNameContext::DoubleQuoted => match next {
+                '$' | '`' | '"' | '\\' => out.push(next),
+                '\n' => {}
+                _ => {
+                    out.push('\\');
+                    out.push(next);
+                }
+            },
+        }
+    }
 }
 
 fn recorded_command_info(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2427,6 +2427,22 @@ source \"$x\"
     }
 
     #[test]
+    fn escaped_dot_source_builtin_still_records_dynamic_source_refs() {
+        let source = "\
+#!/bin/bash
+\\. \"$rvm_environments_path/$1\"
+";
+        let model = model(source);
+
+        assert_eq!(model.source_refs().len(), 1);
+        assert_eq!(model.source_refs()[0].kind, SourceRefKind::Dynamic);
+        assert_eq!(
+            model.source_refs()[0].diagnostic_class,
+            SourceRefDiagnosticClass::DynamicPath
+        );
+    }
+
+    #[test]
     fn builds_transitive_call_graph_and_overwritten_functions() {
         let source = "\
 f() { g; }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2443,6 +2443,23 @@ source \"$x\"
     }
 
     #[test]
+    fn literal_leading_backslashes_do_not_create_source_refs() {
+        for source in [
+            "#!/bin/bash\n\"\\\\.\" \"$rvm_environments_path/$1\"\n",
+            "#!/bin/bash\n'\\source' \"$rvm_environments_path/$1\"\n",
+            "#!/bin/bash\n\\\\. \"$rvm_environments_path/$1\"\n",
+        ] {
+            let model = model(source);
+
+            assert!(
+                model.source_refs().is_empty(),
+                "unexpected source refs for {source:?}: {:?}",
+                model.source_refs()
+            );
+        }
+    }
+
+    #[test]
     fn builds_transitive_call_graph_and_overwritten_functions() {
         let source = "\
 f() { g; }


### PR DESCRIPTION
## Summary

- normalize escaped static command names in the semantic builder so `\.` and `\source` are treated like ordinary source builtins
- preserve dynamic source-path detection for escaped source-builtin spellings used in real-world scripts
- add semantic and linter regressions for the escaped-source C002 case

## Root Cause

Shuck was recording source refs only when the command name was exactly `source` or `.`. Escaped builtin spellings such as `\.` kept the leading backslash in semantic command-name handling, so dynamic source refs were never recorded and C002 missed those cases.

## Validation

- `cargo test -p shuck-semantic escaped_dot_source_builtin_still_records_dynamic_source_refs`
- `cargo test -p shuck-linter flags_escaped_source_builtins_with_dynamic_paths`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C002`
- `cargo test --workspace`
