### PR TITLE
Fix X078 case pattern matching

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/portability/X078.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X078.sh
@@ -1,17 +1,24 @@
 #!/bin/sh
 # shellcheck disable=2154,1087
 
-# Should trigger: bare zsh array subscript in case subject.
+# Should trigger: unbraced array-style syntax leaves a literal `[1]` suffix.
 case "$words[1]" in
     install) echo installing ;;
 esac
 
-# Should also trigger when unquoted.
-case $line[1] in
-    x) : ;;
+# Should also trigger: literal padding around the dynamic subject makes this arm impossible.
+case " $oldobjs " in
+    " ") : ;;
+    "  ") : ;;
 esac
 
-# Should not trigger: braced expansions are handled separately.
+# Should not trigger: this suffix-matching arm can still match.
+case "prefix${value}suffix" in
+    *suffix) : ;;
+    prefix*suffix) : ;;
+esac
+
+# Should not trigger: braced expansions remain unconstrained here.
 case "${words[1]}" in
-    remove) : ;;
+    install) : ;;
 esac

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2951,6 +2951,7 @@ pub struct LinterFacts<'a> {
     select_headers: Vec<SelectHeaderFact<'a>>,
     case_items: Vec<CaseItemFact<'a>>,
     case_pattern_shadows: Vec<CasePatternShadowFact>,
+    case_pattern_impossible_spans: Vec<Span>,
     case_pattern_expansion_spans: Vec<Span>,
     getopts_cases: Vec<GetoptsCaseFact>,
     pipelines: Vec<PipelineFact<'a>>,
