### PR TITLE
Fix S015 loop expansion parity

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/style/S015.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S015.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
 arr=(alpha "two words")
-for item in "$*" "${arr[*]}" "x$*y"; do
+for item in "$*"; do
+  :
+done
+
+for item in "${arr[*]}"; do
+  :
+done
+
+for item in "x$*y"; do
   :
 done
 

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -1,8 +1,8 @@
 use shuck_ast::{
     ArithmeticExpr, Assignment, BinaryCommand, BourneParameterExpansion, CaseItem, ConditionalExpr,
     ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternGroupKind,
-    PatternPart, Position, Redirect, Span, SubscriptSelector, VarRef, Word, WordPart, WordPartNode,
-    ZshExpansionTarget,
+    PatternPart, Position, PrefixMatchKind, Redirect, Span, SubscriptSelector, VarRef, Word,
+    WordPart, WordPartNode, ZshExpansionTarget,
 };
 
 pub fn assignment_name_span(assignment: &Assignment) -> Span {
@@ -958,6 +958,27 @@ fn collect_all_elements_array_expansion_spans(
                     spans.push(span);
                 }
             }
+            WordPart::ArrayIndices(reference)
+                if matches!(
+                    reference
+                        .subscript
+                        .as_ref()
+                        .and_then(|subscript| subscript.selector()),
+                    Some(SubscriptSelector::At)
+                ) =>
+            {
+                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                    spans.push(span);
+                }
+            }
+            WordPart::PrefixMatch {
+                kind: PrefixMatchKind::At,
+                ..
+            } => {
+                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                    spans.push(span);
+                }
+            }
             WordPart::Parameter(parameter)
                 if parameter_might_use_all_elements_array_expansion(
                     parameter, part.span, source,
@@ -1470,12 +1491,16 @@ fn candidate_is_all_elements_array_expansion(candidate: &str) -> bool {
         return false;
     };
 
+    let (inner, indirect_like) = inner
+        .strip_prefix('!')
+        .map_or((inner, false), |stripped| (stripped, true));
+
     let Some(first) = inner.as_bytes().first().copied() else {
         return false;
     };
 
     if first == b'@' {
-        return true;
+        return !indirect_like;
     }
 
     if !is_name_start(first) {
@@ -1488,7 +1513,11 @@ fn candidate_is_all_elements_array_expansion(candidate: &str) -> bool {
         index += 1;
     }
 
-    inner[index..].starts_with("[@]")
+    if inner[index..].starts_with("[@]") {
+        return true;
+    }
+
+    indirect_like && inner[index..].starts_with('@')
 }
 
 fn candidate_is_direct_all_elements_array_expansion(candidate: &str) -> bool {
@@ -2945,13 +2974,15 @@ fn parameter_might_use_all_elements_array_expansion(
     }
 
     match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(syntax) => !matches!(
-            syntax,
-            BourneParameterExpansion::Length { .. }
-                | BourneParameterExpansion::Indices { .. }
-                | BourneParameterExpansion::Indirect { .. }
-                | BourneParameterExpansion::PrefixMatch { .. }
-        ),
+        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+            BourneParameterExpansion::Length { .. } | BourneParameterExpansion::Indirect { .. } => {
+                false
+            }
+            BourneParameterExpansion::PrefixMatch { kind, .. } => {
+                matches!(kind, PrefixMatchKind::At)
+            }
+            _ => true,
+        },
         ParameterExpansionSyntax::Zsh(_) => true,
     }
 }
@@ -3958,9 +3989,9 @@ eval command sudo \\\"\\${sudo_args[@]}\\\" \\\"\\$@\\\"
     }
 
     #[test]
