### PR TITLE
Fix C086 numeric comparison conformance

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C086.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C086.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
 
-# Invalid: `>` inside `[` redirects instead of comparing.
+# Invalid: numeric `<`/`>` in test expressions should use `-lt`/`-gt`.
 [ "$version" > "10" ]
+[ "$version" < 10 ]
 
-# Invalid: literal operands still use a redirecting `>`.
+# Invalid: literal operands still use redirecting or lexical operators.
 [ 1 > 2 ]
+[[ $count > 10 ]]
+[[ "$count" < 1 ]]
 
-# Valid: redirecting the test command after the closing bracket is unrelated.
+# Valid: redirects outside the test expression are unrelated.
 [ "$version" ] > "$log"
 
-# Valid: escaped or quoted `>` stays a test operand.
-[ "$version" \> "$other" ]
-[ "$version" ">" "$other" ]
-
-# Valid: `test` and `[[` are out of scope for this rule.
-test "$version" > "$other"
+# Valid: plain string ordering is outside this numeric-comparison rule.
+[ "$version" > "$other" ]
+[ "$version" < "$other" ]
 [[ "$version" > "$other" ]]
+
+# Valid: escaped or quoted operators stay test operands.
+[ "$version" \> "$other" ]
+[ "$version" \< "$other" ]
+[ "$version" ">" "$other" ]
+[ "$version" "<" "$other" ]
+
+# Valid: decimal/version ordering is handled by C087 instead.
+[[ "$version" > 1.2 ]]
+[[ 1.2 < "$version" ]]
+
+# Valid: `test` is out of scope for this rule.
+test "$version" > 10

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -1,6 +1,10 @@
-use shuck_ast::{RedirectKind, Span};
+use shuck_ast::{ConditionalBinaryOp, RedirectKind, Span};
+use shuck_semantic::{BindingAttributes, BindingId};
 
-use crate::{Checker, CommandFact, RedirectFact, Rule, SimpleTestSyntax, Violation};
+use crate::{
+    Checker, CommandFact, ConditionalBinaryFact, ConditionalNodeFact, ConditionalOperandFact,
+    RedirectFact, Rule, SimpleTestSyntax, Violation, WordFact, static_word_text,
+};
 
 pub struct GreaterThanInTest;
 
