### PR TITLE
Tighten S031 header directive matching

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -3903,8 +3903,12 @@ impl<'a> LinterFactsBuilder<'a> {
                 .any(|set| set.errexit_change == Some(true));
         let commented_continuation_comment_spans =
             build_commented_continuation_comment_spans(self.source, self._indexer);
-        let trailing_directive_comment_spans =
-            build_trailing_directive_comment_spans(&case_items, self.source, self._indexer);
+        let trailing_directive_comment_spans = build_trailing_directive_comment_spans(
+            self.file,
+            &case_items,
+            self.source,
+            self._indexer,
+        );
         let backtick_command_name_spans = build_backtick_command_name_spans(&commands);
         let dollar_question_after_command_spans =
             build_dollar_question_after_command_spans(&self.file.body, self.source);
@@ -7526,6 +7530,7 @@ fn build_commented_continuation_comment_spans(source: &str, indexer: &Indexer) -
 }
 
 fn build_trailing_directive_comment_spans(
+    file: &File,
     case_items: &[CaseItemFact<'_>],
     source: &str,
     indexer: &Indexer,
@@ -7554,9 +7559,7 @@ fn build_trailing_directive_comment_spans(
             if case_item_label_comment(case_items, line, comment_start) {
                 return None;
             }
-            if shellcheck_directive_can_apply_to_following_command(
-                &source[line_start..comment_start],
-            ) {
+            if shellcheck_directive_can_apply_to_following_command(source, file, comment.range) {
                 return None;
             }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -7556,15 +7556,14 @@ fn build_trailing_directive_comment_spans(
             if comment_start < line_start || comment_start >= comment_end {
                 return None;
             }
+            let comment_text = &source[comment_start..comment_end];
+            if !is_inline_shellcheck_directive(comment_text) {
+                return None;
+            }
             if case_item_label_comment(case_items, line, comment_start) {
                 return None;
             }
             if shellcheck_directive_can_apply_to_following_command(source, file, comment.range) {
-                return None;
-            }
-
-            let comment_text = &source[comment_start..comment_end];
-            if !is_inline_shellcheck_directive(comment_text) {
                 return None;
             }
 

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -89,6 +89,8 @@ mod tests {
         let sources = [
             "#!/bin/sh\nif # shellcheck disable=SC2086\n  echo $foo\nthen\n  :\nfi\n",
             "#!/bin/sh\nif true; then # shellcheck disable=SC2086\n  echo $foo\nfi\n",
+            "#!/bin/sh\nif true; then { # shellcheck disable=SC2086\n  echo $foo\n}; fi\n",
+            "#!/bin/sh\nif true; then ( # shellcheck disable=SC2086\n  echo $foo\n); fi\n",
             "#!/bin/sh\nif false; then\n  :\nelif true; then # shellcheck disable=SC2086\n  echo $foo\nfi\n",
             "#!/bin/sh\nif false; then\n  :\nelse # shellcheck disable=SC2086\n  echo $foo\nfi\n",
             "#!/bin/sh\nfor item in 1; do # shellcheck disable=SC2086\n  echo $foo\ndone\n",

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -89,7 +89,9 @@ mod tests {
         let sources = [
             "#!/bin/sh\nif # shellcheck disable=SC2086\n  echo $foo\nthen\n  :\nfi\n",
             "#!/bin/sh\nif true; then # shellcheck disable=SC2086\n  echo $foo\nfi\n",
+            "#!/bin/sh\nif false; then\n  :\nelif true; then # shellcheck disable=SC2086\n  echo $foo\nfi\n",
             "#!/bin/sh\nif false; then\n  :\nelse # shellcheck disable=SC2086\n  echo $foo\nfi\n",
+            "#!/bin/sh\nfor item in 1; do # shellcheck disable=SC2086\n  echo $foo\ndone\n",
             "#!/bin/sh\nwhile # shellcheck disable=SC2086\n  echo $foo\ndo\n  :\ndone\n",
             "#!/bin/sh\nuntil # shellcheck disable=SC2086\n  echo $foo\ndo\n  :\ndone\n",
         ];

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -100,4 +100,13 @@ mod tests {
             assert!(diagnostics.is_empty(), "{source}");
         }
     }
+
+    #[test]
+    fn reports_keyword_like_arguments_with_trailing_directives() {
+        let source = "#!/bin/sh\necho if # shellcheck disable=SC2086\necho $foo\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
 }

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -113,4 +113,14 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
     }
+
+    #[test]
+    fn reports_keyword_suffixes_inside_words_with_trailing_directives() {
+        let source =
+            "#!/bin/sh\nfor item in to-do # shellcheck disable=SC2086\ndo\n  echo $foo\ndone\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
 }

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -22,7 +22,7 @@ pub fn trailing_directive(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_inline_disable_directive() {
@@ -101,6 +101,26 @@ mod tests {
         for source in sources {
             let diagnostics =
                 test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
+            assert!(diagnostics.is_empty(), "{source}");
+        }
+    }
+
+    #[test]
+    fn ignores_directive_after_zsh_brace_control_flow_headers() {
+        let sources = [
+            "#!/bin/zsh\nif [[ -n $foo ]] { # shellcheck disable=SC2086\n  echo $foo\n}\n",
+            "#!/bin/zsh\nif [[ -n $foo ]] { :\n} elif [[ -n $bar ]] { # shellcheck disable=SC2086\n  echo $foo\n}\n",
+            "#!/bin/zsh\nif [[ -n $foo ]] { :\n} else { # shellcheck disable=SC2086\n  echo $foo\n}\n",
+            "#!/bin/zsh\nfor item in 1; { # shellcheck disable=SC2086\n  echo $foo\n}\n",
+            "#!/bin/zsh\nrepeat 2 { # shellcheck disable=SC2086\n  echo $foo\n}\n",
+            "#!/bin/zsh\nforeach item (1 2) { # shellcheck disable=SC2086\n  echo $foo\n}\n",
+        ];
+
+        for source in sources {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::TrailingDirective).with_shell(ShellDialect::Zsh),
+            );
             assert!(diagnostics.is_empty(), "{source}");
         }
     }

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{CaseItem, Command, CompoundCommand, File, TextRange, TextSize};
+use shuck_ast::{CaseItem, Command, CompoundCommand, File, IfSyntax, StmtSeq, TextRange, TextSize};
 use shuck_indexer::{CommentIndex, IndexedComment};
 
 use crate::{
@@ -52,7 +52,9 @@ pub fn parse_directives(
 
         if let Some(directive) = parse_shuck_directive(&comment) {
             directives.push(directive);
-        } else if let Some(directive) = parse_shellcheck_directive(&comment, file, shellcheck_map) {
+        } else if let Some(directive) =
+            parse_shellcheck_directive(source, &comment, file, shellcheck_map)
+        {
             directives.push(directive);
         }
     }
@@ -70,7 +72,6 @@ pub fn parse_directives(
 #[derive(Debug, Clone, Copy)]
 struct NormalizedComment<'a> {
     text: &'a str,
-    line_prefix: &'a str,
     range: TextRange,
     line: u32,
     is_own_line: bool,
@@ -94,7 +95,6 @@ fn normalized_comment<'a>(
 
     Some(NormalizedComment {
         text: &source[comment_start..line_end],
-        line_prefix: &source[line_start..comment_start],
         range: TextRange::new(
             TextSize::new(comment_start as u32),
             TextSize::new(line_end as u32),
@@ -143,12 +143,13 @@ fn parse_shuck_directive(comment: &NormalizedComment<'_>) -> Option<SuppressionD
 }
 
 fn parse_shellcheck_directive(
+    source: &str,
     comment: &NormalizedComment<'_>,
     file: &File,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Option<SuppressionDirective> {
     if !comment.is_own_line
-        && !shellcheck_directive_can_apply_to_following_command(comment.line_prefix)
+        && !shellcheck_directive_can_apply_to_following_command(source, file, comment.range)
         && !is_case_label_directive(comment, file)
     {
         return None;
@@ -192,14 +193,104 @@ fn parse_shellcheck_directive(
     })
 }
 
-pub(crate) fn shellcheck_directive_can_apply_to_following_command(prefix: &str) -> bool {
-    let trimmed = prefix.trim_end();
-    trimmed.ends_with(';')
-        || trimmed.ends_with('{')
-        || trimmed.ends_with('(')
-        || ["if", "elif", "while", "until", "then", "do", "else"]
-            .into_iter()
-            .any(|keyword| ends_with_keyword(trimmed, keyword))
+pub(crate) fn shellcheck_directive_can_apply_to_following_command(
+    source: &str,
+    file: &File,
+    comment_range: TextRange,
+) -> bool {
+    let Some(context) = inline_directive_context(source, comment_range) else {
+        return false;
+    };
+
+    if context.prefix.trim_end().ends_with(';') {
+        return true;
+    }
+
+    iter_commands(
+        &file.body,
+        CommandWalkOptions {
+            descend_nested_word_commands: true,
+        },
+    )
+    .any(|visit| match visit.command {
+        Command::Compound(CompoundCommand::If(command)) => {
+            let if_header = command.condition.first().is_some_and(|stmt| {
+                next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                    && command_start_segment_matches(
+                        source,
+                        visit.stmt.span.start.offset,
+                        context.comment_start,
+                        "if",
+                    )
+            });
+
+            let then_header = match command.syntax {
+                IfSyntax::ThenFi { then_span, .. } => {
+                    command.then_branch.first().is_some_and(|stmt| {
+                        next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                            && span_precedes_comment_on_same_line(then_span, &context)
+                    })
+                }
+                IfSyntax::Brace { .. } => false,
+            };
+
+            let mut previous_branch_end = command.then_branch.span.end.offset;
+            let elif_header = command.elif_branches.iter().any(|(condition, branch)| {
+                let matches = condition.first().is_some_and(|stmt| {
+                    next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                        && gap_segment_ends_with_keyword(
+                            source,
+                            previous_branch_end,
+                            context.comment_start,
+                            "elif",
+                        )
+                });
+                previous_branch_end = branch.span.end.offset;
+                matches
+            });
+
+            let else_header = command.else_branch.as_ref().is_some_and(|branch| {
+                branch.first().is_some_and(|stmt| {
+                    next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                        && gap_segment_ends_with_keyword(
+                            source,
+                            previous_branch_end,
+                            context.comment_start,
+                            "else",
+                        )
+                })
+            });
+
+            if_header || then_header || elif_header || else_header
+        }
+        Command::Compound(CompoundCommand::While(command)) => {
+            loop_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.condition,
+                context,
+                "while",
+            ) || loop_body_matches(source, &command.condition, &command.body, &context)
+        }
+        Command::Compound(CompoundCommand::Until(command)) => {
+            loop_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.condition,
+                context,
+                "until",
+            ) || loop_body_matches(source, &command.condition, &command.body, &context)
+        }
+        Command::Compound(CompoundCommand::Subshell(body)) => body.first().is_some_and(|stmt| {
+            next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                && context.prefix.trim() == "("
+        }),
+        Command::Compound(CompoundCommand::BraceGroup(body)) => body.first().is_some_and(|stmt| {
+            next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                && context.prefix.trim() == "{"
+        }),
+        _ => false,
+    })
 }
 
 fn is_case_label_directive(comment: &NormalizedComment<'_>, file: &File) -> bool {
@@ -250,12 +341,109 @@ fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a
         .then(|| &text[prefix.len()..])
 }
 
-fn ends_with_keyword(text: &str, keyword: &str) -> bool {
-    text == keyword
-        || text
-            .strip_suffix(keyword)
-            .and_then(|prefix| prefix.chars().last())
-            .is_some_and(|ch| ch.is_ascii_whitespace())
+#[derive(Debug, Clone, Copy)]
+struct InlineDirectiveContext<'a> {
+    prefix: &'a str,
+    line_start: usize,
+    line_end: usize,
+    comment_start: usize,
+}
+
+fn inline_directive_context<'a>(
+    source: &'a str,
+    comment_range: TextRange,
+) -> Option<InlineDirectiveContext<'a>> {
+    let comment_start = usize::from(comment_range.start()).min(source.len());
+    let line_start = source[..comment_start]
+        .rfind('\n')
+        .map_or(0, |index| index + 1);
+    let line_end = source[comment_start..]
+        .find('\n')
+        .map_or(source.len(), |index| comment_start + index);
+
+    Some(InlineDirectiveContext {
+        prefix: &source[line_start..comment_start],
+        line_start,
+        line_end,
+        comment_start,
+    })
+}
+
+fn next_command_starts_after_comment_line(
+    next_command_start: usize,
+    context: &InlineDirectiveContext<'_>,
+) -> bool {
+    next_command_start >= context.line_end
+}
+
+fn command_start_segment_matches(
+    source: &str,
+    command_start: usize,
+    comment_start: usize,
+    keyword: &str,
+) -> bool {
+    segment_ends_with_keyword(source, command_start, comment_start, keyword)
+}
+
+fn gap_segment_ends_with_keyword(
+    source: &str,
+    gap_start: usize,
+    comment_start: usize,
+    keyword: &str,
+) -> bool {
+    segment_ends_with_keyword(source, gap_start.min(comment_start), comment_start, keyword)
+}
+
+fn segment_ends_with_keyword(source: &str, start: usize, end: usize, keyword: &str) -> bool {
+    let Some(segment) = source.get(start.min(end)..end) else {
+        return false;
+    };
+    let trimmed = segment.trim_end_matches([' ', '\t', '\r']);
+    let Some(prefix) = trimmed.strip_suffix(keyword) else {
+        return false;
+    };
+
+    prefix
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !(ch.is_ascii_alphanumeric() || ch == '_'))
+}
+
+fn span_precedes_comment_on_same_line(
+    span: shuck_ast::Span,
+    context: &InlineDirectiveContext<'_>,
+) -> bool {
+    span.end.offset <= context.comment_start && span.end.offset >= context.line_start
+}
+
+fn loop_header_matches(
+    source: &str,
+    command_start: usize,
+    condition: &StmtSeq,
+    context: InlineDirectiveContext<'_>,
+    keyword: &str,
+) -> bool {
+    condition.first().is_some_and(|stmt| {
+        next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+            && command_start_segment_matches(source, command_start, context.comment_start, keyword)
+    })
+}
+
+fn loop_body_matches(
+    source: &str,
+    condition: &StmtSeq,
+    body: &StmtSeq,
+    context: &InlineDirectiveContext<'_>,
+) -> bool {
+    body.first().is_some_and(|stmt| {
+        next_command_starts_after_comment_line(stmt.span.start.offset, context)
+            && gap_segment_ends_with_keyword(
+                source,
+                condition.span.end.offset,
+                context.comment_start,
+                "do",
+            )
+    })
 }
 
 fn parse_shuck_action(value: &str) -> Option<SuppressionAction> {
@@ -376,6 +564,19 @@ case $x in
   on) echo \"$x\" # shellcheck disable=SC2086
       ;;
 esac
+";
+        let directives = directives(source);
+
+        assert!(directives.is_empty());
+    }
+
+    #[test]
+    fn rejects_shellcheck_directives_after_keyword_like_arguments() {
+        let source = "\
+echo if # shellcheck disable=SC2086
+echo $foo
+echo { # shellcheck disable=SC2086
+echo $bar
 ";
         let directives = directives(source);
 

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -270,18 +270,34 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
 
             if_header || then_header || elif_header || elif_then_header || else_header
         }
-        Command::Compound(CompoundCommand::For(command)) => {
-            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
-        }
-        Command::Compound(CompoundCommand::Repeat(command)) => {
-            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
-        }
-        Command::Compound(CompoundCommand::Foreach(command)) => {
-            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
-        }
-        Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
-            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
-        }
+        Command::Compound(CompoundCommand::For(command)) => body_header_matches(
+            source,
+            visit.stmt.span.start.offset,
+            &command.body,
+            &context,
+            "do",
+        ),
+        Command::Compound(CompoundCommand::Repeat(command)) => body_header_matches(
+            source,
+            visit.stmt.span.start.offset,
+            &command.body,
+            &context,
+            "do",
+        ),
+        Command::Compound(CompoundCommand::Foreach(command)) => body_header_matches(
+            source,
+            visit.stmt.span.start.offset,
+            &command.body,
+            &context,
+            "do",
+        ),
+        Command::Compound(CompoundCommand::ArithmeticFor(command)) => body_header_matches(
+            source,
+            visit.stmt.span.start.offset,
+            &command.body,
+            &context,
+            "do",
+        ),
         Command::Compound(CompoundCommand::While(command)) => {
             loop_header_matches(
                 source,
@@ -312,9 +328,13 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                 "do",
             )
         }
-        Command::Compound(CompoundCommand::Select(command)) => {
-            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
-        }
+        Command::Compound(CompoundCommand::Select(command)) => body_header_matches(
+            source,
+            visit.stmt.span.start.offset,
+            &command.body,
+            &context,
+            "do",
+        ),
         Command::Compound(CompoundCommand::Subshell(body)) => body.first().is_some_and(|stmt| {
             next_command_starts_after_comment_line(stmt.span.start.offset, &context)
                 && context.prefix.trim() == "("

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -389,7 +389,7 @@ fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a
         .then(|| &text[prefix.len()..])
 }
 
-fn shellcheck_comment_remainder<'a>(comment_text: &'a str) -> Option<&'a str> {
+fn shellcheck_comment_remainder(comment_text: &str) -> Option<&str> {
     let body = strip_comment_prefix(comment_text);
     let remainder = strip_prefix_ignore_ascii_case(body, "shellcheck")?;
     if let Some(first) = remainder.chars().next()

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -337,11 +337,11 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
         ),
         Command::Compound(CompoundCommand::Subshell(body)) => body.first().is_some_and(|stmt| {
             next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                && context.prefix.trim() == "("
+                && context.prefix.trim_end().ends_with('(')
         }),
         Command::Compound(CompoundCommand::BraceGroup(body)) => body.first().is_some_and(|stmt| {
             next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                && context.prefix.trim() == "{"
+                && context.prefix.trim_end().ends_with('{')
         }),
         _ => false,
     })
@@ -694,6 +694,25 @@ done
         assert_eq!(directives[0].source, SuppressionSource::ShellCheck);
         assert_eq!(directives[0].codes, vec![Rule::UnquotedExpansion]);
         assert_eq!(directives[0].line, 1);
+    }
+
+    #[test]
+    fn parses_shellcheck_directives_after_then_inline_group_openers() {
+        let source = "\
+if true; then { # shellcheck disable=SC2086
+  echo $foo
+}; fi
+if true; then ( # shellcheck disable=SC2086
+  echo $bar
+); fi
+";
+        let directives = directives(source);
+
+        assert_eq!(directives.len(), 2);
+        assert!(directives.iter().all(|directive| {
+            directive.source == SuppressionSource::ShellCheck
+                && directive.codes == vec![Rule::UnquotedExpansion]
+        }));
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{CaseItem, Command, CompoundCommand, File, IfSyntax, StmtSeq, TextRange, TextSize};
+use shuck_ast::{CaseItem, Command, CompoundCommand, File, StmtSeq, TextRange, TextSize};
 use shuck_indexer::{CommentIndex, IndexedComment};
 
 use crate::{
@@ -218,18 +218,23 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                     )
             });
 
-            let then_header = matches!(command.syntax, IfSyntax::ThenFi { .. })
-                && body_header_matches(
-                    source,
-                    command.condition.span.end.offset,
-                    &command.then_branch,
-                    &context,
-                    "then",
-                );
+            let then_header = body_header_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.then_branch,
+                &context,
+                "then",
+            ) || body_opener_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.then_branch,
+                &context,
+                '{',
+            );
 
             let mut previous_branch_end = command.then_branch.span.end.offset;
             let mut elif_header = false;
