### PR TITLE
Fix C014 recovered-parse false positives

### DIFF
--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -38,6 +38,7 @@ impl DiagnosticKey {
 }
 
 impl<'a> Checker<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         file: &'a File,
         source: &'a str,

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -15,6 +15,7 @@ pub struct Checker<'a> {
     rules: &'a RuleSet,
     shell: ShellDialect,
     file_context: &'a FileContext,
+    first_parse_error: Option<(usize, usize)>,
     diagnostics: Vec<Diagnostic>,
     reported: FxHashSet<DiagnosticKey>,
 }
@@ -45,6 +46,7 @@ impl<'a> Checker<'a> {
         rules: &'a RuleSet,
         shell: ShellDialect,
         file_context: &'a FileContext,
+        first_parse_error: Option<(usize, usize)>,
     ) -> Self {
         Self {
             semantic,
@@ -56,6 +58,7 @@ impl<'a> Checker<'a> {
             rules,
             shell,
             file_context,
+            first_parse_error,
             diagnostics: Vec::new(),
             reported: FxHashSet::default(),
         }
@@ -95,6 +98,10 @@ impl<'a> Checker<'a> {
 
     pub fn file_context(&self) -> &'a FileContext {
         self.file_context
+    }
+
+    pub fn first_parse_error(&self) -> Option<(usize, usize)> {
+        self.first_parse_error
     }
 
     pub fn report<V: Violation>(&mut self, violation: V, span: Span) {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -260,10 +260,19 @@ fn parse_for_lint(source: &str, shell: ShellDialect) -> ParseResult {
 }
 
 fn parse_error_position(parse_result: &ParseResult) -> Option<(usize, usize)> {
-    parse_result.is_err().then(|| {
-        let shuck_parser::Error::Parse { line, column, .. } = parse_result.strict_error();
-        (line, column)
-    })
+    if !parse_result.is_err() {
+        return None;
+    }
+
+    let shuck_parser::Error::Parse { line, column, .. } = parse_result.strict_error();
+    if line > 0 && column > 0 {
+        return Some((line, column));
+    }
+
+    parse_result
+        .diagnostics
+        .first()
+        .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
 }
 
 pub fn lint_file(
@@ -432,8 +441,11 @@ fn filter_suppressed_diagnostics(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shuck_ast::Command;
-    use shuck_parser::parser::{Parser, ShellDialect as ParseDialect};
+    use shuck_ast::{Command, Position, Span};
+    use shuck_parser::Error as ParseError;
+    use shuck_parser::parser::{
+        ParseDiagnostic, ParseStatus, Parser, ShellDialect as ParseDialect, SyntaxFacts,
+    };
     use std::fs;
     use std::path::Path;
     use tempfile::tempdir;
@@ -522,6 +534,28 @@ mod tests {
         assert!(result.diagnostics.is_empty());
         assert!(!result.semantic.scopes().is_empty());
         assert!(!result.semantic.bindings().is_empty());
+    }
+
+    #[test]
+    fn parse_error_position_falls_back_to_first_diagnostic_span() {
+        let file = Parser::new("#!/bin/bash\n").parse().unwrap().file;
+        let diagnostic_start = Position {
+            line: 3,
+            column: 2,
+            offset: 14,
+        };
+        let parse_result = ParseResult {
+            file,
+            diagnostics: vec![ParseDiagnostic {
+                message: "expected command".to_owned(),
+                span: Span::at(diagnostic_start),
+            }],
+            status: ParseStatus::Recovered,
+            terminal_error: Some(ParseError::parse("expected command")),
+            syntax_facts: SyntaxFacts::default(),
+        };
+
+        assert_eq!(parse_error_position(&parse_result), Some((3, 2)));
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -151,6 +151,33 @@ pub fn analyze_file_at_path_with_resolver(
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> AnalysisResult {
     let shell = resolve_shell(settings, source, source_path);
+    let first_parse_error = parse_error_position(&parse_for_lint(source, shell));
+
+    analyze_file_at_path_with_resolver_and_shell(
+        file,
+        source,
+        indexer,
+        settings,
+        suppression_index,
+        source_path,
+        source_path_resolver,
+        shell,
+        first_parse_error,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_file_at_path_with_resolver_and_shell(
+    file: &File,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+    shell: ShellDialect,
+    first_parse_error: Option<(usize, usize)>,
+) -> AnalysisResult {
     let file_context = classify_file_context(source, source_path, shell);
     let file_entry_contract =
         ambient_contracts::file_entry_contract(source, source_path, shell, &file_context);
@@ -184,6 +211,7 @@ pub fn analyze_file_at_path_with_resolver(
         &settings.rules,
         shell,
         &file_context,
+        first_parse_error,
     );
     let mut diagnostics = observer.into_diagnostics();
     diagnostics.extend(checker.check());
@@ -231,6 +259,13 @@ fn parse_for_lint(source: &str, shell: ShellDialect) -> ParseResult {
     Parser::with_profile(source, inferred_shell_profile(shell)).parse()
 }
 
+fn parse_error_position(parse_result: &ParseResult) -> Option<(usize, usize)> {
+    parse_result.is_err().then(|| {
+        let shuck_parser::Error::Parse { line, column, .. } = parse_result.strict_error();
+        (line, column)
+    })
+}
+
 pub fn lint_file(
     file: &File,
     source: &str,
@@ -272,7 +307,7 @@ pub fn lint_file_at_path_with_resolver(
     let shell = resolve_shell(settings, source, source_path);
     let parse_result = parse_for_lint(source, shell);
 
-    let mut diagnostics = analyze_file_at_path_with_resolver(
+    let mut diagnostics = analyze_file_at_path_with_resolver_and_shell(
         file,
         source,
         indexer,
@@ -280,6 +315,8 @@ pub fn lint_file_at_path_with_resolver(
         None,
         source_path,
         source_path_resolver,
+        shell,
+        parse_error_position(&parse_result),
     )
     .diagnostics;
 
@@ -319,7 +356,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
 ) -> Vec<Diagnostic> {
     let shell = resolve_shell(settings, source, source_path);
 
-    let mut diagnostics = analyze_file_at_path_with_resolver(
+    let mut diagnostics = analyze_file_at_path_with_resolver_and_shell(
         &parse_result.file,
         source,
         indexer,
@@ -327,6 +364,8 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
         None,
         source_path,
         source_path_resolver,
+        shell,
+        parse_error_position(parse_result),
     )
     .diagnostics;
 

--- a/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
+++ b/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
@@ -1,4 +1,5 @@
-use shuck_semantic::{DeclarationBuiltin, ScopeKind};
+use shuck_ast::Span;
+use shuck_semantic::{Binding, BindingAttributes, BindingKind, DeclarationBuiltin, ScopeKind};
 
 use crate::{Checker, Rule, ShellDialect, Violation};
 
@@ -19,21 +20,152 @@ pub fn local_top_level(checker: &mut Checker) {
         return;
     }
 
-    for declaration in checker.semantic().declarations() {
-        if declaration.builtin != DeclarationBuiltin::Local {
-            continue;
-        }
+    let semantic = checker.semantic();
+    let spans = semantic
+        .declarations()
+        .iter()
+        .filter(|declaration| declaration.builtin == DeclarationBuiltin::Local)
+        .filter(|declaration| {
+            checker
+                .first_parse_error()
+                .is_none_or(|(line, column)| {
+                    declaration.span.start.line < line
+                        || (declaration.span.start.line == line
+                            && declaration.span.start.column < column)
+                })
+        })
+        .filter_map(|declaration| {
+            let binding_scopes = semantic
+                .bindings()
+                .iter()
+                .filter(|binding| local_binding_belongs_to_declaration(binding, declaration.span))
+                .map(|binding| binding.scope)
+                .collect::<Vec<_>>();
 
-        let scope = checker.semantic().scope_at(declaration.span.start.offset);
-        let inside_function = checker
-            .semantic()
-            .ancestor_scopes(scope)
-            .any(|scope| matches!(checker.semantic().scope_kind(scope), ScopeKind::Function(_)));
+            if binding_scopes
+                .iter()
+                .any(|scope| matches!(semantic.scope_kind(*scope), ScopeKind::Function(_)))
+            {
+                return None;
+            }
 
-        if inside_function {
-            continue;
-        }
+            if !binding_scopes.is_empty() {
+                return Some(declaration.span);
+            }
 
-        checker.report(LocalTopLevel, declaration.span);
+            let scope = semantic.scope_at(declaration.span.start.offset);
+            let inside_function = semantic
+                .ancestor_scopes(scope)
+                .any(|scope| matches!(semantic.scope_kind(scope), ScopeKind::Function(_)));
+
+            (!inside_function).then_some(declaration.span)
+        })
+        .collect();
+
+    checker.report_all_dedup(spans, || LocalTopLevel);
+}
+
+fn local_binding_belongs_to_declaration(binding: &Binding, declaration_span: Span) -> bool {
+    if binding.span.start.offset < declaration_span.start.offset
+        || binding.span.end.offset > declaration_span.end.offset
+    {
+        return false;
+    }
+
+    matches!(
+        binding.kind,
+        BindingKind::Declaration(DeclarationBuiltin::Local)
+    ) || (matches!(binding.kind, BindingKind::Nameref)
+        && binding.attributes.contains(BindingAttributes::LOCAL))
+}
+
+#[cfg(test)]
+mod tests {
+    use shuck_parser::parser::Parser;
+
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn ignores_local_inside_function_branches() {
+        let source = "\
+#!/bin/bash
+f() {
+  if true; then
+    local scoped=1
+  fi
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LocalTopLevel));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_local_inside_function_loops() {
+        let source = "\
+#!/bin/bash
+f() {
+  local -a items=(one two)
+  for (( i=0; i<${#items[@]}; i++ )); do
+    local item=${items[i]}
+    printf '%s\\n' \"$item\"
+  done
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LocalTopLevel));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_redeclared_locals_inside_functions() {
+        let source = "\
+#!/bin/bash
+f() {
+  local item=first
+  if true; then
+    local item=second
+    printf '%s\\n' \"$item\"
+  fi
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LocalTopLevel));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_top_level_local_nameref() {
+        let source = "\
+#!/bin/bash
+local -n ref=target
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LocalTopLevel));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::LocalTopLevel);
+        assert!(diagnostics[0].span.slice(source).starts_with("local -n ref=target"));
+    }
+
+    #[test]
+    fn ignores_locals_after_recovered_parse_errors() {
+        let source = "\
+#!/bin/bash
+f() {
+  if true; then
+    :
+  else
+}
+
+g() {
+  local recovered=1
+}
+";
+        let parse_result = Parser::new(source).parse();
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LocalTopLevel));
+
+        assert!(parse_result.is_err(), "expected recovered parse");
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
+++ b/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
@@ -26,13 +26,11 @@ pub fn local_top_level(checker: &mut Checker) {
         .iter()
         .filter(|declaration| declaration.builtin == DeclarationBuiltin::Local)
         .filter(|declaration| {
-            checker
-                .first_parse_error()
-                .is_none_or(|(line, column)| {
-                    declaration.span.start.line < line
-                        || (declaration.span.start.line == line
-                            && declaration.span.start.column < column)
-                })
+            checker.first_parse_error().is_none_or(|(line, column)| {
+                declaration.span.start.line < line
+                    || (declaration.span.start.line == line
+                        && declaration.span.start.column < column)
+            })
         })
         .filter_map(|declaration| {
             let binding_scopes = semantic
@@ -145,7 +143,12 @@ local -n ref=target
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::LocalTopLevel);
-        assert!(diagnostics[0].span.slice(source).starts_with("local -n ref=target"));
+        assert!(
+            diagnostics[0]
+                .span
+                .slice(source)
+                .starts_with("local -n ref=target")
+        );
     }
 
     #[test]

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -3830,7 +3830,7 @@ mod tests {
 
         assert!(
             metadata
-                .get("C014")
+                .get("C001")
                 .is_some_and(|rule_metadata| rule_metadata.review_all_divergences)
         );
     }

--- a/crates/shuck/tests/testdata/corpus-metadata/c014.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c014.yaml
@@ -1,1 +1,1 @@
-review_all_divergences: true
+{}

--- a/crates/shuck/tests/zsh_option_state.rs
+++ b/crates/shuck/tests/zsh_option_state.rs
@@ -152,6 +152,7 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
         &rules,
         ShellDialect::Zsh,
         &file_context,
+        None,
     );
 
     for (probe_id, expected) in &fixture.option_probes {


### PR DESCRIPTION
## Summary
- use semantic binding scopes when classifying `local` declarations for C014
- ignore `local` declarations that appear at or after the first recovered parse error
- add regression coverage and remove C014 from the large-corpus allowlist

## Root Cause
C014 kept reporting on recovered AST after parse errors, which let broken scripts produce false positives for top-level `local` declarations.

## Testing
- cargo test -p shuck-linter script_scope_local -- --nocapture
- cargo test -p shuck-linter local_at_script_scope_is_flagged -- --nocapture
- cargo test -p shuck-linter local_inside_function_is_not_flagged -- --nocapture
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C014
