### PR TITLE
Reduce linter word allocation churn

### DIFF
--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -649,10 +649,7 @@ impl<'a> CommandOptionFacts<'a> {
                 .then(|| parse_unset_command(normalized.body_args(), source)),
             find: (normalized.effective_name_is("find")
                 || normalized.literal_name.as_deref() == Some("find"))
-            .then(|| {
-                let args = find_command_args(command, normalized, source);
-                parse_find_command(args.as_slice(), source)
-            }),
+            .then(|| parse_find_command(find_command_args(command, normalized, source), source)),
             find_exec: (normalized.has_wrapper(WrapperKind::FindExec)
                 || normalized.has_wrapper(WrapperKind::FindExecDir))
             .then(|| FindExecCommandFacts {
@@ -779,7 +776,7 @@ fn parse_echo_command<'a>(args: &[&'a Word], source: &str) -> EchoCommandFacts<'
             break;
         };
 
-        if !is_echo_portability_flag(text.as_str()) {
+        if !is_echo_portability_flag(text.as_ref()) {
             break;
         }
 
@@ -1030,7 +1027,7 @@ fn parse_tr_command<'a>(args: &[&'a Word], source: &str) -> TrCommandFacts<'a> {
             break;
         }
 
-        if !is_tr_option(text.as_str()) {
+        if !is_tr_option(text.as_ref()) {
             break;
         }
 
@@ -1156,7 +1153,7 @@ fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
             continue;
         }
 