-            let mut elif_then_header = false;
+            let mut elif_body_header = false;
             for (condition, branch) in &command.elif_branches {
                 elif_header |= condition.first().is_some_and(|stmt| {
                     next_command_starts_after_comment_line(stmt.span.start.offset, &context)
@@ -240,12 +245,18 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                             "elif",
                         )
                 });
-                elif_then_header |= body_header_matches(
+                elif_body_header |= body_header_matches(
                     source,
                     condition.span.end.offset,
                     branch,
                     &context,
                     "then",
+                ) || body_opener_matches(
+                    source,
+                    condition.span.end.offset,
+                    branch,
+                    &context,
+                    '{',
                 );
                 previous_branch_end = branch.span.end.offset;
             }
@@ -253,45 +264,82 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
             let else_header = command.else_branch.as_ref().is_some_and(|branch| {
                 branch.first().is_some_and(|stmt| {
                     next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                        && gap_segment_ends_with_keyword(
+                        && (gap_segment_ends_with_keyword(
                             source,
                             previous_branch_end,
                             context.comment_start,
                             "else",
-                        )
+                        ) || gap_segment_ends_with_char(
+                            source,
+                            previous_branch_end,
+                            context.comment_start,
+                            '{',
+                        ))
                 })
             });
 
-            if_header || then_header || elif_header || elif_then_header || else_header
+            if_header || then_header || elif_header || elif_body_header || else_header
         }
