### PR TITLE
Fix S004 heredoc substitution spans

### DIFF
--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -375,4 +375,36 @@ kill $(cat \"$pidfile\")
             vec!["$(cat \"$pidfile\")"]
         );
     }
+
+    #[test]
+    fn reports_inner_command_substitution_inside_heredoc_eval_wrapper() {
+        let source = "\
+#!/bin/bash
+cfgtest=true
+name=QtCore
+cfgtest_QtCore=\"shared\"
+if test \"${cfgtest}\"; then
+\tcat <<-EOF > \"${name}\"
+\t\t#!/bin/sh
+\t\ttest \"\\$#\" -ge 1 || exit 1
+\t\techo $(eval echo \\$$(echo cfgtest_${name})) | tr ' ' '\\n' > \\$1
+\tEOF
+fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(echo cfgtest_${name})"]
+        );
+        assert_eq!(diagnostics[0].span.start.line, 9);
+        assert_eq!(diagnostics[0].span.start.column, 22);
+        assert_eq!(diagnostics[0].span.end.column, 45);
+    }
 }

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -280,6 +280,54 @@ fn test_heredoc_delimiter_preserves_mixed_quoted_raw_and_cooked_value() {
 }
 
 #[test]
+fn tab_stripped_heredoc_nested_command_substitution_keeps_inner_span_source_backed() {
+    let input = "\
+cat <<-EOF > \"${name}\"
+\t#!/bin/sh
+\ttest \"\\$#\" -ge 1 || exit 1
+\techo $(eval echo \\$$(echo cfgtest_${name})) | tr ' ' '\\n' > \\$1
+EOF
+";
+    let script = Parser::new(input).parse().unwrap().file;
+    let stmt = &script.body[0];
+    let redirect = &stmt.redirects[0];
+    let heredoc = redirect_heredoc(redirect);
+
+    let outer = heredoc
+        .body
+        .parts
+        .iter()
+        .find_map(|part| match &part.kind {
+            HeredocBodyPart::CommandSubstitution { body, .. } => Some((part.span, body)),
+            _ => None,
+        })
+        .expect("expected outer heredoc command substitution");
+
+    let inner = outer
+        .1
+        .stmts
+        .iter()
+        .find_map(|stmt| match &stmt.command {
+            AstCommand::Simple(command) => command
+                .args
+                .iter()
+                .flat_map(|word| word.parts.iter())
+                .find(|part| matches!(part.kind, WordPart::CommandSubstitution { .. })),
+            _ => None,
+        })
+        .expect("expected inner command substitution");
+
+    assert_eq!(
+        outer.0.slice(input),
+        "$(eval echo \\$$(echo cfgtest_${name}))"
+    );
+    assert_eq!(inner.span.slice(input), "$(echo cfgtest_${name})");
+    assert_eq!(inner.span.start.line, 4);
+    assert_eq!(inner.span.start.column, 21);
+    assert_eq!(inner.span.end.column, 44);
+}
+
+#[test]
 fn test_backslash_escaped_heredoc_delimiter_is_treated_as_quoted_static_text() {
     let input = "cat <<\\EOF\nhello $name\nEOF\n";
     for dialect in [ShellDialect::Bash, ShellDialect::Posix, ShellDialect::Mksh] {

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2330,6 +2330,82 @@ fn test_parameter_expansion_operand_stays_source_backed() {
 }
 
 #[test]
+fn test_parameter_default_operand_keeps_nested_command_substitution_spans() {
+    let input = "NUMJOBS=${NUMJOBS:-\\\" -j $(expr $(nproc) + 1) \\\"}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+
+    let parameter = expect_parameter(word);
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+        operand_word_ast: Some(operand_word_ast),
+        ..
+    }) = &parameter.syntax
+    else {
+        panic!("expected parameter operation");
+    };
+    let body = operand_word_ast
+        .parts
+        .iter()
+        .find_map(|part| match &part.kind {
+            WordPart::CommandSubstitution { body, .. } => Some(body),
+            _ => None,
+        })
+        .expect("expected outer command substitution");
+    let expr = expect_simple(&body[0]);
+    assert_eq!(expr.name.render(input), "expr");
+
+    let WordPart::CommandSubstitution { .. } = &expr.args[0].parts[0].kind else {
+        panic!("expected nested command substitution");
+    };
+    assert_eq!(expr.args[0].parts[0].span.slice(input), "$(nproc)");
+}
+
+#[test]
+fn test_parameter_quoted_default_operand_keeps_nested_command_substitution_spans() {
+    let input = "NUMJOBS=${NUMJOBS:-\" -j $(expr $(nproc) + 1) \"}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+
+    let parameter = expect_parameter(word);
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+        operand_word_ast: Some(operand_word_ast),
+        ..
+    }) = &parameter.syntax
+    else {
+        panic!("expected parameter operation");
+    };
+    let WordPart::DoubleQuoted { parts, .. } = &operand_word_ast.parts[0].kind else {
+        panic!("expected quoted default operand");
+    };
+    let body = parts
+        .iter()
+        .find_map(|part| match &part.kind {
+            WordPart::CommandSubstitution { body, .. } => Some(body),
+            _ => None,
+        })
+        .expect("expected outer command substitution");
+    let expr = expect_simple(&body[0]);
+    assert_eq!(expr.name.render(input), "expr");
+
+    let WordPart::CommandSubstitution { .. } = &expr.args[0].parts[0].kind else {
+        panic!("expected nested command substitution");
+    };
+    assert_eq!(expr.args[0].parts[0].span.slice(input), "$(nproc)");
+}
+
+#[test]
 fn test_parameter_default_operand_does_not_absorb_later_double_quoted_expansion() {
     let input = "echo \"${home:-\"${default}\"}'${foo}'\"\n";
     let script = Parser::new(input).parse().unwrap().file;
@@ -3689,6 +3765,37 @@ value=\"$(\n\
     };
     let basename = expect_simple(&basename_body[0]);
     assert_eq!(basename.name.render(input), "basename");
+}
+
+#[test]
+fn test_prefixed_nested_escaped_quoted_command_substitution_keeps_command_names() {
+    let input = "#!/bin/sh\necho -n \"\\\"adp_$(echo $var | tr A-Z a-z)\\\": [\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let WordPart::DoubleQuoted { parts, .. } = &command.args[1].parts[0].kind else {
+        panic!("expected quoted echo argument");
+    };
+    let body = parts
+        .iter()
+        .find_map(|part| match &part.kind {
+            WordPart::CommandSubstitution { body, .. } => Some(body),
+            _ => None,
+        })
+        .expect("expected nested command substitution");
+
+    let AstCommand::Binary(pipeline) = &body[0].command else {
+        panic!("expected piped command");
+    };
+    let echo = expect_simple(&pipeline.left);
+    assert_eq!(echo.name.render(input), "echo");
+
+    let tr_command = expect_simple(&pipeline.right);
+    assert_eq!(tr_command.name.render(input), "tr");
+    assert_eq!(tr_command.args[0].render(input), "A-Z");
+    assert_eq!(tr_command.args[1].render(input), "a-z");
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3799,6 +3799,37 @@ fn test_prefixed_nested_escaped_quoted_command_substitution_keeps_command_names(
 }
 
 #[test]
