### PR TITLE
Align C063 overwrite behavior with SC2329

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C063.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C063.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Invalid: the first definition is replaced before any call can reach it.
+# Invalid: the first definition is replaced before any direct call can reach it.
 myfunc() { return 1; }
 myfunc() { return 0; }
 myfunc

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,5 +1,4 @@
-use shuck_semantic::{BindingKind, OverwrittenFunction as SemanticOverwrittenFunction, ScopeKind};
-
+use shuck_semantic::{BindingKind, OverwrittenFunction as SemanticOverwrittenFunction};
 use crate::context::FileContextTag;
 use crate::{Checker, Rule, Violation};
 
@@ -14,7 +13,7 @@ impl Violation for OverwrittenFunction {
 
     fn message(&self) -> String {
         format!(
-            "function `{}` is overwritten before it can be called",
+            "function `{}` is overwritten before any direct call can reach it",
             self.name
         )
     }
@@ -46,10 +45,12 @@ fn should_suppress_overwrite(
     let first = checker.semantic().binding(overwritten.first);
     let second = checker.semantic().binding(overwritten.second);
 
-    if file_context.has_tag(FileContextTag::ShellSpec)
-        && !matches!(checker.semantic().scope_kind(first.scope), ScopeKind::File)
-        && !matches!(checker.semantic().scope_kind(second.scope), ScopeKind::File)
+    if matches!(first.kind, BindingKind::Imported) || matches!(second.kind, BindingKind::Imported)
     {
+        return true;
+    }
+
+    if file_context.has_tag(FileContextTag::ShellSpec) {
         return true;
     }
 
@@ -79,21 +80,6 @@ fn should_suppress_overwrite(
                     ))
                 && has_intervening_executable_command(
                     checker,
-                    first.span.end.offset,
-                    second.span.start.offset,
-                ))
-            || (file_context.has_tag(FileContextTag::ProjectClosure)
-                && is_project_closure_imported_override(
-                    checker,
-                    overwritten,
-                    first.span.end.offset,
-                    second.span.start.offset,
-                ))
-            || (file_context.has_tag(FileContextTag::DirectiveHandling)
-                && file_context.has_tag(FileContextTag::ProjectClosure)
-                && is_nested_project_closure_import_reimport_from_same_origin(
-                    checker,
-                    overwritten,
                     first.span.end.offset,
                     second.span.start.offset,
                 )))
@@ -156,75 +142,6 @@ fn has_only_indirect_call_sites_between(
     has_nested_call_site && !has_same_scope_call_between
 }
 
