### PR TITLE
Skip S001 reports for :+ parameter replacements

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -69,7 +69,7 @@ pub use rules::common::span::{
     word_unquoted_glob_pattern_spans_outside_brace_expansion,
     word_unquoted_scalar_between_double_quoted_segments_spans, word_unquoted_star_parameter_spans,
     word_unquoted_star_splat_spans, word_unquoted_word_after_single_quoted_segment_spans,
-    word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,
+    word_use_replacement_spans, word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,
 };
 pub use rules::common::word::{
     TestOperandClass, WordClassification, conditional_binary_op_is_string_match,

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -440,6 +440,12 @@ pub fn word_unquoted_assign_default_spans(word: &Word) -> Vec<Span> {
     spans
 }
 
+pub fn word_use_replacement_spans(word: &Word) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_use_replacement_spans(&word.parts, &mut spans);
+    spans
+}
+
 pub fn word_unquoted_word_after_single_quoted_segment_spans(
     word: &Word,
     source: &str,
@@ -1634,6 +1640,40 @@ fn collect_scalar_expansion_spans(
                 }
             }
             WordPart::ArrayIndices(_) | WordPart::ArraySlice { .. } => {}
+        }
+    }
+}
+
+fn collect_use_replacement_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => collect_use_replacement_spans(parts, spans),
+            WordPart::Parameter(parameter) if parameter_uses_replacement_operator(parameter) => {
+                spans.push(part.span);
+            }
+            WordPart::ParameterExpansion { operator, .. }
+            | WordPart::IndirectExpansion {
+                operator: Some(operator),
+                ..
+            } if matches!(operator, ParameterOp::UseReplacement) => spans.push(part.span),
+            WordPart::Literal(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::ZshQualifiedGlob(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. } => {}
+            WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::IndirectExpansion { .. } => {}
         }
     }
 }
@@ -3000,6 +3040,29 @@ fn parameter_is_scalar_like(parameter: &ParameterExpansion) -> bool {
             BourneParameterExpansion::Slice { reference, .. } => !reference.has_array_selector(),
         },
         ParameterExpansionSyntax::Zsh(_) => true,
+    }
+}
+
+fn parameter_uses_replacement_operator(parameter: &ParameterExpansion) -> bool {
+    let ParameterExpansionSyntax::Bourne(syntax) = &parameter.syntax else {
+        return false;
+    };
+
+    match syntax {
+        BourneParameterExpansion::Indirect {
+            operator: Some(operator),
+            ..
+        }
+        | BourneParameterExpansion::Operation { operator, .. } => {
+            matches!(operator, ParameterOp::UseReplacement)
+        }
+        BourneParameterExpansion::Access { .. }
+        | BourneParameterExpansion::Length { .. }
+        | BourneParameterExpansion::Indices { .. }
+        | BourneParameterExpansion::PrefixMatch { .. }
+        | BourneParameterExpansion::Slice { .. }
+        | BourneParameterExpansion::Transformation { .. }
+        | BourneParameterExpansion::Indirect { operator: None, .. } => false,
     }
 }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3,6 +3,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     Checker, ExpansionContext, Rule, SafeValueIndex, SafeValueQuery, ShellDialect, Violation,
     WordFact, word_unquoted_assign_default_spans, word_unquoted_star_parameter_spans,
+    word_use_replacement_spans,
 };
 
 pub struct UnquotedExpansion;
@@ -87,6 +88,7 @@ fn report_word_expansions(
     } else {
         Default::default()
     };
+    let use_replacement_spans = word_use_replacement_spans(fact.word());
     let star_spans = word_unquoted_star_parameter_spans(fact.word(), array_spans);
     if scalar_spans.is_empty() && star_spans.is_empty() {
         return;
@@ -106,6 +108,9 @@ fn report_word_expansions(
             continue;
         }
         if assign_default_spans.contains(&part_span) {
+            continue;
+        }
+        if use_replacement_spans.contains(&part_span) {
             continue;
         }
         if safe_values.part_is_safe(part, part_span, query) {
@@ -370,6 +375,38 @@ printf '%s\\n' ${z:=fallback}
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${x:=fallback}", "${y:=out}"]
+        );
+    }
+
+    #[test]
+    fn skips_use_replacement_expansions() {
+        let source = "\
+#!/bin/bash
+foo='a b'
+arr=('left side' right)
+printf '%s\\n' ${foo:+$foo} ${foo:+\"$foo\"} ${arr:+\"${arr[@]}\"}
+tar ${foo:+-C \"$foo\"} -f archive.tar
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn keeps_default_expansions_with_quoted_operands() {
+        let source = "\
+#!/bin/bash
+foo='a b'
+printf '%s\\n' ${foo:-\"$foo\"}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${foo:-\"$foo\"}"]
         );
     }
 


### PR DESCRIPTION
## Summary
- stop `S001` from reporting `:+` parameter replacement expansions for SC2086 parity
- add a shared span helper for use-replacement expansions and reuse it in the rule
- add focused tests that keep `:-` behavior intact while covering `:+` cases

## Root Cause
`S001` still treated `:+` parameter replacement forms as ordinary scalar expansions, but ShellCheck does not report SC2086 for those forms. That left a large reviewed tail of `shuck-only` overreports in the large corpus.

## Impact
This shrinks the reviewed `S001` divergence tail without changing the blocking compatibility status. It preserves existing `:-` diagnostics while removing an oracle-backed overreport cluster.

## Validation
- `cargo test -p shuck-linter --lib replacement`
- `cargo test -p shuck-linter --lib keeps_default_expansions_with_quoted_operands`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001`

## Results
- 10% sample reviewed divergences: `62 -> 45`
- full `S001` reviewed divergences: `607 -> 488`
- full run remained at `0` blocking diffs and `0` mapping issues
