### PR TITLE
Remove C087 from the large-corpus allowlist

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
@@ -125,6 +125,28 @@ mod tests {
     }
 
     #[test]
+    fn reports_quoted_version_literals_and_dynamic_version_sources() {
+        let source = "\
+#!/bin/bash
+[[ \"$actual\" > \"0.8\" ]]
+[[ \"1.2\" < $ver ]]
+[[ $(cat version.txt) < 2.5.1 ]]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::StringComparisonForVersion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"0.8\"", "\"1.2\"", "2.5.1"]
+        );
+    }
+
+    #[test]
     fn reports_nested_version_comparisons_inside_logical_expressions() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -47,9 +47,9 @@ const LARGE_CORPUS_PROGRESS_BUCKET_COUNT: usize = 100 / LARGE_CORPUS_PROGRESS_PE
 const LARGE_CORPUS_TIMING_LIMIT: usize = 25;
 const RULE_CORPUS_METADATA_DIR: &str = "tests/testdata/corpus-metadata";
 const LARGE_CORPUS_ALLOWED_FAILING_RULES: &[&str] = &[
-    "C001", "C005", "C006", "C010", "C014", "C017", "C019", "C063", "C083", "C086", "C087", "C088",
-    "C091", "C121", "C131", "C132", "K002", "S001", "S004", "S007", "S010", "S015", "S017", "S021",
-    "S045", "S050", "S069", "S075", "X030", "X052",
+    "C001", "C005", "C006", "C010", "C014", "C017", "C019", "C063", "C083", "C086", "C088", "C091",
+    "C121", "C131", "C132", "K002", "S001", "S004", "S007", "S010", "S015", "S017", "S021", "S045",
+    "S050", "S069", "S075", "X030", "X052",
 ];
 const LARGE_CORPUS_ALLOWED_FAILING_RULE_REASON: &str = "known large-corpus rule allowlist";
 


### PR DESCRIPTION
## Summary
- remove `C087` from the large-corpus allowlist
- add `C087` regression coverage for quoted version literals and dynamic version sources

## Why
`C087` is now clean in the large-corpus harness aside from an explicitly reviewed metadata divergence, so it no longer needs the blanket allowlist entry in `large_corpus.rs`.

## Impact
This keeps `C087` held to the normal compatibility path while preserving coverage for the operand shapes we verified during the investigation.

## Validation
- `make test-large-corpus`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C087`
- `cargo test -p shuck-linter string_comparison_for_version`
- `cargo fmt --check`
