### PR TITLE
Implement S039 single-quoted backslash detection

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/style/S039.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S039.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 grep ^start'\s'end file.txt
-printf '%s' 'foo\nbar'
-printf '%s' 'foo\bar'
-printf '%s' 'foo\x41bar'
-printf '%s' 'foo\'
+printf '%s\n' '\n'foo
+printf '%s\n' 'ab\n'c
+printf '%s\n' '\\n'foo
+printf '%s\n' 'foo\nbar'
+printf '%s\n' '\x'41
+printf '%s\n' '\0'foo
+printf '%s\n' $'\n'foo
+printf '%s\n' a'\'bc

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -956,6 +956,7 @@ pub struct SingleQuotedFragmentFact {
     command_name: Option<Box<str>>,
     assignment_target: Option<Box<str>>,
     variable_set_operand: bool,
+    literal_backslash_in_single_quotes_span: Option<Span>,
 }
 
 impl SingleQuotedFragmentFact {
@@ -977,6 +978,10 @@ impl SingleQuotedFragmentFact {
 
     pub fn variable_set_operand(&self) -> bool {
         self.variable_set_operand
+    }
+
+    pub fn literal_backslash_in_single_quotes_span(&self) -> Option<Span> {
+        self.literal_backslash_in_single_quotes_span
     }
 }
 
@@ -24959,6 +24964,51 @@ if [[ \"$@\" =~ x ]]; then :; fi
                 .expect("expected pipeline tail");
             assert_eq!(tail.static_utility_name(), Some("kill"));
             assert!(tail.static_utility_name_is("kill"));
+        });
+    }
+
+    #[test]
+    fn surface_facts_mark_single_quoted_backslash_sequences_that_continue_into_literals() {
+        let source = "\
+#!/bin/sh
+grep ^start'\\s'end file.txt
+printf '%s\\n' '\\n'foo
+printf '%s\\n' 'ab\\n'c
+printf '%s\\n' '\\\\n'foo
+printf '%s\\n' 'foo\\nbar'
+printf '%s\\n' '\\x'41
+printf '%s\\n' '\\0'foo
+printf '%s\\n' '\\n'_
+printf '%s\\n' $'\\n'foo
+printf '%s\\n' a'\\'bc
+";
+
+        with_facts(source, None, |_, facts| {
+            let flagged = facts
+                .single_quoted_fragments()
+                .iter()
+                .filter_map(|fragment| {
+                    fragment
+                        .literal_backslash_in_single_quotes_span()
+                        .map(|span| {
+                            (
+                                fragment.span().slice(source),
+                                span.start.line,
+                                span.start.column,
+                            )
+                        })
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                flagged,
+                vec![
+                    ("'\\s'", 2, 15),
+                    ("'\\n'", 3, 18),
+                    ("'ab\\n'", 4, 20),
+                    ("'\\\\n'", 5, 19),
+                ]
+            );
         });
     }
 

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -351,6 +351,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                                             .map(str::to_owned)
                                             .map(String::into_boxed_str),
                                         variable_set_operand: context.variable_set_operand,
+                                        literal_backslash_in_single_quotes_span: None,
                                     });
                                 } else {
                                     open_quote = Some(quote_start);
@@ -406,6 +407,8 @@ impl<'a> SurfaceFragmentSink<'a> {
                             .map(str::to_owned)
                             .map(String::into_boxed_str),
                         variable_set_operand: context.variable_set_operand,
+                        literal_backslash_in_single_quotes_span:
+                            single_quoted_backslash_continuation_span(parts, index, self.source),
                     });
                 }
                 WordPart::DoubleQuoted { parts, dollar } => {
@@ -1088,6 +1091,51 @@ fn dollar_single_quoted_fragment_len(text: &str) -> Option<usize> {
     }
 
     None
+}
+
+fn single_quoted_backslash_continuation_span(
+    parts: &[WordPartNode],
+    index: usize,
+    source: &str,
+) -> Option<Span> {
+    let part = parts.get(index)?;
+    if !single_quoted_part_contains_backslash_letter(part, source) {
+        return None;
+    }
+
+    let next_part = parts.get(index + 1)?;
+    let WordPart::Literal(text) = &next_part.kind else {
+        return None;
+    };
+    if !text
+        .as_str(source, next_part.span)
+        .starts_with(|char: char| char.is_ascii_alphabetic())
+    {
+        return None;
+    }
+
+    let raw = part.span.slice(source);
+    let closing_quote = part.span.start.advanced_by(&raw[..raw.len() - 1]);
+    Some(Span::from_positions(closing_quote, closing_quote))
+}
+
+fn single_quoted_part_contains_backslash_letter(part: &WordPartNode, source: &str) -> bool {
+    let WordPart::SingleQuoted { dollar: false, .. } = part.kind else {
+        return false;
+    };
+    let Some(inner) = part
+        .span
+        .slice(source)
+        .strip_prefix('\'')
+        .and_then(|text| text.strip_suffix('\''))
+    else {
+        return false;
+    };
+
+    inner
+        .as_bytes()
+        .windows(2)
+        .any(|pair| pair[0] == b'\\' && pair[1].is_ascii_alphabetic())
 }
 
 fn double_quoted_fragment_len(text: &str) -> Option<usize> {

--- a/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
@@ -1,5 +1,3 @@
-use shuck_ast::Span;
-
 use crate::{Checker, Rule, Violation};
 
 pub struct LiteralBackslashInSingleQuotes;
@@ -15,38 +13,14 @@ impl Violation for LiteralBackslashInSingleQuotes {
 }
 
 pub fn literal_backslash_in_single_quotes(checker: &mut Checker) {
-    let source = checker.source();
     let spans = checker
         .facts()
         .single_quoted_fragments()
         .iter()
-        .filter(|fragment| !fragment.dollar_quoted())
-        .filter_map(|fragment| literal_backslash_in_single_quotes_span(fragment.span(), source))
+        .filter_map(|fragment| fragment.literal_backslash_in_single_quotes_span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || LiteralBackslashInSingleQuotes);
-}
-
-fn literal_backslash_in_single_quotes_span(span: Span, source: &str) -> Option<Span> {
-    let text = span.slice(source);
-    let inner = text.strip_prefix('\'')?.strip_suffix('\'')?;
-    if !contains_backslash_letter(inner) {
-        return None;
-    }
-
-    let next_byte = *source.as_bytes().get(span.end.offset)?;
-    if !next_byte.is_ascii_alphabetic() {
-        return None;
-    }
-
-    let closing_quote = span.start.advanced_by(&text[..text.len() - 1]);
-    Some(Span::from_positions(closing_quote, closing_quote))
-}
-
-fn contains_backslash_letter(text: &str) -> bool {
-    text.as_bytes()
-        .windows(2)
-        .any(|pair| pair[0] == b'\\' && pair[1].is_ascii_alphabetic())
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
@@ -1,3 +1,5 @@
+use shuck_ast::Span;
+
 use crate::{Checker, Rule, Violation};
 
 pub struct LiteralBackslashInSingleQuotes;
@@ -12,9 +14,39 @@ impl Violation for LiteralBackslashInSingleQuotes {
     }
 }
 
-pub fn literal_backslash_in_single_quotes(_checker: &mut Checker) {
-    // Current oracle runs do not expose a stable standalone SC2267 boundary in the
-    // compatibility corpus, so keep the legacy rule wired without active reports.
+pub fn literal_backslash_in_single_quotes(checker: &mut Checker) {
+    let source = checker.source();
+    let spans = checker
+        .facts()
+        .single_quoted_fragments()
+        .iter()
+        .filter(|fragment| !fragment.dollar_quoted())
+        .filter_map(|fragment| literal_backslash_in_single_quotes_span(fragment.span(), source))
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || LiteralBackslashInSingleQuotes);
+}
+
+fn literal_backslash_in_single_quotes_span(span: Span, source: &str) -> Option<Span> {
+    let text = span.slice(source);
+    let inner = text.strip_prefix('\'')?.strip_suffix('\'')?;
+    if !contains_backslash_letter(inner) {
+        return None;
+    }
+
+    let next_byte = *source.as_bytes().get(span.end.offset)?;
+    if !next_byte.is_ascii_alphabetic() {
+        return None;
+    }
+
+    let closing_quote = span.start.advanced_by(&text[..text.len() - 1]);
+    Some(Span::from_positions(closing_quote, closing_quote))
+}
+
+fn contains_backslash_letter(text: &str) -> bool {
+    text.as_bytes()
+        .windows(2)
+        .any(|pair| pair[0] == b'\\' && pair[1].is_ascii_alphabetic())
 }
 
 #[cfg(test)]
@@ -23,13 +55,38 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn currently_reports_no_distinct_diagnostics() {
+    fn reports_single_quoted_escape_sequences_that_run_into_more_literal_text() {
         let source = "\
 #!/bin/sh
 grep ^start'\\s'end file.txt
-printf '%s' 'foo\\nbar'
-printf '%s' 'foo\\bar'
-printf '%s' 'foo\\x41bar'
+printf '%s\\n' '\\n'foo
+printf '%s\\n' 'ab\\n'c
+printf '%s\\n' '\\\\n'foo
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralBackslashInSingleQuotes),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .collect::<Vec<_>>(),
+            vec![(2, 15), (3, 18), (4, 20), (5, 19)]
+        );
+    }
+
+    #[test]
+    fn ignores_standalone_digit_continued_and_dollar_quoted_fragments() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' 'foo\\nbar'
+printf '%s\\n' '\\x'41
+printf '%s\\n' '\\0'foo
+printf '%s\\n' '\\n'_
+printf '%s\\n' $'\\n'foo
+printf '%s\\n' a'\\'bc
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S039_S039.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S039_S039.sh.snap
@@ -1,5 +1,26 @@
 ---
 source: crates/shuck-linter/src/rules/style/mod.rs
-assertion_line: 50
 ---
+S039 a backslash inside single quotes stays literal
+ --> <source>:3:15
+  |
+3 | grep ^start'\s'end file.txt
+  |
 
+S039 a backslash inside single quotes stays literal
+ --> <source>:4:18
+  |
+4 | printf '%s\n' '\n'foo
+  |
+
+S039 a backslash inside single quotes stays literal
+ --> <source>:5:20
+  |
+5 | printf '%s\n' 'ab\n'c
+  |
+
+S039 a backslash inside single quotes stays literal
+ --> <source>:6:19
+  |
+6 | printf '%s\n' '\\n'foo
+  |


### PR DESCRIPTION
## Summary
- implement S039 for non-dollar single-quoted fragments that contain backslash-letter sequences and continue into more literal alphabetic text
- add focused unit coverage for report and no-report boundaries
- refresh the S039 fixture and snapshot to match the oracle boundary

## Testing
- cargo test -p shuck-linter literal_backslash_in_single_quotes
- INSTA_UPDATE=always cargo test -p shuck-linter literalbackslashinsinglequotes
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S039