### PR TITLE
Gate formatter behind SHUCK_EXPERIMENTAL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2024"
 license = "MIT"
 authors = ["Eric Hauser"]
 repository = "https://github.com/ewhauser/shuck"
-description = "A fast shell script linter and formatter"
-keywords = ["shell", "bash", "linter", "formatter", "static-analysis"]
+description = "A fast shell script linter"
+keywords = ["shell", "bash", "linter", "static-analysis", "cli"]
 categories = ["command-line-utilities", "development-tools"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # shuck
 
-A shell script linter and formatter, written in Rust.
+A shell script linter, written in Rust.
 
-Shuck parses and analyzes shell scripts to catch common bugs, style issues, and portability problems. It includes a built-in formatter and a caching layer for fast incremental runs.
+Shuck parses and analyzes shell scripts to catch common bugs, style issues, and portability problems. It includes a caching layer for fast incremental runs.
 
 ## Features
 
 - High performance — ~20x faster than ShellCheck
 - Linting with rules across correctness and style categories
-- Formatting with configurable indentation, operator placement, and layout options
+- Safe and unsafe fix support for selected diagnostics
 - Multi-dialect support: bash, sh/POSIX, mksh, zsh
 - Automatic file discovery via extensions and shebang detection
 - ShellCheck suppression compatibility (`# shellcheck disable=SC2086`)
@@ -39,30 +39,17 @@ shuck check .
 # Read from stdin
 echo 'echo $foo' | shuck check -
 
+# Apply safe fixes automatically
+shuck check --fix .
+
+# Apply opt-in unsafe fixes too
+shuck check --unsafe-fixes .
+
 # Skip the cache
 shuck check --no-cache .
 
 # Override the cache location
 shuck --cache-dir .tmp/shuck-cache check .
-```
-
-### Format
-
-```sh
-# Format files in-place
-shuck format .
-
-# Check formatting without modifying files (exit 1 if changes needed)
-shuck format --check .
-
-# Show diffs instead of writing
-shuck format --diff .
-
-# Format with specific options
-shuck format --indent-style space --indent-width 4 .
-
-# Minify (compact form, strip comments)
-shuck format --minify script.sh
 ```
 
 ### Clean caches
@@ -102,7 +89,7 @@ deploy.sh:45:3: warning[S005] legacy backtick command substitution
 | Code | Meaning |
 |------|---------|
 | `0`  | No issues found |
-| `1`  | Lint violations or formatting changes detected |
+| `1`  | Lint violations or parse errors detected |
 | `2`  | Runtime error (bad arguments, I/O failure) |
 
 ## Rules
@@ -152,24 +139,6 @@ code_here
 # shellcheck disable=SC2034,SC2086
 ```
 
-## Configuration
-
-Create a `.shuck.toml` or `shuck.toml` at your project root:
-
-```toml
-[format]
-indent-style = "space"     # tab | space
-indent-width = 4           # 1-255, used when indent-style = "space"
-binary-next-line = false   # place binary operators on the next line
-switch-case-indent = false # indent case branch bodies
-space-redirects = false    # spaces around redirect operators
-keep-padding = false       # preserve original source padding
-function-next-line = false # opening brace on its own line
-never-split = false        # compact single-line layouts
-```
-
-Formatter dialect is auto-discovered from the filename or shebang. Use `shuck format --dialect <shell>` when you need an explicit override, especially for stdin input.
-
 ## File discovery
 
 When given a directory, shuck recursively discovers shell scripts by:
@@ -183,7 +152,7 @@ Gitignore and `.ignore` files are respected by default. Use `--no-respect-gitign
 
 ## Caching
 
-Shuck caches lint and format results per file in a shared cache root outside the project tree by default. The default location follows the OS cache directory convention, which is typically `~/Library/Caches/shuck` on macOS and `$XDG_CACHE_HOME/shuck` or `~/.cache/shuck` on Linux.
+Shuck caches lint results per file in a shared cache root outside the project tree by default. The default location follows the OS cache directory convention, which is typically `~/Library/Caches/shuck` on macOS and `$XDG_CACHE_HOME/shuck` or `~/.cache/shuck` on Linux.
 
 Override the cache root with `--cache-dir` or `SHUCK_CACHE_DIR`.
 
@@ -196,7 +165,6 @@ Shuck builds on ideas and inspiration from several excellent open-source project
 - **[bashkit](https://github.com/everruns/bashkit)** — Source of the bash lexer and parser that powers shuck-parser.
 - **[Ruff](https://github.com/astral-sh/ruff)** — Linter architecture inspiration, particularly around caching, rule organization, and diagnostic output.
 - **[ShellCheck](https://github.com/koalaman/shellcheck)** — An amazing project and the original source of inspiration for shuck. ShellCheck set the standard for shell script analysis.
-- **[shfmt](https://github.com/mvdan/sh)** — Shell formatter whose design informed shuck's formatting approach.
 - **[gbash](https://github.com/ewhauser/gbash)** — A lot of lessons learned from this earlier project carried forward into shuck.
 
 ## License

--- a/crates/shuck/Cargo.toml
+++ b/crates/shuck/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "A fast shell script linter and formatter"
-keywords = ["shell", "bash", "linter", "formatter", "cli"]
+description = "A fast shell script linter"
+keywords = ["shell", "bash", "linter", "static-analysis", "cli"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -1,7 +1,9 @@
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
+use clap::error::ErrorKind;
 use clap::{Args as ClapArgs, Parser, Subcommand, ValueEnum};
 use shuck_formatter::{IndentStyle, ShellDialect};
 
@@ -12,6 +14,7 @@ const STYLES: Styles = Styles::styled()
     .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
     .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
     .placeholder(AnsiColor::Cyan.on_default());
+const EXPERIMENTAL_ENV_VAR: &str = "SHUCK_EXPERIMENTAL";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum FormatDialectArg {
@@ -59,15 +62,118 @@ pub enum CheckOutputFormatArg {
 #[command(name = "shuck")]
 #[command(about = "Shell checker CLI for shuck")]
 #[command(styles = STYLES)]
-pub struct Args {
+struct StableCli {
+    #[command(flatten)]
+    global: GlobalArgs,
+    #[command(subcommand)]
+    command: StableCommand,
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "shuck")]
+#[command(about = "Shell checker CLI for shuck")]
+#[command(styles = STYLES)]
+struct ExperimentalCli {
+    #[command(flatten)]
+    global: GlobalArgs,
+    #[command(subcommand)]
+    command: ExperimentalCommand,
+}
+
+#[derive(Debug, Clone, ClapArgs)]
+struct GlobalArgs {
     /// Path to the cache directory.
     #[arg(long, env = "SHUCK_CACHE_DIR", global = true, value_name = "PATH")]
-    pub cache_dir: Option<PathBuf>,
-    #[command(subcommand)]
-    pub command: Command,
+    cache_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand)]
+enum StableCommand {
+    /// Parse shell files and report syntax failures.
+    Check(CheckCommand),
+    #[command(hide = true)]
+    Format(FormatCommand),
+    /// Remove shuck caches under the provided paths.
+    Clean(CleanCommand),
+}
+
+#[derive(Debug, Subcommand)]
+enum ExperimentalCommand {
+    /// Parse shell files and report syntax failures.
+    Check(CheckCommand),
+    /// Format shell files.
+    Format(FormatCommand),
+    /// Remove shuck caches under the provided paths.
+    Clean(CleanCommand),
+}
+
+#[derive(Debug, Clone)]
+pub struct Args {
+    pub cache_dir: Option<PathBuf>,
+    pub command: Command,
+}
+
+impl Args {
+    pub fn parse() -> Self {
+        Self::try_parse().unwrap_or_else(|err| err.exit())
+    }
+
+    pub fn try_parse() -> Result<Self, clap::Error> {
+        Self::try_parse_from(std::env::args_os())
+    }
+
+    pub fn try_parse_from<I, T>(itr: I) -> Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        if experimental_enabled() {
+            ExperimentalCli::try_parse_from(itr).map(Into::into)
+        } else {
+            let parsed = StableCli::try_parse_from(itr)?;
+            Self::from_stable(parsed)
+        }
+    }
+}
+
+impl Args {
+    fn from_stable(value: StableCli) -> Result<Self, clap::Error> {
+        let command = match value.command {
+            StableCommand::Check(command) => Command::Check(command),
+            StableCommand::Format(_) => {
+                return Err(clap::Error::raw(
+                    ErrorKind::InvalidSubcommand,
+                    format!(
+                        "the `format` subcommand is experimental; set {EXPERIMENTAL_ENV_VAR}=1 to enable it"
+                    ),
+                ));
+            }
+            StableCommand::Clean(command) => Command::Clean(command),
+        };
+
+        Ok(Self {
+            cache_dir: value.global.cache_dir,
+            command,
+        })
+    }
+}
+
+impl From<ExperimentalCli> for Args {
+    fn from(value: ExperimentalCli) -> Self {
+        let command = match value.command {
+            ExperimentalCommand::Check(command) => Command::Check(command),
+            ExperimentalCommand::Format(command) => Command::Format(command),
+            ExperimentalCommand::Clean(command) => Command::Clean(command),
+        };
+
+        Self {
+            cache_dir: value.global.cache_dir,
+            command,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Subcommand)]
 pub enum Command {
     /// Parse shell files and report syntax failures.
     Check(CheckCommand),
@@ -75,6 +181,15 @@ pub enum Command {
     Format(FormatCommand),
     /// Remove shuck caches under the provided paths.
     Clean(CleanCommand),
+}
+
+fn experimental_enabled() -> bool {
+    std::env::var_os(EXPERIMENTAL_ENV_VAR).is_some_and(|value| {
+        !matches!(
+            value.to_string_lossy().trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        )
+    })
 }
 
 #[derive(Debug, Clone, ClapArgs)]

--- a/crates/shuck/src/main.rs
+++ b/crates/shuck/src/main.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 use std::process::ExitCode;
 
-use clap::Parser;
 use colored::Colorize;
 
 use shuck::args::Args;

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -28,6 +28,10 @@ fn configure_default_cache_env(cmd: &mut Command, root: &Path) {
     cmd.env("LOCALAPPDATA", local_appdata);
 }
 
+fn enable_experimental(cmd: &mut Command) {
+    cmd.env("SHUCK_EXPERIMENTAL", "1");
+}
+
 #[test]
 fn help_shows_commands() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
@@ -35,8 +39,29 @@ fn help_shows_commands() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("check"))
-        .stdout(predicate::str::contains("format"))
+        .stdout(predicate::str::contains("Format shell files").not())
         .stdout(predicate::str::contains("clean"));
+}
+
+#[test]
+fn help_shows_format_when_experimental_enabled() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
+    cmd.arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("check"))
+        .stdout(predicate::str::contains("Format shell files"))
+        .stdout(predicate::str::contains("clean"));
+}
+
+#[test]
+fn format_subcommand_requires_experimental_env() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.arg("format");
+    cmd.assert().code(2).stderr(predicate::str::contains(
+        "the `format` subcommand is experimental; set SHUCK_EXPERIMENTAL=1 to enable it",
+    ));
 }
 
 #[test]
@@ -266,6 +291,7 @@ fn format_good_file_succeeds_and_preserves_contents() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
+    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path()).arg("format");
     cmd.assert().success().stdout("");
 
@@ -279,6 +305,7 @@ fn format_check_and_diff_are_clean_for_valid_input() {
 
     let mut check = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut check, tempdir.path());
+    enable_experimental(&mut check);
     check
         .current_dir(tempdir.path())
         .args(["format", "--check"]);
@@ -286,6 +313,7 @@ fn format_check_and_diff_are_clean_for_valid_input() {
 
     let mut diff = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut diff, tempdir.path());
+    enable_experimental(&mut diff);
     diff.current_dir(tempdir.path()).args(["format", "--diff"]);
     diff.assert().success().stdout("");
 }
@@ -297,6 +325,7 @@ fn format_check_and_diff_report_changes_for_noncanonical_input() {
 
     let mut check = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut check, tempdir.path());
+    enable_experimental(&mut check);
     check
         .current_dir(tempdir.path())
         .args(["format", "--check", "--function-next-line"]);
@@ -304,6 +333,7 @@ fn format_check_and_diff_report_changes_for_noncanonical_input() {
 
     let mut diff = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut diff, tempdir.path());
+    enable_experimental(&mut diff);
     diff.current_dir(tempdir.path())
         .args(["format", "--diff", "--function-next-line"]);
     diff.assert()
@@ -319,6 +349,7 @@ fn format_broken_file_reports_parse_error() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
+    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path()).arg("format");
     cmd.assert()
         .code(2)
@@ -331,6 +362,7 @@ fn format_stdin_round_trips_valid_input() {
     let source = "#!/bin/bash\necho ok\n";
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
     cmd.args(["format", "-"]).write_stdin(source);
     cmd.assert().success().stdout(source);
 }
@@ -338,6 +370,7 @@ fn format_stdin_round_trips_valid_input() {
 #[test]
 fn format_stdin_filename_reports_parse_error_with_filename() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
     cmd.args(["format", "--stdin-filename", "foo.sh"])
         .write_stdin("#!/bin/bash\nif true\n");
     cmd.assert()
@@ -356,6 +389,7 @@ fn format_stdin_uses_current_project_config() {
     .unwrap();
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .args(["format", "-"])
         .write_stdin("foo(){\necho hi\n}\n");
@@ -365,6 +399,7 @@ fn format_stdin_uses_current_project_config() {
 #[test]
 fn format_stdin_filename_uses_inferred_posix_dialect() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
     cmd.args(["format", "--stdin-filename", "script.sh"])
         .write_stdin("[[ foo == bar ]]\n");
     cmd.assert()
@@ -377,6 +412,7 @@ fn format_stdin_filename_uses_inferred_posix_dialect() {
 fn format_stdin_filename_infers_remaining_common_shell_extensions() {
     for path in ["script.bash", "script.mksh"] {
         let mut cmd = Command::cargo_bin("shuck").unwrap();
+        enable_experimental(&mut cmd);
         cmd.args(["format", "--stdin-filename", path])
             .write_stdin("[[ foo == bar ]]\n");
         cmd.assert().success().stdout("[[ foo == bar ]]\n");
@@ -384,6 +420,7 @@ fn format_stdin_filename_infers_remaining_common_shell_extensions() {
 
     for path in ["script.ksh", "script.dash"] {
         let mut cmd = Command::cargo_bin("shuck").unwrap();
+        enable_experimental(&mut cmd);
         cmd.args(["format", "--stdin-filename", path])
             .write_stdin("[[ foo == bar ]]\n");
         cmd.assert()
@@ -396,6 +433,7 @@ fn format_stdin_filename_infers_remaining_common_shell_extensions() {
 #[test]
 fn format_stdin_filename_infers_zsh_dialect() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
     cmd.args(["format", "--stdin-filename", "script.zsh"])
         .write_stdin("print ${(m)foo}\n");
     cmd.assert().success().stdout("print ${(m)foo}\n");
@@ -411,6 +449,7 @@ fn format_stdin_rejects_configured_dialect() {
     .unwrap();
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .args(["format", "-"])
         .write_stdin("print ${(m)foo}\n");
@@ -423,6 +462,7 @@ fn format_stdin_rejects_configured_dialect() {
 #[test]
 fn format_stdin_uses_cli_zsh_dialect_override() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
     cmd.args(["format", "--dialect", "zsh", "-"])
         .write_stdin("print ${(m)foo}\n");
     cmd.assert().success().stdout("print ${(m)foo}\n");
@@ -474,6 +514,7 @@ fn format_exclude_skips_walked_files_but_not_explicit_files_without_force_exclud
 
     let mut walked = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut walked, tempdir.path());
+    enable_experimental(&mut walked);
     walked
         .current_dir(tempdir.path())
         .args(["format", "--exclude", "ignored.sh"]);
@@ -481,6 +522,7 @@ fn format_exclude_skips_walked_files_but_not_explicit_files_without_force_exclud
 
     let mut explicit = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut explicit, tempdir.path());
+    enable_experimental(&mut explicit);
     explicit
         .current_dir(tempdir.path())
         .args(["format", "--exclude", "ignored.sh", "ignored.sh"]);
@@ -491,6 +533,7 @@ fn format_exclude_skips_walked_files_but_not_explicit_files_without_force_exclud
 
     let mut forced = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut forced, tempdir.path());
+    enable_experimental(&mut forced);
     forced.current_dir(tempdir.path()).args([
         "format",
         "--exclude",
@@ -509,11 +552,13 @@ fn format_gitignore_and_force_exclude_flags_control_explicit_files() {
 
     let mut default_walk = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut default_walk, tempdir.path());
+    enable_experimental(&mut default_walk);
     default_walk.current_dir(tempdir.path()).arg("format");
     default_walk.assert().success().stdout("");
 
     let mut no_respect = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut no_respect, tempdir.path());
+    enable_experimental(&mut no_respect);
     no_respect
         .current_dir(tempdir.path())
         .args(["format", "--no-respect-gitignore"]);
@@ -524,6 +569,7 @@ fn format_gitignore_and_force_exclude_flags_control_explicit_files() {
 
     let mut explicit = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut explicit, tempdir.path());
+    enable_experimental(&mut explicit);
     explicit
         .current_dir(tempdir.path())
         .args(["format", "ignored.sh"]);
@@ -534,6 +580,7 @@ fn format_gitignore_and_force_exclude_flags_control_explicit_files() {
 
     let mut forced = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut forced, tempdir.path());
+    enable_experimental(&mut forced);
     forced
         .current_dir(tempdir.path())
         .args(["format", "--force-exclude", "ignored.sh"]);
@@ -553,6 +600,7 @@ fn format_honors_project_config_and_cli_overrides_it() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
+    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .args(["format", "--function-next-line"]);
     cmd.assert().success().stdout("");
@@ -583,6 +631,7 @@ fn format_prefers_nested_project_config_for_explicit_files() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
+    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .args(["format", "nested/fn.sh"]);
     cmd.assert().success().stdout("");
@@ -600,11 +649,13 @@ fn format_cache_invalidates_when_formatter_options_change() {
 
     let mut initial = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut initial, tempdir.path());
+    enable_experimental(&mut initial);
     initial.current_dir(tempdir.path()).arg("format");
     initial.assert().success().stdout("");
 
     let mut check = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut check, tempdir.path());
+    enable_experimental(&mut check);
     check
         .current_dir(tempdir.path())
         .args(["format", "--check", "--function-next-line"]);

--- a/docs/archive/formatter.md
+++ b/docs/archive/formatter.md
@@ -1,0 +1,52 @@
+# Archived formatter docs
+
+This file preserves the user-facing formatter docs that were removed from the
+README and website while the formatter stays gated behind
+`SHUCK_EXPERIMENTAL`.
+
+Do not link this from public docs until the formatter is ready to be promoted
+again.
+
+## CLI usage
+
+```sh
+# Format files in-place
+shuck format .
+
+# Check formatting without modifying files (exit 1 if changes are needed)
+shuck format --check .
+
+# Show diffs instead of writing files
+shuck format --diff .
+
+# Format with specific options
+shuck format --indent-style space --indent-width 4 .
+
+# Minify (compact form, strip comments)
+shuck format --minify script.sh
+```
+
+## Config file
+
+```toml
+[format]
+indent-style = "space"     # tab | space
+indent-width = 4           # 1-255, used when indent-style = "space"
+binary-next-line = false   # place binary operators on the next line
+switch-case-indent = false # indent case branch bodies
+space-redirects = false    # spaces around redirect operators
+keep-padding = false       # preserve original source padding
+function-next-line = false # opening brace on its own line
+never-split = false        # compact single-line layouts
+```
+
+Formatter dialect is auto-discovered from the filename or shebang. Use
+`shuck format --dialect <shell>` when you need an explicit override,
+especially for stdin input.
+
+## Website copy
+
+- Built-in formatter with configurable indentation, operator placement, and
+  layout
+- `shuck format .`
+- `shuck format --check .`

--- a/scripts/fuzz_cli.py
+++ b/scripts/fuzz_cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import json
+import os
 import random
 import shlex
 import subprocess
@@ -36,6 +37,7 @@ LITERALS: Final = [
 ]
 VARIABLES: Final = ["foo", "bar", "baz", "count", "path", "item", "name", "value"]
 COMMANDS: Final = ["echo", "printf", "true", "false", "test", "cat", "grep", "mkdir"]
+EXPERIMENTAL_FORMAT_ENV: Final = {"SHUCK_EXPERIMENTAL": "1"}
 
 
 @dataclass(frozen=True)
@@ -89,6 +91,7 @@ def run_command(
     cwd: Path,
     timeout: float,
     input_text: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> CommandResult:
     try:
         completed = subprocess.run(
@@ -98,6 +101,7 @@ def run_command(
             text=True,
             input=input_text,
             timeout=timeout,
+            env=(os.environ | env) if env is not None else None,
         )
     except subprocess.TimeoutExpired as error:
         return CommandResult(
@@ -368,6 +372,7 @@ def evaluate_bug(
             cwd=Path.cwd(),
             timeout=config.timeout,
             input_text=script,
+            env=EXPERIMENTAL_FORMAT_ENV,
         )
         commands.append(format_result)
         bug = classify_command_failure(format_result, allowed_returncodes={0})
@@ -381,6 +386,7 @@ def evaluate_bug(
             cwd=Path.cwd(),
             timeout=config.timeout,
             input_text=formatted,
+            env=EXPERIMENTAL_FORMAT_ENV,
         )
         commands.append(reformatted_result)
         bug = classify_command_failure(reformatted_result, allowed_returncodes={0})
@@ -403,6 +409,7 @@ def evaluate_bug(
             cwd=Path.cwd(),
             timeout=config.timeout,
             input_text=reformatted_result.stdout,
+            env=EXPERIMENTAL_FORMAT_ENV,
         )
         commands.append(format_check_result)
         bug = classify_command_failure(format_check_result, allowed_returncodes={0})
@@ -520,7 +527,7 @@ def save_failure(report: FailureReport) -> Path:
               {shlex.join([report.failing_command[0], 'check', '--no-cache', repro_path.name])}
 
             Run format:
-              {shlex.join([report.failing_command[0], 'format', '--no-cache', '--stdin-filename', repro_path.name, '-'])} < {repro_path.name}
+              SHUCK_EXPERIMENTAL=1 {shlex.join([report.failing_command[0], 'format', '--no-cache', '--stdin-filename', repro_path.name, '-'])} < {repro_path.name}
             """
         )
     )

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -30,22 +30,21 @@ export const metadata: Metadata = {
     },
   },
   title: {
-    default: "shuck - A fast shell script linter and formatter",
+    default: "shuck - A fast shell script linter",
     template: "%s | shuck",
   },
   description:
-    "A fast shell script linter and formatter, built in Rust. Checks for correctness, portability, and style issues in shell scripts.",
+    "A fast shell script linter, built in Rust. Checks for correctness, portability, and style issues in shell scripts.",
   openGraph: {
-    title: "shuck - A fast shell script linter and formatter",
+    title: "shuck - A fast shell script linter",
     description:
-      "A fast shell script linter and formatter, built in Rust. Checks for correctness, portability, and style issues in shell scripts.",
+      "A fast shell script linter, built in Rust. Checks for correctness, portability, and style issues in shell scripts.",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "shuck",
-    description:
-      "A fast shell script linter and formatter, built in Rust.",
+    description: "A fast shell script linter, built in Rust.",
   },
 };
 

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -22,9 +22,8 @@ export default function Home() {
               className="h-28 w-28 sm:h-36 sm:w-36 mb-5"
             />
             <p className="text-base text-fg-secondary leading-relaxed mb-6">
-              A fast shell script linter and formatter, built in Rust. Checks
-              for correctness, portability, and style issues in your shell
-              scripts.
+              A fast shell script linter, built in Rust. Checks for
+              correctness, portability, and style issues in your shell scripts.
             </p>
 
             {/* Install */}

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -1,12 +1,11 @@
 # Getting Started
 
-An extremely fast shell script linter and formatter, written in Rust.
+An extremely fast shell script linter, written in Rust.
 
 - ⚡ 20x faster than ShellCheck, with built-in caching for incremental runs
 - 🐚 Multi-dialect support for bash, sh/POSIX, dash, ksh, mksh, and zsh
 - 🤝 ShellCheck suppression compatibility (`# shellcheck disable=SC2086` just works)
 - 🔧 Fix support, for automatic error correction (`--fix` and `--unsafe-fixes`)
-- 🎨 Built-in formatter with configurable indentation, operator placement, and layout
 - 📏 Rules across correctness, style, performance, and portability categories
 - 💾 Per-file caching to avoid re-analyzing unchanged files
 - 📦 Single binary, zero dependencies
@@ -39,25 +38,4 @@ echo 'echo $foo' | shuck check -
 
 # Apply safe fixes automatically
 shuck check --fix .
-
-# Format files in-place
-shuck format .
-
-# Check formatting without modifying files
-shuck format --check .
-```
-
-## Configuration
-
-Create a `.shuck.toml` or `shuck.toml` at your project root:
-
-```toml
-[format]
-indent-style = "space"     # tab | space
-indent-width = 4           # 1-255, used when indent-style = "space"
-binary-next-line = false   # place binary operators on the next line
-switch-case-indent = false # indent case branch bodies
-space-redirects = false    # spaces around redirect operators
-keep-padding = false       # preserve original source padding
-function-next-line = false # opening brace on its own line
 ```


### PR DESCRIPTION
## Summary
- gate the `format` subcommand behind the `SHUCK_EXPERIMENTAL` environment variable
- hide formatter references from the public README, website copy, and package metadata
- preserve the removed formatter docs in `docs/archive/formatter.md` for later restoration

## Why
The formatter is not ready to be part of the default CLI surface yet. This keeps the existing implementation available for experimentation while removing it from the normal user-facing experience.

## Impact
Users only see `check` and `clean` by default. If someone invokes `shuck format` without opting in, the CLI now explains that they need to set `SHUCK_EXPERIMENTAL=1`.

## Testing
- `cargo fmt`
- `cargo test -p shuck`
