### PR TITLE
Remove large-corpus labels

### DIFF
--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -432,8 +432,6 @@ struct ReviewedDivergenceRecord {
     column: Option<usize>,
     #[serde(default)]
     end_column: Option<usize>,
-    #[serde(default)]
-    labels: Vec<String>,
     reason: String,
 }
 
@@ -459,7 +457,6 @@ struct CompatibilityRecord {
     shellcheck_code: String,
     range: DiagnosticRange,
     message: String,
-    labels: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1308,22 +1305,12 @@ fn evaluate_fixture_compatibility(
                 return evaluation;
             }
 
-            let labels = compatibility_context_labels(&fixture.cache_rel_path, &src);
-            let shellcheck_records = shellcheck_compatibility_records(
-                &sc_run.diagnostics,
-                shellcheck_rule_index,
-                &labels,
-            );
+            let shellcheck_records =
+                shellcheck_compatibility_records(&sc_run.diagnostics, shellcheck_rule_index);
             let shuck_records =
-                shuck_compatibility_records(&shuck_run.diagnostics, shellcheck_index, &labels);
+                shuck_compatibility_records(&shuck_run.diagnostics, shellcheck_index);
             let (shellcheck_only, shuck_only) =
                 unmatched_compatibility_records(&shellcheck_records, &shuck_records);
-            let location_only_codes = location_only_shellcheck_codes(
-                &shellcheck_records,
-                &shuck_records,
-                &shellcheck_only,
-                &shuck_only,
-            );
 
             let cache_rel_path = fixture.cache_rel_path_key();
             let mut implementation_details = Vec::new();
@@ -1333,12 +1320,7 @@ fn evaluate_fixture_compatibility(
             for record in shellcheck_only.into_iter().chain(shuck_only) {
                 let (classification, reason) =
                     classify_compatibility_record(&record, &cache_rel_path, corpus_metadata);
-                let detail = format_compatibility_record(
-                    &record,
-                    reason.as_deref(),
-                    classification == CompatibilityClassification::Implementation
-                        && location_only_codes.contains(record.shellcheck_code.as_str()),
-                );
+                let detail = format_compatibility_record(&record, reason.as_deref());
                 match classification {
                     CompatibilityClassification::Implementation => {
                         implementation_details.push(detail)
@@ -1562,13 +1544,7 @@ fn reviewed_divergence_reason<'a>(
                 .is_none_or(|column| column == record.range.column)
             && entry
                 .end_column
-                .is_none_or(|end_column| end_column == record.range.end_column)
-            && entry.labels.iter().all(|label| {
-                record
-                    .labels
-                    .iter()
-                    .any(|record_label| record_label == label)
-            }))
+                .is_none_or(|end_column| end_column == record.range.end_column))
         .then_some(entry.reason.as_str())
     })
 }
@@ -1630,7 +1606,6 @@ fn classify_compatibility_record(
 fn shellcheck_compatibility_records(
     diagnostics: &[ShellCheckDiagnostic],
     shellcheck_rule_index: &HashMap<u32, Vec<String>>,
-    labels: &[String],
 ) -> Vec<CompatibilityRecord> {
     diagnostics
         .iter()
@@ -1651,7 +1626,6 @@ fn shellcheck_compatibility_records(
                     end_column: diag.end_column,
                 },
                 message: format!("{} {}", diag.level, diag.message),
-                labels: labels.to_vec(),
             }
         })
         .collect()
@@ -1660,7 +1634,6 @@ fn shellcheck_compatibility_records(
 fn shuck_compatibility_records(
     diagnostics: &[shuck_linter::Diagnostic],
     shellcheck_index: &HashMap<String, String>,
-    labels: &[String],
 ) -> Vec<CompatibilityRecord> {
     diagnostics
         .iter()
@@ -1679,7 +1652,6 @@ fn shuck_compatibility_records(
                         end_column: diag.span.end.column,
                     },
                     message: diag.message.clone(),
-                    labels: labels.to_vec(),
                 })
         })
         .collect()
@@ -1753,66 +1725,6 @@ fn unmatched_compatibility_records(
     (shellcheck_only, shuck_only)
 }
 
-fn location_only_shellcheck_codes(
-    shellcheck_records: &[CompatibilityRecord],
-    shuck_records: &[CompatibilityRecord],
-    shellcheck_only: &[CompatibilityRecord],
-    shuck_only: &[CompatibilityRecord],
-) -> HashSet<String> {
-    let shellcheck_counts = count_codes(
-        &shellcheck_records
-            .iter()
-            .map(|record| record.shellcheck_code.clone())
-            .collect::<Vec<_>>(),
-    );
-    let shuck_counts = count_codes(
-        &shuck_records
-            .iter()
-            .map(|record| record.shellcheck_code.clone())
-            .collect::<Vec<_>>(),
-    );
-    let shellcheck_unmatched = count_codes(
-        &shellcheck_only
-            .iter()
-            .map(|record| record.shellcheck_code.clone())
-            .collect::<Vec<_>>(),
-    );
-    let shuck_unmatched = count_codes(
-        &shuck_only
-            .iter()
-            .map(|record| record.shellcheck_code.clone())
-            .collect::<Vec<_>>(),
-    );
-
-    shellcheck_counts
-        .keys()
-        .chain(shuck_counts.keys())
-        .filter(|code| {
-            shellcheck_counts.get(*code) == shuck_counts.get(*code)
-                && shellcheck_unmatched.get(*code).copied().unwrap_or(0) > 0
-                && shuck_unmatched.get(*code).copied().unwrap_or(0) > 0
-        })
-        .cloned()
-        .collect()
-}
-
-fn compatibility_context_labels(path: &Path, src: &[u8]) -> Vec<String> {
-    let mut labels = Vec::new();
-    let source = String::from_utf8_lossy(src);
-    let shell = shuck_linter::ShellDialect::from_name(resolve_shell(path, src).as_str());
-    let file_context = shuck_linter::classify_file_context(&source, Some(path), shell);
-
-    for tag in file_context.tags() {
-        labels.push(tag.label().to_owned());
-    }
-    if source_starts_with_unknown_shell_comment(src) {
-        labels.push("shell-collapse".into());
-    }
-    labels.sort();
-    labels.dedup();
-    labels
-}
-
 fn shuck_parse_aborted(error: &str) -> bool {
     !error.starts_with("read error:")
 }
@@ -1864,22 +1776,7 @@ fn fixture_looks_like_fish(fixture: &LargeCorpusFixture, src: &[u8]) -> bool {
         .contains("oh-my-fish")
 }
 
-fn format_compatibility_record(
-    record: &CompatibilityRecord,
-    reason: Option<&str>,
-    location_only: bool,
-) -> String {
-    let mut labels = record.labels.clone();
-    if location_only {
-        labels.push("location-only".into());
-    }
-    labels.sort();
-    labels.dedup();
-    let labels = if labels.is_empty() {
-        String::new()
-    } else {
-        format!(" labels={}", labels.join(","))
-    };
+fn format_compatibility_record(record: &CompatibilityRecord, reason: Option<&str>) -> String {
     let reason = reason
         .map(|reason| format!(" reason={reason}"))
         .unwrap_or_default();
@@ -1890,13 +1787,12 @@ fn format_compatibility_record(
         rule_codes.join(",")
     };
     format!(
-        "{} {}/{} {} {}{}{}",
+        "{} {}/{} {} {}{}",
         record.side.as_str(),
         rule_code,
         record.shellcheck_code,
         record.range.display(),
         record.message,
-        labels,
         reason,
     )
 }
@@ -3849,7 +3745,6 @@ mod tests {
                     end_line: Some(19),
                     column: Some(1),
                     end_column: Some(14),
-                    labels: Vec::new(),
                     reason: "exact-match reviewed divergence".into(),
                 }],
             },
@@ -3866,7 +3761,6 @@ mod tests {
                 end_column: 14,
             },
             message: "warning reviewed divergence".into(),
-            labels: Vec::new(),
         };
 
         let (classification, reason) =
@@ -3893,7 +3787,6 @@ mod tests {
                     end_line: Some(19),
                     column: Some(1),
                     end_column: Some(14),
-                    labels: Vec::new(),
                     reason: "scripts-prefixed reviewed divergence".into(),
                 }],
             },
@@ -3910,7 +3803,6 @@ mod tests {
                 end_column: 14,
             },
             message: "warning reviewed divergence".into(),
-            labels: Vec::new(),
         };
 
         let (classification, reason) =
@@ -3927,7 +3819,7 @@ mod tests {
     }
 
     #[test]
-    fn reviewed_divergence_classification_matches_label_qualified_record() {
+    fn reviewed_divergence_classification_matches_rule_wide_record() {
         let metadata = HashMap::from([(
             "C999".to_string(),
             RuleCorpusMetadataDocument {
@@ -3940,12 +3832,11 @@ mod tests {
                     end_line: None,
                     column: None,
                     end_column: None,
-                    labels: vec!["project-closure".into()],
-                    reason: "label-qualified reviewed divergence".into(),
+                    reason: "rule-wide reviewed divergence".into(),
                 }],
             },
         )]);
-        let matching = CompatibilityRecord {
+        let record = CompatibilityRecord {
             side: CompatibilitySide::ShuckOnly,
             rule_code: Some("C999".into()),
             rule_codes: Vec::new(),
@@ -3957,30 +3848,20 @@ mod tests {
                 end_column: 10,
             },
             message: "dynamic source path".into(),
-            labels: vec!["project-closure".into()],
-        };
-        let non_matching = CompatibilityRecord {
-            labels: Vec::new(),
-            ..matching.clone()
         };
 
-        let (matching_classification, _) =
-            classify_compatibility_record(&matching, "repo__script.sh", &metadata);
-        let (non_matching_classification, _) =
-            classify_compatibility_record(&non_matching, "repo__script.sh", &metadata);
+        let (classification, reason) =
+            classify_compatibility_record(&record, "repo__script.sh", &metadata);
 
         assert_eq!(
-            matching_classification,
+            classification,
             CompatibilityClassification::ReviewedDivergence
         );
-        assert_eq!(
-            non_matching_classification,
-            CompatibilityClassification::Implementation
-        );
+        assert_eq!(reason.as_deref(), Some("rule-wide reviewed divergence"));
     }
 
     #[test]
-    fn reviewed_divergence_classification_requires_path_line_and_label_constraints() {
+    fn reviewed_divergence_classification_requires_path_and_line_constraints() {
         let metadata = HashMap::from([(
             "X065".to_string(),
             RuleCorpusMetadataDocument {
@@ -3993,7 +3874,6 @@ mod tests {
                     end_line: Some(120),
                     column: None,
                     end_column: None,
-                    labels: vec!["project-closure".into()],
                     reason: "scoped reviewed divergence".into(),
                 }],
             },
@@ -4010,7 +3890,6 @@ mod tests {
                 end_column: 34,
             },
             message: "caret negation in bracket expressions is not portable to POSIX sh".into(),
-            labels: vec!["project-closure".into()],
         };
         let wrong_path = CompatibilityRecord { ..matching.clone() };
         let wrong_line = CompatibilityRecord {
@@ -4020,10 +3899,6 @@ mod tests {
                 column: 22,
                 end_column: 34,
             },
-            ..matching.clone()
-        };
-        let missing_label = CompatibilityRecord {
-            labels: Vec::new(),
             ..matching.clone()
         };
 
@@ -4036,11 +3911,6 @@ mod tests {
             classify_compatibility_record(&wrong_path, "other__repo__script.sh", &metadata);
         let (wrong_line_classification, wrong_line_reason) = classify_compatibility_record(
             &wrong_line,
-            "alpinelinux__aports__scripts__mkimage.sh",
-            &metadata,
-        );
-        let (missing_label_classification, missing_label_reason) = classify_compatibility_record(
-            &missing_label,
             "alpinelinux__aports__scripts__mkimage.sh",
             &metadata,
         );
@@ -4063,11 +3933,6 @@ mod tests {
             CompatibilityClassification::Implementation
         );
         assert!(wrong_line_reason.is_none());
-        assert_eq!(
-            missing_label_classification,
-            CompatibilityClassification::Implementation
-        );
-        assert!(missing_label_reason.is_none());
     }
 
     #[test]
@@ -4084,7 +3949,6 @@ mod tests {
                     end_line: None,
                     column: None,
                     end_column: None,
-                    labels: Vec::new(),
                     reason: "path-contains reviewed divergence".into(),
                 }],
             },
@@ -4101,7 +3965,6 @@ mod tests {
                 end_column: 32,
             },
             message: "warning termux variable".into(),
-            labels: Vec::new(),
         };
 
         let (classification, reason) = classify_compatibility_record(
@@ -4131,7 +3994,6 @@ mod tests {
                     end_line: None,
                     column: None,
                     end_column: None,
-                    labels: Vec::new(),
                     reason: "path-contains reviewed divergence".into(),
                 }],
             },
@@ -4148,7 +4010,6 @@ mod tests {
                 end_column: 32,
             },
             message: "warning unrelated variable".into(),
-            labels: Vec::new(),
         };
 
         let (classification, reason) =
@@ -4179,7 +4040,6 @@ mod tests {
                 end_column: 32,
             },
             message: "warning unused assignment".into(),
-            labels: Vec::new(),
         };
 
         let (classification, reason) =
@@ -4216,7 +4076,6 @@ mod tests {
                 end_column: 32,
             },
             message: "warning mixed mappings".into(),
-            labels: Vec::new(),
         };
 
         let (classification, reason) =
@@ -4439,29 +4298,6 @@ mod tests {
         let diags = decode_shellcheck_diagnostics(data).unwrap();
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].code, 1091);
-    }
-
-    #[test]
-    fn compatibility_labels_include_shared_context_tags() {
-        let labels = compatibility_context_labels(
-            Path::new("ko1nksm__shellspec__spec__core__clone_spec.sh"),
-            b"#!/bin/sh\n# shellcheck disable=SC2086\nDescribe 'clone'\nParameters\n  \"test\"\nEnd\nsource ./helper.sh\n",
-        );
-
-        assert!(labels.contains(&"directive-handling".to_owned()));
-        assert!(labels.contains(&"project-closure".to_owned()));
-        assert!(labels.contains(&"shellspec".to_owned()));
-        assert!(labels.contains(&"test-harness".to_owned()));
-    }
-
-    #[test]
-    fn compatibility_labels_include_generated_configure() {
-        let labels = compatibility_context_labels(
-            Path::new("examples/native/configure"),
-            b"# Generated by GNU Autoconf 2.71\nas_lineno=${as_lineno-$LINENO}\n",
-        );
-
-        assert!(labels.contains(&"generated-configure".to_owned()));
     }
 
     #[test]

