### PR TITLE
Fix C005 heredoc and redirect context handling

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -11630,10 +11630,7 @@ impl<'a> WordFactCollector<'a> {
             }
         }
 
-        self.surface.collect_redirects(
-            redirects,
-            SurfaceScanContext::new(None, self.nested_word_command),
-        );
+        self.surface.collect_redirects(redirects, surface_context);
         for redirect in redirects {
             let Some(context) = ExpansionContext::from_redirect_kind(redirect.kind) else {
                 continue;
@@ -25552,6 +25549,49 @@ if [[ \"$@\" =~ x ]]; then :; fi
                 .expect("expected pipeline tail");
             assert_eq!(tail.static_utility_name(), Some("kill"));
             assert!(tail.static_utility_name_is("kill"));
+        });
+    }
+
+    #[test]
+    fn surface_facts_ignore_single_quoted_payload_text_in_expanding_heredocs() {
+        let source = "\
+#!/bin/sh
+cat <<EOF
+'$HOME' and '$(pwd)'
+EOF
+cat <<-EOF
+\t'${USER}'
+EOF
+";
+
+        with_facts(source, None, |_, facts| {
+            assert!(
+                facts.single_quoted_fragments().is_empty(),
+                "expected heredoc payload quotes to stay out of single-quoted shell fragments"
+            );
+        });
+    }
+
+    #[test]
+    fn surface_facts_keep_command_context_for_here_string_operands() {
+        let source = "\
+#!/bin/bash
+bash --init-file \"${BASH_IT?}/bash_it.sh\" -i <<< '_bash-it-flash-term \"${#BASH_IT_THEME}\" \"${BASH_IT_THEME}\"'
+";
+
+        with_facts(source, None, |_, facts| {
+            let fragment = facts
+                .single_quoted_fragments()
+                .iter()
+                .find(|fragment| {
+                    fragment
+                        .span()
+                        .slice(source)
+                        .contains("_bash-it-flash-term")
+                })
+                .expect("expected here-string single-quoted fragment");
+
+            assert_eq!(fragment.command_name(), Some("bash"));
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -25596,6 +25596,24 @@ bash --init-file \"${BASH_IT?}/bash_it.sh\" -i <<< '_bash-it-flash-term \"${#BAS
     }
 
     #[test]
+    fn surface_facts_do_not_apply_command_context_to_plain_redirect_targets() {
+        let source = "\
+#!/bin/bash
+bash > '$HOME'
+";
+
+        with_facts(source, None, |_, facts| {
+            let fragment = facts
+                .single_quoted_fragments()
+                .iter()
+                .find(|fragment| fragment.span().slice(source) == "'$HOME'")
+                .expect("expected redirect-target single-quoted fragment");
+
+            assert_eq!(fragment.command_name(), None);
+        });
+    }
+
+    #[test]
     fn surface_facts_mark_single_quoted_backslash_sequences_that_continue_into_literals() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -273,7 +273,6 @@ impl<'a> SurfaceFragmentSink<'a> {
         body: &HeredocBody,
         context: SurfaceScanContext<'_>,
     ) {
-        self.collect_single_quoted_fragments_in_heredoc_body_parts(&body.parts, context);
         self.collect_heredoc_body_parts(&body.parts, context);
     }
 
@@ -311,61 +310,6 @@ impl<'a> SurfaceFragmentSink<'a> {
                 self.facts
                     .suspect_closing_quotes
                     .push(SuspectClosingQuoteFragmentFact { span });
-            }
-        }
-    }
-
-    fn collect_single_quoted_fragments_in_heredoc_body_parts(
-        &mut self,
-        parts: &[HeredocBodyPartNode],
-        context: SurfaceScanContext<'_>,
-    ) {
-        let mut open_quote = None;
-
-        for part in parts {
-            match &part.kind {
-                HeredocBodyPart::Literal(text) => {
-                    let text = text.as_str(self.source, part.span);
-
-                    for (quote_offset, ch) in text.char_indices() {
-                        match ch {
-                            '\n' => open_quote = None,
-                            '\'' => {
-                                let quote_start =
-                                    part.span.start.advanced_by(&text[..quote_offset]);
-                                if heredoc_single_quote_is_escaped(text, quote_offset) {
-                                    continue;
-                                }
-                                let quote_end = quote_start.advanced_by("'");
-
-                                if let Some(open_start) = open_quote.take() {
-                                    self.facts.single_quoted.push(SingleQuotedFragmentFact {
-                                        span: Span::from_positions(open_start, quote_end),
-                                        dollar_quoted: false,
-                                        command_name: context
-                                            .command_name
-                                            .map(str::to_owned)
-                                            .map(String::into_boxed_str),
-                                        assignment_target: context
-                                            .assignment_target
-                                            .map(str::to_owned)
-                                            .map(String::into_boxed_str),
-                                        variable_set_operand: context.variable_set_operand,
-                                        literal_backslash_in_single_quotes_span: None,
-                                    });
-                                } else {
-                                    open_quote = Some(quote_start);
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                _ => {
-                    if part.span.start.line != part.span.end.line {
-                        open_quote = None;
-                    }
-                }
             }
         }
     }
@@ -1291,23 +1235,6 @@ fn backtick_substitution_len(text: &str) -> Option<usize> {
     }
 
     None
-}
-
-fn heredoc_single_quote_is_escaped(text: &str, quote_offset: usize) -> bool {
-    let mut backslash_count = 0usize;
-    let mut cursor = quote_offset;
-    while cursor > 0 {
-        match text.as_bytes()[cursor - 1] {
-            b'\\' => {
-                backslash_count += 1;
-                cursor -= 1;
-            }
-            b'\n' => break,
-            _ => break,
-        }
-    }
-
-    !backslash_count.is_multiple_of(2)
 }
 
 fn parameter_expansion_guards_unset_reference(parameter: &shuck_ast::ParameterExpansion) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -77,6 +77,13 @@ impl<'a> SurfaceScanContext<'a> {
         }
     }
 
+    pub(super) fn without_command_name(self) -> Self {
+        Self {
+            command_name: None,
+            ..self
+        }
+    }
+
     pub(super) fn with_pattern_charclass_scan(self) -> Self {
         Self {
             collect_pattern_charclasses: true,
@@ -720,7 +727,12 @@ impl<'a> SurfaceFragmentSink<'a> {
         for redirect in redirects {
             match redirect.word_target() {
                 Some(word) => {
-                    self.collect_word(word, context);
+                    let word_context = if redirect.kind == RedirectKind::HereString {
+                        context
+                    } else {
+                        context.without_command_name()
+                    };
+                    self.collect_word(word, word_context);
                 }
                 None => {
                     let heredoc = redirect.heredoc().expect("expected heredoc redirect");

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -301,50 +301,39 @@ mod tests {
     }
 
     #[test]
-    fn reports_single_quoted_literals_inside_heredoc_bodies() {
+    fn ignores_single_quoted_sequences_inside_expanding_heredoc_bodies() {
         assert_eq!(
             c005("cat <<EOF\n'$HOME should expand but does not'\nEOF\n",),
-            1
+            0
         );
     }
 
     #[test]
-    fn reports_multiple_single_quoted_literals_inside_heredoc_bodies() {
-        let source = "cat <<EOF\n'$HOME' and '$(pwd)'\nEOF\n";
-        let diagnostics = c005_diagnostics(source);
+    fn ignores_multiple_single_quoted_sequences_inside_expanding_heredoc_bodies() {
+        assert_eq!(c005("cat <<EOF\n'$HOME' and '$(pwd)'\nEOF\n"), 0);
+    }
 
+    #[test]
+    fn ignores_single_quoted_sequences_inside_tab_stripped_heredoc_bodies() {
+        assert_eq!(c005("cat <<-EOF\n\t'$HOME'\nEOF\n"), 0);
+    }
+
+    #[test]
+    fn ignores_realistic_config_template_payloads_in_heredocs() {
         assert_eq!(
-            diagnostics
-                .iter()
-                .map(|diagnostic| diagnostic.span.slice(source))
-                .collect::<Vec<_>>(),
-            vec!["'$HOME'", "'$(pwd)'"]
+            c005("cat <<EOF > .cargo/config\ndirectory = '$(pwd)/vendor'\nEOF\n"),
+            0
         );
     }
 
     #[test]
-    fn reports_single_quoted_literals_inside_tab_stripped_heredoc_bodies() {
-        assert_eq!(c005("cat <<-EOF\n\t'$HOME'\nEOF\n"), 1);
-    }
-
-    #[test]
-    fn ignores_unmatched_single_quotes_inside_heredoc_bodies() {
-        assert_eq!(c005("cat <<EOF\n'$HOME\nEOF\n"), 0);
-    }
-
-    #[test]
-    fn ignores_escaped_single_quotes_inside_heredoc_bodies() {
-        assert_eq!(c005("cat <<EOF\n\\'$HOME\\'\nEOF\n"), 0);
-    }
-
-    #[test]
-    fn ignores_escaped_single_quotes_inside_tab_stripped_heredoc_bodies() {
-        assert_eq!(c005("cat <<-EOF\n\t\\'$HOME\\'\nEOF\n"), 0);
-    }
-
-    #[test]
-    fn ignores_single_quotes_paired_across_heredoc_newlines() {
-        assert_eq!(c005("cat <<EOF\n'$HOME\nstill here'\nEOF\n"), 0);
+    fn ignores_single_quoted_here_strings_passed_to_shell_commands() {
+        assert_eq!(
+            c005(
+                "bash --init-file \"${BASH_IT?}/bash_it.sh\" -i <<< '_bash-it-flash-term \"${#BASH_IT_THEME}\" \"${BASH_IT_THEME}\"'\n",
+            ),
+            0
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -337,6 +337,11 @@ mod tests {
     }
 
     #[test]
+    fn reports_single_quoted_plain_redirect_targets_for_exempt_commands() {
+        assert_eq!(c005("bash > '$HOME'\n"), 1);
+    }
+
+    #[test]
     fn ignores_single_quoted_sequences_inside_quoted_heredoc_bodies() {
         assert_eq!(c005("cat <<'EOF'\n'$HOME'\nEOF\n"), 0);
     }

--- a/crates/shuck/tests/testdata/corpus-metadata/c005.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c005.yaml
@@ -1,4 +1,77 @@
-review_all_divergences: true
 reviewed_divergences:
   - side: shuck-only
-    reason: "C005 intentionally treats dollar-like and backtick-like text inside single quotes as a quote mistake, even in helper scripts, generated files, and project-local wrappers where ShellCheck stays silent on SC2016. The remaining corpus hits are all the same policy shape, so one broad reviewed divergence cleanly captures the stricter Shuck behavior without hiding a separate implementation bug."
+    path_suffix: "Bash-it__bash-it__vendor__github.com__rcaloras__bash-preexec__bash-preexec.sh"
+    line: 74
+    end_line: 74
+    column: 21
+    end_column: 87
+    labels:
+      - directive-handling
+      - shell-collapse
+    reason: "This helper stores a bootstrap shell snippet in ANSI-C quoted text for later installation, so the embedded `$(trap -p DEBUG)` is payload rather than something meant to expand during the assignment itself."
+  - side: shuck-only
+    path_suffix: "bitnami__containers__bitnami__appsmith__1__debian-12__rootfs__opt__bitnami__scripts__appsmith__setup.sh"
+    line: 39
+    end_line: 49
+    column: 36
+    end_column: 2
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This option passes an Nginx configuration block through ANSI-C quoting, and names like `$http_x_forwarded_proto`, `$scheme`, and `$host` belong to Nginx's config language rather than the shell."
+  - side: shuck-only
+    path_suffix: "bitnami__containers__bitnami__drupal__11__debian-12__rootfs__opt__bitnami__scripts__libdrupal.sh"
+    line: 509
+    end_line: 509
+    column: 31
+    end_column: 87
+    labels:
+      - directive-handling
+      - project-closure
+    reason: "This helper builds a literal search pattern for later config editing, so the `$databases...` text and trailing `$` are pattern syntax that should stay literal inside the ANSI-C quoted string."
+  - side: shuck-only
+    path_suffix: "lmc999__RegionRestrictionCheck__check.sh"
+    line: 3610
+    end_line: 3610
+    column: 2257
+    end_column: 3967
+    labels:
+      - project-closure
+    reason: "This `curl --data-raw $'...'` body embeds GraphQL variable names like `$repFullPackIds` as request text, so those dollar-prefixed tokens are protocol payload rather than intended shell expansion."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    labels:
+      - project-closure
+    reason: "This generated Autoconf script carries the same sed program across backslash-continued lines, and the remaining comparison differences are location-only anchors between ShellCheck's collapsed assignment line and Shuck's continued `-e '...'` lines."
+  - side: shuck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    labels:
+      - project-closure
+    reason: "This generated Autoconf script carries the same sed program across backslash-continued lines, and the remaining comparison differences are location-only anchors between ShellCheck's collapsed assignment line and Shuck's continued `-e '...'` lines."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    line: 8976
+    end_line: 8976
+    column: 80
+    end_column: 109
+    labels:
+      - shell-collapse
+    reason: "This generated libtool helper leaves one shell-collapse span mismatch inside a sed replacement string, so the remaining comparison here is a location-only oracle difference."
+  - side: shuck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    line: 8976
+    end_line: 8976
+    column: 80
+    end_column: 111
+    labels:
+      - shell-collapse
+    reason: "This generated libtool helper leaves one shell-collapse span mismatch inside a sed replacement string, so the remaining comparison here is a location-only oracle difference."
+  - side: shellcheck-only
+    path_suffix: "scop__bash-completion__completions-core__tmux.bash"
+    line: 216
+    end_line: 216
+    column: 29
+    end_column: 47
+    labels:
+      - shell-collapse
+    reason: "This bash-completion helper is already reduced through the shell-collapse path in the corpus run, and the remaining SC2016 hit depends on that collapsed quoting shape rather than a stable core-rule behavior."


### PR DESCRIPTION
## Summary
- stop classifying single-quoted text inside expanding heredoc payloads as shell single-quoted fragments
- preserve enclosing command context when scanning redirect operands so here-strings passed to shell commands inherit the right C005 exemptions
- replace the broad `C005` corpus allowlist with explicit reviewed divergences after reducing the remaining oracle-only tail

## Root cause
`C005` was treating quotes inside expanding heredoc payloads as shell quoting syntax and scanning redirect operands without the surrounding command context. That produced false positives in template/config payloads, missed command-specific exemptions on here-strings, and forced a rule-wide corpus waiver.

## Impact
This removes the large false-positive class for heredoc payloads and shell handoff here-strings, while tightening corpus metadata so future `C005` regressions are no longer hidden behind a blanket reviewed-divergence entry.

## Validation
- `cargo test -p shuck-linter`
- `make test`
- `cargo test --workspace`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C005`
