### PR TITLE
Fix C117 assignment-like command matching

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -2996,6 +2996,7 @@ pub struct LinterFacts<'a> {
     condition_command_substitution_spans: Vec<Span>,
     backtick_command_name_spans: Vec<Span>,
     dollar_question_after_command_spans: Vec<Span>,
+    assignment_like_command_name_spans: Vec<Span>,
     bare_command_name_assignment_spans: Vec<Span>,
     subshell_assignment_sites: Vec<NamedSpan>,
     subshell_later_use_sites: Vec<NamedSpan>,
@@ -3361,6 +3362,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn dollar_question_after_command_spans(&self) -> &[Span] {
         &self.dollar_question_after_command_spans
+    }
+
+    pub fn assignment_like_command_name_spans(&self) -> &[Span] {
+        &self.assignment_like_command_name_spans
     }
 
     pub fn bare_command_name_assignment_spans(&self) -> &[Span] {
@@ -4000,6 +4005,8 @@ impl<'a> LinterFactsBuilder<'a> {
             &word_index,
             self.source,
         );
+        let assignment_like_command_name_spans =
+            build_assignment_like_command_name_spans(&commands, self.source);
         let bare_command_name_assignment_spans =
             build_bare_command_name_assignment_spans(&commands, &words, &word_index, self.source);
         let unquoted_command_argument_use_offsets =
@@ -4061,6 +4068,7 @@ impl<'a> LinterFactsBuilder<'a> {
             condition_command_substitution_spans,
             backtick_command_name_spans,
             dollar_question_after_command_spans,
+            assignment_like_command_name_spans,
             bare_command_name_assignment_spans,
             subshell_assignment_sites: nonpersistent_assignment_spans.subshell_assignment_sites,
             subshell_later_use_sites: nonpersistent_assignment_spans.subshell_later_use_sites,
@@ -4851,6 +4859,64 @@ fn build_bare_command_name_assignment_spans<'a>(
         .iter()
         .filter_map(|command| bare_command_name_assignment_span(command, words, word_index, source))
         .collect()
+}
+
+fn build_assignment_like_command_name_spans<'a>(
+    commands: &[CommandFact<'a>],
+    source: &str,
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+
+    for fact in commands {
+        collect_assignment_like_command_name_spans_in_command(fact.command(), source, &mut spans);
+    }
+
+    spans
+}
+
+fn collect_assignment_like_command_name_spans_in_command(
+    command: &Command,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match command {
+        Command::Simple(command) => {
+            collect_assignment_like_command_name_span(&command.name, source, spans);
+        }
+        Command::Decl(command) => {
+            for operand in &command.operands {
+                if let DeclOperand::Dynamic(word) = operand {
+                    collect_assignment_like_command_name_span(word, source, spans);
+                }
+            }
+        }
+        Command::Builtin(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => {}
+    }
+}
+
+fn collect_assignment_like_command_name_span(word: &Word, source: &str, spans: &mut Vec<Span>) {
+    if let Some(span) = assignment_like_command_name_span(word, source) {
+        spans.push(span);
+    }
+}
+
+fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> {
+    let prefix = leading_literal_word_prefix(word, source);
+    let target_end = prefix.find("+=").or_else(|| prefix.find('='))?;
+    let target = &prefix[..target_end];
+    if target.is_empty() || target.chars().any(char::is_whitespace) {
+        return None;
+    }
+
+    if let Some(remainder) = target.strip_prefix('+') {
+        is_shell_variable_name(remainder).then_some(word.span)
+    } else {
+        (!is_shell_variable_name(target)).then_some(word.span)
+    }
 }
 
 fn bare_command_name_assignment_span<'a>(
@@ -20063,6 +20129,52 @@ complex[$((i+=1))]+=x
                     .map(|span| span.slice(source))
                     .collect::<Vec<_>>(),
                 vec!["x", "arr", "r", "index[1+2]", "complex[$((i+=1))]"]
+            );
+        });
+    }
+
+    #[test]
+    fn collects_assignment_like_command_name_spans() {
+        let source = r#"#!/bin/bash
++YYYY="$( date +%Y )"
+export +MONTH=12
+network.wan.proto='dhcp'
+@VAR@=$(. /etc/profile >/dev/null 2>&1; echo "${@VAR@}")
+echo +YEAR=2024
++1=bad
+name+=still_ok
+"#;
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .assignment_like_command_name_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec![
+                    "+YYYY=\"$( date +%Y )\"",
+                    "+MONTH=12",
+                    "network.wan.proto='dhcp'",
+                    "@VAR@=$(. /etc/profile >/dev/null 2>&1; echo \"${@VAR@}\")",
+                ]
+            );
+        });
+    }
+
+    #[test]
+    fn ignores_assignment_like_text_after_literal_arrow_prefix() {
+        let source = r#"#!/bin/bash
+rvm_info="
+  bash: \"$(command -v bash) => $(version_for bash)\"
+  zsh:  \"$(command -v zsh) => $(version_for zsh)\"
+"
+"#;
+
+        with_facts(source, None, |_, facts| {
+            assert!(
+                facts.assignment_like_command_name_spans().is_empty(),
+                "quoted arrow text should not look like an assignment command name"
             );
         });
     }

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -1,6 +1,4 @@
-use shuck_ast::{Command, DeclOperand, Span, Word};
-
-use crate::{Checker, Rule, Violation, leading_literal_word_prefix};
+use crate::{Checker, Rule, Violation};
 
 pub struct PlusPrefixInAssignment;
 
