### PR TITLE
Fix S031 inline ShellCheck directive handling

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -48,6 +48,7 @@ use crate::rules::common::{
         classify_contextual_operand, classify_word, static_word_text,
     },
 };
+use crate::suppression::shellcheck_directive_can_apply_to_following_command;
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,
@@ -7521,7 +7522,9 @@ fn build_trailing_directive_comment_spans(
             if case_item_label_comment(case_items, line, comment_start) {
                 return None;
             }
-            if directive_can_apply_to_following_command(&source[line_start..comment_start]) {
+            if shellcheck_directive_can_apply_to_following_command(
+                &source[line_start..comment_start],
+            ) {
                 return None;
             }
 
@@ -9132,16 +9135,6 @@ fn collect_raw_escaped_parameter_exclusions(
     }
 }
 
-fn directive_can_apply_to_following_command(prefix: &str) -> bool {
-    let trimmed = prefix.trim_end();
-    trimmed.ends_with(';')
-        || trimmed.ends_with('{')
-        || trimmed.ends_with('(')
-        || ends_with_keyword(trimmed, "then")
-        || ends_with_keyword(trimmed, "do")
-        || ends_with_keyword(trimmed, "else")
-}
-
 fn is_inline_shellcheck_directive(comment_text: &str) -> bool {
     let body = comment_text
         .trim_start()
@@ -9177,14 +9170,6 @@ fn is_inline_shellcheck_directive(comment_text: &str) -> bool {
                 .is_some_and(|value| !value.trim().is_empty())
         })
     })
-}
-
-fn ends_with_keyword(text: &str, keyword: &str) -> bool {
-    text == keyword
-        || text
-            .strip_suffix(keyword)
-            .and_then(|prefix| prefix.chars().last())
-            .is_some_and(|ch| ch.is_ascii_whitespace())
 }
 
 fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -60,6 +60,14 @@ mod tests {
     }
 
     #[test]
