### PR TITLE
Remove shellcheck no-ext benchmark variant

### DIFF
--- a/scripts/benchmarks/run.sh
+++ b/scripts/benchmarks/run.sh
@@ -21,8 +21,7 @@ for file in "$fixtures_dir"/*.sh; do
                 --runs 10 \
                 --export-json "$cache_dir/bench-$name.json" \
                 -n "shuck/$name" "$shuck check --no-cache $file" \
-                -n "shellcheck/$name" "shellcheck --severity=style $file" \
-                -n "shellcheck-no-ext/$name" "shellcheck --severity=style --extended-analysis=false $file"
+                -n "shellcheck/$name" "shellcheck --severity=style $file"
             ;;
         shuck-only)
             hyperfine \
@@ -51,8 +50,7 @@ case "$benchmark_mode" in
             --export-json "$cache_dir/bench-all.json" \
             --export-markdown "$cache_dir/bench-all.md" \
             -n "shuck/all" "$shuck check --no-cache $*" \
-            -n "shellcheck/all" "shellcheck --severity=style $*" \
-            -n "shellcheck-no-ext/all" "shellcheck --severity=style --extended-analysis=false $*"
+            -n "shellcheck/all" "shellcheck --severity=style $*"
         ;;
     shuck-only)
         hyperfine \

--- a/scripts/benchmarks/run_single.sh
+++ b/scripts/benchmarks/run_single.sh
@@ -10,5 +10,4 @@ hyperfine \
     --warmup 5 \
     --runs 20 \
     -n "shuck" "$shuck check --no-cache $file" \
-    -n "shellcheck" "shellcheck --severity=style $file" \
-    -n "shellcheck-no-ext" "shellcheck --severity=style --extended-analysis=false $file"
+    -n "shellcheck" "shellcheck --severity=style $file"

--- a/scripts/benchmarks/test_run.py
+++ b/scripts/benchmarks/test_run.py
@@ -67,6 +67,55 @@ class RunBenchmarkScriptTests(unittest.TestCase):
             self.assertIn("override-only", log)
             self.assertNotIn("repo-only", log)
 
+    def test_compare_mode_omits_shellcheck_no_ext_variant(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            repo_root = temp_root / "repo"
+            fixtures = repo_root / "crates" / "shuck-benchmark" / "resources" / "files"
+            output_dir = temp_root / "out"
+            fake_bin = temp_root / "bin"
+            hyperfine_log = temp_root / "hyperfine.log"
+
+            fixtures.mkdir(parents=True)
+            output_dir.mkdir()
+            fake_bin.mkdir()
+
+            (fixtures / "fixture.sh").write_text("#!/bin/sh\necho fixture\n")
+
+            fake_hyperfine = fake_bin / "hyperfine"
+            fake_hyperfine.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    printf '%s\\n' "$*" >> "{hyperfine_log}"
+                    exit 0
+                    """
+                )
+            )
+            fake_hyperfine.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{fake_bin}:{env['PATH']}",
+                    "SHUCK_BENCHMARK_MODE": "compare",
+                    "SHUCK_BENCHMARK_OUTPUT_DIR": str(output_dir),
+                    "SHUCK_BENCHMARK_REPO_ROOT": str(repo_root),
+                }
+            )
+
+            subprocess.run(
+                ["sh", str(RUN_SCRIPT)],
+                check=True,
+                cwd=REPO_ROOT,
+                env=env,
+            )
+
+            log = hyperfine_log.read_text()
+            self.assertIn("shellcheck/fixture", log)
+            self.assertIn("shellcheck/all", log)
+            self.assertNotIn("shellcheck-no-ext", log)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/specs/007-benchmarks.md
+++ b/specs/007-benchmarks.md
@@ -279,8 +279,7 @@ for file in "$fixtures_dir"/*.sh; do
         --runs 10 \
         --export-json "$repo_root/.cache/bench-${name}.json" \
         -n "shuck/$name" "$shuck check --no-cache $file" \
-        -n "shellcheck/$name" "shellcheck --severity=style $file" \
-        -n "shellcheck-no-ext/$name" "shellcheck --severity=style --extended-analysis=false $file"
+        -n "shellcheck/$name" "shellcheck --severity=style $file"
 done
 
 # All-files benchmark
@@ -292,11 +291,10 @@ hyperfine \
     --export-json "$repo_root/.cache/bench-all.json" \
     --export-markdown "$repo_root/.cache/bench-all.md" \
     -n "shuck/all" "$shuck check --no-cache $all_files" \
-    -n "shellcheck/all" "shellcheck --severity=style $all_files" \
-    -n "shellcheck-no-ext/all" "shellcheck --severity=style --extended-analysis=false $all_files"
+    -n "shellcheck/all" "shellcheck --severity=style $all_files"
 ```
 
-Note: Three shellcheck variants are benchmarked (matching the Go frontend): default, and with `--extended-analysis=false`. The `--no-cache` flag ensures shuck measures cold parse performance.
+Note: The macro benchmark compares shuck against the default shellcheck CLI invocation. The `--no-cache` flag ensures shuck measures cold parse performance.
 
 #### scripts/benchmarks/run_single.sh
 
@@ -313,8 +311,7 @@ hyperfine \
     --warmup 5 \
     --runs 20 \
     -n "shuck" "$shuck check --no-cache $file" \
-    -n "shellcheck" "shellcheck --severity=style $file" \
-    -n "shellcheck-no-ext" "shellcheck --severity=style --extended-analysis=false $file"
+    -n "shellcheck" "shellcheck --severity=style $file"
 ```
 
 ### Makefile Targets
@@ -363,8 +360,8 @@ This enables `cargo flamegraph` and `samply` on benchmark binaries without losin
 | Micro | Criterion | Parse each fixture | throughput (bytes/s), time (mean ± σ) |
 | Micro | Criterion | Build semantics for each fixture | throughput (bytes/s), time (mean ± σ) |
 | Micro | Criterion | Lint each fixture | throughput (bytes/s), time (mean ± σ) |
-| Macro | Hyperfine | `shuck check` per fixture | wall time (mean ± σ), vs shellcheck (2 variants) |
-| Macro | Hyperfine | `shuck check` all fixtures | wall time (mean ± σ), vs shellcheck (2 variants) |
+| Macro | Hyperfine | `shuck check` per fixture | wall time (mean ± σ), vs shellcheck |
+| Macro | Hyperfine | `shuck check` all fixtures | wall time (mean ± σ), vs shellcheck |
 
 ### What We Don't Measure (Yet)
 
@@ -406,7 +403,7 @@ Once implemented, verify with:
 - **All vendored files load:** Each `TestFile` in `TEST_FILES` has non-empty source (the `include_str!` calls compile).
 - **Throughput reported:** Criterion output includes `throughput: X.XX MiB/s` for each benchmark.
 - **Baseline comparison works:** Run `cargo bench -p shuck-benchmark -- --save-baseline=main`, make a change, then `cargo bench -p shuck-benchmark -- --baseline=main` shows a comparison.
-- **Macro-benchmarks run:** `./scripts/benchmarks/run.sh` produces `bench-*.json` files with timing data for shuck, shellcheck, and shellcheck-no-ext.
+- **Macro-benchmarks run:** `./scripts/benchmarks/run.sh` produces `bench-*.json` files with timing data for shuck and shellcheck.
 - **Per-file and all-files:** The macro-benchmark output includes both individual fixture results and the combined "all" benchmark.
 - **Single-file comparison:** `./scripts/benchmarks/run_single.sh crates/shuck-benchmark/resources/files/nvm.sh` produces hyperfine output comparing shuck vs shellcheck.
 - **Make targets:** `make bench` and `make bench-macro` succeed.


### PR DESCRIPTION
## Summary
- remove the `shellcheck-no-ext` command from the macro benchmark scripts
- add a regression test that keeps `compare` mode limited to shuck and default shellcheck
- update the benchmark spec so it matches the current benchmark matrix

## Why
We no longer need the extra shellcheck no-extension macro benchmark variant, so the benchmark helpers and docs should reflect the smaller comparison set.

## Testing
- python3 scripts/benchmarks/test_run.py
- python3 scripts/benchmarks/test_macro_pr_report.py
- sh -n scripts/benchmarks/run.sh scripts/benchmarks/run_single.sh