### PR TITLE
Fix S007 for escaped command substitution formats

### DIFF
--- a/crates/shuck-linter/src/rules/common/word.rs
+++ b/crates/shuck-linter/src/rules/common/word.rs
@@ -307,6 +307,23 @@ mod tests {
     }
 
     #[test]
+    fn classify_word_treats_escaped_backslash_before_command_substitution_as_mixed() {
+        let source = "printf \"\\\\$(printf '%03o' \"$i\")\"\n";
+        let commands = parse_commands(source);
+        let Command::Simple(command) = &commands[0].command else {
+            panic!("expected simple command");
+        };
+
+        let classification = classify_word(&command.args[0], source);
+        assert_eq!(classification.quote, WordQuote::FullyQuoted);
+        assert_eq!(classification.literalness, WordLiteralness::Expanded);
+        assert_eq!(
+            classification.substitution_shape,
+            WordSubstitutionShape::Mixed
+        );
+    }
+
+    #[test]
     fn shell_variable_name_helper_matches_identifier_rules() {
         assert!(is_shell_variable_name("name"));
         assert!(is_shell_variable_name("_name123"));

--- a/crates/shuck-linter/src/rules/style/printf_format_variable.rs
+++ b/crates/shuck-linter/src/rules/style/printf_format_variable.rs
@@ -82,4 +82,19 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "\"$fmt\"");
     }
+
+    #[test]
+    fn reports_command_substitution_formats_even_with_literal_backslash_prefixes() {
+        let source = "i=65\nkeyassoc=\"$( printf \"\\\\$(printf '%03o' \"$i\")\" )\"\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PrintfFormatVariable),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"\\\\$(printf '%03o' \"$i\")\""
+        );
+    }
 }

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -2339,6 +2339,9 @@ impl<'a> Lexer<'a> {
                                     content_start,
                                     escape_start,
                                 );
+                                if next == '\\' {
+                                    Self::push_capture_char(&mut content, '\x00');
+                                }
                                 if next == '`' {
                                     Self::push_capture_char(&mut content, '\x00');
                                 }

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -299,6 +299,34 @@ fn test_parse_escaped_command_substitution_stays_literal_in_double_quotes() {
 }
 
 #[test]
+fn test_parse_escaped_backslash_before_command_substitution_keeps_substitution_live() {
+    let input = "echo \"\\\\$(pwd)\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let word = &command.args[0];
+
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double-quoted word");
+    };
+    let slices: Vec<&str> = parts.iter().map(|part| part.span.slice(input)).collect();
+    assert_eq!(slices, vec![r#"\\"#, "$(pwd)"]);
+
+    let WordPart::Literal(text) = &parts[0].kind else {
+        panic!("expected literal backslash prefix");
+    };
+    assert_eq!(text.as_str(input, parts[0].span), r#"\"#);
+
+    let WordPart::CommandSubstitution { body, .. } = &parts[1].kind else {
+        panic!("expected live command substitution");
+    };
+    let inner = expect_simple(&body[0]);
+    assert_eq!(inner.name.render(input), "pwd");
+}
+
+#[test]
 fn test_parse_escaped_literal_before_command_substitution_keeps_following_substitution_live() {
     let input = "echo $VERSION\\_$(echo hi)\n";
     let script = Parser::new(input).parse().unwrap().file;


### PR DESCRIPTION
## Summary
- preserve the escaped backslash marker for source-backed double-quoted lexer segments so later decoding keeps following `$(` substitutions live
- add parser and linter regression tests for `printf "\\$(printf '%03o' ...)"` cases
- restore `S007` detection for mixed `printf` format strings built from command substitutions

## Root cause
The double-quoted lexer normalized an escaped backslash into plain text in owned segment captures. When the quoted-word decoder reparsed that content, it treated the following `$(` as escaped literal text instead of a live command substitution, so `S007` missed those formats.

## Validation
- `cargo test -p shuck-parser test_parse_escaped_backslash_before_command_substitution_keeps_substitution_live -- --nocapture`
- `cargo test -p shuck-parser escaped_command_substitution -- --nocapture`
- `cargo test -p shuck-linter printf_format_variable -- --nocapture`
- `cargo test -p shuck-linter classify_word_treats_escaped_backslash_before_command_substitution_as_mixed -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S007`
