### PR TITLE
Fix X052 function span anchoring

### DIFF
--- a/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
@@ -22,8 +22,59 @@ pub fn function_keyword_in_sh(checker: &mut Checker) {
         .function_headers()
         .iter()
         .filter(|header| header.uses_function_keyword() && header.has_trailing_parens())
-        .map(|header| header.span_in_source(checker.source()))
+        .map(|header| header.function_span_in_source(checker.source()))
         .collect::<Vec<_>>();
 
     checker.report_all(spans, || FunctionKeywordInSh);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_function_keyword_with_parens_over_full_function_span() {
+        let source = "\
+#!/bin/sh
+function greet()
+{
+  printf '%s\\n' hi
+}
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::FunctionKeywordInSh));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "function greet()\n{\n  printf '%s\\n' hi\n}"
+        );
+    }
+
+    #[test]
+    fn ignores_function_keyword_without_trailing_parens() {
+        let source = "\
+#!/bin/sh
+function greet { :; }
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::FunctionKeywordInSh));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_non_sh_shells() {
+        let source = "\
+#!/bin/bash
+function greet() { :; }
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionKeywordInSh).with_shell(ShellDialect::Bash),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/x052.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x052.yaml
@@ -1,1 +1,0 @@
-review_all_divergences: true


### PR DESCRIPTION
## Summary
- report `X052` using the full function-definition span instead of only the header span
- add regression coverage for the full-span behavior and the main negative cases
- remove the `x052` large-corpus allowlist now that the rule matches the oracle without special handling

## Root Cause
`X052` was anchoring diagnostics to `function_header.span_in_source(...)`, which only covered the header line. The compatibility harness expects the warning to span the full function definition, so the rule kept needing reviewed large-corpus divergences.

## Validation
- `cargo test -p shuck-linter function_keyword_in_sh`
- `cargo test -p shuck-linter rules::portability::tests::rules`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X052`