-        Command::Compound(CompoundCommand::For(command)) => body_header_matches(
-            source,
-            visit.stmt.span.start.offset,
-            &command.body,
-            &context,
-            "do",
-        ),
-        Command::Compound(CompoundCommand::Repeat(command)) => body_header_matches(
-            source,
-            visit.stmt.span.start.offset,
-            &command.body,
-            &context,
-            "do",
-        ),
-        Command::Compound(CompoundCommand::Foreach(command)) => body_header_matches(
-            source,
-            visit.stmt.span.start.offset,
-            &command.body,
-            &context,
-            "do",
-        ),
-        Command::Compound(CompoundCommand::ArithmeticFor(command)) => body_header_matches(
-            source,
-            visit.stmt.span.start.offset,
-            &command.body,
-            &context,
-            "do",
-        ),
+        Command::Compound(CompoundCommand::For(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::Repeat(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::Foreach(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
         Command::Compound(CompoundCommand::While(command)) => {
             loop_header_matches(
                 source,
@@ -305,6 +353,12 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                 &command.body,
                 &context,
                 "do",
+            ) || body_opener_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.body,
+                &context,
+                '{',
             )
         }
         Command::Compound(CompoundCommand::Until(command)) => {
@@ -320,15 +374,29 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                 &command.body,
                 &context,
                 "do",
+            ) || body_opener_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.body,
+                &context,
+                '{',
             )
         }
-        Command::Compound(CompoundCommand::Select(command)) => body_header_matches(
-            source,
-            visit.stmt.span.start.offset,
-            &command.body,
-            &context,
-            "do",
-        ),
+        Command::Compound(CompoundCommand::Select(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
         Command::Compound(CompoundCommand::Subshell(body)) => body.first().is_some_and(|stmt| {
             next_command_starts_after_comment_line(stmt.span.start.offset, &context)
                 && context.prefix.trim_end().ends_with('(')
@@ -451,6 +519,15 @@ fn gap_segment_ends_with_keyword(
     segment_ends_with_keyword(source, gap_start.min(comment_start), comment_start, keyword)
 }
 
+fn gap_segment_ends_with_char(
+    source: &str,
+    gap_start: usize,
+    comment_start: usize,
+    ch: char,
+) -> bool {
+    segment_ends_with_char(source, gap_start.min(comment_start), comment_start, ch)
+}
+
 fn segment_ends_with_keyword(source: &str, start: usize, end: usize, keyword: &str) -> bool {
     let Some(segment) = source.get(start.min(end)..end) else {
         return false;
@@ -464,6 +541,14 @@ fn segment_ends_with_keyword(source: &str, start: usize, end: usize, keyword: &s
         .chars()
         .next_back()
         .is_none_or(|ch| ch.is_ascii_whitespace())
+}
+
+fn segment_ends_with_char(source: &str, start: usize, end: usize, ch: char) -> bool {
+    let Some(segment) = source.get(start.min(end)..end) else {
+        return false;
+    };
+
+    segment.trim_end_matches([' ', '\t', '\r']).ends_with(ch)
 }
 
 fn loop_header_matches(
@@ -489,6 +574,19 @@ fn body_header_matches(
     body.first().is_some_and(|stmt| {
         next_command_starts_after_comment_line(stmt.span.start.offset, context)
             && gap_segment_ends_with_keyword(source, header_end, context.comment_start, keyword)
+    })
+}
+
+fn body_opener_matches(
+    source: &str,
+    header_end: usize,
+    body: &StmtSeq,
+    context: &InlineDirectiveContext<'_>,
+    opener: char,
+) -> bool {
+    body.first().is_some_and(|stmt| {
+        next_command_starts_after_comment_line(stmt.span.start.offset, context)
+            && gap_segment_ends_with_char(source, header_end, context.comment_start, opener)
     })
 }
 
@@ -524,12 +622,16 @@ fn resolve_rule_code(code: &str) -> Option<Rule> {
 #[cfg(test)]
 mod tests {
     use shuck_indexer::Indexer;
-    use shuck_parser::parser::Parser;
+    use shuck_parser::parser::{Parser, ShellDialect};
 
     use super::*;
 
     fn directives(source: &str) -> Vec<SuppressionDirective> {
-        let output = Parser::new(source).parse().unwrap();
+        directives_with_dialect(source, ShellDialect::Bash)
+    }
+
+    fn directives_with_dialect(source: &str, dialect: ShellDialect) -> Vec<SuppressionDirective> {
+        let output = Parser::with_dialect(source, dialect).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         parse_directives(
             source,
@@ -727,6 +829,48 @@ if true; then ( # shellcheck disable=SC2086
         let directives = directives(source);
 
         assert_eq!(directives.len(), 2);
+        assert!(directives.iter().all(|directive| {
+            directive.source == SuppressionSource::ShellCheck
+                && directive.codes == vec![Rule::UnquotedExpansion]
+        }));
+    }
+
+    #[test]
+    fn parses_shellcheck_directives_after_zsh_brace_if_headers() {
+        let source = "\
+if [[ -n $foo ]] { # shellcheck disable=SC2086
+  echo $foo
+} elif [[ -n $bar ]] { # shellcheck disable=SC2086
+  echo $bar
+} else { # shellcheck disable=SC2086
+  echo $baz
+}
+";
+        let directives = directives_with_dialect(source, ShellDialect::Zsh);
+
+        assert_eq!(directives.len(), 3);
+        assert!(directives.iter().all(|directive| {
+            directive.source == SuppressionSource::ShellCheck
+                && directive.codes == vec![Rule::UnquotedExpansion]
+        }));
+    }
+
+    #[test]
+    fn parses_shellcheck_directives_after_zsh_brace_loop_headers() {
+        let source = "\
+for item in 1; { # shellcheck disable=SC2086
+  echo $foo
+}
+repeat 2 { # shellcheck disable=SC2086
+  echo $bar
+}
+foreach item (1 2) { # shellcheck disable=SC2086
+  echo $baz
+}
+";
+        let directives = directives_with_dialect(source, ShellDialect::Zsh);
+
+        assert_eq!(directives.len(), 3);
         assert!(directives.iter().all(|directive| {
             directive.source == SuppressionSource::ShellCheck
                 && directive.codes == vec![Rule::UnquotedExpansion]

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -224,19 +224,20 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                     )
             });
 
-            let then_header = match command.syntax {
-                IfSyntax::ThenFi { then_span, .. } => {
-                    command.then_branch.first().is_some_and(|stmt| {
-                        next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                            && span_precedes_comment_on_same_line(then_span, &context)
-                    })
-                }
-                IfSyntax::Brace { .. } => false,
-            };
+            let then_header = matches!(command.syntax, IfSyntax::ThenFi { .. })
+                && body_header_matches(
+                    source,
+                    command.condition.span.end.offset,
+                    &command.then_branch,
+                    &context,
+                    "then",
+                );
 
             let mut previous_branch_end = command.then_branch.span.end.offset;
-            let elif_header = command.elif_branches.iter().any(|(condition, branch)| {
-                let matches = condition.first().is_some_and(|stmt| {
+            let mut elif_header = false;
+            let mut elif_then_header = false;
+            for (condition, branch) in &command.elif_branches {
+                elif_header |= condition.first().is_some_and(|stmt| {
                     next_command_starts_after_comment_line(stmt.span.start.offset, &context)
                         && gap_segment_ends_with_keyword(
                             source,
@@ -245,9 +246,15 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                             "elif",
                         )
                 });
+                elif_then_header |= body_header_matches(
+                    source,
+                    condition.span.end.offset,
+                    branch,
+                    &context,
+                    "then",
+                );
                 previous_branch_end = branch.span.end.offset;
-                matches
-            });
+            }
 
             let else_header = command.else_branch.as_ref().is_some_and(|branch| {
                 branch.first().is_some_and(|stmt| {
@@ -261,7 +268,19 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                 })
             });
 
-            if_header || then_header || elif_header || else_header
+            if_header || then_header || elif_header || elif_then_header || else_header
+        }
+        Command::Compound(CompoundCommand::For(command)) => {
+            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
+        }
+        Command::Compound(CompoundCommand::Repeat(command)) => {
+            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
+        }
+        Command::Compound(CompoundCommand::Foreach(command)) => {
+            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
+        }
+        Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
+            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
         }
         Command::Compound(CompoundCommand::While(command)) => {
             loop_header_matches(
@@ -270,7 +289,13 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                 &command.condition,
                 context,
                 "while",
-            ) || loop_body_matches(source, &command.condition, &command.body, &context)
+            ) || body_header_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.body,
+                &context,
+                "do",
+            )
         }
         Command::Compound(CompoundCommand::Until(command)) => {
             loop_header_matches(
@@ -279,7 +304,16 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
                 &command.condition,
                 context,
                 "until",
-            ) || loop_body_matches(source, &command.condition, &command.body, &context)
+            ) || body_header_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.body,
+                &context,
+                "do",
+            )
+        }
+        Command::Compound(CompoundCommand::Select(command)) => {
+            body_header_matches(source, visit.stmt.span.start.offset, &command.body, &context, "do")
         }
         Command::Compound(CompoundCommand::Subshell(body)) => body.first().is_some_and(|stmt| {
             next_command_starts_after_comment_line(stmt.span.start.offset, &context)
@@ -344,7 +378,6 @@ fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a
 #[derive(Debug, Clone, Copy)]
 struct InlineDirectiveContext<'a> {
     prefix: &'a str,
-    line_start: usize,
     line_end: usize,
     comment_start: usize,
 }
@@ -363,7 +396,6 @@ fn inline_directive_context<'a>(
 
     Some(InlineDirectiveContext {
         prefix: &source[line_start..comment_start],
-        line_start,
         line_end,
         comment_start,
     })
@@ -409,13 +441,6 @@ fn segment_ends_with_keyword(source: &str, start: usize, end: usize, keyword: &s
         .is_none_or(|ch| !(ch.is_ascii_alphanumeric() || ch == '_'))
 }
 
-fn span_precedes_comment_on_same_line(
-    span: shuck_ast::Span,
-    context: &InlineDirectiveContext<'_>,
-) -> bool {
-    span.end.offset <= context.comment_start && span.end.offset >= context.line_start
-}
-
 fn loop_header_matches(
     source: &str,
     command_start: usize,
@@ -429,20 +454,16 @@ fn loop_header_matches(
     })
 }
 
-fn loop_body_matches(
+fn body_header_matches(
     source: &str,
-    condition: &StmtSeq,
+    header_end: usize,
     body: &StmtSeq,
     context: &InlineDirectiveContext<'_>,
+    keyword: &str,
 ) -> bool {
     body.first().is_some_and(|stmt| {
         next_command_starts_after_comment_line(stmt.span.start.offset, context)
-            && gap_segment_ends_with_keyword(
-                source,
-                condition.span.end.offset,
-                context.comment_start,
-                "do",
-            )
+            && gap_segment_ends_with_keyword(source, header_end, context.comment_start, keyword)
     })
 }
 
@@ -621,6 +642,38 @@ done
             directive.source == SuppressionSource::ShellCheck
                 && directive.codes == vec![Rule::UnquotedExpansion]
         }));
+    }
+
+    #[test]
+    fn parses_shellcheck_directives_after_elif_then_header() {
+        let source = "\
+if false; then
+  :
+elif true; then # shellcheck disable=SC2086
+  echo $foo
+fi
+";
+        let directives = directives(source);
+
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].source, SuppressionSource::ShellCheck);
+        assert_eq!(directives[0].codes, vec![Rule::UnquotedExpansion]);
+        assert_eq!(directives[0].line, 3);
+    }
+
+    #[test]
+    fn parses_shellcheck_directives_after_for_do_header() {
+        let source = "\
+for item in 1; do # shellcheck disable=SC2086
+  echo $foo
+done
+";
+        let directives = directives(source);
+
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].source, SuppressionSource::ShellCheck);
+        assert_eq!(directives[0].codes, vec![Rule::UnquotedExpansion]);
+        assert_eq!(directives[0].line, 1);
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -463,7 +463,7 @@ fn segment_ends_with_keyword(source: &str, start: usize, end: usize, keyword: &s
     prefix
         .chars()
         .next_back()
-        .is_none_or(|ch| !(ch.is_ascii_alphanumeric() || ch == '_'))
+        .is_none_or(|ch| ch.is_ascii_whitespace())
 }
 
 fn loop_header_matches(
@@ -699,6 +699,19 @@ done
         assert_eq!(directives[0].source, SuppressionSource::ShellCheck);
         assert_eq!(directives[0].codes, vec![Rule::UnquotedExpansion]);
         assert_eq!(directives[0].line, 1);
+    }
+
+    #[test]
+    fn rejects_shellcheck_directives_after_keyword_suffixes_inside_words() {
+        let source = "\
+for item in to-do # shellcheck disable=SC2086
+do
+  echo $foo
+done
+";
+        let directives = directives(source);
+
+        assert!(directives.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -148,20 +148,7 @@ fn parse_shellcheck_directive(
     file: &File,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Option<SuppressionDirective> {
-    if !comment.is_own_line
-        && !shellcheck_directive_can_apply_to_following_command(source, file, comment.range)
-        && !is_case_label_directive(comment, file)
-    {
-        return None;
-    }
-
-    let body = strip_comment_prefix(comment.text);
-    let remainder = strip_prefix_ignore_ascii_case(body, "shellcheck")?;
-    if let Some(first) = remainder.chars().next()
-        && !first.is_ascii_whitespace()
-    {
-        return None;
-    }
+    let remainder = shellcheck_comment_remainder(comment.text)?;
 
     let mut codes = Vec::new();
     for part in remainder.split_ascii_whitespace() {
@@ -181,6 +168,13 @@ fn parse_shellcheck_directive(
     }
 
     if codes.is_empty() {
+        return None;
+    }
+
+    if !comment.is_own_line
+        && !shellcheck_directive_can_apply_to_following_command(source, file, comment.range)
+        && !is_case_label_directive(comment, file)
+    {
         return None;
     }
 
@@ -393,6 +387,17 @@ fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a
     candidate
         .eq_ignore_ascii_case(prefix)
         .then(|| &text[prefix.len()..])
+}
+
+fn shellcheck_comment_remainder<'a>(comment_text: &'a str) -> Option<&'a str> {
+    let body = strip_comment_prefix(comment_text);
+    let remainder = strip_prefix_ignore_ascii_case(body, "shellcheck")?;
+    if let Some(first) = remainder.chars().next()
+        && !first.is_ascii_whitespace()
+    {
+        return None;
+    }
+    Some(remainder)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -725,6 +725,36 @@ echo $foo
     }
 
     #[test]
+    fn scopes_shellcheck_disable_after_then_inline_brace_group_opener() {
+        let source = "\
+foo='a b'
+if true; then { # shellcheck disable=SC2086
+  echo $foo
+}; fi
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
+    fn scopes_shellcheck_disable_after_then_inline_subshell_opener() {
+        let source = "\
+foo='a b'
+if true; then ( # shellcheck disable=SC2086
+  echo $foo
+); fi
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
     fn ignores_shellcheck_directives_after_keyword_like_arguments() {
         let source = "\
 echo if # shellcheck disable=SC2086

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -678,6 +678,38 @@ echo $foo
     }
 
     #[test]
+    fn scopes_shellcheck_disable_after_elif_then_header_to_the_next_command() {
+        let source = "\
+foo='a b'
+if false; then
+  :
+elif true; then # shellcheck disable=SC2086
+  echo $foo
+fi
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 5));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 7));
+    }
+
+    #[test]
+    fn scopes_shellcheck_disable_after_for_do_header_to_the_next_command() {
+        let source = "\
+foo='a b'
+for item in 1; do # shellcheck disable=SC2086
+  echo $foo
+done
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
     fn scopes_shellcheck_disable_after_brace_group_opener_to_the_next_command() {
         let source = "\
 foo='a b'

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -693,6 +693,17 @@ echo $foo
     }
 
     #[test]
+    fn ignores_shellcheck_directives_after_keyword_like_arguments() {
+        let source = "\
+echo if # shellcheck disable=SC2086
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 2));
+    }
+
+    #[test]
     fn ignores_case_label_directives_after_same_line_body_commands() {
         let source = "\
 case $x in

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -766,6 +766,22 @@ echo $foo
     }
 
     #[test]