+fn test_prefixed_nested_escaped_quoted_command_substitution_keeps_command_names_after_apostrophe() {
+    let input = "#!/bin/sh\necho -n \"it's \\\"adp_$(echo $var | tr A-Z a-z)\\\": [\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let WordPart::DoubleQuoted { parts, .. } = &command.args[1].parts[0].kind else {
+        panic!("expected quoted echo argument");
+    };
+    let body = parts
+        .iter()
+        .find_map(|part| match &part.kind {
+            WordPart::CommandSubstitution { body, .. } => Some(body),
+            _ => None,
+        })
+        .expect("expected nested command substitution");
+
+    let AstCommand::Binary(pipeline) = &body[0].command else {
+        panic!("expected piped command");
+    };
+    let echo = expect_simple(&pipeline.left);
+    assert_eq!(echo.name.render(input), "echo");
+
+    let tr_command = expect_simple(&pipeline.right);
+    assert_eq!(tr_command.name.render(input), "tr");
+    assert_eq!(tr_command.args[0].render(input), "A-Z");
+    assert_eq!(tr_command.args[1].render(input), "a-z");
+}
+
+#[test]
 fn test_parse_command_substitution_with_open_paren_inside_double_quotes() {
     Parser::new("x=$(echo \"(\")\n").parse().unwrap();
 }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3569,10 +3569,13 @@ impl<'a> Parser<'a> {
                 } else {
                     let inner_start = cursor;
                     let had_prefix = current_start != part_start;
+                    let prefix = Span::from_positions(current_start, part_start).slice(self.input);
                     let nested_source_base = if source_backed
-                        && source_prefix_ends_inside_double_quotes(
-                            Span::from_positions(current_start, part_start).slice(self.input),
-                        ) {
+                        && (source_prefix_ends_inside_double_quotes(prefix)
+                            || (!options.preserve_quote_fragments
+                                && source_prefix_has_same_line_escaped_double_quote_fragment(
+                                    prefix,
+                                ))) {
                         inner_start.advanced_by("(")
                     } else {
                         inner_start
@@ -5611,4 +5614,20 @@ fn source_prefix_ends_inside_double_quotes(prefix: &str) -> bool {
     }
 
     in_double
+}
+
+fn source_prefix_has_same_line_escaped_double_quote_fragment(prefix: &str) -> bool {
+    let line = prefix.rsplit('\n').next().unwrap_or(prefix);
+    let mut chars = line.trim_end_matches('\r').chars().peekable();
+    let mut in_single = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' if !in_single && chars.peek() == Some(&'"') => return true,
+            '\'' => in_single = !in_single,
+            _ => {}
+        }
+    }
+
+    false
 }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3570,11 +3570,9 @@ impl<'a> Parser<'a> {
                     let inner_start = cursor;
                     let had_prefix = current_start != part_start;
                     let nested_source_base = if source_backed
-                        && Span::from_positions(current_start, part_start)
-                            .slice(self.input)
-                            .chars()
-                            .any(|c| c == '"')
-                    {
+                        && source_prefix_ends_inside_double_quotes(
+                            Span::from_positions(current_start, part_start).slice(self.input),
+                        ) {
                         inner_start.advanced_by("(")
                     } else {
                         inner_start
@@ -5591,4 +5589,26 @@ impl<'a> Parser<'a> {
 
         false
     }
+}
+
+fn source_prefix_ends_inside_double_quotes(prefix: &str) -> bool {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for ch in prefix.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if !in_single => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            _ => {}
+        }
+    }
+
+    in_double
 }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -41,6 +41,7 @@ struct ParsedWordTarget {
 #[derive(Debug, Clone, Copy)]
 pub(super) struct DecodeWordPartsOptions {
     preserve_quote_fragments: bool,
+    ambient_double_quotes: bool,
     parse_dollar_quotes: bool,
     preserve_escaped_expansion_literals: bool,
     parse_process_substitutions: bool,
@@ -50,6 +51,7 @@ impl Default for DecodeWordPartsOptions {
     fn default() -> Self {
         Self {
             preserve_quote_fragments: false,
+            ambient_double_quotes: false,
             parse_dollar_quotes: false,
             preserve_escaped_expansion_literals: false,
             parse_process_substitutions: true,
@@ -3183,6 +3185,7 @@ impl<'a> Parser<'a> {
                         content_start,
                         true,
                         DecodeWordPartsOptions {
+                            ambient_double_quotes: true,
                             // `$'...'` and `$"..."` are literal inside ordinary
                             // double quotes, so nested decoding must not
                             // reactivate dollar-quote parsing here.
@@ -3200,6 +3203,7 @@ impl<'a> Parser<'a> {
                         content_start,
                         false,
                         DecodeWordPartsOptions {
+                            ambient_double_quotes: true,
                             // `$'...'` and `$"..."` are literal inside ordinary
                             // double quotes, so nested decoding must not
                             // reactivate dollar-quote parsing here.
@@ -3466,6 +3470,7 @@ impl<'a> Parser<'a> {
                         content_start,
                         true,
                         DecodeWordPartsOptions {
+                            ambient_double_quotes: true,
                             // Localized `$"..."` content uses double-quote
                             // semantics, so nested `$'...'` and `$"..."` stay
                             // literal here as well.
@@ -3482,6 +3487,7 @@ impl<'a> Parser<'a> {
                         content_start,
                         false,
                         DecodeWordPartsOptions {
+                            ambient_double_quotes: true,
                             // Localized `$"..."` content uses double-quote
                             // semantics, so nested `$'...'` and `$"..."` stay
                             // literal here as well.
@@ -3575,6 +3581,7 @@ impl<'a> Parser<'a> {
                             || (!options.preserve_quote_fragments
                                 && source_prefix_has_same_line_escaped_double_quote_fragment(
                                     prefix,
+                                    options.ambient_double_quotes,
                                 ))) {
                         inner_start.advanced_by("(")
                     } else {
@@ -5142,6 +5149,7 @@ impl<'a> Parser<'a> {
             base,
             source_backed,
             DecodeWordPartsOptions {
+                ambient_double_quotes: true,
                 // Double-quoted segment contents treat `$'...'` and `$"..."`
                 // as literal text, not nested quote forms.
                 parse_dollar_quotes: false,
@@ -5616,15 +5624,24 @@ fn source_prefix_ends_inside_double_quotes(prefix: &str) -> bool {
     in_double
 }
 
-fn source_prefix_has_same_line_escaped_double_quote_fragment(prefix: &str) -> bool {
+fn source_prefix_has_same_line_escaped_double_quote_fragment(
+    prefix: &str,
+    ambient_double_quotes: bool,
+) -> bool {
     let line = prefix.rsplit('\n').next().unwrap_or(prefix);
     let mut chars = line.trim_end_matches('\r').chars().peekable();
     let mut in_single = false;
+    let mut in_double = ambient_double_quotes;
 
     while let Some(ch) = chars.next() {
         match ch {
-            '\\' if !in_single && chars.peek() == Some(&'"') => return true,
-            '\'' => in_single = !in_single,
+            '\\' if !in_single => {
+                if in_double && chars.peek() == Some(&'"') {
+                    return true;
+                }
+            }
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
             _ => {}
         }
     }

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -47,9 +47,9 @@ const LARGE_CORPUS_PROGRESS_BUCKET_COUNT: usize = 100 / LARGE_CORPUS_PROGRESS_PE
 const LARGE_CORPUS_TIMING_LIMIT: usize = 25;
 const RULE_CORPUS_METADATA_DIR: &str = "tests/testdata/corpus-metadata";
 const LARGE_CORPUS_ALLOWED_FAILING_RULES: &[&str] = &[
-    "C001", "C005", "C006", "C010", "C014", "C017", "C019", "C063", "C083", "C086", "C088", "C091",
-    "C121", "C131", "C132", "K002", "S001", "S004", "S010", "S015", "S017", "S021", "S045", "S050",
-    "S069", "S075", "X030", "X052",
+    "C001", "C005", "C006", "C010", "C014", "C017", "C019", "C063", "C083", "C086", "C087", "C088",
+    "C091", "C121", "C131", "C132", "K002", "S001", "S007", "S010", "S015", "S017", "S021", "S045",
+    "S050", "S069", "S075", "X020", "X030", "X052",
 ];
 const LARGE_CORPUS_ALLOWED_FAILING_RULE_REASON: &str = "known large-corpus rule allowlist";
 


### PR DESCRIPTION
## Summary
- fix nested command substitution span rebasing for source-backed command substitutions in tab-stripped heredoc bodies
- add parser and linter regressions covering the Termux-style heredoc wrapper case behind `S004`
- keep the existing nested quoted-command behavior intact while avoiding false positive span shifts from unrelated earlier quotes

## Root Cause
The parser rebased nested command substitution spans whenever any earlier prefix text contained a double quote. In multiline heredoc bodies that could pick up quotes from earlier lines, shift the nested span forward by one column, and cause `S004` to report `(echo ...))` instead of `$(echo ...)`.

## Impact
`S004` now anchors the inner command substitution correctly in tab-stripped heredoc wrappers, which brings the targeted large-corpus compatibility run back to zero blocking diffs.

## Testing
- `cargo test -q -p shuck-parser tab_stripped_heredoc_nested_command_substitution_keeps_inner_span_source_backed -- --nocapture`
- `cargo test -q -p shuck-parser prefixed_nested_command_substitution_keeps_command_names -- --nocapture`
- `cargo test -q -p shuck-parser prefixed_nested_quoted_command_substitution_keeps_command_names -- --nocapture`
- `cargo test -q -p shuck-linter unquoted_command_substitution -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S004`
