### PR TITLE
Update fix-rule skill for corpus metadata cleanup

### DIFF
--- a/.claude/skills/fix-rule/SKILL.md
+++ b/.claude/skills/fix-rule/SKILL.md
@@ -293,10 +293,9 @@ Check that:
 - Fixed deltas are now gone
 - Corpus-metadata entries suppress the reviewed divergences
 - No new regressions appeared
-- If the rule now passes cleanly and its code is listed in
-  `crates/shuck/tests/large_corpus.rs` under `LARGE_CORPUS_ALLOWED_FAILING_RULES`,
-  remove it from that array and rerun the targeted corpus test to confirm it no
-  longer needs the allowlist entry
+- If the rule now passes cleanly and its corpus-metadata file still has
+  `review_all_divergences: true`, remove that field and rerun the targeted
+  corpus test to confirm the rule no longer needs the rule-wide ignore entry
 
 If there are still failures, go back to Step 3 and work through the remaining
 patterns.


### PR DESCRIPTION
## Summary
- update the `fix-rule` skill to remove stale guidance about editing `LARGE_CORPUS_ALLOWED_FAILING_RULES`
- tell rule authors to remove `review_all_divergences: true` from rule corpus metadata once a rule passes cleanly

## Why
The large-corpus ignore flow moved into per-rule corpus metadata, but this skill still pointed people at the old Rust-side allowlist cleanup step.

## Testing
- not run (docs-only skill update)
