### PR TITLE
Fix X068 trap inheritance portability checks

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/portability/X068.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X068.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-set -eE
+set -T

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2373,9 +2373,11 @@ pub struct PsCommandFacts {
 pub struct SetCommandFacts {
     pub errexit_change: Option<bool>,
     pub errtrace_change: Option<bool>,
+    pub functrace_change: Option<bool>,
     pub pipefail_change: Option<bool>,
     resets_positional_parameters: bool,
-    errtrace_option_spans: Box<[Span]>,
+    errtrace_flag_spans: Box<[Span]>,
+    functrace_flag_spans: Box<[Span]>,
     pipefail_option_spans: Box<[Span]>,
     flags_without_prefix_spans: Box<[Span]>,
 }
@@ -2385,8 +2387,12 @@ impl SetCommandFacts {
         self.resets_positional_parameters
     }
 
-    pub fn errtrace_option_spans(&self) -> &[Span] {
-        &self.errtrace_option_spans
+    pub fn errtrace_flag_spans(&self) -> &[Span] {
+        &self.errtrace_flag_spans
+    }
+
+    pub fn functrace_flag_spans(&self) -> &[Span] {
+        &self.functrace_flag_spans
     }
 
     pub fn pipefail_option_spans(&self) -> &[Span] {
@@ -17780,9 +17786,11 @@ fn shell_short_flag_is_clusterable(flag: u8) -> bool {
 fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
     let mut errexit_change = None;
     let mut errtrace_change = None;
+    let mut functrace_change = None;
     let mut pipefail_change = None;
     let mut resets_positional_parameters = false;
-    let mut errtrace_option_spans = Vec::new();
+    let mut errtrace_flag_spans = Vec::new();
+    let mut functrace_flag_spans = Vec::new();
     let mut pipefail_option_spans = Vec::new();
     let mut flags_without_prefix_spans = Vec::new();
     let mut index = 0usize;
@@ -17827,7 +17835,8 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
                     errexit_change = Some(enable);
                 } else if name == "errtrace" {
                     errtrace_change = Some(enable);
-                    errtrace_option_spans.push(name_word.span);
+                } else if name == "functrace" {
+                    functrace_change = Some(enable);
                 } else if name == "pipefail" {
                     pipefail_change = Some(enable);
                     pipefail_option_spans.push(name_word.span);
@@ -17854,7 +17863,11 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
         }
         if flags.chars().any(|flag| flag == 'E') {
             errtrace_change = Some(text.starts_with('-'));
-            errtrace_option_spans.push(word.span);
+            errtrace_flag_spans.push(word.span);
+        }
+        if flags.chars().any(|flag| flag == 'T') {
+            functrace_change = Some(text.starts_with('-'));
+            functrace_flag_spans.push(word.span);
         }
 
         if flags.chars().any(|flag| flag == 'o') {
@@ -17868,7 +17881,8 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
 
             if name == "errtrace" {
                 errtrace_change = Some(enable);
-                errtrace_option_spans.push(name_word.span);
+            } else if name == "functrace" {
+                functrace_change = Some(enable);
             } else if name == "pipefail" {
                 pipefail_change = Some(enable);
                 pipefail_option_spans.push(name_word.span);
@@ -17883,9 +17897,11 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
     SetCommandFacts {
         errexit_change,
         errtrace_change,
+        functrace_change,
         pipefail_change,
         resets_positional_parameters,
-        errtrace_option_spans: errtrace_option_spans.into_boxed_slice(),
+        errtrace_flag_spans: errtrace_flag_spans.into_boxed_slice(),
+        functrace_flag_spans: functrace_flag_spans.into_boxed_slice(),
         pipefail_option_spans: pipefail_option_spans.into_boxed_slice(),
         flags_without_prefix_spans: flags_without_prefix_spans.into_boxed_slice(),
     }
@@ -20522,7 +20538,7 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
 
     #[test]
     fn summarizes_command_options_and_invokers() {
-        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\nsed 's/foo/bar/'\nsed -e 's/foo/bar/'\nsed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\1:'\nsed 's/[]\\[^$.*/]/\\\\&/g'\nsed 's/\\([/&]\\)/\\\\\\1/g'\nsed -n 's/foo/bar/p'\nsed --expression 's/foo/bar/'\nsed -r 's/foo/bar/'\nsed \\\"s/foo/bar/\\\"\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -type d -name CVS | xargs -iX rm -rf X\nfind . -type d -name CVS | xargs --replace rm -rf {}\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eEo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
+        let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\nsed 's/foo/bar/'\nsed -e 's/foo/bar/'\nsed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\1:'\nsed 's/[]\\[^$.*/]/\\\\&/g'\nsed 's/\\([/&]\\)/\\\\\\1/g'\nsed -n 's/foo/bar/p'\nsed --expression 's/foo/bar/'\nsed -r 's/foo/bar/'\nsed \\\"s/foo/bar/\\\"\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -type d -name CVS | xargs -iX rm -rf X\nfind . -type d -name CVS | xargs --replace rm -rf {}\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eETo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -20816,13 +20832,21 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
             .expect("expected set facts");
         assert_eq!(set.errexit_change, Some(true));
         assert_eq!(set.errtrace_change, Some(true));
+        assert_eq!(set.functrace_change, Some(true));
         assert_eq!(set.pipefail_change, Some(true));
         assert_eq!(
-            set.errtrace_option_spans()
+            set.errtrace_flag_spans()
                 .iter()
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-eEo"]
+            vec!["-eETo"]
+        );
+        assert_eq!(
+            set.functrace_flag_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-eETo"]
         );
         assert_eq!(
             set.pipefail_option_spans()

--- a/crates/shuck-linter/src/rules/portability/errexit_trap_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/errexit_trap_in_sh.rs
@@ -8,7 +8,7 @@ impl Violation for ErrexitTrapInSh {
     }
 
     fn message(&self) -> String {
-        "`set -E` is not portable in `sh` scripts".to_owned()
+        "`set` trap inheritance flags are not portable in `sh` scripts".to_owned()
     }
 }
 
@@ -22,20 +22,17 @@ pub fn errexit_trap_in_sh(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("set"))
-        .filter(|fact| {
-            fact.options()
-                .set()
-                .is_some_and(|set| set.errtrace_change.is_some())
-        })
         .flat_map(|fact| {
-            fact.options()
-                .set()
-                .into_iter()
-                .flat_map(|set| set.errtrace_option_spans().iter().copied())
+            fact.options().set().into_iter().flat_map(|set| {
+                set.errtrace_flag_spans()
+                    .iter()
+                    .chain(set.functrace_flag_spans().iter())
+                    .copied()
+            })
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || ErrexitTrapInSh);
+    checker.report_all(spans, || ErrexitTrapInSh);
 }
 
 #[cfg(test)]
@@ -44,22 +41,24 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_errtrace_options_in_sh() {
+    fn reports_nonportable_trap_inheritance_flags_in_sh() {
         let source = "\
 #!/bin/sh
 set -E
-set -eE
+set +T
+set -ET
 set -o errtrace
+set +o functrace
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ErrexitTrapInSh));
 
-        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics.len(), 4);
         assert_eq!(
             diagnostics
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-E", "-eE", "errtrace"]
+            vec!["-E", "+T", "-ET", "-ET"]
         );
     }
 
@@ -68,6 +67,7 @@ set -o errtrace
         let source = "\
 #!/bin/bash
 set -E
+set -T
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ErrexitTrapInSh));
 
@@ -78,8 +78,7 @@ set -E
     fn ignores_positional_operands_after_double_dash() {
         let source = "\
 #!/bin/sh
-set -E -- +E
-set -o errtrace -- errtrace
+set -E -T -- +E +T
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ErrexitTrapInSh));
 
@@ -89,7 +88,7 @@ set -o errtrace -- errtrace
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["-E", "errtrace"]
+            vec!["-E", "-T"]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X068_X068.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X068_X068.sh.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/shuck-linter/src/rules/portability/mod.rs
 ---
-X068 `set -E` is not portable in `sh` scripts
+X068 `set` trap inheritance flags are not portable in `sh` scripts
  --> <source>:2:5
   |
-2 | set -eE
+2 | set -T
   |

--- a/docs/rules/X068.yaml
+++ b/docs/rules/X068.yaml
@@ -6,8 +6,8 @@ runtime_kind: ast
 shellcheck_code: SC3041
 shells:
   - sh
-description: "The `-E` flag for `set` is used in POSIX sh."
-rationale: "Use trap on specific signals instead of `-E` for portability."
+description: "The script uses `set -E` or `set -T` in POSIX sh."
+rationale: "Avoid Bash-only trap inheritance flags in `sh`, or switch to a shell that supports them."
 source:
   shell_checks_rule: rules/SH-275.yaml
   shell_checks_example: examples/275.sh
@@ -18,3 +18,7 @@ examples:
       #!/bin/sh
       set -eE
       echo hello
+  - kind: invalid
+    code: |
+      #!/bin/sh
+      set -T


### PR DESCRIPTION
## Summary
- teach X068 to flag the nonportable short trap-inheritance flags `set -E/+E` and `set -T/+T` in `sh`
- keep `set -o errtrace` and `set -o functrace` out of X068 by tracking short-flag spans separately in the `set` command facts
- update the fixture, snapshot, and rule docs to cover `-T` and combined `-ET` behavior

## Root cause
- X068 only looked at errtrace spans and deduped reports, so `set -T` was missed and `set -ET` could not match the oracle's per-flag reporting
- the `set` command facts also mixed short trap flags with long `set -o` option names, which blurred the SC3041 vs SC3040 boundary

## Validation
- `cargo test -p shuck-linter errexit_trap_in_sh -- --nocapture`
- `cargo test -p shuck-linter summarizes_command_options_and_invokers -- --nocapture`
- `cargo test -p shuck-linter errexittrapinsh_path_new_x068 -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X068`