### PR TITLE
Fix S010 for escaped declaration builtins

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -13910,6 +13910,7 @@ fn is_unescaped_dollar(bytes: &[u8], index: usize) -> bool {
 }
 
 fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let text = std::str::from_utf8(bytes).ok()?;
     let mut paren_depth = 0usize;
     let mut cursor = start + 2;
 
@@ -13936,6 +13937,14 @@ fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
             continue;
         }
 
+        if cursor + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, cursor)
+            && bytes[cursor + 1] == b'{'
+        {
+            cursor = find_runtime_parameter_closing_brace(text, cursor)?;
+            continue;
+        }
+
         match bytes[cursor] {
             b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
             b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
@@ -13957,6 +13966,7 @@ fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
 }
 
 fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let text = std::str::from_utf8(bytes).ok()?;
     let mut paren_depth = 0usize;
     let mut cursor = start + 3;
 
@@ -13980,6 +13990,14 @@ fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<usize> {
             && bytes[cursor + 1] == b'('
         {
             cursor = find_command_substitution_end(bytes, cursor)?;
+            continue;
+        }
+
+        if cursor + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, cursor)
+            && bytes[cursor + 1] == b'{'
+        {
+            cursor = find_runtime_parameter_closing_brace(text, cursor)?;
             continue;
         }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -11314,17 +11314,15 @@ fn build_simple_command_declaration_assignment_probes<'a>(
     let Some(kind) = simple_command_declaration_kind(normalized.effective_or_literal_name()) else {
         return Vec::new().into_boxed_slice();
     };
+    let word_groups = contiguous_word_groups(normalized.body_args());
     let readonly_flag = matches!(
         kind,
         command::DeclarationKind::Local
             | command::DeclarationKind::Declare
             | command::DeclarationKind::Typeset
-    ) && normalized
-        .body_args()
-        .iter()
-        .any(|word| declaration_flag_sets_readonly(word, source));
+    ) && simple_command_declaration_readonly_flag(&word_groups, source);
 
-    contiguous_word_groups(normalized.body_args())
+    word_groups
         .iter()
         .filter_map(|words| {
             let first = *words.first()?;
@@ -11382,8 +11380,51 @@ fn simple_command_declaration_kind(name: Option<&str>) -> Option<command::Declar
     }
 }
 