@@ -10,57 +8,18 @@ impl Violation for PlusPrefixInAssignment {
     }
 
     fn message(&self) -> String {
-        "leading `+` makes this look like a command instead of an assignment".to_owned()
+        "this looks like an assignment, but the shell parses it as a command name".to_owned()
     }
 }
 
 pub fn plus_prefix_in_assignment(checker: &mut Checker) {
-    let source = checker.source();
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .flat_map(|fact| match fact.command() {
-            Command::Simple(command) => assignment_like_plus_span(&command.name, source)
-                .into_iter()
-                .collect::<Vec<_>>(),
-            Command::Decl(command) => command
-                .operands
-                .iter()
-                .filter_map(|operand| match operand {
-                    DeclOperand::Dynamic(word) => assignment_like_plus_span(word, source),
-                    DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Assignment(_) => {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>(),
-            Command::Builtin(_)
-            | Command::Binary(_)
-            | Command::Compound(_)
-            | Command::Function(_)
-            | Command::AnonymousFunction(_) => Vec::new(),
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || PlusPrefixInAssignment);
-}
-
-fn assignment_like_plus_span(word: &Word, source: &str) -> Option<Span> {
-    let prefix = leading_literal_word_prefix(word, source);
-    let target_end = prefix.find("+=").or_else(|| prefix.find('='))?;
-    let target = &prefix[..target_end];
-
-    if let Some(remainder) = target.strip_prefix('+') {
-        is_valid_identifier(remainder).then_some(word.span)
-    } else {
-        (!is_valid_identifier(target)).then_some(word.span)
-    }
-}
-
-fn is_valid_identifier(text: &str) -> bool {
-    let mut chars = text.chars();
-    matches!(chars.next(), Some('A'..='Z' | 'a'..='z' | '_'))
-        && chars.all(|character| matches!(character, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_'))
+    checker.report_all_dedup(
+        checker
+            .facts()
+            .assignment_like_command_name_spans()
+            .to_vec(),
+        || PlusPrefixInAssignment,
+    );
 }
 
 #[cfg(test)]
@@ -127,5 +86,21 @@ network.wan.proto='dhcp'
                 "@VAR@=$(. /etc/profile >/dev/null 2>&1; echo \"${@VAR@}\")"
             ]
         );
+    }
+
+    #[test]
+    fn ignores_assignment_like_text_after_literal_arrow_prefix() {
+        let source = r#"#!/bin/bash
+rvm_info="
+  bash: \"$(command -v bash) => $(version_for bash)\"
+  zsh:  \"$(command -v zsh) => $(version_for zsh)\"
+"
+"#;
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PlusPrefixInAssignment),
+        );
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C117_C117.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C117_C117.sh.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
 ---
-C117 leading `+` makes this look like a command instead of an assignment
+C117 this looks like an assignment, but the shell parses it as a command name
  --> <source>:3:1
   |
 3 | +YYYY="$( date +%Y )"


### PR DESCRIPTION
## Summary
Fix `C117` so it only reports assignment-like command names when the leading literal prefix actually looks like an assignment target.

## Root cause
`C117` was scanning the leading literal prefix of command words directly in the rule and treating the first `=` it found as assignment-like syntax. That incorrectly matched quoted text such as `=> $(version_for bash)` inside multi-line string literals, which produced false positives in the large corpus `rvm` fixture.

## What changed
- moved assignment-like command-name detection into `LinterFacts`
- added a dedicated `assignment_like_command_name_spans` fact consumed by `C117`
- tightened the matcher to ignore prefixes with embedded whitespace before `=`
- added regression tests for the quoted `=> $(...)` form and updated the `C117` snapshot message

## Validation
- `cargo test -p shuck-linter plus_prefix_in_assignment -- --nocapture`
- `cargo test -p shuck-linter rules::correctness::tests::rules -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C117`
