### PR TITLE
Refresh large corpus allowlist

### DIFF
--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -47,9 +47,9 @@ const LARGE_CORPUS_PROGRESS_BUCKET_COUNT: usize = 100 / LARGE_CORPUS_PROGRESS_PE
 const LARGE_CORPUS_TIMING_LIMIT: usize = 25;
 const RULE_CORPUS_METADATA_DIR: &str = "tests/testdata/corpus-metadata";
 const LARGE_CORPUS_ALLOWED_FAILING_RULES: &[&str] = &[
-    "C001", "C005", "C006", "C010", "C014", "C017", "C019", "C035", "C063", "C083", "C086", "C087",
-    "C088", "C091", "C093", "C117", "C119", "C121", "C131", "C132", "K002", "S001", "S004", "S007",
-    "S010", "S015", "S017", "S021", "S045", "S050", "S069", "S075", "X020", "X030", "X052",
+    "C001", "C005", "C006", "C010", "C014", "C017", "C019", "C063", "C083", "C086", "C087", "C088",
+    "C091", "C121", "C131", "C132", "K002", "S001", "S004", "S007", "S010", "S015", "S017", "S021",
+    "S045", "S050", "S069", "S075", "X020", "X030", "X052",
 ];
 const LARGE_CORPUS_ALLOWED_FAILING_RULE_REASON: &str = "known large-corpus rule allowlist";
 


### PR DESCRIPTION
## What changed
- refreshed the large-corpus allowlist in `crates/shuck/tests/large_corpus.rs`
- kept the currently expected failing rule codes and removed stale entries `C035`, `C093`, `C117`, and `C119`

## Why
The ignored large-corpus code list needed to match the latest corpus review so the allowlist reflects the current known compatibility gaps.

## Impact
- keeps the compatibility harness aligned with the latest reviewed exceptions
- avoids carrying outdated ignored rules in the large-corpus test

## Validation
- `cargo test -p shuck --test large_corpus --no-run`