### PR TITLE
Tighten X030 echo escape detection

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -5927,7 +5927,11 @@ fn word_parts_contain_echo_backslash_escape(
                             echo_escape_is_quote_like,
                         ))
                     || text_contains_echo_double_backslash(rendered_text)
-                    || literal_backslash_touches_double_quoted_fragment(parts, index, rendered_text)
+                    || literal_double_backslash_touches_double_quoted_fragment(
+                        parts,
+                        index,
+                        rendered_text,
+                    )
             }
             WordPart::SingleQuoted { value, .. } => {
                 text_contains_echo_backslash_escape(value.slice(source), echo_escape_is_core_family)
@@ -5950,20 +5954,35 @@ fn echo_escape_is_quote_like(byte: u8) -> bool {
     matches!(byte, b'`' | b'\'')
 }
 
-fn literal_backslash_touches_double_quoted_fragment(
+fn literal_double_backslash_touches_double_quoted_fragment(
     parts: &[WordPartNode],
     index: usize,
     rendered_text: &str,
 ) -> bool {
-    (rendered_text.ends_with('\\')
+    (trailing_backslash_count(rendered_text) >= 2
         && parts
             .get(index + 1)
             .is_some_and(|part| matches!(part.kind, WordPart::DoubleQuoted { .. })))
-        || (rendered_text.starts_with('\\')
+        || (leading_backslash_count(rendered_text) >= 2
             && index
                 .checked_sub(1)
                 .and_then(|prev| parts.get(prev))
                 .is_some_and(|part| matches!(part.kind, WordPart::DoubleQuoted { .. })))
+}
+
+fn leading_backslash_count(text: &str) -> usize {
+    text.as_bytes()
+        .iter()
+        .take_while(|byte| **byte == b'\\')
+        .count()
+}
+
+fn trailing_backslash_count(text: &str) -> usize {
+    text.as_bytes()
+        .iter()
+        .rev()
+        .take_while(|byte| **byte == b'\\')
+        .count()
 }
 
 fn text_contains_echo_double_backslash(text: &str) -> bool {
@@ -21907,6 +21926,27 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
     #[test]
     fn ignores_json_like_backslash_quote_wrappers_around_variables() {
         let source = "#!/bin/bash\necho \"LABEL com.dokku.docker-image-labeler/alternate-tags=[\\\\\\\"$DOCKER_IMAGE\\\\\\\"]\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+        assert!(facts.echo_backslash_escape_word_spans().is_empty());
+    }
+
+    #[test]
+    fn ignores_quote_plumbing_around_adjacent_quoted_fragments() {
+        let source = "\
+#!/bin/bash
+echo \"$1\"=\\\"\"${PWD}\"\\\"
+echo pin=\\'\"${new_pinned[*]}\"\\'
+echo 'set -gx PATH '\\''\"${PYENV_ROOT}/shims\"\\'' $PATH'
+echo SHOBJ_CC=\\'\"$SHOBJ_CC\"\\'
+echo aws cloudwatch put-metric-alarm --alarm-actions \\'\"$ALARMACTION\"\\' --output=json
+echo \"Rule \"\\#$COUNT
+echo Saved to \\\"\"$FILENAME\"\\\" \\(\"$(du -h \"$OUTPUT\" | cut -f1)\"\\)
+";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);

--- a/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
@@ -57,6 +57,13 @@ echo \u1234
 echo -n "\"${shortname}\""
 echo "include \"$TERMUX_PREFIX/share/nano/*nanorc\""
 echo "  .TargetPath = \"\\host.lan\\Data\""
+echo "$1"=\""${PWD}"\"
+echo pin=\'"${new_pinned[*]}"\'
+echo 'set -gx PATH '\'"${PYENV_ROOT}/shims"\'' $PATH'
+echo SHOBJ_CC=\'"$SHOBJ_CC"\'
+echo aws cloudwatch put-metric-alarm --alarm-actions \'"$ALARMACTION"\' --output=json
+echo "Rule "\#$COUNT
+echo Saved to \""$FILENAME"\" \("$(du -h "$OUTPUT" | cut -f1)"\)
 command echo \n
 builtin echo \n
 printf '%s\n' \n

--- a/crates/shuck/tests/testdata/corpus-metadata/x030.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x030.yaml
@@ -1,1 +1,0 @@
-review_all_divergences: true


### PR DESCRIPTION
## Summary
- narrow `X030`'s echo escape fact heuristic so adjacent quote-plumbing no longer looks like a portability escape
- add regression coverage for the false-positive shapes while preserving the real `SC2028` matches
- remove the `x030` large-corpus metadata allowlist now that the rule matches the oracle cleanly

## Root Cause
`X030` treated any backslash touching an adjacent double-quoted fragment as an echo escape. That was broad enough to flag quoting glue such as `\""$var"\"`, `\'"$var"\'`, `\#$count`, and `\("$(...)"\)` even when ShellCheck does not consider those portability-sensitive echo escapes.

## Validation
- `cargo test -p shuck-linter echo_backslash -- --nocapture`
- `cargo test -p shuck-linter quote_plumbing -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X030`