### PR TITLE
Fix C083 detection for find -exec patterns

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -18,9 +18,9 @@ pub fn glob_in_find_substitution(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| {
-            fact.wrappers().iter().all(|wrapper| {
-                matches!(wrapper, WrapperKind::FindExec | WrapperKind::FindExecDir)
-            })
+            fact.wrappers()
+                .iter()
+                .all(|wrapper| matches!(wrapper, WrapperKind::FindExec | WrapperKind::FindExecDir))
         })
         .filter_map(|fact| fact.options().find())
         .flat_map(|find| find.glob_pattern_operand_spans().iter().copied())

--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, Violation, WrapperKind};
 
 pub struct GlobInFindSubstitution;
 
@@ -17,7 +17,11 @@ pub fn glob_in_find_substitution(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter(|fact| fact.effective_name_is("find") && fact.wrappers().is_empty())
+        .filter(|fact| {
+            fact.wrappers().iter().all(|wrapper| {
+                matches!(wrapper, WrapperKind::FindExec | WrapperKind::FindExecDir)
+            })
+        })
         .filter_map(|fact| fact.options().find())
         .flat_map(|find| find.glob_pattern_operand_spans().iter().copied())
         .collect::<Vec<_>>();
@@ -37,6 +41,8 @@ mod tests {
 find ./ -name *.jar
 find ./ -name \"$prefix\"*.jar
 find ./ -wholename */tmp/*
+find ./ -name *.so -exec chmod 755 {} \\;
+find ./ -name \\*.[15] -exec gzip -9 {} \\;
 for f in $(find ./ -name *.cfg); do :; done
 printf '%s\\n' \"$(find . -path */tmp/*)\"
 ";
@@ -50,7 +56,15 @@ printf '%s\\n' \"$(find . -path */tmp/*)\"
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["*.jar", "\"$prefix\"*.jar", "*/tmp/*", "*.cfg", "*/tmp/*"]
+            vec![
+                "*.jar",
+                "\"$prefix\"*.jar",
+                "*/tmp/*",
+                "*.so",
+                "\\*.[15]",
+                "*.cfg",
+                "*/tmp/*"
+            ]
         );
     }
 

--- a/crates/shuck/tests/testdata/corpus-metadata/c083.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c083.yaml
@@ -1,1 +1,0 @@
-review_all_divergences: true


### PR DESCRIPTION
## Summary
- keep `C083` active for outer `find` commands even when command normalization attaches `FindExec` or `FindExecDir` wrappers
- add regression coverage for `find -exec` forms with unquoted `-name` patterns
- remove the stale `C083` large-corpus allowlist metadata now that the rule matches the reviewed cases

## Root Cause
`glob_in_find_substitution` only considered `find` command facts with an empty wrapper list. When a `find` invocation also contained `-exec` or `-execdir`, normalization added those wrappers to the outer command fact, so the rule skipped valid `find` pattern operands like `find . -name *.so -exec ...` even though the parsed `find` facts already contained the right operand spans.

## Impact
This restores `C083` diagnostics for the reviewed `find -exec` and `find -execdir` cases and lets the rule pass targeted large-corpus comparison without a blanket divergence allowlist.

## Validation
- `cargo test -p shuck-linter glob_in_find_substitution -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C083`