-fn declaration_flag_sets_readonly(word: &Word, source: &str) -> bool {
-    static_word_text(word, source).is_some_and(|text| text.starts_with('-') && text.contains('r'))
+fn simple_command_declaration_readonly_flag(word_groups: &[&[&Word]], source: &str) -> bool {
+    let mut readonly_flag = false;
+
+    for words in word_groups {
+        let [word] = words else {
+            break;
+        };
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+
+        // Bash stops parsing declaration options after the first name[=value] operand,
+        // so later "-r" words must not retroactively mark earlier assignments readonly.
+        if text == "--" {
+            break;
+        }
+
+        if !simple_command_declaration_option_word(&text) {
+            break;
+        }
+
+        if declaration_flag_sets_readonly_text(&text) {
+            readonly_flag = true;
+        }
+    }
+
+    readonly_flag
+}
+
+fn simple_command_declaration_option_word(text: &str) -> bool {
+    let mut chars = text.chars();
+    let Some(prefix) = chars.next() else {
+        return false;
+    };
+
+    if !matches!(prefix, '-' | '+') {
+        return false;
+    }
+
+    let rest = chars.as_str();
+    !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_alphabetic())
+}
+
+fn declaration_flag_sets_readonly_text(text: &str) -> bool {
+    text.starts_with('-') && text.contains('r')
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -27326,6 +27367,32 @@ echo \"Resolve the conflict and run ``${PROGRAM} --continue`` plus `date`.\"
                 .collect::<Vec<_>>();
 
             assert_eq!(probes, vec![("arr", true)]);
+        });
+    }
+
+    #[test]
+    fn ignores_readonly_like_tokens_after_escaped_declaration_assignments() {
+        let source = "\
+#!/bin/bash
+demo() {
+  \\declare out=$(date) -r
+}
+";
+
+        with_facts(source, None, |_, facts| {
+            let probes = facts
+                .structural_commands()
+                .flat_map(|fact| fact.declaration_assignment_probes().iter())
+                .map(|probe| {
+                    (
+                        probe.target_name(),
+                        probe.readonly_flag(),
+                        probe.has_command_substitution(),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(probes, vec![("out", false, true)]);
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -11324,19 +11324,23 @@ fn build_simple_command_declaration_assignment_probes<'a>(
         .iter()
         .any(|word| declaration_flag_sets_readonly(word, source));
 
-    normalized
-        .body_args()
+    contiguous_word_groups(normalized.body_args())
         .iter()
-        .filter_map(|word| {
-            let parsed = parse_assignment_word(word.span.slice(source))?;
-            let value_text = &word.span.slice(source)[parsed.value_offset..];
+        .filter_map(|words| {
+            let first = *words.first()?;
+            let text = words
+                .iter()
+                .map(|word| word.span.slice(source))
+                .collect::<String>();
+            let parsed = parse_assignment_word(&text)?;
+            let value_text = &text[parsed.value_offset..];
             Some(DeclarationAssignmentProbe {
                 kind: kind.clone(),
                 readonly_flag,
                 target_name: parsed.name.into(),
                 target_name_span: Span::from_positions(
-                    word.span.start,
-                    word.span.start.advanced_by(parsed.name),
+                    first.span.start,
+                    first.span.start.advanced_by(parsed.name),
                 ),
                 has_command_substitution: parsed_assignment_value_has_command_substitution(
                     value_text,
@@ -11346,6 +11350,25 @@ fn build_simple_command_declaration_assignment_probes<'a>(
         })
         .collect::<Vec<_>>()
         .into_boxed_slice()
+}
+
+fn contiguous_word_groups<'a>(words: &'a [&'a Word]) -> Vec<&'a [&'a Word]> {
+    let mut groups = Vec::new();
+    let mut start = 0usize;
+
+    while start < words.len() {
+        let mut end = start + 1;
+        while let Some(next) = words.get(end).copied() {
+            if words[end - 1].span.end.offset != next.span.start.offset {
+                break;
+            }
+            end += 1;
+        }
+        groups.push(&words[start..end]);
+        start = end;
+    }
+
+    groups
 }
 
 fn simple_command_declaration_kind(name: Option<&str>) -> Option<command::DeclarationKind> {
@@ -11426,6 +11449,14 @@ fn parse_assignment_word(word: &str) -> Option<ParsedAssignmentWord<'_>> {
                 && bytes[index + 1] == b'{'
             {
                 index = find_runtime_parameter_closing_brace(word, index)?;
+                continue;
+            }
+
+            if index + 1 < bytes.len()
+                && matches!(bytes[index], b'<' | b'>')
+                && bytes[index + 1] == b'('
+            {
+                index = find_process_substitution_end(bytes, index)?;
                 continue;
             }
 
@@ -13945,6 +13976,14 @@ fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
             continue;
         }
 
+        if cursor + 1 < bytes.len()
+            && matches!(bytes[cursor], b'<' | b'>')
+            && bytes[cursor + 1] == b'('
+        {
+            cursor = find_process_substitution_end(bytes, cursor)?;
+            continue;
+        }
+
         match bytes[cursor] {
             b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
             b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
@@ -14001,6 +14040,14 @@ fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<usize> {
             continue;
         }
 
+        if cursor + 1 < bytes.len()
+            && matches!(bytes[cursor], b'<' | b'>')
+            && bytes[cursor + 1] == b'('
+        {
+            cursor = find_process_substitution_end(bytes, cursor)?;
+            continue;
+        }
+
         match bytes[cursor] {
             b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
             b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
@@ -14013,6 +14060,70 @@ fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<usize> {
                 return Some(cursor + 2);
             }
             b')' if paren_depth > 0 => {
+                paren_depth -= 1;
+                cursor += 1;
+            }
+            _ => cursor += 1,
+        }
+    }
+
+    None
+}
+
+fn find_process_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    let mut paren_depth = 0usize;
+    let mut cursor = start + 2;
+
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            cursor = (cursor + 2).min(bytes.len());
+            continue;
+        }
+
+        if cursor + 2 < bytes.len()
+            && is_unescaped_dollar(bytes, cursor)
+            && bytes[cursor + 1] == b'('
+            && bytes[cursor + 2] == b'('
+        {
+            cursor = find_wrapped_arithmetic_end(bytes, cursor)?;
+            continue;
+        }
+
+        if cursor + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, cursor)
+            && bytes[cursor + 1] == b'('
+        {
+            cursor = find_command_substitution_end(bytes, cursor)?;
+            continue;
+        }
+
+        if cursor + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, cursor)
+            && bytes[cursor + 1] == b'{'
+        {
+            cursor = find_runtime_parameter_closing_brace(text, cursor)?;
+            continue;
+        }
+
+        if cursor + 1 < bytes.len()
+            && matches!(bytes[cursor], b'<' | b'>')
+            && bytes[cursor + 1] == b'('
+        {
+            cursor = find_process_substitution_end(bytes, cursor)?;
+            continue;
+        }
+
+        match bytes[cursor] {
+            b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
+            b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
+            b'`' => cursor = skip_backticks(bytes, cursor + 1)?,
+            b'(' => {
+                paren_depth += 1;
+                cursor += 1;
+            }
+            b')' if paren_depth == 0 => return Some(cursor + 1),
+            b')' => {
                 paren_depth -= 1;
                 cursor += 1;
             }
@@ -27198,5 +27309,32 @@ echo \"Resolve the conflict and run ``${PROGRAM} --continue`` plus `date`.\"
                 vec![("``", true), ("``", true), ("`date`", false)]
             );
         });
+    }
+
+    #[test]
+    fn collects_declaration_assignment_probes_for_process_substitution_subscripts() {
+        let source = "\
+#!/bin/bash
+\\declare -A arr[<(printf \"]\")]=$(date)
+";
+
+        with_facts(source, None, |_, facts| {
+            let probes = facts
+                .structural_commands()
+                .flat_map(|fact| fact.declaration_assignment_probes().iter())
+                .map(|probe| (probe.target_name(), probe.has_command_substitution()))
+                .collect::<Vec<_>>();
+
+            assert_eq!(probes, vec![("arr", true)]);
+        });
+    }
+
+    #[test]
+    fn parses_assignment_words_with_process_substitution_subscripts() {
+        let word = "arr[<(printf \"]\")]=$(date)";
+        let parsed = super::parse_assignment_word(word)
+            .map(|parsed| (parsed.name, &word[parsed.value_offset..]));
+
+        assert_eq!(parsed, Some(("arr", "$(date)")));
     }
 }

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -9077,17 +9077,13 @@ fn find_runtime_parameter_closing_brace(text: &str, start_offset: usize) -> Opti
             continue;
         }
 
-        if index + 1 < bytes.len()
-            && is_unescaped_dollar(bytes, index)
-            && bytes[index + 1] == b'('
+        if index + 1 < bytes.len() && is_unescaped_dollar(bytes, index) && bytes[index + 1] == b'('
         {
             index = find_command_substitution_end(bytes, index)?;
             continue;
         }
 
-        if index + 1 < bytes.len()
-            && is_unescaped_dollar(bytes, index)
-            && bytes[index + 1] == b'{'
+        if index + 1 < bytes.len() && is_unescaped_dollar(bytes, index) && bytes[index + 1] == b'{'
         {
             depth += 1;
             index += "${".len();

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -11383,7 +11383,7 @@ fn parse_assignment_word(word: &str) -> Option<ParsedAssignmentWord<'_>> {
 
         while index < bytes.len() {
             if bytes[index] == b'\\' {
-                index = (index + 2).min(bytes.len());
+                index = advance_escaped_char_boundary(word, index);
                 continue;
             }
 
@@ -11450,6 +11450,15 @@ fn parse_assignment_word(word: &str) -> Option<ParsedAssignmentWord<'_>> {
     } else {
         None
     }
+}
+
+fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
+    let next = start + '\\'.len_utf8();
+    if next >= text.len() {
+        return next;
+    }
+
+    next + text[next..].chars().next().map_or(0, char::len_utf8)
 }
 
 fn word_has_command_substitution(

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -955,6 +955,42 @@ impl<'a> PathWordFact<'a> {
 }
 
 #[derive(Debug, Clone)]
+pub struct DeclarationAssignmentProbe {
+    kind: command::DeclarationKind,
+    readonly_flag: bool,
+    target_name: Box<str>,
+    target_name_span: Span,
+    word_span: Span,
+    expansion_context: ExpansionContext,
+}
+
+impl DeclarationAssignmentProbe {
+    pub fn kind(&self) -> &command::DeclarationKind {
+        &self.kind
+    }
+
+    pub fn readonly_flag(&self) -> bool {
+        self.readonly_flag
+    }
+
+    pub fn target_name(&self) -> &str {
+        &self.target_name
+    }
+
+    pub fn target_name_span(&self) -> Span {
+        self.target_name_span
+    }
+
+    pub fn word_span(&self) -> Span {
+        self.word_span
+    }
+
+    pub fn expansion_context(&self) -> ExpansionContext {
+        self.expansion_context
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct SingleQuotedFragmentFact {
     span: Span,
     dollar_quoted: bool,
@@ -2816,6 +2852,7 @@ pub struct CommandFact<'a> {
     substitution_facts: Box<[SubstitutionFact]>,
     options: CommandOptionFacts<'a>,
     scope_read_source_words: Box<[PathWordFact<'a>]>,
+    declaration_assignment_probes: Box<[DeclarationAssignmentProbe]>,
     glued_closing_bracket_operand_span: Option<Span>,
     simple_test: Option<SimpleTestFact<'a>>,
     conditional: Option<ConditionalFact<'a>>,
@@ -2876,6 +2913,10 @@ impl<'a> CommandFact<'a> {
 
     pub fn scope_read_source_words(&self) -> &[PathWordFact<'a>] {
         &self.scope_read_source_words
+    }
+
+    pub fn declaration_assignment_probes(&self) -> &[DeclarationAssignmentProbe] {
+        &self.declaration_assignment_probes
     }
 
     pub fn glued_closing_bracket_operand_span(&self) -> Option<Span> {
@@ -3714,6 +3755,8 @@ impl<'a> LinterFactsBuilder<'a> {
             let redirect_facts =
                 build_redirect_facts(visit.redirects, self.source, command_zsh_options.as_ref());
             let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
+            let declaration_assignment_probes =
+                build_declaration_assignment_probes(visit.command, &normalized, self.source);
             let glued_closing_bracket_operand_span =
                 build_glued_closing_bracket_operand_span(visit.command, self.source);
             let simple_test =
@@ -3730,6 +3773,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 substitution_facts: Vec::new().into_boxed_slice(),
                 options,
                 scope_read_source_words: Vec::new().into_boxed_slice(),
+                declaration_assignment_probes,
                 glued_closing_bracket_operand_span,
                 simple_test,
                 conditional,
@@ -11202,6 +11246,166 @@ fn brace_fd_gap_allows_attachment(gap: &str) -> bool {
     true
 }
 
+fn build_declaration_assignment_probes<'a>(
+    command: &'a Command,
+    normalized: &NormalizedCommand<'a>,
+    source: &str,
+) -> Box<[DeclarationAssignmentProbe]> {
+    if let Some(declaration) = normalized.declaration.as_ref() {
+        return declaration
+            .assignment_operands
+            .iter()
+            .filter_map(|assignment| {
+                let AssignmentValue::Scalar(word) = &assignment.value else {
+                    return None;
+                };
+
+                Some(DeclarationAssignmentProbe {
+                    kind: declaration.kind.clone(),
+                    readonly_flag: declaration.readonly_flag,
+                    target_name: assignment.target.name.as_str().into(),
+                    target_name_span: assignment.target.name_span,
+                    word_span: word.span,
+                    expansion_context: ExpansionContext::DeclarationAssignmentValue,
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+    }
+
+    build_simple_command_declaration_assignment_probes(command, normalized, source)
+}
+
+fn build_simple_command_declaration_assignment_probes<'a>(
+    command: &'a Command,
+    normalized: &NormalizedCommand<'a>,
+    source: &str,
+) -> Box<[DeclarationAssignmentProbe]> {
+    let Command::Simple(_) = command else {
+        return Vec::new().into_boxed_slice();
+    };
+
+    if !normalized.wrappers.is_empty() {
+        return Vec::new().into_boxed_slice();
+    }
+
+    let Some(kind) = simple_command_declaration_kind(normalized.effective_or_literal_name()) else {
+        return Vec::new().into_boxed_slice();
+    };
+    let readonly_flag = matches!(
+        kind,
+        command::DeclarationKind::Local
+            | command::DeclarationKind::Declare
+            | command::DeclarationKind::Typeset
+    ) && normalized
+        .body_args()
+        .iter()
+        .any(|word| declaration_flag_sets_readonly(word, source));
+
+    normalized
+        .body_args()
+        .iter()
+        .filter_map(|word| {
+            let name = assignment_word_name(word.span.slice(source))?;
+            Some(DeclarationAssignmentProbe {
+                kind: kind.clone(),
+                readonly_flag,
+                target_name: name.into(),
+                target_name_span: Span::from_positions(
+                    word.span.start,
+                    word.span.start.advanced_by(name),
+                ),
+                word_span: word.span,
+                expansion_context: ExpansionContext::CommandArgument,
+            })
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+fn simple_command_declaration_kind(name: Option<&str>) -> Option<command::DeclarationKind> {
+    match name? {
+        "export" => Some(command::DeclarationKind::Export),
+        "local" => Some(command::DeclarationKind::Local),
+        "declare" => Some(command::DeclarationKind::Declare),
+        "typeset" => Some(command::DeclarationKind::Typeset),
+        "readonly" => Some(command::DeclarationKind::Other("readonly".to_owned())),
+        _ => None,
+    }
+}
+
+fn declaration_flag_sets_readonly(word: &Word, source: &str) -> bool {
+    static_word_text(word, source).is_some_and(|text| text.starts_with('-') && text.contains('r'))
+}
+
+fn assignment_word_name(word: &str) -> Option<&str> {
+    if !word.contains('=') {
+        return None;
+    }
+
+    let mut chars = word.char_indices();
+    let (_, first) = chars.next()?;
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return None;
+    }
+
+    let mut ident_end = first.len_utf8();
+    for (index, ch) in chars {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            ident_end = index + ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    let name = &word[..ident_end];
+    let mut cursor = ident_end;
+
+    if word[cursor..].starts_with('[') {
+        let mut close_index = None;
+        let mut bracket_depth = 0_i32;
+        let mut brace_depth = 0_i32;
+        let mut paren_depth = 0_i32;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+
+        for (relative, ch) in word[cursor + 1..].char_indices() {
+            let absolute = cursor + 1 + relative;
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' if !in_single => escaped = true,
+                '\'' if !in_double => in_single = !in_single,
+                '"' if !in_single => in_double = !in_double,
+                '[' if !in_single && !in_double => bracket_depth += 1,
+                ']' if !in_single && !in_double => {
+                    if bracket_depth == 0 && brace_depth == 0 && paren_depth == 0 {
+                        close_index = Some(absolute);
+                        break;
+                    }
+                    bracket_depth -= 1;
+                }
+                '{' if !in_single && !in_double => brace_depth += 1,
+                '}' if !in_single && !in_double && brace_depth > 0 => brace_depth -= 1,
+                '(' if !in_single && !in_double => paren_depth += 1,
+                ')' if !in_single && !in_double && paren_depth > 0 => paren_depth -= 1,
+                _ => {}
+            }
+        }
+
+        cursor = close_index? + 1;
+    }
+
+    if word[cursor..].starts_with("+=") || word[cursor..].starts_with('=') {
+        Some(name)
+    } else {
+        None
+    }
+}
 fn redirect_operator_span(redirect: &Redirect) -> Span {
     let operator_start = redirect
         .fd_var_span

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -9058,36 +9058,57 @@ fn find_runtime_parameter_closing_brace(text: &str, start_offset: usize) -> Opti
         return None;
     }
 
+    let bytes = text.as_bytes();
     let mut index = start_offset + "${".len();
     let mut depth = 1usize;
 
-    while index < text.len() {
-        if text[index..].starts_with("${") {
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = advance_escaped_char_boundary(text, index);
+            continue;
+        }
+
+        if index + 2 < bytes.len()
+            && is_unescaped_dollar(bytes, index)
+            && bytes[index + 1] == b'('
+            && bytes[index + 2] == b'('
+        {
+            index = find_wrapped_arithmetic_end(bytes, index)?;
+            continue;
+        }
+
+        if index + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, index)
+            && bytes[index + 1] == b'('
+        {
+            index = find_command_substitution_end(bytes, index)?;
+            continue;
+        }
+
+        if index + 1 < bytes.len()
+            && is_unescaped_dollar(bytes, index)
+            && bytes[index + 1] == b'{'
+        {
             depth += 1;
             index += "${".len();
             continue;
         }
 
-        let ch = text[index..].chars().next()?;
-
-        if ch == '\\' {
-            index += ch.len_utf8();
-            if let Some(escaped) = text[index..].chars().next() {
-                index += escaped.len_utf8();
+        match bytes[index] {
+            b'\'' => index = skip_single_quoted(bytes, index + 1)?,
+            b'"' => index = skip_double_quoted(bytes, index + 1)?,
+            b'`' => index = skip_backticks(bytes, index + 1)?,
+            b'}' => {
+                depth -= 1;
+                index += '}'.len_utf8();
+                if depth == 0 {
+                    return Some(index);
+                }
             }
-            continue;
-        }
-
-        if ch == '}' {
-            depth -= 1;
-            index += ch.len_utf8();
-            if depth == 0 {
-                return Some(index);
+            _ => {
+                index += text[index..].chars().next()?.len_utf8();
             }
-            continue;
         }
-
-        index += ch.len_utf8();
     }
 
     None

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -11376,42 +11376,61 @@ fn parse_assignment_word(word: &str) -> Option<ParsedAssignmentWord<'_>> {
     let mut cursor = ident_end;
 
     if word[cursor..].starts_with('[') {
+        let bytes = word.as_bytes();
         let mut close_index = None;
-        let mut bracket_depth = 0_i32;
-        let mut brace_depth = 0_i32;
-        let mut paren_depth = 0_i32;
-        let mut in_single = false;
-        let mut in_double = false;
-        let mut escaped = false;
+        let mut bracket_depth = 0usize;
+        let mut index = cursor + 1;
 
-        for (relative, ch) in word[cursor + 1..].char_indices() {
-            let absolute = cursor + 1 + relative;
-            if escaped {
-                escaped = false;
+        while index < bytes.len() {
+            if bytes[index] == b'\\' {
+                index = (index + 2).min(bytes.len());
                 continue;
             }
 
-            match ch {
-                '\\' if !in_single => escaped = true,
-                '\'' if !in_double => in_single = !in_single,
-                '"' if !in_single => in_double = !in_double,
-                '[' if !in_single && !in_double && brace_depth == 0 && paren_depth == 0 => {
-                    bracket_depth += 1
+            if index + 2 < bytes.len()
+                && is_unescaped_dollar(bytes, index)
+                && bytes[index + 1] == b'('
+                && bytes[index + 2] == b'('
+            {
+                index = find_wrapped_arithmetic_end(bytes, index)?;
+                continue;
+            }
+
+            if index + 1 < bytes.len()
+                && is_unescaped_dollar(bytes, index)
+                && bytes[index + 1] == b'('
+            {
+                index = find_command_substitution_end(bytes, index)?;
+                continue;
+            }
+
+            if index + 1 < bytes.len()
+                && is_unescaped_dollar(bytes, index)
+                && bytes[index + 1] == b'{'
+            {
+                index = find_runtime_parameter_closing_brace(word, index)?;
+                continue;
+            }
+
+            match bytes[index] {
+                b'\'' => index = skip_single_quoted(bytes, index + 1)?,
+                b'"' => index = skip_double_quoted(bytes, index + 1)?,
+                b'`' => index = skip_backticks(bytes, index + 1)?,
+                b'[' => {
+                    bracket_depth += 1;
+                    index += 1;
                 }
-                ']' if !in_single && !in_double => {
-                    if bracket_depth == 0 && brace_depth == 0 && paren_depth == 0 {
-                        close_index = Some(absolute);
-                        break;
-                    }
-                    if bracket_depth > 0 && brace_depth == 0 && paren_depth == 0 {
-                        bracket_depth -= 1;
-                    }
+                b']' if bracket_depth == 0 => {
+                    close_index = Some(index);
+                    break;
                 }
-                '{' if !in_single && !in_double => brace_depth += 1,
-                '}' if !in_single && !in_double && brace_depth > 0 => brace_depth -= 1,
-                '(' if !in_single && !in_double => paren_depth += 1,
-                ')' if !in_single && !in_double && paren_depth > 0 => paren_depth -= 1,
-                _ => {}
+                b']' => {
+                    bracket_depth -= 1;
+                    index += 1;
+                }
+                _ => {
+                    index += word[index..].chars().next()?.len_utf8();
+                }
             }
         }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -63,6 +63,7 @@ use shuck_ast::{
     ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob,
 };
 use shuck_indexer::Indexer;
+use shuck_parser::parser::Parser;
 use shuck_semantic::{
     BindingAttributes, BindingId, BindingKind, ScopeId, SemanticModel, ZshOptionState,
 };
@@ -960,8 +961,7 @@ pub struct DeclarationAssignmentProbe {
     readonly_flag: bool,
     target_name: Box<str>,
     target_name_span: Span,
-    word_span: Span,
-    expansion_context: ExpansionContext,
+    has_command_substitution: bool,
 }
 
 impl DeclarationAssignmentProbe {
@@ -981,12 +981,8 @@ impl DeclarationAssignmentProbe {
         self.target_name_span
     }
 
-    pub fn word_span(&self) -> Span {
-        self.word_span
-    }
-
-    pub fn expansion_context(&self) -> ExpansionContext {
-        self.expansion_context
+    pub fn has_command_substitution(&self) -> bool {
+        self.has_command_substitution
     }
 }
 
@@ -3755,8 +3751,12 @@ impl<'a> LinterFactsBuilder<'a> {
             let redirect_facts =
                 build_redirect_facts(visit.redirects, self.source, command_zsh_options.as_ref());
             let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
-            let declaration_assignment_probes =
-                build_declaration_assignment_probes(visit.command, &normalized, self.source);
+            let declaration_assignment_probes = build_declaration_assignment_probes(
+                visit.command,
+                &normalized,
+                self.source,
+                command_zsh_options.as_ref(),
+            );
             let glued_closing_bracket_operand_span =
                 build_glued_closing_bracket_operand_span(visit.command, self.source);
             let simple_test =
@@ -11250,6 +11250,7 @@ fn build_declaration_assignment_probes<'a>(
     command: &'a Command,
     normalized: &NormalizedCommand<'a>,
     source: &str,
+    zsh_options: Option<&ZshOptionState>,
 ) -> Box<[DeclarationAssignmentProbe]> {
     if let Some(declaration) = normalized.declaration.as_ref() {
         return declaration
@@ -11265,21 +11266,25 @@ fn build_declaration_assignment_probes<'a>(
                     readonly_flag: declaration.readonly_flag,
                     target_name: assignment.target.name.as_str().into(),
                     target_name_span: assignment.target.name_span,
-                    word_span: word.span,
-                    expansion_context: ExpansionContext::DeclarationAssignmentValue,
+                    has_command_substitution: word_has_command_substitution(
+                        word,
+                        source,
+                        zsh_options,
+                    ),
                 })
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
     }
 
-    build_simple_command_declaration_assignment_probes(command, normalized, source)
+    build_simple_command_declaration_assignment_probes(command, normalized, source, zsh_options)
 }
 
 fn build_simple_command_declaration_assignment_probes<'a>(
     command: &'a Command,
     normalized: &NormalizedCommand<'a>,
     source: &str,
+    zsh_options: Option<&ZshOptionState>,
 ) -> Box<[DeclarationAssignmentProbe]> {
     let Command::Simple(_) = command else {
         return Vec::new().into_boxed_slice();
@@ -11306,17 +11311,20 @@ fn build_simple_command_declaration_assignment_probes<'a>(
         .body_args()
         .iter()
         .filter_map(|word| {
-            let name = assignment_word_name(word.span.slice(source))?;
+            let parsed = parse_assignment_word(word.span.slice(source))?;
+            let value_text = &word.span.slice(source)[parsed.value_offset..];
             Some(DeclarationAssignmentProbe {
                 kind: kind.clone(),
                 readonly_flag,
-                target_name: name.into(),
+                target_name: parsed.name.into(),
                 target_name_span: Span::from_positions(
                     word.span.start,
-                    word.span.start.advanced_by(name),
+                    word.span.start.advanced_by(parsed.name),
                 ),
-                word_span: word.span,
-                expansion_context: ExpansionContext::CommandArgument,
+                has_command_substitution: parsed_assignment_value_has_command_substitution(
+                    value_text,
+                    zsh_options,
+                ),
             })
         })
         .collect::<Vec<_>>()
@@ -11338,7 +11346,13 @@ fn declaration_flag_sets_readonly(word: &Word, source: &str) -> bool {
     static_word_text(word, source).is_some_and(|text| text.starts_with('-') && text.contains('r'))
 }
 
-fn assignment_word_name(word: &str) -> Option<&str> {
+#[derive(Debug, Clone, Copy)]
+struct ParsedAssignmentWord<'a> {
+    name: &'a str,
+    value_offset: usize,
+}
+
+fn parse_assignment_word(word: &str) -> Option<ParsedAssignmentWord<'_>> {
     if !word.contains('=') {
         return None;
     }
@@ -11381,13 +11395,17 @@ fn assignment_word_name(word: &str) -> Option<&str> {
                 '\\' if !in_single => escaped = true,
                 '\'' if !in_double => in_single = !in_single,
                 '"' if !in_single => in_double = !in_double,
-                '[' if !in_single && !in_double => bracket_depth += 1,
+                '[' if !in_single && !in_double && brace_depth == 0 && paren_depth == 0 => {
+                    bracket_depth += 1
+                }
                 ']' if !in_single && !in_double => {
                     if bracket_depth == 0 && brace_depth == 0 && paren_depth == 0 {
                         close_index = Some(absolute);
                         break;
                     }
-                    bracket_depth -= 1;
+                    if bracket_depth > 0 && brace_depth == 0 && paren_depth == 0 {
+                        bracket_depth -= 1;
+                    }
                 }
                 '{' if !in_single && !in_double => brace_depth += 1,
                 '}' if !in_single && !in_double && brace_depth > 0 => brace_depth -= 1,
@@ -11401,10 +11419,40 @@ fn assignment_word_name(word: &str) -> Option<&str> {
     }
 
     if word[cursor..].starts_with("+=") || word[cursor..].starts_with('=') {
-        Some(name)
+        Some(ParsedAssignmentWord {
+            name,
+            value_offset: cursor
+                + if word[cursor..].starts_with("+=") {
+                    2
+                } else {
+                    1
+                },
+        })
     } else {
         None
     }
+}
+
+fn word_has_command_substitution(
+    word: &Word,
+    source: &str,
+    zsh_options: Option<&ZshOptionState>,
+) -> bool {
+    word_classification_from_analysis(analyze_word(word, source, zsh_options))
+        .has_command_substitution()
+}
+
+fn parsed_assignment_value_has_command_substitution(
+    value_text: &str,
+    zsh_options: Option<&ZshOptionState>,
+) -> bool {
+    if value_text.is_empty() {
+        return false;
+    }
+
+    let word = Parser::parse_word_string(value_text);
+    word_classification_from_analysis(analyze_word(&word, value_text, zsh_options))
+        .has_command_substitution()
 }
 fn redirect_operator_span(redirect: &Redirect) -> Span {
     let operator_start = redirect

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -273,4 +273,24 @@ demo() {
             vec!["name"]
         );
     }
+
+    #[test]
+    fn reports_escaped_declarations_with_literal_braces_inside_command_subscripts() {
+        let source = "\
+#!/bin/bash
+\\declare arr[$(echo {)]=$(date)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["arr"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -333,4 +333,25 @@ demo() {
             vec!["arr"]
         );
     }
+
+    #[test]
+    fn reports_escaped_declarations_with_parameter_expansion_parens_inside_command_subscripts() {
+        let source = "\
+#!/bin/bash
+shopt -s extglob
+\\declare arr[$(printf %s ${x//@(a)/b})]=$(date)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["arr"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -238,6 +238,28 @@ demo() {
     }
 
     #[test]
+    fn reports_escaped_declarations_when_readonly_tokens_appear_after_assignments() {
+        let source = "\
+#!/bin/bash
+demo() {
+  \\declare out=$(date) -r
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["out"]
+        );
+    }
+
+    #[test]
     fn ignores_command_substitutions_in_escaped_assignment_targets() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -293,4 +293,24 @@ demo() {
             vec!["arr"]
         );
     }
+
+    #[test]
+    fn reports_escaped_declarations_with_utf8_escaped_subscript_chars() {
+        let source = "\
+#!/bin/bash
+\\declare arr[\\\u{00e9}]=$(date)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["arr"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -354,4 +354,24 @@ shopt -s extglob
             vec!["arr"]
         );
     }
+
+    #[test]
+    fn reports_escaped_declarations_with_process_substitution_subscripts() {
+        let source = "\
+#!/bin/bash
+\\declare -A arr[<(printf \"]\")]=$(date)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["arr"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -313,4 +313,24 @@ demo() {
             vec!["arr"]
         );
     }
+
+    #[test]
+    fn reports_escaped_declarations_with_nested_parameter_subscript_commands() {
+        let source = "\
+#!/bin/bash
+\\declare arr[${k:-$(printf '}')}]=$(date)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["arr"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -1,6 +1,6 @@
 use shuck_semantic::ScopeKind;
 
-use crate::{Checker, DeclarationKind, Rule, Violation, WordFactContext};
+use crate::{Checker, DeclarationKind, Rule, Violation};
 
 pub struct ExportCommandSubstitution {
     pub name: String,
@@ -30,14 +30,7 @@ pub fn export_command_substitution(checker: &mut Checker) {
                 continue;
             }
 
-            if checker
-                .facts()
-                .word_fact(
-                    probe.word_span(),
-                    WordFactContext::Expansion(probe.expansion_context()),
-                )
-                .is_some_and(|fact| fact.classification().has_command_substitution())
-            {
+            if probe.has_command_substitution() {
                 findings.push((probe.target_name().to_owned(), probe.target_name_span()));
             }
         }
@@ -242,5 +235,42 @@ demo() {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_command_substitutions_in_escaped_assignment_targets() {
+        let source = "\
+#!/bin/bash
+demo() {
+  \\local arr[$(date)]=1
+  \\declare map[${key:-$(printf '%s' fallback)}]=literal
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_escaped_declarations_with_nested_subscript_brackets() {
+        let source = "\
+#!/bin/bash
+\\declare name[${x:-]}]=$(date)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["name"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -1,10 +1,6 @@
-use shuck_ast::AssignmentValue;
 use shuck_semantic::ScopeKind;
 
-use crate::{
-    Checker, DeclarationKind, ExpansionContext, Rule, Violation, WordFactContext,
-    assignment_name_span,
-};
+use crate::{Checker, DeclarationKind, Rule, Violation, WordFactContext};
 
 pub struct ExportCommandSubstitution {
     pub name: String,
@@ -21,40 +17,31 @@ impl Violation for ExportCommandSubstitution {
 }
 
 pub fn export_command_substitution(checker: &mut Checker) {
-    let findings = checker
-        .facts()
-        .structural_commands()
-        .filter_map(|fact| {
-            let declaration = fact.declaration()?;
-            should_report_s010_declaration(
-                checker,
-                &declaration.kind,
-                declaration.readonly_flag,
-                fact.span(),
-            )
-            .then_some(declaration)
-        })
-        .flat_map(|declaration| declaration.assignment_operands.iter().copied())
-        .filter_map(|assignment| {
-            let AssignmentValue::Scalar(word) = &assignment.value else {
-                return None;
-            };
+    let mut findings = Vec::new();
 
-            checker
+    for fact in checker.facts().structural_commands() {
+        for probe in fact.declaration_assignment_probes() {
+            if !should_report_s010_declaration(
+                checker,
+                probe.kind(),
+                probe.readonly_flag(),
+                fact.span(),
+            ) {
+                continue;
+            }
+
+            if checker
                 .facts()
                 .word_fact(
-                    word.span,
-                    WordFactContext::Expansion(ExpansionContext::DeclarationAssignmentValue),
+                    probe.word_span(),
+                    WordFactContext::Expansion(probe.expansion_context()),
                 )
-                .filter(|fact| fact.classification().has_command_substitution())
-                .map(|_| {
-                    (
-                        assignment.target.name.to_string(),
-                        assignment_name_span(assignment),
-                    )
-                })
-        })
-        .collect::<Vec<_>>();
+                .is_some_and(|fact| fact.classification().has_command_substitution())
+            {
+                findings.push((probe.target_name().to_owned(), probe.target_name_span()));
+            }
+        }
+    }
 
     for (name, span) in findings {
         checker.report_dedup(ExportCommandSubstitution { name }, span);
@@ -205,5 +192,55 @@ readonly n_version=\"$(./bin/n --version)\"
                 .collect::<Vec<_>>(),
             vec!["archive_dir_create", "n_version"]
         );
+    }
+
+    #[test]
+    fn reports_escaped_declaration_builtins_with_command_substitution() {
+        let source = "\
+#!/bin/bash
+export_path() {
+  \\local local_name=\"$(date)\"
+  \\declare declared_name=$(pwd)
+  \\typeset typed_name=\"$(mktemp)\"
+  \\readonly kept_name=$(date)
+}
+\\export exported_name=\"$(printf '%s' hi)\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "local_name",
+                "declared_name",
+                "typed_name",
+                "kept_name",
+                "exported_name",
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_escaped_function_local_readonly_modifier_declarations() {
+        let source = "\
+#!/bin/bash
+demo() {
+  \\local -r temp=\"$(date)\"
+  \\declare -r other=$(date)
+  \\typeset -r home=$(pwd)
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/s010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s010.yaml
@@ -51,6 +51,15 @@ reviewed_divergences:
     labels:
       - project-closure
     reason: "The harness context around this package builder makes the top-level readonly assignment diverge from the corpus comparison."
+  - side: shellcheck-only
+    path_suffix: "scop__bash-completion__completions-core__tmux.bash"
+    line: 195
+    end_line: 195
+    column: 11
+    end_column: 16
+    labels:
+      - shell-collapse
+    reason: "This bash-completion helper is compared through a shell-collapsed compatibility path, and the remaining `local usage=$(...)` declaration warning stays on the oracle side in that collapsed helper context."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__install_script__install_nvm_from_git"
     line: 63

--- a/crates/shuck/tests/testdata/corpus-metadata/s010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s010.yaml
@@ -1,4 +1,3 @@
-review_all_divergences: true
 reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "megastep__makeself__test__appendtest"


### PR DESCRIPTION
## Summary
- add declaration-assignment probes for escaped declaration builtins like `\\local`, `\\declare`, `\\typeset`, `\\readonly`, and `\\export`
- switch `S010` to use the shared probe facts instead of only parsed `DeclClause` assignments
- remove `S010` from the large-corpus allowlist now that the rule no longer needs reviewed-divergence masking

## Root cause
`S010` only looked at parsed declaration clauses, so escaped declaration builtins that stayed in simple-command form were invisible to the rule even though ShellCheck still reports SC2155 for them.

## Validation
- `cargo test -p shuck-linter export_command_substitution -- --nocapture`
- `cargo test -p shuck large_corpus -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S010`
