### PR TITLE
Fix S050 quote-adjacency conformance

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/style/S050.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S050.sh
@@ -3,6 +3,9 @@ printf '%s\n' 'foo'Default'baz'
 sed -i 's/${title}/'Default'/g' "$file"
 x='a'b'c'
 arr=('a'123'c')
+sed -i '/.*certs\.h/'d dependencies/file.cpp
+ip route | grep ^default'\s'via | head -1
+sed -i '/install(/s,\<lib\>,'lib$LIBDIRSUFFIX',' CMakeLists.txt
 printf '%s\n' 'foo'-'baz'
 printf '%s\n' 'foo''baz'
 printf '%s\n' 'foo'$bar'baz'

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -67,7 +67,7 @@ pub use rules::common::span::{
     word_unquoted_escaped_pipe_or_brace_spans_in_source, word_unquoted_glob_pattern_spans,
     word_unquoted_glob_pattern_spans_outside_brace_expansion,
     word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_parameter_spans,
-    word_unquoted_star_splat_spans, word_unquoted_word_between_single_quoted_segments_spans,
+    word_unquoted_star_splat_spans, word_unquoted_word_after_single_quoted_segment_spans,
     word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,
 };
 pub use rules::common::word::{

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -419,38 +419,36 @@ pub fn word_unquoted_assign_default_spans(word: &Word) -> Vec<Span> {
     spans
 }
 
-pub fn word_unquoted_word_between_single_quoted_segments_spans(
+pub fn word_unquoted_word_after_single_quoted_segment_spans(
     word: &Word,
     source: &str,
 ) -> Vec<Span> {
-    if word.parts.len() < 3 {
-        return Vec::new();
+    let mut spans = Vec::new();
+
+    for (index, part) in word.parts.iter().enumerate() {
+        if !is_non_dollar_single_quoted(part) {
+            continue;
+        }
+        if single_quoted_fragment_inner_text(part, source).is_some_and(|text| text.ends_with('\\'))
+        {
+            continue;
+        }
+
+        for next_part in word.parts.iter().skip(index + 1) {
+            if next_part.kind.is_quoted() {
+                break;
+            }
+
+            let WordPart::Literal(text) = &next_part.kind else {
+                continue;
+            };
+            if literal_contains_unquoted_word_chars(text.as_str(source, next_part.span)) {
+                spans.push(next_part.span);
+            }
+        }
     }
 
-    word.parts
-        .windows(3)
-        .filter_map(|window| {
-            let [left, middle, right] = window else {
-                return None;
-            };
-            if !is_non_dollar_single_quoted(left) || !is_non_dollar_single_quoted(right) {
-                return None;
-            }
-            if single_quoted_fragment_inner_text(left, source)
-                .is_some_and(|text| text.ends_with('\\'))
-                || single_quoted_fragment_inner_text(right, source)
-                    .is_some_and(|text| text.starts_with('\\'))
-            {
-                return None;
-            }
-
-            let WordPart::Literal(text) = &middle.kind else {
-                return None;
-            };
-            literal_contains_unquoted_word_chars(text.as_str(source, middle.span))
-                .then_some(middle.span)
-        })
-        .collect()
+    spans
 }
 
 pub fn word_unquoted_scalar_between_double_quoted_segments_spans(
@@ -3308,10 +3306,7 @@ fn single_quoted_fragment_inner_text<'a>(part: &WordPartNode, source: &'a str) -
 
 fn literal_contains_unquoted_word_chars(text: &str) -> bool {
     !text.is_empty()
-        && text
-            .as_bytes()
-            .iter()
-            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+        && text.as_bytes().iter().all(u8::is_ascii_alphanumeric)
         && text.as_bytes().iter().any(u8::is_ascii_alphanumeric)
 }
 
@@ -3470,7 +3465,7 @@ mod tests {
         word_unquoted_assign_default_spans, word_unquoted_escaped_pipe_or_brace_spans_in_source,
         word_unquoted_glob_pattern_spans, word_unquoted_glob_pattern_spans_outside_brace_expansion,
         word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_splat_spans,
-        word_unquoted_word_between_single_quoted_segments_spans,
+        word_unquoted_word_after_single_quoted_segment_spans,
     };
 
     #[test]
@@ -4329,9 +4324,9 @@ printf '%s\\n' mode\\|verbose token\\{a,b\\} token\\}end \"mode\\|verbose\" 'tok
     }
 
     #[test]
-    fn word_unquoted_word_between_single_quoted_segments_spans_track_literal_middle_words() {
+    fn word_unquoted_word_after_single_quoted_segment_spans_tracks_literal_suffix_words() {
         let source = "\
-printf '%s\\n' 'foo'Default'baz' 'foo'123'baz' 'foo'-'baz' 'foo''baz' 'foo'$bar'baz' $'foo'Default'baz'
+printf '%s\\n' 'foo'Default'baz' 'foo'123'baz' 'foo'-'baz' 'foo''baz' 'foo'$bar'baz' $'foo'Default'baz' '/x/'d ^default'\\s'via 'left'lib$SUFFIX'right' 'left'fuzz_ng_$SUFFIX'right'
 ";
         let output = Parser::new(source).parse().unwrap();
         let command = &output.file.body[0].command;
@@ -4342,15 +4337,15 @@ printf '%s\\n' 'foo'Default'baz' 'foo'123'baz' 'foo'-'baz' 'foo''baz' 'foo'$bar'
         let spans = command
             .args
             .iter()
-            .flat_map(|word| word_unquoted_word_between_single_quoted_segments_spans(word, source))
+            .flat_map(|word| word_unquoted_word_after_single_quoted_segment_spans(word, source))
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
 
-        assert_eq!(spans, vec!["Default", "123"]);
+        assert_eq!(spans, vec!["Default", "123", "d", "via", "lib"]);
     }
 
     #[test]
-    fn word_unquoted_word_between_single_quoted_segments_ignores_escaped_quote_bridges() {
+    fn word_unquoted_word_after_single_quoted_segment_ignores_escaped_quote_bridges() {
         let source = "\
 printf '%s\\n' 's/foo/'\\''bar'\\''/g' 'foo'Default'baz'
 ";
@@ -4363,7 +4358,7 @@ printf '%s\\n' 's/foo/'\\''bar'\\''/g' 'foo'Default'baz'
         let spans = command
             .args
             .iter()
-            .flat_map(|word| word_unquoted_word_between_single_quoted_segments_spans(word, source))
+            .flat_map(|word| word_unquoted_word_after_single_quoted_segment_spans(word, source))
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S050_S050.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S050_S050.sh.snap
@@ -1,26 +1,45 @@
 ---
 source: crates/shuck-linter/src/rules/style/mod.rs
+assertion_line: 177
 ---
-S050 an unquoted word appears between single-quoted segments
+S050 an unquoted word follows single-quoted text
  --> <source>:2:20
   |
 2 | printf '%s\n' 'foo'Default'baz'
   |
 
-S050 an unquoted word appears between single-quoted segments
+S050 an unquoted word follows single-quoted text
  --> <source>:3:21
   |
 3 | sed -i 's/${title}/'Default'/g' "$file"
   |
 
-S050 an unquoted word appears between single-quoted segments
+S050 an unquoted word follows single-quoted text
  --> <source>:4:6
   |
 4 | x='a'b'c'
   |
 
-S050 an unquoted word appears between single-quoted segments
+S050 an unquoted word follows single-quoted text
  --> <source>:5:9
   |
 5 | arr=('a'123'c')
+  |
+
+S050 an unquoted word follows single-quoted text
+ --> <source>:6:22
+  |
+6 | sed -i '/.*certs\.h/'d dependencies/file.cpp
+  |
+
+S050 an unquoted word follows single-quoted text
+ --> <source>:7:29
+  |
+7 | ip route | grep ^default'\s'via | head -1
+  |
+
+S050 an unquoted word follows single-quoted text
+ --> <source>:8:30
+  |
+8 | sed -i '/install(/s,\<lib\>,'lib$LIBDIRSUFFIX',' CMakeLists.txt
   |

--- a/crates/shuck-linter/src/rules/style/unquoted_word_between_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_word_between_quotes.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation, word_unquoted_word_between_single_quoted_segments_spans};
+use crate::{Checker, Rule, Violation, word_unquoted_word_after_single_quoted_segment_spans};
 
 pub struct UnquotedWordBetweenQuotes;
 
@@ -8,7 +8,7 @@ impl Violation for UnquotedWordBetweenQuotes {
     }
 
     fn message(&self) -> String {
-        "an unquoted word appears between single-quoted segments".to_owned()
+        "an unquoted word follows single-quoted text".to_owned()
     }
 }
 
@@ -18,9 +18,7 @@ pub fn unquoted_word_between_quotes(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| {
-            word_unquoted_word_between_single_quoted_segments_spans(fact.word(), source)
-        })
+        .flat_map(|fact| word_unquoted_word_after_single_quoted_segment_spans(fact.word(), source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || UnquotedWordBetweenQuotes);
@@ -32,13 +30,16 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_unquoted_words_between_single_quoted_segments() {
+    fn reports_unquoted_words_after_single_quoted_segments() {
         let source = "\
 #!/bin/bash
 printf '%s\\n' 'foo'Default'baz'
 sed -i 's/${title}/'Default'/g' \"$file\"
 x='a'b'c'
 arr=('a'123'c')
+sed -i '/.*certs\\.h/'d dependencies/file.cpp
+ip route | grep ^default'\\s'via | head -1
+sed -i '/install(/s,\\<lib\\>,'lib$LIBDIRSUFFIX',' CMakeLists.txt
 ";
         let diagnostics = test_snippet(
             source,
@@ -50,7 +51,7 @@ arr=('a'123'c')
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["Default", "Default", "b", "123"]
+            vec!["Default", "Default", "b", "123", "d", "via", "lib"]
         );
     }
 
@@ -62,6 +63,8 @@ printf '%s\\n' 'foo'-'baz'
 printf '%s\\n' 'foo''baz'
 printf '%s\\n' 'foo'$bar'baz'
 printf '%s\\n' $'foo'Default'baz'
+sed -i -e 's/^package .*/package 'fuzz_ng_$pkg_flat'/' \"$file\"
+sed -i -e 's/^package .*/package 'foo_bar'/' \"$file\"
 printf '%s\\n' 's/foo/'\\''bar'\\''/g'
 sed -i 's/^\\(\\[binaries\\]\\)$/\\1\\nexe_wrapper = '\\''exe_wrapper'\\''/g' \\
   \"$TERMUX_MESON_CROSSFILE\"

--- a/crates/shuck/tests/testdata/corpus-metadata/s050.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s050.yaml
@@ -1,1 +1,10 @@
-review_all_divergences: true
+reviewed_divergences:
+  - side: shuck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    line: 8965
+    end_line: 8965
+    column: 70
+    end_column: 71
+    labels:
+      - project-closure
+    reason: "This generated configure script only picks up the warning in the corpus harness after project-closure expansion. The standalone sed fragment does not reproduce the quote-adjacency hit, so this remaining site is tracked as closure-dependent corpus noise."

--- a/docs/rules/S050.yaml
+++ b/docs/rules/S050.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: An unquoted word sits between two single-quoted segments.
-rationale: Merge the segments into one quoted string.
+description: An unquoted word continues immediately after single-quoted text.
+rationale: Keep the intended word inside single quotes instead of reopening it unquoted.
 source:
   shell_checks_rule: rules/SH-205.yaml
   shell_checks_example: examples/205.sh


### PR DESCRIPTION
## What changed
- broadened `S050` to catch unquoted word fragments that continue immediately after single-quoted text
- added coverage for the corpus-shaped suffix cases that were previously missed
- tightened the matcher so underscore-heavy suffix fragments such as `fuzz_ng_$pkg_flat` stay ignored
- replaced the blanket `s050` corpus allowlist with one narrow reviewed divergence for a closure-dependent generated `configure` site

## Why
`S050` was under-reporting several `SC2026`-style quote-adjacency patterns in the large corpus. The old implementation only recognized a narrow three-part shape, so it missed real cases like sed suffix fragments and literal-plus-expansion continuations.

## Root cause
The helper only looked for a literal segment strictly between two non-dollar single-quoted segments. Real corpus examples also reopen into an unquoted suffix run after a single-quoted fragment, sometimes with expansions later in the same word.

## Impact
This brings `S050` in line with the targeted corpus expectations without reintroducing the new false positives we saw during iteration.

## Validation
- `cargo test -p shuck-linter unquoted_word_between_quotes -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S050`
- `make test`
- `cargo test --workspace`