### PR TITLE
Fix X027 for path-qualified echo invocations

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2689,7 +2689,7 @@ impl<'a> CommandOptionFacts<'a> {
                 .effective_name_is("su")
                 .then(|| parse_su_command(normalized.body_args(), source)),
             echo: normalized
-                .effective_name_is("echo")
+                .effective_basename_is("echo")
                 .then(|| parse_echo_command(normalized.body_args(), source)),
             sed: normalized
                 .effective_name_is("sed")
@@ -20918,6 +20918,29 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
             .and_then(|fact| fact.options().sudo_family())
             .expect("expected sudo-family facts");
         assert_eq!(doas.invoker, SudoFamilyInvoker::Doas);
+    }
+
+    #[test]
+    fn summarizes_echo_options_for_path_qualified_echo() {
+        let source = "#!/bin/sh\nvalue=$(/usr/ucb/echo -n hi)\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        let echo = facts
+            .commands()
+            .iter()
+            .find(|fact| fact.literal_name() == Some("/usr/ucb/echo"))
+            .and_then(|fact| fact.options().echo())
+            .expect("expected path-qualified echo facts");
+
+        assert_eq!(
+            echo.portability_flag_word()
+                .map(|word| word.span.slice(source)),
+            Some("-n")
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/command.rs
+++ b/crates/shuck-linter/src/rules/common/command.rs
@@ -70,6 +70,12 @@ impl<'a> NormalizedCommand<'a> {
         self.effective_name.as_deref() == Some(name)
     }
 
+    pub fn effective_basename_is(&self, name: &str) -> bool {
+        self.effective_name
+            .as_deref()
+            .is_some_and(|effective_name| command_basename(effective_name) == name)
+    }
+
     pub fn has_wrapper(&self, wrapper: WrapperKind) -> bool {
         self.wrappers.contains(&wrapper)
     }
@@ -522,6 +528,10 @@ fn builtin_span(command: &BuiltinCommand) -> Span {
 fn static_command_name_text(word: &Word, source: &str) -> Option<String> {
     static_word_text(word, source)
         .map(|text| text.strip_prefix('\\').map_or(text.clone(), str::to_owned))
+}
+
+fn command_basename(name: &str) -> &str {
+    name.rsplit('/').next().unwrap_or(name)
 }
 
 fn static_word_text(word: &Word, source: &str) -> Option<String> {

--- a/crates/shuck-linter/src/rules/portability/echo_flags.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_flags.rs
@@ -21,7 +21,7 @@ pub fn echo_flags(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter(|fact| fact.effective_name_is("echo") && fact.wrappers().is_empty())
+        .filter(|fact| fact.wrappers().is_empty())
         .filter_map(|fact| {
             fact.options()
                 .echo()
@@ -48,6 +48,7 @@ echo -E hi
 echo -nn hi
 echo -neE hi
 value=$(echo -en hi)
+value=$(/usr/ucb/echo -n hi)
 echo \"-s\"
 echo '-e'
 ";
@@ -58,7 +59,9 @@ echo '-e'
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-n", "-e", "-E", "-nn", "-neE", "-en", "\"-s\"", "'-e'"]
+            vec![
+                "-n", "-e", "-E", "-nn", "-neE", "-en", "-n", "\"-s\"", "'-e'",
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- fix X027 so path-qualified echo invocations like `/usr/ucb/echo -n` are recognized
- make echo option facts key off the command basename instead of only an exact `echo` name match
- add regressions at the fact layer and rule layer for the path-qualified case

## Root Cause
X027 depended on command facts whose echo parsing only activated when the effective command name was exactly `echo`. That excluded path-qualified invocations, so the rule missed real POSIX-sh portability warnings in the corpus.

## Testing
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X027`
