### PR TITLE
Require explicit rule-wide reviewed divergences

### DIFF
--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -458,7 +458,7 @@ impl ReviewedDivergenceRecord {
     fn validate(&self, rule_code: &str, path: &Path, entry_index: usize) -> Result<(), String> {
         match (self.rule_wide, self.has_scope()) {
             (false, false) => Err(format!(
-                "invalid reviewed divergence {} entry {} in {}: add a scope field or set rule-wide: true",
+                "invalid reviewed divergence {} entry {} in {}: add a scope field or set rule_wide: true",
                 rule_code,
                 entry_index,
                 path.display()
@@ -4099,7 +4099,7 @@ mod tests {
             )
             .unwrap_err();
 
-        assert!(error.contains("add a scope field or set rule-wide: true"));
+        assert!(error.contains("add a scope field or set rule_wide: true"));
     }
 
     #[test]

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -398,6 +398,14 @@ impl RuleCorpusMetadataDocument {
     fn has_entries(&self) -> bool {
         self.review_all_divergences || !self.reviewed_divergences.is_empty()
     }
+
+    fn validate(&self, rule_code: &str, path: &Path) -> Result<(), String> {
+        for (index, entry) in self.reviewed_divergences.iter().enumerate() {
+            entry.validate(rule_code, path, index + 1)?;
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -421,6 +429,8 @@ impl CompatibilitySide {
 struct ReviewedDivergenceRecord {
     side: CompatibilitySide,
     #[serde(default)]
+    rule_wide: bool,
+    #[serde(default)]
     path_suffix: Option<String>,
     #[serde(default)]
     path_contains: Option<String>,
@@ -433,6 +443,35 @@ struct ReviewedDivergenceRecord {
     #[serde(default)]
     end_column: Option<usize>,
     reason: String,
+}
+
+impl ReviewedDivergenceRecord {
+    fn has_scope(&self) -> bool {
+        self.path_suffix.is_some()
+            || self.path_contains.is_some()
+            || self.line.is_some()
+            || self.end_line.is_some()
+            || self.column.is_some()
+            || self.end_column.is_some()
+    }
+
+    fn validate(&self, rule_code: &str, path: &Path, entry_index: usize) -> Result<(), String> {
+        match (self.rule_wide, self.has_scope()) {
+            (false, false) => Err(format!(
+                "invalid reviewed divergence {} entry {} in {}: add a scope field or set rule-wide: true",
+                rule_code,
+                entry_index,
+                path.display()
+            )),
+            (true, true) => Err(format!(
+                "invalid reviewed divergence {} entry {} in {}: rule-wide entries cannot also set path or range constraints",
+                rule_code,
+                entry_index,
+                path.display()
+            )),
+            _ => Ok(()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1492,7 +1531,12 @@ fn load_rule_corpus_metadata(rule_code: &str) -> RuleCorpusMetadataDocument {
     }
     let data =
         fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
-    serde_yaml::from_str(&data).unwrap_or_else(|err| panic!("parse {}: {err}", path.display()))
+    let metadata: RuleCorpusMetadataDocument =
+        serde_yaml::from_str(&data).unwrap_or_else(|err| panic!("parse {}: {err}", path.display()));
+    metadata
+        .validate(rule_code, &path)
+        .unwrap_or_else(|err| panic!("{err}"));
+    metadata
 }
 
 fn load_all_rule_corpus_metadata() -> HashMap<String, RuleCorpusMetadataDocument> {
@@ -3729,6 +3773,12 @@ mod tests {
                 .get("C001")
                 .is_some_and(|rule_metadata| rule_metadata.review_all_divergences)
         );
+        assert!(
+            metadata
+                .get("C057")
+                .and_then(|rule_metadata| rule_metadata.reviewed_divergences.first())
+                .is_some_and(|entry| entry.rule_wide)
+        );
     }
 
     #[test]
@@ -3739,6 +3789,7 @@ mod tests {
                 review_all_divergences: false,
                 reviewed_divergences: vec![ReviewedDivergenceRecord {
                     side: CompatibilitySide::ShellcheckOnly,
+                    rule_wide: false,
                     path_suffix: Some("repo__script.sh".into()),
                     path_contains: None,
                     line: Some(19),
@@ -3781,6 +3832,7 @@ mod tests {
                 review_all_divergences: false,
                 reviewed_divergences: vec![ReviewedDivergenceRecord {
                     side: CompatibilitySide::ShuckOnly,
+                    rule_wide: false,
                     path_suffix: Some("scripts/repo__script.sh".into()),
                     path_contains: None,
                     line: Some(19),
@@ -3826,6 +3878,7 @@ mod tests {
                 review_all_divergences: false,
                 reviewed_divergences: vec![ReviewedDivergenceRecord {
                     side: CompatibilitySide::ShuckOnly,
+                    rule_wide: true,
                     path_suffix: None,
                     path_contains: None,
                     line: None,
@@ -3868,6 +3921,7 @@ mod tests {
                 review_all_divergences: false,
                 reviewed_divergences: vec![ReviewedDivergenceRecord {
                     side: CompatibilitySide::ShuckOnly,
+                    rule_wide: false,
                     path_suffix: Some("alpinelinux__aports__scripts__mkimage.sh".into()),
                     path_contains: None,
                     line: Some(120),
@@ -3943,6 +3997,7 @@ mod tests {
                 review_all_divergences: false,
                 reviewed_divergences: vec![ReviewedDivergenceRecord {
                     side: CompatibilitySide::ShuckOnly,
+                    rule_wide: false,
                     path_suffix: None,
                     path_contains: Some("termux__termux-packages__".into()),
                     line: None,
@@ -3988,6 +4043,7 @@ mod tests {
                 review_all_divergences: false,
                 reviewed_divergences: vec![ReviewedDivergenceRecord {
                     side: CompatibilitySide::ShuckOnly,
+                    rule_wide: false,
                     path_suffix: None,
                     path_contains: Some("termux__termux-packages__".into()),
                     line: None,
@@ -4017,6 +4073,60 @@ mod tests {
 
         assert_eq!(classification, CompatibilityClassification::Implementation);
         assert!(reason.is_none());
+    }
+
+    #[test]
+    fn reviewed_divergence_validation_rejects_implicit_rule_wide_entry() {
+        let metadata = RuleCorpusMetadataDocument {
+            review_all_divergences: false,
+            reviewed_divergences: vec![ReviewedDivergenceRecord {
+                side: CompatibilitySide::ShellcheckOnly,
+                rule_wide: false,
+                path_suffix: None,
+                path_contains: None,
+                line: None,
+                end_line: None,
+                column: None,
+                end_column: None,
+                reason: "implicit rule-wide reviewed divergence".into(),
+            }],
+        };
+
+        let error = metadata
+            .validate(
+                "C999",
+                Path::new("tests/testdata/corpus-metadata/c999.yaml"),
+            )
+            .unwrap_err();
+
+        assert!(error.contains("add a scope field or set rule-wide: true"));
+    }
+
+    #[test]
+    fn reviewed_divergence_validation_rejects_rule_wide_entry_with_scope() {
+        let metadata = RuleCorpusMetadataDocument {
+            review_all_divergences: false,
+            reviewed_divergences: vec![ReviewedDivergenceRecord {
+                side: CompatibilitySide::ShellcheckOnly,
+                rule_wide: true,
+                path_suffix: Some("repo__script.sh".into()),
+                path_contains: None,
+                line: None,
+                end_line: None,
+                column: None,
+                end_column: None,
+                reason: "conflicting reviewed divergence".into(),
+            }],
+        };
+
+        let error = metadata
+            .validate(
+                "C999",
+                Path::new("tests/testdata/corpus-metadata/c999.yaml"),
+            )
+            .unwrap_err();
+
+        assert!(error.contains("rule-wide entries cannot also set path or range constraints"));
     }
 
     #[test]

--- a/crates/shuck/tests/testdata/corpus-metadata/c002.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c002.yaml
@@ -1,5 +1,6 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "C002 intentionally treats runtime-built source targets as a correctness hazard even when they come from package build scripts, helper loaders, test harness scaffolding, or other project-local sourcing paths. ShellCheck stays silent on those SC1090 cases, so we keep them reviewed instead of trying to model every repository-specific source convention."
   - side: shellcheck-only
     path_suffix: "tteck__Proxmox__install__cronicle-install.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/c003.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c003.yaml
@@ -1,5 +1,211 @@
 reviewed_divergences:
   - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__completion__available__apm.completion.bash"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__completion__available__defaults.completion.bash"
+    line: 6
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__install.sh"
+    line: 289
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__install.sh"
+    line: 291
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__install.sh"
+    line: 293
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__lib__preexec.bash"
+    line: 12
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__template__bashrc.template.bash"
+    line: 76
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__themes__gitline__gitline.theme.bash"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__themes__powerline-multiline__powerline-multiline.base.bash"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__themes__powerline-multiline__powerline-multiline.theme.bash"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__themes__powerline-naked__powerline-naked.theme.bash"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__themes__powerline__powerline.theme.bash"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__misc__wcd__wcd.sh"
+    line: 3
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__community__fzf__fzf.plugin.sh"
+    line: 1
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__community__fzf__fzf.plugin.sh"
+    line: 2
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__community__skim__skim.plugin.sh"
+    line: 1
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__community__skim__skim.plugin.sh"
+    line: 2
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__main__meson__abuild-meson"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__scripts__mkimage.sh"
+    line: 17
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "awslabs__git-secrets__git-secrets"
+    line: 46
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__auto__autopause-daemon.sh"
+    line: 3
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__auto__autostop-daemon.sh"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__auto__pause.sh"
+    line: 3
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__auto__resume.sh"
+    line: 3
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__auto__stop.sh"
+    line: 3
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "itzg__docker-minecraft-server__scripts__start-deployLimbo"
+    line: 5
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.prompt.sh"
+    line: 8
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__bin__rvm"
+    line: 55
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__binscripts__rvm-installer"
+    line: 898
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__binscripts__rvm-installer"
+    line: 899
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__cd"
+    line: 24
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__completion"
+    line: 22
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__cli"
+    line: 149
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__cli"
+    line: 315
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__env"
+    line: 68
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__functions__environment"
+    line: 330
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "rvm__rvm__scripts__rvm"
+    line: 222
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__openssh__source-ssh-agent.sh"
+    line: 11
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__openssh__sv__ssh-agent.run.in"
+    line: 22
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__packages__openssh__wrap-ssh-agent.sh"
+    line: 3
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__bin__check-pie.sh"
+    line: 4
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__generate-bootstraps.sh"
+    line: 9
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__setup-android-sdk.sh"
+    line: 8
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__setup-android-sdk.sh"
+    line: 9
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__setup-archlinux.sh"
+    line: 55
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__setup-cgct.sh"
+    line: 5
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__setup-cgct.sh"
+    line: 6
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__setup-termux-glibc.sh"
+    line: 3
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__setup-termux.sh"
+    line: 68
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__setup-ubuntu.sh"
+    line: 336
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "termux__termux-packages__scripts__updates__utils__termux_pkg_is_update_needed.sh"
+    line: 32
+    reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
+  - side: shellcheck-only
+    path_suffix: "xwmx__nb__nb.ksh__nb"
+    line: 8
     reason: "These fixtures build helper source paths from repo-local variables or directive hints that still need project-specific path expansion or helper layout knowledge to resolve. We review those ShellCheck-only SC1091 hits instead of teaching C003 repository-specific source resolver heuristics."
   - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"

--- a/crates/shuck/tests/testdata/corpus-metadata/c011.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c011.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "Shuck intentionally treats `for` loops that iterate over command substitution output as a line-orientation hazard, because the shell will re-split that output into separate words before the loop sees it. ShellCheck does not report this SC2013 family of cases, so C011 keeps that stricter policy as a reviewed divergence instead of expanding the rule to match ShellCheck's silence."

--- a/crates/shuck/tests/testdata/corpus-metadata/c048.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c048.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "Variable-built case patterns are currently reviewed Shuck-side strictness rather than a parity bug."

--- a/crates/shuck/tests/testdata/corpus-metadata/c055.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c055.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "Dynamic parameter-expansion patterns are currently reviewed Shuck-side strictness rather than a narrow implementation bug."

--- a/crates/shuck/tests/testdata/corpus-metadata/c057.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c057.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "C057 intentionally flags command substitutions that send stdout to a different sink inside the subshell, even when the surrounding code is a helper wrapper, project-closure script, or test harness. ShellCheck stays silent on these SC2255 cases, and the remaining corpus hits are all the same policy shape, so one broad reviewed divergence captures the stricter Shuck behavior without hiding a distinct implementation bug."

--- a/crates/shuck/tests/testdata/corpus-metadata/c058.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c058.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "C058 intentionally flags command substitutions that discard or reroute stdout inside the subshell, even when they appear in helper wrappers, project-closure scripts, or test harnesses. ShellCheck stays silent on these SC2256 cases, and the remaining corpus hits are all the same policy shape, so one broad reviewed divergence captures the stricter Shuck behavior without hiding a distinct implementation bug."

--- a/crates/shuck/tests/testdata/corpus-metadata/c077.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c077.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "C077 intentionally flags command substitutions nested inside arithmetic expansion, including direct `$(...)` uses and arithmetic expressions that evaluate command output first. The current ShellCheck oracle in this workspace does not emit SC2290 for that construct, so the corpus comparisons for this rule are a reviewed policy divergence rather than a shuck implementation bug."

--- a/crates/shuck/tests/testdata/corpus-metadata/c099.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c099.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shellcheck-only
+    rule_wide: true
     reason: "C099 is intentionally scoped to quoted all-elements @-slice assignments, while the oracle's SC2124 check also reports broader array-to-scalar assignment patterns outside this rule's authored slice scope."

--- a/crates/shuck/tests/testdata/corpus-metadata/c100.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c100.yaml
@@ -1,5 +1,6 @@
 reviewed_divergences:
   - side: shellcheck-only
+    rule_wide: true
     reason: "C100 is intentionally scoped to quoted BASH_SOURCE scalar expansions, while the oracle's SC2128 check also reports broader unindexed array and array-to-scalar patterns."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"

--- a/crates/shuck/tests/testdata/corpus-metadata/c109.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c109.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "C109 intentionally flags `mapfile`/`readarray` reads from process substitutions. In the current large-corpus oracle environment, ShellCheck 0.11.0 does not emit SC2339 for these patterns, so this rule remains a stricter Shuck policy check."

--- a/crates/shuck/tests/testdata/corpus-metadata/c124.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c124.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so a single broad reviewed divergence captures the stricter Shuck policy without hiding a distinct implementation bug."

--- a/crates/shuck/tests/testdata/corpus-metadata/c133.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c133.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shellcheck-only
+    rule_wide: true
     reason: "C133 intentionally requires an actual array-expansion conversion pattern in the assignment value. Plain same-name scalar reassignments after historical array bindings are treated as out of scope for this rule."

--- a/crates/shuck/tests/testdata/corpus-metadata/s020.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s020.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "Shuck intentionally keeps warning on `for` headers that resolve to a single item, including runtime-fixed paths built from quoted scalar expansions or command substitutions. In the pinned large-corpus oracle, SC2043 only appears for a much narrower subset of those loops, so the remaining `shuck-only` sites are treated as a reviewed policy divergence rather than an implementation bug."

--- a/crates/shuck/tests/testdata/corpus-metadata/s038.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s038.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "S038 intentionally flags explicit `return $?` status propagation inside function bodies when the function already preserves the previous command's exit status. The current ShellCheck 0.11.0 comparison target does not report that pattern in the corpus, so these hits are reviewed divergence noise for parity testing."

--- a/crates/shuck/tests/testdata/corpus-metadata/s041.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s041.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "Shuck treats a bare compound command in function position as a missing-braces portability issue. The nix ShellCheck 0.11.0 oracle in this repo does not emit SC2276 for the small probes we checked, including subshell and bare test/if forms, so the corpus comparison is intentionally recorded as a reviewed shuck-only divergence."

--- a/crates/shuck/tests/testdata/corpus-metadata/s058.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s058.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "S058 intentionally keeps a dedicated mkdir-path quoting diagnostic, while the current ShellCheck comparison target reports overlapping cases through SC2086 instead of SC2335."

--- a/crates/shuck/tests/testdata/corpus-metadata/s063.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s063.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "S063 intentionally keeps flagging deep `../` symlink targets on literal `ln -s` operands, while the pinned ShellCheck oracle currently emits no matching diagnostics for this warning family."

--- a/crates/shuck/tests/testdata/corpus-metadata/s064.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s064.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "S064 intentionally reports deprecated short `xargs -i` forms while the corpus comparison target remains authored SC2350 and current ShellCheck emits this warning family under SC2267."

--- a/crates/shuck/tests/testdata/corpus-metadata/s066.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s066.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "Shuck flags a declaration that mixes `local` and `declare` in one statement. The current oracle build in this repo does not surface the authored SC2362 target for that pattern, so the remaining corpus hits are treated as reviewed shuck-only divergence."

--- a/crates/shuck/tests/testdata/corpus-metadata/s068.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s068.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "S068 intentionally flags literal numeric trap signal IDs, while the pinned ShellCheck oracle currently emits no matching diagnostics for this warning family."

--- a/crates/shuck/tests/testdata/corpus-metadata/x010.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x010.yaml
@@ -1,5 +1,6 @@
 reviewed_divergences:
   - side: shellcheck-only
+    rule_wide: true
     reason: "The remaining ShellCheck-only SC3009 corpus hits come from sourced Termux package recipes and build helpers that the comparison path collapses to POSIX sh more aggressively than Shuck's project-aware dialect resolution. X010 intentionally stays tied to files Shuck actually treats as sh or dash."
   - side: shuck-only
     path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"

--- a/crates/shuck/tests/testdata/corpus-metadata/x012.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x012.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "Shuck treats `# -*- sh -*-` and similar shell-collapse headers as POSIX sh, so `&>` is flagged wherever those files use it. ShellCheck stays silent on the corpus hits here, which indicates it is resolving those helpers differently, so we record the mismatch as a reviewed divergence instead of weakening the portability rule."

--- a/crates/shuck/tests/testdata/corpus-metadata/x016.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x016.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shellcheck-only
+    rule_wide: true
     reason: "The remaining ShellCheck-only SC3044 sites in the corpus are other bash-only builtins such as `shopt`, `compgen`, `complete`, `typeset`, `pushd`, and `popd`. X016 intentionally covers only `declare`; the other commands need their own portability rules."

--- a/crates/shuck/tests/testdata/corpus-metadata/x040.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x040.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "the current nix-provided ShellCheck build does not expose array-style subscripts in POSIX test brackets under a stable dedicated compatibility code, so Shuck's X040 portability hits stay reviewed until the oracle has a directly comparable warning"

--- a/crates/shuck/tests/testdata/corpus-metadata/x046.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x046.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "the current nix-provided ShellCheck build does not expose extglob syntax inside POSIX test operands under a stable dedicated compatibility code, so Shuck's X046 portability hits stay reviewed until the oracle has a directly comparable warning"

--- a/crates/shuck/tests/testdata/corpus-metadata/x080.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/x080.yaml
@@ -1,3 +1,4 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
     reason: "This rule intentionally keeps the dedicated function-local `source` portability split, but the current ShellCheck comparison target only exposes the broader `source` portability family on these sites, so X080 reports are reviewed divergence noise for corpus parity."


### PR DESCRIPTION
## What changed

This change makes broad reviewed-divergence approvals explicit in the large-corpus harness.

- add `rule_wide: true` as the explicit marker for intentionally broad `reviewed_divergences` entries
- reject implicit unscoped reviewed-divergence entries during metadata load
- reject `rule_wide: true` entries that also carry path or range constraints
- migrate the existing intentional broad metadata entries to use `rule_wide: true`
- narrow C003's shellcheck-only reviewed divergence to exact `path_suffix` and `line` matches

## Why

A previous metadata cleanup removed fields that had been constraining a C003 reviewed-divergence entry. Because unscoped `reviewed_divergences` still implicitly behaved as rule-wide approvals, that entry silently became a blanket allowlist for all future shellcheck-only C003 mismatches.

This change removes that fall-through path by requiring broad reviewed-divergence approvals to opt in explicitly.

## Impact

Future accidental scope drops in corpus metadata will now fail fast at metadata load time instead of quietly masking compatibility regressions.

## Validation

- `cargo test -p shuck --test large_corpus reviewed_divergence -- --nocapture`
- `cargo test -p shuck --test large_corpus load_all_rule_corpus_metadata_keeps_rule_wide_review_entries -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C003`
