### PR TITLE
Broaden K004 coverage for find -exec shell commands

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2243,11 +2243,11 @@ impl FindExecCommandFacts {
 }
 
 #[derive(Debug, Clone)]
-pub struct FindExecDirCommandFacts {
+pub struct FindExecShellCommandFacts {
     shell_command_spans: Box<[Span]>,
 }
 
-impl FindExecDirCommandFacts {
+impl FindExecShellCommandFacts {
     pub fn shell_command_spans(&self) -> &[Span] {
         &self.shell_command_spans
     }
@@ -2547,7 +2547,7 @@ pub struct CommandOptionFacts<'a> {
     unset: Option<UnsetCommandFacts<'a>>,
     find: Option<FindCommandFacts>,
     find_exec: Option<FindExecCommandFacts>,
-    find_execdir: Option<FindExecDirCommandFacts>,
+    find_exec_shell: Option<FindExecShellCommandFacts>,
     mapfile: Option<MapfileCommandFacts>,
     xargs: Option<XargsCommandFacts>,
     wait: Option<WaitCommandFacts>,
@@ -2609,8 +2609,8 @@ impl<'a> CommandOptionFacts<'a> {
         self.find_exec.as_ref()
     }
 
-    pub fn find_execdir(&self) -> Option<&FindExecDirCommandFacts> {
-        self.find_execdir.as_ref()
+    pub fn find_exec_shell(&self) -> Option<&FindExecShellCommandFacts> {
+        self.find_exec_shell.as_ref()
     }
 
     pub fn mapfile(&self) -> Option<&MapfileCommandFacts> {
@@ -2721,16 +2721,16 @@ impl<'a> CommandOptionFacts<'a> {
                 argument_word_spans: parse_find_exec_argument_word_spans(command, source)
                     .into_boxed_slice(),
             }),
-            find_execdir: normalized
-                .has_wrapper(WrapperKind::FindExecDir)
-                .then(|| {
-                    parse_find_execdir_shell_command(
-                        normalized.effective_name.as_deref(),
-                        normalized.body_args(),
-                        source,
-                    )
-                })
-                .flatten(),
+            find_exec_shell: (normalized.has_wrapper(WrapperKind::FindExec)
+                || normalized.has_wrapper(WrapperKind::FindExecDir))
+            .then(|| {
+                parse_find_exec_shell_command(
+                    normalized.effective_name.as_deref(),
+                    normalized.body_args(),
+                    source,
+                )
+            })
+            .flatten(),
             mapfile: (normalized.effective_name_is("mapfile")
                 || normalized.effective_name_is("readarray"))
             .then(|| parse_mapfile_command(normalized.body_args(), source)),
@@ -17332,11 +17332,11 @@ fn collect_prefix_match_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
     }
 }
 
-fn parse_find_execdir_shell_command(
+fn parse_find_exec_shell_command(
     shell_name: Option<&str>,
     args: &[&Word],
     source: &str,
-) -> Option<FindExecDirCommandFacts> {
+) -> Option<FindExecShellCommandFacts> {
     if !matches!(shell_name, Some("sh" | "bash" | "dash" | "ksh")) {
         return None;
     }
@@ -17357,7 +17357,7 @@ fn parse_find_execdir_shell_command(
         })
         .collect::<Vec<_>>();
 
-    (!shell_command_spans.is_empty()).then_some(FindExecDirCommandFacts {
+    (!shell_command_spans.is_empty()).then_some(FindExecShellCommandFacts {
         shell_command_spans: shell_command_spans.into_boxed_slice(),
     })
 }
@@ -20767,14 +20767,17 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
             vec!["*.cfg", "\"$prefix\"*.jar", "*/tmp/*"]
         );
 
-        let find_execdir = facts
+        let find_exec_shell = facts
             .commands()
             .iter()
-            .find(|fact| fact.has_wrapper(WrapperKind::FindExecDir))
-            .and_then(|fact| fact.options().find_execdir());
+            .filter(|fact| {
+                fact.has_wrapper(WrapperKind::FindExec)
+                    || fact.has_wrapper(WrapperKind::FindExecDir)
+            })
+            .find_map(|fact| fact.options().find_exec_shell());
         assert!(
-            find_execdir.is_none(),
-            "fixture without execdir should not match"
+            find_exec_shell.is_none(),
+            "fixture without a shell-backed find exec should not match"
         );
 
         let xargs = facts
@@ -21873,7 +21876,7 @@ echo ${foo:-${1##*/}}
     }
 
     #[test]
-    fn builds_find_execdir_command_facts_for_shell_targets() {
+    fn builds_find_exec_shell_command_facts_for_execdir_shell_targets() {
         let source = "\
 #!/bin/sh
 # shellcheck disable=2086,2154
@@ -21890,17 +21893,48 @@ find $dir -type f -name \"rename*\" -execdir sh -c 'mv {} $(echo {} | sed \"s|re
             assert_eq!(find.effective_name(), Some("sh"));
             assert_eq!(find.wrappers(), &[WrapperKind::FindExecDir]);
 
-            let find_execdir = find
+            let find_exec_shell = find
                 .options()
-                .find_execdir()
+                .find_exec_shell()
                 .expect("expected shell command fact for find -execdir");
             assert_eq!(
-                find_execdir
+                find_exec_shell
                     .shell_command_spans()
                     .iter()
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["'mv {} $(echo {} | sed \"s|rename|perl-rename|\")'"]
+            );
+        });
+    }
+
+    #[test]
+    fn builds_find_exec_shell_command_facts_for_exec_shell_targets() {
+        let source = "\
+#!/bin/sh
+find . -exec bash -c 'hash=($(sha1sum {})); mv {} fuzz/corpus/$hash' \\;
+";
+
+        with_facts(source, None, |_, facts| {
+            let find = facts
+                .commands()
+                .iter()
+                .find(|fact| {
+                    fact.has_wrapper(WrapperKind::FindExec) && fact.effective_name_is("bash")
+                })
+                .expect("expected find -exec fact");
+
+            let find_exec_shell = find
+                .options()
+                .find_exec_shell()
+                .expect("expected shell command fact for find -exec");
+            assert_eq!(
+                find_exec_shell
+                    .shell_command_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["'hash=($(sha1sum {})); mv {} fuzz/corpus/$hash'"]
             );
         });
     }
@@ -22186,7 +22220,7 @@ find . -execdir sh -c 'printf \"%s\\n\" {}' {} \\;
     }
 
     #[test]
-    fn builds_find_execdir_command_facts_for_bundled_shell_c_flags() {
+    fn builds_find_exec_shell_command_facts_for_bundled_execdir_shell_c_flags() {
         let source = "\
 #!/bin/sh
 find . -execdir sh -ec 'mv {} \"$target\"' \\;
@@ -22199,12 +22233,12 @@ find . -execdir sh -ec 'mv {} \"$target\"' \\;
                 .find(|fact| fact.has_wrapper(WrapperKind::FindExecDir))
                 .expect("expected find -execdir fact");
 
-            let find_execdir = find
+            let find_exec_shell = find
                 .options()
-                .find_execdir()
+                .find_exec_shell()
                 .expect("expected shell command fact for bundled -c flags");
             assert_eq!(
-                find_execdir
+                find_exec_shell
                     .shell_command_spans()
                     .iter()
                     .map(|span| span.slice(source))

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -17343,7 +17343,7 @@ fn parse_find_exec_shell_command(
             index += 1;
             continue;
         };
-        if !matches!(action.as_str(), "-exec" | "-execdir") {
+        if !matches!(action.as_str(), "-exec" | "-execdir" | "-ok" | "-okdir") {
             index += 1;
             continue;
         }
@@ -17356,7 +17356,9 @@ fn parse_find_exec_shell_command(
             .map(|offset| argument_start + offset);
         let argument_end = terminator_index.unwrap_or(words.len());
 
-        if let Some(segment) = words.get(argument_start..argument_end) {
+        if matches!(action.as_str(), "-exec" | "-execdir")
+            && let Some(segment) = words.get(argument_start..argument_end)
+        {
             shell_command_spans.extend(find_exec_shell_command_spans(segment, source));
         }
 
@@ -22069,6 +22071,30 @@ find . -okdir bash -c 'printf \"%s\\n\" {}' \\;
 #!/bin/sh
 find . -exec find {} -ok sh -c 'printf \"%s\\n\" {}' \\; \\;
 find . -execdir busybox find {} -okdir bash -c 'printf \"%s\\n\" {}' \\; \\;
+";
+
+        with_facts(source, None, |_, facts| {
+            let shell_spans = facts
+                .commands()
+                .iter()
+                .filter_map(|fact| fact.options().find_exec_shell())
+                .flat_map(|find_exec_shell| find_exec_shell.shell_command_spans().iter())
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+
+            assert!(
+                shell_spans.is_empty(),
+                "unexpected shell spans: {shell_spans:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn ignores_exec_tokens_nested_inside_find_ok_segments() {
+        let source = "\
+#!/bin/sh
+find . -ok find {} -exec sh -c 'printf \"%s\\n\" {}' \\; \\;
+find . -okdir busybox find {} -execdir bash -c 'printf \"%s\\n\" {}' \\; \\;
 ";
 
         with_facts(source, None, |_, facts| {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -17369,18 +17369,22 @@ fn parse_find_exec_shell_command(
 }
 
 fn find_exec_shell_command_spans(args: &[&Word], source: &str) -> Vec<Span> {
-    let Some(shell_name) = args
-        .first()
-        .and_then(|word| static_word_text(word, source))
-        .map(|name| name.rsplit('/').next().unwrap_or(name.as_str()).to_owned())
+    let Some(normalized) = command::normalize_command_words(args, source) else {
+        return Vec::new();
+    };
+    let Some(shell_name) = normalized
+        .effective_name
+        .as_deref()
+        .map(|name| name.rsplit('/').next().unwrap_or(name))
     else {
         return Vec::new();
     };
-    if !matches!(shell_name.as_str(), "sh" | "bash" | "dash" | "ksh") {
+    if !matches!(shell_name, "sh" | "bash" | "dash" | "ksh") {
         return Vec::new();
     }
 
-    args[1..]
+    normalized
+        .body_args()
         .windows(2)
         .filter_map(|pair| {
             let flag = static_word_text(pair[0], source)?;
@@ -22001,6 +22005,31 @@ find . -exec echo {} + -name '*.cfg' -exec sh -c 'printf \"%s\\n\" {}' \\;
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["'printf \"%s\\n\" {}'"]
+            );
+        });
+    }
+
+    #[test]
+    fn builds_find_exec_shell_command_facts_for_wrapped_shell_targets() {
+        let source = "\
+#!/bin/sh
+find . -exec busybox sh -c 'printf \"%s\\n\" {}' \\;
+find . -exec sudo sh -c 'printf \"%s\\n\" {}' \\;
+";
+
+        with_facts(source, None, |_, facts| {
+            let shell_spans = facts
+                .commands()
+                .iter()
+                .filter(|fact| fact.has_wrapper(WrapperKind::FindExec))
+                .filter_map(|fact| fact.options().find_exec_shell())
+                .flat_map(|find_exec_shell| find_exec_shell.shell_command_spans().iter())
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                shell_spans,
+                vec!["'printf \"%s\\n\" {}'", "'printf \"%s\\n\" {}'"]
             );
         });
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2723,13 +2723,7 @@ impl<'a> CommandOptionFacts<'a> {
             }),
             find_exec_shell: (normalized.has_wrapper(WrapperKind::FindExec)
                 || normalized.has_wrapper(WrapperKind::FindExecDir))
-            .then(|| {
-                parse_find_exec_shell_command(
-                    normalized.effective_name.as_deref(),
-                    normalized.body_args(),
-                    source,
-                )
-            })
+            .then(|| parse_find_exec_shell_command(command, source))
             .flatten(),
             mapfile: (normalized.effective_name_is("mapfile")
                 || normalized.effective_name_is("readarray"))
@@ -17333,15 +17327,60 @@ fn collect_prefix_match_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
 }
 
 fn parse_find_exec_shell_command(
-    shell_name: Option<&str>,
-    args: &[&Word],
+    command: &Command,
     source: &str,
 ) -> Option<FindExecShellCommandFacts> {
-    if !matches!(shell_name, Some("sh" | "bash" | "dash" | "ksh")) {
+    let Command::Simple(command) = command else {
         return None;
+    };
+
+    let words = simple_command_body_words(command, source).collect::<Vec<_>>();
+    let mut shell_command_spans = Vec::new();
+    let mut index = 0usize;
+
+    while index < words.len() {
+        let Some(action) = static_word_text(words[index], source) else {
+            index += 1;
+            continue;
+        };
+        if !matches!(action.as_str(), "-exec" | "-ok" | "-execdir" | "-okdir") {
+            index += 1;
+            continue;
+        }
+
+        let Some(command_name_index) = words.get(index + 1).map(|_| index + 1) else {
+            break;
+        };
+        let argument_start = command_name_index;
+        let terminator_index = find_exec_terminator_index(&words[argument_start..], source)
+            .map(|offset| argument_start + offset);
+        let argument_end = terminator_index.unwrap_or(words.len());
+
+        if let Some(segment) = words.get(argument_start..argument_end) {
+            shell_command_spans.extend(find_exec_shell_command_spans(segment, source));
+        }
+
+        index = terminator_index.map_or(words.len(), |terminator_index| terminator_index + 1);
     }
 
-    let shell_command_spans = args
+    (!shell_command_spans.is_empty()).then_some(FindExecShellCommandFacts {
+        shell_command_spans: shell_command_spans.into_boxed_slice(),
+    })
+}
+
+fn find_exec_shell_command_spans(args: &[&Word], source: &str) -> Vec<Span> {
+    let Some(shell_name) = args
+        .first()
+        .and_then(|word| static_word_text(word, source))
+        .map(|name| name.rsplit('/').next().unwrap_or(name.as_str()).to_owned())
+    else {
+        return Vec::new();
+    };
+    if !matches!(shell_name.as_str(), "sh" | "bash" | "dash" | "ksh") {
+        return Vec::new();
+    }
+
+    args[1..]
         .windows(2)
         .filter_map(|pair| {
             let flag = static_word_text(pair[0], source)?;
@@ -17355,11 +17394,7 @@ fn parse_find_exec_shell_command(
                 .contains("{}")
                 .then_some(script.span)
         })
-        .collect::<Vec<_>>();
-
-    (!shell_command_spans.is_empty()).then_some(FindExecShellCommandFacts {
-        shell_command_spans: shell_command_spans.into_boxed_slice(),
-    })
+        .collect()
 }
 
 fn parse_find_exec_argument_word_spans(command: &Command, source: &str) -> Vec<Span> {
@@ -21935,6 +21970,37 @@ find . -exec bash -c 'hash=($(sha1sum {})); mv {} fuzz/corpus/$hash' \\;
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["'hash=($(sha1sum {})); mv {} fuzz/corpus/$hash'"]
+            );
+        });
+    }
+
+    #[test]
+    fn builds_find_exec_shell_command_facts_for_later_exec_shell_targets() {
+        let source = "\
+#!/bin/sh
+find . -exec echo {} + -name '*.cfg' -exec sh -c 'printf \"%s\\n\" {}' \\;
+";
+
+        with_facts(source, None, |_, facts| {
+            let find = facts
+                .commands()
+                .iter()
+                .find(|fact| {
+                    fact.has_wrapper(WrapperKind::FindExec) && fact.effective_name_is("echo")
+                })
+                .expect("expected first find -exec fact");
+
+            let find_exec_shell = find
+                .options()
+                .find_exec_shell()
+                .expect("expected shell command fact for later find -exec");
+            assert_eq!(
+                find_exec_shell
+                    .shell_command_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["'printf \"%s\\n\" {}'"]
             );
         });
     }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -17372,6 +17372,11 @@ fn find_exec_shell_command_spans(args: &[&Word], source: &str) -> Vec<Span> {
     let Some(normalized) = command::normalize_command_words(args, source) else {
         return Vec::new();
     };
+    if normalized.has_wrapper(WrapperKind::FindExec)
+        || normalized.has_wrapper(WrapperKind::FindExecDir)
+    {
+        return Vec::new();
+    }
     let Some(shell_name) = normalized
         .effective_name
         .as_deref()
@@ -22040,6 +22045,30 @@ find . -exec sudo sh -c 'printf \"%s\\n\" {}' \\;
 #!/bin/sh
 find . -ok sh -c 'printf \"%s\\n\" {}' \\;
 find . -okdir bash -c 'printf \"%s\\n\" {}' \\;
+";
+
+        with_facts(source, None, |_, facts| {
+            let shell_spans = facts
+                .commands()
+                .iter()
+                .filter_map(|fact| fact.options().find_exec_shell())
+                .flat_map(|find_exec_shell| find_exec_shell.shell_command_spans().iter())
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+
+            assert!(
+                shell_spans.is_empty(),
+                "unexpected shell spans: {shell_spans:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn ignores_nested_find_exec_wrappers_for_find_exec_shell_command_facts() {
+        let source = "\
+#!/bin/sh
+find . -exec find {} -ok sh -c 'printf \"%s\\n\" {}' \\; \\;
+find . -execdir busybox find {} -okdir bash -c 'printf \"%s\\n\" {}' \\; \\;
 ";
 
         with_facts(source, None, |_, facts| {

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -17343,7 +17343,7 @@ fn parse_find_exec_shell_command(
             index += 1;
             continue;
         };
-        if !matches!(action.as_str(), "-exec" | "-ok" | "-execdir" | "-okdir") {
+        if !matches!(action.as_str(), "-exec" | "-execdir") {
             index += 1;
             continue;
         }
@@ -22030,6 +22030,30 @@ find . -exec sudo sh -c 'printf \"%s\\n\" {}' \\;
             assert_eq!(
                 shell_spans,
                 vec!["'printf \"%s\\n\" {}'", "'printf \"%s\\n\" {}'"]
+            );
+        });
+    }
+
+    #[test]
+    fn ignores_find_ok_shell_targets_for_find_exec_shell_command_facts() {
+        let source = "\
+#!/bin/sh
+find . -ok sh -c 'printf \"%s\\n\" {}' \\;
+find . -okdir bash -c 'printf \"%s\\n\" {}' \\;
+";
+
+        with_facts(source, None, |_, facts| {
+            let shell_spans = facts
+                .commands()
+                .iter()
+                .filter_map(|fact| fact.options().find_exec_shell())
+                .flat_map(|find_exec_shell| find_exec_shell.shell_command_spans().iter())
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>();
+
+            assert!(
+                shell_spans.is_empty(),
+                "unexpected shell spans: {shell_spans:?}"
             );
         });
     }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -25,7 +25,7 @@ pub use facts::{
     BacktickFragmentFact, CommandFact, CommandOptionFacts, ConditionalBareWordFact,
     ConditionalBinaryFact, ConditionalFact, ConditionalNodeFact, ConditionalOperandFact,
     ConditionalOperatorFamily, ConditionalPortabilityFacts, ConditionalUnaryFact, ExitCommandFacts,
-    FactSpan, FindCommandFacts, FindExecCommandFacts, FindExecDirCommandFacts, ForHeaderFact,
+    FactSpan, FindCommandFacts, FindExecCommandFacts, FindExecShellCommandFacts, ForHeaderFact,
     FunctionCallArityFacts, FunctionHeaderFact, GrepPatternSourceKind,
     LegacyArithmeticFragmentFact, LinterFacts, ListFact, ListOperatorFact, LoopHeaderWordFact,
     PathWordFact, PipelineFact, PipelineOperatorFact, PipelineSegmentFact,

--- a/crates/shuck-linter/src/rules/common/command.rs
+++ b/crates/shuck-linter/src/rules/common/command.rs
@@ -114,16 +114,24 @@ fn normalize_simple_command<'a>(command: &'a SimpleCommand, source: &str) -> Nor
     let words = std::iter::once(&command.name)
         .chain(command.args.iter())
         .collect::<Vec<_>>();
-    let literal_name = static_command_name_text(&command.name, source);
+    normalize_command_words(words.as_slice(), source).expect("simple commands always have a name")
+}
+
+pub(crate) fn normalize_command_words<'a>(
+    words: &[&'a Word],
+    source: &str,
+) -> Option<NormalizedCommand<'a>> {
+    let first_word = words.first().copied()?;
+    let literal_name = static_command_name_text(first_word, source);
     let mut normalized = NormalizedCommand {
         literal_name: literal_name.clone(),
         effective_name: literal_name.clone(),
         wrappers: Vec::new(),
-        body_span: command.name.span,
-        body_word_span: Some(command.name.span),
+        body_span: first_word.span,
+        body_word_span: Some(first_word.span),
         body_words: literal_name
             .as_ref()
-            .map_or_else(Vec::new, |_| words.clone()),
+            .map_or_else(Vec::new, |_| words.to_vec()),
         declaration: None,
     };
     let mut current_index = 0usize;
@@ -170,7 +178,7 @@ fn normalize_simple_command<'a>(command: &'a SimpleCommand, source: &str) -> Nor
         }
     }
 
-    normalized
+    Some(normalized)
 }
 
 fn normalize_decl_command<'a>(command: &'a DeclClause, source: &str) -> NormalizedCommand<'a> {

--- a/crates/shuck-linter/src/rules/common/command.rs
+++ b/crates/shuck-linter/src/rules/common/command.rs
@@ -138,7 +138,7 @@ pub(crate) fn normalize_command_words<'a>(
 
     while let Some(current_name) = normalized.effective_name.clone() {
         let Some(resolution) =
-            resolve_command_resolution(&words, current_index, current_name.as_str(), source)
+            resolve_command_resolution(words, current_index, current_name.as_str(), source)
         else {
             break;
         };

--- a/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
+++ b/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
@@ -104,4 +104,15 @@ mod tests {
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
+
+    #[test]
+    fn ignores_nested_find_exec_wrappers_with_inner_ok_actions() {
+        let source = "#!/bin/sh\nfind . -exec find {} -ok sh -c 'printf \"%s\\n\" {}' \\; \\;\nfind . -execdir busybox find {} -okdir bash -c 'printf \"%s\\n\" {}' \\; \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindExecDirWithShell),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }

--- a/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
+++ b/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
@@ -115,4 +115,15 @@ mod tests {
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
+
+    #[test]
+    fn ignores_exec_tokens_nested_inside_ok_segments() {
+        let source = "#!/bin/sh\nfind . -ok find {} -exec sh -c 'printf \"%s\\n\" {}' \\; \\;\nfind . -okdir busybox find {} -execdir bash -c 'printf \"%s\\n\" {}' \\; \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindExecDirWithShell),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }

--- a/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
+++ b/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
@@ -65,4 +65,17 @@ mod tests {
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
+
+    #[test]
+    fn reports_later_exec_shell_interpolation_after_non_shell_exec() {
+        let source = "#!/bin/sh\nfind . -exec echo {} + -name '*.cfg' -exec sh -c 'printf \"%s\\n\" {}' \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindExecDirWithShell),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::FindExecDirWithShell);
+        assert_eq!(diagnostics[0].span.slice(source), "'printf \"%s\\n\" {}'");
+    }
 }

--- a/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
+++ b/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
@@ -78,4 +78,19 @@ mod tests {
         assert_eq!(diagnostics[0].rule, Rule::FindExecDirWithShell);
         assert_eq!(diagnostics[0].span.slice(source), "'printf \"%s\\n\" {}'");
     }
+
+    #[test]
+    fn reports_wrapped_exec_shell_interpolation() {
+        let source = "#!/bin/sh\nfind . -exec busybox sh -c 'printf \"%s\\n\" {}' \\;\nfind . -exec sudo sh -c 'printf \"%s\\n\" {}' \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindExecDirWithShell),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].rule, Rule::FindExecDirWithShell);
+        assert_eq!(diagnostics[1].rule, Rule::FindExecDirWithShell);
+        assert_eq!(diagnostics[0].span.slice(source), "'printf \"%s\\n\" {}'");
+        assert_eq!(diagnostics[1].span.slice(source), "'printf \"%s\\n\" {}'");
+    }
 }

--- a/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
+++ b/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
@@ -8,7 +8,8 @@ impl Violation for FindExecDirWithShell {
     }
 
     fn message(&self) -> String {
-        "shell command text passed through `find -execdir` can inject filenames".to_owned()
+        "shell command text passed through `find -exec` or `-execdir` can inject filenames"
+            .to_owned()
     }
 }
 
@@ -16,7 +17,7 @@ pub fn find_execdir_with_shell(checker: &mut Checker) {
     let spans = checker
         .facts()
         .structural_commands()
-        .filter_map(|fact| fact.options().find_execdir())
+        .filter_map(|fact| fact.options().find_exec_shell())
         .flat_map(|fact| fact.shell_command_spans().iter().copied())
         .collect::<Vec<_>>();
 
@@ -29,8 +30,8 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_sh_c_execdir_shell_interpolation() {
-        let source = "#!/bin/sh\nfind . -execdir sh -c 'printf \"%s\\n\" {}' \\;\n";
+    fn reports_sh_c_exec_shell_interpolation() {
+        let source = "#!/bin/sh\nfind . -exec sh -c 'printf \"%s\\n\" {}' \\;\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::FindExecDirWithShell),
@@ -55,8 +56,8 @@ mod tests {
     }
 
     #[test]
-    fn ignores_execdir_forms_without_shell_interpolation() {
-        let source = "#!/bin/sh\nfind . -execdir mv -- {} renamed-file \\;\nfind . -execdir sh ./rename-helper {} \\;\nfind . -execdir sh -c 'printf safe\\n' \\;\nfind . -execdir bash -c 'echo safe' \\;\n";
+    fn ignores_find_exec_shell_forms_without_shell_interpolation() {
+        let source = "#!/bin/sh\nfind . -exec mv -- {} renamed-file \\;\nfind . -exec sh ./rename-helper {} \\;\nfind . -exec sh -c 'printf safe\\n' \\;\nfind . -execdir mv -- {} renamed-file \\;\nfind . -execdir sh ./rename-helper {} \\;\nfind . -execdir sh -c 'printf safe\\n' \\;\nfind . -execdir bash -c 'echo safe' \\;\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::FindExecDirWithShell),

--- a/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
+++ b/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
@@ -93,4 +93,15 @@ mod tests {
         assert_eq!(diagnostics[0].span.slice(source), "'printf \"%s\\n\" {}'");
         assert_eq!(diagnostics[1].span.slice(source), "'printf \"%s\\n\" {}'");
     }
+
+    #[test]
+    fn ignores_ok_variants_even_with_shell_interpolation() {
+        let source = "#!/bin/sh\nfind . -ok sh -c 'printf \"%s\\n\" {}' \\;\nfind . -okdir bash -c 'printf \"%s\\n\" {}' \\;\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FindExecDirWithShell),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }

--- a/crates/shuck-linter/src/rules/security/snapshots/shuck_linter__rules__security__tests__K004_K004.sh.snap
+++ b/crates/shuck-linter/src/rules/security/snapshots/shuck_linter__rules__security__tests__K004_K004.sh.snap
@@ -2,7 +2,7 @@
 source: crates/shuck-linter/src/rules/security/mod.rs
 assertion_line: 25
 ---
-K004 shell command text passed through `find -execdir` can inject filenames
+K004 shell command text passed through `find -exec` or `-execdir` can inject filenames
  --> <source>:3:50
   |
 3 | find $dir -type f -name "rename*" -execdir sh -c 'mv {} $(echo {} | sed "s|rename|perl-rename|")' \;

--- a/docs/rules/K004.yaml
+++ b/docs/rules/K004.yaml
@@ -9,7 +9,7 @@ shells:
   - bash
   - dash
   - ksh
-description: "A `find -execdir` passes `{}` to a shell command that may mishandle filenames."
+description: "A `find -exec` or `-execdir` passes `{}` to shell command text that may mishandle filenames."
 rationale: "Use safe quoting or `-print0` with `xargs -0` instead."
 source:
   shell_checks_rule: rules/SH-283.yaml


### PR DESCRIPTION
## Summary
- broaden K004's fact extraction from `find -execdir`-only to shell-backed `find -exec` and `find -execdir` forms
- update the rule message and rule metadata to describe the wider coverage
- add regression tests for the missed `find -exec bash -c '... {} ...'` shape and keep existing `-execdir` coverage

## Why
A large-corpus K004 run still had a blocking ShellCheck-only hit in `google__oss-fuzz__projects__sharp__build.sh` for a plain `find -exec bash -c '... {} ...'` invocation. Shuck only modeled the `-execdir` wrapper, so it missed the same filename-injection hazard when the shell command was passed through `-exec`.

## Impact
K004 now reports the unsafe shell-text interpolation pattern for both `find` execution modes, which closes the remaining implementation diff without changing unrelated rules.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=K004`