@@ -3244,6 +3245,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn case_pattern_shadows(&self) -> &[CasePatternShadowFact] {
         &self.case_pattern_shadows
+    }
+
+    pub fn case_pattern_impossible_spans(&self) -> &[Span] {
+        &self.case_pattern_impossible_spans
     }
 
     pub fn case_pattern_expansion_spans(&self) -> &[Span] {
@@ -3839,6 +3844,8 @@ impl<'a> LinterFactsBuilder<'a> {
             build_select_header_facts(&commands, &command_ids_by_span, self.source);
         let case_items = build_case_item_facts(&commands);
         let case_pattern_shadows = build_case_pattern_shadow_facts(&commands, self.source);
+        let case_pattern_impossible_spans =
+            build_case_pattern_impossible_spans(&commands, self.source);
         let pipelines = build_pipeline_facts(&commands, &command_ids_by_span);
         let scope_read_source_words =
             build_scope_read_source_words(&commands, &pipelines, &if_condition_command_ids);
@@ -3996,6 +4003,7 @@ impl<'a> LinterFactsBuilder<'a> {
             select_headers,
             case_items,
             case_pattern_shadows,
+            case_pattern_impossible_spans,
             case_pattern_expansion_spans,
             getopts_cases,
             pipelines,
@@ -12206,6 +12214,33 @@ impl StaticCasePatternMatcher {
         })
     }
 
+    fn from_case_subject(word: &Word, source: &str) -> Option<Self> {
+        let mut tokens = Vec::new();
+        let mut saw_dynamic = false;
+        collect_static_case_subject_tokens(&word.parts, source, &mut tokens, &mut saw_dynamic)?;
+        if !saw_dynamic {
+            return None;
+        }
+
+        let StaticCasePatternSummary {
+            min_len,
+            max_len,
+            literal_prefix,
+            literal_suffix,
+            literal_symbols,
+            start_states,
+        } = summarize_static_case_pattern_tokens(&tokens);
+        Some(Self {
+            tokens,
+            min_len,
+            max_len,
+            literal_prefix,
+            literal_suffix,
+            literal_symbols,
+            start_states,
+        })
+    }
+
     fn subsumes(&self, other: &Self) -> bool {
         if !self.could_subsume(other) {
             return false;
@@ -12240,6 +12275,42 @@ impl StaticCasePatternMatcher {
         }
 
         true
+    }
+
+    fn intersects(&self, other: &Self) -> bool {
+        let symbols = merged_case_pattern_symbols(
+            self.literal_symbols.as_ref(),
+            other.literal_symbols.as_ref(),
+        );
+
+        let start = (self.start_states.to_vec(), other.start_states.to_vec());
+        let mut seen = FxHashSet::default();
+        let mut worklist = vec![start.clone()];
+        seen.insert(start);
+
+        while let Some((left, right)) = worklist.pop() {
+            if self.is_accepting(&left) && other.is_accepting(&right) {
+                return true;
+            }
+
+            for symbol in symbols.iter().copied() {
+                let next_left = self.advance(&left, symbol);
+                if next_left.is_empty() {
+                    continue;
+                }
+
+                let next_right = other.advance(&right, symbol);
+                if next_right.is_empty() {
+                    continue;
+                }
+
+                if seen.insert((next_left.clone(), next_right.clone())) {
+                    worklist.push((next_left, next_right));
+                }
+            }
+        }
+
+        false
     }
 
     fn could_subsume(&self, other: &Self) -> bool {
@@ -12506,6 +12577,52 @@ fn collect_static_case_pattern_tokens(
     Some(())
 }
 
+fn collect_static_case_subject_tokens(
+    parts: &[WordPartNode],
+    source: &str,
+    out: &mut Vec<CasePatternToken>,
+    saw_dynamic: &mut bool,
+) -> Option<()> {
+    for part in parts {
+        match &part.kind {
+            WordPart::Literal(text) => {
+                for ch in text.as_str(source, part.span).chars() {
+                    push_case_pattern_literal_tokens_char(ch, out);
+                }
+            }
+            WordPart::SingleQuoted { value, .. } => {
+                for ch in value.slice(source).chars() {
+                    push_case_pattern_literal_tokens_char(ch, out);
+                }
+            }
+            WordPart::DoubleQuoted { parts, .. } => {
+                collect_static_case_subject_tokens(parts, source, out, saw_dynamic)?;
+            }
+            WordPart::Variable(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. } => {
+                *saw_dynamic = true;
+                push_case_pattern_token(out, CasePatternToken::AnyString);
+            }
+            WordPart::ZshQualifiedGlob(_) => return None,
+        }
+    }
+
+    Some(())
+}
+
 fn push_case_pattern_literal_tokens_char(ch: char, out: &mut Vec<CasePatternToken>) {
     out.push(CasePatternToken::Literal(ch));
 }
@@ -12584,6 +12701,37 @@ fn build_case_pattern_shadow_facts(
     }
 
     shadows
+}
+
+fn build_case_pattern_impossible_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+
+    for fact in commands {
+        let Command::Compound(CompoundCommand::Case(command)) = fact.command() else {
+            continue;
+        };
+
+        let Some(subject_matcher) =
+            StaticCasePatternMatcher::from_case_subject(&command.word, source)
+        else {
+            continue;
+        };
+
+        for item in &command.cases {
+            for pattern in &item.patterns {
+                let Some(pattern_matcher) = StaticCasePatternMatcher::from_pattern(pattern, source)
+                else {
+                    continue;
+                };
+
+                if !subject_matcher.intersects(&pattern_matcher) {
+                    spans.push(pattern.span);
+                }
+            }
+        }
+    }
+
+    spans
 }
 
 #[derive(Debug, Clone)]
@@ -25182,6 +25330,39 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["${items[@]}"]
+            );
+        });
+    }
+
+    #[test]
+    fn builds_impossible_case_pattern_spans_from_subject_shape() {
+        let source = "\
+#!/bin/sh
+case \"$words[1]\" in
+  install) : ;;
+  *\"[1]\") : ;;
+esac
+case \" $oldobjs \" in
+  \" \") : ;;
+  \"  \") : ;;
+esac
+case foo in
+  bar) : ;;
+esac
+case \"x${val}z\" in
+  y*) : ;;
+  *z) : ;;
+esac
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .case_pattern_impossible_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["install", "\" \"", "y*"]
             );
         });
     }

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X078_X078.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X078_X078.sh.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/shuck-linter/src/rules/portability/mod.rs
 ---