--- a/crates/shuck/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c001.yaml
@@ -26,14 +26,9 @@ reviewed_divergences:
     reason: "The remaining shellcheck-only Bats sites depend on the outer harness contract and sourced helper plumbing that Shuck does not treat as ordinary dead assignments."
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This Neofetch script builds a generated config surface and then interprets those option variables and helper names through later config-driven entrypoints. The remaining C001 hits are reviewed config-template state rather than dead assignments."
   - side: shuck-only
     path_contains: "megastep__makeself__"
-    labels:
-      - project-closure
     reason: "Makeself threads header flags and archive settings through generated stub output and later extraction-time behavior. The remaining C001 hits are reviewed archive-metadata handoffs rather than dead assignments in the local file."
   - side: shuck-only
     path_suffix: "dehydrated-io__dehydrated__docs__examples__hook.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/c002.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c002.yaml
@@ -1,6 +1,6 @@
 reviewed_divergences:
   - side: shuck-only
-    reason: "C002 intentionally treats runtime-built source targets as a correctness hazard even when ShellCheck stays silent in package build scripts, helper loaders, and test harness scaffolding. The remaining unlabeled SC1090 mismatches are this same policy shape, so they are tracked as reviewed divergence instead of treated as a rule bug."
+    reason: "C002 intentionally treats runtime-built source targets as a correctness hazard even when they come from package build scripts, helper loaders, test harness scaffolding, or other project-local sourcing paths. ShellCheck stays silent on those SC1090 cases, so we keep them reviewed instead of trying to model every repository-specific source convention."
   - side: shellcheck-only
     path_suffix: "tteck__Proxmox__install__cronicle-install.sh"
     line: 28
@@ -9,6 +9,3 @@ reviewed_divergences:
     path_suffix: "tteck__Proxmox__install__nginxproxymanager-install.sh"
     line: 58
     reason: "ShellCheck warns on source /dev/stdin here-strings even though the source target is fixed"
-  - side: shuck-only
-    labels: ["project-closure"]
-    reason: "Shuck intentionally treats runtime-built source targets as a correctness hazard even when they come from project-local state, helper scripts, directives, or test harnesses. ShellCheck stays silent on these SC1090 cases, so C002 keeps that broader policy as a reviewed divergence instead of trying to model every possible project-closure source path."

--- a/crates/shuck/tests/testdata/corpus-metadata/c003.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c003.yaml
@@ -1,12 +1,6 @@
 reviewed_divergences:
   - side: shellcheck-only
-    labels:
-      - project-closure
-    reason: "These corpus fixtures build helper source paths from repo-local variables, helper roots, or test harness state that ShellCheck still treats as missing explicit inputs. Shuck keeps C003 generic and avoids baking repository-specific path conventions into its source resolver."
-  - side: shellcheck-only
-    labels:
-      - directive-handling
-    reason: "These fixtures rely on directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repo-specific directive heuristics."
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
     line: 987
@@ -46,16 +40,10 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
     line: 71
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This shell-collapsed Oh My Zsh entrypoint loads internal helpers through the repo-root `$ZSH/...` library path. The current oracle run stays silent on those shell-collapse library loads, while Shuck keeps the not-provided helper dependencies visible."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
     line: 125
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This shell-collapsed Oh My Zsh entrypoint loads internal helpers through the repo-root `$ZSH/...` library path. The current oracle run stays silent on those shell-collapse library loads, while Shuck keeps the not-provided helper dependencies visible."
   - side: shuck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__install"
@@ -64,56 +52,36 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
     line: 2591
-    labels:
-      - project-closure
     reason: "This macOS probe re-sources a cached GPU detail file under a runtime cache directory rather than a checked project input. ShellCheck stays silent on that user-cache helper path in the full fixture, while Shuck keeps the sourced dependency visible."
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
     line: 4783
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This config loader conditionally sources a user config file under `XDG_CONFIG_HOME`, which lives outside the analyzed project inputs. ShellCheck stays silent on that full-file user-config path, while Shuck keeps the sourced dependency visible."
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
     line: 4787
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This config loader conditionally sources a user config file under `XDG_CONFIG_HOME`, which lives outside the analyzed project inputs. ShellCheck stays silent on that full-file user-config path, while Shuck keeps the sourced dependency visible."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc"
     line: 3
-    labels:
-      - project-closure
     reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc"
     line: 4
-    labels:
-      - project-closure
     reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc"
     line: 5
-    labels:
-      - project-closure
     reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc"
     line: 6
-    labels:
-      - project-closure
     reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc"
     line: 7
-    labels:
-      - project-closure
     reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc"
     line: 8
-    labels:
-      - project-closure
     reason: "This runtime loader sources helper libraries from the tool-managed `rvm_scripts_path` root instead of from the checked project tree. ShellCheck stays silent on those full-file runtime library loads, while Shuck keeps the sourced dependencies visible."

--- a/crates/shuck/tests/testdata/corpus-metadata/c004.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c004.yaml
@@ -5,12 +5,10 @@ reviewed_divergences:
     reason: "This installer unpacks a release tarball in a throwaway subshell, changes into the extracted tree, then immediately tears it back down. We review Shuck's stricter directory-hop warning for this project-specific upgrade helper."
   - side: shuck-only
     path_suffix: "leebaird__discover__passive.sh"
-    labels: ["directive-handling", "project-closure"]
     reason: "This reconnaissance workflow intentionally steps into theHarvester's checkout to sync and run it, then switches back into the Discover output directory before continuing the report pipeline. We review Shuck's stricter unchecked directory-change warnings for this tool-specific handoff."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
     line: 114
-    labels: ["project-closure", "shell-collapse"]
     reason: "This shell-collapsed Oh My Zsh bootstrap file trips the current ShellCheck 0.11.0 oracle's POSIX parse stop earlier in the file, so the later command-substitution directory hop never gets compared there. Shuck recovers far enough to keep that project-specific directory change visible."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__nvm.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/c005.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c005.yaml
@@ -5,9 +5,6 @@ reviewed_divergences:
     end_line: 74
     column: 21
     end_column: 87
-    labels:
-      - directive-handling
-      - shell-collapse
     reason: "This helper stores a bootstrap shell snippet in ANSI-C quoted text for later installation, so the embedded `$(trap -p DEBUG)` is payload rather than something meant to expand during the assignment itself."
   - side: shuck-only
     path_suffix: "bitnami__containers__bitnami__appsmith__1__debian-12__rootfs__opt__bitnami__scripts__appsmith__setup.sh"
@@ -15,9 +12,6 @@ reviewed_divergences:
     end_line: 49
     column: 36
     end_column: 2
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This option passes an Nginx configuration block through ANSI-C quoting, and names like `$http_x_forwarded_proto`, `$scheme`, and `$host` belong to Nginx's config language rather than the shell."
   - side: shuck-only
     path_suffix: "bitnami__containers__bitnami__drupal__11__debian-12__rootfs__opt__bitnami__scripts__libdrupal.sh"
@@ -25,9 +19,6 @@ reviewed_divergences:
     end_line: 509
     column: 31
     end_column: 87
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This helper builds a literal search pattern for later config editing, so the `$databases...` text and trailing `$` are pattern syntax that should stay literal inside the ANSI-C quoted string."
   - side: shuck-only
     path_suffix: "lmc999__RegionRestrictionCheck__check.sh"
@@ -35,18 +26,12 @@ reviewed_divergences:
     end_line: 3610
     column: 2257
     end_column: 3967
-    labels:
-      - project-closure
     reason: "This `curl --data-raw $'...'` body embeds GraphQL variable names like `$repFullPackIds` as request text, so those dollar-prefixed tokens are protocol payload rather than intended shell expansion."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__configure"
-    labels:
-      - project-closure
     reason: "This generated Autoconf script carries the same sed program across backslash-continued lines, and the remaining comparison differences are location-only anchors between ShellCheck's collapsed assignment line and Shuck's continued `-e '...'` lines."
   - side: shuck-only
     path_suffix: "moovweb__gvm__examples__native__configure"
-    labels:
-      - project-closure
     reason: "This generated Autoconf script carries the same sed program across backslash-continued lines, and the remaining comparison differences are location-only anchors between ShellCheck's collapsed assignment line and Shuck's continued `-e '...'` lines."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
@@ -54,8 +39,6 @@ reviewed_divergences:
     end_line: 8976
     column: 80
     end_column: 109
-    labels:
-      - shell-collapse
     reason: "This generated libtool helper leaves one shell-collapse span mismatch inside a sed replacement string, so the remaining comparison here is a location-only oracle difference."
   - side: shuck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
@@ -63,8 +46,6 @@ reviewed_divergences:
     end_line: 8976
     column: 80
     end_column: 111
-    labels:
-      - shell-collapse
     reason: "This generated libtool helper leaves one shell-collapse span mismatch inside a sed replacement string, so the remaining comparison here is a location-only oracle difference."
   - side: shellcheck-only
     path_suffix: "scop__bash-completion__completions-core__tmux.bash"
@@ -72,6 +53,4 @@ reviewed_divergences:
     end_line: 216
     column: 29
     end_column: 47
-    labels:
-      - shell-collapse
     reason: "This bash-completion helper is already reduced through the shell-collapse path in the corpus run, and the remaining SC2016 hit depends on that collapsed quoting shape rather than a stable core-rule behavior."

--- a/crates/shuck/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c006.yaml
@@ -2,50 +2,27 @@ review_all_divergences: true
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This acme.sh helper uses directive-heavy project-local plumbing that ShellCheck leaves alone in the corpus run, so we review this file narrowly instead of teaching C006 a special helper contract."
   - side: shuck-only
     path_suffix: "acmesh-official__acme.sh__dnsapi__dns_dnsservices.sh"
-    labels:
-      - directive-handling
     reason: "This acme.sh helper uses directive-heavy project-local plumbing that ShellCheck leaves alone in the corpus run, so we review this file narrowly instead of teaching C006 a special helper contract."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__fast__Unit tests__nvm_install_no_progress_bar"
-    labels:
-      - project-closure
-      - test-harness
     reason: "This nvm test harness reads helper-produced line bookkeeping that ShellCheck does not compare as live state in the corpus run."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    labels:
-      - helper-library
-      - project-closure
     reason: "This oh-my-zsh helper relies on completion/runtime state provided by surrounding functions, so the remaining Shuck-side read is reviewed narrowly."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This oh-my-zsh entrypoint uses zsh-only loop bindings and `${name:h:t}`-style modifiers inside a shell-collapse/project-closure context, so we review these Shuck-only reads narrowly instead of widening C006 around non-native zsh syntax."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    labels:
-      - helper-library
-      - test-harness
     reason: "This zunit test harness populates `lines` as framework-managed result state, and ShellCheck does not compare that helper-owned array as a live undefined-variable read here."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
-    labels:
-      - helper-library
-      - shell-collapse
     reason: "This completion helper reaches into zsh's special `parameters` table inside a shell-collapse helper context, and ShellCheck stays quiet on that zsh-specific runtime surface in the corpus run."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
-    labels:
-      - helper-library
-      - shell-collapse
     reason: "This zsh completion helper uses a zsh-specific mapfile expansion shape inside a shell-collapse context, and ShellCheck stays quiet on the corpus fixture."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__bin__rvmsudo"
@@ -55,21 +32,15 @@ reviewed_divergences:
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__binscripts__rvm-installer"
-    labels:
-      - project-closure
     reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__contrib__ps1_functions"
     reason: "This prompt helper still carries an isolated runtime-formatting C006 difference, and we keep it reviewed narrowly instead of broadening C006 around prompt text."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__cli"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__docs"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__extras__rails"
@@ -79,50 +50,36 @@ reviewed_divergences:
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__cli"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__gemset"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__init"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__list"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_install"
-    labels:
-      - project-closure
     reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_install"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_install_patches"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_remove"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
@@ -171,8 +128,6 @@ reviewed_divergences:
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc_set"
@@ -185,84 +140,54 @@ reviewed_divergences:
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__selector"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__support"
-    labels:
-      - project-closure
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__support"
-    labels:
-      - project-closure
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__utility_logging"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__gemsets"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__help"
-    labels:
-      - project-closure
     reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__info"
-    labels:
-      - project-closure
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__info"
-    labels:
-      - project-closure
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__install"
-    labels:
-      - project-closure
     reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__list"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__maglev"
-    labels:
-      - project-closure
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__maglev"
-    labels:
-      - project-closure
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__migrate"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__notes"
-    labels:
-      - project-closure
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__rvm"
-    labels:
-      - project-closure
     reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
   - side: shuck-only
     path_suffix: "termux__termux-packages__packages__tsocks__04_getpeername.patch"
     reason: "This patch fixture contains generated configure-style placeholders that ShellCheck does not compare as live shell variables in the corpus run."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__config.guess"
-    labels:
-      - directive-handling
     reason: "This imported config.guess helper is directive-heavy, and ShellCheck stays quiet on this exact placeholder read in the corpus run."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__x11-packages__librewolf__build.sh"
@@ -272,152 +197,93 @@ reviewed_divergences:
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__cmake.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__fetch.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__build-style__gem.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__gemspec.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__build-style__gemspec.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__go.sh"
-    labels:
-      - shell-collapse
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__build-style__go.sh"
-    labels:
-      - shell-collapse
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__haskell-stack.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__perl-module.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__python3-pep517.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__qmake.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__sip-build.sh"
-    labels:
-      - shell-collapse
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__build-style__sip-build.sh"
-    labels:
-      - shell-collapse
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__texmf.sh"
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__build-style__void-cross.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__chroot-style__ethereal.sh"
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__environment__setup__replace-interpreter.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__environment__setup__sourcepkg.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__hooks__post-install__04-create-xbps-metadata-scripts.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__hooks__post-install__04-create-xbps-metadata-scripts.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__hooks__post-install__15-qt-private-api.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__hooks__post-install__15-qt-private-api.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__hooks__pre-pkg__04-generate-runtime-deps.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__hooks__pre-pkg__99-pkglint.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__libexec__build.sh"
-    labels:
-      - project-closure
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__build_dependencies.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__bulk.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__pkgtarget.sh"
-    labels:
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__show.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__update_check.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__pycompile"

--- a/crates/shuck/tests/testdata/corpus-metadata/c008.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c008.yaml
@@ -4,9 +4,6 @@ reviewed_divergences:
     line: 2734
     column: 14
     end_column: 23
-    labels:
-      - helper-library
-      - project-closure
     reason: "This trap handler is part of a helper script target, and the corpus comparison does not surface the same ShellCheck warning at this site. Keeping it reviewed avoids broadening C008 beyond the trap-action cases ShellCheck and Shuck already agree on."
   - side: shuck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__install"

