### PR TITLE
Fix X020 large-corpus parity

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -905,6 +905,7 @@ impl<'a> ConditionalFact<'a> {
 #[derive(Debug, Clone)]
 pub struct RedirectFact<'a> {
     redirect: &'a Redirect,
+    brace_fd_redirection_span: Option<Span>,
     operator_span: Span,
     target_span: Option<Span>,
     arithmetic_update_operator_spans: Box<[Span]>,
@@ -914,6 +915,10 @@ pub struct RedirectFact<'a> {
 impl<'a> RedirectFact<'a> {
     pub fn redirect(&self) -> &'a Redirect {
         self.redirect
+    }
+
+    pub fn brace_fd_redirection_span(&self) -> Option<Span> {
+        self.brace_fd_redirection_span
     }
 
     pub fn operator_span(&self) -> Span {
@@ -11148,6 +11153,7 @@ fn build_redirect_facts<'a>(
         .iter()
         .map(|redirect| RedirectFact {
             redirect,
+            brace_fd_redirection_span: brace_fd_redirection_span(redirect, source),
             operator_span: redirect_operator_span(redirect),
             target_span: redirect.word_target().map(|word| word.span),
             arithmetic_update_operator_spans: redirect
@@ -11166,6 +11172,34 @@ fn build_redirect_facts<'a>(
         })
         .collect::<Vec<_>>()
         .into_boxed_slice()
+}
+
+fn brace_fd_redirection_span(redirect: &Redirect, source: &str) -> Option<Span> {
+    let brace_span = redirect_fd_var_brace_span(redirect, source)?;
+    let gap = source.get(brace_span.end.offset..redirect.span.start.offset)?;
+    brace_fd_gap_allows_attachment(gap)
+        .then(|| Span::from_positions(brace_span.start, redirect.span.end))
+}
+
+fn brace_fd_gap_allows_attachment(gap: &str) -> bool {
+    if gap.is_empty() {
+        return true;
+    }
+
+    let mut remaining = gap;
+    while !remaining.is_empty() {
+        if let Some(stripped) = remaining.strip_prefix("\\\r\n") {
+            remaining = stripped;
+            continue;
+        }
+        if let Some(stripped) = remaining.strip_prefix("\\\n") {
+            remaining = stripped;
+            continue;
+        }
+        return false;
+    }
+
+    true
 }
 
 fn redirect_operator_span(redirect: &Redirect) -> Span {

--- a/crates/shuck-linter/src/rules/portability/brace_fd_redirection.rs
+++ b/crates/shuck-linter/src/rules/portability/brace_fd_redirection.rs
@@ -1,5 +1,3 @@
-use shuck_ast::Span;
-
 use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct BraceFdRedirection;
@@ -24,38 +22,10 @@ pub fn brace_fd_redirection(checker: &mut Checker) {
         .commands()
         .iter()
         .flat_map(|fact| fact.redirect_facts().iter())
-        .filter_map(|redirect| brace_fd_span(redirect.redirect(), checker.source()))
+        .filter_map(|redirect| redirect.brace_fd_redirection_span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || BraceFdRedirection);
-}
-
-fn brace_fd_span(redirect: &shuck_ast::Redirect, source: &str) -> Option<Span> {
-    let fd_var_span = redirect.fd_var_span?;
-    let brace_close = fd_var_span.end.advanced_by("}");
-    let gap = &source[brace_close.offset..redirect.span.start.offset];
-    brace_fd_gap_allows_attachment(gap).then_some(fd_var_span)
-}
-
-fn brace_fd_gap_allows_attachment(gap: &str) -> bool {
-    if gap.is_empty() {
-        return true;
-    }
-
-    let mut remaining = gap;
-    while !remaining.is_empty() {
-        if let Some(stripped) = remaining.strip_prefix("\\\r\n") {
-            remaining = stripped;
-            continue;
-        }
-        if let Some(stripped) = remaining.strip_prefix("\\\n") {
-            remaining = stripped;
-            continue;
-        }
-        return false;
-    }
-
-    true
 }
 
 #[cfg(test)]
@@ -79,9 +49,9 @@ EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BraceFdRedirection));
 
         assert_eq!(diagnostics.len(), 3);
-        assert_eq!(diagnostics[0].span.slice(source), "fd");
-        assert_eq!(diagnostics[1].span.slice(source), "docfd");
-        assert_eq!(diagnostics[2].span.slice(source), "contfd");
+        assert_eq!(diagnostics[0].span.slice(source), "{fd}>/dev/null");
+        assert_eq!(diagnostics[1].span.slice(source), "{docfd}<<EOF");
+        assert_eq!(diagnostics[2].span.slice(source), "{contfd}<<EOF");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X020_X020.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X020_X020.sh.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/shuck-linter/src/rules/portability/mod.rs
-assertion_line: 21
 ---
 X020 brace-based file-descriptor redirects are not portable in `sh`
- --> <source>:2:7
+ --> <source>:2:6
   |
 2 | exec {fd}>/dev/null
   |

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -49,7 +49,7 @@ const RULE_CORPUS_METADATA_DIR: &str = "tests/testdata/corpus-metadata";
 const LARGE_CORPUS_ALLOWED_FAILING_RULES: &[&str] = &[
     "C001", "C005", "C006", "C010", "C014", "C017", "C019", "C063", "C083", "C086", "C087", "C088",
     "C091", "C121", "C131", "C132", "K002", "S001", "S004", "S007", "S010", "S015", "S017", "S021",
-    "S045", "S050", "S069", "S075", "X020", "X030", "X052",
+    "S045", "S050", "S069", "S075", "X030", "X052",
 ];
 const LARGE_CORPUS_ALLOWED_FAILING_RULE_REASON: &str = "known large-corpus rule allowlist";
 


### PR DESCRIPTION
## Summary
- move X020 brace-FD span calculation into redirect facts so the rule can report the full redirect span instead of only the inner descriptor name
- update the X020 rule test expectations and snapshot to match the corrected span anchoring
- remove `X020` from the large-corpus allowed failing rule list now that the rule no longer needs the exemption

## Why
X020 still depended on a reviewed large-corpus allowlist entry because Shuck anchored brace-based descriptor redirects to the descriptor name alone, while the corpus oracle compared the full redirect site. That left a location-only mismatch even though the rule was otherwise finding the right construct.

## Impact
The portability check now reports the full brace-based redirect site, which matches the large-corpus comparison expectations and lets X020 stand on its own without a harness-specific ignore.

## Validation
- `cargo test -p shuck-linter brace_fd_redirection -- --nocapture`
- `cargo test -p shuck-linter portability::tests::rules -- X020.sh`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X020`