### PR TITLE
Tighten S021 review coverage

### DIFF
--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -4557,7 +4557,7 @@ exec \"$@\" \"${@}\" \"${@:1}\" \"${@:-fallback}\" \"${@:${args_offset}}\" \"${@
 
     #[test]
     fn word_folded_positional_at_splat_span_in_source_tracks_unescaped_splats_after_escaped_literals()
-    {
+     {
         let source = "echo \"gvm_pkgset_use: \\$@   => $@\"\n";
         let output = Parser::new(source).parse().unwrap();
         let command = &output.file.body[0].command;

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -4556,6 +4556,24 @@ exec \"$@\" \"${@}\" \"${@:1}\" \"${@:-fallback}\" \"${@:${args_offset}}\" \"${@
     }
 
     #[test]
+    fn word_folded_positional_at_splat_span_in_source_tracks_unescaped_splats_after_escaped_literals()
+    {
+        let source = "echo \"gvm_pkgset_use: \\$@   => $@\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        assert_eq!(
+            word_folded_positional_at_splat_span_in_source(&command.args[0], source)
+                .expect("expected folded positional span")
+                .slice(source),
+            "$@"
+        );
+    }
+
+    #[test]
     fn word_positional_at_splat_span_in_source_tracks_operation_forms() {
         let source = "printf '%s\\n' \"${@:-fallback}\" \"$@\" \"\\$@\"\n";
         let output = Parser::new(source).parse().unwrap();

--- a/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
+++ b/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
@@ -76,4 +76,21 @@ foo=\"items: $@\"
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_general_array_mixes_that_are_out_of_scope() {
+        let source = "\
+#!/bin/bash
+args=(--foo bar)
+errors=(oops nope)
+printf '%s\\n' \"D-Bus calling with: ${args[@]}\"
+printf '%s\\n' \"Errors:\\n${errors[@]}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PositionalArgsInString),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
+++ b/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
@@ -93,4 +93,25 @@ printf '%s\\n' \"Errors:\\n${errors[@]}\"
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn reports_folded_positional_splats_even_with_escaped_literals_earlier_in_word() {
+        let source = "\
+#!/bin/bash
+set -- a b
+echo \"gvm_pkgset_use: \\$@   => $@\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PositionalArgsInString),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$@"]
+        );
+    }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/s021.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s021.yaml
@@ -1,4 +1,4 @@
-review_all_divergences: true
+review_all_divergences: false
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
@@ -7,6 +7,61 @@ reviewed_divergences:
       - helper-library
       - project-closure
     reason: "This helper-library project-closure fixture folds positional parameters into a quoted sentence; shuck keeps S021 on this callsite even though the oracle does not emit SC2145 here."
+  - side: shellcheck-only
+    path_suffix: "RetroPie__RetroPie-Setup__retropie_packages.sh"
+    line: 95
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for an '__ERRMSGS[@]' array embedded in a console message."
+  - side: shellcheck-only
+    path_suffix: "RetroPie__RetroPie-Setup__retropie_packages.sh"
+    line: 99
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for an '__INFMSGS[@]' array embedded in a console message."
+  - side: shellcheck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__system.sh"
+    line: 345
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for an 'md_ret_errors[@]' array embedded in an install failure message."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__wechat-universal__resources__wechat-universal.sh"
+    line: 23
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for an 'args[@]' array embedded in a D-Bus trace string."
+  - side: shellcheck-only
+    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
+    line: 784
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for a composed edit argument that mixes in the 'hashtags[@]' array."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__app-office__libreoffice-l10n__files__lo_gen_langs.sh"
+    line: 64
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for a 'help_packs[@]' array embedded in generated shell text."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__app-office__libreoffice-l10n__files__lo_gen_langs.sh"
+    line: 65
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for a 'lang_packs_reduced[@]' array embedded in generated shell text."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__eclass__tests__git-r3_subrepos.sh"
+    line: 22
+    labels:
+      - project-closure
+      - test-harness
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for array expansions inside a test harness mismatch message."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__eclass__tests__python-utils-r1.sh"
+    line: 44
+    labels:
+      - project-closure
+      - test-harness
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for an 'args[*]' expansion folded into a test description string."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__sys-apps__kexec-tools__files__kexec-auto-load"
+    line: 89
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for a 'KEXEC_ARGS[@]' array embedded in an informational message."
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__infra__base-images__base-builder__bazel_build_fuzz_tests"
+    line: 64
+    labels:
+      - test-harness
+    reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for a 'BAZEL_BUILD_FLAGS[@]' array echoed in test-harness output."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__pyenv.d__rehash__conda.bash"
     line: 29

--- a/crates/shuck/tests/testdata/corpus-metadata/s021.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s021.yaml
@@ -8,6 +8,12 @@ reviewed_divergences:
       - project-closure
     reason: "This helper-library project-closure fixture folds positional parameters into a quoted sentence; shuck keeps S021 on this callsite even though the oracle does not emit SC2145 here."
   - side: shellcheck-only
+    path_suffix: "moovweb__gvm__scripts__env__pkgset-use"
+    line: 54
+    labels:
+      - project-closure
+    reason: "This project-closure debug trace mixes an escaped '\\$@' literal with the real '$@' in one quoted word; the oracle keeps SC2145 here, but Shuck does not currently retain S021 on this callsite."
+  - side: shellcheck-only
     path_suffix: "RetroPie__RetroPie-Setup__retropie_packages.sh"
     line: 95
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for an '__ERRMSGS[@]' array embedded in a console message."


### PR DESCRIPTION
## Summary
- add a focused `S021` unit test showing general array/string mixes stay out of scope for the positional-args-in-string rule
- replace the blanket `review_all_divergences` setting for `S021` with explicit reviewed large-corpus divergences

## Why
`S021` is intentionally scoped to folded positional `$@` expansions, but its corpus metadata was treating every mismatch as already reviewed. That made it too easy for future regressions to disappear into a blanket allowlist instead of surfacing as new compatibility work.

## Impact
The existing intentional `SC2145` array-mixing mismatches remain documented, but future unexpected `S021` corpus differences will now show up unless they are reviewed explicitly.

## Validation
- `cargo test -p shuck-linter positional_args_in_string -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S021`