--- a/crates/shuck/tests/testdata/corpus-metadata/c010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c010.yaml
@@ -2,35 +2,22 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "scop__bash-completion__completions-core__7z.bash"
     line: 95
-    labels:
-      - shell-collapse
     reason: "This bash-completion helper intentionally falls back from the write-mode archive matcher to the broader archive matcher when the first completion pass returns no candidates. Shuck keeps the mixed short-circuit warning, while the pinned oracle stays silent in this shell-collapsed helper."
   - side: shuck-only
     path_suffix: "scop__bash-completion__completions-core__hostname.bash"
     line: 20
-    labels:
-      - shell-collapse
     reason: "This bash-completion helper intentionally falls back from help-option completions to the general usage completions when the first generator returns no matches. Shuck keeps the mixed short-circuit warning, while the pinned oracle stays silent in this shell-collapsed helper."
   - side: shuck-only
     path_suffix: "scop__bash-completion__completions-core__mussh.bash"
     line: 37
-    labels:
-      - shell-collapse
     reason: "This bash-completion helper intentionally falls back from `user@host` completion to the known-host list when the first generator yields no candidates. Shuck keeps the mixed short-circuit warning, while the pinned oracle stays silent in this shell-collapsed helper."
   - side: shuck-only
     path_suffix: "scop__bash-completion__completions-core__rcs.bash"
     line: 35
-    labels:
-      - shell-collapse
     reason: "This bash-completion helper intentionally falls back from file matches to directory suggestions when the first completion pass returns nothing. Shuck keeps the mixed short-circuit warning, while the pinned oracle stays silent in this shell-collapsed helper."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
-    labels:
-      - helper-library
-      - project-closure
     reason: "ShellCheck stops at an unrelated parse failure earlier in this helper, so it never reaches the later fallback-download chains that shuck still analyzes and reports."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc"
-    labels:
-      - project-closure
     reason: "ShellCheck fails on the nonstandard function header near the top of this file, so the later trust-reset helper chains never get an oracle-side SC2015 comparison."

--- a/crates/shuck/tests/testdata/corpus-metadata/c018.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c018.yaml
@@ -2,20 +2,14 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "void-linux__void-packages__xbps-src"
     line: 361
-    labels:
-      - project-closure
     reason: "This early loop control is only relevant in the package-manager flow around this helper, and ShellCheck does not flag it in the corpus fixture."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__xbps-src"
     line: 365
-    labels:
-      - project-closure
     reason: "This early loop control is only relevant in the package-manager flow around this helper, and ShellCheck does not flag it in the corpus fixture."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__xbps-src"
     line: 428
-    labels:
-      - project-closure
     reason: "This command-line parser exit path is treated as reviewed divergence because ShellCheck stays quiet on the corpus fixture."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__gdk-pixbuf-loaders"

--- a/crates/shuck/tests/testdata/corpus-metadata/c039.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c039.yaml
@@ -1,23 +1,15 @@
 reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__configure"
-    labels:
-      - project-closure
     reason: "This project-closure libtool configure copy still carries SC1078 on nested single-quoted export-script text. C039 stays scoped to reopened double-quoted fragments, so this generated single-quote string remains a reviewed divergence."
   - side: shuck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
-    labels:
-      - shell-collapse
     reason: "This libtool wrapper is already shell-collapsed into a malformed quote state before the continued `$ECHO \"\\` block, so the remaining C039 hit is treated as a reviewed shell-collapse artifact."
   - side: shuck-only
     path_suffix: "termux__termux-packages__packages__luvit__build.sh"
-    labels:
-      - project-closure
     reason: "This Termux recipe is compared through a project-closure path that sources `packages/lit/build.sh` inside a quoted URL fragment. Shuck still sees the reopened quote around that sourced command substitution, while the standalone file does not surface SC1078."
   - side: shuck-only
     path_suffix: "tteck__Proxmox__install__heimdall-dashboard-install.sh"
-    labels:
-      - project-closure
     reason: "This Proxmox helper writes a systemd unit with a multiline `echo \"[Unit]...` block. The remaining C039 hit appears only on the project-closure copy, so it stays reviewed instead of broadening the rule."
   - side: shellcheck-only
     path_suffix: "google__oss-fuzz__projects__ox-ruby__build.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/c041.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c041.yaml
@@ -1,5 +1,4 @@
 reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__tsocks__04_getpeername.patch"
-    labels: ["patch-file"]
     reason: "This fixture is a unified diff containing C source fragments, so SC1127 hits C-style comment markers that are not shell syntax we lint in patch-file context."

--- a/crates/shuck/tests/testdata/corpus-metadata/c050.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c050.yaml
@@ -4,7 +4,4 @@ reviewed_divergences:
     line: 808
     column: 32
     end_column: 120
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This helper formats elapsed time by feeding a computed string through a here-string target inside a command substitution. Shuck flags the arithmetic expansion in that redirection target, while ShellCheck stays silent on this exact project-local helper shape, so we review this one fixture as an intentional stricter policy choice instead of broadening the rule to every formatted output string."

--- a/crates/shuck/tests/testdata/corpus-metadata/c056.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c056.yaml
@@ -29,8 +29,6 @@ reviewed_divergences:
     reason: "This guard chain reads `$?` from the preceding condition branch through `|| return $?`. Shuck keeps that explicit status-capture warning, while ShellCheck is silent for this corpus location."
   - side: shuck-only
     path_suffix: "CISOfy__lynis__include__tests_mac_frameworks"
-    labels:
-      - test-harness
     reason: "This AppArmor status probe keeps chaining explicit `$?` checks through an `elif` ladder. Shuck keeps the first follow-up branch warning here, while ShellCheck stays silent on that harness-flavored classifier arm in the corpus run."
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__tools__copy-data__home-assistant-container-copy-data-home-assistant-container.sh"
@@ -61,43 +59,24 @@ reviewed_divergences:
     reason: "This copy-data helper routes the failing test status into a `die` alias that captures `$?` at invocation time. Shuck keeps that strict condition-status warning, while ShellCheck stays silent for this file."
   - side: shuck-only
     path_suffix: "itzg__docker-minecraft-server__scripts__start-deployLimbo"
-    labels:
-      - project-closure
     reason: "This deploy helper logs `$?` from inside a condition branch immediately after testing it. Shuck keeps that strict branch-status warning, while ShellCheck stays silent at this project-local site."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__edo.sh"
-    labels:
-      - project-closure
-      - test-harness
     reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps one extra C056 anchor here that we review narrowly instead of widening the core rule around harness sequencing."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__estack_eshopts.sh"
-    labels:
-      - project-closure
-      - test-harness
     reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps a few extra C056 anchors here that we review narrowly instead of widening the core rule around harness sequencing."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__estack_estack.sh"
-    labels:
-      - project-closure
-      - test-harness
     reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps a few extra C056 anchors here that we review narrowly instead of widening the core rule around harness sequencing."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__estack_evar.sh"
-    labels:
-      - project-closure
-      - test-harness
     reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps a few extra C056 anchors here that we review narrowly instead of widening the core rule around harness sequencing."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__toolchain-funcs.sh"
-    labels:
-      - project-closure
-      - test-harness
     reason: "This Gentoo test harness uses helper-managed assertion flow under project-local sourcing, and ShellCheck keeps a few extra C056 anchors here that we review narrowly instead of widening the core rule around harness sequencing."
   - side: shellcheck-only
     path_suffix: "ko1nksm__shellspec__contrib__bugs.sh"
-    labels:
-      - directive-handling
     reason: "This ShellSpec bug harness combines directive-heavy fixtures with helper assertions, so we review the remaining ShellCheck-only C056 anchors narrowly instead of teaching the rule ShellSpec-specific directive flow."
   - side: shuck-only
     path_suffix: "tteck__Proxmox__misc__copy-data__home-assistant-container-copy-data-home-assistant-container.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/c063.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c063.yaml
@@ -23,9 +23,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
     line: 3
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This formatter helper is replaced with a no-op only on the non-terminal branch, while terminal output still uses the original definition later in the file."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__requirements__openindiana"

--- a/crates/shuck/tests/testdata/corpus-metadata/c087.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c087.yaml
@@ -2,6 +2,4 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__ct__immich.sh"
     line: 114
-    labels:
-      - project-closure
     reason: "This Proxmox update helper reads a saved version string through `$(cat ~/.immich)` and then compares it lexically against `2.5.1`. Shuck intentionally keeps the version-comparison warning for that file-backed value, while the current oracle stays silent on this project-closure fixture."

--- a/crates/shuck/tests/testdata/corpus-metadata/c091.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c091.yaml
@@ -33,9 +33,6 @@ reviewed_divergences:
     end_line: 98
     column: 13
     end_column: 30
-    labels:
-      - helper-library
-      - project-closure
     reason: "This `[` expression is a unary `-e` path probe, not a binary string comparison. C091 deliberately does not treat quoted path-test operands as its target shape."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -43,9 +40,6 @@ reviewed_divergences:
     end_line: 99
     column: 15
     end_column: 32
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper assigns a quoted profile path into `profile` for later use. C091 is comparison-specific and intentionally skips assignment-only literals."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -53,9 +47,6 @@ reviewed_divergences:
     end_line: 101
     column: 15
     end_column: 27
-    labels:
-      - helper-library
-      - project-closure
     reason: "This branch stores `~/.profile` as data in `profile` rather than comparing it. That assignment shape is outside C091's intended scope."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -63,9 +54,6 @@ reviewed_divergences:
     end_line: 103
     column: 22
     end_column: 72
-    labels:
-      - helper-library
-      - project-closure
     reason: "This quoted `~/...` text is explanatory string content shown to the user, not a string-comparison operand. C091 intentionally leaves documentation text alone."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -73,9 +61,6 @@ reviewed_divergences:
     end_line: 104
     column: 8
     end_column: 19
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper assigns `~/.bashrc` into `rc` for later use. C091 only warns when a quoted `~/...` literal participates in a string comparison."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -83,9 +68,6 @@ reviewed_divergences:
     end_line: 107
     column: 13
     end_column: 47
-    labels:
-      - helper-library
-      - project-closure
     reason: "This PowerShell profile path is stored as a quoted string value, not compared. Assignment literals remain out of scope for C091."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -93,9 +75,6 @@ reviewed_divergences:
     end_line: 108
     column: 8
     end_column: 42
-    labels:
-      - helper-library
-      - project-closure
     reason: "This `rc` assignment carries a quoted home-relative path for later output. C091 is intentionally narrower than ShellCheck's broader SC2088 family here."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -103,9 +82,6 @@ reviewed_divergences:
     end_line: 111
     column: 13
     end_column: 26
-    labels:
-      - helper-library
-      - project-closure
     reason: "This zsh profile assignment stores `~/.zprofile` as data rather than comparing it, so it remains outside C091."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -113,9 +89,6 @@ reviewed_divergences:
     end_line: 112
     column: 8
     end_column: 18
-    labels:
-      - helper-library
-      - project-closure
     reason: "This zsh rc-path assignment is another non-comparison quoted tilde literal that C091 intentionally ignores."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -123,9 +96,6 @@ reviewed_divergences:
     end_line: 120
     column: 13
     end_column: 25
-    labels:
-      - helper-library
-      - project-closure
     reason: "This Korn-shell profile path is assigned into a variable for later use, not compared as a string. That keeps it out of C091's comparison-focused rule definition."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
@@ -133,9 +103,6 @@ reviewed_divergences:
     end_line: 121
     column: 8
     end_column: 20
-    labels:
-      - helper-library
-      - project-closure
     reason: "This quoted `~/.profile` assignment feeds later helper output rather than a string comparison, so C091 intentionally does not report it."
   - side: shellcheck-only
     path_suffix: "xwmx__nb__nb"
@@ -143,7 +110,4 @@ reviewed_divergences:
     end_line: 25657
     column: 41
     end_column: 44
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This occurrence is part of a help-text string shown to users, not a shell string comparison. C091 is intentionally limited to comparison operands and skips display text."

--- a/crates/shuck/tests/testdata/corpus-metadata/c094.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c094.yaml
@@ -49,8 +49,6 @@ reviewed_divergences:
     reason: "This build helper reuses redirected filename text through shell variables and derived output templates, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening the redirect target as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
   - side: shellcheck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
-    labels:
-      - project-closure
     reason: "This helper reuses redirected filename tokens as scalar values and formatting placeholders, and the pinned ShellCheck SC2094 oracle treats that text collision as a same-file read/write site even though the command is not reopening that path as input. Shuck keeps C094 scoped to actual file operands and redirect sources."
   - side: shellcheck-only
     path_suffix: "swoodford__aws__s3-restrict-bucket-policy.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/c095.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c095.yaml
@@ -54,9 +54,6 @@ reviewed_divergences:
     column: 14
     end_line: 889
     end_column: 19
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This directive-driven assignment is treated as a known project-specific exception."
   - side: shuck-only
     path_suffix: "google__oss-fuzz__projects__llvm__build.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/c100.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c100.yaml
@@ -4,21 +4,12 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 146
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper fixture hits a ShellCheck parse abort before full analysis, so SC2128 is not emitted while shuck still reports the quoted BASH_SOURCE scalar expansion."
   - side: shuck-only
     path_suffix: "sstephenson__bats__libexec__bats-exec-test"
     line: 216
-    labels:
-      - helper-library
-      - project-closure
-      - test-harness
     reason: "This Bats helper still uses a quoted scalar BASH_SOURCE check inside its trap setup, and shuck intentionally keeps the explicit-index warning even though the current oracle does not surface the comparable diagnostic here."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__bin__add-to-path.sh"
     line: 7
-    labels:
-      - shell-collapse
     reason: "This Termux bootstrap script derives its bin directory from a quoted scalar BASH_SOURCE expansion, and shuck intentionally keeps the explicit-index warning even when the current oracle does not report the same scalar-access form in this collapsed-shell fixture."

--- a/crates/shuck/tests/testdata/corpus-metadata/c105.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c105.yaml
@@ -2,22 +2,14 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
     line: 2484
-    labels:
-      - directive-handling
-      - project-closure
     reason: "C105 is intentionally scoped to positional-parameter @ splats, while the oracle's SC2163 check also flags exporting values through general variable expansion."
   - side: shellcheck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
     line: 2490
-    labels:
-      - directive-handling
-      - project-closure
     reason: "C105 is intentionally scoped to positional-parameter @ splats, while the oracle's SC2163 check also flags exporting values through general variable expansion."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__configure"
     line: 1166
