### PR TITLE
Fix S045 associative subscript handling across caller chains

### DIFF
--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1255,6 +1255,36 @@ main
 }
 
 #[test]
+fn reports_wrapper_shadowing_local_subscripts_even_when_outer_callers_have_assoc_bindings() {
+    let source = "\
+#!/bin/bash
+helper() {
+  map[$key]=1
+}
+wrapper() {
+  local map
+  helper
+}
+main() {
+  local key=name
+  declare -A map
+  wrapper
+}
+main
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(spans, vec!["$key"]);
+    });
+}
+
+#[test]
 fn collects_dollar_spans_for_nested_arithmetic_in_array_access_subscripts() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1285,6 +1285,24 @@ main
 }
 
 #[test]
+fn ignores_associative_declaration_initializer_subscripts_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+declare -A map=([$key]=1)
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
 fn collects_dollar_spans_for_nested_arithmetic_in_array_access_subscripts() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1200,6 +1200,61 @@ main
 }
 
 #[test]
+fn reports_shadowing_local_subscripts_even_when_callers_have_assoc_bindings() {
+    let source = "\
+#!/bin/bash
+helper() {
+  local map
+  map[$key]=1
+}
+main() {
+  local key=name
+  declare -A map
+  helper
+}
+main
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(spans, vec!["$key"]);
+    });
+}
+
+#[test]
+fn ignores_repeated_dynamic_scope_associative_assignment_subscripts_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+helper() {
+  map[${key}]=1
+  map[${other}]=2
+}
+main() {
+  local key=alpha
+  local other=beta
+  declare -A map
+  helper
+}
+main
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
 fn collects_dollar_spans_for_nested_arithmetic_in_array_access_subscripts() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1171,6 +1171,35 @@ assoc[$key/sfx]=z
 }
 
 #[test]
+fn ignores_dynamic_scope_associative_assignment_subscripts_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+helper() {
+  map[${key}]=1
+}
+wrapper() {
+  helper
+}
+main() {
+  local key=name
+  declare -A map
+  wrapper
+}
+main
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
 fn collects_dollar_spans_for_nested_arithmetic_in_array_access_subscripts() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2264,11 +2264,58 @@ impl<'a> WordFactCollector<'a> {
             return false;
         }
 
