### PR TITLE
Reuse full-output source buffers in check diagnostics

### DIFF
--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -27,6 +27,8 @@ tikv-jemallocator = "0.6"
 criterion = { version = "0.5", features = ["html_reports"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shuck = { path = "../shuck" }
+tempfile = { workspace = true }
 
 [[example]]
 name = "parser_counts"
@@ -62,4 +64,8 @@ harness = false
 
 [[bench]]
 name = "formatter"
+harness = false
+
+[[bench]]
+name = "check_command"
 harness = false

--- a/crates/shuck-benchmark/benches/check_command.rs
+++ b/crates/shuck-benchmark/benches/check_command.rs
@@ -1,0 +1,65 @@
+use std::fs;
+use std::path::PathBuf;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use shuck::args::CheckOutputFormatArg;
+use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator};
+use tempfile::TempDir;
+
+configure_benchmark_allocator!();
+
+struct PreparedCheckCase {
+    _tempdir: TempDir,
+    cwd: PathBuf,
+    paths: Vec<PathBuf>,
+}
+
+fn prepare_check_case(case: shuck_benchmark::TestCase) -> PreparedCheckCase {
+    let tempdir = tempfile::tempdir().expect("benchmark tempdir should exist");
+    let cwd = tempdir.path().to_path_buf();
+    let mut paths = Vec::with_capacity(case.files.len());
+
+    for (index, file) in case.files.iter().enumerate() {
+        let path = cwd.join(format!("{index:02}-{}.sh", file.name));
+        fs::write(&path, file.source).expect("benchmark fixture should write");
+        paths.push(path);
+    }
+
+    PreparedCheckCase {
+        _tempdir: tempdir,
+        cwd,
+        paths,
+    }
+}
+
+fn bench_check_command(c: &mut Criterion) {
+    let cases = benchmark_cases();
+
+    for output_format in [CheckOutputFormatArg::Concise, CheckOutputFormatArg::Full] {
+        let group_name = match output_format {
+            CheckOutputFormatArg::Concise => "check_command_concise",
+            CheckOutputFormatArg::Full => "check_command_full",
+        };
+        let mut group = c.benchmark_group(group_name);
+
+        for case in &cases {
+            group.sample_size(case.speed.sample_size());
+            group.throughput(Throughput::Bytes(case.total_bytes()));
+            let prepared = prepare_check_case(*case);
+
+            group.bench_with_input(BenchmarkId::from_parameter(case.name), &prepared, |b, input| {
+                b.iter(|| {
+                    black_box(
+                        shuck::benchmark_check_paths(&input.cwd, &input.paths, output_format)
+                            .expect("check benchmark should succeed"),
+                    )
+                });
+            });
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_check_command);
+criterion_main!(benches);

--- a/crates/shuck-benchmark/benches/check_command.rs
+++ b/crates/shuck-benchmark/benches/check_command.rs
@@ -47,14 +47,18 @@ fn bench_check_command(c: &mut Criterion) {
             group.throughput(Throughput::Bytes(case.total_bytes()));
             let prepared = prepare_check_case(*case);
 
-            group.bench_with_input(BenchmarkId::from_parameter(case.name), &prepared, |b, input| {
-                b.iter(|| {
-                    black_box(
-                        shuck::benchmark_check_paths(&input.cwd, &input.paths, output_format)
-                            .expect("check benchmark should succeed"),
-                    )
-                });
-            });
+            group.bench_with_input(
+                BenchmarkId::from_parameter(case.name),
+                &prepared,
+                |b, input| {
+                    b.iter(|| {
+                        black_box(
+                            shuck::benchmark_check_paths(&input.cwd, &input.paths, output_format)
+                                .expect("check benchmark should succeed"),
+                        )
+                    });
+                },
+            );
         }
 
         group.finish();

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io::{self, BufWriter};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
@@ -240,6 +240,26 @@ fn run_check_with_cwd(args: &CheckCommand, cwd: &Path, cache_root: &Path) -> Res
     Ok(report)
 }
 
+pub(crate) fn benchmark_check_paths(
+    cwd: &Path,
+    paths: &[PathBuf],
+    output_format: crate::args::CheckOutputFormatArg,
+) -> Result<usize> {
+    let report = run_check_with_cwd(
+        &CheckCommand {
+            fix: false,
+            unsafe_fixes: false,
+            no_cache: true,
+            output_format,
+            paths: paths.to_vec(),
+        },
+        cwd,
+        &cwd.join("cache"),
+    )?;
+
+    Ok(report.diagnostics.len())
+}
+
 fn analyze_file(
     pending: PendingProjectFile,
     base_linter_settings: &LinterSettings,
@@ -301,7 +321,7 @@ fn analyze_file(
 
 fn lint_parsed_output(
     pending: &PendingProjectFile,
-    source: &str,
+    source: &Arc<str>,
     parse_result: &ParseResult,
     linter_settings: &LinterSettings,
     shellcheck_map: &ShellCheckCodeMap,
@@ -329,8 +349,7 @@ fn lint_parsed_output(
         suppression_index.as_ref(),
         Some(&pending.file.absolute_path),
     );
-    let diagnostic_source =
-        (!diagnostics.is_empty() && include_source).then(|| Arc::<str>::from(source));
+    let diagnostic_source = (!diagnostics.is_empty() && include_source).then(|| source.clone());
 
     (
         CheckCacheData::Success(
@@ -763,5 +782,31 @@ mod tests {
             second.diagnostics[0].source.as_deref(),
             Some("#!/bin/bash\nunused=1\necho ok\n")
         );
+    }
+
+    #[test]
+    fn lint_diagnostics_share_the_original_source_arc_for_full_output() {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("warn.sh");
+        fs::write(&path, "#!/bin/bash\nunused=1\necho ok\n").unwrap();
+
+        let pending = pending_project_file(&path, tempdir.path());
+        let source = read_shared_source(&path).unwrap();
+        let parse_result = Parser::with_dialect(&source, shuck_parser::ShellDialect::Bash).parse();
+
+        let (_, diagnostics) = lint_parsed_output(
+            &pending,
+            &source,
+            &parse_result,
+            &LinterSettings::default(),
+            &ShellCheckCodeMap::default(),
+            true,
+        );
+
+        let diagnostic_source = diagnostics[0]
+            .source
+            .as_ref()
+            .expect("full output should retain source");
+        assert!(Arc::ptr_eq(diagnostic_source, &source));
     }
 }

--- a/crates/shuck/src/lib.rs
+++ b/crates/shuck/src/lib.rs
@@ -40,6 +40,15 @@ pub fn run(args: Args) -> Result<ExitStatus> {
     }
 }
 
+#[doc(hidden)]
+pub fn benchmark_check_paths(
+    cwd: &Path,
+    paths: &[PathBuf],
+    output_format: args::CheckOutputFormatArg,
+) -> Result<usize> {
+    commands::check::benchmark_check_paths(cwd, paths, output_format)
+}
+
 fn format(mut args: FormatCommand, cache_dir: Option<&Path>) -> Result<ExitStatus> {
     let stdin = is_stdin(&args.files, args.stdin_filename.as_deref());
     args.files = resolve_default_files(args.files, stdin);


### PR DESCRIPTION
## Summary
- reuse the original `Arc<str>` when `shuck check --output-format full` stores diagnostic source text
- add a regression test that asserts full-output diagnostics share the original source buffer
- add a targeted `check_command` Criterion bench that exercises the real `shuck check` path in both concise and full modes

## Testing
- `cargo test -p shuck --quiet`
- `cargo bench -p shuck-benchmark --bench check_command --no-run`
- `cargo bench -p shuck-benchmark --bench check_command -- --save-baseline=main --noplot`
- `cargo bench -p shuck-benchmark --bench check_command -- --baseline=main --noplot`

## Benchmark Notes
Dedicated `check_command` bench deltas vs `main`:

`check_command_concise`
- `all`: `-7.15%`
- `fzf-install`: `-19.46%`
- `homebrew-install`: `+1.47%`
- `nvm`: `-6.16%`
- `pyenv-python-build`: `+5.96%`
- `ruby-build`: `+5.36%`

`check_command_full`
- `all`: `+10.18%`
- `fzf-install`: `-6.22%`
- `homebrew-install`: `+1.19%`
- `nvm`: `+5.88%`
- `pyenv-python-build`: `+11.25%`
- `ruby-build`: `-15.76%`

These results are mixed, but this bench now covers the exact `check --output-format full` path that previously wasn't represented in the suite.