-X078 zsh-style array subscripts in case subjects are not portable to this shell
- --> <source>:5:13
+X078 this case pattern cannot match the case subject in this shell
+ --> <source>:6:5
   |
-5 | case "$words[1]" in
+6 |     install) echo installing ;;
   |
 
-X078 zsh-style array subscripts in case subjects are not portable to this shell
-  --> <source>:10:11
+X078 this case pattern cannot match the case subject in this shell
+  --> <source>:11:5
    |
-10 | case $line[1] in
+11 |     " ") : ;;
    |

--- a/crates/shuck-linter/src/rules/portability/zsh_array_subscript_in_case.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_array_subscript_in_case.rs
@@ -1,5 +1,3 @@
-use shuck_ast::Span;
-
 use super::targets_non_zsh_shell;
 use crate::{Checker, Rule, Violation};
 
@@ -11,7 +9,7 @@ impl Violation for ZshArraySubscriptInCase {
     }
 
     fn message(&self) -> String {
-        "zsh-style array subscripts in case subjects are not portable to this shell".to_owned()
+        "this case pattern cannot match the case subject in this shell".to_owned()
     }
 }
 
@@ -20,91 +18,10 @@ pub fn zsh_array_subscript_in_case(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
-        .facts()
-        .case_subject_facts()
-        .flat_map(|fact| {
-            case_subscript_spans(fact.word().span.slice(checker.source()), fact.word().span)
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || ZshArraySubscriptInCase);
-}
-
-fn case_subscript_spans(text: &str, span: Span) -> Vec<Span> {
-    let bytes = text.as_bytes();
-    let mut spans = Vec::new();
-    let mut index = 0usize;
-    let mut in_single = false;
-    let mut in_double = false;
-
-    while index < bytes.len() {
-        if in_single {
-            if bytes[index] == b'\'' {
-                in_single = false;
-            }
-            index += 1;
-            continue;
-        }
-
-        if bytes[index] == b'\\' {
-            index += usize::from(index + 1 < bytes.len()) + 1;
-            continue;
-        }
-
-        if bytes[index] == b'\'' && !in_double {
-            in_single = true;
-            index += 1;
-            continue;
-        }
-
-        if bytes[index] == b'"' {
-            in_double = !in_double;
-            index += 1;
-            continue;
-        }
-
-        if bytes[index] != b'$' || bytes.get(index + 1) == Some(&b'{') {
-            index += 1;
-            continue;
-        }
-
-        let name_start = index + 1;
-        let Some(&first) = bytes.get(name_start) else {
-            break;
-        };
-        if !(first == b'_' || first.is_ascii_alphabetic()) {
-            index += 1;
-            continue;
-        }
-
-        let mut cursor = name_start + 1;
-        while bytes
-            .get(cursor)
-            .is_some_and(|byte| *byte == b'_' || byte.is_ascii_alphanumeric())
-        {
-            cursor += 1;
-        }
-
-        if bytes.get(cursor) != Some(&b'[') {
-            index = cursor;
-            continue;
-        }
-        let Some(relative_end) = text[cursor + 1..].find(']') else {
-            index = cursor + 1;
-            continue;
-        };
-
-        let bracket_offset = cursor;
-        let bracket_start = span.start.advanced_by(&text[..bracket_offset]);
-        spans.push(Span::from_positions(
-            bracket_start,
-            bracket_start.advanced_by("["),
-        ));
-        index = cursor + relative_end + 2;
-    }
-
-    spans
+    checker.report_all_dedup(
+        checker.facts().case_pattern_impossible_spans().to_vec(),
+        || ZshArraySubscriptInCase,
+    );
 }
 
 #[cfg(test)]
@@ -113,19 +30,25 @@ mod tests {
     use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
-    fn ignores_braced_parameter_expansions() {
-        let source = "#!/bin/sh\ncase \"${words[1]}\" in\n  install) : ;;\nesac\n";
+    fn reports_unbraced_array_style_subjects_as_impossible_patterns() {
+        let source = "#!/bin/sh\ncase \"$words[1]\" in\n  install) : ;;\nesac\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::ZshArraySubscriptInCase),
         );
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["install"]
+        );
     }
 
     #[test]
     fn ignores_zsh_scripts() {
-        let source = "#!/bin/zsh\ncase \"$words[1]\" in\n  install) : ;;\nesac\n";
+        let source = "#!/bin/zsh\ncase \" $oldobjs \" in\n  \" \") : ;;\nesac\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::ZshArraySubscriptInCase).with_shell(ShellDialect::Zsh),
@@ -135,8 +58,25 @@ mod tests {
     }
 
     #[test]
-    fn ignores_single_quoted_case_subject_literals() {
-        let source = "#!/bin/sh\ncase '$words[1]' in\n  install) : ;;\nesac\n";
+    fn reports_literal_padding_that_rules_out_a_pattern() {
+        let source = "#!/bin/sh\ncase \" $oldobjs \" in\n  \" \") : ;;\n  \"  \") : ;;\nesac\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ZshArraySubscriptInCase),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\" \""]
+        );
+    }
+
+    #[test]
+    fn ignores_reachable_patterns_on_dynamic_subjects() {
+        let source = "#!/bin/sh\ncase \"prefix${value}suffix\" in\n  *suffix) : ;;\n  prefix*suffix) : ;;\nesac\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::ZshArraySubscriptInCase),
@@ -146,8 +86,16 @@ mod tests {
     }
 
     #[test]
-    fn ignores_escaped_dollar_case_subject_literals() {
-        let source = "#!/bin/sh\ncase \"\\$words[1]\" in\n  install) : ;;\nesac\n";
+    fn ignores_braced_and_fully_fixed_subjects() {
+        let source = "\
+#!/bin/sh
+case \"${words[1]}\" in
+  install) : ;;
+esac
+case foo in
+  bar) : ;;
+esac
+";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::ZshArraySubscriptInCase),

--- a/docs/rules/X078.yaml
+++ b/docs/rules/X078.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: A zsh-style array subscript is used in a case subject.
-rationale: Use a variable to hold the value before the case statement.
+description: A case pattern cannot match the subject shape produced by this shell.
+rationale: Make the subject and pattern agree on any fixed prefixes or suffixes before matching.
 source:
   shell_checks_rule: rules/SH-299.yaml
   shell_checks_example: examples/299.sh


### PR DESCRIPTION
## Summary
- replace X078's raw text scan with a fact-driven matcher that detects case patterns whose language cannot overlap the case subject's shell-visible shape
- update the X078 rule message, fixture, snapshot, and rule docs to reflect the current SC2195 behavior family
- remove the temporary reviewed-divergence workaround by fixing the implementation directly

## Root cause
X078 was still modeling an older narrow interpretation of SC2195 and only looked for unbraced array-style syntax inside case subjects. The current oracle behavior is broader: it warns when a case pattern can never match the subject as parsed by the target shell. That left the large-corpus `ltmain.sh` fixture as a real implementation miss.

## What changed
The fact layer now derives impossible case-pattern spans by intersecting static case-pattern automatons with a matcher built from the subject's fixed literal segments plus wildcard dynamic gaps. The rule consumes those precomputed spans instead of rescanning source text in the rule module.

## Validation
- `cargo test -p shuck-linter zsh_array_subscript_in_case`
- `cargo test -p shuck-linter builds_impossible_case_pattern_spans_from_subject_shape`
- `INSTA_UPDATE=always cargo test -p shuck-linter 'rules::portability::tests::rules'`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X078`