-        match text.as_str() {
+        match text.as_ref() {
             "-" | "-l" | "--login" => {
                 return SuCommandFacts {
                     has_login_or_command_flag: true,
@@ -1179,7 +1176,7 @@ fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
                     };
                 }
             }
-            _ if su_long_option_takes_argument(text.as_str()) => {
+            _ if su_long_option_takes_argument(text.as_ref()) => {
                 pending_option_arg = true;
                 index += 1;
                 continue;
@@ -1265,7 +1262,7 @@ fn ssh_remote_args<'a>(args: &'a [&'a Word], source: &str) -> Option<&'a [&'a Wo
         }
 
         saw_local_option = true;
-        let consumes_next = ssh_option_consumes_next_argument(text.as_str())?;
+        let consumes_next = ssh_option_consumes_next_argument(text.as_ref())?;
         index += 1;
         if consumes_next {
             args.get(index)?;
@@ -1750,7 +1747,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
         }
 
         if matches!(
-            text.as_str(),
+            text.as_ref(),
             "--basic-regexp" | "--extended-regexp" | "--perl-regexp"
         ) {
             uses_fixed_strings = false;
@@ -1798,7 +1795,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
         }
 
         if text.starts_with("--") {
-            index += if grep_long_option_takes_argument(text.as_str())
+            index += if grep_long_option_takes_argument(text.as_ref())
                 && args.get(index + 1).is_some()
             {
                 2
@@ -1968,11 +1965,11 @@ fn sed_has_explicit_script_source(args: &[&Word], source: &str) -> bool {
     args.iter()
         .filter_map(|word| static_word_text(word, source))
         .any(|text| {
-            matches!(text.as_str(), "-e" | "-f" | "--expression" | "--file")
+            matches!(text.as_ref(), "-e" | "-f" | "--expression" | "--file")
                 || text.starts_with("--expression=")
                 || text.starts_with("--file=")
-                || short_option_cluster_contains_flag(text.as_str(), 'e')
-                || short_option_cluster_contains_flag(text.as_str(), 'f')
+                || short_option_cluster_contains_flag(text.as_ref(), 'e')
+                || short_option_cluster_contains_flag(text.as_ref(), 'f')
         })
 }
 
@@ -1980,9 +1977,9 @@ fn awk_has_file_program_source(args: &[&Word], source: &str) -> bool {
     args.iter()
         .filter_map(|word| static_word_text(word, source))
         .any(|text| {
-            matches!(text.as_str(), "-f" | "--file")
+            matches!(text.as_ref(), "-f" | "--file")
                 || text.starts_with("--file=")
-                || short_option_cluster_contains_flag(text.as_str(), 'f')
+                || short_option_cluster_contains_flag(text.as_ref(), 'f')
         })
 }
 
@@ -2049,7 +2046,7 @@ fn collect_file_operand_words_after_prefix<'a>(
         }
 
         if options_open && text.starts_with('-') && text != "-" {
-            if let Some(action) = option_arg_action(text.as_str()) {
+            if let Some(action) = option_arg_action(text.as_ref()) {
                 pending_option_arg_action = Some(action);
             }
             index += 1;
@@ -2167,7 +2164,7 @@ fn jq_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
                 }
             }
 
-            match text.as_str() {
+            match text.as_ref() {
                 "-n" | "--null-input" => {
                     null_input = true;
                 }
@@ -2264,7 +2261,7 @@ fn grep_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word>
         if text == "--only-matching"
             || text == "--fixed-strings"
             || matches!(
-                text.as_str(),
+                text.as_ref(),
                 "--basic-regexp" | "--extended-regexp" | "--perl-regexp"
             )
         {
@@ -2285,7 +2282,7 @@ fn grep_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word>
         }
 
         if text.starts_with("--") {
-            index += if grep_long_option_takes_argument(text.as_str())
+            index += if grep_long_option_takes_argument(text.as_ref())
                 && args.get(index + 1).is_some()
             {
                 2
@@ -2604,7 +2601,7 @@ fn parse_ps_command(args: &[&Word], source: &str) -> PsCommandFacts {
             break;
         }
 
-        if matches!(text.as_str(), "p" | "q") {
+        if matches!(text.as_ref(), "p" | "q") {
             has_pid_selector = true;
             pending_option_arg = true;
             index += 1;
@@ -2618,13 +2615,13 @@ fn parse_ps_command(args: &[&Word], source: &str) -> PsCommandFacts {
                 continue;
             }
 
-            if text != "-" && ps_bare_pid_selector(text.as_str()) {
+            if text != "-" && ps_bare_pid_selector(text.as_ref()) {
                 has_pid_selector = true;
                 index += 1;
                 continue;
             }
 
-            if ps_bsd_option_cluster(text.as_str()) {
+            if ps_bsd_option_cluster(text.as_ref()) {
                 index += 1;
                 continue;
             }
@@ -2813,7 +2810,7 @@ fn first_nonportable_sh_export_option_span(operands: &[DeclOperand], source: &st
                 }
 
                 if sh_builtin_option_word_is_portable(
-                    text.as_str(),
+                    text.as_ref(),
                     ShBuiltinOptionPolicy::AllowOnly("p"),
                 ) {
                     continue;
@@ -2849,7 +2846,7 @@ fn first_nonportable_sh_option_span_in_words(
             return None;
         }
 
-        if sh_builtin_option_word_is_portable(text.as_str(), policy) {
+        if sh_builtin_option_word_is_portable(text.as_ref(), policy) {
             continue;
         }
 
@@ -3104,7 +3101,7 @@ fn parse_find_exec_shell_command(
             index += 1;
             continue;
         };
-        if !matches!(action.as_str(), "-exec" | "-execdir" | "-ok" | "-okdir") {
+        if !matches!(action.as_ref(), "-exec" | "-execdir" | "-ok" | "-okdir") {
             index += 1;
             continue;
         }
@@ -3117,7 +3114,7 @@ fn parse_find_exec_shell_command(
             .map(|offset| argument_start + offset);
         let argument_end = terminator_index.unwrap_or(words.len());
 
-        if matches!(action.as_str(), "-exec" | "-execdir")
+        if matches!(action.as_ref(), "-exec" | "-execdir")
             && let Some(segment) = words.get(argument_start..argument_end)
         {
             shell_command_spans.extend(find_exec_shell_command_spans(segment, source));
@@ -3156,7 +3153,7 @@ fn find_exec_shell_command_spans(args: &[&Word], source: &str) -> Vec<Span> {
         .windows(2)
         .filter_map(|pair| {
             let flag = static_word_text(pair[0], source)?;
-            if !shell_flag_contains_command_string(flag.as_str()) {
+            if !shell_flag_contains_command_string(flag.as_ref()) {
                 return None;
             }
             let script = pair[1];
@@ -3183,7 +3180,7 @@ fn parse_find_exec_argument_word_spans(command: &Command, source: &str) -> Vec<S
             index += 1;
             continue;
         };
-        if !matches!(action.as_str(), "-exec" | "-ok" | "-execdir" | "-okdir") {
+        if !matches!(action.as_ref(), "-exec" | "-ok" | "-execdir" | "-okdir") {
             index += 1;
             continue;
         }
@@ -3240,19 +3237,42 @@ fn is_find_exec_semicolon_terminator(word: &Word, source: &str) -> bool {
 
 fn find_command_args<'a>(
     command: &'a Command,
-    normalized: &NormalizedCommand<'a>,
+    normalized: &'a NormalizedCommand<'a>,
     source: &'a str,
-) -> Vec<&'a Word> {
+) -> impl Iterator<Item = &'a Word> + 'a {
     if normalized.literal_name.as_deref() == Some("find")
         && let Command::Simple(command) = command
     {
-        return simple_command_body_words(command, source).skip(1).collect();
+        return EitherFindCommandArgs::Simple(simple_command_body_words(command, source).skip(1));
     }
 
-    normalized.body_args().to_vec()
+    EitherFindCommandArgs::Normalized(normalized.body_args().iter().copied())
 }
 
-fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
+enum EitherFindCommandArgs<I, J> {
+    Simple(I),
+    Normalized(J),
+}
+
+impl<'a, I, J> Iterator for EitherFindCommandArgs<I, J>
+where
+    I: Iterator<Item = &'a Word>,
+    J: Iterator<Item = &'a Word>,
+{
+    type Item = &'a Word;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Simple(iter) => iter.next(),
+            Self::Normalized(iter) => iter.next(),
+        }
+    }
+}
+
+fn parse_find_command<'a>(
+    args: impl IntoIterator<Item = &'a Word>,
+    source: &str,
+) -> FindCommandFacts {
     let mut has_print0 = false;
     let mut has_formatted_output_action = false;
     let mut or_without_grouping_spans = Vec::new();
@@ -3279,7 +3299,7 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
             {
                 glob_pattern_operand_spans.push(word.span);
             }
-            pending_argument = state.after_consuming(text.as_str());
+            pending_argument = state.after_consuming(text.as_ref());
             continue;
         }
 
@@ -3287,12 +3307,12 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
             has_print0 = true;
         }
 
-        if is_find_group_open_token(text.as_str()) {
+        if is_find_group_open_token(text.as_ref()) {
             group_stack.push(FindGroupState::default());
             continue;
         }
 
-        if is_find_group_close_token(text.as_str()) {
+        if is_find_group_close_token(text.as_ref()) {
             if let Some(child) = (group_stack.len() > 1).then(|| group_stack.pop()).flatten() {
                 group_stack
                     .last_mut()
@@ -3306,32 +3326,32 @@ fn parse_find_command(args: &[&Word], source: &str) -> FindCommandFacts {
             .last_mut()
             .expect("group stack retains the root frame");
 
-        if is_find_or_token(text.as_str()) {
+        if is_find_or_token(text.as_ref()) {
             state.note_or();
             continue;
         }
 
-        if is_find_and_token(text.as_str()) {
+        if is_find_and_token(text.as_ref()) {
             state.note_and();
             continue;
         }
 
-        if is_find_branch_action_token(text.as_str()) {
-            if matches!(text.as_str(), "-fprint0" | "-printf" | "-fprintf") {
+        if is_find_branch_action_token(text.as_ref()) {
+            if matches!(text.as_ref(), "-fprint0" | "-printf" | "-fprintf") {
                 has_formatted_output_action = true;
             }
             state.note_action(
                 word.span,
-                is_find_reportable_action_token(text.as_str()),
+                is_find_reportable_action_token(text.as_ref()),
                 &mut or_without_grouping_spans,
             );
-            pending_argument = find_pending_argument(text.as_str());
+            pending_argument = find_pending_argument(text.as_ref());
             continue;
         }
 
-        if is_find_predicate_token(text.as_str()) {
+        if is_find_predicate_token(text.as_ref()) {
             state.note_predicate();
-            pending_argument = find_pending_argument(text.as_str());
+            pending_argument = find_pending_argument(text.as_ref());
         }
     }
 
@@ -3603,7 +3623,7 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
         && first_text != "--"
         && !first_text.starts_with('-')
         && !first_text.starts_with('+')
-        && is_shell_variable_name(first_text.as_str())
+        && is_shell_variable_name(first_text.as_ref())
     {
         flags_without_prefix_spans.push(first_word.span);
     }
@@ -3619,7 +3639,7 @@ fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
             break;
         }
 
-        match text.as_str() {
+        match text.as_ref() {
             "-o" | "+o" => {
                 let enable = text.starts_with('-');
                 if text.starts_with('+') {
@@ -3730,12 +3750,12 @@ fn parse_directory_change_command(
     ) && normalized.wrappers.is_empty()
         && target
             .as_ref()
-            .is_some_and(|target| is_directory_stack_marker(target.as_str()));
+            .is_some_and(|target| is_directory_stack_marker(target.as_ref()));
 
     let manual_restore_candidate = kind == DirectoryChangeCommandKind::Cd
         && target
             .as_ref()
-            .is_some_and(|target| matches!(target.as_str(), ".." | "-"));
+            .is_some_and(|target| matches!(target.as_ref(), ".." | "-"));
 
     Some(DirectoryChangeCommandFacts {
         kind,
@@ -3759,4 +3779,3 @@ fn is_directory_stack_marker(target: &str) -> bool {
 
     saw_segment
 }
-

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -263,7 +263,7 @@ fn collect_c107_status_spans_in_simple_test(
         return;
     };
     if !matches!(
-        operator.as_str(),
+        operator.as_ref(),
         "=" | "==" | "!=" | "-eq" | "-ne" | "-lt" | "-le" | "-gt" | "-ge"
     ) {
         return;

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -653,15 +653,15 @@ fn simple_test_effective_operand_text(
 
     let mut text = static_word_text(word, source)?;
     if classify_word(word, source).quote == WordQuote::Unquoted {
-        match text.as_str() {
-            r"\(" => text = "(".to_owned(),
-            r"\)" => text = ")".to_owned(),
-            r"\!" => text = "!".to_owned(),
+        match text.as_ref() {
+            r"\(" => text = "(".into(),
+            r"\)" => text = ")".into(),
+            r"\!" => text = "!".into(),
             _ => {}
         }
     }
 
-    Some(text)
+    Some(text.into_owned())
 }
 
 fn simple_test_effective_unquoted_operand_text(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1356,7 +1356,8 @@ struct DerivedWordFactData {
 
 fn derive_word_fact_data(word: &Word, source: &str) -> DerivedWordFactData {
     DerivedWordFactData {
-        static_text: static_word_text(word, source).map(String::into_boxed_str),
+        static_text: static_word_text(word, source)
+            .map(|text| text.into_owned().into_boxed_str()),
         starts_with_extglob: span::word_starts_with_extglob(word, source),
         has_literal_affixes: word_has_literal_affixes(word),
         contains_shell_quoting_literals: word_contains_shell_quoting_literals(word, source),
@@ -1822,8 +1823,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                                 self.collect_array_index_arithmetic_spans(word);
                                 self.collect_dollar_prefixed_indexed_subscript_spans(word);
                             }
-                            self.push_owned_word_with_surface(
-                                word.clone(),
+                            self.push_word_with_surface(
+                                word,
                                 WordFactContext::Expansion(
                                     ExpansionContext::DeclarationAssignmentValue,
                                 ),
@@ -1870,8 +1871,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     self.collect_array_index_arithmetic_spans(word);
                     self.collect_dollar_prefixed_indexed_subscript_spans(word);
                 }
-                self.push_owned_word_with_surface(
-                    word.clone(),
+                self.push_word_with_surface(
+                    word,
                     context,
                     WordFactHostKind::AssignmentTargetSubscript,
                     surface_context,
@@ -1915,8 +1916,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                                 if indexed_semantics {
                                     self.collect_dollar_prefixed_indexed_subscript_spans(word);
                                 }
-                                self.push_owned_word_with_surface(
-                                    word.clone(),
+                                self.push_word_with_surface(
+                                    word,
                                     context,
                                     WordFactHostKind::ArrayKeySubscript,
                                     surface_context,
@@ -1950,7 +1951,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
 
     fn collect_pattern_context_words(
         &mut self,
-        pattern: &Pattern,
+        pattern: &'a Pattern,
         context: WordFactContext,
         host_kind: WordFactHostKind,
         surface_context: Option<SurfaceScanContext<'_>>,
@@ -1976,14 +1977,9 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 }
                 PatternPart::Word(word) => {
                     if let Some(surface_context) = surface_context {
-                        self.push_owned_word_with_surface(
-                            word.clone(),
-                            context,
-                            host_kind,
-                            surface_context,
-                        );
+                        self.push_word_with_surface(word, context, host_kind, surface_context);
                     } else {
-                        self.push_owned_word(word.clone(), context, host_kind);
+                        self.push_word(word, context, host_kind);
                     }
                 }
                 PatternPart::Literal(_) | PatternPart::CharClass(_) if is_case_pattern => {}
@@ -2034,7 +2030,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
 
     fn collect_zsh_qualified_glob_context_words(
         &mut self,
-        glob: &ZshQualifiedGlob,
+        glob: &'a ZshQualifiedGlob,
         context: WordFactContext,
         host_kind: WordFactHostKind,
     ) {
@@ -2098,8 +2094,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     reference,
                     self.source,
                     &mut |word| {
-                        self.push_owned_word_with_surface(
-                            word.clone(),
+                        self.push_word_with_surface(
+                            word,
                             WordFactContext::Expansion(
                                 ExpansionContext::ConditionalVarRefSubscript,
                             ),
@@ -2114,7 +2110,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
 
     fn collect_word_parameter_patterns(
         &mut self,
-        parts: &[WordPartNode],
+        parts: &'a [WordPartNode],
         host_kind: WordFactHostKind,
     ) {
         for part in parts {
@@ -2164,7 +2160,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
 
     fn collect_parameter_operator_patterns(
         &mut self,
-        operator: &ParameterOp,
+        operator: &'a ParameterOp,
         host_kind: WordFactHostKind,
     ) {
         match operator {
@@ -2196,8 +2192,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         context: WordFactContext,
         host_kind: WordFactHostKind,
     ) -> Option<usize> {
-        self.push_cow_word(Cow::Borrowed(word), context, host_kind, None)
-            .0
+        self.push_cow_word(word, context, host_kind, None).0
     }
 
     fn push_word_with_surface(
@@ -2207,58 +2202,32 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         host_kind: WordFactHostKind,
         surface_context: SurfaceScanContext<'_>,
     ) -> (Option<usize>, bool) {
-        self.push_cow_word(
-            Cow::Borrowed(word),
-            context,
-            host_kind,
-            Some(surface_context),
-        )
-    }
-
-    fn push_owned_word(
-        &mut self,
-        word: Word,
-        context: WordFactContext,
-        host_kind: WordFactHostKind,
-    ) -> Option<usize> {
-        self.push_cow_word(Cow::Owned(word), context, host_kind, None)
-            .0
-    }
-
-    fn push_owned_word_with_surface(
-        &mut self,
-        word: Word,
-        context: WordFactContext,
-        host_kind: WordFactHostKind,
-        surface_context: SurfaceScanContext<'_>,
-    ) -> (Option<usize>, bool) {
-        self.push_cow_word(Cow::Owned(word), context, host_kind, Some(surface_context))
+        self.push_cow_word(word, context, host_kind, Some(surface_context))
     }
 
     fn push_cow_word(
         &mut self,
-        word: Cow<'a, Word>,
+        word: &'a Word,
         context: WordFactContext,
         host_kind: WordFactHostKind,
         surface_context: Option<SurfaceScanContext<'_>>,
     ) -> (Option<usize>, bool) {
-        let word_ref = word.as_ref();
         let opened_double_quote = surface_context
-            .map(|surface_context| self.surface.collect_word(word_ref, surface_context))
+            .map(|surface_context| self.surface.collect_word(word, surface_context))
             .unwrap_or(false);
-        let key = FactSpan::new(word_ref.span);
+        let key = FactSpan::new(word.span);
         if !self.seen.insert((key, context, host_kind)) {
             return (None, opened_double_quote);
         }
 
-        self.collect_word_parameter_patterns(&word_ref.parts, host_kind);
-        self.collect_arithmetic_summary(word_ref, context, host_kind);
+        self.collect_word_parameter_patterns(&word.parts, host_kind);
+        self.collect_arithmetic_summary(word, context, host_kind);
 
         let zsh_options = self.command_zsh_options.clone();
-        let analysis = analyze_word(word_ref, self.source, zsh_options.as_ref());
+        let analysis = analyze_word(word, self.source, zsh_options.as_ref());
         let runtime_literal = match context {
             WordFactContext::Expansion(context) => {
-                analyze_literal_runtime(word_ref, self.source, context, zsh_options.as_ref())
+                analyze_literal_runtime(word, self.source, context, zsh_options.as_ref())
             }
             WordFactContext::CaseSubject | WordFactContext::ArithmeticCommand => {
                 RuntimeLiteralAnalysis::default()
@@ -2280,7 +2249,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             | WordFactContext::CaseSubject
             | WordFactContext::ArithmeticCommand => None,
         };
-        let derived = derive_word_fact_data(word_ref, self.source);
+        let derived = derive_word_fact_data(word, self.source);
         let index = self.facts.len();
         self.facts.push(WordFact {
             key,
@@ -2304,7 +2273,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             double_quoted_expansion_spans: derived.double_quoted_expansion_spans,
             unquoted_literal_between_double_quoted_segments_spans:
                 derived.unquoted_literal_between_double_quoted_segments_spans,
-            word,
+            word: Cow::Borrowed(word),
             command_id: self.command_id,
             nested_word_command: self.nested_word_command,
             context,
@@ -4203,7 +4172,7 @@ fn parse_mapfile_command(args: &[&Word], source: &str) -> MapfileCommandFacts {
                 args.get(index)
                     .and_then(|next| static_word_text(next, source))
             } else {
-                Some(remainder.to_owned())
+                Some(remainder.into())
             };
 
             if flag == 'u' {
@@ -4433,7 +4402,7 @@ fn detect_sudo_family_invoker(
         // even when there is no statically known inner command.
         .take_while(|word| scan_all_words || word.span.start.offset < body_start)
         .filter_map(|word| static_word_text(word, source))
-        .map(|word| word.strip_prefix('\\').map_or(word.clone(), str::to_owned))
+        .map(|word| word.strip_prefix('\\').unwrap_or(word.as_ref()).to_owned())
         .filter_map(|word| match word.as_str() {
             "sudo" => Some(SudoFamilyInvoker::Sudo),
             "doas" => Some(SudoFamilyInvoker::Doas),
@@ -4459,7 +4428,7 @@ fn trap_action_word<'a>(command: &'a Command, source: &str) -> Option<&'a Word> 
         .first()
         .and_then(|word| static_word_text(word, source))
     {
-        match first.as_str() {
+        match first.as_ref() {
             "-p" | "-l" => return None,
             "--" => start = 1,
             _ => {}

--- a/crates/shuck-linter/src/rules/common/command.rs
+++ b/crates/shuck-linter/src/rules/common/command.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use shuck_ast::{
     Assignment, BuiltinCommand, Command, DeclClause, DeclOperand, Redirect, SimpleCommand, Span,
     Word,
@@ -50,8 +52,8 @@ pub struct NormalizedDeclaration<'a> {
 
 #[derive(Debug, Clone)]
 pub struct NormalizedCommand<'a> {
-    pub literal_name: Option<String>,
-    pub effective_name: Option<String>,
+    pub literal_name: Option<Cow<'a, str>>,
+    pub effective_name: Option<Cow<'a, str>>,
     pub wrappers: Vec<WrapperKind>,
     pub body_span: Span,
     pub body_word_span: Option<Span>,
@@ -93,22 +95,22 @@ impl<'a> NormalizedCommand<'a> {
     }
 }
 
-pub(crate) fn normalize_command<'a>(command: &'a Command, source: &str) -> NormalizedCommand<'a> {
+pub(crate) fn normalize_command<'a>(
+    command: &'a Command,
+    source: &'a str,
+) -> NormalizedCommand<'a> {
     match command {
         Command::Simple(command) => normalize_simple_command(command, source),
         Command::Decl(command) => normalize_decl_command(command, source),
-        Command::Builtin(command) => {
-            let name = builtin_name(command).to_owned();
-            NormalizedCommand {
-                literal_name: Some(name.clone()),
-                effective_name: Some(name),
-                wrappers: Vec::new(),
-                body_span: builtin_span(command),
-                body_word_span: None,
-                body_words: Vec::new(),
-                declaration: None,
-            }
-        }
+        Command::Builtin(command) => NormalizedCommand {
+            literal_name: Some(Cow::Borrowed(builtin_name(command))),
+            effective_name: Some(Cow::Borrowed(builtin_name(command))),
+            wrappers: Vec::new(),
+            body_span: builtin_span(command),
+            body_word_span: None,
+            body_words: Vec::new(),
+            declaration: None,
+        },
         Command::Binary(command) => empty_normalized_command(command.span),
         Command::Compound(command) => empty_normalized_command(compound_span(command)),
         Command::Function(command) => empty_normalized_command(command.span),
@@ -116,7 +118,10 @@ pub(crate) fn normalize_command<'a>(command: &'a Command, source: &str) -> Norma
     }
 }
 
-fn normalize_simple_command<'a>(command: &'a SimpleCommand, source: &str) -> NormalizedCommand<'a> {
+fn normalize_simple_command<'a>(
+    command: &'a SimpleCommand,
+    source: &'a str,
+) -> NormalizedCommand<'a> {
     let words = std::iter::once(&command.name)
         .chain(command.args.iter())
         .collect::<Vec<_>>();
@@ -125,7 +130,7 @@ fn normalize_simple_command<'a>(command: &'a SimpleCommand, source: &str) -> Nor
 
 pub(crate) fn normalize_command_words<'a>(
     words: &[&'a Word],
-    source: &str,
+    source: &'a str,
 ) -> Option<NormalizedCommand<'a>> {
     let first_word = words.first().copied()?;
     let literal_name = static_command_name_text(first_word, source);
@@ -151,7 +156,7 @@ pub(crate) fn normalize_command_words<'a>(
                 body_span = words[body_index].span;
                 body_word_span = Some(words[body_index].span);
                 body_start = Some(body_index);
-                effective_name = Some(resolved_name);
+                effective_name = Some(Cow::Owned(resolved_name));
                 break;
             }
             CommandResolution::Wrapper { kind, target_index } => {
@@ -188,8 +193,8 @@ pub(crate) fn normalize_command_words<'a>(
     })
 }
 
-fn normalize_decl_command<'a>(command: &'a DeclClause, source: &str) -> NormalizedCommand<'a> {
-    let raw_kind = command.variant.as_ref().to_owned();
+fn normalize_decl_command<'a>(command: &'a DeclClause, source: &'a str) -> NormalizedCommand<'a> {
+    let raw_kind = command.variant.as_ref();
     let assignment_operands = command
         .operands
         .iter()
@@ -200,8 +205,8 @@ fn normalize_decl_command<'a>(command: &'a DeclClause, source: &str) -> Normaliz
         .collect::<Vec<_>>();
 
     NormalizedCommand {
-        literal_name: Some(raw_kind.clone()),
-        effective_name: Some(raw_kind.clone()),
+        literal_name: Some(Cow::Borrowed(raw_kind)),
+        effective_name: Some(Cow::Borrowed(raw_kind)),
         wrappers: Vec::new(),
         body_span: command.variant_span,
         body_word_span: None,
@@ -219,13 +224,13 @@ fn normalize_decl_command<'a>(command: &'a DeclClause, source: &str) -> Normaliz
     }
 }
 
-fn declaration_kind(raw_kind: String) -> DeclarationKind {
-    match raw_kind.as_str() {
+fn declaration_kind(raw_kind: &str) -> DeclarationKind {
+    match raw_kind {
         "export" => DeclarationKind::Export,
         "local" => DeclarationKind::Local,
         "declare" => DeclarationKind::Declare,
         "typeset" => DeclarationKind::Typeset,
-        _ => DeclarationKind::Other(raw_kind),
+        _ => DeclarationKind::Other(raw_kind.to_owned()),
     }
 }
 
@@ -358,7 +363,7 @@ fn command_wrapper_target_index(
             return Some(index);
         };
 
-        match arg.as_str() {
+        match arg.as_ref() {
             "--" => return words.get(index + 1).map(|_| index + 1),
             "-p" => index += 1,
             "-v" | "-V" => return None,
@@ -378,7 +383,7 @@ fn exec_wrapper_target_index(words: &[&Word], current_index: usize, source: &str
             return Some(index);
         };
 
-        match arg.as_str() {
+        match arg.as_ref() {
             "--" => return words.get(index + 1).map(|_| index + 1),
             "-c" | "-l" => index += 1,
             "-a" => {
@@ -404,7 +409,7 @@ fn find_exec_target_index(
         let Some(arg) = static_word_text(words[index], source) else {
             continue;
         };
-        match arg.as_str() {
+        match arg.as_ref() {
             "-exec" | "-ok" => {
                 if fallback.is_none() {
                     fallback = words
@@ -447,11 +452,11 @@ fn sudo_family_target_index(words: &[&Word], current_index: usize, source: &str)
             return Some(index);
         }
 
-        if arg.len() == 2 && matches!(arg.as_str(), "-l" | "-v" | "-V") {
+        if arg.len() == 2 && matches!(arg.as_ref(), "-l" | "-v" | "-V") {
             return None;
         }
 
-        if sudo_option_takes_value(arg.as_str()) {
+        if sudo_option_takes_value(arg.as_ref()) {
             if arg.len() == 2 {
                 words.get(index + 1)?;
                 index += 2;
@@ -461,7 +466,7 @@ fn sudo_family_target_index(words: &[&Word], current_index: usize, source: &str)
             continue;
         }
 
-        if arg.starts_with("--") && !matches!(arg.as_str(), "--preserve-env" | "--login") {
+        if arg.starts_with("--") && !matches!(arg.as_ref(), "--preserve-env" | "--login") {
             return None;
         }
 
@@ -506,7 +511,7 @@ fn mumps_run_resolution(
         .get(current_index + 2)
         .and_then(|word| static_word_text(word, source))?;
 
-    if run_flag == "-run" && matches!(entrypoint.as_str(), "%XCMD" | "LOOP%XCMD") {
+    if run_flag == "-run" && matches!(entrypoint.as_ref(), "%XCMD" | "LOOP%XCMD") {
         Some(CommandResolution::Alias {
             effective_name: format!("mumps -run {entrypoint}"),
             body_index: current_index + 2,
@@ -534,16 +539,19 @@ fn builtin_span(command: &BuiltinCommand) -> Span {
     }
 }
 
-fn static_command_name_text(word: &Word, source: &str) -> Option<String> {
-    static_word_text(word, source)
-        .map(|text| text.strip_prefix('\\').map_or(text.clone(), str::to_owned))
+fn static_command_name_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
+    let text = static_word_text(word, source)?;
+    match text.strip_prefix('\\') {
+        Some(stripped) => Some(Cow::Owned(stripped.to_owned())),
+        None => Some(text),
+    }
 }
 
 fn command_basename(name: &str) -> &str {
     name.rsplit('/').next().unwrap_or(name)
 }
 
-fn static_word_text(word: &Word, source: &str) -> Option<String> {
+fn static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
     super::word::static_word_text(word, source)
 }
 

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -133,44 +133,64 @@ pub(crate) fn declaration_operands(command: &Command) -> &[DeclOperand] {
     }
 }
 
-pub(crate) fn visit_arithmetic_words(
-    expression: &ArithmeticExprNode,
-    visitor: &mut impl FnMut(&Word),
+pub(crate) fn visit_arithmetic_words<'a>(
+    expression: &'a ArithmeticExprNode,
+    visitor: &mut impl FnMut(&'a Word),
 ) {
     visit_arithmetic_words_in_expr(expression, visitor);
 }
 
-pub(crate) fn visit_var_ref_subscript_words(reference: &VarRef, visitor: &mut impl FnMut(&Word)) {
-    let mut words = Vec::new();
-    collect_var_ref_subscript_words(reference, &mut words);
-    for word in words {
+pub(crate) fn visit_var_ref_subscript_words<'a>(
+    reference: &'a VarRef,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    visit_optional_arithmetic_words(
+        reference
+            .subscript
+            .as_ref()
+            .and_then(|subscript| subscript.arithmetic_ast.as_ref()),
+        visitor,
+    );
+}
+
+pub(crate) fn visit_var_ref_subscript_words_with_source<'a>(
+    reference: &'a VarRef,
+    _source: &'a str,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    visit_subscript_words(reference.subscript.as_ref(), _source, visitor);
+}
+
+pub(crate) fn visit_subscript_words<'a>(
+    subscript: Option<&'a Subscript>,
+    _source: &'a str,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    let Some(subscript) = subscript else {
+        return;
+    };
+    if subscript.selector().is_some() {
+        return;
+    }
+    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
+        visit_arithmetic_words_in_expr(expression, visitor);
+        return;
+    }
+
+    if let Some(word) = subscript.word_ast() {
         visitor(word);
+        return;
     }
+
+    debug_assert!(
+        subscript.word_ast().is_some(),
+        "ordinary subscripts should always carry a word AST"
+    );
 }
 
-pub(crate) fn visit_var_ref_subscript_words_with_source(
-    reference: &VarRef,
-    source: &str,
-    visitor: &mut impl FnMut(&Word),
-) {
-    visit_subscript_words(reference.subscript.as_ref(), source, visitor);
-}
-
-pub(crate) fn visit_subscript_words(
-    subscript: Option<&Subscript>,
-    source: &str,
-    visitor: &mut impl FnMut(&Word),
-) {
-    let mut words = Vec::new();
-    collect_subscript_words(subscript, source, &mut words);
-    for word in words {
-        visitor(&word);
-    }
-}
-
-fn visit_arithmetic_words_in_expr(
-    expression: &ArithmeticExprNode,
-    visitor: &mut impl FnMut(&Word),
+fn visit_arithmetic_words_in_expr<'a>(
+    expression: &'a ArithmeticExprNode,
+    visitor: &mut impl FnMut(&'a Word),
 ) {
     match &expression.kind {
         ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
@@ -202,39 +222,13 @@ fn visit_arithmetic_words_in_expr(
     }
 }
 
-fn collect_var_ref_subscript_words<'a>(reference: &'a VarRef, words: &mut Vec<&'a Word>) {
-    collect_optional_arithmetic_words(
-        reference
-            .subscript
-            .as_ref()
-            .and_then(|subscript| subscript.arithmetic_ast.as_ref()),
-        words,
-    );
-}
-
-fn collect_subscript_words(subscript: Option<&Subscript>, _source: &str, words: &mut Vec<Word>) {
-    let Some(subscript) = subscript else {
-        return;
-    };
-    if subscript.selector().is_some() {
-        return;
+fn visit_optional_arithmetic_words<'a>(
+    expression: Option<&'a ArithmeticExprNode>,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    if let Some(expression) = expression {
+        visit_arithmetic_words_in_expr(expression, visitor);
     }
-    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
-        let mut arithmetic_words = Vec::new();
-        collect_arithmetic_words(expression, &mut arithmetic_words);
-        words.extend(arithmetic_words.into_iter().cloned());
-        return;
-    }
-
-    if let Some(word) = subscript.word_ast() {
-        words.push(word.clone());
-        return;
-    }
-
-    debug_assert!(
-        subscript.word_ast().is_some(),
-        "ordinary subscripts should always carry a word AST"
-    );
 }
 
 fn collect_optional_arithmetic_words<'a>(
@@ -244,6 +238,16 @@ fn collect_optional_arithmetic_words<'a>(
     if let Some(expression) = expression {
         collect_arithmetic_words(expression, words);
     }
+}
+
+fn collect_var_ref_subscript_words<'a>(reference: &'a VarRef, words: &mut Vec<&'a Word>) {
+    collect_optional_arithmetic_words(
+        reference
+            .subscript
+            .as_ref()
+            .and_then(|subscript| subscript.arithmetic_ast.as_ref()),
+        words,
+    );
 }
 
 fn collect_arithmetic_lvalue_words<'a>(target: &'a ArithmeticLvalue, words: &mut Vec<&'a Word>) {
@@ -282,7 +286,10 @@ fn collect_arithmetic_words<'a>(expression: &'a ArithmeticExprNode, words: &mut 
     }
 }
 
-fn visit_arithmetic_lvalue_words(target: &ArithmeticLvalue, visitor: &mut impl FnMut(&Word)) {
+fn visit_arithmetic_lvalue_words<'a>(
+    target: &'a ArithmeticLvalue,
+    visitor: &mut impl FnMut(&'a Word),
+) {
     match target {
         ArithmeticLvalue::Variable(_) => {}
         ArithmeticLvalue::Indexed { index, .. } => visit_arithmetic_words_in_expr(index, visitor),

--- a/crates/shuck-linter/src/rules/common/word.rs
+++ b/crates/shuck-linter/src/rules/common/word.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use shuck_ast::{
     ArithmeticExpr, BourneParameterExpansion, Command, CompoundCommand, ConditionalBinaryOp,
     ConditionalExpr, Pattern, PatternPart, Word, WordPart, WordPartNode,
@@ -60,21 +62,8 @@ impl TestOperandClass {
     }
 }
 
-pub fn static_word_text(word: &Word, source: &str) -> Option<String> {
-    if let [part] = word.parts.as_slice() {
-        match &part.kind {
-            WordPart::Literal(text) => return Some(text.as_str(source, word.span).to_owned()),
-            WordPart::SingleQuoted { value, .. } => return Some(value.slice(source).to_owned()),
-            WordPart::DoubleQuoted { parts, .. } => {
-                let mut result = String::new();
-                return collect_static_word_text(parts, source, &mut result).then_some(result);
-            }
-            _ => {}
-        }
-    }
-
-    let mut result = String::new();
-    collect_static_word_text(&word.parts, source, &mut result).then_some(result)
+pub fn static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
+    static_word_parts_text(&word.parts, source)
 }
 
 pub fn is_shell_variable_name(name: &str) -> bool {
@@ -247,6 +236,24 @@ pub(crate) fn classify_contextual_operand(
     }
 }
 
+fn static_word_parts_text<'a>(parts: &'a [WordPartNode], source: &'a str) -> Option<Cow<'a, str>> {
+    if let [part] = parts {
+        return static_word_part_text(part, source);
+    }
+
+    let mut result = String::new();
+    collect_static_word_text(parts, source, &mut result).then_some(Cow::Owned(result))
+}
+
+fn static_word_part_text<'a>(part: &'a WordPartNode, source: &'a str) -> Option<Cow<'a, str>> {
+    match &part.kind {
+        WordPart::Literal(text) => Some(Cow::Borrowed(text.as_str(source, part.span))),
+        WordPart::SingleQuoted { value, .. } => Some(Cow::Borrowed(value.slice(source))),
+        WordPart::DoubleQuoted { parts, .. } => static_word_parts_text(parts, source),
+        _ => None,
+    }
+}
+
 fn collect_static_word_text(parts: &[WordPartNode], source: &str, out: &mut String) -> bool {
     for part in parts {
         match &part.kind {
@@ -319,6 +326,8 @@ fn classify_pattern_operand(pattern: &Pattern, source: &str) -> TestOperandClass
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use shuck_ast::{BuiltinCommand, Command, CompoundCommand};
     use shuck_parser::parser::Parser;
 
@@ -442,6 +451,44 @@ echo \"\\\"$BUILDSCRIPT\\\" --library $(test \"${PKG_DIR%/*}\" = \"gpkg\" && ech
             static_word_text(&else_echo.name, source).as_deref(),
             Some("echo")
         );
+    }
+
+    #[test]
+    fn static_word_text_borrows_literal_and_single_quoted_words() {
+        let source = "printf plain 'single' \"double\"\n";
+        let commands = parse_commands(source);
+        let Command::Simple(command) = &commands[0].command else {
+            panic!("expected simple command");
+        };
+
+        assert!(matches!(
+            static_word_text(&command.args[0], source),
+            Some(Cow::Borrowed("plain"))
+        ));
+        assert!(matches!(
+            static_word_text(&command.args[1], source),
+            Some(Cow::Borrowed("single"))
+        ));
+        assert!(matches!(
+            static_word_text(&command.args[2], source),
+            Some(Cow::Borrowed("double"))
+        ));
+    }
+
+    #[test]
+    fn static_word_text_cooks_concatenated_words_only_when_needed() {
+        let source = "printf \"pre${x}post\" \"ab$cd\" foo\"bar\"\n";
+        let commands = parse_commands(source);
+        let Command::Simple(command) = &commands[0].command else {
+            panic!("expected simple command");
+        };
+
+        assert!(static_word_text(&command.args[0], source).is_none());
+        assert!(static_word_text(&command.args[1], source).is_none());
+        assert!(matches!(
+            static_word_text(&command.args[2], source),
+            Some(Cow::Owned(ref value)) if value == "foobar"
+        ));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
@@ -32,7 +32,7 @@ fn report_span(simple_test: &crate::SimpleTestFact<'_>, source: &str) -> Option<
     }
 
     let operator = static_word_text(simple_test.effective_operands().get(1)?, source)?;
-    if !matches!(operator.as_str(), "=" | "==" | "!=") {
+    if !matches!(operator.as_ref(), "=" | "==" | "!=") {
         return None;
     }
 

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
@@ -137,7 +137,8 @@ fn simple_test_unary_file_test_span(
     if !is_simple_test_file_test_unary_operator(
         simple_test
             .effective_operator_word()
-            .and_then(|word| static_word_text(word, source)),
+            .and_then(|word| static_word_text(word, source))
+            .as_deref(),
     ) {
         return None;
     }
@@ -182,8 +183,8 @@ fn is_file_test_operator(token: Option<&str>) -> bool {
     )
 }
 
-fn is_simple_test_file_test_unary_operator(token: Option<String>) -> bool {
-    matches!(token.as_deref(), Some("-a")) || is_file_test_operator(token.as_deref())
+fn is_simple_test_file_test_unary_operator(token: Option<&str>) -> bool {
+    matches!(token, Some("-a")) || is_file_test_operator(token)
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
@@ -46,7 +46,7 @@ fn non_shell_syntax_span(
     }
 
     let name = static_word_text(&simple.name, source)?;
-    if !looks_like_c_declaration_keyword(name.as_str()) || simple.args.is_empty() {
+    if !looks_like_c_declaration_keyword(name.as_ref()) || simple.args.is_empty() {
         return None;
     }
 

--- a/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
+++ b/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
@@ -391,7 +391,7 @@ fn bracket_v_name_spans(
             let name = static_word_text(operand, checker.source())?;
             let binding_id = checker
                 .semantic()
-                .bindings_for(&Name::from(name.as_str()))
+                .bindings_for(&Name::from(name.as_ref()))
                 .iter()
                 .copied()
                 .filter(|binding_id| {

--- a/crates/shuck-linter/src/rules/correctness/syntax.rs
+++ b/crates/shuck-linter/src/rules/correctness/syntax.rs
@@ -3,7 +3,7 @@ use shuck_ast::{Assignment, SimpleCommand, Word};
 pub use crate::static_word_text;
 
 fn simple_command_name(command: &SimpleCommand, source: &str) -> Option<String> {
-    static_word_text(&command.name, source)
+    static_word_text(&command.name, source).map(|text| text.into_owned())
 }
 
 pub fn assignment_target_name(assignment: &Assignment) -> &str {

--- a/crates/shuck-linter/src/rules/portability/sourced_with_args.rs
+++ b/crates/shuck-linter/src/rules/portability/sourced_with_args.rs
@@ -43,8 +43,8 @@ fn targets_posix_dot_shell(shell: ShellDialect) -> bool {
 }
 
 fn static_command_name_text(word: &shuck_ast::Word, source: &str) -> Option<String> {
-    static_word_text(word, source)
-        .map(|text| text.strip_prefix('\\').map_or(text.clone(), str::to_owned))
+    let text = static_word_text(word, source)?;
+    Some(text.strip_prefix('\\').unwrap_or(text.as_ref()).to_owned())
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
@@ -62,7 +62,7 @@ fn mkdir_path_operand_spans(command: &CommandFact<'_>, source: &str) -> Vec<shuc
             continue;
         }
 
-        if options_open && is_mkdir_option(word.span, text.as_str(), &mut expects_mode_operand) {
+        if options_open && is_mkdir_option(word.span, text.as_ref(), &mut expects_mode_operand) {
             continue;
         }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_tr_class.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_tr_class.rs
@@ -30,7 +30,7 @@ pub fn unquoted_tr_class(checker: &mut Checker) {
                     return None;
                 }
                 let text = static_word_text(word, checker.source())?;
-                is_unquoted_tr_class(text.as_str()).then_some(word.span)
+                is_unquoted_tr_class(text.as_ref()).then_some(word.span)
             })
         })
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/style/unquoted_tr_range.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_tr_range.rs
@@ -21,7 +21,7 @@ pub fn unquoted_tr_range(checker: &mut Checker) {
         .flat_map(|fact| {
             fact.body_args().iter().filter_map(|word| {
                 let text = static_word_text(word, checker.source())?;
-                is_bracketed_tr_set(text.as_str()).then_some(word.span)
+                is_bracketed_tr_set(text.as_ref()).then_some(word.span)
             })
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

This PR reduces linter allocation churn in the borrowed-text and word-facts paths.

## What changed

- changed `static_word_text` to return borrowed-or-owned text so literal and single-quoted words can stay source-backed instead of always allocating `String`
- updated linter fact and rule consumers to stay borrowed where possible and only own at storage boundaries
- removed unnecessary `Word` clones in subscript and pattern word collection paths
- changed `NormalizedCommand` to keep borrowed command names with `Cow<'_, str>` so builtin and declaration normalization avoid eager name allocation
- removed a temporary `Vec<&Word>` in `find` command option parsing by streaming body words directly into `parse_find_command`

## Why

Allocation profiling showed repeated transient string materialization and word-fact churn in the linter hot path. The concise output path was not dominated by full script-body clones; the more actionable issues were repeated borrowed-to-owned conversions and unnecessary temporary word collections.

## Impact

Focused Criterion comparison against `main`:

- `linter_facts`: `+1.02%`
- `linter_word_facts`: `-5.35%`
- `linter_normalization`: `+0.23%`
- `linter`: `-13.16%`

Concise-path `heap` snapshots on the repeated `nvm.sh` corpus still show `read_shared_source` staying small, while the targeted clone-heavy sites improved:

- `static_word_text` dropped out of the top live allocators
- `String::clone`: about `2.22 MB -> 1.35 MB`
- `WordPart::clone`: about `2.84 MB -> 2.10 MB`

## Validation

- `cargo test -p shuck-linter`
- `cargo test -p shuck`
- `cargo bench -p shuck-benchmark --bench linter -- --baseline=main --noplot`