-    labels:
-      - project-closure
     reason: "The script validates that ac_envvar holds a shell variable name, assigns through that name, and then exports it via expansion. C105 stays focused on positional-parameter @ splats rather than indirect name export."
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__misc__stardict__stardict-wayland"
@@ -26,38 +18,24 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "alpinelinux__aports__main__compat-pvgrub__update-pvgrub"
     line: 40
-    labels:
-      - project-closure
     reason: "blkid -o export emits KEY=value records, so exporting the expanded result is a different pattern from C105's positional-parameter @ splat check."
   - side: shellcheck-only
     path_suffix: "alpinelinux__aports__main__compat-pvgrub__update-pvgrub"
     line: 48
-    labels:
-      - project-closure
     reason: "blkid -o export emits KEY=value records, so exporting the expanded result is a different pattern from C105's positional-parameter @ splat check."
   - side: shellcheck-only
     path_suffix: "alpinelinux__aports__main__syslinux__update-extlinux"
     line: 63
-    labels:
-      - project-closure
     reason: "blkid -o export emits KEY=value records, so exporting the expanded result is a different pattern from C105's positional-parameter @ splat check."
   - side: shellcheck-only
     path_suffix: "alpinelinux__aports__main__syslinux__update-extlinux"
     line: 71
-    labels:
-      - project-closure
     reason: "blkid -o export emits KEY=value records, so exporting the expanded result is a different pattern from C105's positional-parameter @ splat check."
   - side: shellcheck-only
     path_suffix: "itzg__docker-minecraft-server__scripts__start-utils"
     line: 218
-    labels:
-      - directive-handling
-      - project-closure
     reason: "The function receives a variable name, assigns through that name with eval, and exports it via expansion. That indirect-name pattern is outside C105's positional-parameter @ splat scope."
   - side: shellcheck-only
     path_suffix: "itzg__docker-minecraft-server__scripts__start-utils"
     line: 228
-    labels:
-      - directive-handling
-      - project-closure
     reason: "The function receives a variable name, assigns through that name with eval, and exports it via expansion. That indirect-name pattern is outside C105's positional-parameter @ splat scope."

--- a/crates/shuck/tests/testdata/corpus-metadata/c111.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c111.yaml
@@ -2,20 +2,12 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "nvm-sh__nvm__test__fast__Unit tests__nvm_print_npm_version"
     line: 19
-    labels:
-      - project-closure
-      - test-harness
     reason: "This test-harness fixture compares quoted positional parameters inside a single-bracket string test, and the oracle attributes it to SC2198 while shuck currently compares C111 through SC2199."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__fast__Unit tests__nvm_print_npm_version"
     line: 19
-    labels:
-      - project-closure
-      - test-harness
     reason: "This test-harness fixture compares quoted positional parameters inside a single-bracket string test, and shuck currently reports it through the SC2199 comparison target while the oracle uses SC2198."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__binscripts__rvm-installer"
     line: 757
-    labels:
-      - project-closure
     reason: "C111 is scoped to positional-parameter at-splats, while this SC2199 finding is for an array expansion `${sources[@]}` inside a string comparison."

--- a/crates/shuck/tests/testdata/corpus-metadata/c112.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c112.yaml
@@ -2,7 +2,4 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 2543
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper-library fixture folds `${PYTHON_CONFIGURE_OPTS_ARRAY[@]}` into a project-scoped `[[ ... ]]` operand, but the current ShellCheck 0.11.0 oracle emits no SC2199 finding for that source-closure path, so we treat it as a reviewed divergence rather than narrowing C112."

--- a/crates/shuck/tests/testdata/corpus-metadata/c117.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c117.yaml
@@ -1,13 +1,7 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "ko1nksm__shellspec__spec__general_spec.sh"
-    labels:
-      - directive-handling
-      - shellspec
-      - test-harness
     reason: "This fixture is ShellSpec table data, not a shell assignment stream. The `=` tokens belong to test-case rows, so flagging them would misread the harness syntax."
   - side: shuck-only
     path_suffix: "moovweb__gvm__examples__native__configure"
-    labels:
-      - project-closure
     reason: "This generated configure script embeds symbol-detection text, and the `=` token is part of that embedded metadata rather than a shell assignment."

--- a/crates/shuck/tests/testdata/corpus-metadata/c121.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c121.yaml
@@ -2,6 +2,4 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
     line: 1269
-    labels:
-      - project-closure
     reason: "This runcommand helper compares a quoted variable-name token after configuration globals have been populated through another helper path. The remaining C121 hit depends on cross-function project-closure state that shuck does not yet promote into this literal-name suppression, so we record the narrow divergence instead of restoring the old blanket allowlist."

--- a/crates/shuck/tests/testdata/corpus-metadata/c123.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c123.yaml
@@ -1,71 +1,39 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "Bash-it__bash-it__completion__available__salt.completion.bash"
-    labels:
-      - directive-handling
-      - helper-library
     reason: "These bash-completion helpers are compared as sourced library code, and the remaining zero-argument `_salt_get_grains` calls run inside helper-library and directive-handling context rather than a standalone command-line entrypoint. Shuck's file-local call graph still reports the helper invocation sites, so this completion-library drift is reviewed instead of broadening C123 to trust incomplete closure state."
   - side: shuck-only
     path_suffix: "Bash-it__bash-it__completion__available__virtualbox.completion.bash"
-    labels:
-      - directive-handling
-      - helper-library
     reason: "These VirtualBox completion helpers are sourced library code, and the pinned oracle's helper-library plus directive-handling path suppresses the local zero-argument helper invocations. Shuck still reports the in-file `__vboxmanage_list_vms` call sites from its standalone view, so this completion-helper divergence is reviewed."
   - side: shuck-only
     path_suffix: "Bash-it__bash-it__plugins__available__browser.plugin.bash"
-    labels:
-      - directive-handling
-      - helper-library
     reason: "This browser plugin is evaluated as sourced helper code, where the plugin entrypoints rely on ambient shell state more than positional arguments. Shuck still sees the local `browser` helper call without that surrounding plugin context, so the remaining helper-library drift is reviewed."
   - side: shuck-only
     path_suffix: "Bash-it__bash-it__plugins__available__z_autoenv.plugin.bash"
-    labels:
-      - directive-handling
-      - helper-library
-      - project-closure
     reason: "This autoenv plugin is compared through helper-library and project-closure context, and the remaining `autoenv_init` site is part of sourced plugin initialization rather than a self-contained script entrypoint. Shuck's local view still reports the zero-argument helper call, so this closure-dependent difference is reviewed."
   - side: shuck-only
     path_suffix: "HariSekhon__DevOps-Bash-tools__.bash.d__git.sh"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This bash.d helper is sourced into a larger shell environment, and the remaining `pull` invocation depends on project-closure plus directive-handling context that Shuck does not reconstruct for C123. The standalone local warning is therefore kept as a reviewed closure-side divergence."
   - side: shellcheck-only
     path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
     line: 33
     end_line: 33
-    labels:
-      - project-closure
-      - test-harness
     reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
   - side: shuck-only
     path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
     line: 33
     end_line: 33
-    labels:
-      - project-closure
-      - test-harness
     reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
   - side: shellcheck-only
     path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
     line: 37
     end_line: 37
-    labels:
-      - project-closure
-      - test-harness
     reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
   - side: shuck-only
     path_suffix: "docker-library__official-images__test__tests__postgres-basics__run.sh"
     line: 37
     end_line: 37
-    labels:
-      - project-closure
-      - test-harness
     reason: "Both tools agree on the heredoc-driven zero-argument `psql` helper call at this site, but the pinned oracle anchors the whole `psql <<'EOSQL'` command while Shuck anchors just the callee token. The remaining difference is reviewed as location drift under the harness and project-closure path."
   - side: shuck-only
     path_suffix: "scop__bash-completion__completions-core__ssh.bash"
-    labels:
-      - directive-handling
-      - helper-library
-      - shell-collapse
     reason: "This ssh completion helper is compared through helper-library and shell-collapse context, and the remaining `_comp_xfunc_scp_compgen_remote_files` call depends on sourced completion state outside the file-local argv model. Shuck's standalone helper warning is reviewed rather than treated as a live C123 gap."

--- a/crates/shuck/tests/testdata/corpus-metadata/c138.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c138.yaml
@@ -5,6 +5,4 @@ reviewed_divergences:
     end_line: 33
     column: 43
     end_column: 48
-    labels:
-      - patch-file
     reason: "This fixture is a patch payload embedded in a shell wrapper. The heredoc token appears inside diff context text rather than live shell syntax, so this C138 hit is treated as patch-data noise."

--- a/crates/shuck/tests/testdata/corpus-metadata/c144.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c144.yaml
@@ -5,6 +5,4 @@ reviewed_divergences:
     end_line: 51
     column: 31
     end_column: 34
-    labels:
-      - patch-file
     reason: "This fixture is a patch payload wrapped by a shell launcher. The matched `EOF` token is part of diff text rather than an executed heredoc closer, so this C144 result is recorded as patch-data noise."

--- a/crates/shuck/tests/testdata/corpus-metadata/c150.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c150.yaml
@@ -5,9 +5,6 @@ reviewed_divergences:
     end_line: 5908
     column: 69
     end_column: 76
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This renewal-list helper compares through directive-handling and project-closure, and the remaining C150 difference is the exact anchor inside one dense formatted expansion. The warning shape matches, but the oracle pins the later-use span on the `Le_Alt` expansion while shuck currently lands slightly earlier in the same output expression."
   - side: shuck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
@@ -15,181 +12,110 @@ reviewed_divergences:
     end_line: 5908
     column: 67
     end_column: 74
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This renewal-list helper compares through directive-handling and project-closure, and the remaining C150 difference is the exact anchor inside one dense formatted expansion. The warning shape matches, but shuck currently lands slightly earlier in the same output expression than the oracle."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1318
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1502
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1520
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1521
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1883
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C150 hits come from shuck's file-wide later-use heuristic on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__cli"
     line: 404
-    labels:
-      - project-closure
     reason: "This project-closure helper gets its effective `__search_list` mutation through sourced helper behavior that shuck still does not promote into a later-read C150 fact."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 236
-    labels:
-      - project-closure
     reason: "This installer helper's remaining C150 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 280
-    labels:
-      - project-closure
     reason: "This installer helper's remaining C150 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 285
-    labels:
-      - project-closure
     reason: "This installer helper's remaining C150 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__gemsets"
     line: 379
-    labels:
-      - project-closure
     reason: "This gemset helper's remaining C150 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__gemsets"
     line: 510
-    labels:
-      - project-closure
     reason: "This gemset helper's remaining C150 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__gemsets"
     line: 514
-    labels:
-      - project-closure
     reason: "This gemset helper's remaining C150 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__tools"
     line: 106
-    labels:
-      - project-closure
     reason: "This tools helper's remaining C150 hits depend on sourced helper-side effects for `HOME` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__tools"
     line: 128
-    labels:
-      - project-closure
     reason: "This tools helper's remaining C150 hits depend on sourced helper-side effects for `HOME` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shuck-only
     path_suffix: "HariSekhon__DevOps-Bash-tools__bin__find_broken_symlinks.sh"
     line: 53
     end_line: 53
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This script sources shared HariSekhon bash helpers before the pipeline. The remaining `exitcode` later-read depends on project-closure shell state rather than the standalone file text, so we record the closure-sensitive comparison."
   - side: shuck-only
     path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "These gist listing and detail loops compare through directive-handling and project-closure after sourcing user configuration. The remaining C150 hits are closure-sensitive pipeline noise rather than stable standalone mismatches."
   - side: shuck-only
     path_suffix: "aristocratos__bashtop__bashtop"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "Bashtop bootstraps runtime state from sourced config and theme files before these `proc[...]` reads. The remaining C150 hits only reproduce in the directive-handling/project-closure harness, so they are recorded as closure-sensitive noise."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
-    labels:
-      - project-closure
     reason: "This monitoring generator repeatedly sources per-network data files and helper state. The remaining shuck-only C150 hits in this file are closure-sensitive monitor wiring rather than stable standalone mismatches."
   - side: shellcheck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
-    labels:
-      - project-closure
     reason: "This monitoring generator repeatedly sources per-network data files and helper state. The remaining shellcheck-only C150 hits depend on project-closure globals that shuck does not yet lift across sourced helper boundaries."
   - side: shuck-only
     path_suffix: "oh-my-fish__oh-my-fish__bin__install"
-    labels:
-      - project-closure
     reason: "This installer is written for fish rather than a Bourne shell, so the project-closure shell-collapsed comparison is not a reliable SC2031 oracle for these `OMF_PATH` reads."
   - side: shuck-only
     path_suffix: "xwmx__nb__nb"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "These nb helper sections run inside a directive-heavy project context that sources wrapper code before reusing locals. The remaining C150 hits are closure-sensitive comparison noise rather than standalone mismatches."
   - side: shuck-only
     path_suffix: "HariSekhon__DevOps-Bash-tools__bin__find_broken_symlinks.sh"
     line: 49
     end_line: 49
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This script sources shared HariSekhon bash helpers before the pipeline. The child-shell `exitcode` assignment is only reportable because the project-closure harness later exits through helper-influenced shell state, so we record the assignment-side anchor as closure-sensitive noise."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 916
-    labels:
-      - helper-library
-      - project-closure
     reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C150 hit comes from closure-sensitive helper-library analysis rather than a stable standalone mismatch."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 919
-    labels:
-      - helper-library
-      - project-closure
     reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C150 hit comes from closure-sensitive helper-library analysis rather than a stable standalone mismatch."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 922
-    labels:
-      - helper-library
-      - project-closure
     reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C150 hit comes from closure-sensitive helper-library analysis rather than a stable standalone mismatch."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 925
-    labels:
-      - helper-library
-      - project-closure
     reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C150 hit comes from closure-sensitive helper-library analysis rather than a stable standalone mismatch."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 226
-    labels:
-      - project-closure
     reason: "This installer subshell mutates `rvm_path` only for helper flow that is compared through project-closure analysis, so the remaining C150 assignment-side hit is tracked as a closure-sensitive oracle difference rather than a standalone parser or fact bug."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
@@ -197,8 +123,6 @@ reviewed_divergences:
     end_line: 2497
     column: 7
     end_column: 10
-    labels:
-      - shell-collapse
     reason: "This shell-collapsed libtool help pipeline matches in warning shape, but the pinned oracle anchors SC2030 on the `for` header token while shuck anchors the loop variable name itself. The remaining difference is reviewed as loop-header location drift."
   - side: shuck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
