### PR TITLE
Fix C124 reachability analysis

### DIFF
--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -384,7 +384,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     &command.extra_args,
                     flow,
                 );
-                self.record_command(command.span, nested_regions, RecordedCommandKind::Return)
+                self.record_command(
+                    command.span,
+                    nested_regions,
+                    RecordedCommandKind::Return {
+                        in_function: flow.in_function,
+                    },
+                )
             }
             BuiltinCommand::Exit(command) => {
                 let nested_regions = self.visit_builtin_parts(
@@ -2789,7 +2795,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             RecordedCommandKind::Linear
             | RecordedCommandKind::Break { .. }
             | RecordedCommandKind::Continue { .. }
-            | RecordedCommandKind::Return
+            | RecordedCommandKind::Return { .. }
             | RecordedCommandKind::Exit => {}
             RecordedCommandKind::List { first, rest } => {
                 regions.extend(self.flatten_recorded_regions(first));

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -200,7 +200,9 @@ pub(crate) enum RecordedCommandKind {
     Continue {
         depth: usize,
     },
-    Return,
+    Return {
+        in_function: bool,
+    },
     Exit,
     List {
         first: RecordedCommandId,
@@ -422,6 +424,31 @@ struct SequenceResult {
     exits: Vec<BlockId>,
 }
 
+struct ConditionalSequenceResult {
+    entry: Option<BlockId>,
+    true_exits: Vec<BlockId>,
+    false_exits: Vec<BlockId>,
+}
+
+impl ConditionalSequenceResult {
+    fn from_sequence(sequence: SequenceResult) -> Self {
+        Self {
+            entry: sequence.entry,
+            true_exits: sequence.exits.clone(),
+            false_exits: sequence.exits,
+        }
+    }
+
+    fn into_sequence(self) -> SequenceResult {
+        let mut exits = self.true_exits;
+        exits.extend(self.false_exits);
+        SequenceResult {
+            entry: self.entry,
+            exits,
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 struct LoopTarget {
     continue_target: BlockId,
@@ -548,42 +575,62 @@ impl<'a> GraphBuilder<'a> {
         command_id: RecordedCommandId,
         loops: &[LoopTarget],
     ) -> SequenceResult {
+        self.build_command_conditional(command_id, loops)
+            .into_sequence()
+    }
+
+    fn build_command_conditional(
+        &mut self,
+        command_id: RecordedCommandId,
+        loops: &[LoopTarget],
+    ) -> ConditionalSequenceResult {
         let command = self.program.command(command_id);
         match &command.kind {
             RecordedCommandKind::Linear => {
                 let block = self.command_block(command.span);
                 self.attach_nested_regions(block, command.nested_regions, loops);
-                SequenceResult {
+                ConditionalSequenceResult::from_sequence(SequenceResult {
                     entry: Some(block),
                     exits: vec![block],
-                }
+                })
             }
             RecordedCommandKind::Break { depth } => {
                 let block = self.command_block(command.span);
                 if let Some(target) = resolve_break_target(loops, *depth) {
                     self.add_edge(block, target.break_target, EdgeKind::LoopExit);
                 }
-                SequenceResult {
+                ConditionalSequenceResult::from_sequence(SequenceResult {
                     entry: Some(block),
                     exits: Vec::new(),
-                }
+                })
             }
             RecordedCommandKind::Continue { depth } => {
                 let block = self.command_block(command.span);
                 if let Some(target) = resolve_break_target(loops, *depth) {
                     self.add_edge(block, target.continue_target, EdgeKind::LoopBack);
                 }
-                SequenceResult {
+                ConditionalSequenceResult::from_sequence(SequenceResult {
                     entry: Some(block),
                     exits: Vec::new(),
-                }
+                })
             }
-            RecordedCommandKind::Return | RecordedCommandKind::Exit => {
+            RecordedCommandKind::Return { in_function } => {
                 let block = self.command_block(command.span);
-                SequenceResult {
+                ConditionalSequenceResult::from_sequence(SequenceResult {
+                    entry: Some(block),
+                    exits: if *in_function {
+                        Vec::new()
+                    } else {
+                        vec![block]
+                    },
+                })
+            }
+            RecordedCommandKind::Exit => {
+                let block = self.command_block(command.span);
+                ConditionalSequenceResult::from_sequence(SequenceResult {
                     entry: Some(block),
                     exits: Vec::new(),
-                }
+                })
             }
             RecordedCommandKind::List { first, rest } => {
                 self.build_list(command_id, *first, *rest, loops)
@@ -593,29 +640,39 @@ impl<'a> GraphBuilder<'a> {
                 then_branch,
                 elif_branches,
                 else_branch,
-            } => self.build_if(
+            } => ConditionalSequenceResult::from_sequence(self.build_if(
                 command_id,
                 *condition,
                 *then_branch,
                 *elif_branches,
                 *else_branch,
                 loops,
-            ),
+            )),
             RecordedCommandKind::While { condition, body } => {
-                self.build_while_like(command_id, *condition, *body, loops, true)
+                ConditionalSequenceResult::from_sequence(
+                    self.build_while_like(command_id, *condition, *body, loops, true),
+                )
             }
             RecordedCommandKind::Until { condition, body } => {
-                self.build_while_like(command_id, *condition, *body, loops, false)
+                ConditionalSequenceResult::from_sequence(
+                    self.build_while_like(command_id, *condition, *body, loops, false),
+                )
             }
             RecordedCommandKind::For { body }
             | RecordedCommandKind::Select { body }
             | RecordedCommandKind::ArithmeticFor { body } => {
-                self.build_loop_command(command_id, *body, loops)
+                ConditionalSequenceResult::from_sequence(
+                    self.build_loop_command(command_id, *body, loops),
+                )
             }
-            RecordedCommandKind::Case { arms } => self.build_case(command_id, *arms, loops),
+            RecordedCommandKind::Case { arms } => {
+                ConditionalSequenceResult::from_sequence(self.build_case(command_id, *arms, loops))
+            }
             RecordedCommandKind::BraceGroup { body } => {
                 let sequence = self.build_sequence(*body, loops);
-                self.wrap_sequence_with_command_header(command_id, sequence, loops)
+                ConditionalSequenceResult::from_sequence(
+                    self.wrap_sequence_with_command_header(command_id, sequence, loops),
+                )
             }
             RecordedCommandKind::Subshell { body, .. } => {
                 let block = self.command_block(command.span);
@@ -624,10 +681,10 @@ impl<'a> GraphBuilder<'a> {
                 if let Some(body_entry) = body_sequence.entry {
                     self.add_edge(block, body_entry, EdgeKind::Sequential);
                 }
-                SequenceResult {
+                ConditionalSequenceResult::from_sequence(SequenceResult {
                     entry: Some(block),
                     exits: vec![block],
-                }
+                })
             }
             RecordedCommandKind::Pipeline { segments } => {
                 let block = self.command_block(command.span);
@@ -641,10 +698,10 @@ impl<'a> GraphBuilder<'a> {
                         self.add_edge(block, segment_entry, EdgeKind::Sequential);
                     }
                 }
-                SequenceResult {
+                ConditionalSequenceResult::from_sequence(SequenceResult {
                     entry: Some(block),
                     exits: vec![block],
-                }
+                })
             }
         }
     }
@@ -671,39 +728,76 @@ impl<'a> GraphBuilder<'a> {
         sequence
     }
 
+    fn wrap_conditional_sequence_with_command_header(
+        &mut self,
+        command_id: RecordedCommandId,
+        mut sequence: ConditionalSequenceResult,
+        loops: &[LoopTarget],
+    ) -> ConditionalSequenceResult {
+        let command = self.program.command(command_id);
+        if command.nested_regions.is_empty() {
+            return sequence;
+        }
+
+        let header = self.command_block(command.span);
+        self.attach_nested_regions(header, command.nested_regions, loops);
+        if let Some(entry) = sequence.entry {
+            self.add_edge(header, entry, EdgeKind::Sequential);
+        } else {
+            sequence.true_exits = vec![header];
+            sequence.false_exits = vec![header];
+        }
+        sequence.entry = Some(header);
+        sequence
+    }
+
     fn build_list(
         &mut self,
         command: RecordedCommandId,
         first: RecordedCommandId,
         rest: RecordedListItemRange,
         loops: &[LoopTarget],
-    ) -> SequenceResult {
-        let mut current = self.build_command(first, loops);
+    ) -> ConditionalSequenceResult {
+        let mut current = self.build_command_conditional(first, loops);
         let entry = current.entry;
-        let mut shortcut_exits = Vec::new();
 
         for item in self.program.list_items(rest) {
-            let next = self.build_command(item.command, loops);
-            if let Some(next_entry) = next.entry {
-                for exit in &current.exits {
-                    let edge = match item.operator {
-                        RecordedListOperator::And => EdgeKind::ConditionalTrue,
-                        RecordedListOperator::Or => EdgeKind::ConditionalFalse,
+            let next = self.build_command_conditional(item.command, loops);
+            match item.operator {
+                RecordedListOperator::And => {
+                    if let Some(next_entry) = next.entry {
+                        for exit in &current.true_exits {
+                            self.add_edge(*exit, next_entry, EdgeKind::ConditionalTrue);
+                        }
+                    }
+
+                    let mut false_exits = current.false_exits;
+                    false_exits.extend(next.false_exits);
+                    current = ConditionalSequenceResult {
+                        entry,
+                        true_exits: next.true_exits,
+                        false_exits,
                     };
-                    self.add_edge(*exit, next_entry, edge);
+                }
+                RecordedListOperator::Or => {
+                    if let Some(next_entry) = next.entry {
+                        for exit in &current.false_exits {
+                            self.add_edge(*exit, next_entry, EdgeKind::ConditionalFalse);
+                        }
+                    }
+
+                    let mut true_exits = current.true_exits;
+                    true_exits.extend(next.true_exits);
+                    current = ConditionalSequenceResult {
+                        entry,
+                        true_exits,
+                        false_exits: next.false_exits,
+                    };
                 }
             }
-
-            shortcut_exits.extend(current.exits.clone());
-            current = SequenceResult {
-                entry,
-                exits: next.exits,
-            };
         }
 
-        let mut exits = current.exits;
-        exits.extend(shortcut_exits);
-        self.wrap_sequence_with_command_header(command, SequenceResult { entry, exits }, loops)
+        self.wrap_conditional_sequence_with_command_header(command, current, loops)
     }
 
     fn build_if(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3987,6 +3987,40 @@ printf '%s\\n' \"$cache_dir\"
     }
 
     #[test]
+    fn short_circuit_lists_preserve_reachable_commands_after_continue() {
+        let source = "\
+#!/bin/bash
+for line in a b; do
+  [ \"$last_line\" = \"$line\" ] && continue || last_line=$line
+  printf '%s\\n' \"$line\"
+done
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
+    fn top_level_return_does_not_mark_following_commands_unreachable() {
+        let source = "\
+#!/usr/bin/env bash
+return 0
+echo after
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
     fn deferred_function_bodies_resolve_later_file_scope_bindings() {
         let source = "f() { echo $X; }\nX=1\nf\n";
         let model = model(source);

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -312,7 +312,7 @@ impl<'a> Analyzer<'a> {
             RecordedCommandKind::Linear
             | RecordedCommandKind::Break { .. }
             | RecordedCommandKind::Continue { .. }
-            | RecordedCommandKind::Return
+            | RecordedCommandKind::Return { .. }
             | RecordedCommandKind::Exit => self.analyze_linear_command(scope, command, state, leak),
             RecordedCommandKind::List { first, rest } => {
                 let mut list_state = self.analyze_command(scope, *first, state, leak);

--- a/crates/shuck/tests/testdata/corpus-metadata/c124.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c124.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so a single broad reviewed divergence captures the stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "termux__termux-packages__x11-packages__libncnn__build.sh"
+    reason: "This Termux package helper has an unconditional `return` before an intentionally disabled test-tool packaging block. Shuck still treats the later block as unreachable in that helper, while the current ShellCheck oracle does not emit a matching SC2365 report for this file."


### PR DESCRIPTION
## What changed

This fixes `C124` reachability analysis so it no longer reports false unreachable-code warnings after short-circuit list control flow or file-scope `return` statements.

It also narrows `crates/shuck/tests/testdata/corpus-metadata/c124.yaml` from a broad rule-wide reviewed divergence to the one remaining sampled corpus exception in `termux__termux-packages__x11-packages__libncnn__build.sh`.

## Why it changed

The semantic CFG was treating two patterns as terminating when they are not:

- `&& continue || ...` lists were collapsing true/false exits together, which let `continue` incorrectly poison later reachable statements.
- `return` was modeled as an unconditional terminator everywhere, even at file scope where Bash/ShellCheck treat it as an erroring command rather than dead-code cutoff.

Those bugs were being papered over by incoherent `C124` corpus metadata. Fixing the CFG lets us remove the bogus suppressions instead of widening the metadata.

## Impact

- `C124` is now more precise and should stop flagging reachable code in these control-flow shapes.
- The corpus metadata for `C124` is much narrower and easier to trust.
- Existing true unreachable-after-exit/return behavior inside function bodies is preserved.

## Validation

- `cargo test -p shuck-semantic short_circuit_lists_preserve_reachable_commands_after_continue -- --nocapture`
- `cargo test -p shuck-semantic top_level_return_does_not_mark_following_commands_unreachable -- --nocapture`
- `cargo test -p shuck-linter unreachable_after_exit_reports_each_unreachable_command -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C124 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=5`
