### PR TITLE
Fix S045 arithmetic context detection

### DIFF
--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1058,6 +1058,36 @@ fn collects_dollar_spans_for_wrapped_substring_length_arithmetic() {
 }
 
 #[test]
+fn ignores_plain_substring_offset_parameter_expansions_for_dollar_in_arithmetic() {
+    let source = "#!/bin/bash\nrest=abcdef\nlen=2\nprintf '%s\\n' \"${rest:${len}:1}\"\n";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
+fn ignores_plain_positional_slice_parameter_expansions_for_dollar_in_arithmetic() {
+    let source = "#!/bin/bash\nargs_offset=$#\nprintf '%s\\n' \"${@:1:${args_offset}}\"\n";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
 fn collects_dollar_spans_for_parameter_replacement_arithmetic() {
     let source = "#!/bin/bash\noffset=1\nindex=2\nline=x\necho \"${line/ $index / $(($offset + $index)) }\"\n";
 
@@ -1157,6 +1187,125 @@ lang=en
 assoc[$key]=x
 assoc[${lang},27]=y
 assoc[$key/sfx]=z
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
+fn ignores_quoted_indexed_assignment_subscripts_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+declare -a arr
+wash_counter=1
+arr[\"${wash_counter}\"]=x
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
+fn ignores_command_substitutions_in_indexed_assignment_subscripts_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+declare -a arr
+i=file
+arr[$(printf '%s' \"$i\")]=x
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
+fn ignores_multi_declared_associative_append_assignment_subscripts_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+declare -A one=() two=() seen=()
+key=name
+one[$key]+=x
+two[$key]+=y
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
+fn ignores_globally_declared_associative_assignment_subscripts_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+init() {
+  declare -gA map
+}
+helper() {
+  map[$key]=1
+}
+main() {
+  key=name
+  init
+  helper
+}
+main
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
+fn ignores_globally_declared_associative_assignment_subscripts_with_combined_flags() {
+    let source = "\
+#!/bin/bash
+init() {
+  declare -Ag map=()
+}
+helper() {
+  map[$key/field]=1
+}
+main() {
+  key=name
+  init
+  helper
+}
+main
 ";
 
     with_facts(source, None, |_, facts| {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2517,8 +2517,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     }
 
     fn collect_dollar_prefixed_indexed_subscript_spans(&mut self, word: &Word) {
-        collect_dollar_prefixed_arithmetic_variable_spans(
-            word.span,
+        collect_dollar_prefixed_indexed_subscript_word_spans(
+            word,
             self.source,
             &mut self.arithmetic.dollar_in_arithmetic_spans,
         );
@@ -2710,6 +2710,28 @@ fn collect_arithmetic_command_spans(
     });
 }
 
+fn collect_slice_arithmetic_expression_spans(
+    expression: &ArithmeticExprNode,
+    source: &str,
+    dollar_spans: &mut Vec<Span>,
+    command_substitution_spans: &mut Vec<Span>,
+) {
+    query::visit_arithmetic_words(expression, &mut |word| {
+        collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+            &word.parts,
+            source,
+            dollar_spans,
+        );
+        collect_arithmetic_context_spans_in_word(
+            word,
+            source,
+            false,
+            dollar_spans,
+            command_substitution_spans,
+        );
+    });
+}
+
 fn collect_arithmetic_spans_in_fragment(
     word: Option<&Word>,
     text: Option<&SourceText>,
@@ -2824,6 +2846,53 @@ fn collect_dollar_prefixed_arithmetic_variable_spans(
         let end = start.advanced_by(&text[index..match_end]);
         spans.push(Span::from_positions(start, end));
         index = match_end;
+    }
+}
+
+fn collect_dollar_prefixed_indexed_subscript_word_spans(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for part in &word.parts {
+        match &part.kind {
+            WordPart::Variable(name) if is_shell_variable_name(name.as_str()) => {
+                spans.push(part.span);
+            }
+            WordPart::Variable(_) => {}
+            WordPart::Parameter(parameter) => {
+                if matches!(
+                    parameter.bourne(),
+                    Some(BourneParameterExpansion::Access { reference })
+                        if is_shell_variable_name(reference.name.as_str())
+                            && reference
+                                .subscript
+                                .as_ref()
+                                .is_none_or(|subscript| {
+                                    is_simple_arithmetic_reference_subscript(subscript, source)
+                                })
+                ) {
+                    spans.push(part.span);
+                }
+            }
+            WordPart::Literal(_)
+            | WordPart::DoubleQuoted { .. }
+            | WordPart::SingleQuoted { .. }
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. }
+            | WordPart::ZshQualifiedGlob(_) => {}
+        }
     }
 }
 
@@ -3475,33 +3544,43 @@ fn collect_arithmetic_expansion_spans_from_parts(
                     command_substitution_spans,
                 );
                 if let Some(expression) = offset_ast {
-                    collect_arithmetic_command_spans(
+                    collect_slice_arithmetic_expression_spans(
                         expression,
                         source,
                         dollar_spans,
                         command_substitution_spans,
                     );
                 } else {
+                    collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+                        &offset_word_ast.parts,
+                        source,
+                        dollar_spans,
+                    );
                     collect_arithmetic_expansion_spans_from_parts(
                         &offset_word_ast.parts,
                         source,
-                        collect_dollar_spans,
+                        false,
                         dollar_spans,
                         command_substitution_spans,
                     );
                 }
                 if let Some(expression) = length_ast {
-                    collect_arithmetic_command_spans(
+                    collect_slice_arithmetic_expression_spans(
                         expression,
                         source,
                         dollar_spans,
                         command_substitution_spans,
                     );
                 } else if let Some(length_word_ast) = length_word_ast {
+                    collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+                        &length_word_ast.parts,
+                        source,
+                        dollar_spans,
+                    );
                     collect_arithmetic_expansion_spans_from_parts(
                         &length_word_ast.parts,
                         source,
-                        collect_dollar_spans,
+                        false,
                         dollar_spans,
                         command_substitution_spans,
                     );
@@ -3866,33 +3945,43 @@ fn collect_arithmetic_spans_in_parameter_expansion(
                     command_substitution_spans,
                 );
                 if let Some(expression) = offset_ast {
-                    collect_arithmetic_command_spans(
+                    collect_slice_arithmetic_expression_spans(
                         expression,
                         source,
                         dollar_spans,
                         command_substitution_spans,
                     );
                 } else {
+                    collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+                        &offset_word_ast.parts,
+                        source,
+                        dollar_spans,
+                    );
                     collect_arithmetic_expansion_spans_from_parts(
                         &offset_word_ast.parts,
                         source,
-                        collect_dollar_spans,
+                        false,
                         dollar_spans,
                         command_substitution_spans,
                     );
                 }
                 if let Some(expression) = length_ast {
-                    collect_arithmetic_command_spans(
+                    collect_slice_arithmetic_expression_spans(
                         expression,
                         source,
                         dollar_spans,
                         command_substitution_spans,
                     );
                 } else if let Some(length_word_ast) = length_word_ast {
+                    collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+                        &length_word_ast.parts,
+                        source,
+                        dollar_spans,
+                    );
                     collect_arithmetic_expansion_spans_from_parts(
                         &length_word_ast.parts,
                         source,
-                        collect_dollar_spans,
+                        false,
                         dollar_spans,
                         command_substitution_spans,
                     );

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -97,6 +97,22 @@ mod tests {
     }
 
     #[test]
+    fn ignores_plain_substring_offset_parameter_expansions() {
+        let source = "#!/bin/bash\nrest=abcdef\nlen=2\nprintf '%s\\n' \"${rest:${len}:1}\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_plain_positional_slice_parameter_expansions() {
+        let source = "#!/bin/bash\nargs_offset=$#\nprintf '%s\\n' \"${@:1:${args_offset}}\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_dollar_prefixed_variables_in_parameter_replacement_arithmetic() {
         let source = "#!/bin/bash\noffset=1\nindex=2\nline=x\necho \"${line/ $index / $(($offset + $index)) }\"\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
@@ -174,6 +190,90 @@ lang=en
 assoc[$key]=x
 assoc[${lang},27]=y
 assoc[$key/sfx]=z
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_quoted_indexed_assignment_subscripts() {
+        let source = "\
+#!/bin/bash
+declare -a arr
+wash_counter=1
+arr[\"${wash_counter}\"]=x
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_command_substitutions_in_indexed_assignment_subscripts() {
+        let source = "\
+#!/bin/bash
+declare -a arr
+i=file
+arr[$(printf '%s' \"$i\")]=x
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_multi_declared_associative_append_assignment_subscripts() {
+        let source = "\
+#!/bin/bash
+declare -A one=() two=() seen=()
+key=name
+one[$key]+=x
+two[$key]+=y
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_globally_declared_associative_assignment_subscripts() {
+        let source = "\
+#!/bin/bash
+init() {
+  declare -gA map
+}
+helper() {
+  map[$key]=1
+}
+main() {
+  key=name
+  init
+  helper
+}
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_globally_declared_associative_assignment_subscripts_with_combined_flags() {
+        let source = "\
+#!/bin/bash
+init() {
+  declare -Ag map=()
+}
+helper() {
+  map[$key/field]=1
+}
+main() {
+  key=name
+  init
+  helper
+}
+main
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
 

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -445,6 +445,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
         let builtin = declaration_builtin(&command.variant);
         let flags = declaration_flags(&command.operands, self.source);
+        let global_flag_enabled =
+            declaration_flag_is_enabled(&command.operands, self.source, 'g').unwrap_or(false);
         self.declarations.push(Declaration {
             builtin,
             span: command.span,
@@ -465,12 +467,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         &mut nested_regions,
                     );
                     self.visit_name_only_declaration_operand(
-                        builtin, &flags, &name.name, name.span,
+                        builtin,
+                        &flags,
+                        global_flag_enabled,
+                        &name.name,
+                        name.span,
                     );
                 }
                 DeclOperand::Assignment(assignment) => {
                     let (scope, mut attributes) =
-                        self.declaration_scope_and_attributes(builtin, &flags);
+                        self.declaration_scope_and_attributes(builtin, &flags, global_flag_enabled);
                     attributes |= BindingAttributes::DECLARATION_INITIALIZED;
                     let kind = if attributes.contains(BindingAttributes::NAMEREF) {
                         BindingKind::Nameref
@@ -2418,6 +2424,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         &self,
         builtin: DeclarationBuiltin,
         flags: &FxHashSet<char>,
+        global_flag_enabled: bool,
     ) -> (ScopeId, BindingAttributes) {
         let mut attributes = BindingAttributes::empty();
         if matches!(builtin, DeclarationBuiltin::Export) || flags.contains(&'x') {
@@ -2448,13 +2455,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let global_like = matches!(
             builtin,
             DeclarationBuiltin::Declare | DeclarationBuiltin::Typeset
-        ) && flags.contains(&'g');
+        ) && global_flag_enabled;
         let local_like = matches!(builtin, DeclarationBuiltin::Local)
             || (matches!(
                 builtin,
                 DeclarationBuiltin::Declare | DeclarationBuiltin::Typeset
             ) && self.nearest_function_scope().is_some()
-                && !flags.contains(&'g'));
+                && !global_flag_enabled);
 
         if local_like {
             attributes |= BindingAttributes::LOCAL;
@@ -2465,7 +2472,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.nearest_function_scope()
                     .unwrap_or_else(|| self.current_scope())
             } else if global_like {
-                ScopeId(0)
+                self.nearest_execution_scope()
             } else {
                 self.current_scope()
             },
@@ -2477,10 +2484,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         &mut self,
         builtin: DeclarationBuiltin,
         flags: &FxHashSet<char>,
+        global_flag_enabled: bool,
         name: &Name,
         span: Span,
     ) {
-        let (scope, attributes) = self.declaration_scope_and_attributes(builtin, flags);
+        let (scope, attributes) =
+            self.declaration_scope_and_attributes(builtin, flags, global_flag_enabled);
         let local_like = attributes.contains(BindingAttributes::LOCAL);
         let existing = self.resolve_reference(name, scope, span.start.offset);
 
@@ -2873,6 +2882,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             .copied()
             .find(|scope| matches!(self.scopes[scope.index()].kind, ScopeKind::Function(_)))
     }
+
+    fn nearest_execution_scope(&self) -> ScopeId {
+        self.scope_stack
+            .iter()
+            .rev()
+            .copied()
+            .find(|scope| !matches!(self.scopes[scope.index()].kind, ScopeKind::Function(_)))
+            .unwrap_or(ScopeId(0))
+    }
 }
 
 fn parameter_operator_guards_unset_reference(operator: &ParameterOp) -> bool {
@@ -2908,6 +2926,35 @@ fn declaration_flags(operands: &[DeclOperand], source: &str) -> FxHashSet<char> 
         }
     }
     flags
+}
+
+fn declaration_flag_is_enabled(
+    operands: &[DeclOperand],
+    source: &str,
+    target: char,
+) -> Option<bool> {
+    let mut enabled = None;
+    for operand in operands {
+        if let DeclOperand::Flag(word) = operand
+            && let Some(text) = static_word_text(word, source)
+        {
+            let mut chars = text.chars();
+            let Some(polarity) = chars.next() else {
+                continue;
+            };
+            let enabled_for_operand = match polarity {
+                '-' => true,
+                '+' => false,
+                _ => continue,
+            };
+            for flag in chars {
+                if flag == target {
+                    enabled = Some(enabled_for_operand);
+                }
+            }
+        }
+    }
+    enabled
 }
 
 fn declaration_operands(operands: &[DeclOperand], source: &str) -> Vec<DeclarationOperand> {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2445,6 +2445,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             attributes |= BindingAttributes::UPPERCASE;
         }
 
+        let global_like = matches!(
+            builtin,
+            DeclarationBuiltin::Declare | DeclarationBuiltin::Typeset
+        ) && flags.contains(&'g');
         let local_like = matches!(builtin, DeclarationBuiltin::Local)
             || (matches!(
                 builtin,
@@ -2460,6 +2464,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             if local_like {
                 self.nearest_function_scope()
                     .unwrap_or_else(|| self.current_scope())
+            } else if global_like {
+                ScopeId(0)
             } else {
                 self.current_scope()
             },

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1826,6 +1826,49 @@ mod tests {
     }
 
     #[test]
+    fn declare_plus_g_stays_local_inside_functions() {
+        let source = "\
+#!/bin/bash
+f() {
+  declare +g scoped=1
+  printf '%s\\n' \"$scoped\"
+}
+printf '%s\\n' \"$scoped\"
+";
+        let model = model(source);
+
+        let scoped_binding = binding_for_name(&model, "scoped");
+        let ScopeKind::Function(function_scope) = model.scope_kind(scoped_binding.scope) else {
+            panic!("expected declare +g binding to live in the function scope");
+        };
+        assert!(function_scope.contains_name_str("f"));
+
+        let scoped_refs = model
+            .references()
+            .iter()
+            .filter(|reference| {
+                reference.kind == ReferenceKind::Expansion && reference.name == "scoped"
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(scoped_refs.len(), 2);
+
+        let inner_ref = scoped_refs
+            .iter()
+            .find(|reference| reference.span.start.line == 4)
+            .unwrap();
+        let outer_ref = scoped_refs
+            .iter()
+            .find(|reference| reference.span.start.line == 6)
+            .unwrap();
+
+        assert_eq!(
+            model.resolved_binding(inner_ref.id).unwrap().id,
+            scoped_binding.id
+        );
+        assert!(model.resolved_binding(outer_ref.id).is_none());
+    }
+
+    #[test]
     fn zsh_anonymous_functions_create_function_scoped_locals() {
         let source =
             "function { local scoped=1; echo \"$scoped\" \"$1\"; } arg\necho \"$scoped\"\n";
@@ -2175,6 +2218,28 @@ printf '%s\\n' \"$pkgname\"
         let reference = model.references().last().unwrap();
         let binding = model.resolved_binding(reference.id).unwrap();
         assert_eq!(binding.span.slice(source), "VAR");
+    }
+
+    #[test]
+    fn declare_g_in_command_substitution_stays_in_that_execution_scope() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"$(
+  f() { declare -gA assoc=([key]=1); }
+  f
+  printf '%s\\n' \"${assoc[key]}\"
+)\"
+printf '%s\\n' \"${assoc[key]}\"
+";
+        let model = model(source);
+
+        let assoc_binding = binding_for_name(&model, "assoc");
+        assert!(assoc_binding.attributes.contains(BindingAttributes::ARRAY));
+        assert!(assoc_binding.attributes.contains(BindingAttributes::ASSOC));
+        assert!(matches!(
+            model.scope_kind(assoc_binding.scope),
+            ScopeKind::CommandSubstitution
+        ));
     }
 
     #[test]

--- a/crates/shuck/tests/testdata/corpus-metadata/s045.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/s045.yaml
@@ -1,4 +1,4 @@
-review_all_divergences: true
+review_all_divergences: false
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
@@ -128,3 +128,19 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "tmux-plugins__tmux-resurrect__scripts__tmux_spinner.sh"
     reason: "The current ShellCheck oracle reuses SC2004 for substring and slice bounds, while Shuck keeps S045 scoped to explicit dollar-prefixed arithmetic operands rather than slice offsets and lengths."
+  - side: shuck-only
+    path_suffix: "docker-library__official-images__naughty-commits.sh"
+    line: 87
+    reason: "This loop-scoped associative map appends through keyed writes after a grouped `declare -A` declaration. The current ShellCheck oracle stays silent on those keyed appends, while Shuck still treats the subscripts as arithmetic-style indexed writes at this site."
+  - side: shuck-only
+    path_suffix: "docker-library__official-images__naughty-commits.sh"
+    line: 90
+    reason: "This loop-scoped associative map appends through keyed writes after a grouped `declare -A` declaration. The current ShellCheck oracle stays silent on those keyed appends, while Shuck still treats the subscripts as arithmetic-style indexed writes at this site."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__hash"
+    line: 32
+    reason: "This eval-built arithmetic string mixes dynamic variable names with array-length expansion. The current ShellCheck oracle does not emit SC2004 for that generated expression, while Shuck still reports the dollar-prefixed operands inside the eval payload."
+  - side: shuck-only
+    path_suffix: "v1s1t0r1sh3r3__airgeddon__airgeddon.sh"
+    line: 15602
+    reason: "This helper records an interface key in a global associative map immediately after declaring it with `declare -gA`. The current ShellCheck oracle does not flag that keyed write, while Shuck still treats the subscript as indexed arithmetic at this site."


### PR DESCRIPTION
## What changed

This tightens `S045` so it only reports dollar-prefixed arithmetic operands in contexts that actually match the current ShellCheck SC2004 behavior.

The change narrows several over-reporting paths in the linter facts layer:
- stop flagging plain substring/slice bounds like `${var:${len}:1}` while still reporting wrapped arithmetic forms like `${var:$(( $len - 1 ))}`
- ignore quoted indexed subscripts and command substitutions used as array keys
- preserve the intended indexed-assignment behavior for real arithmetic-style subscripts

It also fixes semantic handling for `declare -gA` / `declare -Ag` so global associative declarations made inside functions are recorded in global scope instead of being treated as function-local bindings.

Finally, it replaces `S045`'s blanket large-corpus allowlist with explicit reviewed divergence entries for the few remaining mismatches.

## Why

`S045` had grown too broad around slice operands and associative/indexed subscript detection, which caused a large number of false positives in the compatibility corpus. The global associative declaration scope bug also made Shuck misclassify some associative writes as arithmetic-style indexed writes.

## Impact

- reduces `S045` large-corpus warnings from 56 to 29
- reduces reviewed `S045` divergence groups from a blanket rule-wide allowlist to 3 explicit file patterns
- keeps `implementation_diffs=0` for the targeted large-corpus rule run

## Validation

- `cargo test -p shuck-linter dollar_in_arithmetic -- --nocapture`
- `cargo test -p shuck-linter 'surface::' -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S045`