@@ -10,47 +14,81 @@ impl Violation for GreaterThanInTest {
     }
 
     fn message(&self) -> String {
-        "`>` inside `[` redirects output instead of comparing values".to_owned()
+        "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons".to_owned()
     }
 }
 
 pub fn greater_than_in_test(checker: &mut Checker) {
+    let source = checker.source();
     let spans = checker
         .facts()
         .commands()
         .iter()
-        .filter_map(|command| comparison_redirect_span(command, checker.source()))
+        .flat_map(|command| comparison_operator_spans(command, checker, source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || GreaterThanInTest);
 }
 
-fn comparison_redirect_span(command: &CommandFact<'_>, source: &str) -> Option<Span> {
-    let simple_test = command.simple_test()?;
-    if simple_test.syntax() != SimpleTestSyntax::Bracket {
-        return None;
-    }
-
-    let opening_bracket = command.body_word_span()?;
-    let closing_bracket = command.body_args().last()?;
-
-    command.redirect_facts().iter().find_map(|redirect| {
-        internal_plain_output_redirect_span(redirect, opening_bracket, closing_bracket.span, source)
-    })
+fn comparison_operator_spans(
+    command: &CommandFact<'_>,
+    checker: &Checker<'_>,
+    source: &str,
+) -> Vec<Span> {
+    let mut spans = bracket_comparison_redirect_spans(command, source);
+    spans.extend(double_bracket_numeric_comparison_spans(
+        command, checker, source,
+    ));
+    spans
 }
 
-fn internal_plain_output_redirect_span(
+fn bracket_comparison_redirect_spans(command: &CommandFact<'_>, source: &str) -> Vec<Span> {
+    let Some(simple_test) = command.simple_test() else {
+        return Vec::new();
+    };
+    if simple_test.syntax() != SimpleTestSyntax::Bracket {
+        return Vec::new();
+    }
+
+    let Some(opening_bracket) = command.body_word_span() else {
+        return Vec::new();
+    };
+    let Some(closing_bracket) = command.body_args().last() else {
+        return Vec::new();
+    };
+
+    command
+        .redirect_facts()
+        .iter()
+        .filter_map(|redirect| {
+            numeric_comparison_redirect_span(
+                redirect,
+                opening_bracket,
+                closing_bracket.span,
+                source,
+            )
+        })
+        .collect()
+}
+
+fn numeric_comparison_redirect_span(
     redirect: &RedirectFact<'_>,
     opening_bracket_span: Span,
     closing_bracket_span: Span,
     source: &str,
 ) -> Option<Span> {
     let redirect_data = redirect.redirect();
-    if redirect_data.kind != RedirectKind::Output {
+    let operator = match redirect_data.kind {
+        RedirectKind::Input => "<",
+        RedirectKind::Output => ">",
+        _ => return None,
+    };
+
+    let target = redirect_data.word_target()?;
+    if !static_word_text(target, source).is_some_and(|text| looks_like_decimal_integer(&text)) {
         return None;
     }
 
-    let target = redirect_data.word_target()?;
     if redirect_data.span.start.offset < opening_bracket_span.end.offset
         || redirect_data.span.start.offset >= closing_bracket_span.start.offset
     {
@@ -60,14 +98,179 @@ fn internal_plain_output_redirect_span(
     let operator_text = source
         .get(redirect_data.span.start.offset..target.span.start.offset)?
         .trim_end();
-    if operator_text != ">" {
+    if operator_text != operator {
         return None;
     }
 
     Some(Span::from_positions(
         redirect_data.span.start,
-        redirect_data.span.start.advanced_by(">"),
+        redirect_data.span.start.advanced_by(operator),
     ))
+}
+
+fn double_bracket_numeric_comparison_spans(
+    command: &CommandFact<'_>,
+    checker: &Checker<'_>,
+    source: &str,
+) -> Vec<Span> {
+    let Some(conditional) = command.conditional() else {
+        return Vec::new();
+    };
+
+    conditional
+        .nodes()
+        .iter()
+        .filter_map(|node| numeric_double_bracket_operator_span(node, checker, source))
+        .collect()
+}
+
+fn numeric_double_bracket_operator_span(
+    node: &ConditionalNodeFact<'_>,
+    checker: &Checker<'_>,
+    source: &str,
+) -> Option<Span> {
+    let ConditionalNodeFact::Binary(binary) = node else {
+        return None;
+    };
+    if !matches!(
+        binary.op(),
+        ConditionalBinaryOp::LexicalBefore | ConditionalBinaryOp::LexicalAfter
+    ) {
+        return None;
+    }
+
+    if has_decimal_version_like_operand(binary, source)
+        || !has_numeric_operand(binary, checker, source)
+    {
+        return None;
+    }
+
+    Some(binary.operator_span())
+}
+
+fn has_numeric_operand(
+    binary: &ConditionalBinaryFact<'_>,
+    checker: &Checker<'_>,
+    source: &str,
+) -> bool {
+    [binary.left(), binary.right()]
+        .into_iter()
+        .any(|operand| operand_is_numeric_literal(checker, operand, source))
+}
+
+fn has_decimal_version_like_operand(binary: &ConditionalBinaryFact<'_>, source: &str) -> bool {
+    [binary.left(), binary.right()].into_iter().any(|operand| {
+        operand
+            .word()
+            .and_then(|word| static_word_text(word, source))
+            .is_some_and(|text| is_decimal_version_like(&text))
+    })
+}
+
+fn operand_is_numeric_literal(
+    checker: &Checker<'_>,
+    operand: ConditionalOperandFact<'_>,
+    source: &str,
+) -> bool {
+    let Some(word) = operand.word() else {
+        return false;
+    };
+
+    static_word_text(word, source).is_some_and(|text| looks_like_decimal_integer(&text))
+        || word_is_numeric_binding_reference(checker, word.span, source)
+}
+
+fn word_is_numeric_binding_reference(checker: &Checker<'_>, span: Span, source: &str) -> bool {
+    let Some(word_fact) = checker.facts().any_word_fact(span) else {
+        return false;
+    };
+    if !word_fact_is_pure_scalar_reference(word_fact, span, source) {
+        return false;
+    }
+
+    let mut references = checker.semantic().references().iter().filter(|reference| {
+        reference.span.start.offset >= span.start.offset
+            && reference.span.end.offset <= span.end.offset
+    });
+    let Some(reference) = references.next() else {
+        return false;
+    };
+    if references.next().is_some() {
+        return false;
+    }
+
+    let reaching = checker
+        .semantic_analysis()
+        .reaching_bindings_for_name(&reference.name, reference.span);
+    !reaching.is_empty()
+        && reaching
+            .iter()
+            .all(|binding_id| binding_is_numeric_literal(checker, *binding_id))
+}
+
+fn word_fact_is_pure_scalar_reference(word_fact: &WordFact<'_>, span: Span, source: &str) -> bool {
+    if word_fact.static_text().is_some()
+        || word_fact.scalar_expansion_spans().len() != 1
+        || !word_fact.array_expansion_spans().is_empty()
+        || !word_fact.command_substitution_spans().is_empty()
+    {
+        return false;
+    }
+
+    if !word_fact.has_literal_affixes() {
+        return true;
+    }
+
+    let expansion_span = word_fact.scalar_expansion_spans()[0];
+    span.slice(source) == format!("\"{}\"", expansion_span.slice(source))
+}
+
+fn binding_is_numeric_literal(checker: &Checker<'_>, binding_id: BindingId) -> bool {
+    let binding = checker.semantic().binding(binding_id);
+    if binding.attributes.contains(BindingAttributes::INTEGER) {
+        return true;
+    }
+
+    checker
+        .facts()
+        .binding_value(binding_id)
+        .and_then(|value| value.scalar_word())
+        .and_then(|word| static_word_text(word, checker.source()))
+        .is_some_and(|text| looks_like_decimal_integer(&text))
+}
+
+fn looks_like_decimal_integer(text: &str) -> bool {
+    let text = text
+        .strip_prefix('+')
+        .or_else(|| text.strip_prefix('-'))
+        .unwrap_or(text);
+
+    !text.is_empty() && text.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn is_decimal_version_like(text: &str) -> bool {
+    let mut saw_dot = false;
+    let mut saw_digit = false;
+    let mut segment_has_digit = false;
+
+    for ch in text.chars() {
+        match ch {
+            '0'..='9' => {
+                saw_digit = true;
+                segment_has_digit = true;
+            }
+            '.' => {
+                if !segment_has_digit {
+                    return false;
+                }
+                saw_dot = true;
+                segment_has_digit = false;
+            }
+            _ => return false,
+        }
+    }
+
+    saw_digit && saw_dot && segment_has_digit
 }
 
 #[cfg(test)]
@@ -76,11 +279,18 @@ mod tests {
     use crate::{LinterSettings, Rule};
 
     #[test]
-    fn reports_plain_greater_than_redirects_inside_bracket_tests() {
+    fn reports_numeric_less_and_greater_operators_in_test_expressions() {
         let source = "\
 #!/bin/bash
 [ \"$version\" > \"10\" ]
+[ \"$version\" < 10 ]
 [ 1 > 2 ]
+[[ $count > 10 ]]
+[[ \"$count\" < 1 ]]
+left=1
+right=2
+[[ $left < $right ]]
+[[ \"$left\" < \"$right\" ]]
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GreaterThanInTest));
 
@@ -89,20 +299,29 @@ mod tests {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec![">", ">"]
+            vec![">", "<", ">", ">", "<", "<", "<"]
         );
     }
 
     #[test]
-    fn ignores_redirects_after_the_test_and_non_operator_literals() {
+    fn ignores_string_ordering_and_non_numeric_targets() {
         let source = "\
 #!/bin/bash
 >\"$log\" [ \"$value\" ]
 [ \"$value\" ] > \"$log\"
+[ \"$value\" > \"$other\" ]
+[ \"$value\" < \"$other\" ]
 [ \"$value\" \\> \"$other\" ]
+[ \"$value\" \\< \"$other\" ]
 [ \"$value\" \">\" \"$other\" ]
-test \"$value\" > \"$other\"
+[ \"$value\" \"<\" \"$other\" ]
+test \"$value\" > 10
 [[ \"$value\" > \"$other\" ]]
+[[ \"$value\" < 1.2 ]]
+[[ 1.2 > \"$value\" ]]
+left=alpha
+right=beta
+[[ $left < $right ]]
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GreaterThanInTest));
 

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C086_C086.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C086_C086.sh.snap
@@ -1,15 +1,32 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 205
 ---
-C086 `>` inside `[` redirects output instead of comparing values
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
  --> <source>:4:14
   |
 4 | [ "$version" > "10" ]
   |
 
-C086 `>` inside `[` redirects output instead of comparing values
- --> <source>:7:5
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+ --> <source>:5:14
   |
-7 | [ 1 > 2 ]
+5 | [ "$version" < 10 ]
   |
+
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+ --> <source>:8:5
+  |
+8 | [ 1 > 2 ]
+  |
+
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+ --> <source>:9:11
+  |
+9 | [[ $count > 10 ]]
+  |
+
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+  --> <source>:10:13
+   |
+10 | [[ "$count" < 1 ]]
+   |

--- a/crates/shuck/tests/testdata/corpus-metadata/c086.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c086.yaml
@@ -1,1 +1,0 @@
-review_all_divergences: true

--- a/docs/rules/C086.yaml
+++ b/docs/rules/C086.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: "A `>` operator inside `[ ]` creates a file instead of comparing."
-rationale: "Use `-gt` for numeric comparison or `[[ ]]` for string ordering."
+description: "A numeric comparison uses `<` or `>` instead of `-lt` or `-gt`."
+rationale: "Use `-lt` or `-gt` for integer comparisons. Inside `[ ]`, raw `<` or `>` redirects instead of comparing; inside `[[ ]]`, they order text lexicographically."
 source:
   shell_checks_rule: rules/SH-213.yaml
   shell_checks_example: examples/213.sh
@@ -21,3 +21,9 @@ examples:
       #!/bin/bash
       # shellcheck disable=2154
       if [ "$version" > "10" ]; then echo newer; fi
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      if [[ $count < 1 ]]; then
+        echo empty
+      fi


### PR DESCRIPTION
## Summary
- expand `C086` beyond raw `>` inside `[` so it catches numeric `<`/`>` misuse across both bracket tests and `[[ ... ]]`
- treat variable-backed `[[ ... ]]` comparisons as numeric when their reaching bindings resolve to numeric literals or integer-typed values
- refresh the C086 fixture, snapshot, and authored rule docs, then remove the stale large-corpus allowlist for `c086`

## Why
`C086` was narrower than its intended SC2071 mapping. It only caught one redirect-shaped bracket-test form, which left legitimate numeric comparison mistakes uncovered in `[[ ... ]]` and in variable-to-variable cases backed by numeric assignments. That gap forced a broad corpus metadata allowlist to keep the rule green.

## Impact
This brings the rule behavior in line with the authored intent and lets the repo enforce C086 directly instead of relying on reviewed divergence metadata.

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter rules::correctness::greater_than_in_test::tests:: -- --nocapture`
- `cargo test -p shuck-linter rule_greaterthanintest_path_new_c086_sh_expects`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C086`

## Result
The targeted large-corpus run now finishes with `reviewed_divergences=0` for `C086`.