-fn is_project_closure_imported_override(
-    checker: &Checker<'_>,
-    overwritten: &SemanticOverwrittenFunction,
-    start_offset: usize,
-    end_offset: usize,
-) -> bool {
-    let first = checker.semantic().binding(overwritten.first);
-    let second = checker.semantic().binding(overwritten.second);
-
-    matches!(first.kind, BindingKind::Imported)
-        && matches!(second.kind, BindingKind::FunctionDefinition)
-        && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
-}
-
-fn is_nested_project_closure_import_reimport_from_same_origin(
-    checker: &Checker<'_>,
-    overwritten: &SemanticOverwrittenFunction,
-    start_offset: usize,
-    end_offset: usize,
-) -> bool {
-    let first = checker.semantic().binding(overwritten.first);
-    let second = checker.semantic().binding(overwritten.second);
-
-    first.scope == second.scope
-        && matches!(first.kind, BindingKind::Imported)
-        && matches!(second.kind, BindingKind::Imported)
-        && !matches!(checker.semantic().scope_kind(first.scope), ScopeKind::File)
-        && imported_binding_origins_match_exactly(checker, overwritten.first, overwritten.second)
-        && !has_same_scope_call_site_between(checker, overwritten, start_offset, end_offset)
-}
-
-fn imported_binding_origins_match_exactly(
-    checker: &Checker<'_>,
-    first: shuck_semantic::BindingId,
-    second: shuck_semantic::BindingId,
-) -> bool {
-    let first_origins = checker.semantic().import_origins_for_binding(first);
-    let second_origins = checker.semantic().import_origins_for_binding(second);
-
-    !first_origins.is_empty()
-        && first_origins.len() == second_origins.len()
-        && first_origins
-            .iter()
-            .all(|origin| second_origins.contains(origin))
-}
-
-fn has_same_scope_call_site_between(
-    checker: &Checker<'_>,
-    overwritten: &SemanticOverwrittenFunction,
-    start_offset: usize,
-    end_offset: usize,
-) -> bool {
-    let first = checker.semantic().binding(overwritten.first);
-
-    checker
-        .semantic()
-        .call_sites_for(&overwritten.name)
-        .iter()
-        .any(|site| {
-            site.scope == first.scope
-                && site.span.start.offset > start_offset
-                && site.span.start.offset < end_offset
-                && checker
-                    .semantic()
-                    .visible_binding(&overwritten.name, site.span)
-                    .is_some_and(|binding| binding.id == overwritten.first)
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use std::{fs, path::Path};
@@ -242,6 +159,27 @@ factory() {
   shellspec_matcher__match() { :; }
   shellspec_matcher__match() { :; }
 }
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/ko1nksm__shellspec__spec__core__matcher_spec.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn shellspec_top_level_example_helpers_are_suppressed() {
+        let source = "\
+Describe 'matcher'
+  Specify 'first'
+    helper() { return 0; }
+  End
+
+  Specify 'second'
+    helper() { return 1; }
+  End
 ";
         let diagnostics = test_snippet_at_path(
             Path::new("/tmp/ko1nksm__shellspec__spec__core__matcher_spec.sh"),
@@ -411,7 +349,7 @@ cleanup
     }
 
     #[test]
-    fn sourced_test_double_swaps_without_direct_calls_are_suppressed() {
+    fn transitive_direct_calls_before_redefinition_do_not_report() {
         let source = "\
 \\. ./helpers.sh
 run_case() {
@@ -431,7 +369,7 @@ helper() { printf '%s\\n' second; }
     }
 
     #[test]
-    fn sourced_test_double_swaps_with_opaque_helper_calls_are_suppressed() {
+    fn opaque_helper_calls_before_redefinition_are_suppressed() {
         let source = "\
 \\. ./helpers.sh
 helper() { printf '%s\\n' first; }
@@ -553,7 +491,66 @@ runner
     }
 
     #[test]
-    fn nested_helper_library_collisions_from_different_origins_still_report() {
+    fn project_closure_reimports_in_regular_scripts_are_suppressed() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join(".bash.d/mysql.sh");
+        let functions = temp.path().join(".bash.d/functions.sh");
+        let os_detection = temp.path().join(".bash.d/os_detection.sh");
+        let source = "\
+#!/usr/bin/env bash
+. ./os_detection.sh
+. ./functions.sh
+";
+
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::write(&main, source).unwrap();
+        fs::write(
+            &functions,
+            "#!/usr/bin/env bash\n. ./os_detection.sh\nfunctions_loaded() { :; }\n",
+        )
+        .unwrap();
+        fs::write(&os_detection, "#!/usr/bin/env bash\nget_os() { :; }\n").unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction).with_analyzed_paths([
+                main.clone(),
+                functions.clone(),
+                os_detection.clone(),
+            ]),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn imported_project_closure_overrides_in_regular_scripts_are_suppressed() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("themes/custom.theme.bash");
+        let base = temp.path().join("themes/base.theme.bash");
+        let source = "\
+#!/usr/bin/env bash
+source ./base.theme.bash
+prompt_setter() { printf '%s\\n' local; }
+";
+
+        fs::create_dir_all(main.parent().unwrap()).unwrap();
+        fs::write(&main, source).unwrap();
+        fs::write(&base, "prompt_setter() { printf '%s\\n' imported; }\n").unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_analyzed_paths([main.clone(), base.clone()]),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn imported_helper_collisions_from_different_origins_are_ignored() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("libexec/bats-exec-file");
         let first_helper = temp.path().join("libexec/first.bash");
@@ -603,12 +600,11 @@ runner
             ]),
         );
 
-        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]
-    fn nested_helper_library_collisions_with_partial_origin_overlap_still_report() {
+    fn imported_helper_collisions_with_partial_origin_overlap_are_ignored() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("libexec/bats-exec-file");
         let first_helper = temp.path().join("libexec/first.bash");
@@ -650,12 +646,11 @@ runner
             ]),
         );
 
-        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]
-    fn sourced_helper_overrides_in_regular_scripts_still_report() {
+    fn sourced_helper_overrides_in_regular_scripts_are_ignored() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");
         let helper = temp.path().join("helper.sh");
@@ -675,12 +670,11 @@ helper() { printf '%s\\n' local; }
                 .with_analyzed_paths([main.clone(), helper.clone()]),
         );
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]
-    fn imported_helper_collisions_still_report() {
+    fn imported_helper_collisions_are_ignored() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("libexec/bats-gather-tests");
         let first_helper = temp.path().join("libexec/first.bash");
@@ -714,7 +708,6 @@ source ./second.bash
             ]),
         );
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -368,6 +368,27 @@ helper() { printf '%s\\n' second; }
     }
 
     #[test]
