### PR TITLE
Handle negated P003 subshells

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/performance/P003.sh
+++ b/crates/shuck-linter/resources/test/fixtures/performance/P003.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 if (test -f /etc/passwd); then :; fi
 if (test -f /etc/passwd) >/dev/null 2>&1; then :; fi
+if ! (test -f /etc/passwd); then :; fi
+if ( ! test -f /etc/passwd ); then :; fi
 while ([ -f /etc/passwd ]); do :; done
+while ! ([ -f /etc/passwd ]); do :; done
 until (test -f /etc/passwd); do :; done
+until ! (test -f /etc/passwd); do :; done

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -1893,11 +1893,16 @@ fn single_test_subshell_span<'a>(
         return None;
     }
 
-    if !simple_test && !is_test_condition_command(body_fact.command(), commands, command_ids_by_span) {
+    if !simple_test
+        && !is_test_condition_command(body_fact.command(), commands, command_ids_by_span)
+    {
         return None;
     }
 
-    Some(subshell_anchor_span(condition_fact.span_in_source(source), source))
+    Some(subshell_anchor_span(
+        condition_fact.span_in_source(source),
+        source,
+    ))
 }
 
 fn is_test_like_command(fact: &CommandFact<'_>) -> bool {

--- a/crates/shuck-linter/src/facts/command_flow.rs
+++ b/crates/shuck-linter/src/facts/command_flow.rs
@@ -1877,9 +1877,6 @@ fn single_test_subshell_span<'a>(
     let [stmt] = condition.as_slice() else {
         return None;
     };
-    if stmt.negated {
-        return None;
-    }
 
     let condition_fact = command_fact_for_stmt(stmt, commands, command_ids_by_span)?;
     let Command::Compound(CompoundCommand::Subshell(body)) = condition_fact.command() else {
@@ -1889,18 +1886,18 @@ fn single_test_subshell_span<'a>(
     let [body_stmt] = body.as_slice() else {
         return None;
     };
-    if body_stmt.negated {
-        return None;
-    }
 
     let body_fact = command_fact_for_stmt(body_stmt, commands, command_ids_by_span)?;
-    if !is_test_like_command(body_fact)
-        && !is_test_condition_command(body_fact.command(), commands, command_ids_by_span)
-    {
+    let simple_test = is_test_like_command(body_fact);
+    if stmt.negated && !simple_test {
         return None;
     }
 
-    Some(subshell_anchor_span(stmt.span, source))
+    if !simple_test && !is_test_condition_command(body_fact.command(), commands, command_ids_by_span) {
+        return None;
+    }
+
+    Some(subshell_anchor_span(condition_fact.span_in_source(source), source))
 }
 
 fn is_test_like_command(fact: &CommandFact<'_>) -> bool {

--- a/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
+++ b/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
@@ -28,9 +28,14 @@ mod tests {
 #!/bin/sh
 if (test -f /etc/passwd); then :; fi
 if (test -f /etc/passwd) >/dev/null 2>&1; then :; fi
+if ! (test -f /etc/passwd); then :; fi
+if ( ! test -f /etc/passwd ); then :; fi
 if (test -f /etc/passwd || test -f /etc/hosts); then :; fi
+if ! (test -f /etc/passwd || test -f /etc/hosts); then :; fi
 while ([ -f /etc/passwd ]); do :; done
+while ! ([ -f /etc/passwd ]); do :; done
 until (command test -f /etc/passwd); do :; done
+until ! (command test -f /etc/passwd); do :; done
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SingleTestSubshell));
 
@@ -42,8 +47,12 @@ until (command test -f /etc/passwd); do :; done
             vec![
                 "(test -f /etc/passwd)",
                 "(test -f /etc/passwd)",
+                "(test -f /etc/passwd)",
+                "( ! test -f /etc/passwd )",
                 "(test -f /etc/passwd || test -f /etc/hosts)",
                 "([ -f /etc/passwd ])",
+                "([ -f /etc/passwd ])",
+                "(command test -f /etc/passwd)",
                 "(command test -f /etc/passwd)",
             ]
         );

--- a/crates/shuck-linter/src/rules/performance/snapshots/shuck_linter__rules__performance__tests__P003_P003.sh.snap
+++ b/crates/shuck-linter/src/rules/performance/snapshots/shuck_linter__rules__performance__tests__P003_P003.sh.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shuck-linter/src/rules/performance/mod.rs
+assertion_line: 25
 ---
 P003 drop the subshell around this single test condition
  --> <source>:2:4
@@ -14,13 +15,37 @@ P003 drop the subshell around this single test condition
   |
 
 P003 drop the subshell around this single test condition
- --> <source>:4:7
+ --> <source>:4:6
   |
-4 | while ([ -f /etc/passwd ]); do :; done
+4 | if ! (test -f /etc/passwd); then :; fi
   |
 
 P003 drop the subshell around this single test condition
- --> <source>:5:7
+ --> <source>:5:4
   |
-5 | until (test -f /etc/passwd); do :; done
+5 | if ( ! test -f /etc/passwd ); then :; fi
+  |
+
+P003 drop the subshell around this single test condition
+ --> <source>:6:7
+  |
+6 | while ([ -f /etc/passwd ]); do :; done
+  |
+
+P003 drop the subshell around this single test condition
+ --> <source>:7:9
+  |
+7 | while ! ([ -f /etc/passwd ]); do :; done
+  |
+
+P003 drop the subshell around this single test condition
+ --> <source>:8:7
+  |
+8 | until (test -f /etc/passwd); do :; done
+  |
+
+P003 drop the subshell around this single test condition
+ --> <source>:9:9
+  |
+9 | until ! (test -f /etc/passwd); do :; done
   |


### PR DESCRIPTION
## Summary

- teach `P003` to report negated single-test subshell conditions like `if ! (test ...)`
- keep outer-negated grouped test subshells routed to `P004` instead of broadening `P003` too far
- update the focused fixture, unit coverage, and snapshot for the new diagnostic anchors

## Why

`P003` previously bailed out when the condition statement or subshell body was marked negated, so it missed ShellCheck-compatible cases such as `if ! (test ...)`, `while ! ([ ... ])`, and `until ! (command test ...)`.

## Impact

Negated lone-test subshells now produce the same performance warning as the non-negated form, while grouped test subshells continue to be handled by `P004`.

## Validation

- `cargo test -p shuck-linter single_test_subshell -- --nocapture`
- `cargo test -p shuck-linter anchors_on_the_grouping_subshell -- --nocapture`
- `cargo test -p shuck-linter rules::performance::tests::rules -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=P003`
