### PR TITLE
Cap large corpus workers to available threads

### DIFF
--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -1086,7 +1086,6 @@ fn large_corpus_worker_count(fixtures_len: usize) -> usize {
 
 fn clamp_large_corpus_worker_count(available_parallelism: usize, fixtures_len: usize) -> usize {
     available_parallelism
-        .max(1)
         .min(LARGE_CORPUS_MAX_WORKER_COUNT)
         .min(fixtures_len)
 }

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -40,7 +40,7 @@ const LARGE_CORPUS_AUTOSCALED_SHUCK_TIMEOUT_BUFFER: Duration = Duration::from_se
 const LARGE_CORPUS_MAX_AUTOSCALED_SHUCK_TIMEOUT: Duration = Duration::from_secs(150);
 const LARGE_CORPUS_AUTOSCALED_SHUCK_LINES_PER_SEC: usize = 175;
 const LARGE_CORPUS_CACHE_DIR_NAME: &str = ".cache/large-corpus";
-const LARGE_CORPUS_WORKER_COUNT: usize = 4;
+const LARGE_CORPUS_MAX_WORKER_COUNT: usize = 4;
 const LARGE_CORPUS_TIMEOUT_FAILURE_CAP: usize = 5;
 const LARGE_CORPUS_PROGRESS_PERCENT_STEP: usize = 5;
 const LARGE_CORPUS_PROGRESS_BUCKET_COUNT: usize = 100 / LARGE_CORPUS_PROGRESS_PERCENT_STEP;
@@ -1067,13 +1067,28 @@ where
     if keep_going {
         return collect_fixture_failures_in_parallel(
             fixtures,
-            LARGE_CORPUS_WORKER_COUNT,
+            large_corpus_worker_count(fixtures.len()),
             &evaluate,
             &progress,
         );
     }
 
     collect_fixture_failures_sequential(fixtures, &evaluate, &progress)
+}
+
+fn large_corpus_worker_count(fixtures_len: usize) -> usize {
+    let available_parallelism = thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1);
+
+    clamp_large_corpus_worker_count(available_parallelism, fixtures_len)
+}
+
+fn clamp_large_corpus_worker_count(available_parallelism: usize, fixtures_len: usize) -> usize {
+    available_parallelism
+        .max(1)
+        .min(LARGE_CORPUS_MAX_WORKER_COUNT)
+        .min(fixtures_len)
 }
 
 fn collect_fixture_failures_sequential<F>(
@@ -4138,6 +4153,16 @@ mod tests {
         assert_eq!(failures.implementation_diffs.len(), 2);
         assert!(failures.implementation_diffs[0].contains("first.sh"));
         assert!(failures.implementation_diffs[1].contains("second.sh"));
+    }
+
+    #[test]
+    fn clamp_large_corpus_worker_count_uses_machine_parallelism_with_cap() {
+        assert_eq!(clamp_large_corpus_worker_count(2, 10), 2);
+        assert_eq!(
+            clamp_large_corpus_worker_count(8, 10),
+            LARGE_CORPUS_MAX_WORKER_COUNT
+        );
+        assert_eq!(clamp_large_corpus_worker_count(8, 3), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- size the large corpus keep-going worker pool from `std::thread::available_parallelism()`
- cap the worker count at 4 while still respecting the fixture count
- add a unit test covering the worker-count clamp behavior

## Why
The large corpus harness previously hard-coded 4 workers, which can overcommit CI runners that only expose 2 threads.

## Validation
- `cargo test -p shuck --test large_corpus tests::clamp_large_corpus_worker_count_uses_machine_parallelism_with_cap -- --exact`
- `cargo test -p shuck --test large_corpus tests::keep_going_collects_multiple_fixture_failures -- --exact`