### PR TITLE
Add X065 reviewed divergence metadata

### DIFF
--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -3934,6 +3934,98 @@ mod tests {
     }
 
     #[test]
+    fn reviewed_divergence_classification_requires_path_line_and_label_constraints() {
+        let metadata = HashMap::from([(
+            "X065".to_string(),
+            RuleCorpusMetadataDocument {
+                reviewed_divergences: vec![ReviewedDivergenceRecord {
+                    side: CompatibilitySide::ShuckOnly,
+                    path_suffix: Some("alpinelinux__aports__scripts__mkimage.sh".into()),
+                    path_contains: None,
+                    line: Some(120),
+                    end_line: Some(120),
+                    column: None,
+                    end_column: None,
+                    labels: vec!["project-closure".into()],
+                    reason: "scoped reviewed divergence".into(),
+                }],
+            },
+        )]);
+        let matching = CompatibilityRecord {
+            side: CompatibilitySide::ShuckOnly,
+            rule_code: Some("X065".into()),
+            rule_codes: Vec::new(),
+            shellcheck_code: "SC3026".into(),
+            range: DiagnosticRange {
+                line: 120,
+                end_line: 120,
+                column: 22,
+                end_column: 34,
+            },
+            message: "caret negation in bracket expressions is not portable to POSIX sh".into(),
+            labels: vec!["project-closure".into()],
+        };
+        let wrong_path = CompatibilityRecord {
+            ..matching.clone()
+        };
+        let wrong_line = CompatibilityRecord {
+            range: DiagnosticRange {
+                line: 121,
+                end_line: 121,
+                column: 22,
+                end_column: 34,
+            },
+            ..matching.clone()
+        };
+        let missing_label = CompatibilityRecord {
+            labels: Vec::new(),
+            ..matching.clone()
+        };
+
+        let (matching_classification, matching_reason) = classify_compatibility_record(
+            &matching,
+            "alpinelinux__aports__scripts__mkimage.sh",
+            &metadata,
+        );
+        let (wrong_path_classification, wrong_path_reason) = classify_compatibility_record(
+            &wrong_path,
+            "other__repo__script.sh",
+            &metadata,
+        );
+        let (wrong_line_classification, wrong_line_reason) = classify_compatibility_record(
+            &wrong_line,
+            "alpinelinux__aports__scripts__mkimage.sh",
+            &metadata,
+        );
+        let (missing_label_classification, missing_label_reason) = classify_compatibility_record(
+            &missing_label,
+            "alpinelinux__aports__scripts__mkimage.sh",
+            &metadata,
+        );
+
+        assert_eq!(
+            matching_classification,
+            CompatibilityClassification::ReviewedDivergence
+        );
+        assert_eq!(matching_reason.as_deref(), Some("scoped reviewed divergence"));
+        assert_eq!(
+            wrong_path_classification,
+            CompatibilityClassification::Implementation
+        );
+        assert!(wrong_path_reason.is_none());
+        assert_eq!(
+            wrong_line_classification,
+            CompatibilityClassification::Implementation
+        );
+        assert!(wrong_line_reason.is_none());
+        assert_eq!(
+            missing_label_classification,
+            CompatibilityClassification::Implementation
+        );
+        assert!(missing_label_reason.is_none());
+    }
+
+    #[test]
     fn reviewed_divergence_classification_matches_path_contains_record() {
         let metadata = HashMap::from([(
             "C999".to_string(),

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -3965,9 +3965,7 @@ mod tests {
             message: "caret negation in bracket expressions is not portable to POSIX sh".into(),
             labels: vec!["project-closure".into()],
         };
-        let wrong_path = CompatibilityRecord {
-            ..matching.clone()
-        };
+        let wrong_path = CompatibilityRecord { ..matching.clone() };
         let wrong_line = CompatibilityRecord {
             range: DiagnosticRange {
                 line: 121,
@@ -3987,11 +3985,8 @@ mod tests {
             "alpinelinux__aports__scripts__mkimage.sh",
             &metadata,
         );
-        let (wrong_path_classification, wrong_path_reason) = classify_compatibility_record(
-            &wrong_path,
-            "other__repo__script.sh",
-            &metadata,
-        );
+        let (wrong_path_classification, wrong_path_reason) =
+            classify_compatibility_record(&wrong_path, "other__repo__script.sh", &metadata);
         let (wrong_line_classification, wrong_line_reason) = classify_compatibility_record(
             &wrong_line,
             "alpinelinux__aports__scripts__mkimage.sh",
@@ -4007,7 +4002,10 @@ mod tests {
             matching_classification,
             CompatibilityClassification::ReviewedDivergence
         );
-        assert_eq!(matching_reason.as_deref(), Some("scoped reviewed divergence"));
+        assert_eq!(
+            matching_reason.as_deref(),
+            Some("scoped reviewed divergence")
+        );
         assert_eq!(
             wrong_path_classification,
             CompatibilityClassification::Implementation

--- a/crates/shuck/tests/testdata/corpus-metadata/x065.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x065.yaml
@@ -1,0 +1,3 @@
+reviewed_divergences:
+  - side: shuck-only
+    reason: "Shuck intentionally keeps X065 hits inside POSIX parameter-trimming and replacement patterns. The current oracle does not surface SC3026 for those parameter-pattern contexts and, for replacement operators, only emits the broader SC3060 portability warning."

--- a/crates/shuck/tests/testdata/corpus-metadata/x065.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x065.yaml
@@ -1,3 +1,8 @@
 reviewed_divergences:
   - side: shuck-only
-    reason: "Shuck intentionally keeps X065 hits inside POSIX parameter-trimming and replacement patterns. The current oracle does not surface SC3026 for those parameter-pattern contexts and, for replacement operators, only emits the broader SC3060 portability warning."
+    path_suffix: "alpinelinux__aports__scripts__mkimage.sh"
+    line: 120
+    end_line: 120
+    labels:
+      - project-closure
+    reason: "This mkimage helper uses `[^a-zA-Z0-9]` inside a POSIX parameter-replacement pattern. Shuck intentionally keeps X065 active in that parameter-pattern context, while the current oracle only reports the broader SC3060 portability warning there and does not emit SC3026."


### PR DESCRIPTION
## Summary
- add reviewed divergence metadata for X065 in the large-corpus fixtures
- classify the remaining parameter-pattern `[^...]` mismatch as an intentional shuck-only divergence

## Why
The targeted X065 corpus run had one remaining blocking diff in Alpine's `mkimage.sh`.
Investigation showed the current ShellCheck build still reports `SC3026` for plain globs and `case` patterns, but not for `[^...]` inside POSIX parameter-trimming and replacement operators. Shuck intentionally keeps warning in those contexts, so this change records that policy/oracle mismatch instead of narrowing the rule.

## Validation
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X065`
