### PR TITLE
Fix C136 false positives on associative-array arithmetic keys

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
+++ b/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
@@ -123,4 +123,19 @@ local a=1 a=2 c=$a
             source.find("a=2").unwrap()
         );
     }
+
+    #[test]
+    fn ignores_associative_array_keys_inside_arithmetic_subscripts() {
+        let source = "\
+#!/bin/bash
+f() {
+  declare -A box=([m_width]=1 [mem_col]=5)
+  local m_width=1 mem_line=$((box[mem_col]+box[m_width]))
+}
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::LocalCrossReference));
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
+++ b/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
@@ -138,4 +138,20 @@ f() {
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_associative_array_keys_after_arithmetic_writes() {
+        let source = "\
+#!/bin/bash
+f() {
+  declare -A box=([key]=1)
+  (( box[seed] = 1 ))
+  local key=1 value=$((box[key]))
+}
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::LocalCrossReference));
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2111,13 +2111,36 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         owner_name: &Name,
         offset: usize,
     ) -> bool {
-        self.resolve_reference(owner_name, self.current_scope(), offset)
+        self.visible_binding_is_assoc(owner_name, offset)
+    }
+
+    fn visible_binding_is_assoc(&self, name: &Name, offset: usize) -> bool {
+        self.resolve_reference(name, self.current_scope(), offset)
             .map(|binding_id| {
                 self.bindings[binding_id.index()]
                     .attributes
                     .contains(BindingAttributes::ASSOC)
             })
             .unwrap_or(false)
+    }
+
+    fn arithmetic_binding_attributes(
+        &self,
+        target: &ArithmeticLvalue,
+        target_offset: usize,
+    ) -> BindingAttributes {
+        let mut attributes = match target {
+            ArithmeticLvalue::Variable(_) => BindingAttributes::empty(),
+            ArithmeticLvalue::Indexed { .. } => BindingAttributes::ARRAY,
+        };
+
+        if let ArithmeticLvalue::Indexed { name, .. } = target
+            && self.visible_binding_is_assoc(name, target_offset)
+        {
+            attributes |= BindingAttributes::ASSOC;
+        }
+
+        attributes
     }
 
     fn visit_associative_arithmetic_key_into(
@@ -2209,7 +2232,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     BindingOrigin::ArithmeticAssignment {
                         definition_span: span,
                     },
-                    BindingAttributes::ARRAY,
+                    self.arithmetic_binding_attributes(
+                        &ArithmeticLvalue::Indexed {
+                            name: name.clone(),
+                            index: index.clone(),
+                        },
+                        span.start.offset,
+                    ),
                 );
             }
             _ => {}
@@ -2226,9 +2255,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
         self.visit_arithmetic_lvalue_indices_into(target, flow, nested_regions);