+    fn ignores_shellcheck_directives_after_keyword_suffixes_inside_words() {
+        let source = "\
+foo='a b'
+for item in to-do # shellcheck disable=SC2086
+do
+  echo $foo
+done
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 4));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 6));
+    }
+
+    #[test]
     fn ignores_case_label_directives_after_same_line_body_commands() {
         let source = "\
 case $x in

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -491,13 +491,17 @@ where
 #[cfg(test)]
 mod tests {
     use shuck_indexer::Indexer;
-    use shuck_parser::parser::Parser;
+    use shuck_parser::parser::{Parser, ShellDialect};
 
     use super::*;
     use crate::{ShellCheckCodeMap, parse_directives};
 
     fn suppression_index(source: &str) -> SuppressionIndex {
-        let output = Parser::new(source).parse().unwrap();
+        suppression_index_with_dialect(source, ShellDialect::Bash)
+    }
+
+    fn suppression_index_with_dialect(source: &str, dialect: ShellDialect) -> SuppressionIndex {
+        let output = Parser::with_dialect(source, dialect).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let directives = parse_directives(
             source,
@@ -752,6 +756,50 @@ echo $foo
 
         assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
         assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
+    fn scopes_shellcheck_disable_after_zsh_brace_if_headers() {
+        let source = "\
+foo='a b'
+if [[ -n $foo ]] { # shellcheck disable=SC2086
+  echo $foo
+} elif [[ -n $foo ]] { # shellcheck disable=SC2086
+  echo $foo
+} else { # shellcheck disable=SC2086
+  echo $foo
+}
+echo $foo
+";
+        let index = suppression_index_with_dialect(source, ShellDialect::Zsh);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 5));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 7));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 9));
+    }
+
+    #[test]
+    fn scopes_shellcheck_disable_after_zsh_brace_loop_headers() {
+        let source = "\
+foo='a b'
+for item in 1; { # shellcheck disable=SC2086
+  echo $foo
+}
+repeat 2 { # shellcheck disable=SC2086
+  echo $foo
+}
+foreach item (1 2) { # shellcheck disable=SC2086
+  echo $foo
+}
+echo $foo
+";
+        let index = suppression_index_with_dialect(source, ShellDialect::Zsh);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 6));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 9));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 11));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- tighten S031/ShellCheck inline-directive matching to use parsed command context instead of raw line suffixes alone
- keep valid header and group-opener sites working while rejecting keyword-like arguments such as `echo if # shellcheck disable=...`
- add regression coverage for directive parsing, suppression scoping, and the S031 rule surface

## Why
PR #273 merged before this review-driven follow-up commit landed. This patch addresses the remaining inline review finding so the S031 fix does not accept ordinary arguments as control-flow headers.

## Validation
- `cargo test -p shuck-linter suppression:: -- --nocapture`
- `cargo test -p shuck-linter trailing_directive -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S031`