@@ -206,16 +130,10 @@ reviewed_divergences:
     end_line: 2497
     column: 11
     end_column: 19
-    labels:
-      - shell-collapse
     reason: "This shell-collapsed libtool help pipeline matches in warning shape, but shuck anchors C150 on the loop variable name while the pinned oracle lands on the `for` header token. The remaining difference is reviewed as loop-header location drift."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
-    labels:
-      - shell-collapse
     reason: "This shell-collapsed libtool help pipeline matches in warning shape, but the remaining C150 difference is only the exact anchor inside the loop header. We record it broadly as reviewed loop-header location drift for this file."
   - side: shuck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
-    labels:
-      - shell-collapse
     reason: "This shell-collapsed libtool help pipeline matches in warning shape, but the remaining C150 difference is only the exact anchor inside the loop header. We record it broadly as reviewed loop-header location drift for this file."

--- a/crates/shuck/tests/testdata/corpus-metadata/c155.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c155.yaml
@@ -2,56 +2,35 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 916
-    labels:
-      - helper-library
-      - project-closure
     reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C155 hit comes from file-wide later-use inference across helper-library and project-closure analysis where the pinned oracle stays silent."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 919
-    labels:
-      - helper-library
-      - project-closure
     reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C155 hit comes from file-wide later-use inference across helper-library and project-closure analysis where the pinned oracle stays silent."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 922
-    labels:
-      - helper-library
-      - project-closure
     reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C155 hit comes from file-wide later-use inference across helper-library and project-closure analysis where the pinned oracle stays silent."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 925
-    labels:
-      - helper-library
-      - project-closure
     reason: "This configure helper intentionally exports build flags only for the nested configure subshell, and the remaining C155 hit comes from file-wide later-use inference across helper-library and project-closure analysis where the pinned oracle stays silent."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__cli"
     line: 385
-    labels:
-      - project-closure
     reason: "This function-style subshell relies on helper-side mutation flow through sourced project-closure behavior, which shuck does not yet promote into a later-read C155 fact."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 226
-    labels:
-      - project-closure
     reason: "This installer subshell mutates `rvm_path` only for a helper path that is compared through project-closure analysis, and shuck does not currently lift that sourced helper dependency into C155."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__tools"
     line: 69
-    labels:
-      - project-closure
     reason: "This HOME reassignment sits in a helper path whose observable effect depends on project-closure context from sibling helper execution, which shuck does not currently model as a C155 side effect."
   - side: shuck-only
     path_suffix: "HariSekhon__DevOps-Bash-tools__bin__find_broken_symlinks.sh"
     line: 53
     end_line: 53
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This script sources shared HariSekhon bash helpers before the pipeline. The remaining `exitcode` later-read depends on project-closure shell state rather than the standalone file text, so we record the closure-sensitive comparison on the C155 read-side anchor."
   - side: shellcheck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
@@ -59,9 +38,6 @@ reviewed_divergences:
     end_line: 5908
     column: 69
     end_column: 76
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This renewal-list helper compares through directive-handling and project-closure, and the remaining C155 difference is the exact anchor inside one dense formatted expansion. The warning shape matches, but the oracle pins the later-use span on the `Le_Alt` expansion while shuck currently lands slightly earlier in the same output expression."
   - side: shuck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
@@ -69,123 +45,72 @@ reviewed_divergences:
     end_line: 5908
     column: 67
     end_column: 74
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This renewal-list helper compares through directive-handling and project-closure, and the remaining C155 difference is the exact anchor inside one dense formatted expansion. The warning shape matches, but shuck currently lands slightly earlier in the same output expression than the oracle."
   - side: shuck-only
     path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "These gist listing and detail loops compare through directive-handling and project-closure after sourcing user configuration. The remaining C155 hits are closure-sensitive pipeline noise rather than stable standalone mismatches."
   - side: shuck-only
     path_suffix: "aristocratos__bashtop__bashtop"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "Bashtop bootstraps runtime state from sourced config and theme files before these `proc[...]` later reads. The remaining C155 hits only reproduce in the directive-handling/project-closure harness, so they are recorded as closure-sensitive noise."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
-    labels:
-      - project-closure
     reason: "This monitoring generator repeatedly sources per-network data files and helper state. The remaining shuck-only C155 hits in this file are closure-sensitive monitor wiring rather than stable standalone mismatches."
   - side: shellcheck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
-    labels:
-      - project-closure
     reason: "This monitoring generator repeatedly sources per-network data files and helper state. The remaining shellcheck-only C155 hits depend on project-closure globals that shuck does not yet lift across sourced helper boundaries."
   - side: shuck-only
     path_suffix: "oh-my-fish__oh-my-fish__bin__install"
-    labels:
-      - project-closure
     reason: "This installer is written for fish rather than a Bourne shell, so the project-closure shell-collapsed comparison is not a reliable SC2031 oracle for these `OMF_PATH` later reads."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1318
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C155 later-read hits come from shuck's file-wide helper-closure inference on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1502
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C155 later-read hits come from shuck's file-wide helper-closure inference on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1520
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C155 later-read hits come from shuck's file-wide helper-closure inference on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1521
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C155 later-read hits come from shuck's file-wide helper-closure inference on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1883
-    labels:
-      - helper-library
-      - project-closure
     reason: "These helper-library builder functions are compared through project-closure, and the remaining C155 later-read hits come from shuck's file-wide helper-closure inference on environment setup variables where the pinned oracle stays silent in this fixture."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 236
-    labels:
-      - project-closure
     reason: "This installer helper's remaining C155 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 280
-    labels:
-      - project-closure
     reason: "This installer helper's remaining C155 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 285
-    labels:
-      - project-closure
     reason: "This installer helper's remaining C155 hits depend on sourced helper-side effects for `rvm_path` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__gemsets"
     line: 379
-    labels:
-      - project-closure
     reason: "This gemset helper's remaining C155 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__gemsets"
     line: 510
-    labels:
-      - project-closure
     reason: "This gemset helper's remaining C155 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__gemsets"
     line: 514
-    labels:
-      - project-closure
     reason: "This gemset helper's remaining C155 hits depend on sourced helper-side effects for `rvm_ruby_string` inside project-closure analysis, which shuck does not yet lift into later-read facts."
   - side: shuck-only
     path_suffix: "xwmx__nb__nb"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "These nb helper sections run inside a directive-heavy project context that sources wrapper code before reusing locals. The remaining C155 hits are closure-sensitive comparison noise rather than standalone mismatches."
   - side: shellcheck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This renewal-list helper compares through directive-handling and project-closure, and the remaining C155 difference is only the exact anchor inside one dense formatted expansion. We record the file-level location drift as reviewed for this oracle pair."
   - side: shuck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This renewal-list helper compares through directive-handling and project-closure, and the remaining C155 difference is only the exact anchor inside one dense formatted expansion. We record the file-level location drift as reviewed for this oracle pair."

--- a/crates/shuck/tests/testdata/corpus-metadata/c156.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c156.yaml
@@ -5,9 +5,6 @@ reviewed_divergences:
     end_line: 4919
     column: 33
     end_column: 38
-    labels:
-      - directive-handling
-      - project-closure
     reason: "PPID is a shell-provided parent-process variable here, so the uppercase read can be intentional even though a lowercase helper binding exists elsewhere in the script."
   - side: shellcheck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__drush__drush.complete.sh"
@@ -15,9 +12,6 @@ reviewed_divergences:
     end_line: 24
     column: 20
     end_column: 32
-    labels:
-      - helper-library
-      - shell-collapse
     reason: "This helper intentionally mirrors a project-specific double-underscore variable name, and shuck keeps C156 narrower than ShellCheck's helper-name guessing in collapsed plugin code."
   - side: shellcheck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
@@ -25,9 +19,6 @@ reviewed_divergences:
     end_line: 197
     column: 67
     end_column: 85
-    labels:
-      - helper-library
-      - project-closure
     reason: "This is a one-off string typo inside helper code, but shuck does not broaden C156 into a general edit-distance spell checker for arbitrary uppercase names."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
@@ -35,9 +26,6 @@ reviewed_divergences:
     end_line: 116
     column: 11
     end_column: 16
-    labels:
-      - helper-library
-      - project-closure
     reason: "NAME is populated by the sourced os-release file in this branch, so matching it against an unrelated lowercase helper name elsewhere in the file is misleading."
   - side: shellcheck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
@@ -45,9 +33,6 @@ reviewed_divergences:
     end_line: 423
     column: 35
     end_column: 67
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "The trailing-underscore variant is a project-specific helper naming convention, and shuck intentionally avoids teaching C156 every collapsed helper suffix pattern."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__alpine__build.sh"
@@ -111,8 +96,6 @@ reviewed_divergences:
     end_line: 11
     column: 76
     end_column: 97
-    labels:
-      - directive-handling
     reason: "This sourced build helper intentionally threads different TERMUX_* variables together, and shuck does not treat those project-specific name shifts as misspellings."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__scripts__build__toolchain__termux_setup_toolchain_23c.sh"
@@ -141,9 +124,6 @@ reviewed_divergences:
     end_line: 417
     column: 70
     end_column: 87
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
@@ -151,9 +131,6 @@ reviewed_divergences:
     end_line: 418
     column: 68
     end_column: 83
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
@@ -161,9 +138,6 @@ reviewed_divergences:
     end_line: 419
     column: 74
     end_column: 95
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
@@ -171,9 +145,6 @@ reviewed_divergences:
     end_line: 420
     column: 69
     end_column: 85
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
@@ -181,9 +152,6 @@ reviewed_divergences:
     end_line: 421
     column: 69
     end_column: 85
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
@@ -191,9 +159,6 @@ reviewed_divergences:
     end_line: 435
     column: 28
     end_column: 45
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
@@ -201,9 +166,6 @@ reviewed_divergences:
     end_line: 436
     column: 30
     end_column: 49
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "These cross-build helper names intentionally switch between *_CMD and *_XCMD forms, and shuck does not guess across that project-specific naming family."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
@@ -211,9 +173,6 @@ reviewed_divergences:
     end_line: 128
     column: 17
     end_column: 32
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "FUNCNAME is a Bash runtime array in this error helper, so matching it against an unrelated lowercase helper variable elsewhere in the file is too aggressive."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__cross.sh"
@@ -221,8 +180,6 @@ reviewed_divergences:
     end_line: 131
     column: 5
     end_column: 21
-    labels:
-      - shell-collapse
     reason: "This cross-build helper intentionally distinguishes *_XCMD from *_CMD names, and shuck keeps C156 narrower than ShellCheck's project-specific helper guess."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__disabled-packages__botan2__build.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/k001.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/k001.yaml
@@ -5,8 +5,6 @@ reviewed_divergences:
     end_line: 683
     column: 9
     end_column: 53
-    labels:
-      - shell-collapse
     reason: "the sysroot path is built from a fixed /usr/<target> staging prefix, so this delete is constrained to the build sysroot rather than an arbitrary user-controlled directory"
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__development__ciforth__ciforth.SlackBuild"
@@ -42,6 +40,4 @@ reviewed_divergences:
     end_line: 32
     column: 8
     end_column: 19
-    labels:
-      - project-closure
     reason: "This project-closure helper removes the archive staging directory ${PACKAGE}/ directly. K001 keeps those lone staging-root cleanups out of scope until it can distinguish them from real system-root deletes."

--- a/crates/shuck/tests/testdata/corpus-metadata/s004.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s004.yaml
@@ -12,44 +12,26 @@ reviewed_divergences:
     path_suffix: "bats-core__bats-core__lib__bats-core__warnings.bash"
     line: 41
     end_line: 41
-    labels:
-      - directive-handling
-      - helper-library
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "bats-core__bats-core__lib__bats-core__warnings.bash"
     line: 41
     end_line: 41
-    labels:
-      - directive-handling
-      - helper-library
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "bats-core__bats-core__lib__bats-core__warnings.bash"
     line: 42
     end_line: 42
-    labels:
-      - directive-handling
-      - helper-library
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__install.sh"
     line: 70
     end_line: 70
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__install.sh"
     line: 71
     end_line: 71
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__completions__pyenv.bash"
@@ -60,9 +42,6 @@ reviewed_divergences:
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 388
     end_line: 388
-    labels:
-      - helper-library
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rbenv__rbenv__completions__rbenv.bash"
@@ -73,29 +52,21 @@ reviewed_divergences:
     path_suffix: "rvm__rvm__scripts__base"
     line: 54
     end_line: 54
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__cli"
     line: 114
     end_line: 114
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__init"
     line: 12
     end_line: 12
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
     line: 164
     end_line: 164
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__requirements__openbsd"
@@ -106,15 +77,11 @@ reviewed_divergences:
     path_suffix: "rvm__rvm__scripts__initialize"
     line: 57
     end_line: 57
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__rvm"
     line: 71
     end_line: 71
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__packages__ldd__ldd.in"
@@ -150,8 +117,6 @@ reviewed_divergences:
     path_suffix: "termux__termux-packages__packages__rust__build.sh"
     line: 260
     end_line: 260
-    labels:
-      - shell-collapse
     reason: "This command-substitution site is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__texlive-installer__build.sh"
@@ -162,33 +127,21 @@ reviewed_divergences:
     path_suffix: "termux__termux-packages__scripts__bin__check-auto-update"
     line: 172
     end_line: 172
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__bin__update-packages"
     line: 482
     end_line: 482
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__bin__update-packages"
     line: 542
     end_line: 542
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__bin__update-packages"
     line: 556
     end_line: 556
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__bin__validation"
@@ -204,95 +157,66 @@ reviewed_divergences:
     path_suffix: "termux__termux-packages__scripts__build-bootstraps.sh"
     line: 15
     end_line: 15
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_dotnet.sh"
     line: 32
     end_line: 32
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_dotnet.sh"
     line: 81
     end_line: 81
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_dotnet.sh"
     line: 82
     end_line: 82
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_dotnet.sh"
     line: 83
     end_line: 83
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_ldc.sh"
     line: 49
     end_line: 50
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_ldc.sh"
     line: 86
     end_line: 87
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_rust.sh"
     line: 15
     end_line: 15
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_xmake.sh"
     line: 11
     end_line: 11
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_xmake.sh"
     line: 40
     end_line: 40
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_zig.sh"
     line: 54
     end_line: 54
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__scripts__build__termux_create_debian_subpackages.sh"
     line: 10
     end_line: 10
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__scripts__build__termux_create_pacman_subpackages.sh"
     line: 10
     end_line: 10
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__termux_download_deb_pac.sh"
@@ -308,57 +232,41 @@ reviewed_divergences:
     path_suffix: "termux__termux-packages__scripts__check-versions.sh"
     line: 9
     end_line: 9
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__generate-bootstraps.sh"
     line: 8
     end_line: 8
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__generate-bootstraps.sh"
     line: 204
     end_line: 204
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__generate-bootstraps.sh"
     line: 218
     end_line: 218
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__list-packages.sh"
     line: 6
     end_line: 6
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__list-versions.sh"
     line: 8
     end_line: 8
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__setup-offline-bundle.sh"
     line: 31
     end_line: 31
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__setup-termux.sh"
     line: 67
     end_line: 67
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__x11-packages__pyqt5__cxx-wrapper"
@@ -374,44 +282,31 @@ reviewed_divergences:
     path_suffix: "tj__n__bin__n"
     line: 481
     end_line: 481
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "tj__n__bin__n"
     line: 1143
     end_line: 1143
