### PR TITLE
Narrow X079 to quoted-target index flags

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/portability/X079.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X079.sh
@@ -6,8 +6,9 @@ if is-at-least 3.1 ${"$(rsync --version 2>&1)"[(w)3]}; then
   echo new
 fi
 
-# Should also trigger for other index flags.
+# Should not trigger: reference targets with zsh-style subscripts belong to array portability rules.
 value=${map[(I)needle]}
+value="${precmd_functions[(r)_z_precmd]}"
 
-# Should not trigger: ordinary braced subscript without a zsh flag.
+# Should not trigger: ordinary braced subscript without a quoted target.
 value=${map[1]}

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -25952,8 +25952,10 @@ crypt=${crypt//\\//\\\\\\/}
 #!/bin/sh
 printf '%s\\n' ${\"$foo\"[1]}
 printf '%s\\n' ${\"$(printf '%s\\n' \"$PWD\")\"[(w)1]}
+printf '%s\\n' ${\"$(printf \"%s\" \")\")\"[(w)1]}
 printf '%s\\n' ${map[(I)needle]}
 printf '%s\\n' \"${precmd_functions[(r)_z_precmd]}\"
+printf '%s\\n' '${\"$bar\"[1]}'
 ";
 
         with_facts(source, None, |_, facts| {
@@ -25963,7 +25965,11 @@ printf '%s\\n' \"${precmd_functions[(r)_z_precmd]}\"
                     .iter()
                     .map(|fragment| fragment.span().slice(source))
                     .collect::<Vec<_>>(),
-                vec!["${\"$foo\"", "${\"$(printf '%s\\n' \"$PWD\")\""]
+                vec![
+                    "${\"$foo\"",
+                    "${\"$(printf '%s\\n' \"$PWD\")\"",
+                    "${\"$(printf \"%s\" \")\")\"",
+                ]
             );
         });
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -1109,6 +1109,17 @@ impl IndexedArrayReferenceFragmentFact {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub struct ZshParameterIndexFlagFragmentFact {
+    span: Span,
+}
+
+impl ZshParameterIndexFlagFragmentFact {
+    pub fn span(&self) -> Span {
+        self.span
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct SubstringExpansionFragmentFact {
     span: Span,
 }
@@ -3011,6 +3022,7 @@ pub struct LinterFacts<'a> {
     nested_parameter_expansion_fragments: Vec<NestedParameterExpansionFragmentFact>,
     indirect_expansion_fragments: Vec<IndirectExpansionFragmentFact>,
     indexed_array_reference_fragments: Vec<IndexedArrayReferenceFragmentFact>,
+    zsh_parameter_index_flag_fragments: Vec<ZshParameterIndexFlagFragmentFact>,
     substring_expansion_fragments: Vec<SubstringExpansionFragmentFact>,
     case_modification_fragments: Vec<CaseModificationFragmentFact>,
     replacement_expansion_fragments: Vec<ReplacementExpansionFragmentFact>,
@@ -3482,6 +3494,10 @@ impl<'a> LinterFacts<'a> {
         &self.indexed_array_reference_fragments
     }
 
+    pub fn zsh_parameter_index_flag_fragments(&self) -> &[ZshParameterIndexFlagFragmentFact] {
+        &self.zsh_parameter_index_flag_fragments
+    }
+
     pub fn substring_expansion_fragments(&self) -> &[SubstringExpansionFragmentFact] {
         &self.substring_expansion_fragments
     }
@@ -3896,6 +3912,7 @@ impl<'a> LinterFactsBuilder<'a> {
             nested_parameter_expansions,
             indirect_expansions,
             indexed_array_references,
+            zsh_parameter_index_flags,
             substring_expansions,
             case_modifications,
             replacement_expansions,
@@ -4057,6 +4074,7 @@ impl<'a> LinterFactsBuilder<'a> {
             nested_parameter_expansion_fragments: nested_parameter_expansions,
             indirect_expansion_fragments: indirect_expansions,
             indexed_array_reference_fragments: indexed_array_references,
+            zsh_parameter_index_flag_fragments: zsh_parameter_index_flags,
             substring_expansion_fragments: substring_expansions,
             case_modification_fragments: case_modifications,
             replacement_expansion_fragments: replacement_expansions,
@@ -11168,6 +11186,9 @@ fn extend_surface_fragment_facts(target: &mut SurfaceFragmentFacts, source: Surf
     target
         .indexed_array_references
         .extend(source.indexed_array_references);
+    target
+        .zsh_parameter_index_flags
+        .extend(source.zsh_parameter_index_flags);
     target
         .substring_expansions
         .extend(source.substring_expansions);
@@ -24613,6 +24634,10 @@ if [[ \"$@\" =~ x ]]; then :; fi
                     .collect::<Vec<_>>(),
                 vec!["${arr[0]}", "${arr[@]}", "${arr[*]}"]
             );
+            assert!(
+                facts.zsh_parameter_index_flag_fragments().is_empty(),
+                "did not expect quoted-target index facts in the baseline surface fixture"
+            );
             assert_eq!(
                 facts
                     .substring_expansion_fragments()
@@ -25917,6 +25942,28 @@ crypt=${crypt//\\//\\\\\\/}
                     .map(|fragment| fragment.span().slice(source))
                     .collect::<Vec<_>>(),
                 vec!["${crypt//\\\\/\\\\\\\\}", "${crypt//\\//\\\\\\/}"]
+            );
+        });
+    }
+
+    #[test]
+    fn surface_facts_track_zsh_parameter_index_flags_only_for_word_targets() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' ${\"$foo\"[1]}
+printf '%s\\n' ${\"$(printf '%s\\n' \"$PWD\")\"[(w)1]}
+printf '%s\\n' ${map[(I)needle]}
+printf '%s\\n' \"${precmd_functions[(r)_z_precmd]}\"
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .zsh_parameter_index_flag_fragments()
+                    .iter()
+                    .map(|fragment| fragment.span().slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["${\"$foo\"", "${\"$(printf '%s\\n' \"$PWD\")\""]
             );
         });
     }

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -984,57 +984,18 @@ impl<'a> SurfaceFragmentSink<'a> {
 }
 
 fn quoted_parameter_target_len(text: &str) -> Option<usize> {
-    let quote = text.chars().next()?;
-    if !matches!(quote, '"' | '\'') {
-        return None;
+    match text.as_bytes().first().copied() {
+        Some(b'\'') => single_quoted_fragment_len(text),
+        Some(b'"') => double_quoted_fragment_len(text),
+        _ => None,
     }
-
-    let bytes = text.as_bytes();
-    let mut index = quote.len_utf8();
-    let mut parameter_depth = 0usize;
-    let mut command_depth = 0usize;
-
-    while index < bytes.len() {
-        if bytes[index] == b'\\' {
-            index += usize::from(index + 1 < bytes.len()) + 1;
-            continue;
-        }
-        if bytes[index..].starts_with(b"${") {
-            parameter_depth += 1;
-            index += 2;
-            continue;
-        }
-        if bytes[index..].starts_with(b"$(") {
-            command_depth += 1;
-            index += 2;
-            continue;
-        }
-        if bytes[index] == b'}' && parameter_depth > 0 {
-            parameter_depth -= 1;
-            index += 1;
-            continue;
-        }
-        if bytes[index] == b')' && command_depth > 0 {
-            command_depth -= 1;
-            index += 1;
-            continue;
-        }
-        if bytes[index] == quote as u8 && parameter_depth == 0 && command_depth == 0 {
-            return Some(index + 1);
-        }
-
-        index += 1;
-    }
-
-    None
 }
 
 fn zsh_parameter_index_flag_spans_in_word(text: &str, span: Span) -> Vec<Span> {
     let mut spans = Vec::new();
     let mut search_from = 0usize;
 
-    while let Some(relative) = text[search_from..].find("${") {
-        let start = search_from + relative;
+    while let Some(start) = next_live_parameter_expansion_start(text, search_from) {
         let body = &text[start + 2..];
         let Some(target_len) = quoted_parameter_target_len(body) else {
             search_from = start + 2;
@@ -1052,6 +1013,222 @@ fn zsh_parameter_index_flag_spans_in_word(text: &str, span: Span) -> Vec<Span> {
     }
 
     spans
+}
+
+fn next_live_parameter_expansion_start(text: &str, search_from: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut index = search_from;
+    let mut in_double_quotes = false;
+
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'\\' {
+            index += usize::from(index + 1 < bytes.len()) + 1;
+            continue;
+        }
+
+        if !in_double_quotes && bytes[index..].starts_with(b"$'") {
+            index += 1 + dollar_single_quoted_fragment_len(&text[index + 1..])?;
+            continue;
+        }
+
+        if !in_double_quotes && bytes[index] == b'\'' {
+            index += single_quoted_fragment_len(&text[index..])?;
+            continue;
+        }
+
+        if bytes[index] == b'"' {
+            in_double_quotes = !in_double_quotes;
+            index += 1;
+            continue;
+        }
+
+        if bytes[index..].starts_with(b"${") {
+            return Some(index);
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+fn single_quoted_fragment_len(text: &str) -> Option<usize> {
+    debug_assert!(text.starts_with('\''));
+    text[1..].find('\'').map(|offset| offset + 2)
+}
+
+fn dollar_single_quoted_fragment_len(text: &str) -> Option<usize> {
+    debug_assert!(text.starts_with('\''));
+    let bytes = text.as_bytes();
+    let mut index = 1usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index += usize::from(index + 1 < bytes.len()) + 1;
+            continue;
+        }
+        if bytes[index] == b'\'' {
+            return Some(index + 1);
+        }
+        index += 1;
+    }
+
+    None
+}
+
+fn double_quoted_fragment_len(text: &str) -> Option<usize> {
+    debug_assert!(text.starts_with('"'));
+    let bytes = text.as_bytes();
+    let mut index = 1usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index += usize::from(index + 1 < bytes.len()) + 1;
+            continue;
+        }
+        if bytes[index..].starts_with(b"${") {
+            index += parameter_expansion_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index..].starts_with(b"$(") {
+            index += command_substitution_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'`' {
+            index += backtick_substitution_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'"' {
+            return Some(index + 1);
+        }
+        index += 1;
+    }
+
+    None
+}
+
+fn parameter_expansion_len(text: &str) -> Option<usize> {
+    debug_assert!(text.starts_with("${"));
+    let bytes = text.as_bytes();
+    let mut index = 2usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index += usize::from(index + 1 < bytes.len()) + 1;
+            continue;
+        }
+        if bytes[index] == b'\'' {
+            index += single_quoted_fragment_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'"' {
+            index += double_quoted_fragment_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'`' {
+            index += backtick_substitution_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index..].starts_with(b"${") {
+            index += parameter_expansion_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index..].starts_with(b"$(") {
+            index += command_substitution_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'}' {
+            return Some(index + 1);
+        }
+        index += 1;
+    }
+
+    None
+}
+
+fn command_substitution_len(text: &str) -> Option<usize> {
+    debug_assert!(text.starts_with("$("));
+    let bytes = text.as_bytes();
+    let mut index = 2usize;
+    let mut paren_depth = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index += usize::from(index + 1 < bytes.len()) + 1;
+            continue;
+        }
+        if bytes[index] == b'\'' {
+            index += single_quoted_fragment_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'"' {
+            index += double_quoted_fragment_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'`' {
+            index += backtick_substitution_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index..].starts_with(b"${") {
+            index += parameter_expansion_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index..].starts_with(b"$(") {
+            index += command_substitution_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'(' {
+            paren_depth += 1;
+            index += 1;
+            continue;
+        }
+        if bytes[index] == b')' {
+            if paren_depth == 0 {
+                return Some(index + 1);
+            }
+            paren_depth -= 1;
+            index += 1;
+            continue;
+        }
+        index += 1;
+    }
+
+    None
+}
+
+fn backtick_substitution_len(text: &str) -> Option<usize> {
+    debug_assert!(text.starts_with('`'));
+    let bytes = text.as_bytes();
+    let mut index = 1usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index += usize::from(index + 1 < bytes.len()) + 1;
+            continue;
+        }
+        if bytes[index] == b'\'' {
+            index += single_quoted_fragment_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'"' {
+            index += double_quoted_fragment_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index..].starts_with(b"${") {
+            index += parameter_expansion_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index..].starts_with(b"$(") {
+            index += command_substitution_len(&text[index..])?;
+            continue;
+        }
+        if bytes[index] == b'`' {
+            return Some(index + 1);
+        }
+        index += 1;
+    }
+
+    None
 }
 
 fn heredoc_single_quote_is_escaped(text: &str, quote_offset: usize) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -19,6 +19,7 @@ pub(super) struct SurfaceFragmentFacts {
     pub(super) nested_parameter_expansions: Vec<NestedParameterExpansionFragmentFact>,
     pub(super) indirect_expansions: Vec<IndirectExpansionFragmentFact>,
     pub(super) indexed_array_references: Vec<IndexedArrayReferenceFragmentFact>,
+    pub(super) zsh_parameter_index_flags: Vec<ZshParameterIndexFlagFragmentFact>,
     pub(super) substring_expansions: Vec<SubstringExpansionFragmentFact>,
     pub(super) case_modifications: Vec<CaseModificationFragmentFact>,
     pub(super) replacement_expansions: Vec<ReplacementExpansionFragmentFact>,
@@ -152,6 +153,20 @@ impl<'a> SurfaceFragmentSink<'a> {
             .push(SubstringExpansionFragmentFact { span });
     }
 
+    fn record_zsh_parameter_index_flag(&mut self, span: Span) {
+        if self
+            .facts
+            .zsh_parameter_index_flags
+            .iter()
+            .any(|fragment| fragment.span() == span)
+        {
+            return;
+        }
+        self.facts
+            .zsh_parameter_index_flags
+            .push(ZshParameterIndexFlagFragmentFact { span });
+    }
+
     fn record_case_modification(&mut self, span: Span) {
         if self
             .facts
@@ -230,6 +245,10 @@ impl<'a> SurfaceFragmentSink<'a> {
             false,
             &mut self.facts.unicode_smart_quote_spans,
         );
+        for span in zsh_parameter_index_flag_spans_in_word(word.span.slice(self.source), word.span)
+        {
+            self.record_zsh_parameter_index_flag(span);
+        }
         if context.collect_open_double_quotes && context.assignment_target.is_none() {
             self.collect_open_double_quote_fragments(word, context.command_name);
         }
@@ -962,6 +981,77 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
         self.facts.subscript_spans.push(subscript.span());
     }
+}
+
+fn quoted_parameter_target_len(text: &str) -> Option<usize> {
+    let quote = text.chars().next()?;
+    if !matches!(quote, '"' | '\'') {
+        return None;
+    }
+
+    let bytes = text.as_bytes();
+    let mut index = quote.len_utf8();
+    let mut parameter_depth = 0usize;
+    let mut command_depth = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index += usize::from(index + 1 < bytes.len()) + 1;
+            continue;
+        }
+        if bytes[index..].starts_with(b"${") {
+            parameter_depth += 1;
+            index += 2;
+            continue;
+        }
+        if bytes[index..].starts_with(b"$(") {
+            command_depth += 1;
+            index += 2;
+            continue;
+        }
+        if bytes[index] == b'}' && parameter_depth > 0 {
+            parameter_depth -= 1;
+            index += 1;
+            continue;
+        }
+        if bytes[index] == b')' && command_depth > 0 {
+            command_depth -= 1;
+            index += 1;
+            continue;
+        }
+        if bytes[index] == quote as u8 && parameter_depth == 0 && command_depth == 0 {
+            return Some(index + 1);
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+fn zsh_parameter_index_flag_spans_in_word(text: &str, span: Span) -> Vec<Span> {
+    let mut spans = Vec::new();
+    let mut search_from = 0usize;
+
+    while let Some(relative) = text[search_from..].find("${") {
+        let start = search_from + relative;
+        let body = &text[start + 2..];
+        let Some(target_len) = quoted_parameter_target_len(body) else {
+            search_from = start + 2;
+            continue;
+        };
+        if !body[target_len..].starts_with('[') {
+            search_from = start + 2;
+            continue;
+        }
+
+        let target_start = span.start.advanced_by(&text[..start]);
+        let target_end = target_start.advanced_by(&text[start..start + 2 + target_len]);
+        spans.push(Span::from_positions(target_start, target_end));
+        search_from = start + 2 + target_len;
+    }
+
+    spans
 }
 
 fn heredoc_single_quote_is_escaped(text: &str, quote_offset: usize) -> bool {

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X079_X079.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X079_X079.sh.snap
@@ -2,13 +2,7 @@
 source: crates/shuck-linter/src/rules/portability/mod.rs
 ---
 X079 zsh parameter index flags are not portable to this shell
- --> <source>:5:47
+ --> <source>:5:20
   |
 5 | if is-at-least 3.1 ${"$(rsync --version 2>&1)"[(w)3]}; then
   |
-
-X079 zsh parameter index flags are not portable to this shell
-  --> <source>:10:12
-   |
-10 | value=${map[(I)needle]}
-   |

--- a/crates/shuck-linter/src/rules/portability/zsh_parameter_index_flag.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_parameter_index_flag.rs
@@ -77,4 +77,30 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "${\"$foo\"");
     }
+
+    #[test]
+    fn reports_quoted_targets_with_quoted_parens_in_command_substitutions() {
+        let source = "#!/bin/sh\nx=${\"$(printf \"%s\" \")\")\"[(w)1]}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ZshParameterIndexFlag),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "${\"$(printf \"%s\" \")\")\""
+        );
+    }
+
+    #[test]
+    fn ignores_single_quoted_literal_parameter_text() {
+        let source = "#!/bin/sh\nx='${\"$foo\"[1]}'\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ZshParameterIndexFlag),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/portability/zsh_parameter_index_flag.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_parameter_index_flag.rs
@@ -1,5 +1,3 @@
-use shuck_ast::Span;
-
 use super::targets_non_zsh_shell;
 use crate::{Checker, Rule, Violation};
 
@@ -22,105 +20,12 @@ pub fn zsh_parameter_index_flag(checker: &mut Checker) {
 
     let spans = checker
         .facts()
-        .word_facts()
+        .zsh_parameter_index_flag_fragments()
         .iter()
-        .flat_map(|fact| {
-            index_flag_spans(fact.word().span.slice(checker.source()), fact.word().span)
-        })
+        .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ZshParameterIndexFlag);
-}
-
-fn index_flag_spans(text: &str, span: Span) -> Vec<Span> {
-    let mut spans = Vec::new();
-    let mut search_from = 0usize;
-
-    while let Some(relative) = text[search_from..].find("[(") {
-        let start = search_from + relative;
-        let Some(expansion_start) = innermost_parameter_expansion_start(text, start) else {
-            search_from = start + 2;
-            continue;
-        };
-
-        let Some(close_paren) = text[start + 2..].find(')') else {
-            search_from = start + 2;
-            continue;
-        };
-        let close_paren = start + 2 + close_paren;
-        if close_paren == start + 2 {
-            search_from = start + 2;
-            continue;
-        }
-        if !text[start + 2..close_paren]
-            .chars()
-            .all(|ch| ch.is_ascii_alphabetic())
-        {
-            search_from = start + 2;
-            continue;
-        }
-        let Some(close_bracket) = text[close_paren + 1..].find(']') else {
-            search_from = close_paren + 1;
-            continue;
-        };
-        let close_bracket = close_paren + 1 + close_bracket;
-        if parameter_expansion_end(text, expansion_start) != Some(close_bracket + 1) {
-            search_from = close_bracket + 1;
-            continue;
-        }
-
-        let bracket_start = span.start.advanced_by(&text[..start]);
-        spans.push(Span::from_positions(
-            bracket_start,
-            bracket_start.advanced_by("["),
-        ));
-        search_from = close_bracket + 1;
-    }
-
-    spans
-}
-
-fn innermost_parameter_expansion_start(text: &str, end: usize) -> Option<usize> {
-    let bytes = text.as_bytes();
-    let mut stack = Vec::new();
-    let mut index = 0usize;
-
-    while index < end {
-        if bytes[index..].starts_with(b"${") {
-            stack.push(index);
-            index += 2;
-            continue;
-        }
-        if bytes[index] == b'}' {
-            stack.pop();
-        }
-        index += 1;
-    }
-
-    stack.last().copied()
-}
-
-fn parameter_expansion_end(text: &str, start: usize) -> Option<usize> {
-    let bytes = text.as_bytes();
-    let mut depth = 0usize;
-    let mut index = start;
-
-    while index < bytes.len() {
-        if bytes[index..].starts_with(b"${") {
-            depth += 1;
-            index += 2;
-            continue;
-        }
-        if bytes[index] == b'}' {
-            depth = depth.saturating_sub(1);
-            if depth == 0 {
-                return Some(index);
-            }
-        }
-        index += 1;
-    }
-
-    None
 }
 
 #[cfg(test)]
@@ -151,13 +56,25 @@ mod tests {
     }
 
     #[test]
-    fn ignores_literal_index_flag_text_after_a_closed_expansion() {
-        let source = "#!/bin/sh\nx=\"${a}[(w)3]}\"\n";
+    fn ignores_reference_targets_with_zsh_style_subscripts() {
+        let source = "#!/bin/sh\nx=${map[(I)needle]}\ny=\"${precmd_functions[(r)_z_precmd]}\"\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::ZshParameterIndexFlag),
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_quoted_word_targets_with_indexing() {
+        let source = "#!/bin/sh\nx=${\"$foo\"[1]}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ZshParameterIndexFlag),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "${\"$foo\"");
     }
 }


### PR DESCRIPTION
## Summary
- narrow X079 so it only reports quoted-target index-flag forms instead of any zsh-style reference subscript
- move the detection into surface facts so the rule consumes precomputed structure instead of rescanning word text
- add regression coverage for quoted targets vs reference targets and refresh the X079 fixture snapshot

## Why
The old rule matched raw `[(...)` text inside any word, which over-reported X079 for ordinary reference targets like `${precmd_functions[(r)_z_precmd]}`. In the large corpus that showed up as a shuck-only X079/SC2301 diff, while the oracle treated the reference-target form as an array portability case instead.

## Impact
This keeps X079 focused on the quoted-target syntax that actually corresponds to the SC2301 compatibility shape and avoids duplicate or incorrect portability reports on reference-target subscripts.

## Validation
- `cargo test -p shuck-linter surface_facts_track_zsh_parameter_index_flags_only_for_word_targets -- --nocapture`
- `cargo test -p shuck-linter zsh_parameter_index_flag -- --nocapture`
- `cargo test -p shuck-linter rule_zshparameterindexflag_path_new_x079_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X079`