### PR TITLE
Fix false positive C035 on line-continued heredoc pipelines

### DIFF
--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -902,6 +902,48 @@ mod tests {
     }
 
     #[test]
+    fn does_not_map_line_continued_heredoc_pipeline_to_c035() {
+        let source = "\
+#!/bin/sh
+if [ ! -f ${sslcert} ] ; then
+cat << EOF | openssl req -new -key ${sslkey} \\
+         -x509 -days 365 -set_serial $RANDOM \\
+         -out ${sslcert} 2>/dev/null
+--
+SomeState
+SomeCity
+SomeOrganization
+SomeOrganizationalUnit
+${FQDN}
+root@${FQDN}
+EOF
+fi
+";
+        let recovered = Parser::new(source).parse();
+        let settings = LinterSettings::for_rule(Rule::MissingFi);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            Some(&recovered),
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics: {diagnostics:?}"
+        );
+        assert!(
+            !recovered
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.starts_with("expected 'fi'")),
+            "unexpected parse diagnostics: {:?}",
+            recovered.diagnostics
+        );
+    }
+
+    #[test]
     fn maps_function_parameter_parse_error_to_x035() {
         let source = "#!/bin/sh\nfunction g(y) { :; }\n";
         let recovered = Parser::new(source).parse();

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3688,15 +3688,37 @@ impl<'a> Lexer<'a> {
         let rest_of_line_start = self.current_position();
         let mut in_double_quote = false;
         let mut in_single_quote = false;
+        let mut in_comment = false;
         let mut saw_non_whitespace_tail = false;
         let mut consecutive_backslashes = 0usize;
+        let mut previous_tail_char = None;
         while let Some(ch) = self.peek_char() {
             self.advance();
+            if in_comment {
+                if ch == '\n' {
+                    break;
+                }
+                rest_of_line.push(ch);
+                previous_tail_char = Some(ch);
+                continue;
+            }
+            if ch == '#'
+                && !in_single_quote
+                && !in_double_quote
+                && self.comments_enabled()
+                && heredoc_tail_hash_starts_comment(previous_tail_char)
+            {
+                in_comment = true;
+                rest_of_line.push(ch);
+                previous_tail_char = Some(ch);
+                consecutive_backslashes = 0;
+                continue;
+            }
             let backslash_continues_line = ch == '\\'
                 && !in_single_quote
                 && self.peek_char() == Some('\n')
                 && saw_non_whitespace_tail
-                && consecutive_backslashes % 2 == 0;
+                && consecutive_backslashes.is_multiple_of(2);
             if backslash_continues_line {
                 rest_of_line.push(ch);
                 rest_of_line.push('\n');
@@ -3729,6 +3751,7 @@ impl<'a> Lexer<'a> {
             } else {
                 consecutive_backslashes = 0;
             }
+            previous_tail_char = Some(ch);
         }
 
         // If we just drained a heredoc replay buffer (for example when multiple
@@ -3848,6 +3871,11 @@ fn heredoc_line_matches_delimiter(line: &str, delimiter: &str, strip_tabs: bool)
     };
 
     trailing.chars().all(|ch| matches!(ch, ' ' | '\t'))
+}
+
+fn heredoc_tail_hash_starts_comment(previous_tail_char: Option<char>) -> bool {
+    previous_tail_char
+        .is_none_or(|prev| prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>'))
 }
 
 fn next_char_boundary(input: &str, index: usize) -> Option<(char, usize)> {
@@ -5548,6 +5576,19 @@ EOF
     #[test]
     fn test_read_heredoc_escaped_backslash_before_newline_does_not_continue_tail() {
         let source = "cat <<EOF foo\\\\\nbody\nEOF\n";
+        let mut lexer = Lexer::new(source);
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("cat"));
+        assert_next_token(&mut lexer, TokenKind::HereDoc, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("EOF"));
+
+        let heredoc = lexer.read_heredoc("EOF", false);
+        assert_eq!(heredoc.content, "body\n");
+    }
+
+    #[test]
+    fn test_read_heredoc_comment_backslash_does_not_continue_tail() {
+        let source = "cat <<EOF # note \\\nbody\nEOF\n";
         let mut lexer = Lexer::new(source);
 
         assert_next_token(&mut lexer, TokenKind::Word, Some("cat"));

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3688,12 +3688,20 @@ impl<'a> Lexer<'a> {
         let rest_of_line_start = self.current_position();
         let mut in_double_quote = false;
         let mut in_single_quote = false;
+        let mut saw_non_whitespace_tail = false;
+        let mut consecutive_backslashes = 0usize;
         while let Some(ch) = self.peek_char() {
             self.advance();
-            if ch == '\\' && !in_single_quote && self.peek_char() == Some('\n') {
+            let backslash_continues_line = ch == '\\'
+                && !in_single_quote
+                && self.peek_char() == Some('\n')
+                && saw_non_whitespace_tail
+                && consecutive_backslashes % 2 == 0;
+            if backslash_continues_line {
                 rest_of_line.push(ch);
                 rest_of_line.push('\n');
                 self.advance();
+                consecutive_backslashes = 0;
                 continue;
             }
             if ch == '\n' && !in_double_quote && !in_single_quote {
@@ -3713,6 +3721,14 @@ impl<'a> Lexer<'a> {
                 continue;
             }
             rest_of_line.push(ch);
+            if !ch.is_whitespace() {
+                saw_non_whitespace_tail = true;
+            }
+            if ch == '\\' && !in_single_quote {
+                consecutive_backslashes += 1;
+            } else {
+                consecutive_backslashes = 0;
+            }
         }
 
         // If we just drained a heredoc replay buffer (for example when multiple
@@ -5514,6 +5530,32 @@ EOF
         assert_next_token(&mut lexer, TokenKind::Word, Some("sort"));
         assert_next_token(&mut lexer, TokenKind::RedirectOut, None);
         assert_next_token(&mut lexer, TokenKind::Word, Some("out.txt"));
+    }
+
+    #[test]
+    fn test_read_heredoc_does_not_continue_body_when_backslash_is_immediately_after_delimiter() {
+        let source = "cat <<EOF \\\n1\n2\n3\nEOF\n| tac\n";
+        let mut lexer = Lexer::new(source);
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("cat"));
+        assert_next_token(&mut lexer, TokenKind::HereDoc, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("EOF"));
+
+        let heredoc = lexer.read_heredoc("EOF", false);
+        assert_eq!(heredoc.content, "1\n2\n3\n");
+    }
+
+    #[test]
+    fn test_read_heredoc_escaped_backslash_before_newline_does_not_continue_tail() {
+        let source = "cat <<EOF foo\\\\\nbody\nEOF\n";
+        let mut lexer = Lexer::new(source);
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("cat"));
+        assert_next_token(&mut lexer, TokenKind::HereDoc, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("EOF"));
+
+        let heredoc = lexer.read_heredoc("EOF", false);
+        assert_eq!(heredoc.content, "body\n");
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3690,6 +3690,12 @@ impl<'a> Lexer<'a> {
         let mut in_single_quote = false;
         while let Some(ch) = self.peek_char() {
             self.advance();
+            if ch == '\\' && !in_single_quote && self.peek_char() == Some('\n') {
+                rest_of_line.push(ch);
+                rest_of_line.push('\n');
+                self.advance();
+                continue;
+            }
             if ch == '\n' && !in_double_quote && !in_single_quote {
                 break;
             }
@@ -5487,6 +5493,27 @@ EOF
         // The redirect tokens are now available from the lexer
         assert_next_token(&mut lexer, TokenKind::RedirectOut, None);
         assert_next_token(&mut lexer, TokenKind::Word, Some("file.txt"));
+    }
+
+    #[test]
+    fn test_read_heredoc_reinjects_line_continued_pipeline_tail() {
+        let source = "cat <<EOF | grep hello \\\n  | sort \\\n  > out.txt\nhello\nEOF\n";
+        let mut lexer = Lexer::new(source);
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("cat"));
+        assert_next_token(&mut lexer, TokenKind::HereDoc, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("EOF"));
+
+        let heredoc = lexer.read_heredoc("EOF", false);
+        assert_eq!(heredoc.content, "hello\n");
+
+        assert_next_token(&mut lexer, TokenKind::Pipe, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("grep"));
+        assert_next_token(&mut lexer, TokenKind::Word, Some("hello"));
+        assert_next_token(&mut lexer, TokenKind::Pipe, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("sort"));
+        assert_next_token(&mut lexer, TokenKind::RedirectOut, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("out.txt"));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3894,8 +3894,9 @@ fn heredoc_line_matches_delimiter(line: &str, delimiter: &str, strip_tabs: bool)
 }
 
 fn heredoc_tail_hash_starts_comment(previous_tail_char: Option<char>) -> bool {
-    previous_tail_char
-        .is_none_or(|prev| prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>'))
+    previous_tail_char.is_none_or(|prev| {
+        prev.is_whitespace() || matches!(prev, ';' | '|' | '&' | '<' | '>' | ')')
+    })
 }
 
 fn next_char_boundary(input: &str, index: usize) -> Option<(char, usize)> {
@@ -5617,6 +5618,22 @@ EOF
 
         let heredoc = lexer.read_heredoc("EOF", false);
         assert_eq!(heredoc.content, "body\n");
+    }
+
+    #[test]
+    fn test_read_heredoc_right_paren_comment_backslash_does_not_continue_tail() {
+        let source = "( cat <<EOF )# note \\\nbody\nEOF\n";
+        let mut lexer = Lexer::new(source);
+
+        assert_next_token(&mut lexer, TokenKind::LeftParen, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("cat"));
+        assert_next_token(&mut lexer, TokenKind::HereDoc, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("EOF"));
+
+        let heredoc = lexer.read_heredoc("EOF", false);
+        assert_eq!(heredoc.content, "body\n");
+
+        assert_next_token(&mut lexer, TokenKind::RightParen, None);
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3717,7 +3717,7 @@ impl<'a> Lexer<'a> {
             let backslash_continues_line = ch == '\\'
                 && !in_single_quote
                 && self.peek_char() == Some('\n')
-                && saw_non_whitespace_tail
+                && (saw_non_whitespace_tail || self.heredoc_tail_line_join_stays_in_tail())
                 && consecutive_backslashes.is_multiple_of(2);
             if backslash_continues_line {
                 rest_of_line.push(ch);
@@ -3852,6 +3852,26 @@ impl<'a> Lexer<'a> {
             content,
             content_span: Span::from_positions(content_start, content_end),
         }
+    }
+
+    fn heredoc_tail_line_join_stays_in_tail(&mut self) -> bool {
+        let mut chars = self.cursor.rest().chars();
+        if chars.next() != Some('\n') {
+            return false;
+        }
+
+        for ch in chars {
+            if matches!(ch, ' ' | '\t') {
+                continue;
+            }
+            if ch == '\n' {
+                return false;
+            }
+            return matches!(ch, '|' | '&' | ';' | '<' | '>')
+                || (ch == '#' && self.comments_enabled());
+        }
+
+        false
     }
 }
 
@@ -5597,6 +5617,22 @@ EOF
 
         let heredoc = lexer.read_heredoc("EOF", false);
         assert_eq!(heredoc.content, "body\n");
+    }
+
+    #[test]
+    fn test_read_heredoc_blank_prefix_continues_into_operator_led_tail() {
+        let source = "cat <<EOF \\\n| tac\n1\nEOF\n";
+        let mut lexer = Lexer::new(source);
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("cat"));
+        assert_next_token(&mut lexer, TokenKind::HereDoc, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("EOF"));
+
+        let heredoc = lexer.read_heredoc("EOF", false);
+        assert_eq!(heredoc.content, "1\n");
+
+        assert_next_token(&mut lexer, TokenKind::Pipe, None);
+        assert_next_token(&mut lexer, TokenKind::Word, Some("tac"));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -24,6 +24,12 @@ fn test_prefix_heredoc_before_command_in_pipeline_parses() {
 }
 
 #[test]
+fn test_heredoc_with_bare_line_continuation_after_delimiter_still_parses() {
+    let input = "cat <<EOF \\\n1\n2\n3\nEOF\n| tac\n";
+    assert!(Parser::new(input).parse().is_ok());
+}
+
+#[test]
 fn test_function_definition_absorbs_trailing_heredoc_redirect() {
     let input = "f() { cat; } <<EOF\nhello\nEOF\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -36,6 +36,12 @@ fn test_heredoc_comment_backslash_after_delimiter_still_parses() {
 }
 
 #[test]
+fn test_heredoc_blank_prefix_line_continuation_into_pipe_tail_still_parses() {
+    let input = "cat <<EOF \\\n| tac\n1\nEOF\n";
+    assert!(Parser::new(input).parse().is_ok());
+}
+
+#[test]
 fn test_function_definition_absorbs_trailing_heredoc_redirect() {
     let input = "f() { cat; } <<EOF\nhello\nEOF\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -36,6 +36,12 @@ fn test_heredoc_comment_backslash_after_delimiter_still_parses() {
 }
 
 #[test]
+fn test_heredoc_right_paren_comment_backslash_after_delimiter_still_parses() {
+    let input = "( cat <<EOF )# note \\\nbody\nEOF\n";
+    assert!(Parser::new(input).parse().is_ok());
+}
+
+#[test]
 fn test_heredoc_blank_prefix_line_continuation_into_pipe_tail_still_parses() {
     let input = "cat <<EOF \\\n| tac\n1\nEOF\n";
     assert!(Parser::new(input).parse().is_ok());

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -30,6 +30,12 @@ fn test_heredoc_with_bare_line_continuation_after_delimiter_still_parses() {
 }
 
 #[test]
+fn test_heredoc_comment_backslash_after_delimiter_still_parses() {
+    let input = "cat <<EOF # note \\\nbody\nEOF\n";
+    assert!(Parser::new(input).parse().is_ok());
+}
+
+#[test]
 fn test_function_definition_absorbs_trailing_heredoc_redirect() {
     let input = "f() { cat; } <<EOF\nhello\nEOF\n";
     let script = Parser::new(input).parse().unwrap().file;


### PR DESCRIPTION
## Summary
- preserve backslash-continued heredoc command tails during lexer replay
- add parser coverage for continued pipeline tails after a heredoc
- add a C035 regression to ensure valid `if ... fi` blocks are not misreported

## Root cause
`read_heredoc` only captured the first physical line after the heredoc delimiter token. For a heredoc piped into a backslash-continued command, the replay buffer dropped the continued tail, which left the parser in the wrong state and surfaced a false `expected 'fi'` parse diagnostic.

## Impact
This removes a false-positive `C035`/`SC1047` report for valid scripts that use line-continued pipelines or redirects after a heredoc inside an `if` body.

## Validation
- `cargo test -p shuck-parser test_read_heredoc_reinjects_line_continued_pipeline_tail`
- `cargo test -p shuck-linter does_not_map_line_continued_heredoc_pipeline_to_c035`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C035`