-    labels:
-      - directive-handling
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__libexec__xbps-src-dopkg.sh"
     line: 40
     end_line: 40
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__bulk.sh"
     line: 58
     end_line: 58
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__xbps-src"
     line: 314
     end_line: 314
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__xbps-src"
     line: 316
     end_line: 316
-    labels:
-      - project-closure
     reason: "This wrapper or helper is treated as a reviewed S004 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__network__modemu2k__modemu2k.SlackBuild"
@@ -442,73 +337,49 @@ reviewed_divergences:
     path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
     line: 178
     end_line: 178
-    labels:
-      - project-closure
     reason: "This CGI helper is compared through a project-closure path, so the remaining S004 site is treated as a reviewed divergence."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
     line: 337
     end_line: 337
-    labels:
-      - project-closure
     reason: "This CGI helper is compared through a project-closure path, so the remaining S004 site is treated as a reviewed divergence."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
     line: 444
     end_line: 444
-    labels:
-      - project-closure
     reason: "This CGI helper is compared through a project-closure path, so the remaining S004 site is treated as a reviewed divergence."
   - side: shuck-only
     path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
     line: 153
     end_line: 153
-    labels:
-      - test-harness
     reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
   - side: shuck-only
     path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
     line: 154
     end_line: 154
-    labels:
-      - test-harness
     reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
   - side: shuck-only
     path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
     line: 155
     end_line: 155
-    labels:
-      - test-harness
     reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
   - side: shuck-only
     path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
     line: 160
     end_line: 160
-    labels:
-      - test-harness
     reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
   - side: shuck-only
     path_suffix: "docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
     line: 161
     end_line: 161
-    labels:
-      - test-harness
     reason: "This test harness composes docker filter probes with command substitutions, and the remaining S004 site is treated as a reviewed divergence in corpus comparison."
   - side: shuck-only
     path_suffix: "paulirish__dotfiles__.git-completion.bash"
     line: 483
     end_line: 483
-    labels:
-      - directive-handling
-      - helper-library
-      - shell-collapse
     reason: "This helper-library completion script falls under a shell-collapsed oracle path, so the remaining S004 site is treated as a reviewed divergence."
   - side: shuck-only
     path_suffix: "paulirish__dotfiles__.git-completion.bash"
     line: 2401
     end_line: 2401
-    labels:
-      - directive-handling
-      - helper-library
-      - shell-collapse
     reason: "This helper-library completion script falls under a shell-collapsed oracle path, so the remaining S004 site is treated as a reviewed divergence."

--- a/crates/shuck/tests/testdata/corpus-metadata/s005.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s005.yaml
@@ -10,10 +10,6 @@ reviewed_divergences:
     reason: "This package recipe writes a post-install maintainer script into a heredoc, so the remaining legacy-backtick site belongs to emitted script text instead of live package-build logic."
   - side: shuck-only
     path_suffix: "bats-core__bats-core__lib__bats-core__warnings.bash"
-    labels:
-      - directive-handling
-      - helper-library
-      - project-closure
     reason: "This helper wrapper is compared through a project-closure path and the remaining backtick spans are treated as reviewed differences for the corpus."
   - side: shuck-only
     path_suffix: "megastep__makeself__makeself-header.sh"
@@ -27,57 +23,36 @@ reviewed_divergences:
     reason: "This generated installer header is evaluated as a large wrapper file, so the corpus keeps the trailing backtick block as a reviewed difference."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__install.sh"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "The project-closure copy of this installer wrapper is intentionally left as a reviewed S005 divergence."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__nvm.sh"
     line: 2250
     end_line: 2250
-    labels:
-      - directive-handling
-      - shell-collapse
     reason: "This shell-collapse wrapper is kept as a reviewed S005 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
     line: 63
     end_line: 63
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper-library help text is compared through the project-closure copy, and the corpus treats the backtick style warning as reviewed there."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
     line: 327
     end_line: 327
-    labels:
-      - helper-library
-      - project-closure
     reason: "The helper-library copy of this init script is treated as a reviewed divergence for the corpus comparison."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 205
     end_line: 205
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper-library wrapper is compared through project-closure and the corpus keeps the backtick warning reviewed."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 388
     end_line: 388
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper-library wrapper is compared through project-closure and the corpus keeps the backtick warning reviewed."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1411
     end_line: 1411
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper-library wrapper is compared through project-closure and the corpus keeps the backtick warning reviewed."
   - side: shuck-only
     path_suffix: "termux__termux-packages__packages__jira-go__build.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/s008.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s008.yaml
@@ -1,57 +1,33 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "dehydrated-io__dehydrated__dehydrated"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This project-closure helper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This project-closure copy is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "megastep__makeself__test__extracttest"
-    labels:
-      - project-closure
-      - test-harness
     reason: "This harnessed test fixture is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "nvm-sh__nvm__test__common.sh"
-    labels:
-      - shell-collapse
-      - test-harness
     reason: "This shell-collapse test helper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper-library wrapper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__pyenv.d__install__latest.bash"
     reason: "This helper script is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__pyenv.d__rehash__conda.bash"
-    labels:
-      - shell-collapse
     reason: "This shell-collapse helper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This shell-collapse helper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__cli"
-    labels:
-      - project-closure
     reason: "This project-closure helper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__build_requirements"
-    labels:
-      - project-closure
     reason: "This project-closure helper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
@@ -67,13 +43,9 @@ reviewed_divergences:
     reason: "This helper script is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__selector"
-    labels:
-      - project-closure
     reason: "This project-closure helper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__set"
-    labels:
-      - project-closure
     reason: "This project-closure helper is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__root-packages__docker__build.sh"
@@ -95,6 +67,4 @@ reviewed_divergences:
     reason: "This launcher script is treated as a reviewed S008 divergence in the corpus comparison."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__xbps-src"
-    labels:
-      - project-closure
     reason: "This package-builder wrapper is treated as a reviewed S008 divergence in the corpus comparison."

--- a/crates/shuck/tests/testdata/corpus-metadata/s009.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s009.yaml
@@ -5,9 +5,6 @@ reviewed_divergences:
     end_line: 388
     column: 33
     end_column: 69
-    labels:
-      - helper-library
-      - project-closure
     reason: "ShellCheck does not reach this later wrapper diagnostic in the full corpus file because it aborts earlier on unrelated syntax, so the comparison is not reliable here."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_gn.sh"
@@ -22,9 +19,6 @@ reviewed_divergences:
     end_line: 76
     column: 41
     end_column: 98
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "ShellCheck leaves this PATH-rewrite helper shape alone even though the echoed substitution is present."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_xmake.sh"
@@ -32,6 +26,4 @@ reviewed_divergences:
     end_line: 49
     column: 36
     end_column: 95
-    labels:
-      - directive-handling
     reason: "ShellCheck does not report SC2005 on this directive-heavy PATH rewrite helper shape."

--- a/crates/shuck/tests/testdata/corpus-metadata/s010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s010.yaml
@@ -5,9 +5,6 @@ reviewed_divergences:
     end_line: 12
     column: 10
     end_column: 28
-    labels:
-      - project-closure
-      - test-harness
     reason: "This harness file is a full-script test fixture; the corpus comparison treats the top-level readonly assignment as a ShellCheck-only hit here."
   - side: shellcheck-only
     path_suffix: "megastep__makeself__test__appendtest"
@@ -15,9 +12,6 @@ reviewed_divergences:
     end_line: 13
     column: 10
     end_column: 28
-    labels:
-      - project-closure
-      - test-harness
     reason: "This harness file is a full-script test fixture; the corpus comparison treats the top-level readonly assignment as a ShellCheck-only hit here."
   - side: shellcheck-only
     path_suffix: "tj__n__bin__dev__release"
@@ -39,8 +33,6 @@ reviewed_divergences:
     end_line: 15
     column: 18
     end_column: 30
-    labels:
-      - project-closure
     reason: "The harness context around this package builder makes the top-level readonly assignment diverge from the corpus comparison."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__xbps-src"
@@ -48,8 +40,6 @@ reviewed_divergences:
     end_line: 470
     column: 18
     end_column: 30
-    labels:
-      - project-closure
     reason: "The harness context around this package builder makes the top-level readonly assignment diverge from the corpus comparison."
   - side: shellcheck-only
     path_suffix: "scop__bash-completion__completions-core__tmux.bash"
@@ -57,8 +47,6 @@ reviewed_divergences:
     end_line: 195
     column: 11
     end_column: 16
-    labels:
-      - shell-collapse
     reason: "This bash-completion helper is compared through a shell-collapsed compatibility path, and the remaining `local usage=$(...)` declaration warning stays on the oracle side in that collapsed helper context."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__install_script__install_nvm_from_git"
@@ -66,14 +54,9 @@ reviewed_divergences:
     end_line: 63
     column: 9
     end_column: 17
-    labels:
-      - test-harness
     reason: "The surrounding test fixture stops ShellCheck on a malformed conditional later in the file, so this declaration assignment is not reliably comparable."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
-    labels:
-      - helper-library
-      - project-closure
     reason: "ShellCheck aborts on earlier syntax errors in this helper, so the later declaration-assignment warnings are not stable comparison targets."
   - side: shuck-only
     path_suffix: "alpinelinux__aports__community__dnscrypt-proxy__dnscrypt-proxy.setup"
@@ -94,13 +77,7 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__www__cgi-bin-status.sh"
     line: 69
-    labels:
-      - project-closure
     reason: "This CGI helper is compared through a project-closure path, and the pinned ShellCheck run does not surface SC2155 for the `local mult_list` aggregation in that closure context. Shuck still reports the declaration-assignment combination on the helper itself."
   - side: shuck-only
     path_suffix: "paulirish__dotfiles__.git-completion.bash"
-    labels:
-      - directive-handling
-      - helper-library
-      - shell-collapse
     reason: "This Git completion helper carries a file-wide `shellcheck disable=all`, so the pinned oracle stays silent on SC2155 throughout the shell-collapsed helper-library copy. Shuck still reports the live declaration assignments there."

--- a/crates/shuck/tests/testdata/corpus-metadata/s012.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s012.yaml
@@ -1,7 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This fixture uses a top-level ShellCheck disable for SC2009. ShellCheck suppresses the ps|grep findings in this script under that directive context, while Shuck still surfaces the S012 diagnostics."

--- a/crates/shuck/tests/testdata/corpus-metadata/s013.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s013.yaml
@@ -1,7 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
-    labels:
-      - helper-library
-      - project-closure
     reason: "In this helper-library fixture, ShellCheck's project-closure analysis omits SC2010 for these ls|grep pipelines, while Shuck still reports S013 from direct pipeline facts."

--- a/crates/shuck/tests/testdata/corpus-metadata/s014.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s014.yaml
@@ -2,14 +2,8 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
     line: 5
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This project-closure bootstrap fixture is shell-collapsed by the oracle, so SC2048 is not surfaced at this unquoted star-splat callsite."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 314
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper-library fixture falls into a project-closure path where the oracle does not emit SC2048 for this forwarding form, while shuck still reports the star-splat expansion."

--- a/crates/shuck/tests/testdata/corpus-metadata/s016.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s016.yaml
@@ -28,16 +28,10 @@ reviewed_divergences:
     line: 420
     column: 5
     end_column: 55
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This Bitnami helper is analyzed through project-closure context that ShellCheck does not follow in the single-file corpus comparison, so shuck still reports the embedded command-substitution cleanup here."
   - side: shuck-only
     path_suffix: "bitnami__containers__bitnami__zookeeper__3.9__debian-12__rootfs__opt__bitnami__scripts__libzookeeper.sh"
     line: 442
     column: 9
     end_column: 66
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This Bitnami helper is analyzed through project-closure context that ShellCheck does not follow in the single-file corpus comparison, so shuck still reports the embedded command-substitution cleanup here."

--- a/crates/shuck/tests/testdata/corpus-metadata/s017.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s017.yaml
@@ -1,7 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This brace-expansion template combines variable prefixes with literal fanout to build candidate config paths, and the oracle does not report SC2206 for that pattern."

--- a/crates/shuck/tests/testdata/corpus-metadata/s019.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s019.yaml
@@ -4,9 +4,6 @@ reviewed_divergences:
     line: 10
     column: 3
     end_column: 5
-    labels:
-      - project-closure
-      - test-harness
     reason: "This test harness keeps the legacy backtick pipeline inside a string test, and ShellCheck stays silent on SC2143 for that project-closure comparison. Shuck keeps the grep-output-in-test warning on the same legacy substitution shape."
   - side: shuck-only
     path_suffix: "scripts/SlackBuildsOrg__slackbuilds__network__jboss-as__rc.jboss-as"
@@ -23,17 +20,11 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "scripts/bittorf__kalua__openwrt-addons__usr__sbin__cron.monitoring"
     line: 707
-    labels:
-      - project-closure
     reason: "This hardware probe helper tests the printed output of a nested grep pipeline, and the broader project-closure fixture is consumed through command substitution elsewhere in the script. The current ShellCheck run does not surface SC2143 for this helper predicate, while Shuck keeps the grep-output-in-test warning."
   - side: shuck-only
     path_suffix: "scripts/docker__docker-bench-security__tests__2_docker_daemon_configuration.sh"
-    labels:
-      - test-harness
     reason: "This test-harness file uses `[[ $(... | grep ...) ]]` helper predicates to inspect JSON-like Docker settings. The current ShellCheck run does not emit SC2143 for these harness checks, while Shuck consistently warns on using grep output as a boolean test."
   - side: shuck-only
     path_suffix: "scripts/spiritLHLS__one-click-installation-script__install_scripts__go.sh"
     line: 163
-    labels:
-      - project-closure
     reason: "This proxy setup guard uses a legacy backtick pipeline inside a conditional, and the current ShellCheck run reports only the backtick form rather than surfacing SC2143. Shuck keeps the grep-output-in-test warning on the same substitution shape."

