### PR TITLE
Align K002 with SC2029 behavior

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -15412,16 +15412,14 @@ fn parse_rm_command(args: &[&Word], source: &str) -> Option<RmCommandFacts> {
 
 fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
     let remote_args = ssh_remote_args(args, source)?;
-    if remote_args.is_empty() {
-        return None;
-    }
-
     let local_expansion_spans = remote_args
-        .iter()
-        .flat_map(|word| expansion_part_spans(word))
+        .last()
+        .filter(|word| word.is_fully_double_quoted())
+        .and_then(|word| double_quoted_expansion_part_spans(word).into_iter().next())
+        .into_iter()
         .collect::<Vec<_>>();
 
-    Some(SshCommandFacts {
+    (!local_expansion_spans.is_empty()).then_some(SshCommandFacts {
         local_expansion_spans: local_expansion_spans.into_boxed_slice(),
     })
 }

--- a/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
+++ b/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
@@ -15,7 +15,8 @@ impl Violation for SshLocalExpansion {
 pub fn ssh_local_expansion(checker: &mut Checker) {
     let spans = checker
         .facts()
-        .structural_commands()
+        .commands()
+        .iter()
         .filter_map(|fact| fact.options().ssh())
         .flat_map(|fact| fact.local_expansion_spans().iter().copied())
         .collect::<Vec<_>>();
@@ -65,5 +66,44 @@ ssh -p 2222 host \"echo $USER\"
         assert_eq!(diagnostics.len(), 2, "{diagnostics:#?}");
         assert_eq!(diagnostics[0].span.slice(source), "$HOME");
         assert_eq!(diagnostics[1].span.slice(source), "$USER");
+    }
+
+    #[test]
+    fn ignores_non_terminal_and_assignment_style_remote_expansions() {
+        let source = "\
+#!/bin/sh
+ssh \"$host\" cmd \"$HOME\" --force
+ssh \"$host\" HELLO=\"$HOME\"
+ssh \"$host\" foo=\"$USER\" bar
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SshLocalExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_only_the_final_fully_quoted_remote_argument() {
+        let source = "\
+#!/bin/sh
+ssh \"$host\" \"$HOME\" \"$USER\"
+ssh \"$host\" cmd \"$HOME\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SshLocalExpansion));
+
+        assert_eq!(diagnostics.len(), 2, "{diagnostics:#?}");
+        assert_eq!(diagnostics[0].span.slice(source), "$USER");
+        assert_eq!(diagnostics[1].span.slice(source), "$HOME");
+    }
+
+    #[test]
+    fn reports_expansions_inside_command_substitutions() {
+        let source = "\
+#!/bin/sh
+URL=$(ssh \"$host\" url \"$REPO\")
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SshLocalExpansion));
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        assert_eq!(diagnostics[0].span.slice(source), "$REPO");
     }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/k002.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/k002.yaml
@@ -1,9 +1,1 @@
 review_all_divergences: true
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "rvm__rvm__update-remote.sh"
-    line: 11
-    end_line: 11
-    column: 52
-    end_column: 57
-    reason: "this ssh command still assembles a remote command from a locally expanded loop variable, and we keep flagging that shape even though ShellCheck does not emit SC2029 for the pipeline-to-while-read form"


### PR DESCRIPTION
## Summary
- narrow `K002`'s `ssh` fact handling to the ShellCheck-shaped case: the first expansion inside the final fully double-quoted remote argument
- evaluate `K002` across all command facts so nested `$(ssh ...)` calls are checked too
- add focused regression coverage and remove the stale `rvm` reviewed-divergence entry from `k002.yaml`

## Why
`K002` was over-reporting on assignment-style and non-terminal remote arguments while also missing `ssh` calls nested inside command substitutions. Tightening the fact-layer span selection and widening the rule's command coverage brings the rule into closer SC2029 parity without pushing structural logic into the rule file.

## Impact
This leaves `K002` with zero active implementation diffs in the targeted large-corpus run and reduces its reviewed divergences from 9 to 4, with the remainder still in reviewed oracle-noisy territory.

## Validation
- `cargo test -p shuck-linter ssh_local_expansion`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=K002`