### PR TITLE
Fix C093 and C119 corpus conformance

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -9403,7 +9403,9 @@ fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) -> Vec<Span> 
     let mut spans = commands
         .iter()
         .filter_map(|fact| match fact.command() {
-            Command::Simple(command) => plain_backtick_command_name_span(&command.name),
+            Command::Simple(command) if command.args.is_empty() => {
+                plain_backtick_command_name_span(&command.name)
+            }
             _ => None,
         })
         .collect::<Vec<_>>();
@@ -24312,6 +24314,36 @@ f() {
                     "tool=sh printf '%s\\n' hi",
                     "pager=cat \"$1\" -u perl",
                     "state=sh return 0",
+                ]
+            );
+        });
+    }
+
+    #[test]
+    fn backtick_command_name_spans_skip_argument_forms_but_keep_redirect_only_cases() {
+        let source = "\
+#!/bin/sh
+`echo bare`
+`echo bare` arg
+`echo bare` 2>/dev/null
+`echo bare` arg 2>/dev/null
+true && `echo and_only`
+true && `echo and_arg` arg
+true && `echo and_redirect` 2>/dev/null
+";
+
+        with_facts(source, None, |_, facts| {
+            assert_eq!(
+                facts
+                    .backtick_command_name_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec![
+                    "`echo bare`",
+                    "`echo bare`",
+                    "`echo and_only`",
+                    "`echo and_redirect`",
                 ]
             );
         });

--- a/crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
+++ b/crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
@@ -31,6 +31,8 @@ mod tests {
 `echo hello` | cat
 if `echo true`; then :; fi
 FOO=1 `echo run`
+`echo run` 2>/dev/null
+true && `echo go` 2>/dev/null
 ";
         let diagnostics = test_snippet(
             source,
@@ -42,18 +44,27 @@ FOO=1 `echo run`
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["`echo hello`", "`echo true`", "`echo run`"]
+            vec![
+                "`echo hello`",
+                "`echo true`",
+                "`echo run`",
+                "`echo run`",
+                "`echo go`",
+            ]
         );
     }
 
     #[test]
-    fn ignores_wrapped_quoted_and_affixed_backticks() {
+    fn ignores_wrapped_quoted_affixed_and_argument_backticks() {
         let source = "\
 #!/bin/sh
 command `echo hello`
 \"`echo hello`\" | cat
 x`echo hello`
 echo `date`
+`echo hello` arg
+true && `echo hello` arg
+`echo hello` arg 2>/dev/null
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
@@ -35,10 +35,9 @@ fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact<'_
             let fact = checker.facts().command(segment.command_id());
             fact.redirect_facts()
                 .iter()
-                .enumerate()
-                .filter_map(|(index, redirect)| {
+                .filter_map(|redirect| {
                     stdout_redirect_span_before_pipe(redirect, checker.source()).filter(|_| {
-                        !has_prior_stderr_to_stdout_dup(&fact.redirect_facts()[..index])
+                        !has_independent_stderr_to_stdout_dup(fact.redirect_facts(), redirect)
                     })
                 })
                 .collect::<Vec<_>>()
@@ -46,14 +45,30 @@ fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact<'_
         .collect()
 }
 
-fn has_prior_stderr_to_stdout_dup(redirects: &[crate::RedirectFact<'_>]) -> bool {
+fn has_independent_stderr_to_stdout_dup(
+    redirects: &[crate::RedirectFact<'_>],
+    stdout_redirect: &crate::RedirectFact<'_>,
+) -> bool {
     redirects.iter().any(|redirect| {
-        redirect.redirect().kind == RedirectKind::DupOutput
-            && redirect.redirect().fd == Some(2)
-            && redirect
-                .analysis()
-                .is_some_and(|analysis| analysis.numeric_descriptor_target == Some(1))
+        is_stderr_to_stdout_dup(redirect)
+            && !is_synthetic_append_both_dup(redirect, stdout_redirect)
     })
+}
+
+fn is_stderr_to_stdout_dup(redirect: &crate::RedirectFact<'_>) -> bool {
+    redirect.redirect().kind == RedirectKind::DupOutput
+        && redirect.redirect().fd == Some(2)
+        && redirect
+            .analysis()
+            .is_some_and(|analysis| analysis.numeric_descriptor_target == Some(1))
+}
+
+fn is_synthetic_append_both_dup(
+    dup_redirect: &crate::RedirectFact<'_>,
+    stdout_redirect: &crate::RedirectFact<'_>,
+) -> bool {
+    stdout_redirect.redirect().kind == RedirectKind::Append
+        && dup_redirect.redirect().span.start == stdout_redirect.redirect().span.start
 }
 
 fn stdout_redirect_span_before_pipe(
@@ -137,7 +152,9 @@ cmd 1>out | next
 cmd | next >/dev/null
 cmd >/dev/null |& next
 cmd 1>&2 | next
+cmd >/dev/null 2>&1 | next
 cmd 2>&1 1>/dev/null | next
+cmd 2>&1 >/dev/null | next
 cmd <>file | next
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RedirectBeforePipe));
@@ -164,11 +181,26 @@ cmd &>>out | next
     }
 
     #[test]
-    fn reports_output_redirects_with_late_or_unrelated_dup_redirects() {
+    fn ignores_stdout_redirects_when_stderr_is_duplicated_to_stdout() {
+        let source = "\
+#!/bin/sh
+cmd >out 2>&1 | next
+cmd 2>&1 >out | next
+cmd >>out 2>&1 | next
+cmd 2>&1 >>out | next
+cmd >|out 2>&1 | next
+cmd 2>&1 >|out | next
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RedirectBeforePipe));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn still_reports_unrelated_descriptor_redirects() {
         let source = "\
 #!/bin/sh
 cmd >out 1>&2 | next
-cmd >out 2>&1 | next
 cmd >out 3>&1 | next
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RedirectBeforePipe));
@@ -178,7 +210,7 @@ cmd >out 3>&1 | next
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec![">", ">", ">"]
+            vec![">", ">"]
         );
     }
 }


### PR DESCRIPTION
## Summary
- tighten C093 so backtick command-name diagnostics only fire when the dynamic command name has no positional arguments, while still keeping redirect-only cases
- narrow C119 so redirects paired with an independent `2>&1` dup no longer report, but real `&>` and `&>>` pipeline cases still do
- add focused regression coverage for both rule boundaries to keep the large-corpus behavior stable

## Why
C093 still had a large-corpus false positive for backtick-derived command names with arguments. The fact builder was treating those the same as bare command-name substitutions.

C119 still had a large-corpus false positive for pipeline heads like `cmd >/dev/null 2>&1 | next`. ShellCheck suppresses SC2260 when the same command also has an independent stderr-to-stdout dup, but it still reports real append-both forms like `&>>`.

## Impact
These fixes bring both rules into line with the current ShellCheck oracle without weakening the intended diagnostics for the valid target patterns.

## Validation
- `cargo test -p shuck-linter backtick`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C093`
- `cargo test -p shuck-linter redirect_before_pipe`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C119`
- `make test`
- `cargo test --workspace`
