### PR TITLE
Fix C025 nested quoted substitution false positive

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -24906,6 +24906,32 @@ if [[ \"$@\" =~ x ]]; then :; fi
     }
 
     #[test]
+    fn positional_parameter_surface_facts_ignore_single_digit_suffixes_in_nested_substitutions() {
+        let source = r#"#!/bin/sh
+eval "$(printf '%s\n' x | "$2_rework")"
+eval "$(printf '%s\n' x | "$10_rework")"
+"#;
+
+        with_facts(source, None, |_, facts| {
+            let above_nine = facts
+                .positional_parameter_fragments()
+                .iter()
+                .filter(|fragment| fragment.is_above_nine())
+                .map(|fragment| fragment.span().slice(source))
+                .collect::<Vec<_>>();
+
+            assert_eq!(above_nine.len(), 1, "fragments: {above_nine:?}");
+            assert!(above_nine[0].contains("$10"), "fragments: {above_nine:?}");
+            assert!(
+                !above_nine
+                    .iter()
+                    .any(|fragment| fragment.contains("$2_rework")),
+                "fragments: {above_nine:?}"
+            );
+        });
+    }
+
+    #[test]
     fn builds_nested_legacy_arithmetic_fragments_from_surface_words() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -124,6 +124,18 @@ impl<'a> SurfaceFragmentSink<'a> {
         backslashes % 2 == 1
     }
 
+    fn looks_like_unbraced_positional_above_nine(&self, span: Span) -> bool {
+        let fragment = span.slice(self.source);
+        let fragment = fragment.strip_prefix('"').unwrap_or(fragment);
+        let mut chars = fragment.chars();
+
+        matches!(
+            (chars.next(), chars.next(), chars.next()),
+            (Some('$'), Some(digit), Some(next))
+                if matches!(digit, '1'..='9') && next.is_ascii_digit()
+        )
+    }
+
     fn record_array_reference(&mut self, span: Span) {
         if self
             .facts
@@ -350,6 +362,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 && text
                     .as_str(self.source, next_part.span)
                     .starts_with(|char: char| char.is_ascii_digit())
+                && self.looks_like_unbraced_positional_above_nine(part.span.merge(next_part.span))
             {
                 self.facts
                     .positional_parameters
@@ -591,6 +604,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 && text
                     .as_str(self.source, next_part.span)
                     .starts_with(|char: char| char.is_ascii_digit())
+                && self.looks_like_unbraced_positional_above_nine(part.span.merge(next_part.span))
             {
                 self.facts
                     .positional_parameters

--- a/crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
@@ -52,4 +52,30 @@ mod tests {
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
+
+    #[test]
+    fn ignores_single_digit_suffixes_in_nested_quoted_command_substitutions() {
+        let source = r#"#!/bin/sh
+eval "$(printf '%s\n' x | "$2_rework")"
+"#;
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::PositionalTenBraces));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_above_nine_suffixes_in_nested_quoted_command_substitutions() {
+        let source = r#"#!/bin/sh
+eval "$(printf '%s\n' x | "$10_rework")"
+"#;
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::PositionalTenBraces));
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert!(
+            diagnostics[0].span.slice(source).contains("$10"),
+            "diagnostics: {diagnostics:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- tighten C025 surface-fragment classification so only real unbraced `$10`-style spans are treated as positional parameters above nine
- avoid false positives in nested quoted command substitutions like `"$2_rework"`
- add focused fact-layer and rule-layer regressions for the nested quoted substitution cases

## Root cause
The C025 fact builder inferred an above-nine positional fragment from a single-digit positional parameter followed by a literal digit, but in nested quoted command substitutions the merged span could include wrapper text that did not actually represent raw `$10` syntax. That let `"$2_rework"` get misclassified as an above-nine positional parameter.

## Impact
This removes a real large-corpus false positive for C025 while preserving valid warnings for nested forms that do contain raw `$10`-style references.

## Validation
- `cargo test -p shuck-linter positional_ten_braces -- --nocapture`
- `cargo test -p shuck-linter positional_parameter_surface_facts_ignore_single_digit_suffixes_in_nested_substitutions -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C025`