-        let (name, attributes) = match target {
-            ArithmeticLvalue::Variable(name) => (name, BindingAttributes::empty()),
-            ArithmeticLvalue::Indexed { name, .. } => (name, BindingAttributes::ARRAY),
+        let attributes = self.arithmetic_binding_attributes(target, target_span.start.offset);
+        let name = match target {
+            ArithmeticLvalue::Variable(name) | ArithmeticLvalue::Indexed { name, .. } => name,
         };
         let name_span = arithmetic_name_span(target_span, name);
         if !matches!(op, ArithmeticAssignOp::Assign) {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2042,7 +2042,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     ReferenceKind::ArithmeticRead,
                     arithmetic_name_span(expr.span, name),
                 );
-                self.visit_arithmetic_expr_into(index, flow, nested_regions);
+                self.visit_arithmetic_index_into(name, index, flow, nested_regions);
             }
             ArithmeticExpr::ShellWord(word) => {
                 self.visit_word_into(word, WordVisitKind::Expansion, flow, nested_regions);
@@ -2089,6 +2089,94 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_arithmetic_index_into(
+        &mut self,
+        owner_name: &Name,
+        index: &ArithmeticExprNode,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        if self
+            .arithmetic_index_uses_associative_word_semantics(owner_name, index.span.start.offset)
+        {
+            self.visit_associative_arithmetic_key_into(index, flow, nested_regions);
+            return;
+        }
+
+        self.visit_arithmetic_expr_into(index, flow, nested_regions);
+    }
+
+    fn arithmetic_index_uses_associative_word_semantics(
+        &self,
+        owner_name: &Name,
+        offset: usize,
+    ) -> bool {
+        self.resolve_reference(owner_name, self.current_scope(), offset)
+            .map(|binding_id| {
+                self.bindings[binding_id.index()]
+                    .attributes
+                    .contains(BindingAttributes::ASSOC)
+            })
+            .unwrap_or(false)
+    }
+
+    fn visit_associative_arithmetic_key_into(
+        &mut self,
+        expr: &ArithmeticExprNode,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match &expr.kind {
+            ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
+            ArithmeticExpr::Indexed { index, .. } => {
+                self.visit_associative_arithmetic_key_into(index, flow, nested_regions);
+            }
+            ArithmeticExpr::ShellWord(word) => {
+                self.visit_word_into(word, WordVisitKind::Expansion, flow, nested_regions);
+            }
+            ArithmeticExpr::Parenthesized { expression } => {
+                self.visit_associative_arithmetic_key_into(expression, flow, nested_regions);
+            }
+            ArithmeticExpr::Unary { expr: inner, .. } => {
+                self.visit_associative_arithmetic_key_into(inner, flow, nested_regions);
+            }
+            ArithmeticExpr::Postfix { expr: inner, .. } => {
+                self.visit_associative_arithmetic_key_into(inner, flow, nested_regions);
+            }
+            ArithmeticExpr::Binary { left, right, .. } => {
+                self.visit_associative_arithmetic_key_into(left, flow, nested_regions);
+                self.visit_associative_arithmetic_key_into(right, flow, nested_regions);
+            }
+            ArithmeticExpr::Conditional {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.visit_associative_arithmetic_key_into(condition, flow, nested_regions);
+                self.visit_associative_arithmetic_key_into(then_expr, flow, nested_regions);
+                self.visit_associative_arithmetic_key_into(else_expr, flow, nested_regions);
+            }
+            ArithmeticExpr::Assignment { target, value, .. } => {
+                self.visit_associative_arithmetic_lvalue_into(target, flow, nested_regions);
+                self.visit_associative_arithmetic_key_into(value, flow, nested_regions);
+            }
+        }
+    }
+
+    fn visit_associative_arithmetic_lvalue_into(
+        &mut self,
+        target: &ArithmeticLvalue,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match target {
+            ArithmeticLvalue::Variable(_) => {}
+            ArithmeticLvalue::Indexed { index, .. } => {
+                self.visit_associative_arithmetic_key_into(index, flow, nested_regions);
+            }
+        }
+    }
+
     fn visit_arithmetic_update_into(
         &mut self,
         expr: &ArithmeticExprNode,
@@ -2110,7 +2198,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 );
             }
             ArithmeticExpr::Indexed { name, index } => {
-                self.visit_arithmetic_expr_into(index, flow, nested_regions);
+                self.visit_arithmetic_index_into(name, index, flow, nested_regions);
                 let span = arithmetic_name_span(expr.span, name);
                 self.add_reference(name, ReferenceKind::ArithmeticRead, span);
                 self.add_binding(
@@ -2167,8 +2255,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     ) {
         match target {
             ArithmeticLvalue::Variable(_) => {}
-            ArithmeticLvalue::Indexed { index, .. } => {
-                self.visit_arithmetic_expr_into(index, flow, nested_regions);
+            ArithmeticLvalue::Indexed { name, index } => {
+                self.visit_arithmetic_index_into(name, index, flow, nested_regions);
             }
         }
     }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5759,6 +5759,40 @@ printf '%s\\n' \"$((box[m_width]))\" \"$((box[$dynamic_key]))\"
     }
 
     #[test]
+    fn arithmetic_indexed_writes_preserve_associative_attributes() {
+        let source = "\
+#!/bin/bash
+declare -A box
+(( box[key] = 1 ))
+printf '%s\\n' \"$((box[m_width]))\" \"$((box[$dynamic_key]))\"
+";
+        let model = model(source);
+        let unresolved = unresolved_names(&model);
+
+        assert_names_absent(&["key", "m_width"], &unresolved);
+        assert_names_present(&["dynamic_key"], &unresolved);
+
+        let arithmetic_binding = model
+            .bindings()
+            .iter()
+            .rev()
+            .find(|binding| {
+                binding.name == "box" && binding.kind == BindingKind::ArithmeticAssignment
+            })
+            .expect("expected arithmetic box binding");
+        assert!(
+            arithmetic_binding
+                .attributes
+                .contains(BindingAttributes::ARRAY)
+        );
+        assert!(
+            arithmetic_binding
+                .attributes
+                .contains(BindingAttributes::ASSOC)
+        );
+    }
+
+    #[test]
     fn escaped_parameter_replacement_patterns_do_not_register_variable_reads() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5745,6 +5745,20 @@ printf '%s\\n' \"${map[swift-cmark]}\" \"${map[$dynamic_key]}\"
     }
 
     #[test]
+    fn associative_arithmetic_subscript_literals_do_not_register_variable_reads() {
+        let source = "\
+#!/bin/bash
+declare -A box
+printf '%s\\n' \"$((box[m_width]))\" \"$((box[$dynamic_key]))\"
+";
+        let model = model(source);
+        let unresolved = unresolved_names(&model);
+
+        assert_names_absent(&["m_width"], &unresolved);
+        assert_names_present(&["dynamic_key"], &unresolved);
+    }
+
+    #[test]
     fn escaped_parameter_replacement_patterns_do_not_register_variable_reads() {
         let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- fix semantic arithmetic-index traversal so associative-array keys like `box[m_width]` are treated as literal keys instead of variable reads when the owner binding is associative
- keep walking dynamic associative keys and nested expansions so real reads still show up in semantic analysis
- add semantic and linter regressions covering the arithmetic associative-subscript case that was tripping `C136`

## Root Cause
`C136` was reporting a false positive because semantic arithmetic handling treated bare associative-array keys inside arithmetic subscripts as variable reads. In code like `mem_line=$((box[mem_col]+box[m_width]))`, that made `m_width` look reused later in the same `local` declaration even though it was only an associative-array key.

## Validation
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter local_cross_reference -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C136`