-        !owner_name.is_some_and(|name| {
-            self.semantic
-                .visible_binding(name, subscript.span())
-                .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
-        })
+        !owner_name.is_some_and(|name| self.assoc_binding_visible_for_subscript(name, subscript))
+    }
+
+    fn assoc_binding_visible_for_subscript(&self, owner_name: &Name, subscript: &Subscript) -> bool {
+        self.semantic
+            .visible_binding(owner_name, subscript.span())
+            .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+            || self.assoc_binding_visible_from_named_callers(owner_name, subscript.span())
+    }
+
+    fn assoc_binding_visible_from_named_callers(&self, owner_name: &Name, span: Span) -> bool {
+        let Some(function_names) = self.named_function_scope_names(span.start.offset) else {
+            return false;
+        };
+
+        let mut seen = FxHashSet::default();
+        let mut worklist = function_names.to_vec();
+
+        while let Some(function_name) = worklist.pop() {
+            if !seen.insert(function_name.clone()) {
+                continue;
+            }
+
+            for call_site in self.semantic.call_sites_for(&function_name) {
+                if self
+                    .semantic
+                    .visible_binding(owner_name, call_site.name_span)
+                    .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+                {
+                    return true;
+                }
+
+                if let Some(caller_names) = self.named_function_scope_names(call_site.name_span.start.offset)
+                {
+                    worklist.extend(caller_names.iter().cloned());
+                }
+            }
+        }
+
+        false
+    }
+
+    fn named_function_scope_names(&self, offset: usize) -> Option<&[Name]> {
+        let scope = self.semantic.scope_at(offset);
+        self.semantic
+            .ancestor_scopes(scope)
+            .find_map(|scope_id| match &self.semantic.scope(scope_id).kind {
+                shuck_semantic::ScopeKind::Function(
+                    shuck_semantic::FunctionScopeKind::Named(names),
+                ) => Some(names.as_slice()),
+                _ => None,
+            })
     }
 
     fn collect_array_index_arithmetic_spans(&mut self, word: &Word) {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1728,6 +1728,7 @@ impl<'a> WordFactCollector<'a> {
                     self.surface.record_var_ref_subscript(reference);
                     let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
                         Some(&reference.name),
+                        Some(reference.name_span),
                         reference.subscript.as_ref(),
                     );
                     query::visit_var_ref_subscript_words_with_source(
@@ -1778,6 +1779,7 @@ impl<'a> WordFactCollector<'a> {
         self.surface.record_var_ref_subscript(&assignment.target);
         let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
             Some(&assignment.target.name),
+            Some(assignment.target.name_span),
             assignment.target.subscript.as_ref(),
         );
         query::visit_var_ref_subscript_words_with_source(
@@ -1824,6 +1826,7 @@ impl<'a> WordFactCollector<'a> {
                             self.surface.record_subscript(Some(key));
                             let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
                                 Some(&assignment.target.name),
+                                Some(assignment.target.name_span),
                                 Some(key),
                             );
                             query::visit_subscript_words(Some(key), self.source, &mut |word| {
@@ -2249,6 +2252,7 @@ impl<'a> WordFactCollector<'a> {
     fn subscript_uses_index_arithmetic_semantics(
         &self,
         owner_name: Option<&Name>,
+        owner_name_span: Option<Span>,
         subscript: Option<&Subscript>,
     ) -> bool {
         let Some(subscript) = subscript else {
@@ -2264,14 +2268,23 @@ impl<'a> WordFactCollector<'a> {
             return false;
         }
 
-        !owner_name.is_some_and(|name| self.assoc_binding_visible_for_subscript(name, subscript))
+        !owner_name
+            .is_some_and(|name| self.assoc_binding_visible_for_subscript(name, owner_name_span, subscript))
     }
 
-    fn assoc_binding_visible_for_subscript(&self, owner_name: &Name, subscript: &Subscript) -> bool {
-        self.semantic
-            .visible_binding(owner_name, subscript.span())
-            .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
-            || self.assoc_binding_visible_from_named_callers(owner_name, subscript.span())
+    fn assoc_binding_visible_for_subscript(
+        &self,
+        owner_name: &Name,
+        owner_name_span: Option<Span>,
+        subscript: &Subscript,
+    ) -> bool {
+        if let Some(binding) =
+            self.prior_visible_binding_for_subscript(owner_name, owner_name_span, subscript.span())
+        {
+            return binding.attributes.contains(BindingAttributes::ASSOC);
+        }
+
+        self.assoc_binding_visible_from_named_callers(owner_name, subscript.span())
     }
 
     fn assoc_binding_visible_from_named_callers(&self, owner_name: &Name, span: Span) -> bool {
@@ -2304,6 +2317,52 @@ impl<'a> WordFactCollector<'a> {
         }
 
         false
+    }
+
+    fn prior_visible_binding_for_subscript(
+        &self,
+        owner_name: &Name,
+        owner_name_span: Option<Span>,
+        span: Span,
+    ) -> Option<&shuck_semantic::Binding> {
+        let current_scope = self.semantic.scope_at(span.start.offset);
+        self.semantic
+            .bindings_for(owner_name)
+            .iter()
+            .rev()
+            .copied()
+            .find(|binding_id| {
+                self.semantic.binding_visible_at(*binding_id, span)
+                    && self.binding_blocks_caller_assoc_lookup(
+                        *binding_id,
+                        current_scope,
+                        owner_name_span,
+                    )
+            })
+            .map(|binding_id| self.semantic.binding(binding_id))
+    }
+
+    fn binding_blocks_caller_assoc_lookup(
+        &self,
+        binding_id: shuck_semantic::BindingId,
+        current_scope: shuck_semantic::ScopeId,
+        owner_name_span: Option<Span>,
+    ) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        if owner_name_span.is_some_and(|owner_span| binding.span == owner_span) {
+            return false;
+        }
+        if binding.scope != current_scope || binding.attributes.contains(BindingAttributes::LOCAL) {
+            return true;
+        }
+
+        !matches!(
+            binding.kind,
+            shuck_semantic::BindingKind::Assignment
+                | shuck_semantic::BindingKind::AppendAssignment
+                | shuck_semantic::BindingKind::ArrayAssignment
+                | shuck_semantic::BindingKind::ArithmeticAssignment
+        )
     }
 
     fn named_function_scope_names(&self, offset: usize) -> Option<&[Name]> {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2301,12 +2301,13 @@ impl<'a> WordFactCollector<'a> {
             }
 
             for call_site in self.semantic.call_sites_for(&function_name) {
-                if self
-                    .semantic
-                    .visible_binding(owner_name, call_site.name_span)
-                    .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+                if let Some(binding) =
+                    self.visible_binding_for_caller_assoc_lookup(owner_name, call_site.name_span)
                 {
-                    return true;
+                    if binding.attributes.contains(BindingAttributes::ASSOC) {
+                        return true;
+                    }
+                    continue;
                 }
 
                 if let Some(caller_names) = self.named_function_scope_names(call_site.name_span.start.offset)
@@ -2338,6 +2339,24 @@ impl<'a> WordFactCollector<'a> {
                         current_scope,
                         owner_name_span,
                     )
+            })
+            .map(|binding_id| self.semantic.binding(binding_id))
+    }
+
+    fn visible_binding_for_caller_assoc_lookup(
+        &self,
+        owner_name: &Name,
+        span: Span,
+    ) -> Option<&shuck_semantic::Binding> {
+        let current_scope = self.semantic.scope_at(span.start.offset);
+        self.semantic
+            .bindings_for(owner_name)
+            .iter()
+            .rev()
+            .copied()
+            .find(|binding_id| {
+                self.semantic.binding_visible_at(*binding_id, span)
+                    && self.binding_blocks_caller_assoc_lookup(*binding_id, current_scope, None)
             })
             .map(|binding_id| self.semantic.binding(binding_id))
     }

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2368,7 +2368,15 @@ impl<'a> WordFactCollector<'a> {
         owner_name_span: Option<Span>,
     ) -> bool {
         let binding = self.semantic.binding(binding_id);
-        if owner_name_span.is_some_and(|owner_span| binding.span == owner_span) {
+        if owner_name_span.is_some_and(|owner_span| binding.span == owner_span)
+            && matches!(
+                binding.kind,
+                shuck_semantic::BindingKind::Assignment
+                    | shuck_semantic::BindingKind::AppendAssignment
+                    | shuck_semantic::BindingKind::ArrayAssignment
+                    | shuck_semantic::BindingKind::ArithmeticAssignment
+            )
+        {
             return false;
         }
         if binding.scope != current_scope || binding.attributes.contains(BindingAttributes::LOCAL) {

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -245,6 +245,30 @@ main
     }
 
     #[test]
+    fn reports_wrapper_shadowing_local_subscripts_even_when_outer_callers_have_assoc_bindings() {
+        let source = "\
+#!/bin/bash
+helper() {
+  map[$key]=1
+}
+wrapper() {
+  local map
+  helper
+}
+main() {
+  local key=name
+  declare -A map
+  wrapper
+}
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "$key");
+    }
+
+    #[test]
     fn reports_nested_arithmetic_in_array_access_subscripts() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -203,6 +203,48 @@ main
     }
 
     #[test]
+    fn reports_shadowing_local_subscripts_even_when_callers_have_assoc_bindings() {
+        let source = "\
+#!/bin/bash
+helper() {
+  local map
+  map[$key]=1
+}
+main() {
+  local key=name
+  declare -A map
+  helper
+}
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "$key");
+    }
+
+    #[test]
+    fn ignores_repeated_dynamic_scope_associative_assignment_subscripts() {
+        let source = "\
+#!/bin/bash
+helper() {
+  map[${key}]=1
+  map[${other}]=2
+}
+main() {
+  local key=alpha
+  local other=beta
+  declare -A map
+  helper
+}
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_nested_arithmetic_in_array_access_subscripts() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -269,6 +269,17 @@ main
     }
 
     #[test]
+    fn ignores_associative_declaration_initializer_subscripts() {
+        let source = "\
+#!/bin/bash
+declare -A map=([$key]=1)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_nested_arithmetic_in_array_access_subscripts() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -181,6 +181,28 @@ assoc[$key/sfx]=z
     }
 
     #[test]
+    fn ignores_dynamic_scope_associative_assignment_subscripts() {
+        let source = "\
+#!/bin/bash
+helper() {
+  map[${key}]=1
+}
+wrapper() {
+  helper
+}
+main() {
+  local key=name
+  declare -A map
+  wrapper
+}
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_nested_arithmetic_in_array_access_subscripts() {
         let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- teach the S045 fact builder to recognize associative array bindings that are visible through named caller chains, not just the current scope
- add fact-level and rule-level regressions for dynamic-scope associative subscripts routed through helper wrappers
- keep S045 focused on true arithmetic-dollar cases while preserving the existing substring and arithmetic coverage

## Why
S045 was still flagging some associative array subscripts as arithmetic when the associative binding was introduced in a caller and the write happened inside one or more helper functions. The `Bash-it__bash-it__plugins__available__pack.plugin.bash` corpus case exposed that gap.

## Impact
This removes false positives for helper-chain writes like `map[${key}]=...` when `map` is known to be associative in the calling context, without weakening real arithmetic detections.

## Root Cause
The fact builder only checked whether an associative binding was directly visible at the subscript site. In Bash's dynamic function scoping, a named helper can inherit locals from transitive callers, so helper subscripts were sometimes misclassified as indexed arithmetic.

## Validation
- `cargo test -p shuck-linter ignores_dynamic_scope_associative_assignment_subscripts -- --nocapture`
- `cargo test -p shuck-linter dollar_in_arithmetic -- --nocapture`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S045`

## Notes
The targeted corpus rerun dropped reviewed S045 divergences from 34 to 32 and removed the `pack.plugin.bash` false positives. The existing corpus metadata for S045 still has remaining reviewed divergences outside this fix.