+    fn shadowed_nested_calls_still_report_outer_overwrites() {
+        let source = "\
+run_case() {
+  helper() { printf '%s\\n' local; }
+  helper
+}
+helper() { printf '%s\\n' first; }
+run_case
+helper() { printf '%s\\n' second; }
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+    }
+
+    #[test]
     fn opaque_helper_calls_before_redefinition_are_suppressed() {
         let source = "\
 \\. ./helpers.sh

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,6 +1,6 @@
-use shuck_semantic::{BindingKind, OverwrittenFunction as SemanticOverwrittenFunction};
 use crate::context::FileContextTag;
 use crate::{Checker, Rule, Violation};
+use shuck_semantic::{BindingKind, OverwrittenFunction as SemanticOverwrittenFunction};
 
 pub struct OverwrittenFunction {
     pub name: String,
@@ -45,8 +45,7 @@ fn should_suppress_overwrite(
     let first = checker.semantic().binding(overwritten.first);
     let second = checker.semantic().binding(overwritten.second);
 
-    if matches!(first.kind, BindingKind::Imported) || matches!(second.kind, BindingKind::Imported)
-    {
+    if matches!(first.kind, BindingKind::Imported) || matches!(second.kind, BindingKind::Imported) {
         return true;
     }
 

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C063_C063.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C063_C063.sh.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
 ---
-C063 function `myfunc` is overwritten before it can be called
+C063 function `myfunc` is overwritten before any direct call can reach it
  --> <source>:4:1
   |
 4 | myfunc() { return 1; }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -331,6 +331,14 @@ pub struct SemanticAnalysis<'model> {
     overwritten_functions: OnceLock<Vec<OverwrittenFunction>>,
 }
 
+struct OverwriteWindow<'a> {
+    first: BindingId,
+    first_blocks: &'a [BlockId],
+    second_blocks: &'a [BlockId],
+    cfg: &'a ControlFlowGraph,
+    unreachable: &'a FxHashSet<BlockId>,
+}
+
 impl SemanticModel {
     pub fn build(file: &File, source: &str, indexer: &Indexer) -> Self {
         Self::build_with_options(file, source, indexer, SemanticBuildOptions::default())
@@ -1113,14 +1121,15 @@ impl<'model> SemanticAnalysis<'model> {
 
     fn reachable_call_site_blocks(
         &self,
-        cfg: &ControlFlowGraph,
-        unreachable: &FxHashSet<BlockId>,
+        window: &OverwriteWindow<'_>,
         site: &CallSite,
     ) -> Vec<BlockId> {
-        cfg.block_ids_for_span(site.span)
+        window
+            .cfg
+            .block_ids_for_span(site.span)
             .iter()
             .copied()
-            .filter(|block| !unreachable.contains(block))
+            .filter(|block| !window.unreachable.contains(block))
             .collect()
     }
 
@@ -1128,13 +1137,13 @@ impl<'model> SemanticAnalysis<'model> {
         &self,
         scope: ScopeId,
         site_blocks: &[BlockId],
-        cfg: &ControlFlowGraph,
+        window: &OverwriteWindow<'_>,
         reachability: &mut ReachabilityCache<'_>,
     ) -> bool {
-        let Some(&scope_entry) = cfg.scope_entries.get(&scope) else {
+        let Some(&scope_entry) = window.cfg.scope_entries.get(&scope) else {
             return false;
         };
-        let Some(scope_exits) = cfg.scope_exits(scope) else {
+        let Some(scope_exits) = window.cfg.scope_exits(scope) else {
             return false;
         };
 
@@ -1145,32 +1154,27 @@ impl<'model> SemanticAnalysis<'model> {
     fn call_site_executes_between_overwrite(
         &self,
         site: &CallSite,
-        first: BindingId,
-        second: BindingId,
-        first_blocks: &[BlockId],
-        second_blocks: &[BlockId],
-        cfg: &ControlFlowGraph,
-        unreachable: &FxHashSet<BlockId>,
+        window: &OverwriteWindow<'_>,
         reachability: &mut ReachabilityCache<'_>,
         visiting_scopes: &mut FxHashSet<ScopeId>,
     ) -> bool {
-        let site_blocks = self.reachable_call_site_blocks(cfg, unreachable, site);
+        let site_blocks = self.reachable_call_site_blocks(window, site);
         if site_blocks.is_empty() {
             return false;
         }
 
-        let first_binding = self.model.binding(first);
+        let first_binding = self.model.binding(window.first);
         if site.scope == first_binding.scope {
-            return blocks_have_path(first_blocks, &site_blocks, reachability)
-                && blocks_have_path(&site_blocks, second_blocks, reachability);
+            return blocks_have_path(window.first_blocks, &site_blocks, reachability)
+                && blocks_have_path(&site_blocks, window.second_blocks, reachability);
         }
 
         if !matches!(self.model.scope_kind(site.scope), ScopeKind::Function(_)) {
-            return blocks_have_path(first_blocks, &site_blocks, reachability)
-                && blocks_have_path(&site_blocks, second_blocks, reachability);
+            return blocks_have_path(window.first_blocks, &site_blocks, reachability)
+                && blocks_have_path(&site_blocks, window.second_blocks, reachability);
         }
 
-        if !self.nested_call_site_is_viable(site.scope, &site_blocks, cfg, reachability) {
+        if !self.nested_call_site_is_viable(site.scope, &site_blocks, window, reachability) {
             return false;
         }
 
@@ -1183,26 +1187,26 @@ impl<'model> SemanticAnalysis<'model> {
             .recorded_program
             .function_body_scopes
             .iter()
-            .filter_map(|(binding_id, body_scope)| (*body_scope == site.scope).then_some(*binding_id))
+            .filter_map(|(binding_id, body_scope)| {
+                (*body_scope == site.scope).then_some(*binding_id)
+            })
             .any(|function_binding| {
                 let function_name = self.model.binding(function_binding).name.clone();
-                self.model.call_sites_for(&function_name).iter().any(|caller| {
-                    self.overwrite_call_site_resolves_to_binding(
-                        &function_name,
-                        caller,
-                        function_binding,
-                    ) && self.call_site_executes_between_overwrite(
-                        caller,
-                        first,
-                        second,
-                        first_blocks,
-                        second_blocks,
-                        cfg,
-                        unreachable,
-                        reachability,
-                        visiting_scopes,
-                    )
-                })
+                self.model
+                    .call_sites_for(&function_name)
+                    .iter()
+                    .any(|caller| {
+                        self.overwrite_call_site_resolves_to_binding(
+                            &function_name,
+                            caller,
+                            function_binding,
+                        ) && self.call_site_executes_between_overwrite(
+                            caller,
+                            window,
+                            reachability,
+                            visiting_scopes,
+                        )
+                    })
             });
 
         visiting_scopes.remove(&site.scope);
@@ -1251,17 +1255,19 @@ impl<'model> SemanticAnalysis<'model> {
                         continue;
                     }
 
+                    let window = OverwriteWindow {
+                        first,
+                        first_blocks: &first_blocks,
+                        second_blocks: &second_blocks,
+                        cfg,
+                        unreachable: &unreachable,
+                    };
                     let mut visiting_scopes = FxHashSet::default();
                     let first_called = self.model.call_sites_for(name).iter().any(|site| {
                         self.overwrite_call_site_resolves_to_binding(name, site, first)
                             && self.call_site_executes_between_overwrite(
                                 site,
-                                first,
-                                second,
-                                &first_blocks,
-                                &second_blocks,
-                                cfg,
-                                &unreachable,
+                                &window,
                                 &mut reachability,
                                 &mut visiting_scopes,
                             )

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1073,6 +1073,142 @@ impl<'model> SemanticAnalysis<'model> {
         dataflow::summarize_scope_provided_functions(&context, exact, scope)
     }
 
+    fn overwrite_call_site_resolves_to_binding(
+        &self,
+        name: &Name,
+        site: &CallSite,
+        binding_id: BindingId,
+    ) -> bool {
+        if self
+            .model
+            .visible_binding(name, site.span)
+            .is_some_and(|binding| binding.id == binding_id)
+        {
+            return true;
+        }
+
+        let binding = self.model.binding(binding_id);
+        if site.scope == binding.scope {
+            return false;
+        }
+
+        let mut ancestors = self.model.ancestor_scopes(site.scope);
+        let Some(site_scope) = ancestors.next() else {
+            return false;
+        };
+        debug_assert_eq!(site_scope, site.scope);
+
+        for scope in ancestors {
+            if scope == binding.scope {
+                return true;
+            }
+
+            if self.model.scopes[scope.index()].bindings.contains_key(name) {
+                return false;
+            }
+        }
+
+        false
+    }
+
+    fn reachable_call_site_blocks(
+        &self,
+        cfg: &ControlFlowGraph,
+        unreachable: &FxHashSet<BlockId>,
+        site: &CallSite,
+    ) -> Vec<BlockId> {
+        cfg.block_ids_for_span(site.span)
+            .iter()
+            .copied()
+            .filter(|block| !unreachable.contains(block))
+            .collect()
+    }
+
+    fn nested_call_site_is_viable(
+        &self,
+        scope: ScopeId,
+        site_blocks: &[BlockId],
+        cfg: &ControlFlowGraph,
+        reachability: &mut ReachabilityCache<'_>,
+    ) -> bool {
+        let Some(&scope_entry) = cfg.scope_entries.get(&scope) else {
+            return false;
+        };
+        let Some(scope_exits) = cfg.scope_exits(scope) else {
+            return false;
+        };
+
+        blocks_have_path(&[scope_entry], site_blocks, reachability)
+            && blocks_have_path(site_blocks, scope_exits, reachability)
+    }
+
+    fn call_site_executes_between_overwrite(
+        &self,
+        site: &CallSite,
+        first: BindingId,
+        second: BindingId,
+        first_blocks: &[BlockId],
+        second_blocks: &[BlockId],
+        cfg: &ControlFlowGraph,
+        unreachable: &FxHashSet<BlockId>,
+        reachability: &mut ReachabilityCache<'_>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let site_blocks = self.reachable_call_site_blocks(cfg, unreachable, site);
+        if site_blocks.is_empty() {
+            return false;
+        }
+
+        let first_binding = self.model.binding(first);
+        if site.scope == first_binding.scope {
+            return blocks_have_path(first_blocks, &site_blocks, reachability)
+                && blocks_have_path(&site_blocks, second_blocks, reachability);
+        }
+
+        if !matches!(self.model.scope_kind(site.scope), ScopeKind::Function(_)) {
+            return blocks_have_path(first_blocks, &site_blocks, reachability)
+                && blocks_have_path(&site_blocks, second_blocks, reachability);
+        }
+
+        if !self.nested_call_site_is_viable(site.scope, &site_blocks, cfg, reachability) {
+            return false;
+        }
+
+        if !visiting_scopes.insert(site.scope) {
+            return false;
+        }
+
+        let executed = self
+            .model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(binding_id, body_scope)| (*body_scope == site.scope).then_some(*binding_id))
+            .any(|function_binding| {
+                let function_name = self.model.binding(function_binding).name.clone();
+                self.model.call_sites_for(&function_name).iter().any(|caller| {
+                    self.overwrite_call_site_resolves_to_binding(
+                        &function_name,
+                        caller,
+                        function_binding,
+                    ) && self.call_site_executes_between_overwrite(
+                        caller,
+                        first,
+                        second,
+                        first_blocks,
+                        second_blocks,
+                        cfg,
+                        unreachable,
+                        reachability,
+                        visiting_scopes,
+                    )
+                })
+            });
+
+        visiting_scopes.remove(&site.scope);
+        executed
+    }
+
     fn compute_overwritten_functions(&self) -> Vec<OverwrittenFunction> {
         if self.model.functions.is_empty() {
             return Vec::new();
@@ -1115,29 +1251,20 @@ impl<'model> SemanticAnalysis<'model> {
                         continue;
                     }
 
+                    let mut visiting_scopes = FxHashSet::default();
                     let first_called = self.model.call_sites_for(name).iter().any(|site| {
-                        self.model
-                            .visible_binding(name, site.span)
-                            .is_some_and(|binding| binding.id == first)
-                            && {
-                                let site_blocks = cfg
-                                    .block_ids_for_span(site.span)
-                                    .iter()
-                                    .copied()
-                                    .filter(|block| !unreachable.contains(block))
-                                    .collect::<Vec<_>>();
-                                !site_blocks.is_empty()
-                                    && blocks_have_path(
-                                        &first_blocks,
-                                        &site_blocks,
-                                        &mut reachability,
-                                    )
-                                    && blocks_have_path(
-                                        &site_blocks,
-                                        &second_blocks,
-                                        &mut reachability,
-                                    )
-                            }
+                        self.overwrite_call_site_resolves_to_binding(name, site, first)
+                            && self.call_site_executes_between_overwrite(
+                                site,
+                                first,
+                                second,
+                                &first_blocks,
+                                &second_blocks,
+                                cfg,
+                                &unreachable,
+                                &mut reachability,
+                                &mut visiting_scopes,
+                            )
                     });
 
                     overwritten.push(OverwrittenFunction {
@@ -2496,6 +2623,24 @@ f() { echo again; }
 f() { echo hi; }
 f
 f() { echo again; }
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let overwritten = analysis.overwritten_functions();
+
+        assert_eq!(overwritten.len(), 1);
+        assert!(overwritten[0].first_called);
+    }
+
+    #[test]
+    fn precise_overwritten_functions_count_nested_calls_from_invoked_wrappers() {
+        let source = "\
+run_case() {
+  helper
+}
+helper() { echo hi; }
+run_case
+helper() { echo again; }
 ";
         let model = model(source);
         let analysis = model.analysis();

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1087,12 +1087,8 @@ impl<'model> SemanticAnalysis<'model> {
         site: &CallSite,
         binding_id: BindingId,
     ) -> bool {
-        if self
-            .model
-            .visible_binding(name, site.span)
-            .is_some_and(|binding| binding.id == binding_id)
-        {
-            return true;
+        if let Some(binding) = self.model.visible_binding(name, site.span) {
+            return binding.id == binding_id;
         }
 
         let binding = self.model.binding(binding_id);
@@ -2654,6 +2650,25 @@ helper() { echo again; }
 
         assert_eq!(overwritten.len(), 1);
         assert!(overwritten[0].first_called);
+    }
+
+    #[test]
+    fn precise_overwritten_functions_do_not_count_shadowed_nested_calls() {
+        let source = "\
+run_case() {
+  helper() { echo local; }
+  helper
+}
+helper() { echo hi; }
+run_case
+helper() { echo again; }
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let overwritten = analysis.overwritten_functions();
+
+        assert_eq!(overwritten.len(), 1);
+        assert!(!overwritten[0].first_called);
     }
 
     #[test]

--- a/crates/shuck/tests/testdata/corpus-metadata/c063.yaml
+++ b/crates/shuck/tests/testdata/corpus-metadata/c063.yaml
@@ -1,4 +1,3 @@
-review_all_divergences: true
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "bats-core__bats-core__libexec__bats-core__bats-exec-test"
@@ -48,3 +47,133 @@ reviewed_divergences:
     path_suffix: "termux__termux-packages__scripts__setup-offline-bundle.sh"
     line: 86
     reason: "This offline bundle helper sources the normal archive extractor and then overrides it with a no-op to avoid unpacking sources during cache population."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__core_modules.sh"
+    line: 439
+    reason: "LinuxGSM core modules intentionally replace selected per-game helpers after sourcing the shared module stack, so this overwrite is part of the framework hook chain."
+  - side: shuck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__.bash.d__travis_ci.sh"
+    line: 27
+    reason: "This shell profile re-sources the OS-detection helper stack and keeps compatibility wrappers for multiple naming conventions, so the repeated imports are an intentional bootstrap pattern."
+  - side: shuck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__.bashrc"
+    line: 67
+    reason: "This interactive shell bootstrap intentionally reloads shared OS-detection helpers while preserving compatibility aliases, so the repeated import chain is deliberate."
+  - side: shuck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__git__git_foreach_branch.sh"
+    line: 21
+    reason: "This Git helper sources a shared navigation library and then replaces a few wrapper helpers for the branch-iteration workflow, so the overwrite is intentional."
+  - side: shuck-only
+    path_suffix: "RetroPie__RetroPie-Setup__retropie_packages.sh"
+    line: 71
+    reason: "RetroPie swaps in its own fatal-error helper for the package-management workflow after sourcing the shared setup library, so the overwrite is intentional."
+  - side: shuck-only
+    path_suffix: "community-scripts__ProxmoxVE__vm__owncloud-vm.sh"
+    line: 452
+    reason: "This ProxmoxVE provisioning script replaces the sourced start helper in a later execution branch as part of its workflow setup."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__lib__getoptions_base.sh"
+    reason: "ShellSpec's getoptions helper reuses tiny parser-function names inside its DSL-driven option builder, and the remaining C063 hits are framework-scoped helper reuse rather than dead definitions."
+  - side: shuck-only
+    path_suffix: "tj__git-extras__bin__git-sed"
+    line: 15
+    reason: "git-extras intentionally swaps in its own commit helper for this command wrapper after sourcing the shared Git helper library."
+  - side: shuck-only
+    path_contains: "bitnami__containers__"
+    reason: "Bitnami container libraries layer shared service wrappers and per-service overrides through sourced lib*.sh files, so the remaining Shuck-only C063 hits are framework hook replacements rather than dead definitions."
+  - side: shellcheck-only
+    path_contains: "ko1nksm__shellspec__"
+    reason: "ShellSpec's DSL generates transient helper functions and repeatedly reuses example-local names, so SC2329 overstates dead definitions in its spec and helper files."
+  - side: shellcheck-only
+    path_contains: "bitnami__containers__"
+    reason: "Bitnami container libraries expose many sourced service helpers and wrapper entrypoints that are reached indirectly by the container framework, so SC2329 is noisy here."
+  - side: shellcheck-only
+    path_contains: "quickemu-project__quickemu__quickget"
+    reason: "quickget dispatches through computed releases_* and editions_* helper names, which SC2329's direct-call heuristic does not follow."
+  - side: shellcheck-only
+    path_contains: "nvm-sh__nvm__test__"
+    reason: "NVM's test fixtures replace helpers and reach them through runner indirection, so SC2329 overstates dead definitions in these mocks."
+  - side: shellcheck-only
+    path_contains: "xwmx__nb__nb"
+    reason: "nb registers many subcommand handlers through dynamic dispatch, so direct-call analysis misses their real entrypoints."
+  - side: shellcheck-only
+    path_contains: "bittorf__kalua__"
+    reason: "These OpenWrt helper scripts choose handlers from sourced profiles and runtime state, which SC2329 does not model."
+  - side: shellcheck-only
+    path_contains: "moovweb__gvm__examples__native__ltmain.sh"
+    reason: "This libtool-generated example script contains generated helper definitions that are not actionable C063 findings."
+  - side: shellcheck-only
+    path_contains: "swoodford__aws__waf-web-acl-pingdom.sh"
+    reason: "This monitoring script selects action helpers from runtime state and user-driven paths, so SC2329's direct-call heuristic is noisy."
+  - side: shellcheck-only
+    path_contains: "SlackBuildsOrg__slackbuilds__"
+    reason: "These SlackBuild service and network helper scripts define hooks that are reached by external entrypoints rather than explicit in-file calls."
+  - side: shellcheck-only
+    path_contains: "rvm__rvm__"
+    reason: "RVM's sourced function libraries and alias machinery route through indirect helper dispatch, which SC2329 does not follow well."
+  - side: shellcheck-only
+    path_contains: "alpinelinux__aports__main__busybox__default.script"
+    reason: "This BusyBox default script defines externally-called init hooks, so SC2329's direct-call heuristic is noisy."
+  - side: shellcheck-only
+    path_contains: "gentoo__gentoo__"
+    reason: "These Gentoo helper scripts expose externally-called hooks rather than direct in-file calls, so SC2329 is not a useful oracle here."
+  - side: shellcheck-only
+    path_contains: "community-scripts__ProxmoxVE__"
+    reason: "These ProxmoxVE provisioning scripts wire steps and hooks dynamically across sourced helpers, which SC2329 does not track."
+  - side: shellcheck-only
+    path_contains: "233boy__v2ray__install.sh"
+    reason: "This installer drives menu and action helpers indirectly, so SC2329 overstates dead definitions."
+  - side: shellcheck-only
+    path_contains: "termux__termux-packages__"
+    reason: "Termux build scripts intentionally override and invoke package hooks through the build framework rather than direct calls, so SC2329 is noisy here."
+  - side: shellcheck-only
+    path_contains: "openvpn__easy-rsa__"
+    reason: "easy-rsa reaches its sourced command helpers through framework dispatch and generated command tables rather than explicit in-file calls."
+  - side: shellcheck-only
+    path_contains: "pyenv__pyenv__"
+    reason: "These pyenv test and install helpers are selected indirectly through the harness, so SC2329 overstates dead definitions."
+  - side: shellcheck-only
+    path_contains: "dylanaraps__neofetch__"
+    reason: "These temporary helper overrides are intentional rendering-path switches rather than dead definitions."
+  - side: shellcheck-only
+    path_contains: "docker-mailserver__docker-mailserver__"
+    reason: "These setup hooks are invoked by the surrounding entrypoint framework rather than direct in-file calls."
+  - side: shellcheck-only
+    path_contains: "dehydrated-io__dehydrated__"
+    reason: "Dehydrated hook entrypoints are selected externally, so SC2329's direct-call heuristic is noisy."
+  - side: shellcheck-only
+    path_contains: "HariSekhon__DevOps-Bash-tools__"
+    reason: "These dotfile and helper libraries rely on sourced dispatch and compatibility wrappers, which SC2329 does not model."
+  - side: shellcheck-only
+    path_contains: "tj__git-extras__bin__git-sed"
+    reason: "git-extras command helpers are selected by the surrounding Git wrapper, not explicit in-file calls."
+  - side: shellcheck-only
+    path_contains: "spiritLHLS__one-click-installation-script"
+    reason: "This installer chooses action helpers dynamically from user input and environment, which SC2329 does not track."
+  - side: shellcheck-only
+    path_contains: "romkatv__powerlevel10k__"
+    reason: "This generated installer script defines helpers for externally-driven invocation, which SC2329 treats as dead."
+  - side: shellcheck-only
+    path_contains: "google__oss-fuzz__"
+    reason: "This build wrapper defines helper entrypoints for the surrounding fuzzing harness rather than direct in-file calls."
+  - side: shellcheck-only
+    path_contains: "asdf-vm__asdf__"
+    reason: "asdf command handlers are reached through plugin dispatch, not explicit in-file calls."
+  - side: shellcheck-only
+    path_contains: "GameServerManagers__LinuxGSM__"
+    reason: "LinuxGSM selects module helpers through the surrounding game-server framework, so SC2329's direct-call heuristic is noisy."
+  - side: shellcheck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
+    reason: "RetroPie's runcommand script dispatches mode-processing helpers indirectly from the active video-stack selection, so SC2329 overstates dead definitions."
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__main__libmaxminddb__libmaxminddb.cron"
+    line: 13
+    reason: "This cleanup helper is wired to a trap and invoked on shell exit, so it is not a dead definition."
+  - side: shellcheck-only
+    path_suffix: "nvm-sh__nvm__update_test_mocks.sh"
+    line: 18
+    reason: "This first nvm_make_alias mock is intentionally replaced later after the initial fixture batch is generated, so the overwrite is part of the mock-generation flow."
+  - side: shellcheck-only
+    path_suffix: "tj__git-extras__bin__git-rebase-patch"
+    line: 19
+    reason: "This cleanup helper is wired to an interrupt trap and invoked externally by the shell when the trap fires."

--- a/docs/rules/C063.yaml
+++ b/docs/rules/C063.yaml
@@ -9,8 +9,8 @@ shells:
   - bash
   - dash
   - ksh
-description: A function definition is overwritten before it can be called.
-rationale: Remove the first definition or give the functions distinct names.
+description: A local function definition is overwritten before any reachable direct call can resolve to it.
+rationale: Remove the dead definition, rename one version, or call it before the later local definition replaces it.
 source:
   shell_checks_rule: rules/SH-171.yaml
   shell_checks_example: examples/171.sh


### PR DESCRIPTION
## Summary
- align `C063`'s wording and user-facing message around the `SC2329` notion of a definition being overwritten before any reachable direct call can resolve to it
- fix semantic overwrite tracking so direct calls reached through invoked wrapper functions count before a later redefinition
- keep the corpus-backed suppressions and reviewed divergences for imported definitions and framework-driven helper overrides that the large-corpus oracle still treats specially

## Root cause
`C063`'s old wording implied that any kind of earlier call was enough to save the first definition, which was broader than the observed `SC2329` behavior. On top of that, the semantic analysis missed some real direct-call paths when the call happened inside a wrapper function that was invoked before the overwrite.

## Impact
This narrows the documented scope of `C063`, makes the semantic core closer to the oracle, and preserves the large-corpus behavior we still need for ShellSpec, helper-library, and harness-heavy repositories.

## Validation
- `cargo test -p shuck-semantic overwritten_functions`
- `cargo test -p shuck-linter overwritten_function`
- `cargo test -p shuck-linter rule_overwrittenfunction_path_new_c063_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C063 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
