### PR TITLE
Reduce parser command allocation churn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ annotate-snippets = "0.10"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 compact_str = "0.8"
+smallvec = "1.15"
 
 # Checksums
 sha2 = "0.11"

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,12 @@ bench-save:
 bench-compare:
 	python3 scripts/benchmarks/run_criterion.py --repo-root . --baseline main
 
+bench-memory-save:
+	python3 scripts/benchmarks/run_parser_memory.py --repo-root . --save-baseline main --release
+
+bench-memory-compare:
+	python3 scripts/benchmarks/run_parser_memory.py --repo-root . --baseline main --release
+
 bench-parser:
 	cargo bench -p shuck-benchmark --bench parser
 

--- a/crates/shuck-benchmark/examples/parser_memory.rs
+++ b/crates/shuck-benchmark/examples/parser_memory.rs
@@ -234,7 +234,9 @@ fn parse_case_arg() -> Option<String> {
             value
         }
         "--help" | "-h" => {
-            eprintln!("usage: cargo run -p shuck-benchmark --example parser_memory -- [--case NAME]");
+            eprintln!(
+                "usage: cargo run -p shuck-benchmark --example parser_memory -- [--case NAME]"
+            );
             process::exit(0);
         }
         _ => {

--- a/crates/shuck-benchmark/examples/parser_memory.rs
+++ b/crates/shuck-benchmark/examples/parser_memory.rs
@@ -1,0 +1,260 @@
+use std::cell::RefCell;
+use std::process;
+
+use serde::Serialize;
+use shuck_benchmark::benchmark_cases;
+use shuck_parser::parser::{ParseResult, ParseStatus, Parser};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator<std::alloc::System> = CountingAllocator(std::alloc::System);
+
+const MAX_MEASURE_DEPTH: usize = 8;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Frame {
+    allocation_count: u64,
+    reallocation_count: u64,
+    total_allocated_bytes: u64,
+    total_reallocated_bytes: u64,
+    current_live_bytes: i64,
+    peak_live_bytes: u64,
+}
+
+impl Frame {
+    fn on_alloc(&mut self, size: usize) {
+        self.allocation_count += 1;
+        self.total_allocated_bytes += size as u64;
+        self.current_live_bytes += size as i64;
+        self.peak_live_bytes = self
+            .peak_live_bytes
+            .max(self.current_live_bytes.max(0) as u64);
+    }
+
+    fn on_dealloc(&mut self, size: usize) {
+        self.current_live_bytes -= size as i64;
+    }
+
+    fn on_realloc(&mut self, old_size: usize, new_size: usize) {
+        self.reallocation_count += 1;
+        self.total_reallocated_bytes += new_size as u64;
+        self.current_live_bytes += new_size as i64 - old_size as i64;
+        self.peak_live_bytes = self
+            .peak_live_bytes
+            .max(self.current_live_bytes.max(0) as u64);
+    }
+}
+
+#[derive(Debug, Default)]
+struct CounterState {
+    depth: usize,
+    frames: [Frame; MAX_MEASURE_DEPTH],
+}
+
+thread_local! {
+    static COUNTER_STATE: RefCell<CounterState> = RefCell::new(CounterState::default());
+}
+
+struct CountingAllocator<A>(A);
+
+unsafe impl<A: std::alloc::GlobalAlloc> std::alloc::GlobalAlloc for CountingAllocator<A> {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        let ptr = unsafe { self.0.alloc(layout) };
+        if !ptr.is_null() {
+            record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        record_dealloc(layout.size());
+        unsafe { self.0.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { self.0.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            record_realloc(layout.size(), new_size);
+        }
+        new_ptr
+    }
+}
+
+fn record_alloc(size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_alloc(size);
+        }
+    });
+}
+
+fn record_dealloc(size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_dealloc(size);
+        }
+    });
+}
+
+fn record_realloc(old_size: usize, new_size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_realloc(old_size, new_size);
+        }
+    });
+}
+
+fn measure<T>(f: impl FnOnce() -> T) -> (Frame, T) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        assert!(
+            state.depth + 1 < MAX_MEASURE_DEPTH,
+            "measurement nesting too deep"
+        );
+        state.depth += 1;
+        let depth = state.depth;
+        state.frames[depth] = Frame::default();
+    });
+
+    let result = f();
+
+    let frame = COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        let frame = state.frames[depth];
+        state.frames[depth] = Frame::default();
+        state.depth -= 1;
+        frame
+    });
+
+    (frame, result)
+}
+
+#[derive(Debug, Serialize)]
+struct ParseMemoryMetrics {
+    allocation_count: u64,
+    reallocation_count: u64,
+    total_allocated_bytes: u64,
+    total_reallocated_bytes: u64,
+    peak_live_bytes: u64,
+    final_live_bytes: u64,
+}
+
+impl From<Frame> for ParseMemoryMetrics {
+    fn from(frame: Frame) -> Self {
+        Self {
+            allocation_count: frame.allocation_count,
+            reallocation_count: frame.reallocation_count,
+            total_allocated_bytes: frame.total_allocated_bytes,
+            total_reallocated_bytes: frame.total_reallocated_bytes,
+            peak_live_bytes: frame.peak_live_bytes,
+            final_live_bytes: frame.current_live_bytes.max(0) as u64,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CaseReport {
+    case: String,
+    files: usize,
+    recovered_files: usize,
+    command_count: usize,
+    metrics: ParseMemoryMetrics,
+}
+
+fn parse_source(source: &str) -> ParseResult {
+    Parser::new(source).parse()
+}
+
+fn single_case_report(case_name: &str) -> Option<CaseReport> {
+    let cases = benchmark_cases();
+    let case = cases.into_iter().find(|case| case.name == case_name)?;
+
+    if case.files.len() == 1 {
+        let file = case.files[0];
+        let (frame, output) = measure(|| parse_source(file.source));
+        let recovered_files = usize::from(output.status != ParseStatus::Clean);
+        let command_count = output.file.body.len();
+        return Some(CaseReport {
+            case: case.name.to_string(),
+            files: 1,
+            recovered_files,
+            command_count,
+            metrics: frame.into(),
+        });
+    }
+
+    let (frame, (recovered_files, command_count)) = measure(|| {
+        let mut recovered_files = 0usize;
+        let mut command_count = 0usize;
+
+        for file in case.files {
+            let output = parse_source(file.source);
+            recovered_files += usize::from(output.status != ParseStatus::Clean);
+            command_count += output.file.body.len();
+        }
+
+        (recovered_files, command_count)
+    });
+
+    Some(CaseReport {
+        case: case.name.to_string(),
+        files: case.files.len(),
+        recovered_files,
+        command_count,
+        metrics: frame.into(),
+    })
+}
+
+fn parse_case_arg() -> Option<String> {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--case" => return args.next(),
+            "--help" | "-h" => {
+                eprintln!(
+                    "usage: cargo run -p shuck-benchmark --example parser_memory -- [--case NAME]"
+                );
+                process::exit(0);
+            }
+            _ => {
+                eprintln!("unknown argument `{arg}`");
+                process::exit(2);
+            }
+        }
+    }
+    None
+}
+
+fn main() {
+    let requested_case = parse_case_arg();
+    let reports = if let Some(case_name) = requested_case {
+        let Some(report) = single_case_report(&case_name) else {
+            eprintln!("unknown benchmark case `{case_name}`");
+            process::exit(2);
+        };
+        vec![report]
+    } else {
+        benchmark_cases()
+            .into_iter()
+            .filter_map(|case| single_case_report(case.name))
+            .collect::<Vec<_>>()
+    };
+
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports).unwrap();
+    println!();
+}