+    fn ignores_directive_after_brace_group_opener() {
+        let source = "#!/bin/sh\n{ # shellcheck disable=SC2164\n  cd /tmp\n}\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_directive_after_semicolon_separator() {
         let source = "#!/bin/sh\ntrue; # shellcheck disable=SC2317\nfalse\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
@@ -74,5 +82,22 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_directive_after_control_flow_headers() {
+        let sources = [
+            "#!/bin/sh\nif # shellcheck disable=SC2086\n  echo $foo\nthen\n  :\nfi\n",
+            "#!/bin/sh\nif true; then # shellcheck disable=SC2086\n  echo $foo\nfi\n",
+            "#!/bin/sh\nif false; then\n  :\nelse # shellcheck disable=SC2086\n  echo $foo\nfi\n",
+            "#!/bin/sh\nwhile # shellcheck disable=SC2086\n  echo $foo\ndo\n  :\ndone\n",
+            "#!/bin/sh\nuntil # shellcheck disable=SC2086\n  echo $foo\ndo\n  :\ndone\n",
+        ];
+
+        for source in sources {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
+            assert!(diagnostics.is_empty(), "{source}");
+        }
     }
 }

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -70,6 +70,7 @@ pub fn parse_directives(
 #[derive(Debug, Clone, Copy)]
 struct NormalizedComment<'a> {
     text: &'a str,
+    line_prefix: &'a str,
     range: TextRange,
     line: u32,
     is_own_line: bool,
@@ -93,6 +94,7 @@ fn normalized_comment<'a>(
 
     Some(NormalizedComment {
         text: &source[comment_start..line_end],
+        line_prefix: &source[line_start..comment_start],
         range: TextRange::new(
             TextSize::new(comment_start as u32),
             TextSize::new(line_end as u32),
@@ -145,7 +147,10 @@ fn parse_shellcheck_directive(
     file: &File,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Option<SuppressionDirective> {
-    if !comment.is_own_line && !is_case_label_directive(comment, file) {
+    if !comment.is_own_line
+        && !shellcheck_directive_can_apply_to_following_command(comment.line_prefix)
+        && !is_case_label_directive(comment, file)
+    {
         return None;
     }
 
@@ -185,6 +190,16 @@ fn parse_shellcheck_directive(
         range: comment.range,
         line: comment.line,
     })
+}
+
+pub(crate) fn shellcheck_directive_can_apply_to_following_command(prefix: &str) -> bool {
+    let trimmed = prefix.trim_end();
+    trimmed.ends_with(';')
+        || trimmed.ends_with('{')
+        || trimmed.ends_with('(')
+        || ["if", "elif", "while", "until", "then", "do", "else"]
+            .into_iter()
+            .any(|keyword| ends_with_keyword(trimmed, keyword))
 }
 
 fn is_case_label_directive(comment: &NormalizedComment<'_>, file: &File) -> bool {
@@ -233,6 +248,14 @@ fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a
     candidate
         .eq_ignore_ascii_case(prefix)
         .then(|| &text[prefix.len()..])
+}
+
+fn ends_with_keyword(text: &str, keyword: &str) -> bool {
+    text == keyword
+        || text
+            .strip_suffix(keyword)
+            .and_then(|prefix| prefix.chars().last())
+            .is_some_and(|ch| ch.is_ascii_whitespace())
 }
 
 fn parse_shuck_action(value: &str) -> Option<SuppressionAction> {
@@ -357,6 +380,46 @@ esac
         let directives = directives(source);
 
         assert!(directives.is_empty());
+    }
+
+    #[test]
+    fn parses_shellcheck_directives_after_control_flow_headers_and_group_openers() {
+        let source = "\
+if # shellcheck disable=SC2086
+  echo $foo
+then # shellcheck disable=SC2086
+  echo $foo
+elif # shellcheck disable=SC2086
+  echo $bar
+then
+  :
+else # shellcheck disable=SC2086
+  echo $baz
+fi
+while # shellcheck disable=SC2086
+  echo $foo
+do # shellcheck disable=SC2086
+  echo $foo
+done
+until # shellcheck disable=SC2086
+  echo $foo
+do
+  :
+done
+{ # shellcheck disable=SC2086
+  echo $foo
+}
+( # shellcheck disable=SC2086
+  echo $foo
+)
+";
+        let directives = directives(source);
+
+        assert_eq!(directives.len(), 9);
+        assert!(directives.iter().all(|directive| {
+            directive.source == SuppressionSource::ShellCheck
+                && directive.codes == vec![Rule::UnquotedExpansion]
+        }));
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -647,6 +647,52 @@ esac
     }
 
     #[test]
+    fn scopes_shellcheck_disable_after_if_header_to_the_next_command() {
+        let source = "\
+foo='a b'
+if # shellcheck disable=SC2086
+  echo $foo
+then
+  echo $foo
+fi
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
+    fn scopes_shellcheck_disable_after_then_header_to_the_next_command() {
+        let source = "\
+foo='a b'
+if true; then # shellcheck disable=SC2086
+  echo $foo
+fi
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
+    fn scopes_shellcheck_disable_after_brace_group_opener_to_the_next_command() {
+        let source = "\
+foo='a b'
+{ # shellcheck disable=SC2086
+  echo $foo
+}
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
     fn ignores_case_label_directives_after_same_line_body_commands() {
         let source = "\
 case $x in

--- a/crates/shuck-linter/src/suppression/mod.rs
+++ b/crates/shuck-linter/src/suppression/mod.rs
@@ -2,6 +2,7 @@ mod directive;
 mod index;
 mod shellcheck_map;
 
+pub(crate) use directive::shellcheck_directive_can_apply_to_following_command;
 pub use directive::{SuppressionAction, SuppressionDirective, SuppressionSource, parse_directives};
 pub use index::{SuppressionIndex, first_statement_line};
 pub use shellcheck_map::ShellCheckCodeMap;


### PR DESCRIPTION
## Summary
- share the ShellCheck inline-directive applicability check between S031 detection and suppression parsing
- allow valid inline directives after control-flow headers and group openers such as `if`, `elif`, `while`, `until`, `then`, `do`, `else`, `{`, and `(`
- add regression tests for directive parsing, suppression scoping, and the S031 rule surface

## Root cause
The S031 fact builder and the ShellCheck suppression parser had drifted apart. Shuck could treat some inline directive sites as non-trailing for S031 while still failing to parse them as effective suppressions for the following command.

## Validation
- `cargo test -p shuck-linter suppression:: -- --nocapture`
- `cargo test -p shuck-linter trailing_directive -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S031`
