### PR TITLE
Refine C091 reviewed divergences

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
@@ -202,4 +202,21 @@ mod tests {
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_quoted_tilde_literals_outside_string_comparisons() {
+        let source = "\
+#!/bin/bash
+profile='~/.bash_profile'
+VAGRANT_HOME=\"~/.vagrant.d\"
+[ -e '~/.bash_profile' ]
+printf '%s\n' \"~/.config/powershell/profile.ps1\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::TildeInStringComparison),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/c091.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c091.yaml
@@ -1,1 +1,149 @@
-review_all_divergences: true
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__scraper.sh"
+    line: 76
+    end_line: 76
+    column: 19
+    end_column: 57
+    reason: "This helper assigns a quoted home-relative path into `img_path` for later option assembly. C091 is limited to string-comparison operands, so it intentionally does not warn on assignment sites."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__crawl__crawl.SlackBuild"
+    line: 98
+    end_line: 98
+    column: 13
+    end_column: 24
+    reason: "This build script stores the save directory in an environment-style assignment before invoking `make`. C091 only covers quoted `~/...` literals inside string comparisons, not assignment values."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__games__crawl__crawl.SlackBuild"
+    line: 109
+    end_line: 109
+    column: 13
+    end_column: 24
+    reason: "This second `SAVEDIR` assignment is the same out-of-scope shape: quoted `~/...` stored as command input rather than compared as a string."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__app-emulation__vagrant__files__vagrant.in"
+    line: 34
+    end_line: 34
+    column: 17
+    end_column: 29
+    reason: "This script initializes `VAGRANT_HOME` with a quoted home-relative string. C091 intentionally stays scoped to string-comparison operands instead of general assignment literals."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 98
+    end_line: 98
+    column: 13
+    end_column: 30
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This `[` expression is a unary `-e` path probe, not a binary string comparison. C091 deliberately does not treat quoted path-test operands as its target shape."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 99
+    end_line: 99
+    column: 15
+    end_column: 32
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This helper assigns a quoted profile path into `profile` for later use. C091 is comparison-specific and intentionally skips assignment-only literals."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 101
+    end_line: 101
+    column: 15
+    end_column: 27
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This branch stores `~/.profile` as data in `profile` rather than comparing it. That assignment shape is outside C091's intended scope."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 103
+    end_line: 103
+    column: 22
+    end_column: 72
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This quoted `~/...` text is explanatory string content shown to the user, not a string-comparison operand. C091 intentionally leaves documentation text alone."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 104
+    end_line: 104
+    column: 8
+    end_column: 19
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This helper assigns `~/.bashrc` into `rc` for later use. C091 only warns when a quoted `~/...` literal participates in a string comparison."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 107
+    end_line: 107
+    column: 13
+    end_column: 47
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This PowerShell profile path is stored as a quoted string value, not compared. Assignment literals remain out of scope for C091."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 108
+    end_line: 108
+    column: 8
+    end_column: 42
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This `rc` assignment carries a quoted home-relative path for later output. C091 is intentionally narrower than ShellCheck's broader SC2088 family here."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 111
+    end_line: 111
+    column: 13
+    end_column: 26
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This zsh profile assignment stores `~/.zprofile` as data rather than comparing it, so it remains outside C091."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 112
+    end_line: 112
+    column: 8
+    end_column: 18
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This zsh rc-path assignment is another non-comparison quoted tilde literal that C091 intentionally ignores."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 120
+    end_line: 120
+    column: 13
+    end_column: 25
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This Korn-shell profile path is assigned into a variable for later use, not compared as a string. That keeps it out of C091's comparison-focused rule definition."
+  - side: shellcheck-only
+    path_suffix: "pyenv__pyenv__libexec__pyenv-init"
+    line: 121
+    end_line: 121
+    column: 8
+    end_column: 20
+    labels:
+      - helper-library
+      - project-closure
+    reason: "This quoted `~/.profile` assignment feeds later helper output rather than a string comparison, so C091 intentionally does not report it."
+  - side: shellcheck-only
+    path_suffix: "xwmx__nb__nb"
+    line: 25657
+    end_line: 25657
+    column: 41
+    end_column: 44
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This occurrence is part of a help-text string shown to users, not a shell string comparison. C091 is intentionally limited to comparison operands and skips display text."


### PR DESCRIPTION
## Summary
- replace the C091 rule-wide reviewed divergence allowlist with explicit reviewed divergence entries
- add a regression test covering quoted tilde literals outside string comparisons
- keep C091 scoped to string comparisons while documenting why the broader SC2088 sites stay out of scope

## Why
- targeted large-corpus validation showed no implementation diffs for C091
- the remaining SC2088 mismatches are assignments, unary path tests, and help text rather than string comparisons
- explicit reviewed divergence records make those cases auditable instead of relying on a blanket rule-wide escape hatch

## Testing
- cargo test -p shuck-linter tilde_in_string_comparison
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C091
- make test
- cargo test --workspace
