### PR TITLE
Fix stale ShellCheck mapping for C088

### DIFF
--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -196,5 +196,6 @@ mod tests {
             map.code_for_rule(Rule::LeadingGlobInGrepPattern),
             Some(2063)
         );
+        assert_eq!(map.code_for_rule(Rule::MixedAndOrInCondition), None);
     }
 }

--- a/crates/shuck/tests/testdata/corpus-metadata/c088.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c088.yaml
@@ -1,9 +1,0 @@
-review_all_divergences: true
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__clvk__build.sh"
-    line: 73
-    end_line: 73
-    column: 54
-    end_column: 56
-    reason: "This `[[ ... ]]` chain mixes `||` and `&&` without any inner grouping. Shuck keeps warning on that readability hazard even though the pinned ShellCheck oracle stays silent on this fixture."

--- a/docs/rules/C088.yaml
+++ b/docs/rules/C088.yaml
@@ -3,7 +3,6 @@ legacy_name: mixed-and-or-in-condition
 new_category: Correctness
 new_code: C088
 runtime_kind: ast
-shellcheck_code: SC2077
 shells:
   - sh
   - bash
@@ -17,4 +16,6 @@ source:
 examples:
   - kind: invalid
     source: shell-checks/examples/215.sh
-    code: "#!/bin/bash\n# shellcheck disable=2154\n[[ -n $file && file=\"$file\n\" || -n $content ]]\n"
+    code: |
+      #!/bin/bash
+      [[ -n ${1-} && -n ${2-} || -n ${3-} ]]


### PR DESCRIPTION
## Summary
- remove the stale `SC2077` mapping from `C088`
- replace the old noisy rule example with a clean mixed-operator reproducer
- drop the obsolete `c088` large-corpus allowlist and assert the rule remains unmapped

## Why
`C088` does not have a current one-to-one ShellCheck equivalent. The previous metadata pointed at `SC2077` only because the old example accidentally triggered ShellCheck's spacing diagnostic, which caused the large-corpus harness to compare the rule against the wrong oracle code.

## Impact
This keeps `C088` as a Shuck-only readability rule, avoids bogus ShellCheck parity comparisons, and removes dead reviewed-divergence metadata.

## Validation
- `cargo test -p shuck-linter can_reverse_lookup_canonical_codes -- --nocapture`
- `cargo test -p shuck-linter mixed_and_or_in_condition -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C088`