--- a/crates/shuck-benchmark/examples/parser_memory.rs
+++ b/crates/shuck-benchmark/examples/parser_memory.rs
@@ -222,22 +222,26 @@ fn single_case_report(case_name: &str) -> Option<CaseReport> {
 
 fn parse_case_arg() -> Option<String> {
     let mut args = std::env::args().skip(1);
-    while let Some(arg) = args.next() {
-        match arg.as_str() {
-            "--case" => return args.next(),
-            "--help" | "-h" => {
-                eprintln!(
-                    "usage: cargo run -p shuck-benchmark --example parser_memory -- [--case NAME]"
-                );
-                process::exit(0);
-            }
-            _ => {
-                eprintln!("unknown argument `{arg}`");
+    let arg = args.next()?;
+
+    match arg.as_str() {
+        "--case" => {
+            let value = args.next();
+            if let Some(extra) = args.next() {
+                eprintln!("unknown argument `{extra}`");
                 process::exit(2);
             }
+            value
+        }
+        "--help" | "-h" => {
+            eprintln!("usage: cargo run -p shuck-benchmark --example parser_memory -- [--case NAME]");
+            process::exit(0);
+        }
+        _ => {
+            eprintln!("unknown argument `{arg}`");
+            process::exit(2);
         }
     }
-    None
 }
 
 fn main() {

--- a/crates/shuck-parser/Cargo.toml
+++ b/crates/shuck-parser/Cargo.toml
@@ -18,6 +18,7 @@ benchmarking = []
 [dependencies]
 shuck-ast = { path = "../shuck-ast" }
 memchr.workspace = true
+smallvec.workspace = true
 
 [dev-dependencies]
 serde.workspace = true

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -4331,8 +4331,8 @@ impl<'a> Parser<'a> {
         self.check_error_token()?;
         let start_span = self.current_span;
 
-        let mut assignments = Vec::with_capacity(1);
-        let mut words = Vec::with_capacity(4);
+        let mut assignments = SmallAssignmentList::new();
+        let mut words = SmallWordList::new();
         let mut redirects = Vec::with_capacity(1);
 
         loop {
@@ -4347,13 +4347,8 @@ impl<'a> Parser<'a> {
                 && self.should_consume_right_brace_as_literal_argument(next_kind_after_right_brace);
             match self.current_token_kind {
                 Some(kind) if kind.is_word_like() => {
-                    let is_literal = kind == TokenKind::LiteralWord;
-                    let word_text = self.current_source_like_word_text().unwrap();
-                    let assignment_shape = (!is_literal && words.is_empty())
-                        .then(|| Self::is_assignment(word_text.as_ref()));
-                    let assignment_shape = assignment_shape.flatten();
-
-                    // Stop if this word cannot start a command (like 'then', 'fi', etc.)
+                    // Bail out before touching word text when the token is a
+                    // reserved word that cannot begin a simple command.
                     if words.is_empty()
                         && self
                             .current_keyword()
@@ -4361,6 +4356,12 @@ impl<'a> Parser<'a> {
                     {
                         break;
                     }
+
+                    let is_literal = kind == TokenKind::LiteralWord;
+                    let word_text = self.current_source_like_word_text().unwrap();
+                    let assignment_shape = (!is_literal && words.is_empty())
+                        .then(|| Self::is_assignment(word_text.as_ref()));
+                    let assignment_shape = assignment_shape.flatten();
 
                     // Check for assignment (only before the command name, not for literal words)
                     if words.is_empty()
@@ -4393,7 +4394,7 @@ impl<'a> Parser<'a> {
                         let saved_span = self.current_span;
                         self.advance();
                         if let Some(word) =
-                            self.try_parse_compound_array_arg(word_text.into_owned(), saved_span)
+                            self.try_parse_compound_array_arg(word_text.as_ref(), saved_span)
                         {
                             words.push(word);
                             continue;
@@ -4524,7 +4525,7 @@ impl<'a> Parser<'a> {
                 name: Word::literal(""),
                 args: Vec::new(),
                 redirects,
-                assignments,
+                assignments: assignments.into_vec(),
                 span: start_span.merge(self.current_span),
             }));
         }
@@ -4533,6 +4534,7 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
 
+        let mut words = words.into_vec();
         let name = words.remove(0);
         let args = words;
 
@@ -4540,7 +4542,7 @@ impl<'a> Parser<'a> {
             name,
             args,
             redirects,
-            assignments,
+            assignments: assignments.into_vec(),
             span: start_span.merge(self.current_span),
         }))
     }
@@ -4548,7 +4550,7 @@ impl<'a> Parser<'a> {
     /// Extract fd-variable name from `{varname}` pattern in the last word.
     /// If the last word is a single literal `{identifier}`, pop it and return the name.
     /// Used for `exec {var}>file` / `exec {var}>&-` syntax.
-    fn pop_fd_var(&self, words: &mut Vec<Word>) -> (Option<Name>, Option<Span>) {
+    fn pop_fd_var(&self, words: &mut SmallWordList) -> (Option<Name>, Option<Span>) {
         if let Some(last) = words.last()
             && last.parts.len() == 1
             && let WordPart::Literal(ref s) = last.parts[0].kind
@@ -4579,7 +4581,10 @@ impl<'a> Parser<'a> {
             && Self::fd_var_gap_allows_attachment(&self.input[start..end])
     }
 
-    fn pop_line_continuation_fd_var(&self, words: &mut Vec<Word>) -> (Option<Name>, Option<Span>) {
+    fn pop_line_continuation_fd_var(
+        &self,
+        words: &mut SmallWordList,
+    ) -> (Option<Name>, Option<Span>) {
         let Some(last) = words.last() else {
             return (None, None);
         };

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use memchr::{memchr, memchr2, memchr3};
+use smallvec::SmallVec;
 
 pub use lexer::{
     HeredocRead, LexedToken, LexedWord, LexedWordSegment, LexedWordSegmentKind, Lexer,
@@ -177,6 +178,9 @@ struct SimpleCommand {
     assignments: Vec<Assignment>,
     span: Span,
 }
+
+type SmallWordList = SmallVec<[Word; 4]>;
+type SmallAssignmentList = SmallVec<[Assignment; 1]>;
 
 #[derive(Debug, Clone)]
 struct BreakCommand {
@@ -2883,8 +2887,8 @@ impl<'a> Parser<'a> {
 
     fn literal_part_from_text(&self, text: &str, span: Span, source_backed: bool) -> WordPartNode {
         WordPartNode::new(
-            WordPart::Literal(self.literal_text(
-                text.to_string(),
+            WordPart::Literal(self.literal_text_from_str(
+                text,
                 span.start,
                 span.end,
                 source_backed,
@@ -2902,7 +2906,7 @@ impl<'a> Parser<'a> {
     ) -> WordPartNode {
         WordPartNode::new(
             WordPart::SingleQuoted {
-                value: self.source_text(text.to_string(), content_span.start, content_span.end),
+                value: self.source_text_from_str(text, content_span.start, content_span.end),
                 dollar,
             },
             wrapper_span,
@@ -5025,12 +5029,59 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn literal_text_from_str(
+        &self,
+        text: &str,
+        start: Position,
+        end: Position,
+        source_backed: bool,
+    ) -> LiteralText {
+        self.literal_text_impl(text, None, start, end, source_backed)
+    }
+
+    fn literal_text_impl(
+        &self,
+        text: &str,
+        owned: Option<String>,
+        start: Position,
+        end: Position,
+        source_backed: bool,
+    ) -> LiteralText {
+        let span = Span::from_positions(start, end);
+        if self.source_matches(span, text) {
+            LiteralText::source()
+        } else if source_backed {
+            LiteralText::cooked_source(owned.unwrap_or_else(|| text.to_owned()))
+        } else {
+            LiteralText::owned(owned.unwrap_or_else(|| text.to_owned()))
+        }
+    }
+
     fn source_text(&self, text: String, start: Position, end: Position) -> SourceText {
         let span = Span::from_positions(start, end);
         if self.source_matches(span, &text) {
             SourceText::source(span)
         } else {
             SourceText::cooked(span, text)
+        }
+    }
+
+    fn source_text_from_str(&self, text: &str, start: Position, end: Position) -> SourceText {
+        self.source_text_impl(text, None, start, end)
+    }
+
+    fn source_text_impl(
+        &self,
+        text: &str,
+        owned: Option<String>,
+        start: Position,
+        end: Position,
+    ) -> SourceText {
+        let span = Span::from_positions(start, end);
+        if self.source_matches(span, text) {
+            SourceText::source(span)
+        } else {
+            SourceText::cooked(span, owned.unwrap_or_else(|| text.to_owned()))
         }
     }
 

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2765,7 +2765,7 @@ impl<'a> Parser<'a> {
     /// Returns the compound word if successful, or `None` if not a compound assignment.
     pub(super) fn try_parse_compound_array_arg(
         &mut self,
-        saved_w: String,
+        saved_w: &str,
         saved_span: Span,
     ) -> Option<Word> {
         if !self.at(TokenKind::LeftParen) {
@@ -2775,7 +2775,8 @@ impl<'a> Parser<'a> {
         let open_paren_span = self.current_span;
         if let Some(closing_span) = self.scan_compound_array_close(open_paren_span) {
             let paren_text = &self.input[open_paren_span.start.offset..closing_span.end.offset];
-            let mut compound = saved_w;
+            let mut compound = String::with_capacity(saved_w.len() + paren_text.len());
+            compound.push_str(saved_w);
             compound.push_str(paren_text);
             while self.current_token.is_some()
                 && self.current_span.start.offset < closing_span.end.offset
@@ -2787,7 +2788,8 @@ impl<'a> Parser<'a> {
         }
 
         self.advance(); // consume '('
-        let mut compound = saved_w;
+        let mut compound = String::with_capacity(saved_w.len() + 32);
+        compound.push_str(saved_w);
         let mut closing_span = Span::new();
         loop {
             match self.current_token_kind {

--- a/scripts/benchmarks/run_parser_memory.py
+++ b/scripts/benchmarks/run_parser_memory.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+PRIMARY_METRICS = [
+    "total_allocated_bytes",
+    "total_reallocated_bytes",
+    "allocation_count",
+    "reallocation_count",
+    "peak_live_bytes",
+    "final_live_bytes",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run parser memory benchmarks with explicit save/compare baseline modes."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        required=True,
+        help="Path to the shuck repository checkout to benchmark.",
+    )
+
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--save-baseline",
+        metavar="NAME",
+        help="Save parser memory results into the named baseline.",
+    )
+    mode.add_argument(
+        "--baseline",
+        metavar="NAME",
+        help="Compare parser memory results against the named baseline.",
+    )
+
+    parser.add_argument(
+        "--package",
+        default="shuck-benchmark",
+        help="Cargo package that owns the parser memory example.",
+    )
+    parser.add_argument(
+        "--example",
+        default="parser_memory",
+        help="Example target that emits parser memory JSON.",
+    )
+    parser.add_argument(
+        "--release",
+        action="store_true",
+        help="Run the memory harness in release mode.",
+    )
+    return parser.parse_args()
+
+
+def target_dir(repo_root: Path) -> Path:
+    cargo_target_dir = os.environ.get("CARGO_TARGET_DIR")
+    if cargo_target_dir:
+        return Path(cargo_target_dir)
+    return repo_root / "target"
+
+
+def run_example(repo_root: Path, package: str, example: str, release: bool) -> list[dict]:
+    command = ["cargo", "run", "-p", package, "--example", example]
+    if release:
+        command.append("--release")
+    command.append("--quiet")
+
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def baseline_path(repo_root: Path, baseline_name: str) -> Path:
+    return target_dir(repo_root) / "parser-memory-baselines" / f"{baseline_name}.json"
+
+
+def metric_change(current: int, baseline: int) -> str:
+    if baseline == 0:
+        return "n/a" if current == 0 else "inf"
+    change = ((current / baseline) - 1.0) * 100.0
+    sign = "+" if change > 0 else ""
+    return f"{sign}{change:.2f}%"
+
+
+def index_cases(payload: list[dict]) -> dict[str, dict]:
+    return {entry["case"]: entry for entry in payload}
+
+
+def print_comparison(current: list[dict], baseline: list[dict]) -> None:
+    current_cases = index_cases(current)
+    baseline_cases = index_cases(baseline)
+
+    missing_in_current = sorted(set(baseline_cases) - set(current_cases))
+    missing_in_baseline = sorted(set(current_cases) - set(baseline_cases))
+    if missing_in_current or missing_in_baseline:
+        raise SystemExit(
+            "case mismatch between current and baseline: "
+            f"missing_in_current={missing_in_current}, missing_in_baseline={missing_in_baseline}"
+        )
+
+    for case_name in sorted(current_cases):
+        current_case = current_cases[case_name]
+        baseline_case = baseline_cases[case_name]
+        print(f"{case_name}: commands={baseline_case['command_count']} -> {current_case['command_count']}")
+        for metric_name in PRIMARY_METRICS:
+            baseline_value = baseline_case["metrics"][metric_name]
+            current_value = current_case["metrics"][metric_name]
+            print(
+                f"  {metric_name}: {baseline_value} -> {current_value} "
+                f"({metric_change(current_value, baseline_value)})"
+            )
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    current = run_example(repo_root, args.package, args.example, args.release)
+
+    if args.save_baseline is not None:
+        path = baseline_path(repo_root, args.save_baseline)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(current, indent=2) + "\n")
+        print(f"saved parser memory baseline `{args.save_baseline}` to {path}")
+        return 0
+
+    path = baseline_path(repo_root, args.baseline)
+    if not path.is_file():
+        raise SystemExit(f"missing parser memory baseline: {path}")
+
+    baseline = json.loads(path.read_text())
+    print_comparison(current, baseline)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmarks/run_parser_memory.py
+++ b/scripts/benchmarks/run_parser_memory.py
@@ -64,7 +64,10 @@ def parse_args() -> argparse.Namespace:
 def target_dir(repo_root: Path) -> Path:
     cargo_target_dir = os.environ.get("CARGO_TARGET_DIR")
     if cargo_target_dir:
-        return Path(cargo_target_dir)
+        target = Path(cargo_target_dir)
+        if not target.is_absolute():
+            target = repo_root / target
+        return target
     return repo_root / "target"
 
 
@@ -115,6 +118,11 @@ def print_comparison(current: list[dict], baseline: list[dict]) -> None:
     for case_name in sorted(current_cases):
         current_case = current_cases[case_name]
         baseline_case = baseline_cases[case_name]
+        if current_case["command_count"] != baseline_case["command_count"]:
+            raise SystemExit(
+                "command-count mismatch between current and baseline for "
+                f"{case_name}: {baseline_case['command_count']} != {current_case['command_count']}"
+            )
         print(f"{case_name}: commands={baseline_case['command_count']} -> {current_case['command_count']}")
         for metric_name in PRIMARY_METRICS:
             baseline_value = baseline_case["metrics"][metric_name]


### PR DESCRIPTION
## Summary

This change reduces parser allocation churn in the simple-command hot path and adds a repo-supported parser memory benchmark workflow.

## What changed

- keeps `parse_simple_command` builders inline for common tiny command shapes instead of immediately allocating heap-backed vectors
- avoids forcing owned text for compound array argument parsing until we know a synthetic buffer is required
- adds borrowed/source-backed literal helpers in the parser so source-backed segments avoid eager `String` materialization
- adds a JSON-emitting `parser_memory` benchmark example in `crates/shuck-benchmark`
- adds a baseline/compare runner and `make bench-memory-save` / `make bench-memory-compare`

## Why

Allocation profiling pointed at parser command-building as the next large allocation site. The parser was still paying a lot of small per-command allocation costs even when the resulting command shape was tiny, and some source-backed text helpers were allocating before they had to.

## Impact

The new memory harness gives us repeatable parser allocation measurements against `main`, and the parser changes reduce allocation pressure on the benchmark corpus without changing parser APIs or AST semantics.

Release-mode parser memory comparison against a `main` baseline:

- `all`: allocation count `122,040 -> 98,734` (`-19.10%`), total allocated bytes `95,722,408 -> 93,264,253` (`-2.57%`)
- `nvm`: allocation count `58,388 -> 46,501` (`-20.36%`), total allocated bytes `45,283,276 -> 44,209,693` (`-2.37%`)

## Validation

- `cargo test -p shuck-parser`
- `cargo test -p shuck-benchmark`
- `cargo run -p shuck-benchmark --example parser_memory --release -- --case nvm`
- `python3 scripts/benchmarks/run_parser_memory.py --repo-root . --baseline main --release`

## Follow-up

Criterion throughput comparisons were not stable enough during this session to treat as merge-quality evidence. The parser-only and full-suite runs were noisy, so a quieter follow-up Criterion pass against `main` is still needed before treating runtime results as conclusive.