--- a/crates/shuck/tests/testdata/corpus-metadata/s021.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s021.yaml
@@ -3,15 +3,10 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 1457
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper-library project-closure fixture folds positional parameters into a quoted sentence; shuck keeps S021 on this callsite even though the oracle does not emit SC2145 here."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__scripts__env__pkgset-use"
     line: 54
-    labels:
-      - project-closure
     reason: "This project-closure debug trace mixes an escaped '\\$@' literal with the real '$@' in one quoted word; the oracle keeps SC2145 here, but Shuck does not currently retain S021 on this callsite."
   - side: shellcheck-only
     path_suffix: "RetroPie__RetroPie-Setup__retropie_packages.sh"
@@ -32,9 +27,6 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
     line: 784
-    labels:
-      - directive-handling
-      - project-closure
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for a composed edit argument that mixes in the 'hashtags[@]' array."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__app-office__libreoffice-l10n__files__lo_gen_langs.sh"
@@ -47,16 +39,10 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__git-r3_subrepos.sh"
     line: 22
-    labels:
-      - project-closure
-      - test-harness
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for array expansions inside a test harness mismatch message."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__python-utils-r1.sh"
     line: 44
-    labels:
-      - project-closure
-      - test-harness
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for an 'args[*]' expansion folded into a test description string."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__sys-apps__kexec-tools__files__kexec-auto-load"
@@ -65,20 +51,14 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "google__oss-fuzz__infra__base-images__base-builder__bazel_build_fuzz_tests"
     line: 64
-    labels:
-      - test-harness
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for a 'BAZEL_BUILD_FLAGS[@]' array echoed in test-harness output."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__pyenv.d__rehash__conda.bash"
     line: 29
-    labels:
-      - shell-collapse
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for mixed array expansion inside an eval-generated string."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__pyenv.d__rehash__source.bash"
     line: 11
-    labels:
-      - project-closure
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for mixed array expansion inside an eval-generated string."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__extras__rails"
@@ -87,20 +67,14 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_install"
     line: 198
-    labels:
-      - project-closure
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for mixed array expansion inside a diagnostic string."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__support"
     line: 231
-    labels:
-      - project-closure
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for mixed array expansion inside a diagnostic string."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__set"
     line: 198
-    labels:
-      - project-closure
     reason: "S021 is scoped to positional-parameter '$@' folding, while this SC2145 finding is for mixed array expansion in a deprecation message."
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__srcpkgs__lxc__files__lxc-void"

--- a/crates/shuck/tests/testdata/corpus-metadata/s028.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s028.yaml
@@ -4,23 +4,16 @@ reviewed_divergences:
     line: 2965
     column: 57
     end_column: 57
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This project-closure music helper builds the awk program through nested command-substitution text, and the remaining S028 hit is confined to that helper-side string assembly."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__configure"
     line: 8965
     column: 16
     end_column: 16
-    labels:
-      - project-closure
     reason: "This libtool configure fragment lives inside a project-closure helper assignment, and shuck does not currently model that helper string body as a closing-quote S028 site."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__configure"
     line: 8967
     column: 13
     end_column: 13
-    labels:
-      - project-closure
     reason: "This libtool configure fragment lives inside a project-closure helper assignment, and shuck does not currently model that helper string body as a closing-quote S028 site."

--- a/crates/shuck/tests/testdata/corpus-metadata/s036.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s036.yaml
@@ -4,16 +4,10 @@ reviewed_divergences:
     line: 15
     column: 37
     end_column: 41
-    labels:
-      - project-closure
-      - test-harness
     reason: "This nvm test harness keeps a bare `read` in a pipe-only assertion helper, and the current ShellCheck corpus comparison does not surface SC2258 for that harness path while shuck still reports the bare-read pattern directly."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__fast__Unit tests__nvm_stdout_is_terminal"
     line: 23
     column: 45
     end_column: 49
-    labels:
-      - project-closure
-      - test-harness
     reason: "This nvm test harness keeps a bare `read` in a pipe-only assertion helper, and the current ShellCheck corpus comparison does not surface SC2258 for that harness path while shuck still reports the bare-read pattern directly."

--- a/crates/shuck/tests/testdata/corpus-metadata/s037.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s037.yaml
@@ -5,8 +5,4 @@ reviewed_divergences:
     column: 7
     end_line: 70
     end_column: 86
-    labels:
-      - directive-handling
-      - helper-library
-      - project-closure
     reason: "This helper-library fixture keeps the stderr message split across a backslash-continued line, so the indentation is not a standalone run of repeated spaces on one physical echo line. ShellCheck 0.11.0 stays silent here while shuck currently flags the continued spacing pattern."

--- a/crates/shuck/tests/testdata/corpus-metadata/s044.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s044.yaml
@@ -4,9 +4,6 @@ reviewed_divergences:
     reason: "The pinned ShellCheck run aborts later in this build script before it reaches the earlier `echo | sed` rewrite, so the remaining S044 hit is treated as an oracle-side parse-abort artifact rather than a live SC2001 mismatch."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
-    labels:
-      - helper-library
-      - project-closure
     reason: "This python-build helper is compared through helper-library and project-closure context, and the pinned ShellCheck run aborts earlier in the file before it reaches these `echo | sed` rewrites. Shuck keeps the direct S044 reports on the live rewrite sites."
   - side: shellcheck-only
     path_suffix: "google__oss-fuzz__projects__sudoers__build.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/s046.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s046.yaml
@@ -5,6 +5,4 @@ reviewed_divergences:
     column: 2
     end_line: 256
     end_column: 4
-    labels:
-      - shell-collapse
     reason: "ShellCheck 0.11.0 does not report SC2293 for this raw ls-to-xargs pipeline, but shuck follows the repo-authored S046 scope and flags the unsafe pipeline shape."

--- a/crates/shuck/tests/testdata/corpus-metadata/s050.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s050.yaml
@@ -5,6 +5,4 @@ reviewed_divergences:
     end_line: 8965
     column: 70
     end_column: 71
-    labels:
-      - project-closure
     reason: "This generated configure script only picks up the warning in the corpus harness after project-closure expansion. The standalone sed fragment does not reproduce the quote-adjacency hit, so this remaining site is tracked as closure-dependent corpus noise."

--- a/crates/shuck/tests/testdata/corpus-metadata/s054.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s054.yaml
@@ -2,16 +2,10 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "89luca89__distrobox__distrobox-init"
     line: 1886
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This compatibility probe calls `su --version` while deciding whether to install a wrapper. Direct oracle probes still surface SC2117 for that standalone form, so the missing full-file report here is treated as project-closure oracle noise."
   - side: shuck-only
     path_suffix: "89luca89__distrobox__distrobox-init"
     line: 1887
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This compatibility probe calls `su --version` while deciding whether to install a wrapper. Direct oracle probes still surface SC2117 for that standalone form, so the missing full-file report here is treated as project-closure oracle noise."
   - side: shuck-only
     path_suffix: "HariSekhon__DevOps-Bash-tools__install__install_homebrew.sh"
@@ -20,20 +14,12 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "bitnami__containers__bitnami__discourse__2026__debian-12__rootfs__opt__bitnami__scripts__discourse__postunpack.sh"
     line: 40
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This command-substitution uses the locally tested `su \"$user\" -s \"$SHELL\" -c ...` shape. The standalone form no longer triggers S054, so the remaining corpus miss is treated as project-closure oracle noise in the full-file run."
   - side: shuck-only
     path_suffix: "bitnami__containers__bitnami__redmine__6.1__debian-12__rootfs__opt__bitnami__scripts__redmine__postunpack.sh"
     line: 45
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This command-substitution uses the locally tested `su \"$user\" -s \"$SHELL\" -c ...` shape. The standalone form no longer triggers S054, so the remaining corpus miss is treated as project-closure oracle noise in the full-file run."
   - side: shuck-only
     path_suffix: "sickcodes__Docker-OSX__tests__test.sh"
     line: 168
-    labels:
-      - test-harness
     reason: "This test harness passes the command as trailing argv after the target user instead of using `-c`. Shuck intentionally keeps preferring explicit command or login forms for S054, while the oracle does not surface SC2117 for this argv-forwarding style."

--- a/crates/shuck/tests/testdata/corpus-metadata/s057.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s057.yaml
@@ -5,8 +5,6 @@ reviewed_divergences:
     end_line: 52
     column: 7
     end_column: 53
-    labels:
-      - project-closure
     reason: "This alias value defines a helper function before sourcing another script, so it remains an S057 hit even though the oracle does not surface a matching comparison record for that profile helper."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__configure"
@@ -14,8 +12,6 @@ reviewed_divergences:
     end_line: 22
     column: 12
     end_column: 30
-    labels:
-      - project-closure
     reason: "This zsh bootstrap alias rewrites positional-parameter forwarding, but it does not define a function inside the alias value, so it falls outside S057's independently authored scope."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
@@ -23,6 +19,4 @@ reviewed_divergences:
     end_line: 93
     column: 12
     end_column: 30
-    labels:
-      - shell-collapse
     reason: "This zsh bootstrap alias rewrites positional-parameter forwarding, but it does not define a function inside the alias value, so it falls outside S057's independently authored scope."

--- a/crates/shuck/tests/testdata/corpus-metadata/s077.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s077.yaml
@@ -5,7 +5,4 @@ reviewed_divergences:
     end_line: 827
     column: 16
     end_column: 16
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper intentionally builds literal `NAME[@]` text for a later indirect expansion, so the adjacent bracket suffix is deliberate and warning here would be noisy."

--- a/crates/shuck/tests/testdata/corpus-metadata/x001.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x001.yaml
@@ -1,7 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "the script exits before its zsh-only body when it is sourced outside zsh, so later `[[ ... ]]` forms are intentionally guarded"

--- a/crates/shuck/tests/testdata/corpus-metadata/x004.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x004.yaml
@@ -1,27 +1,15 @@
 reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__catimg__catimg.sh"
-    labels:
-      - helper-library
-      - shell-collapse
     reason: "ShellCheck still anchors this helper's `function` portability hit to the whole multi-line definition body. Shuck now reports the same X004 finding on the header span only, so this remaining delta is range-only."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__catimg__catimg.sh"
-    labels:
-      - helper-library
-      - shell-collapse
     reason: "ShellCheck still anchors this helper's `function` portability hit to the whole multi-line definition body. Shuck now reports the same X004 finding on the header span only, so this remaining delta is range-only."
   - side: shellcheck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
-    labels:
-      - helper-library
-      - shell-collapse
     reason: "ShellCheck still anchors this helper's `function` portability hit to the whole multi-line definition body. Shuck now reports the same X004 finding on the header span only, so this remaining delta is range-only."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
-    labels:
-      - helper-library
-      - shell-collapse
     reason: "ShellCheck still anchors this helper's `function` portability hit to the whole multi-line definition body. Shuck now reports the same X004 finding on the header span only, so this remaining delta is range-only."
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__system__munin-node__rc.munin-node"

--- a/crates/shuck/tests/testdata/corpus-metadata/x007.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x007.yaml
@@ -3,7 +3,4 @@ reviewed_divergences:
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__show.sh"
     line: 54
     end_line: 54
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "this helper already uses bash-only `[[ ... =~ ... ]]` syntax at the same site, so treating the nested `$'\\n'` as a standalone sh portability warning is a shell-collapse artifact"

--- a/crates/shuck/tests/testdata/corpus-metadata/x008.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x008.yaml
@@ -1,7 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This bootstrap script returns before the `(( ))` commands when `ZSH_VERSION` is unset, so the arithmetic form is intentionally confined to the zsh-only execution path for this fixture."

--- a/crates/shuck/tests/testdata/corpus-metadata/x010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x010.yaml
@@ -3,9 +3,6 @@ reviewed_divergences:
     reason: "The remaining ShellCheck-only SC3009 corpus hits come from sourced Termux package recipes and build helpers that the comparison path collapses to POSIX sh more aggressively than Shuck's project-aware dialect resolution. X010 intentionally stays tied to files Shuck actually treats as sh or dash."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This startup file is loading zsh-specific function paths, so the brace lists belong to intentional zsh setup rather than the POSIX sh portability target for X010."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__termux_create_debian_subpackages.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/x013.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x013.yaml
@@ -1,7 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This startup file is building zsh-specific arrays such as `fpath`, `aliases_pre`, and `galiases_pre`, so the remaining X013 hits are intentional zsh setup that only shows up after the corpus path collapses the project to POSIX sh."

--- a/crates/shuck/tests/testdata/corpus-metadata/x019.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x019.yaml
@@ -1,9 +1,6 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    labels:
-      - helper-library
-      - test-harness
     reason: "This zunit test harness is exercising zsh plugin behavior through the `${lines[@]}` capture array, so the remaining X019 hits are test-only array references that appear after the corpus path collapses the helper into portable sh."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__pyenv.d__rehash__source.bash"
@@ -11,13 +8,9 @@ reviewed_divergences:
     end_line: 11
     column: 42
     end_column: 53
-    labels:
-      - project-closure
     reason: "This shim builder is already Bash-specific, and the shell-collapse comparison path still maps the same `${shims[@]}` array use back to slightly different columns between the two analyzers."
   - side: shellcheck-only
     path_suffix: "pyenv__pyenv__pyenv.d__rehash__source.bash"
     line: 11
     end_line: 11
-    labels:
-      - project-closure
     reason: "This rehash helper already depends on bash arrays, `shopt`, and `BASH_SOURCE`, so the remaining SC3054 hit reflects project-closure collapsing a bash helper to POSIX sh more aggressively than Shuck's dialect resolution."

--- a/crates/shuck/tests/testdata/corpus-metadata/x021.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x021.yaml
@@ -5,8 +5,6 @@ reviewed_divergences:
     end_line: 27
     column: 12
     end_column: 17
-    labels:
-      - project-closure
     reason: "X021 is scoped to the non-POSIX `pipefail` toggle. This autoconf helper is using `set -o posix`, and the current SC3040 oracle groups that different option under the same compatibility code during project-closure comparison."
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__desktop__gdm__wayland-session"
@@ -14,8 +12,6 @@ reviewed_divergences:
     end_line: 17
     column: 12
     end_column: 17
-    labels:
-      - project-closure
     reason: "X021 is scoped to the non-POSIX `pipefail` toggle. This login helper flips `set +o posix`, and the current SC3040 oracle groups that different option under the same compatibility code during project-closure comparison."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
@@ -23,6 +19,4 @@ reviewed_divergences:
     end_line: 96
     column: 50
     end_column: 55
