### PR TITLE
Fix C087 lexical > version comparisons

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C087.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C087.sh
@@ -9,6 +9,9 @@
 # Invalid: comparing two dotted numeric literals still uses lexical ordering.
 [[ 1.2.3 < 2.0 ]]
 
+# Invalid: lexical `>` still compares version-like values as strings.
+[[ $ver > 1.27 ]]
+
 # Invalid: nested lexical version comparisons inside logical conditions still compare strings.
 [[ $ver < 1.27 && -n $x ]]
 

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C087_C087.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C087_C087.sh.snap
@@ -1,27 +1,33 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 207
+assertion_line: 285
 ---
-C087 this `[[ ... < ... ]]` comparison orders version-like values lexicographically
+C087 this `[[ ... ]]` comparison orders version-like values lexicographically
  --> <source>:4:11
   |
 4 | [[ $ver < 1.27 ]]
   |
 
-C087 this `[[ ... < ... ]]` comparison orders version-like values lexicographically
+C087 this `[[ ... ]]` comparison orders version-like values lexicographically
  --> <source>:7:4
   |
 7 | [[ 1.2 < $ver ]]
   |
 
-C087 this `[[ ... < ... ]]` comparison orders version-like values lexicographically
+C087 this `[[ ... ]]` comparison orders version-like values lexicographically
   --> <source>:10:12
    |
 10 | [[ 1.2.3 < 2.0 ]]
    |
 
-C087 this `[[ ... < ... ]]` comparison orders version-like values lexicographically
+C087 this `[[ ... ]]` comparison orders version-like values lexicographically
   --> <source>:13:11
    |
-13 | [[ $ver < 1.27 && -n $x ]]
+13 | [[ $ver > 1.27 ]]
+   |
+
+C087 this `[[ ... ]]` comparison orders version-like values lexicographically
+  --> <source>:16:11
+   |
+16 | [[ $ver < 1.27 && -n $x ]]
    |

--- a/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
@@ -11,7 +11,7 @@ impl Violation for StringComparisonForVersion {
     }
 
     fn message(&self) -> String {
-        "this `[[ ... < ... ]]` comparison orders version-like values lexicographically".to_owned()
+        "this `[[ ... ]]` comparison orders version-like values lexicographically".to_owned()
     }
 }
 
@@ -36,7 +36,10 @@ fn report_span(node: &ConditionalNodeFact<'_>, source: &str) -> Option<Span> {
     let ConditionalNodeFact::Binary(binary) = node else {
         return None;
     };
-    if binary.op() != ConditionalBinaryOp::LexicalBefore {
+    if !matches!(
+        binary.op(),
+        ConditionalBinaryOp::LexicalBefore | ConditionalBinaryOp::LexicalAfter
+    ) {
         return None;
     }
 
@@ -103,6 +106,8 @@ mod tests {
 [[ $ver < 1.27 ]]
 [[ 1.2 < $ver ]]
 [[ 1.2.3 < 2.0 ]]
+[[ $ver > 1.27 ]]
+[[ 1.2 > $ver ]]
 [[ $ver < 1.27 && -n $x ]]
 ";
         let diagnostics = test_snippet(
@@ -115,7 +120,7 @@ mod tests {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["1.27", "1.2", "2.0", "1.27"]
+            vec!["1.27", "1.2", "2.0", "1.27", "1.2", "1.27"]
         );
     }
 
@@ -141,7 +146,6 @@ mod tests {
 [[ $count < 10 ]]
 [[ foo < bar ]]
 [[ $tag < v1.2 ]]
-[[ $tag > 1.2 ]]
 [ \"$ver\" \\< 1.27 ]
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck/tests/testdata/corpus-metadata/c087.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c087.yaml
@@ -1,0 +1,7 @@
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__ct__immich.sh"
+    line: 114
+    labels:
+      - project-closure
+    reason: "This Proxmox update helper reads a saved version string through `$(cat ~/.immich)` and then compares it lexically against `2.5.1`. Shuck intentionally keeps the version-comparison warning for that file-backed value, while the current oracle stays silent on this project-closure fixture."

--- a/docs/rules/C087.yaml
+++ b/docs/rules/C087.yaml
@@ -8,7 +8,7 @@ shells:
   - sh
   - bash
   - dash
-description: "A `<` operator inside `[[ ]]` compares lexicographically, not numerically."
+description: "A `<` or `>` operator inside `[[ ]]` compares lexicographically, not numerically."
 rationale: "Use `-lt` for numeric comparison or a version-aware tool."
 source:
   shell_checks_rule: rules/SH-214.yaml
@@ -20,3 +20,9 @@ examples:
       #!/bin/bash
       # shellcheck disable=2154
       if [[ $ver < 1.27 ]]; then echo old; fi
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      if [[ "$actual" > "0.8" ]]; then
+        echo new
+      fi


### PR DESCRIPTION
## Summary
Fix C087 so it reports both lexical `<` and `>` comparisons on version-like values inside `[[ ... ]]`.

## What changed
- extend the rule to handle `ConditionalBinaryOp::LexicalAfter` in addition to `LexicalBefore`
- update the diagnostic wording, focused fixtures, and snapshots for the broader comparison shape
- refresh the public rule docs with a `>` example
- record the remaining `project-closure` corpus site as a reviewed divergence for C087

## Root cause
C087 only matched lexical `<` comparisons, so `[[ ... > ... ]]` version checks were missing from the rule and showed up as a ShellCheck-only corpus diff.

## Validation
- `cargo test -p shuck-linter rules::correctness::string_comparison_for_version::tests -- --nocapture`
- `cargo test -p shuck-linter rule_stringcomparisonforversion_path_new_c087_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C087`
