### PR TITLE
Fix K002 SC2029 conformance

### DIFF
--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -15834,6 +15834,11 @@ fn word_starts_with_literal_dash(word: &Word, source: &str) -> bool {
     )
 }
 
+fn word_starts_with_static_or_literal_dash(word: &Word, source: &str) -> bool {
+    static_word_text(word, source).is_some_and(|text| text.starts_with('-'))
+        || word_starts_with_literal_dash(word, source)
+}
+
 fn parse_rm_command(args: &[&Word], source: &str) -> Option<RmCommandFacts> {
     let mut index = 0usize;
     let mut recursive = false;
@@ -15882,7 +15887,7 @@ fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
     let (last_remote_arg, leading_remote_args) = remote_args.split_last()?;
     if leading_remote_args
         .iter()
-        .any(|word| word_starts_with_literal_dash(word, source))
+        .any(|word| word_starts_with_static_or_literal_dash(word, source))
     {
         return None;
     }
@@ -21816,6 +21821,8 @@ ssh host \"echo $HOME\"
 ssh -i key host \"echo $PATH\"
 ssh host -t \"echo $PWD\"
 ssh host ls -l \"$TMPDIR\"
+ssh host cmd \"--flag\" \"$HOME\"
+ssh host cmd '-t' \"$USER\"
 ";
 
         with_facts(source, None, |_, facts| {
@@ -21825,7 +21832,7 @@ ssh host ls -l \"$TMPDIR\"
                 .filter(|fact| fact.effective_name_is("ssh") && fact.wrappers().is_empty())
                 .collect::<Vec<_>>();
 
-            assert_eq!(ssh_commands.len(), 5);
+            assert_eq!(ssh_commands.len(), 7);
             assert_eq!(
                 ssh_commands[0]
                     .options()
@@ -21843,6 +21850,8 @@ ssh host ls -l \"$TMPDIR\"
             assert!(ssh_commands[2].options().ssh().is_none());
             assert!(ssh_commands[3].options().ssh().is_none());
             assert!(ssh_commands[4].options().ssh().is_none());
+            assert!(ssh_commands[5].options().ssh().is_none());
+            assert!(ssh_commands[6].options().ssh().is_none());
         });
     }
 

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -15879,10 +15879,18 @@ fn parse_rm_command(args: &[&Word], source: &str) -> Option<RmCommandFacts> {
 
 fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
     let remote_args = ssh_remote_args(args, source)?;
-    let local_expansion_spans = remote_args
-        .last()
-        .filter(|word| word.is_fully_double_quoted())
-        .and_then(|word| double_quoted_expansion_part_spans(word).into_iter().next())
+    let (last_remote_arg, leading_remote_args) = remote_args.split_last()?;
+    if leading_remote_args
+        .iter()
+        .any(|word| word_starts_with_literal_dash(word, source))
+    {
+        return None;
+    }
+
+    let local_expansion_spans = last_remote_arg
+        .is_fully_double_quoted()
+        .then(|| double_quoted_expansion_part_spans(last_remote_arg).into_iter().next())
+        .flatten()
         .into_iter()
         .collect::<Vec<_>>();
 
@@ -16006,6 +16014,7 @@ fn su_short_option_takes_argument(flag: char) -> bool {
 
 fn ssh_remote_args<'a>(args: &'a [&'a Word], source: &str) -> Option<&'a [&'a Word]> {
     let mut index = 0usize;
+    let mut saw_local_option = false;
 
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
@@ -16013,6 +16022,7 @@ fn ssh_remote_args<'a>(args: &'a [&'a Word], source: &str) -> Option<&'a [&'a Wo
         };
 
         if text == "--" {
+            saw_local_option = true;
             index += 1;
             break;
         }
@@ -16021,12 +16031,17 @@ fn ssh_remote_args<'a>(args: &'a [&'a Word], source: &str) -> Option<&'a [&'a Wo
             break;
         }
 
+        saw_local_option = true;
         let consumes_next = ssh_option_consumes_next_argument(text.as_str())?;
         index += 1;
         if consumes_next {
             args.get(index)?;
             index += 1;
         }
+    }
+
+    if saw_local_option {
+        return None;
     }
 
     let _destination = args.get(index)?;
@@ -21786,6 +21801,45 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
             .and_then(|fact| fact.options().sudo_family())
             .expect("expected sudo-family facts");
         assert_eq!(doas.invoker, SudoFamilyInvoker::Doas);
+    }
+
+    #[test]
+    fn ssh_command_facts_match_shellcheck_command_shape() {
+        let source = "\
+#!/bin/bash
+ssh host \"echo $HOME\"
+\\ssh host \"echo $USER\"
+ssh -i key host \"echo $PATH\"
+ssh host -t \"echo $PWD\"
+ssh host ls -l \"$TMPDIR\"
+";
+
+        with_facts(source, None, |_, facts| {
+            let ssh_commands = facts
+                .commands()
+                .iter()
+                .filter(|fact| fact.effective_name_is("ssh") && fact.wrappers().is_empty())
+                .collect::<Vec<_>>();
+
+            assert_eq!(ssh_commands.len(), 5);
+            assert_eq!(
+                ssh_commands[0]
+                    .options()
+                    .ssh()
+                    .map(|ssh| ssh.local_expansion_spans().len()),
+                Some(1)
+            );
+            assert_eq!(
+                ssh_commands[1]
+                    .options()
+                    .ssh()
+                    .map(|ssh| ssh.local_expansion_spans().len()),
+                Some(1)
+            );
+            assert!(ssh_commands[2].options().ssh().is_none());
+            assert!(ssh_commands[3].options().ssh().is_none());
+            assert!(ssh_commands[4].options().ssh().is_none());
+        });
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts.rs
+++ b/crates/shuck-linter/src/facts.rs
@@ -15889,7 +15889,11 @@ fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
 
     let local_expansion_spans = last_remote_arg
         .is_fully_double_quoted()
-        .then(|| double_quoted_expansion_part_spans(last_remote_arg).into_iter().next())
+        .then(|| {
+            double_quoted_expansion_part_spans(last_remote_arg)
+                .into_iter()
+                .next()
+        })
         .flatten()
         .into_iter()
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/security/snapshots/shuck_linter__rules__security__tests__K002_K002.sh.snap
+++ b/crates/shuck-linter/src/rules/security/snapshots/shuck_linter__rules__security__tests__K002_K002.sh.snap
@@ -13,15 +13,3 @@ K002 ssh command text is expanded locally before the remote shell sees it
   |
 3 | \ssh host "echo $HOME"
   |
-
-K002 ssh command text is expanded locally before the remote shell sees it
- --> <source>:5:19
-  |
-5 | ssh -v host "echo $HOME"
-  |
-
-K002 ssh command text is expanded locally before the remote shell sees it
- --> <source>:6:19
-  |
-6 | ssh host -v "echo $HOME"
-  |

--- a/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
+++ b/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
@@ -55,17 +55,16 @@ ssh \"$host\" \"echo $HOME\"
     }
 
     #[test]
-    fn reports_expansions_after_static_ssh_options() {
+    fn ignores_local_ssh_options_before_destination() {
         let source = "\
 #!/bin/sh
 ssh -i \"$key\" \"$host\" \"echo $HOME\"
-ssh -p 2222 host \"echo $USER\"
+ssh -o BatchMode=yes host \"echo $USER\"
+ssh -- host \"echo $PATH\"
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SshLocalExpansion));
 
-        assert_eq!(diagnostics.len(), 2, "{diagnostics:#?}");
-        assert_eq!(diagnostics[0].span.slice(source), "$HOME");
-        assert_eq!(diagnostics[1].span.slice(source), "$USER");
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 
     #[test]
@@ -93,6 +92,19 @@ ssh \"$host\" cmd \"$HOME\"
         assert_eq!(diagnostics.len(), 2, "{diagnostics:#?}");
         assert_eq!(diagnostics[0].span.slice(source), "$USER");
         assert_eq!(diagnostics[1].span.slice(source), "$HOME");
+    }
+
+    #[test]
+    fn ignores_remote_command_shapes_with_leading_dash_arguments() {
+        let source = "\
+#!/bin/sh
+ssh host -t \"echo $HOME\"
+ssh host ls -l \"$HOME\"
+ssh host cmd --flag \"$HOME\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SshLocalExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
+++ b/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
@@ -101,6 +101,8 @@ ssh \"$host\" cmd \"$HOME\"
 ssh host -t \"echo $HOME\"
 ssh host ls -l \"$HOME\"
 ssh host cmd --flag \"$HOME\"
+ssh host cmd \"--flag\" \"$HOME\"
+ssh host cmd '-t' \"$USER\"
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SshLocalExpansion));
 

--- a/crates/shuck/tests/testdata/corpus-metadata/k002.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/k002.yaml
@@ -1,1 +1,0 @@
-review_all_divergences: true


### PR DESCRIPTION
## Summary
- tighten `K002` fact extraction to match the `ssh` command shapes that `SC2029` actually reports
- stop reporting when `ssh` uses local options before the destination or when earlier remote args start with `-`
- add fact-layer and rule-level regression coverage, update the fixture snapshot, and remove the old rule-wide corpus allowlist

## Why
`K002` was still passing the large corpus because of a blanket reviewed-divergence entry. The underlying issue was that Shuck treated more `ssh` invocation shapes as reportable than ShellCheck does, especially around option handling and certain remote command argv layouts.

## Impact
This makes `K002` pass targeted large-corpus conformance cleanly without metadata suppression and keeps the rule behavior aligned with the current SC2029 oracle.

## Validation
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=K002`
- `cargo test -p shuck-linter ssh_command_facts_match_shellcheck_command_shape -- --nocapture`
- `cargo test -p shuck-linter ssh_local_expansion -- --nocapture`
- `cargo test -p shuck-linter rules::security::tests::rules -- --nocapture`
- `make test`
- `cargo test --workspace`