-    labels:
-      - shell-collapse
     reason: "X021 is scoped to the non-POSIX `pipefail` toggle. This libtool helper is using `set -o posix`, and the current SC3040 oracle groups that different option under the same compatibility code when the corpus collapses the shell mode."

--- a/crates/shuck/tests/testdata/corpus-metadata/x022.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x022.yaml
@@ -5,12 +5,7 @@ reviewed_divergences:
     reason: "This Termux build helper uses Bash arrays and `[[ ... ]]` conditionals in a file without a concrete shell header. Shuck still reaches the `wait -n` site through its collapsed-shell path, while the current ShellCheck oracle leaves that Bash-specific helper unclassified for X022."
   - side: shuck-only
     path_suffix: "oh-my-fish__oh-my-fish__bin__install"
-    labels:
-      - project-closure
     reason: "This installer is a fish script with fish-specific `read -g` and `read -l` flag usage. Shuck can still see those helper paths through project-closure analysis, but they are outside the POSIX sh portability target for X022."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This upgrade helper belongs to a zsh codebase and uses zsh-specific syntax such as `[[ ... ]]` patterns alongside `read -k`. X022 intentionally stays scoped to files Shuck actually treats as sh or dash instead of collapsing that helper to POSIX sh."

--- a/crates/shuck/tests/testdata/corpus-metadata/x023.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x023.yaml
@@ -1,9 +1,6 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This startup script is intentionally zsh-specific and already depends on zsh path modifiers, associative arrays, and glob qualifiers, so the remaining X023 hits are zsh substring forms exposed only after the corpus path collapses the file to POSIX sh."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__luajit__build.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/x025.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x025.yaml
@@ -5,9 +5,6 @@ reviewed_divergences:
     end_line: 103
     column: 71
     end_column: 82
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This fixture is a zsh startup script. The replacement form is part of zsh-only control flow, so a shell-collapsed sh comparison is not a reliable portability oracle here."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
@@ -15,7 +12,4 @@ reviewed_divergences:
     end_line: 105
     column: 15
     end_column: 26
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This fixture is a zsh startup script. The replacement form is part of zsh-only control flow, so a shell-collapsed sh comparison is not a reliable portability oracle here."

--- a/crates/shuck/tests/testdata/corpus-metadata/x027.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x027.yaml
@@ -3,15 +3,11 @@ reviewed_divergences:
     path_suffix: "nvm-sh__nvm__test__install_script__install_nvm_from_git"
     line: 14
     end_line: 14
-    labels:
-      - test-harness
     reason: "The shell-collapse comparison forces this NVM test helper through POSIX sh, but the pinned ShellCheck oracle stops at a later malformed test expression and never reports the earlier `echo -e` site. Shuck still reaches the echo command facts, so this harness-only gap is reviewed narrowly on the affected test file."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__install_script__install_nvm_from_git"
     line: 24
     end_line: 24
-    labels:
-      - test-harness
     reason: "The shell-collapse comparison forces this NVM test helper through POSIX sh, but the pinned ShellCheck oracle stops at a later malformed test expression and never reports the earlier `echo -e` site. Shuck still reaches the echo command facts, so this harness-only gap is reviewed narrowly on the affected test file."
   - side: shuck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__install"

--- a/crates/shuck/tests/testdata/corpus-metadata/x028.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x028.yaml
@@ -3,7 +3,4 @@ reviewed_divergences:
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 96
     end_line: 96
-    labels:
-      - helper-library
-      - project-closure
     reason: "This helper is a Bash library entrypoint, but the shell-collapse comparison path still feeds it through a POSIX sh oracle. The pinned ShellCheck run aborts later on sh-incompatible syntax before it ever reaches this `tr a-z A-Z` helper, so the missed SC2018 report is treated as a narrow reviewed divergence."

--- a/crates/shuck/tests/testdata/corpus-metadata/x031.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x031.yaml
@@ -31,9 +31,6 @@ reviewed_divergences:
     reason: "This helper sources another script from inside a function while project-closure analysis treats the file as POSIX `sh`. Shuck now routes that function-local `source` case to X080, while the current ShellCheck oracle still emits the generic X031 portability code on this path."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This fixture is an Oh My Zsh startup script. In the shell-collapse comparison path it gets treated like portable `sh`, but these `source` commands belong to Zsh-specific startup loading rather than the POSIX portability target for X031."
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__misc__cwiid__rc.cwiid.new"
@@ -50,14 +47,8 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
     line: 164
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This fixture is a bash gitstatus plugin that only shows up through the shell-collapse portability comparison path. The generic POSIX-sh X031 comparison target is not the right match for this function-local `source` call."
   - side: shellcheck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
     line: 206
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This fixture is a bash gitstatus plugin that only shows up through the shell-collapse portability comparison path. The generic POSIX-sh X031 comparison target is not the right match for this function-local `source` call."

--- a/crates/shuck/tests/testdata/corpus-metadata/x035.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x035.yaml
@@ -3,15 +3,9 @@ reviewed_divergences:
     path_suffix: "aristocratos__bashtop__bashtop"
     line: 5287
     end_line: 5287
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This helper uses bash `coproc` syntax in a file that is compared through the project-closure harness. The oracle collapses that path into a false X035 report on the process-coprocess call, but Shuck correctly leaves the bash construct alone."
   - side: shellcheck-only
     path_suffix: "aristocratos__bashtop__bashtop"
     line: 5302
     end_line: 5302
-    labels:
-      - directive-handling
-      - project-closure
     reason: "This later `coproc` invocation is the same bash-only construct in the same project-closure fixture, and the current oracle still turns it into a false X035 hit. Shuck correctly accepts the bash syntax here."

--- a/crates/shuck/tests/testdata/corpus-metadata/x043.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x043.yaml
@@ -3,37 +3,24 @@ reviewed_divergences:
     path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
     line: 326
     end_line: 326
-    labels:
-      - helper-library
-      - shell-collapse
     reason: "This completion helper reaches the nested `${(M)${(k)...}}` form only inside a guarded `ZSH_VERSION` branch. Shuck keeps that compound expansion on X044 and does not duplicate separate X043 modifier hits for the inner and outer flag groups in this shell-collapsed helper."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__build"
-    labels:
-      - project-closure
     reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
-    labels:
-      - project-closure
     reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_install"
-    labels:
-      - project-closure
     reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__ree"
     reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path, so the remaining X043 hit is reviewed for this helper."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__rubinius"
-    labels:
-      - project-closure
     reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__utility"
-    labels:
-      - project-closure
     reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__utility_package"

--- a/crates/shuck/tests/testdata/corpus-metadata/x044.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x044.yaml
@@ -5,8 +5,6 @@ reviewed_divergences:
     end_line: 143
     column: 49
     end_column: 51
-    labels:
-      - project-closure
     reason: "This fixture's SC2252 record is the unrelated `||`/`&&` warning surfaced in the corpus, not nested zsh substitution syntax."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"

--- a/crates/shuck/tests/testdata/corpus-metadata/x065.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x065.yaml
@@ -3,6 +3,4 @@ reviewed_divergences:
     path_suffix: "alpinelinux__aports__scripts__mkimage.sh"
     line: 120
     end_line: 120
-    labels:
-      - project-closure
     reason: "This mkimage helper uses `[^a-zA-Z0-9]` inside a POSIX parameter-replacement pattern. Shuck intentionally keeps X065 active in that parameter-pattern context, while the current oracle only reports the broader SC3060 portability warning there and does not emit SC3026."

--- a/crates/shuck/tests/testdata/corpus-metadata/x068.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x068.yaml
@@ -1,25 +1,13 @@
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__nvm.sh"
-    labels:
-      - directive-handling
-      - shell-collapse
     reason: "This NVM helper toggles `set +/-E` inside a Bash-guarded branch and carries the current ShellCheck suppression code on those lines. Shuck still sees the `sh` shell-collapse path here, so the remaining X068 hits are reviewed narrowly on this helper."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__installation_node__install on bash with ERR trap and set -E"
-    labels:
-      - directive-handling
-      - project-closure
-      - test-harness
     reason: "This test fixture is explicitly for the Bash ERR-trap path and already suppresses the current ShellCheck code for `set -E`. Shuck keeps the portability warning visible through the project-closure test harness, so this single helper stays reviewed."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__hooks__pre-pkg__99-pkglint.sh"
-    labels:
-      - shell-collapse
     reason: "This Void package hook is compared through a shell-collapse path rather than a concrete POSIX entrypoint, and the remaining `set +/-E` toggle is treated as a reviewed X068 divergence for that helper."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__common.sh"
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This shared xbps-src helper flips `set +/-E` around ERR-trap plumbing inside the project-closure flow. Shuck still flags those sites on the collapsed `sh` path, so the helper stays reviewed narrowly rather than weakening X068 overall."

--- a/crates/shuck/tests/testdata/corpus-metadata/x070.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x070.yaml
@@ -2,8 +2,4 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "scripts/ko1nksm__shellspec__lib__libexec__list.sh"
     line: 52
-    labels:
-      - directive-handling
-      - helper-library
-      - project-closure
     reason: "This shared helper is compared through the project-closure harness, and the oracle does not emit the arithmetic-base warning for this file. Shuck keeps the portable arithmetic check visible on the helper itself, so this reviewed divergence narrows the corpus mismatch to this sourced library path."

--- a/crates/shuck/tests/testdata/corpus-metadata/x076.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x076.yaml
@@ -5,7 +5,4 @@ reviewed_divergences:
     end_line: 51
     column: 44
     end_column: 45
-    labels:
-      - project-closure
-      - shell-collapse
     reason: "This bootstrap file is sourced by zsh entrypoints despite its `.sh` suffix, so the nested `${${(%):-%x}:a:h}` path setup is intentional project-specific zsh code."

--- a/scripts/large_corpus_report.py
+++ b/scripts/large_corpus_report.py
@@ -59,9 +59,9 @@ class RuleSummary:
     description: str
     mismatches: int = 0
     fixtures: set[str] = field(default_factory=set)
-    grouped_reasons: Counter[tuple[str, tuple[str, ...]]] = field(default_factory=Counter)
+    grouped_reasons: Counter[str] = field(default_factory=Counter)
 
-    def top_reason_groups(self, limit: int = 3) -> list[tuple[tuple[str, tuple[str, ...]], int]]:
+    def top_reason_groups(self, limit: int = 3) -> list[tuple[str, int]]:
         return self.grouped_reasons.most_common(limit)
 
 
@@ -202,17 +202,6 @@ def parse_rule_metadata(repo_root: Path, rule_code: str) -> tuple[str, str]:
     return description, shellcheck_code
 
 
-def parse_labels(message: str) -> tuple[str, tuple[str, ...]]:
-    body = message
-    labels: tuple[str, ...] = ()
-    if " labels=" in body:
-        _, label_part = body.split(" labels=", 1)
-        if " reason=" in label_part:
-            label_part, _ = label_part.split(" reason=", 1)
-        labels = tuple(sorted(filter(None, label_part.split(","))))
-    return body, labels
-
-
 def parse_rule_summaries(section: str | None, repo_root: Path) -> list[RuleSummary]:
     if not section:
         return []
@@ -238,11 +227,10 @@ def parse_rule_summaries(section: str | None, repo_root: Path) -> list[RuleSumma
                 description=description,
             )
 
-        _, labels = parse_labels(match.group("message"))
         summary.mismatches += 1
         if current_fixture is not None:
             summary.fixtures.add(current_fixture)
-        summary.grouped_reasons[(match.group("side"), labels)] += 1
+        summary.grouped_reasons[match.group("side")] += 1
 
     return sorted(summaries.values(), key=lambda summary: summary.mismatches, reverse=True)
 
@@ -385,21 +373,6 @@ def format_number(value: int) -> str:
     return f"{value:,}"
 
 
-def label_phrase(labels: tuple[str, ...]) -> str:
-    if not labels:
-        return "plain scripts"
-
-    mapping = {
-        "directive-handling": "directive handling",
-        "helper-library": "helper library",
-        "location-only": "span-only diffs",
-        "project-closure": "project closure",
-        "shell-collapse": "shell collapse",
-        "test-harness": "test harness",
-    }
-    return " + ".join(mapping.get(label, label) for label in labels)
-
-
 def side_phrase(side: str) -> str:
     return "SC-only" if side == "shellcheck-only" else "Shuck-only"
 
@@ -414,12 +387,11 @@ def rendered_reason_items(summary: RuleSummary) -> str:
     top_count = sum(count for _, count in top_groups)
     other_count = summary.mismatches - top_count
 
-    for (side, labels), count in top_groups:
+    for side, count in top_groups:
         items.append(
             "<li>"
             f'<span class="count-tag">{format_number(count)}</span>'
-            f'<span class="{side_class(side)}">{html.escape(side_phrase(side))}</span> '
-            f"in {html.escape(label_phrase(labels))}"
+            f'<span class="{side_class(side)}">{html.escape(side_phrase(side))}</span>'
             "</li>"
         )
 
@@ -1071,10 +1043,8 @@ def render_html(
     <section class="section">
       <h2>How To Read This</h2>
       <p>
-        The grouped-reason bullets show where a rule's mismatches cluster. Labels come from the
-        large-corpus harness and highlight common contexts such as directive handling, project
-        closure, shell collapse, helper libraries, test harness scripts, and span-only location
-        differences.
+        The grouped-reason bullets show whether a rule's mismatches skew toward ShellCheck-only
+        or Shuck-only records.
       </p>
       <div class="legend">
         <div class="legend-item"><span class="sc-only">SC-only</span> = ShellCheck reported it, Shuck did not.</div>
@@ -1189,7 +1159,7 @@ def main() -> int:
     shellcheck_only = sum(
         count
         for summary in rule_summaries
-        for (side, _labels), count in summary.grouped_reasons.items()
+        for side, count in summary.grouped_reasons.items()
         if side == "shellcheck-only"
     )
     shuck_only = rule_records - shellcheck_only


### PR DESCRIPTION
## Summary
- remove large-corpus compatibility label generation and label-aware matching from the Rust harness
- simplify the HTML report so mismatch grouping is based on side only instead of side-plus-label buckets
- strip `labels:` entries from the corpus metadata fixtures and merge the two cases that were only distinguished by labels

## Why
The large-corpus label/classifier layer is no longer needed, and keeping it around adds extra metadata plumbing in the harness, report renderer, and reviewed-divergence fixtures.

## Impact
Large-corpus reviewed divergences are now keyed only by side, path, and span constraints. The report output is simpler, and the metadata files no longer carry label-only matching state.

## Validation
- `cargo fmt --all`
- `cargo test -p shuck --test large_corpus`
- `python3 -m unittest scripts/test_large_corpus_report.py`
