### PR TITLE
Limit S052 to bracket tests

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/style/S052.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S052.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 [ -n $foo ]
-test -n ${bar}
+[ -n ${bar} ]
 [ -n prefix$baz ]
-test -n ${qux:-fallback}
+[ -n ${qux:-fallback} ]
 
 [ -n "$foo" ]
+test -n $foo
 test -z $foo
 [ -n literal ]
 test -n $(printf '%s\n' "$foo")
+test -n ${qux:-fallback}
 [ -n ${arr[*]} ]

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S052_S052.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S052_S052.sh.snap
@@ -8,9 +8,9 @@ S052 quote variable expansions in -n tests
   |
 
 S052 quote variable expansions in -n tests
- --> <source>:3:9
+ --> <source>:3:6
   |
-3 | test -n ${bar}
+3 | [ -n ${bar} ]
   |
 
 S052 quote variable expansions in -n tests
@@ -20,7 +20,7 @@ S052 quote variable expansions in -n tests
   |
 
 S052 quote variable expansions in -n tests
- --> <source>:5:9
+ --> <source>:5:6
   |
-5 | test -n ${qux:-fallback}
+5 | [ -n ${qux:-fallback} ]
   |

--- a/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Checker, ExpansionContext, Rule, SimpleTestShape, SimpleTestSyntax, Violation,
-    WordFactContext, static_word_text,
+    Checker, ExpansionContext, Rule, SimpleTestShape, SimpleTestSyntax, Violation, WordFactContext,
+    static_word_text,
 };
 
 pub struct UnquotedVariableInTest;

--- a/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Checker, ExpansionContext, Rule, SimpleTestShape, Violation, WordFactContext, static_word_text,
+    Checker, ExpansionContext, Rule, SimpleTestShape, SimpleTestSyntax, Violation,
+    WordFactContext, static_word_text,
 };
 
 pub struct UnquotedVariableInTest;
@@ -23,6 +24,9 @@ pub fn unquoted_variable_in_test(checker: &mut Checker) {
             let Some(simple_test) = fact.simple_test() else {
                 return Vec::new();
             };
+            if simple_test.syntax() != SimpleTestSyntax::Bracket {
+                return Vec::new();
+            }
             if simple_test.shape() != SimpleTestShape::Unary || simple_test.operands().len() != 2 {
                 return Vec::new();
             }
@@ -57,9 +61,9 @@ mod tests {
         let source = "\
 #!/bin/sh
 [ -n $foo ]
-test -n ${bar}
 [ -n prefix$baz ]
-test -n ${qux:-fallback}
+[ -n ${bar} ]
+[ -n ${qux:-fallback} ]
 ";
         let diagnostics = test_snippet(
             source,
@@ -71,7 +75,7 @@ test -n ${qux:-fallback}
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$foo", "${bar}", "$baz", "${qux:-fallback}"]
+            vec!["$foo", "$baz", "${bar}", "${qux:-fallback}"]
         );
     }
 
@@ -79,11 +83,13 @@ test -n ${qux:-fallback}
     fn ignores_quoted_and_non_n_unary_tests() {
         let source = "\
 #!/bin/sh
+[ -n ${arr[*]} ]
 [ -n \"$foo\" ]
+test -n $foo
 test -z $foo
 [ -n literal ]
 test -n $(printf '%s\\n' \"$foo\")
-[ -n ${arr[*]} ]
+test -n ${qux:-fallback}
 ";
         let diagnostics = test_snippet(
             source,


### PR DESCRIPTION
## Summary
- restrict `S052` to bracket-form string tests (`[ -n ... ]`)
- stop reporting `test -n ...` forms under the dedicated `S052` diagnostic
- update the rule fixture, snapshot, and focused unit coverage to match the narrowed behavior

## Why
`S052` was over-reporting by treating bracket and `test` syntax as the same oracle target. In practice, the current ShellCheck `SC2070` behavior is specific to bracket tests, while `test -n $var` is handled differently or left to broader quoting diagnostics. That mismatch produced a false positive in the targeted corpus run.

## Impact
This keeps the dedicated `S052` warning aligned with the intended bracket-test pattern and removes the generated `configure` false positive without weakening unrelated quoting checks.

## Validation
- `cargo test -p shuck-linter unquoted_variable_in_test -- --nocapture`
- `cargo test -p shuck-linter style::tests::rules -- --nocapture S052`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S052`