-    fn all_elements_array_expansion_spans_ignore_non_selector_at_text() {
+    fn all_elements_array_expansion_spans_track_safe_quoted_name_fanout() {
         let source = "\
-printf '%s\\n' ${#arr[@]} ${!arr[@]} ${name:-safe[@]} ${arr[@]}
+printf '%s\\n' ${#arr[@]} ${!arr[@]} ${!cfg@} ${name:-safe[@]} ${arr[@]}
 ";
         let output = Parser::new(source).parse().unwrap();
         let command = &output.file.body[0].command;
@@ -3969,10 +4000,23 @@ printf '%s\\n' ${#arr[@]} ${!arr[@]} ${name:-safe[@]} ${arr[@]}
         };
 
         assert!(all_elements_array_expansion_part_spans(&command.args[1], source).is_empty());
-        assert!(all_elements_array_expansion_part_spans(&command.args[2], source).is_empty());
-        assert!(all_elements_array_expansion_part_spans(&command.args[3], source).is_empty());
         assert_eq!(
-            all_elements_array_expansion_part_spans(&command.args[4], source)
+            all_elements_array_expansion_part_spans(&command.args[2], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${!arr[@]}"]
+        );
+        assert_eq!(
+            all_elements_array_expansion_part_spans(&command.args[3], source)
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${!cfg@}"]
+        );
+        assert!(all_elements_array_expansion_part_spans(&command.args[4], source).is_empty());
+        assert_eq!(
+            all_elements_array_expansion_part_spans(&command.args[5], source)
                 .iter()
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),

--- a/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
+++ b/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
@@ -21,21 +21,23 @@ pub fn quoted_dollar_star_loop(checker: &mut Checker) {
         .facts()
         .for_headers()
         .iter()
-        .flat_map(|header| {
-            header.words().iter().filter_map(|word| {
-                let classification = word.classification();
-                if classification.quote != WordQuote::FullyQuoted
-                    || classification.is_fixed_literal()
-                    || !all_elements_array_expansion_part_spans(word.word(), source).is_empty()
-                {
-                    return None;
-                }
+        .filter_map(|header| {
+            let [word] = header.words() else {
+                return None;
+            };
 
-                (classification.has_command_substitution()
-                    || !word_double_quoted_scalar_only_expansion_spans(word.word()).is_empty()
-                    || !word_quoted_star_splat_spans(word.word()).is_empty())
-                .then_some(word.span())
-            })
+            let classification = word.classification();
+            if classification.quote != WordQuote::FullyQuoted
+                || classification.is_fixed_literal()
+                || !all_elements_array_expansion_part_spans(word.word(), source).is_empty()
+            {
+                return None;
+            }
+
+            (classification.has_command_substitution()
+                || !word_double_quoted_scalar_only_expansion_spans(word.word()).is_empty()
+                || !word_quoted_star_splat_spans(word.word()).is_empty())
+            .then_some(word.span())
         })
         .collect::<Vec<_>>();
 
@@ -52,9 +54,15 @@ mod tests {
         let source = "\
 #!/bin/bash
 arr=(a b)
-for item in \"$var\" \"${var}\" \"$(printf x)\" \"$*\" \"${*}\" \"${*:1}\" \"${arr[*]}\" \"x$*y\"; do
-  :
-done
+for item in \"$var\"; do :; done
+for item in \"${var}\"; do :; done
+for item in \"${!name}\"; do :; done
+for item in \"$(printf x)\"; do :; done
+for item in \"$*\"; do :; done
+for item in \"${*}\"; do :; done
+for item in \"${*:1}\"; do :; done
+for item in \"${arr[*]}\"; do :; done
+for item in \"x$*y\"; do :; done
 ";
         let diagnostics = test_snippet(
             source,
@@ -69,6 +77,7 @@ done
             vec![
                 "\"$var\"",
                 "\"${var}\"",
+                "\"${!name}\"",
                 "\"$(printf x)\"",
                 "\"$*\"",
                 "\"${*}\"",
@@ -80,7 +89,7 @@ done
     }
 
     #[test]
-    fn reports_problematic_words_in_mixed_loop_lists() {
+    fn ignores_mixed_loop_lists_with_explicit_items() {
         let source = "\
 #!/bin/bash
 for item in \"$var\" literal \"$@\" \"$*\"; do
@@ -92,13 +101,7 @@ done
             &LinterSettings::for_rule(Rule::QuotedDollarStarLoop),
         );
 
-        assert_eq!(
-            diagnostics
-                .iter()
-                .map(|diagnostic| diagnostic.span.slice(source))
-                .collect::<Vec<_>>(),
-            vec!["\"$var\"", "\"$*\""]
-        );
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]
@@ -106,7 +109,9 @@ done
         let source = "\
 #!/bin/bash
 arr=(a b)
-for item in \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"x$@y\" \"x${arr[@]}y\" ${arr[*]}; do
+cfg_one=1
+cfg_two=2
+for item in \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${!arr[@]}\" \"${!cfg@}\" \"x$@y\" \"x${arr[@]}y\" ${arr[*]}; do
   printf '%s\\n' \"$item\"
 done
 select item in \"$*\"; do

--- a/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
+++ b/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
@@ -111,7 +111,10 @@ done
 arr=(a b)
 cfg_one=1
 cfg_two=2
-for item in \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${!arr[@]}\" \"${!cfg@}\" \"x$@y\" \"x${arr[@]}y\" ${arr[*]}; do
+for item in \"${!name@Q}\"; do
+  printf '%s\\n' \"$item\"
+done
+for item in \"$@\" \"${arr[@]}\" \"${arr[@]:1}\" \"${arr[@]:-fallback}\" \"${!arr[@]}\" \"${!cfg@}\" \"${!name@Q}\" \"x$@y\" \"x${arr[@]}y\" ${arr[*]}; do
   printf '%s\\n' \"$item\"
 done
 select item in \"$*\"; do

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S015_S015.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S015_S015.sh.snap
@@ -1,21 +1,20 @@
 ---
 source: crates/shuck-linter/src/rules/style/mod.rs
-assertion_line: 177
 ---
 S015 fully quoted loop-list expansions collapse into one value
  --> <source>:4:13
   |
-4 | for item in "$*" "${arr[*]}" "x$*y"; do
+4 | for item in "$*"; do
   |
 
 S015 fully quoted loop-list expansions collapse into one value
- --> <source>:4:18
+ --> <source>:8:13
   |
-4 | for item in "$*" "${arr[*]}" "x$*y"; do
+8 | for item in "${arr[*]}"; do
   |
 
 S015 fully quoted loop-list expansions collapse into one value
- --> <source>:4:30
-  |
-4 | for item in "$*" "${arr[*]}" "x$*y"; do
-  |
+  --> <source>:12:13
+   |
+12 | for item in "x$*y"; do
+   |

--- a/crates/shuck/tests/testdata/corpus-metadata/s015.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s015.yaml
@@ -1,4 +1,3 @@
-review_all_divergences: true
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "Bash-it__bash-it__lib__search.bash"
@@ -125,7 +124,7 @@ reviewed_divergences:
     end_line: 112
     column: 16
     end_column: 37
-    reason: "Current corpus-reviewed S015 loop-list span in this fixture."
+    reason: "This JSON-building helper loops over `\"${arns_to_block[@]}\"`, which preserves one item per array element. A standalone oracle probe stays quiet on that shape, so the remaining full-file hit is treated as project-closure noise rather than a live S015 bug."
   - side: shuck-only
     path_suffix: "HariSekhon__DevOps-Bash-tools__bin__open.sh"
     line: 59
@@ -4472,7 +4471,7 @@ reviewed_divergences:
     end_line: 258
     column: 18
     end_column: 33
-    reason: "Current corpus-reviewed S015 loop-list span in this fixture."
+    reason: "This GraphQL-query builder iterates `\"${COMMITS[@]}\"`, which keeps one loop item per commit. Direct oracle probes stay quiet on that loop shape, so the remaining corpus-only miss is reviewed narrowly instead of widening S015 again."
   - side: shuck-only
     path_suffix: "tj__git-extras__bin__git-brv"
     line: 41


### PR DESCRIPTION
## Summary

- tighten S015 so it only reports single-item quoted loop lists
- treat quoted `${!arr[@]}` and `${!prefix@}` fanout as safe expansions
- update fixtures and corpus metadata so S015 no longer needs a blanket divergence review mask

## Why

Black-box oracle checks exposed two false-positive clusters in the current implementation:
- shared span detection did not recognize safe quoted fanout forms
- the rule warned on problematic words inside multi-item explicit loop lists, where the oracle stays quiet

## Validation

- cargo test -p shuck-linter quoted_dollar_star_loop
- cargo test -p shuck-linter all_elements_array_expansion_spans_track_safe_quoted_name_fanout
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S015
- make test
- cargo test --workspace