### PR TITLE
Refactor word facts into shared nodes and occurrences

### DIFF
--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -48,7 +48,7 @@ fn build_linter_facts(input: &PreparedFactsInput) -> usize {
 
     black_box(
         facts.commands().len()
-            + facts.word_facts().len()
+            + facts.word_facts().count()
             + facts.single_quoted_fragments().len()
             + facts.backtick_fragments().len()
             + facts.pattern_charclass_spans().len()

--- a/crates/shuck-linter/Cargo.toml
+++ b/crates/shuck-linter/Cargo.toml
@@ -14,6 +14,7 @@ benchmarking = []
 
 [dependencies]
 rustc-hash = "2"
+smallvec.workspace = true
 thiserror = { workspace = true }
 shuck-ast = { path = "../shuck-ast" }
 shuck-indexer = { path = "../shuck-indexer" }

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -1,53 +1,3 @@
-fn populate_array_assignment_split_scalar_expansion_spans(
-    words: &mut [WordFact<'_>],
-    array_assignment_split_word_indices: &[usize],
-    commands: &[CommandFact<'_>],
-    source: &str,
-) {
-    if array_assignment_split_word_indices.is_empty() {
-        return;
-    }
-
-    let command_spans = commands.iter().map(CommandFact::span).collect::<Vec<_>>();
-    let mut word_indices_by_command = vec![Vec::new(); commands.len()];
-    for (index, fact) in words.iter().enumerate() {
-        word_indices_by_command[fact.command_id().index()].push(index);
-    }
-
-    let updated_spans = array_assignment_split_word_indices
-        .iter()
-        .copied()
-        .map(|index| {
-            let fact = &words[index];
-            let mut split_sensitive_spans = fact.unquoted_scalar_expansion_spans().to_vec();
-            let use_replacement_spans =
-                collect_array_assignment_use_replacement_expansion_spans(fact.word());
-
-            if !word_fact_is_double_quoted_command_substitution_only(fact, source) {
-                for nested_command_index in command_spans.iter().enumerate().filter_map(
-                    |(nested_command_index, command_span)| {
-                        contains_span_strictly(fact.span(), *command_span)
-                            .then_some(nested_command_index)
-                    },
-                ) {
-                    for word_index in &word_indices_by_command[nested_command_index] {
-                        split_sensitive_spans
-                            .extend(words[*word_index].scalar_expansion_spans().iter().copied());
-                    }
-                }
-            }
-
-            split_sensitive_spans.retain(|span| !use_replacement_spans.contains(span));
-            sort_and_dedup_spans(&mut split_sensitive_spans);
-            (index, split_sensitive_spans.into_boxed_slice())
-        })
-        .collect::<Vec<_>>();
-
-    for (index, spans) in updated_spans {
-        words[index].array_assignment_split_scalar_expansion_spans = spans;
-    }
-}
-
 fn collect_array_assignment_use_replacement_expansion_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_use_replacement_expansion_spans(&word.parts, &mut spans);
@@ -317,5 +267,4 @@ fn compound_assignment_paren_span(assignment: &Assignment, source: &str) -> Opti
         .advanced_by(&text[..close + ')'.len_utf8()]);
     Some(Span::from_positions(start, end))
 }
-
 

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -81,13 +81,22 @@ impl<'a> BindingValueFact<'a> {
 
 fn build_bare_command_name_assignment_spans<'a>(
     commands: &[CommandFact<'a>],
-    words: &[WordFact<'a>],
-    word_index: &FxHashMap<FactSpan, Vec<usize>>,
+    word_nodes: &[WordNode<'a>],
+    word_occurrences: &[WordOccurrence],
+    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     source: &str,
 ) -> Vec<Span> {
     commands
         .iter()
-        .filter_map(|command| bare_command_name_assignment_span(command, words, word_index, source))
+        .filter_map(|command| {
+            bare_command_name_assignment_span(
+                command,
+                word_nodes,
+                word_occurrences,
+                word_index,
+                source,
+            )
+        })
         .collect()
 }
 
@@ -151,8 +160,9 @@ fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> 
 
 fn bare_command_name_assignment_span<'a>(
     command: &CommandFact<'a>,
-    words: &[WordFact<'a>],
-    word_index: &FxHashMap<FactSpan, Vec<usize>>,
+    word_nodes: &[WordNode<'a>],
+    word_occurrences: &[WordOccurrence],
+    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     source: &str,
 ) -> Option<Span> {
     let (assignment, anchor_full_command) = match command.command() {
@@ -184,19 +194,20 @@ fn bare_command_name_assignment_span<'a>(
     let AssignmentValue::Scalar(word) = &assignment.value else {
         return None;
     };
-    let fact = word_fact_with_context(
-        words,
+    let fact = word_occurrence_with_context(
+        word_nodes,
+        word_occurrences,
         word_index,
         word.span,
         WordFactContext::Expansion(ExpansionContext::AssignmentValue),
     )?;
-    if fact.classification().quote != WordQuote::Unquoted
-        || !fact.classification().is_fixed_literal()
+    let analysis = occurrence_analysis(word_nodes, fact);
+    if analysis.quote != WordQuote::Unquoted || analysis.literalness != WordLiteralness::FixedLiteral
     {
         return None;
     }
 
-    let text = fact.static_text()?;
+    let text = occurrence_static_text(word_nodes, fact, source)?;
     if !is_bare_command_name_assignment_value(text) {
         return None;
     }

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -1,20 +1,22 @@
 fn build_literal_brace_spans(
-    words: &[WordFact<'_>],
+    nodes: &[WordNode<'_>],
+    occurrences: &[WordOccurrence],
     commands: &[CommandFact<'_>],
     source: &str,
     heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {
     let mut spans = Vec::new();
 
-    for fact in words {
-        if fact.expansion_context() == Some(ExpansionContext::RegexOperand) {
+    for fact in occurrences {
+        if fact.context == WordFactContext::Expansion(ExpansionContext::RegexOperand) {
             continue;
         }
 
-        let is_find_exec_placeholder_word = is_find_exec_placeholder_word(commands, fact, source);
-        let is_xargs_replacement_word = is_xargs_replacement_word(commands, fact, source);
-        let direct_spans = fact
-            .word()
+        let word = occurrence_word(nodes, fact);
+        let is_find_exec_placeholder_word =
+            is_find_exec_placeholder_word(commands, nodes, fact, source);
+        let is_xargs_replacement_word = is_xargs_replacement_word(commands, nodes, fact, source);
+        let direct_spans = word
             .brace_syntax()
             .iter()
             .copied()
@@ -33,37 +35,25 @@ fn build_literal_brace_spans(
                     && !is_xargs_replacement_word
             })
             .flat_map(|brace| brace_character_spans(brace.span, source))
-            .filter(|span| {
-                !span_inside_nested_escaped_parameter_template(fact.word(), *span, source)
-            })
-            .filter(|span| {
-                !brace_span_is_plain_parameter_expansion_edge(fact.word(), *span, source)
-            })
-            .filter(|span| !word_span_is_inside_command_substitution(fact, *span))
+            .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
+            .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
+            .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source))
             .collect::<Vec<_>>();
         spans.extend(direct_spans);
 
         if !is_find_exec_placeholder_word && !is_xargs_replacement_word {
-            let unclassified = unclassified_literal_brace_spans(fact.word(), source)
+            let unclassified = unclassified_literal_brace_spans(word, source)
                 .into_iter()
-                .filter(|span| {
-                    !span_inside_nested_escaped_parameter_template(fact.word(), *span, source)
-                })
-                .filter(|span| {
-                    !brace_span_is_plain_parameter_expansion_edge(fact.word(), *span, source)
-                })
-                .filter(|span| !word_span_is_inside_command_substitution(fact, *span))
+                .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
+                .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
+                .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source))
                 .collect::<Vec<_>>();
             spans.extend(unclassified);
-            let escaped = escaped_parameter_expansion_brace_edge_spans(fact.word(), source)
+            let escaped = escaped_parameter_expansion_brace_edge_spans(word, source)
                 .into_iter()
-                .filter(|span| {
-                    !span_inside_nested_escaped_parameter_template(fact.word(), *span, source)
-                })
-                .filter(|span| {
-                    !brace_span_is_plain_parameter_expansion_edge(fact.word(), *span, source)
-                })
-                .filter(|span| !word_span_is_inside_command_substitution(fact, *span))
+                .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
+                .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
+                .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source))
                 .collect::<Vec<_>>();
             spans.extend(escaped);
         }
@@ -84,8 +74,14 @@ fn build_literal_brace_spans(
     spans
 }
 
-fn word_span_is_inside_command_substitution(fact: &WordFact<'_>, span: Span) -> bool {
-    fact.command_substitution_spans()
+fn word_span_is_inside_command_substitution(
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
+    span: Span,
+    source: &str,
+) -> bool {
+    word_node_derived(&nodes[fact.node_id.index()], source)
+        .command_substitution_spans
         .iter()
         .copied()
         .any(|substitution| contains_span(substitution, span))
@@ -194,26 +190,27 @@ fn span_is_active_brace_expansion_edge_in_source(span: Span, source: &str) -> bo
 
 fn is_find_exec_placeholder_word(
     commands: &[CommandFact<'_>],
-    fact: &WordFact<'_>,
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
     source: &str,
 ) -> bool {
-    if !word_is_empty_brace_pair_variant(fact.word(), source) {
+    if !word_is_empty_brace_pair_variant(occurrence_word(nodes, fact), source) {
         return false;
     }
-    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
+    if fact.context != WordFactContext::Expansion(ExpansionContext::CommandArgument) {
         return false;
     }
 
-    let command = &commands[fact.command_id().index()];
+    let command = &commands[fact.command_id.index()];
     if command.has_wrapper(WrapperKind::FindExec) || command.has_wrapper(WrapperKind::FindExecDir) {
         return true;
     }
 
     commands.iter().any(|command| {
-        command.stmt().span.start.offset <= fact.span().start.offset
-            && command.stmt().span.end.offset >= fact.span().end.offset
+        command.stmt().span.start.offset <= occurrence_span(nodes, fact).start.offset
+            && command.stmt().span.end.offset >= occurrence_span(nodes, fact).end.offset
             && is_find_exec_command(command, source)
-    }) || line_has_find_exec_placeholder_context(source, fact.span())
+    }) || line_has_find_exec_placeholder_context(source, occurrence_span(nodes, fact))
 }
 
 fn is_find_exec_command(command: &CommandFact<'_>, source: &str) -> bool {
@@ -282,21 +279,22 @@ fn line_has_find_exec_placeholder_context(source: &str, brace_span: Span) -> boo
 
 fn is_xargs_replacement_word(
     commands: &[CommandFact<'_>],
-    fact: &WordFact<'_>,
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
     source: &str,
 ) -> bool {
-    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
+    if fact.context != WordFactContext::Expansion(ExpansionContext::CommandArgument) {
         return false;
     }
 
-    let command = &commands[fact.command_id().index()];
+    let command = &commands[fact.command_id.index()];
     if !command.effective_name_is("xargs") {
         return false;
     }
 
     xargs_replacement_spans(command.body_args(), source)
         .into_iter()
-        .any(|span| span == fact.word().span)
+        .any(|span| span == occurrence_span(nodes, fact))
 }
 
 fn xargs_replacement_spans(args: &[&Word], source: &str) -> Vec<Span> {
@@ -1626,5 +1624,3 @@ fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a
         .eq_ignore_ascii_case(prefix)
         .then(|| &text[prefix.len()..])
 }
-
-

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -453,11 +453,15 @@ impl<'a> LinterFactsBuilder<'a> {
             expansion_scope_spans: env_prefix_expansion_scope_spans,
         } = build_env_prefix_scope_spans(self.source, &commands);
         let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
+        let mut word_occurrence_ids_by_command =
+            vec![SmallVec::<[WordOccurrenceId; 4]>::new(); commands.len()];
         for (index, fact) in word_occurrences.iter().enumerate() {
+            let id = WordOccurrenceId::new(index);
             word_index
                 .entry(occurrence_key(&word_nodes, fact))
                 .or_default()
-                .push(WordOccurrenceId::new(index));
+                .push(id);
+            word_occurrence_ids_by_command[fact.command_id.index()].push(id);
         }
         let echo_to_sed_substitution_spans = build_echo_to_sed_substitution_spans(
             &commands,
@@ -515,6 +519,7 @@ impl<'a> LinterFactsBuilder<'a> {
             word_nodes,
             word_occurrences,
             word_index,
+            word_occurrence_ids_by_command,
             unquoted_command_argument_use_offsets,
             array_assignment_split_word_ids,
             brace_variable_before_bracket_spans,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -439,11 +439,13 @@ impl<'a> LinterFactsBuilder<'a> {
         let conditional_portability = build_conditional_portability_facts(
             &commands,
             &elif_condition_command_ids,
-            &word_nodes,
-            &word_occurrences,
-            &pattern_exactly_one_extglob_spans,
-            &pattern_charclass_spans,
-            &nested_pattern_charclass_spans,
+            ConditionalPortabilityInputs {
+                word_nodes: &word_nodes,
+                word_occurrences: &word_occurrences,
+                pattern_exactly_one_extglob_spans: &pattern_exactly_one_extglob_spans,
+                pattern_charclass_spans: &pattern_charclass_spans,
+                nested_pattern_charclass_spans: &nested_pattern_charclass_spans,
+            },
             source,
         );
         let EnvPrefixScopeSpans {

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -43,6 +43,7 @@ impl<'a> LinterFactsBuilder<'a> {
     }
 
     fn build(self) -> LinterFacts<'a> {
+        let source = self.source;
         let mut commands = Vec::new();
         let mut structural_command_ids = Vec::new();
         let mut command_ids_by_span = CommandLookupIndex::default();
@@ -52,9 +53,11 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
         let mut ifs_literal_backslash_assignment_value_spans = Vec::new();
-        let mut words = Vec::new();
+        let mut word_nodes = Vec::new();
+        let mut word_node_ids_by_span = FxHashMap::default();
+        let mut word_occurrences = Vec::new();
         let mut compound_assignment_value_word_spans = FxHashSet::default();
-        let mut array_assignment_split_word_indices = Vec::new();
+        let mut array_assignment_split_word_ids = Vec::new();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut case_pattern_expansion_spans = Vec::new();
         let mut pattern_literal_spans = Vec::new();
@@ -132,9 +135,11 @@ impl<'a> LinterFactsBuilder<'a> {
                 &normalized,
                 command_zsh_options.clone(),
                 WordFactOutputs {
-                    facts: &mut words,
+                    word_nodes: &mut word_nodes,
+                    word_node_ids_by_span: &mut word_node_ids_by_span,
+                    word_occurrences: &mut word_occurrences,
                     compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
-                    array_assignment_split_word_indices: &mut array_assignment_split_word_indices,
+                    array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
                     case_pattern_expansion_spans: &mut case_pattern_expansion_spans,
                     pattern_literal_spans: &mut pattern_literal_spans,
                     arithmetic: &mut arithmetic_summary,
@@ -364,9 +369,10 @@ impl<'a> LinterFactsBuilder<'a> {
             build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
         let literal_brace_spans = build_literal_brace_spans(
-            &words,
+            &word_nodes,
+            &word_occurrences,
             &commands,
-            self.source,
+            source,
             self._indexer.region_index().heredoc_ranges(),
         );
         let SurfaceFragmentFacts {
@@ -410,7 +416,8 @@ impl<'a> LinterFactsBuilder<'a> {
         pattern_charclass_spans.extend(surface_pattern_charclass_spans);
         let escape_scan_matches = build_escape_scan_matches(
             &commands,
-            &words,
+            &word_nodes,
+            &word_occurrences,
             EscapeScanInputs {
                 pattern_literal_spans: &pattern_literal_spans,
                 pattern_charclass_spans: &pattern_charclass_spans,
@@ -432,46 +439,62 @@ impl<'a> LinterFactsBuilder<'a> {
         let conditional_portability = build_conditional_portability_facts(
             &commands,
             &elif_condition_command_ids,
-            &words,
+            &word_nodes,
+            &word_occurrences,
             &pattern_exactly_one_extglob_spans,
             &pattern_charclass_spans,
             &nested_pattern_charclass_spans,
-            self.source,
+            source,
         );
         let EnvPrefixScopeSpans {
             assignment_scope_spans: env_prefix_assignment_scope_spans,
             expansion_scope_spans: env_prefix_expansion_scope_spans,
         } = build_env_prefix_scope_spans(self.source, &commands);
-        populate_array_assignment_split_scalar_expansion_spans(
-            &mut words,
-            &array_assignment_split_word_indices,
-            &commands,
-            self.source,
-        );
-        let mut word_index = FxHashMap::<FactSpan, Vec<usize>>::default();
-        for (index, fact) in words.iter().enumerate() {
-            word_index.entry(fact.key()).or_default().push(index);
+        let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
+        for (index, fact) in word_occurrences.iter().enumerate() {
+            word_index
+                .entry(occurrence_key(&word_nodes, fact))
+                .or_default()
+                .push(WordOccurrenceId::new(index));
         }
         let echo_to_sed_substitution_spans = build_echo_to_sed_substitution_spans(
             &commands,
             &pipelines,
             &backticks,
-            &words,
+            &word_nodes,
+            &word_occurrences,
             &word_index,
-            self.source,
+            source,
         );
         let assignment_like_command_name_spans =
             build_assignment_like_command_name_spans(&commands, self.source);
         let bare_command_name_assignment_spans =
-            build_bare_command_name_assignment_spans(&commands, &words, &word_index, self.source);
+            build_bare_command_name_assignment_spans(
+                &commands,
+                &word_nodes,
+                &word_occurrences,
+                &word_index,
+                source,
+            );
         let unquoted_command_argument_use_offsets =
-            build_unquoted_command_argument_use_offsets(self.semantic, &words);
+            build_unquoted_command_argument_use_offsets(
+                self.semantic,
+                &word_nodes,
+                &word_occurrences,
+            );
         let brace_variable_before_bracket_spans =
-            build_brace_variable_before_bracket_spans(&words, self.source);
+            build_brace_variable_before_bracket_spans(&word_nodes, &word_occurrences, source);
         let alias_definition_expansion_spans =
-            build_alias_definition_expansion_spans(&commands, &words, &word_index, self.source);
+            build_alias_definition_expansion_spans(
+                &commands,
+                &word_nodes,
+                &word_occurrences,
+                &word_index,
+                source,
+            );
 
         LinterFacts {
+            source,
             commands,
             structural_command_ids,
             command_ids_by_span,
@@ -487,10 +510,11 @@ impl<'a> LinterFactsBuilder<'a> {
             nested_presence_test_spans: presence_tested_names.nested_command_spans_by_name,
             subscript_index_reference_spans,
             compound_assignment_value_word_spans,
-            words,
+            word_nodes,
+            word_occurrences,
             word_index,
             unquoted_command_argument_use_offsets,
-            array_assignment_split_word_indices,
+            array_assignment_split_word_ids,
             brace_variable_before_bracket_spans,
             function_headers,
             function_in_alias_spans,

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -96,14 +96,18 @@ impl ConditionalPortabilityFacts {
     }
 }
 
+pub(super) struct ConditionalPortabilityInputs<'a> {
+    pub word_nodes: &'a [WordNode<'a>],
+    pub word_occurrences: &'a [WordOccurrence],
+    pub pattern_exactly_one_extglob_spans: &'a [Span],
+    pub pattern_charclass_spans: &'a [Span],
+    pub nested_pattern_charclass_spans: &'a FxHashSet<FactSpan>,
+}
+
 pub(super) fn build_conditional_portability_facts<'a>(
     commands: &[CommandFact<'a>],
     elif_condition_command_ids: &FxHashSet<CommandId>,
-    word_nodes: &[WordNode<'a>],
-    word_occurrences: &[WordOccurrence],
-    pattern_exactly_one_extglob_spans: &[Span],
-    pattern_charclass_spans: &[Span],
-    nested_pattern_charclass_spans: &FxHashSet<FactSpan>,
+    inputs: ConditionalPortabilityInputs<'a>,
     source: &str,
 ) -> ConditionalPortabilityFacts {
     let mut facts = ConditionalPortabilityFacts::default();
@@ -146,22 +150,27 @@ pub(super) fn build_conditional_portability_facts<'a>(
 
     facts
         .extglob_in_sh
-        .extend(pattern_exactly_one_extglob_spans.iter().copied());
+        .extend(inputs.pattern_exactly_one_extglob_spans.iter().copied());
 
     facts.caret_negation_in_bracket.extend(
-        pattern_charclass_spans
+        inputs
+            .pattern_charclass_spans
             .iter()
-            .filter(|span| !nested_pattern_charclass_spans.contains(&FactSpan::new(**span)))
+            .filter(|span| {
+                !inputs
+                    .nested_pattern_charclass_spans
+                    .contains(&FactSpan::new(**span))
+            })
             .filter(|span| text_looks_like_caret_negated_bracket(span.slice(source)))
             .copied(),
     );
 
-    for fact in word_occurrences {
+    for fact in inputs.word_occurrences {
         let expansion_context = match fact.context {
             super::WordFactContext::Expansion(context) => Some(context),
             super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
         };
-        let word = occurrence_word(word_nodes, fact);
+        let word = occurrence_word(inputs.word_nodes, fact);
         if supports_extglob_portability_context(expansion_context)
             && let Some(span) = word_exactly_one_extglob_span(word, source)
         {

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -3,7 +3,7 @@ use shuck_ast::{ConditionalBinaryOp, ConditionalUnaryOp, Span};
 
 use super::{
     CommandFact, CommandId, ConditionalFact, ConditionalNodeFact, FactSpan, SimpleTestFact,
-    SimpleTestSyntax, WordFact,
+    SimpleTestSyntax, WordNode, WordOccurrence,
 };
 use crate::rules::common::expansion::ExpansionContext;
 use crate::rules::common::span::{
@@ -11,8 +11,8 @@ use crate::rules::common::span::{
     word_exactly_one_extglob_span,
 };
 use crate::{
-    conditional_array_subscript_span, conditional_extglob_span, static_word_text,
-    word_array_subscript_span, word_extglob_span,
+    conditional_array_subscript_span, conditional_extglob_span, facts::occurrence_word,
+    static_word_text, word_array_subscript_span, word_extglob_span,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -99,7 +99,8 @@ impl ConditionalPortabilityFacts {
 pub(super) fn build_conditional_portability_facts<'a>(
     commands: &[CommandFact<'a>],
     elif_condition_command_ids: &FxHashSet<CommandId>,
-    word_facts: &[WordFact<'a>],
+    word_nodes: &[WordNode<'a>],
+    word_occurrences: &[WordOccurrence],
     pattern_exactly_one_extglob_spans: &[Span],
     pattern_charclass_spans: &[Span],
     nested_pattern_charclass_spans: &FxHashSet<FactSpan>,
@@ -155,17 +156,22 @@ pub(super) fn build_conditional_portability_facts<'a>(
             .copied(),
     );
 
-    for fact in word_facts {
-        if supports_extglob_portability_context(fact.expansion_context())
-            && let Some(span) = word_exactly_one_extglob_span(fact.word(), source)
+    for fact in word_occurrences {
+        let expansion_context = match fact.context {
+            super::WordFactContext::Expansion(context) => Some(context),
+            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+        };
+        let word = occurrence_word(word_nodes, fact);
+        if supports_extglob_portability_context(expansion_context)
+            && let Some(span) = word_exactly_one_extglob_span(word, source)
         {
             facts.extglob_in_sh.push(span);
         }
 
-        if supports_bracket_glob_portability_context(fact.expansion_context()) {
+        if supports_bracket_glob_portability_context(expansion_context) {
             facts
                 .caret_negation_in_bracket
-                .extend(word_caret_negated_bracket_spans(fact.word(), source));
+                .extend(word_caret_negated_bracket_spans(word, source));
         }
     }
 

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -33,6 +33,32 @@ impl CommandId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WordNodeId(u32);
+
+impl WordNodeId {
+    fn new(index: usize) -> Self {
+        Self(index as u32)
+    }
+
+    fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WordOccurrenceId(u32);
+
+impl WordOccurrenceId {
+    fn new(index: usize) -> Self {
+        Self(index as u32)
+    }
+
+    fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum CommandLookupKind {
     Simple,
     Builtin(BuiltinLookupKind),

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -1,8 +1,11 @@
 use shuck_ast::Span;
 
-use super::{BacktickFragmentFact, CommandFact, SingleQuotedFragmentFact, WordFact};
+use super::{
+    BacktickFragmentFact, CommandFact, SingleQuotedFragmentFact, WordNode, WordOccurrence,
+};
 use crate::FileContext;
 use crate::context::FileContextTag;
+use crate::facts::{occurrence_span, occurrence_word};
 use crate::rules::common::expansion::ExpansionContext;
 use crate::rules::common::span::{
     word_has_single_literal_part, word_literal_part_spans_excluding_parameter_operator_tails,
@@ -87,7 +90,8 @@ struct EscapeScanMatchContext {
 
 pub(super) fn build_escape_scan_matches(
     commands: &[CommandFact<'_>],
-    words: &[WordFact<'_>],
+    nodes: &[WordNode<'_>],
+    occurrences: &[WordOccurrence],
     inputs: EscapeScanInputs<'_>,
     context: EscapeScanContext<'_>,
 ) -> Vec<EscapeScanMatch> {
@@ -97,21 +101,29 @@ pub(super) fn build_escape_scan_matches(
 
     let mut matches = Vec::new();
 
-    for fact in words
-        .iter()
-        .filter(|fact| is_relevant_word_context(fact.expansion_context()))
-    {
-        let grep_style_argument = is_grep_style_argument(commands, fact);
-        let tr_operand_argument = is_tr_operand_argument(commands, fact);
-        if is_regex_like_context(fact.expansion_context()) {
+    for fact in occurrences.iter().filter(|fact| {
+        is_relevant_word_context(match fact.context {
+            super::WordFactContext::Expansion(context) => Some(context),
+            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+        })
+    }) {
+        let grep_style_argument = is_grep_style_argument(commands, nodes, fact);
+        let tr_operand_argument = is_tr_operand_argument(commands, nodes, fact);
+        let expansion_context = match fact.context {
+            super::WordFactContext::Expansion(context) => Some(context),
+            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+        };
+        if is_regex_like_context(expansion_context) {
             continue;
         }
 
-        let host_contains_single_quoted_fragment =
-            span_contains_single_quoted_fragment(fact.span(), inputs.single_quoted_fragments);
+        let word = occurrence_word(nodes, fact);
+        let host_contains_single_quoted_fragment = span_contains_single_quoted_fragment(
+            occurrence_span(nodes, fact),
+            inputs.single_quoted_fragments,
+        );
 
-        for span in
-            word_literal_part_spans_excluding_parameter_operator_tails(fact.word(), context.source)
+        for span in word_literal_part_spans_excluding_parameter_operator_tails(word, context.source)
         {
             append_escape_scan_matches(
                 &mut matches,
@@ -128,24 +140,26 @@ pub(super) fn build_escape_scan_matches(
         }
     }
 
-    for fact in words
-        .iter()
-        .filter(|fact| is_assignment_value_context(fact.expansion_context()))
-    {
-        if !word_has_single_literal_part(fact.word()) {
+    for fact in occurrences.iter().filter(|fact| {
+        is_assignment_value_context(match fact.context {
+            super::WordFactContext::Expansion(context) => Some(context),
+            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+        })
+    }) {
+        if !word_has_single_literal_part(occurrence_word(nodes, fact)) {
             continue;
         }
 
         append_escape_scan_matches(
             &mut matches,
-            fact.span(),
+            occurrence_span(nodes, fact),
             context.source,
             EscapeScanMatchContext {
                 source_kind: EscapeScanSourceKind::SingleLiteralAssignmentWord,
-                grep_style_argument: is_grep_style_argument(commands, fact),
-                tr_operand_argument: is_tr_operand_argument(commands, fact),
+                grep_style_argument: is_grep_style_argument(commands, nodes, fact),
+                tr_operand_argument: is_tr_operand_argument(commands, nodes, fact),
                 host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
-                    fact.span(),
+                    occurrence_span(nodes, fact),
                     inputs.single_quoted_fragments,
                 ),
             },
@@ -153,22 +167,30 @@ pub(super) fn build_escape_scan_matches(
         );
     }
 
-    for fact in words.iter().filter(|fact| {
+    for fact in occurrences.iter().filter(|fact| {
         matches!(
-            fact.expansion_context(),
-            Some(ExpansionContext::RedirectTarget(_))
+            fact.context,
+            super::WordFactContext::Expansion(ExpansionContext::RedirectTarget(_))
         )
     }) {
-        let grep_style_argument = is_grep_style_argument(commands, fact);
-        let tr_operand_argument = is_tr_operand_argument(commands, fact);
-        if is_regex_like_context(fact.expansion_context()) {
+        let grep_style_argument = is_grep_style_argument(commands, nodes, fact);
+        let tr_operand_argument = is_tr_operand_argument(commands, nodes, fact);
+        if is_regex_like_context(match fact.context {
+            super::WordFactContext::Expansion(context) => Some(context),
+            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+        }) {
             continue;
         }
 
-        let host_contains_single_quoted_fragment =
-            span_contains_single_quoted_fragment(fact.span(), inputs.single_quoted_fragments);
+        let host_contains_single_quoted_fragment = span_contains_single_quoted_fragment(
+            occurrence_span(nodes, fact),
+            inputs.single_quoted_fragments,
+        );
 
-        for span in word_literal_scan_segments_excluding_expansions(fact.word(), context.source) {
+        for span in word_literal_scan_segments_excluding_expansions(
+            occurrence_word(nodes, fact),
+            context.source,
+        ) {
             append_escape_scan_matches(
                 &mut matches,
                 span,
@@ -410,15 +432,19 @@ fn span_within_any(span: Span, hosts: &[Span]) -> bool {
         .any(|host| span.start.offset >= host.start.offset && span.end.offset <= host.end.offset)
 }
 
-fn is_grep_style_argument(commands: &[CommandFact<'_>], fact: &WordFact<'_>) -> bool {
-    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
+fn is_grep_style_argument(
+    commands: &[CommandFact<'_>],
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
+) -> bool {
+    if fact.context != super::WordFactContext::Expansion(ExpansionContext::CommandArgument) {
         return false;
     }
 
-    let command = &commands[fact.command_id().index()];
+    let command = &commands[fact.command_id.index()];
     if command
         .body_name_word()
-        .is_some_and(|word| word.span == fact.span())
+        .is_some_and(|word| word.span == occurrence_span(nodes, fact))
     {
         return false;
     }
@@ -428,18 +454,22 @@ fn is_grep_style_argument(commands: &[CommandFact<'_>], fact: &WordFact<'_>) -> 
         .is_some_and(|name| name.contains("grep"))
 }
 
-fn is_tr_operand_argument(commands: &[CommandFact<'_>], fact: &WordFact<'_>) -> bool {
-    if fact.expansion_context() != Some(ExpansionContext::CommandArgument) {
+fn is_tr_operand_argument(
+    commands: &[CommandFact<'_>],
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
+) -> bool {
+    if fact.context != super::WordFactContext::Expansion(ExpansionContext::CommandArgument) {
         return false;
     }
 
-    commands[fact.command_id().index()]
+    commands[fact.command_id.index()]
         .options()
         .tr()
         .is_some_and(|tr| {
             tr.operand_words()
                 .iter()
-                .any(|word| word.span == fact.span())
+                .any(|word| word.span == occurrence_span(nodes, fact))
         })
 }
 

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -66,7 +66,8 @@ use shuck_parser::parser::Parser;
 use shuck_semantic::{
     BindingAttributes, BindingId, BindingKind, ScopeId, SemanticModel, ZshOptionState,
 };
-use std::{borrow::Cow, ops::ControlFlow};
+use smallvec::SmallVec;
+use std::{borrow::Cow, cell::OnceCell, ops::ControlFlow};
 
 pub use self::conditional_portability::ConditionalPortabilityFacts;
 pub(crate) use self::escape_scan::{EscapeScanMatch, EscapeScanSourceKind};
@@ -100,7 +101,7 @@ include!("words.rs");
 
 #[allow(unused_imports)]
 pub(crate) mod core {
-    pub use super::{CommandId, FactSpan, SudoFamilyInvoker};
+    pub use super::{CommandId, FactSpan, SudoFamilyInvoker, WordNodeId, WordOccurrenceId};
 }
 
 #[allow(unused_imports)]
@@ -168,5 +169,8 @@ pub(crate) mod commands {
 
 #[allow(unused_imports)]
 pub(crate) mod words {
-    pub use super::{WordFact, WordFactContext, WordFactHostKind, leading_literal_word_prefix};
+    pub use super::{
+        WordFactContext, WordFactHostKind, WordOccurrence, WordOccurrenceIter, WordOccurrenceRef,
+        leading_literal_word_prefix,
+    };
 }

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod surface;
 mod tests;
 
 use self::{
-    conditional_portability::build_conditional_portability_facts,
+    conditional_portability::{ConditionalPortabilityInputs, build_conditional_portability_facts},
     escape_scan::{EscapeScanContext, EscapeScanInputs, build_escape_scan_matches},
     presence::build_presence_tested_names,
     surface::{

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -19,6 +19,7 @@ pub struct LinterFacts<'a> {
     word_nodes: Vec<WordNode<'a>>,
     word_occurrences: Vec<WordOccurrence>,
     word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+    word_occurrence_ids_by_command: Vec<SmallVec<[WordOccurrenceId; 4]>>,
     unquoted_command_argument_use_offsets: FxHashMap<Name, Vec<usize>>,
     array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     brace_variable_before_bracket_spans: Vec<Span>,
@@ -327,6 +328,15 @@ impl<'a> LinterFacts<'a> {
         &self.word_occurrences[id.index()]
     }
 
+    fn word_occurrence_ids_for_command(
+        &self,
+        id: CommandId,
+    ) -> &[WordOccurrenceId] {
+        self.word_occurrence_ids_by_command
+            .get(id.index())
+            .map_or(&[], SmallVec::as_slice)
+    }
+
     fn word_node(&self, id: WordNodeId) -> &WordNode<'a> {
         &self.word_nodes[id.index()]
     }
@@ -352,11 +362,13 @@ impl<'a> LinterFacts<'a> {
         ) {
             for command in &self.commands {
                 if contains_span_strictly(fact.span(), command.span()) {
-                    for nested_fact in self.word_facts() {
-                        if nested_fact.command_id() == command.id() {
-                            split_sensitive_spans
-                                .extend(nested_fact.scalar_expansion_spans().iter().copied());
-                        }
+                    for nested_id in self.word_occurrence_ids_for_command(command.id()) {
+                        split_sensitive_spans.extend(
+                            self.word_occurrence_ref(*nested_id)
+                                .scalar_expansion_spans()
+                                .iter()
+                                .copied(),
+                        );
                     }
                 }
             }

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1,4 +1,5 @@
 pub struct LinterFacts<'a> {
+    source: &'a str,
     commands: Vec<CommandFact<'a>>,
     structural_command_ids: Vec<CommandId>,
     #[cfg_attr(not(test), allow(dead_code))]
@@ -15,10 +16,11 @@ pub struct LinterFacts<'a> {
     nested_presence_test_spans: FxHashMap<Name, Vec<Span>>,
     subscript_index_reference_spans: FxHashSet<FactSpan>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
-    words: Vec<WordFact<'a>>,
-    word_index: FxHashMap<FactSpan, Vec<usize>>,
+    word_nodes: Vec<WordNode<'a>>,
+    word_occurrences: Vec<WordOccurrence>,
+    word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     unquoted_command_argument_use_offsets: FxHashMap<Name, Vec<usize>>,
-    array_assignment_split_word_indices: Vec<usize>,
+    array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     brace_variable_before_bracket_spans: Vec<Span>,
     function_headers: Vec<FunctionHeaderFact<'a>>,
     function_in_alias_spans: Vec<Span>,
@@ -237,11 +239,18 @@ impl<'a> LinterFacts<'a> {
             .contains(&FactSpan::new(span))
     }
 
-    pub fn word_facts(&self) -> &[WordFact<'a>] {
-        &self.words
+    pub fn word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
+        WordOccurrenceIter {
+            inner: Box::new(
+                self.word_occurrences
+                    .iter()
+                    .enumerate()
+                    .map(|(index, _)| self.word_occurrence_ref(WordOccurrenceId::new(index))),
+            ),
+        }
     }
 
-    pub fn is_compound_assignment_value_word(&self, fact: &WordFact<'_>) -> bool {
+    pub fn is_compound_assignment_value_word(&self, fact: WordOccurrenceRef<'_, '_>) -> bool {
         self.compound_assignment_value_word_spans
             .contains(&fact.key())
     }
@@ -249,30 +258,40 @@ impl<'a> LinterFacts<'a> {
     pub fn expansion_word_facts(
         &self,
         context: ExpansionContext,
-    ) -> impl Iterator<Item = &WordFact<'a>> + '_ {
-        self.words
-            .iter()
-            .filter(move |fact| fact.expansion_context() == Some(context))
+    ) -> WordOccurrenceIter<'_, 'a> {
+        WordOccurrenceIter {
+            inner: Box::new(
+                self.word_facts()
+                    .filter(move |fact| fact.expansion_context() == Some(context)),
+            ),
+        }
     }
 
-    pub fn case_subject_facts(&self) -> impl Iterator<Item = &WordFact<'a>> + '_ {
-        self.words.iter().filter(|fact| fact.is_case_subject())
+    pub fn case_subject_facts(&self) -> WordOccurrenceIter<'_, 'a> {
+        WordOccurrenceIter {
+            inner: Box::new(self.word_facts().filter(|fact| fact.is_case_subject())),
+        }
     }
 
-    pub fn word_fact(&self, span: Span, context: WordFactContext) -> Option<&WordFact<'a>> {
+    pub fn word_fact(
+        &self,
+        span: Span,
+        context: WordFactContext,
+    ) -> Option<WordOccurrenceRef<'_, 'a>> {
         self.word_index
             .get(&FactSpan::new(span))
             .into_iter()
             .flat_map(|indices| indices.iter())
-            .map(|&index| &self.words[index])
+            .copied()
+            .map(|id| self.word_occurrence_ref(id))
             .find(|fact| fact.context() == context)
     }
 
-    pub fn any_word_fact(&self, span: Span) -> Option<&WordFact<'a>> {
+    pub fn any_word_fact(&self, span: Span) -> Option<WordOccurrenceRef<'_, 'a>> {
         self.word_index
             .get(&FactSpan::new(span))
             .and_then(|indices| indices.first().copied())
-            .map(|index| &self.words[index])
+            .map(|id| self.word_occurrence_ref(id))
     }
 
     pub fn has_later_unquoted_command_argument_use(
@@ -287,10 +306,65 @@ impl<'a> LinterFacts<'a> {
             })
     }
 
-    pub fn array_assignment_split_word_facts(&self) -> impl Iterator<Item = &WordFact<'a>> + '_ {
-        self.array_assignment_split_word_indices
-            .iter()
-            .map(|&index| &self.words[index])
+    pub fn array_assignment_split_word_facts(
+        &self,
+    ) -> WordOccurrenceIter<'_, 'a> {
+        WordOccurrenceIter {
+            inner: Box::new(
+                self.array_assignment_split_word_ids
+                    .iter()
+                    .copied()
+                    .map(|id| self.word_occurrence_ref(id)),
+            ),
+        }
+    }
+
+    fn word_occurrence_ref(&self, id: WordOccurrenceId) -> WordOccurrenceRef<'_, 'a> {
+        WordOccurrenceRef { facts: self, id }
+    }
+
+    fn word_occurrence(&self, id: WordOccurrenceId) -> &WordOccurrence {
+        &self.word_occurrences[id.index()]
+    }
+
+    fn word_node(&self, id: WordNodeId) -> &WordNode<'a> {
+        &self.word_nodes[id.index()]
+    }
+
+    fn word_node_derived(&self, id: WordNodeId) -> &WordNodeDerived {
+        word_node_derived(self.word_node(id), self.source)
+    }
+
+    fn compute_array_assignment_split_scalar_expansion_spans(
+        &self,
+        id: WordOccurrenceId,
+    ) -> Box<[Span]> {
+        let fact = self.word_occurrence_ref(id);
+        let mut split_sensitive_spans = fact.unquoted_scalar_expansion_spans().to_vec();
+        let use_replacement_spans = collect_array_assignment_use_replacement_expansion_spans(
+            occurrence_word(&self.word_nodes, self.word_occurrence(id)),
+        );
+
+        if !word_occurrence_is_double_quoted_command_substitution_only(
+            &self.word_nodes,
+            self.word_occurrence(id),
+            self.source,
+        ) {
+            for command in &self.commands {
+                if contains_span_strictly(fact.span(), command.span()) {
+                    for nested_fact in self.word_facts() {
+                        if nested_fact.command_id() == command.id() {
+                            split_sensitive_spans
+                                .extend(nested_fact.scalar_expansion_spans().iter().copied());
+                        }
+                    }
+                }
+            }
+        }
+
+        split_sensitive_spans.retain(|span| !use_replacement_spans.contains(span));
+        sort_and_dedup_spans(&mut split_sensitive_spans);
+        split_sensitive_spans.into_boxed_slice()
     }
 
     pub fn brace_variable_before_bracket_spans(&self) -> &[Span] {
@@ -611,4 +685,3 @@ impl<'a> LinterFacts<'a> {
         &self.conditional_portability
     }
 }
-

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -14,18 +14,16 @@ pub enum WordFactHostKind {
     ConditionalVarRefSubscript,
 }
 
-#[derive(Debug, Clone)]
-pub struct WordFact<'a> {
+#[derive(Debug)]
+pub struct WordNode<'a> {
     key: FactSpan,
-    word: Cow<'a, Word>,
-    command_id: CommandId,
-    nested_word_command: bool,
-    context: WordFactContext,
-    host_kind: WordFactHostKind,
-    zsh_options: Option<ZshOptionState>,
+    word: &'a Word,
     analysis: ExpansionAnalysis,
-    runtime_literal: RuntimeLiteralAnalysis,
-    operand_class: Option<TestOperandClass>,
+    derived: OnceCell<WordNodeDerived>,
+}
+
+#[derive(Debug)]
+pub(crate) struct WordNodeDerived {
     static_text: Option<Box<str>>,
     starts_with_extglob: bool,
     has_literal_affixes: bool,
@@ -33,7 +31,6 @@ pub struct WordFact<'a> {
     active_expansion_spans: Box<[Span]>,
     scalar_expansion_spans: Box<[Span]>,
     unquoted_scalar_expansion_spans: Box<[Span]>,
-    array_assignment_split_scalar_expansion_spans: Box<[Span]>,
     array_expansion_spans: Box<[Span]>,
     all_elements_array_expansion_spans: Box<[Span]>,
     direct_all_elements_array_expansion_spans: Box<[Span]>,
@@ -45,158 +42,348 @@ pub struct WordFact<'a> {
     unquoted_literal_between_double_quoted_segments_spans: Box<[Span]>,
 }
 
-impl<'a> WordFact<'a> {
-    pub fn key(&self) -> FactSpan {
-        self.key
+#[derive(Debug)]
+pub struct WordOccurrence {
+    node_id: WordNodeId,
+    command_id: CommandId,
+    nested_word_command: bool,
+    context: WordFactContext,
+    host_kind: WordFactHostKind,
+    runtime_literal: RuntimeLiteralAnalysis,
+    operand_class: Option<TestOperandClass>,
+    array_assignment_split_scalar_expansion_spans: OnceCell<Box<[Span]>>,
+}
+
+#[derive(Clone, Copy)]
+pub struct WordOccurrenceRef<'facts, 'a> {
+    facts: &'facts LinterFacts<'a>,
+    id: WordOccurrenceId,
+}
+
+pub struct WordOccurrenceIter<'facts, 'a> {
+    inner: Box<dyn Iterator<Item = WordOccurrenceRef<'facts, 'a>> + 'facts>,
+}
+
+impl<'facts, 'a> WordOccurrenceIter<'facts, 'a> {
+    pub fn iter(self) -> Self {
+        self
+    }
+}
+
+impl<'facts, 'a> Iterator for WordOccurrenceIter<'facts, 'a> {
+    type Item = WordOccurrenceRef<'facts, 'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
+    fn occurrence(self) -> &'facts WordOccurrence {
+        self.facts.word_occurrence(self.id)
     }
 
-    pub fn word(&self) -> &Word {
-        self.word.as_ref()
+    fn node(self) -> &'facts WordNode<'a> {
+        self.facts.word_node(self.occurrence().node_id)
     }
 
-    pub fn span(&self) -> Span {
-        self.word.span
+    fn derived(self) -> &'facts WordNodeDerived {
+        self.facts.word_node_derived(self.occurrence().node_id)
     }
 
-    pub fn command_id(&self) -> CommandId {
-        self.command_id
+    fn word(self) -> &'a Word {
+        self.node().word
     }
 
-    pub fn is_nested_word_command(&self) -> bool {
-        self.nested_word_command
+    pub fn key(self) -> FactSpan {
+        self.node().key
     }
 
-    pub fn context(&self) -> WordFactContext {
-        self.context
+    pub fn span(self) -> Span {
+        self.word().span
     }
 
-    pub fn expansion_context(&self) -> Option<ExpansionContext> {
-        match self.context {
+    pub fn command_id(self) -> CommandId {
+        self.occurrence().command_id
+    }
+
+    pub fn is_nested_word_command(self) -> bool {
+        self.occurrence().nested_word_command
+    }
+
+    pub fn context(self) -> WordFactContext {
+        self.occurrence().context
+    }
+
+    pub fn expansion_context(self) -> Option<ExpansionContext> {
+        match self.context() {
             WordFactContext::Expansion(context) => Some(context),
             WordFactContext::CaseSubject => None,
             WordFactContext::ArithmeticCommand => None,
         }
     }
 
-    pub fn is_case_subject(&self) -> bool {
-        self.context == WordFactContext::CaseSubject
+    pub fn is_case_subject(self) -> bool {
+        self.context() == WordFactContext::CaseSubject
     }
 
-    pub fn is_arithmetic_command(&self) -> bool {
-        self.context == WordFactContext::ArithmeticCommand
+    pub fn is_arithmetic_command(self) -> bool {
+        self.context() == WordFactContext::ArithmeticCommand
     }
 
-    pub fn host_kind(&self) -> WordFactHostKind {
-        self.host_kind
+    pub fn host_kind(self) -> WordFactHostKind {
+        self.occurrence().host_kind
     }
 
-    pub fn analysis(&self) -> ExpansionAnalysis {
-        self.analysis
+    pub fn analysis(self) -> ExpansionAnalysis {
+        self.node().analysis
     }
 
-    pub fn runtime_literal(&self) -> RuntimeLiteralAnalysis {
-        self.runtime_literal
+    pub fn runtime_literal(self) -> RuntimeLiteralAnalysis {
+        self.occurrence().runtime_literal
     }
 
-    pub fn zsh_options(&self) -> Option<&ZshOptionState> {
-        self.zsh_options.as_ref()
+    pub fn classification(self) -> WordClassification {
+        word_classification_from_analysis(self.analysis())
     }
 
-    pub fn classification(&self) -> WordClassification {
-        word_classification_from_analysis(self.analysis)
+    pub fn operand_class(self) -> Option<TestOperandClass> {
+        self.occurrence().operand_class
     }
 
-    pub fn operand_class(&self) -> Option<TestOperandClass> {
-        self.operand_class
+    pub fn static_text(self) -> Option<&'facts str> {
+        self.derived().static_text.as_deref()
     }
 
-    pub fn static_text(&self) -> Option<&str> {
-        self.static_text.as_deref()
-    }
-
-    pub fn is_plain_scalar_reference(&self) -> bool {
+    pub fn is_plain_scalar_reference(self) -> bool {
         word_is_plain_scalar_reference(self.word())
     }
 
-    pub fn is_direct_numeric_expansion(&self) -> bool {
+    pub fn is_direct_numeric_expansion(self) -> bool {
         word_is_direct_numeric_expansion(self.word())
     }
 
-    pub fn starts_with_extglob(&self) -> bool {
-        self.starts_with_extglob
+    pub fn starts_with_extglob(self) -> bool {
+        self.derived().starts_with_extglob
     }
 
-    pub fn has_literal_affixes(&self) -> bool {
-        self.has_literal_affixes
+    pub fn has_literal_affixes(self) -> bool {
+        self.derived().has_literal_affixes
     }
 
-    pub fn contains_shell_quoting_literals(&self) -> bool {
-        self.contains_shell_quoting_literals
+    pub fn contains_shell_quoting_literals(self) -> bool {
+        self.derived().contains_shell_quoting_literals
     }
 
-    pub fn active_expansion_spans(&self) -> &[Span] {
-        &self.active_expansion_spans
+    pub fn active_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().active_expansion_spans
     }
 
-    pub fn scalar_expansion_spans(&self) -> &[Span] {
-        &self.scalar_expansion_spans
+    pub fn scalar_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().scalar_expansion_spans
     }
 
-    pub fn unquoted_scalar_expansion_spans(&self) -> &[Span] {
-        &self.unquoted_scalar_expansion_spans
+    pub fn unquoted_scalar_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().unquoted_scalar_expansion_spans
     }
 
-    pub fn array_assignment_split_scalar_expansion_spans(&self) -> &[Span] {
-        &self.array_assignment_split_scalar_expansion_spans
+    pub fn array_assignment_split_scalar_expansion_spans(self) -> &'facts [Span] {
+        self.occurrence()
+            .array_assignment_split_scalar_expansion_spans
+            .get_or_init(|| self.facts.compute_array_assignment_split_scalar_expansion_spans(self.id))
+            .as_ref()
     }
 
-    pub fn array_expansion_spans(&self) -> &[Span] {
-        &self.array_expansion_spans
+    pub fn array_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().array_expansion_spans
     }
 
-    pub fn all_elements_array_expansion_spans(&self) -> &[Span] {
-        &self.all_elements_array_expansion_spans
+    pub fn all_elements_array_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().all_elements_array_expansion_spans
     }
 
-    pub fn direct_all_elements_array_expansion_spans(&self) -> &[Span] {
-        &self.direct_all_elements_array_expansion_spans
+    pub fn direct_all_elements_array_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().direct_all_elements_array_expansion_spans
     }
 
-    pub fn unquoted_all_elements_array_expansion_spans(&self) -> &[Span] {
-        &self.unquoted_all_elements_array_expansion_spans
+    pub fn unquoted_all_elements_array_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().unquoted_all_elements_array_expansion_spans
     }
 
-    pub fn unquoted_array_expansion_spans(&self) -> &[Span] {
-        &self.unquoted_array_expansion_spans
+    pub fn unquoted_array_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().unquoted_array_expansion_spans
     }
 
-    pub fn command_substitution_spans(&self) -> &[Span] {
-        &self.command_substitution_spans
+    pub fn command_substitution_spans(self) -> &'facts [Span] {
+        &self.derived().command_substitution_spans
     }
 
-    pub fn unquoted_command_substitution_spans(&self) -> &[Span] {
-        &self.unquoted_command_substitution_spans
+    pub fn unquoted_command_substitution_spans(self) -> &'facts [Span] {
+        &self.derived().unquoted_command_substitution_spans
     }
 
-    pub fn double_quoted_expansion_spans(&self) -> &[Span] {
-        &self.double_quoted_expansion_spans
+    pub fn double_quoted_expansion_spans(self) -> &'facts [Span] {
+        &self.derived().double_quoted_expansion_spans
     }
 
-    pub fn unquoted_literal_between_double_quoted_segments_spans(&self) -> &[Span] {
-        &self.unquoted_literal_between_double_quoted_segments_spans
+    pub fn unquoted_literal_between_double_quoted_segments_spans(self) -> &'facts [Span] {
+        &self
+            .derived()
+            .unquoted_literal_between_double_quoted_segments_spans
+    }
+
+    pub fn has_single_part(self) -> bool {
+        self.word().parts.len() == 1
+    }
+
+    pub fn parts_len(self) -> usize {
+        self.word().parts.len()
+    }
+
+    pub fn parts_with_spans(self) -> impl Iterator<Item = (&'a WordPart, Span)> + 'a {
+        self.word().parts_with_spans()
+    }
+
+    pub fn has_direct_all_elements_array_expansion_in_source(self, source: &str) -> bool {
+        crate::word_has_direct_all_elements_array_expansion_in_source(self.word(), source)
+    }
+
+    pub fn has_quoted_all_elements_array_slice(self) -> bool {
+        crate::word_has_quoted_all_elements_array_slice(self.word())
+    }
+
+    pub fn double_quoted_scalar_affix_span(self) -> Option<Span> {
+        crate::double_quoted_scalar_affix_span(self.word())
+    }
+
+    pub fn is_pure_positional_at_splat(self) -> bool {
+        crate::word_is_pure_positional_at_splat(self.word())
+    }
+
+    pub fn quoted_unindexed_bash_source_span_in_source(self, source: &str) -> Option<Span> {
+        crate::word_quoted_unindexed_bash_source_span_in_source(self.word(), source)
+    }
+
+    pub fn unquoted_glob_pattern_spans(self, source: &str) -> Vec<Span> {
+        crate::word_unquoted_glob_pattern_spans(self.word(), source)
+    }
+
+    pub fn unquoted_glob_pattern_spans_outside_brace_expansion(self, source: &str) -> Vec<Span> {
+        crate::word_unquoted_glob_pattern_spans_outside_brace_expansion(self.word(), source)
+    }
+
+    pub fn suspicious_bracket_glob_spans(self, source: &str) -> Vec<Span> {
+        crate::word_suspicious_bracket_glob_spans(self.word(), source)
+    }
+
+    pub fn standalone_literal_backslash_span(self, source: &str) -> Option<Span> {
+        crate::word_standalone_literal_backslash_span(self.word(), source)
+    }
+
+    pub fn unquoted_assign_default_spans(self) -> Vec<Span> {
+        crate::word_unquoted_assign_default_spans(self.word())
+    }
+
+    pub fn use_replacement_spans(self) -> Vec<Span> {
+        crate::word_use_replacement_spans(self.word())
+    }
+
+    pub fn unquoted_star_parameter_spans(self) -> Vec<Span> {
+        crate::word_unquoted_star_parameter_spans(self.word(), self.unquoted_array_expansion_spans())
+    }
+
+    pub fn unquoted_star_splat_spans(self) -> Vec<Span> {
+        crate::word_unquoted_star_splat_spans(self.word())
+    }
+
+    pub fn unquoted_word_after_single_quoted_segment_spans(self, source: &str) -> Vec<Span> {
+        crate::word_unquoted_word_after_single_quoted_segment_spans(self.word(), source)
+    }
+
+    pub fn unquoted_scalar_between_double_quoted_segments_spans(
+        self,
+        candidate_spans: &[Span],
+    ) -> Vec<Span> {
+        crate::word_unquoted_scalar_between_double_quoted_segments_spans(
+            self.word(),
+            candidate_spans,
+        )
+    }
+
+    pub fn nested_dynamic_double_quote_spans(self) -> Vec<Span> {
+        crate::word_nested_dynamic_double_quote_spans(self.word())
+    }
+
+    pub fn folded_positional_at_splat_span_in_source(self, source: &str) -> Option<Span> {
+        crate::word_folded_positional_at_splat_span_in_source(self.word(), source)
+    }
+
+    pub fn zsh_flag_modifier_spans(self) -> Vec<Span> {
+        crate::word_zsh_flag_modifier_spans(self.word())
+    }
+
+    pub fn zsh_nested_expansion_spans(self) -> Vec<Span> {
+        crate::word_zsh_nested_expansion_spans(self.word())
+    }
+
+    pub fn nested_zsh_substitution_spans(self) -> Vec<Span> {
+        crate::word_nested_zsh_substitution_spans(self.word())
+    }
+
+    pub fn brace_expansion_spans(self) -> Vec<Span> {
+        self.word()
+            .brace_syntax()
+            .iter()
+            .copied()
+            .filter(|brace| brace.expands())
+            .map(|brace| brace.span)
+            .collect()
     }
 }
 
 
-fn build_brace_variable_before_bracket_spans(words: &[WordFact<'_>], source: &str) -> Vec<Span> {
-    let mut spans = words
+fn build_brace_variable_before_bracket_spans<'a>(
+    nodes: &[WordNode<'a>],
+    occurrences: &[WordOccurrence],
+    source: &str,
+) -> Vec<Span> {
+    let mut spans = occurrences
         .iter()
-        .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
-        .filter(|fact| !fact.is_arithmetic_command())
-        .flat_map(|fact| word_unbraced_variable_before_bracket_spans(fact.word(), source))
+        .filter(|fact| fact.host_kind == WordFactHostKind::Direct)
+        .filter(|fact| fact.context != WordFactContext::ArithmeticCommand)
+        .flat_map(|fact| {
+            word_unbraced_variable_before_bracket_spans(occurrence_word(nodes, fact), source)
+        })
         .collect::<Vec<_>>();
     sort_and_dedup_spans(&mut spans);
     spans
+}
+
+pub(crate) fn occurrence_word<'a>(
+    nodes: &[WordNode<'a>],
+    occurrence: &WordOccurrence,
+) -> &'a Word {
+    nodes[occurrence.node_id.index()].word
+}
+
+pub(crate) fn occurrence_key(nodes: &[WordNode<'_>], occurrence: &WordOccurrence) -> FactSpan {
+    nodes[occurrence.node_id.index()].key
+}
+
+pub(crate) fn occurrence_span(nodes: &[WordNode<'_>], occurrence: &WordOccurrence) -> Span {
+    occurrence_word(nodes, occurrence).span
+}
+
+pub(crate) fn occurrence_analysis(
+    nodes: &[WordNode<'_>],
+    occurrence: &WordOccurrence,
+) -> ExpansionAnalysis {
+    nodes[occurrence.node_id.index()].analysis
+}
+
+pub(crate) fn word_node_derived<'a>(node: &'a WordNode<'_>, source: &str) -> &'a WordNodeDerived {
+    node.derived
+        .get_or_init(|| derive_word_fact_data(node.word, source))
 }
 
 fn word_is_plain_scalar_reference(word: &Word) -> bool {
@@ -286,8 +473,9 @@ fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source: &str) -> 
 
 fn build_alias_definition_expansion_spans(
     commands: &[CommandFact<'_>],
-    words: &[WordFact<'_>],
-    word_index: &FxHashMap<FactSpan, Vec<usize>>,
+    nodes: &[WordNode<'_>],
+    occurrences: &[WordOccurrence],
+    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     source: &str,
 ) -> Vec<Span> {
     let mut spans = commands
@@ -302,13 +490,19 @@ fn build_alias_definition_expansion_spans(
                         .get(&FactSpan::new(candidate.span))
                         .into_iter()
                         .flat_map(|indices| indices.iter().copied())
-                        .map(|index| &words[index])
+                        .map(|id| &occurrences[id.index()])
                         .filter(move |fact| {
-                            fact.expansion_context() == Some(ExpansionContext::CommandArgument)
-                                && fact.span() == candidate.span
+                            fact.context
+                                == WordFactContext::Expansion(ExpansionContext::CommandArgument)
+                                && occurrence_span(nodes, fact) == candidate.span
                         })
                 })
-                .flat_map(|fact| fact.active_expansion_spans().iter().copied())
+                .flat_map(|fact| {
+                    word_node_derived(&nodes[fact.node_id.index()], source)
+                        .active_expansion_spans
+                        .iter()
+                        .copied()
+                })
                 .min_by_key(|span| (span.start.offset, span.end.offset))
         })
         .collect::<Vec<_>>();
@@ -675,8 +869,9 @@ fn build_echo_to_sed_substitution_spans<'a>(
     commands: &[CommandFact<'a>],
     pipelines: &[PipelineFact<'a>],
     backticks: &[BacktickFragmentFact],
-    words: &[WordFact<'a>],
-    word_index: &FxHashMap<FactSpan, Vec<usize>>,
+    nodes: &[WordNode<'a>],
+    occurrences: &[WordOccurrence],
+    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     source: &str,
 ) -> Vec<Span> {
     let mut spans = Vec::new();
@@ -684,7 +879,15 @@ fn build_echo_to_sed_substitution_spans<'a>(
 
     for pipeline in pipelines {
         if let Some(span) =
-            sc2001_like_pipeline_span(commands, pipeline, backticks, words, word_index, source)
+            sc2001_like_pipeline_span(
+                commands,
+                pipeline,
+                backticks,
+                nodes,
+                occurrences,
+                word_index,
+                source,
+            )
         {
             spans.push(span);
             if let Some(last_segment) = pipeline.last_segment() {
@@ -707,8 +910,9 @@ fn sc2001_like_pipeline_span<'a>(
     commands: &[CommandFact<'a>],
     pipeline: &PipelineFact<'a>,
     backticks: &[BacktickFragmentFact],
-    words: &[WordFact<'a>],
-    word_index: &FxHashMap<FactSpan, Vec<usize>>,
+    nodes: &[WordNode<'a>],
+    occurrences: &[WordOccurrence],
+    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     source: &str,
 ) -> Option<Span> {
     let [left_segment, right_segment] = pipeline.segments() else {
@@ -739,25 +943,29 @@ fn sc2001_like_pipeline_span<'a>(
         return None;
     };
 
-    let word_fact = word_fact_with_context(
-        words,
+    let word_fact = word_occurrence_with_context(
+        nodes,
+        occurrences,
         word_index,
         argument.span,
         WordFactContext::Expansion(ExpansionContext::CommandArgument),
     )?;
 
-    if word_fact.static_text().is_some() {
+    if occurrence_static_text(nodes, word_fact, source).is_some() {
         return None;
     }
 
-    if word_fact.scalar_expansion_spans().is_empty()
-        && word_fact.array_expansion_spans().is_empty()
-        && word_fact.command_substitution_spans().is_empty()
+    let derived = word_node_derived(&nodes[word_fact.node_id.index()], source);
+    if derived.scalar_expansion_spans.is_empty()
+        && derived.array_expansion_spans.is_empty()
+        && derived.command_substitution_spans.is_empty()
     {
         return None;
     }
 
-    if word_fact.has_literal_affixes() && !word_fact_is_pure_quoted_dynamic(word_fact, source) {
+    if derived.has_literal_affixes
+        && !word_occurrence_is_pure_quoted_dynamic(nodes, word_fact, source)
+    {
         return None;
     }
 
@@ -824,25 +1032,41 @@ fn command_is_inside_backtick_fragment(
     })
 }
 
-fn word_fact_with_context<'a>(
-    words: &'a [WordFact<'a>],
-    word_index: &FxHashMap<FactSpan, Vec<usize>>,
+fn word_occurrence_with_context<'a>(
+    nodes: &[WordNode<'a>],
+    occurrences: &'a [WordOccurrence],
+    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     span: Span,
     context: WordFactContext,
-) -> Option<&'a WordFact<'a>> {
+) -> Option<&'a WordOccurrence> {
     word_index
         .get(&FactSpan::new(span))
         .into_iter()
-        .flat_map(|indices| indices.iter())
-        .map(|&index| &words[index])
-        .find(|fact| fact.context() == context)
+        .flat_map(|indices| indices.iter().copied())
+        .map(|id| &occurrences[id.index()])
+        .find(|fact| occurrence_span(nodes, fact) == span && fact.context == context)
 }
 
-fn word_fact_is_pure_quoted_dynamic(fact: &WordFact<'_>, source: &str) -> bool {
-    !span::word_double_quoted_scalar_only_expansion_spans(fact.word()).is_empty()
-        || !span::word_quoted_all_elements_array_slice_spans(fact.word()).is_empty()
-        || word_fact_is_double_quoted_command_substitution_only(fact, source)
-        || word_fact_is_backtick_escaped_double_quoted_dynamic(fact, source)
+pub(crate) fn occurrence_static_text<'a>(
+    nodes: &'a [WordNode<'a>],
+    occurrence: &WordOccurrence,
+    source: &str,
+) -> Option<&'a str> {
+    word_node_derived(&nodes[occurrence.node_id.index()], source)
+        .static_text
+        .as_deref()
+}
+
+pub(crate) fn word_occurrence_is_pure_quoted_dynamic(
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
+    source: &str,
+) -> bool {
+    let word = occurrence_word(nodes, fact);
+    !span::word_double_quoted_scalar_only_expansion_spans(word).is_empty()
+        || !span::word_quoted_all_elements_array_slice_spans(word).is_empty()
+        || word_occurrence_is_double_quoted_command_substitution_only(nodes, fact, source)
+        || word_occurrence_is_backtick_escaped_double_quoted_dynamic(nodes, fact, source)
 }
 
 fn build_unquoted_literal_between_double_quoted_segments_spans(
@@ -1137,33 +1361,43 @@ fn mixed_quote_trailing_line_join_between_double_quotes_span(
 }
 
 
-fn word_fact_is_double_quoted_command_substitution_only(fact: &WordFact<'_>, source: &str) -> bool {
-    let [command_substitution] = fact.command_substitution_spans() else {
+pub(crate) fn word_occurrence_is_double_quoted_command_substitution_only(
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
+    source: &str,
+) -> bool {
+    let derived = word_node_derived(&nodes[fact.node_id.index()], source);
+    let [command_substitution] = derived.command_substitution_spans.as_ref() else {
         return false;
     };
 
-    if !fact.scalar_expansion_spans().is_empty() || !fact.array_expansion_spans().is_empty() {
+    if !derived.scalar_expansion_spans.is_empty() || !derived.array_expansion_spans.is_empty() {
         return false;
     }
 
-    let word_text = fact.span().slice(source);
+    let word_text = occurrence_span(nodes, fact).slice(source);
     word_text.len() == command_substitution.slice(source).len() + 2
         && word_text.starts_with('"')
         && word_text.ends_with('"')
         && &word_text[1..word_text.len() - 1] == command_substitution.slice(source)
 }
 
-fn word_fact_is_backtick_escaped_double_quoted_dynamic(fact: &WordFact<'_>, source: &str) -> bool {
-    let word_text = fact.span().slice(source);
+pub(crate) fn word_occurrence_is_backtick_escaped_double_quoted_dynamic(
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
+    source: &str,
+) -> bool {
+    let derived = word_node_derived(&nodes[fact.node_id.index()], source);
+    let word_text = occurrence_span(nodes, fact).slice(source);
     if !word_text.starts_with("\\\"") || !word_text.ends_with("\\\"") {
         return false;
     }
 
     let inner = &word_text[2..word_text.len() - 2];
     match (
-        fact.scalar_expansion_spans(),
-        fact.array_expansion_spans(),
-        fact.command_substitution_spans(),
+        derived.scalar_expansion_spans.as_ref(),
+        derived.array_expansion_spans.as_ref(),
+        derived.command_substitution_spans.as_ref(),
     ) {
         ([scalar], [], []) => inner == scalar.slice(source),
         ([], [array], []) => inner == array.slice(source),
@@ -1174,13 +1408,14 @@ fn word_fact_is_backtick_escaped_double_quoted_dynamic(fact: &WordFact<'_>, sour
 
 fn build_unquoted_command_argument_use_offsets(
     semantic: &SemanticModel,
-    words: &[WordFact<'_>],
+    nodes: &[WordNode<'_>],
+    occurrences: &[WordOccurrence],
 ) -> FxHashMap<Name, Vec<usize>> {
-    let unquoted_command_argument_word_spans = words
+    let unquoted_command_argument_word_spans = occurrences
         .iter()
-        .filter(|fact| fact.expansion_context() == Some(ExpansionContext::CommandArgument))
-        .filter(|fact| fact.classification().quote == WordQuote::Unquoted)
-        .map(WordFact::span)
+        .filter(|fact| fact.context == WordFactContext::Expansion(ExpansionContext::CommandArgument))
+        .filter(|fact| occurrence_analysis(nodes, fact).quote == WordQuote::Unquoted)
+        .map(|fact| occurrence_span(nodes, fact))
         .collect::<Vec<_>>();
     if unquoted_command_argument_word_spans.is_empty() {
         return FxHashMap::default();
@@ -1255,9 +1490,11 @@ pub(crate) fn benchmark_collect_word_facts(
     source: &str,
     semantic: &SemanticModel,
 ) -> usize {
-    let mut words = Vec::new();
+    let mut word_nodes = Vec::new();
+    let mut word_node_ids_by_span = FxHashMap::default();
+    let mut word_occurrences = Vec::new();
     let mut compound_assignment_value_word_spans = FxHashSet::default();
-    let mut array_assignment_split_word_indices = Vec::new();
+    let mut array_assignment_split_word_ids = Vec::new();
     let mut case_pattern_expansion_spans = Vec::new();
     let mut pattern_literal_spans = Vec::new();
     let mut arithmetic_summary = ArithmeticFactSummary::default();
@@ -1289,9 +1526,11 @@ pub(crate) fn benchmark_collect_word_facts(
             &normalized,
             command_zsh_options,
             WordFactOutputs {
-                facts: &mut words,
+                word_nodes: &mut word_nodes,
+                word_node_ids_by_span: &mut word_node_ids_by_span,
+                word_occurrences: &mut word_occurrences,
                 compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
-                array_assignment_split_word_indices: &mut array_assignment_split_word_indices,
+                array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
                 case_pattern_expansion_spans: &mut case_pattern_expansion_spans,
                 pattern_literal_spans: &mut pattern_literal_spans,
                 arithmetic: &mut arithmetic_summary,
@@ -1302,9 +1541,10 @@ pub(crate) fn benchmark_collect_word_facts(
 
     let surface_fragments = surface_fragments.finish();
 
-    words.len()
+    word_occurrences.len()
+        + word_nodes.len()
         + compound_assignment_value_word_spans.len()
-        + array_assignment_split_word_indices.len()
+        + array_assignment_split_word_ids.len()
         + case_pattern_expansion_spans.len()
         + pattern_literal_spans.len()
         + arithmetic_summary.array_index_arithmetic_spans.len()
@@ -1326,36 +1566,19 @@ struct WordFactCommandContext {
 }
 
 struct WordFactOutputs<'out, 'a> {
-    facts: &'out mut Vec<WordFact<'a>>,
+    word_nodes: &'out mut Vec<WordNode<'a>>,
+    word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
+    word_occurrences: &'out mut Vec<WordOccurrence>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
-    array_assignment_split_word_indices: &'out mut Vec<usize>,
+    array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     case_pattern_expansion_spans: &'out mut Vec<Span>,
     pattern_literal_spans: &'out mut Vec<Span>,
     arithmetic: &'out mut ArithmeticFactSummary,
     surface: &'out mut SurfaceFragmentSink<'a>,
 }
 
-struct DerivedWordFactData {
-    static_text: Option<Box<str>>,
-    starts_with_extglob: bool,
-    has_literal_affixes: bool,
-    contains_shell_quoting_literals: bool,
-    active_expansion_spans: Box<[Span]>,
-    scalar_expansion_spans: Box<[Span]>,
-    unquoted_scalar_expansion_spans: Box<[Span]>,
-    array_expansion_spans: Box<[Span]>,
-    all_elements_array_expansion_spans: Box<[Span]>,
-    direct_all_elements_array_expansion_spans: Box<[Span]>,
-    unquoted_all_elements_array_expansion_spans: Box<[Span]>,
-    unquoted_array_expansion_spans: Box<[Span]>,
-    command_substitution_spans: Box<[Span]>,
-    unquoted_command_substitution_spans: Box<[Span]>,
-    double_quoted_expansion_spans: Box<[Span]>,
-    unquoted_literal_between_double_quoted_segments_spans: Box<[Span]>,
-}
-
-fn derive_word_fact_data(word: &Word, source: &str) -> DerivedWordFactData {
-    DerivedWordFactData {
+fn derive_word_fact_data(word: &Word, source: &str) -> WordNodeDerived {
+    WordNodeDerived {
         static_text: static_word_text(word, source)
             .map(|text| text.into_owned().into_boxed_str()),
         starts_with_extglob: span::word_starts_with_extglob(word, source),
@@ -1397,8 +1620,10 @@ struct WordFactCollector<'out, 'a, 'norm> {
     nested_word_command: bool,
     surface_command_name: Option<&'norm str>,
     command_zsh_options: Option<ZshOptionState>,
-    facts: &'out mut Vec<WordFact<'a>>,
-    array_assignment_split_word_indices: &'out mut Vec<usize>,
+    word_nodes: &'out mut Vec<WordNode<'a>>,
+    word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
+    word_occurrences: &'out mut Vec<WordOccurrence>,
+    array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     seen: FxHashSet<(FactSpan, WordFactContext, WordFactHostKind)>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     case_pattern_expansion_spans: &'out mut Vec<Span>,
@@ -1424,8 +1649,10 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             nested_word_command,
             surface_command_name: normalized.effective_or_literal_name(),
             command_zsh_options,
-            facts: outputs.facts,
-            array_assignment_split_word_indices: outputs.array_assignment_split_word_indices,
+            word_nodes: outputs.word_nodes,
+            word_node_ids_by_span: outputs.word_node_ids_by_span,
+            word_occurrences: outputs.word_occurrences,
+            array_assignment_split_word_ids: outputs.array_assignment_split_word_ids,
             seen: FxHashSet::default(),
             compound_assignment_value_word_spans: outputs.compound_assignment_value_word_spans,
             case_pattern_expansion_spans: outputs.case_pattern_expansion_spans,
@@ -1897,7 +2124,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                                 surface_context,
                             )
                             {
-                                self.array_assignment_split_word_indices.push(index);
+                                self.array_assignment_split_word_ids.push(index);
                             }
                         }
                         ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
@@ -2192,8 +2419,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         word: &'a Word,
         context: WordFactContext,
         host_kind: WordFactHostKind,
-    ) -> Option<usize> {
-        self.push_cow_word(word, context, host_kind, None).0
+    ) -> Option<WordOccurrenceId> {
+        self.push_word_occurrence(word, context, host_kind, None).0
     }
 
     fn push_word_with_surface(
@@ -2202,17 +2429,35 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         context: WordFactContext,
         host_kind: WordFactHostKind,
         surface_context: SurfaceScanContext<'_>,
-    ) -> (Option<usize>, bool) {
-        self.push_cow_word(word, context, host_kind, Some(surface_context))
+    ) -> (Option<WordOccurrenceId>, bool) {
+        self.push_word_occurrence(word, context, host_kind, Some(surface_context))
     }
 
-    fn push_cow_word(
+    fn intern_word_node(&mut self, word: &'a Word) -> WordNodeId {
+        let key = FactSpan::new(word.span);
+        if let Some(id) = self.word_node_ids_by_span.get(&key).copied() {
+            return id;
+        }
+
+        let id = WordNodeId::new(self.word_nodes.len());
+        let analysis = analyze_word(word, self.source, self.command_zsh_options.as_ref());
+        self.word_nodes.push(WordNode {
+            key,
+            word,
+            analysis,
+            derived: OnceCell::new(),
+        });
+        self.word_node_ids_by_span.insert(key, id);
+        id
+    }
+
+    fn push_word_occurrence(
         &mut self,
         word: &'a Word,
         context: WordFactContext,
         host_kind: WordFactHostKind,
         surface_context: Option<SurfaceScanContext<'_>>,
-    ) -> (Option<usize>, bool) {
+    ) -> (Option<WordOccurrenceId>, bool) {
         let opened_double_quote = surface_context
             .map(|surface_context| self.surface.collect_word(word, surface_context))
             .unwrap_or(false);
@@ -2224,11 +2469,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         self.collect_word_parameter_patterns(&word.parts, host_kind);
         self.collect_arithmetic_summary(word, context, host_kind);
 
-        let zsh_options = self.command_zsh_options.clone();
-        let analysis = analyze_word(word, self.source, zsh_options.as_ref());
+        let node_id = self.intern_word_node(word);
+        let analysis = self.word_nodes[node_id.index()].analysis;
         let runtime_literal = match context {
             WordFactContext::Expansion(context) => {
-                analyze_literal_runtime(word, self.source, context, zsh_options.as_ref())
+                analyze_literal_runtime(word, self.source, context, self.command_zsh_options.as_ref())
             }
             WordFactContext::CaseSubject | WordFactContext::ArithmeticCommand => {
                 RuntimeLiteralAnalysis::default()
@@ -2250,41 +2495,18 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             | WordFactContext::CaseSubject
             | WordFactContext::ArithmeticCommand => None,
         };
-        let derived = derive_word_fact_data(word, self.source);
-        let index = self.facts.len();
-        self.facts.push(WordFact {
-            key,
-            static_text: derived.static_text,
-            starts_with_extglob: derived.starts_with_extglob,
-            has_literal_affixes: derived.has_literal_affixes,
-            contains_shell_quoting_literals: derived.contains_shell_quoting_literals,
-            active_expansion_spans: derived.active_expansion_spans,
-            scalar_expansion_spans: derived.scalar_expansion_spans,
-            unquoted_scalar_expansion_spans: derived.unquoted_scalar_expansion_spans,
-            array_assignment_split_scalar_expansion_spans: Box::default(),
-            array_expansion_spans: derived.array_expansion_spans,
-            all_elements_array_expansion_spans: derived.all_elements_array_expansion_spans,
-            direct_all_elements_array_expansion_spans:
-                derived.direct_all_elements_array_expansion_spans,
-            unquoted_all_elements_array_expansion_spans:
-                derived.unquoted_all_elements_array_expansion_spans,
-            unquoted_array_expansion_spans: derived.unquoted_array_expansion_spans,
-            command_substitution_spans: derived.command_substitution_spans,
-            unquoted_command_substitution_spans: derived.unquoted_command_substitution_spans,
-            double_quoted_expansion_spans: derived.double_quoted_expansion_spans,
-            unquoted_literal_between_double_quoted_segments_spans:
-                derived.unquoted_literal_between_double_quoted_segments_spans,
-            word: Cow::Borrowed(word),
+        let id = WordOccurrenceId::new(self.word_occurrences.len());
+        self.word_occurrences.push(WordOccurrence {
+            node_id,
             command_id: self.command_id,
             nested_word_command: self.nested_word_command,
             context,
             host_kind,
-            zsh_options,
-            analysis,
             runtime_literal,
             operand_class,
+            array_assignment_split_scalar_expansion_spans: OnceCell::new(),
         });
-        (Some(index), opened_double_quote)
+        (Some(id), opened_double_quote)
     }
 
     fn collect_arithmetic_summary(

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -33,8 +33,8 @@ pub use facts::{
     SimpleTestFact, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax,
     SingleQuotedFragmentFact, SshCommandFacts, StatementFact, SubstitutionFact,
     SubstitutionHostKind, SudoFamilyCommandFacts, SudoFamilyInvoker, UnsetCommandFacts,
-    WaitCommandFacts, WordFact, WordFactContext, WordFactHostKind, XargsCommandFacts,
-    leading_literal_word_prefix,
+    WaitCommandFacts, WordFactContext, WordFactHostKind, WordOccurrence, WordOccurrenceIter,
+    WordOccurrenceRef, XargsCommandFacts, leading_literal_word_prefix,
 };
 pub use facts::{CommandId, FactSpan, LinterFacts};
 pub use registry::{Category, Rule, code_to_rule};

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -174,6 +174,22 @@ impl<'a> SafeValueIndex<'a> {
             .all(|(part, span)| self.part_is_safe(part, span, query))
     }
 
+    pub fn word_occurrence_is_safe(
+        &mut self,
+        fact: crate::WordOccurrenceRef<'_, 'a>,
+        query: SafeValueQuery,
+    ) -> bool {
+        let analysis = fact.analysis();
+        if query != SafeValueQuery::Quoted
+            && (analysis.array_valued || analysis.hazards.command_or_process_substitution)
+        {
+            return false;
+        }
+
+        fact.parts_with_spans()
+            .all(|(part, span)| self.part_is_safe(part, span, query))
+    }
+
     fn literal_part_is_safe(&self, part: &WordPart, span: Span, query: SafeValueQuery) -> bool {
         let word = Word {
             parts: vec![WordPartNode::new(part.clone(), span)],
@@ -1031,7 +1047,7 @@ f() {
             })
             .expect("expected loop-body command argument");
 
-        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1059,7 +1075,7 @@ f() {
             })
             .expect("expected direct slice command argument");
 
-        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1125,7 +1141,7 @@ done
         assert!(
             unsafe_words
                 .iter()
-                .all(|fact| !safe_values.word_is_safe(fact.word(), SafeValueQuery::Argv))
+                .all(|fact| !safe_values.word_occurrence_is_safe(*fact, SafeValueQuery::Argv))
         );
 
         let safe_words = facts
@@ -1140,7 +1156,7 @@ done
         assert!(
             safe_words
                 .iter()
-                .all(|fact| safe_values.word_is_safe(fact.word(), SafeValueQuery::Argv))
+                .all(|fact| safe_values.word_occurrence_is_safe(*fact, SafeValueQuery::Argv))
         );
     }
 
@@ -1182,8 +1198,8 @@ iptables $flag -t nat -N chain
             })
             .expect("expected if/else command argument");
 
-        assert!(!safe_values.word_is_safe(short_circuit_word.word(), SafeValueQuery::Argv));
-        assert!(safe_values.word_is_safe(if_else_word.word(), SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(short_circuit_word, SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(if_else_word, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1217,7 +1233,7 @@ f() {
             })
             .expect("expected guarded function command argument");
 
-        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1328,7 +1344,7 @@ value=\"$(free ${humanreadable} | awk '{print $2}')\"
             })
             .expect("expected nested command argument fact");
 
-        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1386,7 +1402,7 @@ fn_backup_compression
             })
             .expect("expected helper-provided command argument fact");
 
-        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1430,7 +1446,7 @@ unsafe_path
             })
             .expect("expected shared helper-derived command argument fact");
 
-        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1465,7 +1481,7 @@ render() {
             })
             .expect("expected conditionally helper-initialized argument fact");
 
-        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1514,7 +1530,7 @@ safe_path_b
             })
             .expect("expected multi-caller helper-derived argument fact");
 
-        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1556,7 +1572,7 @@ printf '%s\\n' $pkgname
             })
             .expect("expected imported command argument fact");
 
-        assert!(!safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1582,7 +1598,7 @@ bash ${debug:+\"-x\"} script
             })
             .expect("expected replacement-operator command argument fact");
 
-        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -1608,6 +1624,6 @@ printf '%s\\n' ${debug:+\"a b\"}
             })
             .expect("expected replacement-operator command argument fact");
 
-        assert!(safe_values.word_is_safe(word_fact.word(), SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
@@ -2,8 +2,6 @@ use shuck_ast::Span;
 
 use crate::{
     Checker, ConditionalNodeFact, ConditionalOperatorFamily, ExpansionContext, Rule, Violation,
-    command_substitution_part_spans, word_has_direct_all_elements_array_expansion_in_source,
-    word_is_pure_positional_at_splat,
 };
 
 pub struct ArraySliceInComparison;
@@ -23,24 +21,20 @@ pub fn array_slice_in_comparison(checker: &mut Checker) {
         ExpansionContext::StringTestOperand,
         ExpansionContext::RegexOperand,
     ]
-    .into_iter()
-    .flat_map(|context| checker.facts().expansion_word_facts(context))
-    .filter(|fact| !fact.is_nested_word_command())
-    .filter(|fact| {
-        word_has_direct_all_elements_array_expansion_in_source(fact.word(), checker.source())
-    })
-    .map(|fact| fact.span())
-    .collect::<Vec<_>>();
+        .into_iter()
+        .flat_map(|context| checker.facts().expansion_word_facts(context))
+        .filter(|fact| !fact.is_nested_word_command())
+        .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(checker.source()))
+        .map(|fact| fact.span())
+        .collect::<Vec<_>>();
 
     let risky_pattern_word_spans = checker
         .facts()
         .expansion_word_facts(ExpansionContext::ConditionalPattern)
         .filter(|fact| !fact.is_nested_word_command())
-        .filter(|fact| command_substitution_part_spans(fact.word()).is_empty())
-        .filter(|fact| !word_is_pure_positional_at_splat(fact.word()))
-        .filter(|fact| {
-            word_has_direct_all_elements_array_expansion_in_source(fact.word(), checker.source())
-        })
+        .filter(|fact| fact.command_substitution_spans().is_empty())
+        .filter(|fact| !fact.is_pure_positional_at_splat())
+        .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(checker.source()))
         .map(|fact| fact.span())
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
@@ -21,12 +21,12 @@ pub fn array_slice_in_comparison(checker: &mut Checker) {
         ExpansionContext::StringTestOperand,
         ExpansionContext::RegexOperand,
     ]
-        .into_iter()
-        .flat_map(|context| checker.facts().expansion_word_facts(context))
-        .filter(|fact| !fact.is_nested_word_command())
-        .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(checker.source()))
-        .map(|fact| fact.span())
-        .collect::<Vec<_>>();
+    .into_iter()
+    .flat_map(|context| checker.facts().expansion_word_facts(context))
+    .filter(|fact| !fact.is_nested_word_command())
+    .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(checker.source()))
+    .map(|fact| fact.span())
+    .collect::<Vec<_>>();
 
     let risky_pattern_word_spans = checker
         .facts()

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -58,7 +58,7 @@ fn binding_assignment_value_context(binding: &Binding) -> Option<WordFactContext
 fn uses_array_to_scalar_conversion_pattern(
     checker: &Checker<'_>,
     binding: &Binding,
-    value_fact: &crate::WordFact<'_>,
+    value_fact: crate::WordOccurrenceRef<'_, '_>,
 ) -> bool {
     value_fact
         .array_expansion_spans()

--- a/crates/shuck-linter/src/rules/correctness/constant_in_test_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/constant_in_test_assignment.rs
@@ -79,8 +79,8 @@ fn simple_test_operand_looks_like_assignment_like(
         )
         .is_some_and(|fact| {
             let classification = fact.classification();
-            word_looks_like_assignment_like(
-                fact.word(),
+            word_fact_looks_like_assignment_like(
+                fact,
                 classification.quote,
                 classification.is_fixed_literal(),
                 source,
@@ -142,6 +142,28 @@ fn word_looks_like_assignment_like(
     }
 
     let Some(prefix_span) = double_quoted_scalar_affix_span(word) else {
+        return false;
+    };
+    let prefix = prefix_span.slice(source);
+    if !prefix.ends_with('=') {
+        return false;
+    }
+
+    let name = prefix.trim_end_matches('=');
+    is_shell_variable_name(name)
+}
+
+fn word_fact_looks_like_assignment_like(
+    fact: crate::WordOccurrenceRef<'_, '_>,
+    quote: WordQuote,
+    is_fixed_literal: bool,
+    source: &str,
+) -> bool {
+    if quote != WordQuote::FullyQuoted || is_fixed_literal {
+        return false;
+    }
+
+    let Some(prefix_span) = fact.double_quoted_scalar_affix_span() else {
         return false;
     };
     let prefix = prefix_span.slice(source);

--- a/crates/shuck-linter/src/rules/correctness/export_with_positional_params.rs
+++ b/crates/shuck-linter/src/rules/correctness/export_with_positional_params.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashSet;
 
-use crate::{Checker, ExpansionContext, Rule, Violation, word_is_pure_positional_at_splat};
+use crate::{Checker, ExpansionContext, Rule, Violation};
 
 pub struct ExportWithPositionalParams;
 
@@ -26,7 +26,7 @@ pub fn export_with_positional_params(checker: &mut Checker) {
         .facts()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| export_ids.contains(&fact.command_id()))
-        .filter(|fact| word_is_pure_positional_at_splat(fact.word()))
+        .filter(|fact| fact.is_pure_positional_at_splat())
         .map(|fact| fact.span())
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Checker, ExpansionContext, Rule, Violation, WordFact,
-    word_unquoted_glob_pattern_spans_outside_brace_expansion,
-};
+use crate::{Checker, ExpansionContext, Rule, Violation, WordOccurrenceRef};
 use shuck_ast::Span;
 
 pub struct GlobWithExpansionInLoop;
@@ -21,17 +18,14 @@ pub fn glob_with_expansion_in_loop(checker: &mut Checker) {
     let spans = checker
         .facts()
         .expansion_word_facts(ExpansionContext::ForList)
-        .filter(|fact| {
-            !word_unquoted_glob_pattern_spans_outside_brace_expansion(fact.word(), source)
-                .is_empty()
-        })
+        .filter(|fact| !fact.unquoted_glob_pattern_spans_outside_brace_expansion(source).is_empty())
         .flat_map(unquoted_expansion_prefix_spans)
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || GlobWithExpansionInLoop);
 }
 
-fn unquoted_expansion_prefix_spans(fact: &WordFact<'_>) -> Vec<Span> {
+fn unquoted_expansion_prefix_spans(fact: WordOccurrenceRef<'_, '_>) -> Vec<Span> {
     let quoted = fact.double_quoted_expansion_spans();
     let mut spans = fact
         .scalar_expansion_spans()

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -18,7 +18,11 @@ pub fn glob_with_expansion_in_loop(checker: &mut Checker) {
     let spans = checker
         .facts()
         .expansion_word_facts(ExpansionContext::ForList)
-        .filter(|fact| !fact.unquoted_glob_pattern_spans_outside_brace_expansion(source).is_empty())
+        .filter(|fact| {
+            !fact
+                .unquoted_glob_pattern_spans_outside_brace_expansion(source)
+                .is_empty()
+        })
         .flat_map(unquoted_expansion_prefix_spans)
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -3,7 +3,7 @@ use shuck_semantic::{BindingAttributes, BindingId};
 
 use crate::{
     Checker, CommandFact, ConditionalBinaryFact, ConditionalNodeFact, ConditionalOperandFact,
-    RedirectFact, Rule, SimpleTestSyntax, Violation, WordFact, static_word_text,
+    RedirectFact, Rule, SimpleTestSyntax, Violation, WordOccurrenceRef, static_word_text,
 };
 
 pub struct GreaterThanInTest;
@@ -186,7 +186,10 @@ fn operand_is_numeric_literal(
             })
 }
 
-fn word_is_numeric_binding_reference(checker: &Checker<'_>, word_fact: &WordFact<'_>) -> bool {
+fn word_is_numeric_binding_reference(
+    checker: &Checker<'_>,
+    word_fact: WordOccurrenceRef<'_, '_>,
+) -> bool {
     if !word_fact.is_plain_scalar_reference() {
         return false;
     }

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -25,12 +25,17 @@ pub fn leading_glob_argument(checker: &mut Checker) {
     checker.report_all_dedup(spans, || LeadingGlobArgument);
 }
 
-fn reportable_glob_span(checker: &Checker<'_>, fact: &crate::facts::WordFact<'_>) -> Option<Span> {
+fn reportable_glob_span(
+    checker: &Checker<'_>,
+    fact: crate::facts::WordOccurrenceRef<'_, '_>,
+) -> Option<Span> {
     let command = checker.facts().command(fact.command_id());
     if command_exempts_glob_warning(command.effective_name()) {
         return None;
     }
-    if fact
+    if checker
+        .facts()
+        .command(fact.command_id())
         .zsh_options()
         .is_some_and(|options| options.glob.is_definitely_off())
     {
@@ -50,11 +55,11 @@ fn reportable_glob_span(checker: &Checker<'_>, fact: &crate::facts::WordFact<'_>
         return None;
     }
 
-    if command_has_separator_before(command, fact.word().span, checker.source()) {
+    if command_has_separator_before(command, fact.span(), checker.source()) {
         return None;
     }
 
-    Some(anchor_span(fact.word().span))
+    Some(anchor_span(fact.span()))
 }
 
 fn command_exempts_glob_warning(command: Option<&str>) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
@@ -1,8 +1,6 @@
 use rustc_hash::FxHashSet;
 
-use crate::{
-    Checker, ExpansionContext, FactSpan, Rule, Violation, word_has_quoted_all_elements_array_slice,
-};
+use crate::{Checker, ExpansionContext, FactSpan, Rule, Violation};
 
 pub struct QuotedArraySlice;
 
@@ -32,7 +30,7 @@ pub fn quoted_array_slice(checker: &mut Checker) {
     .into_iter()
     .flat_map(|context| checker.facts().expansion_word_facts(context))
     .filter(|fact| scalar_assignment_value_spans.contains(&fact.key()))
-    .filter(|fact| word_has_quoted_all_elements_array_slice(fact.word()))
+    .filter(|fact| fact.has_quoted_all_elements_array_slice())
     .map(|fact| fact.span())
     .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -1,6 +1,4 @@
-use crate::{
-    Checker, Rule, Violation, WordFactContext, word_quoted_unindexed_bash_source_span_in_source,
-};
+use crate::{Checker, Rule, Violation, WordFactContext};
 
 pub struct QuotedBashSource;
 
@@ -20,9 +18,7 @@ pub fn quoted_bash_source(checker: &mut Checker) {
         .word_facts()
         .iter()
         .filter(|fact| matches!(fact.context(), WordFactContext::Expansion(_)))
-        .filter_map(|fact| {
-            word_quoted_unindexed_bash_source_span_in_source(fact.word(), checker.source())
-        })
+        .filter_map(|fact| fact.quoted_unindexed_bash_source_span_in_source(checker.source()))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || QuotedBashSource);

--- a/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
@@ -160,7 +160,7 @@ fn simple_test_word_looks_like_quoted_pipeline(checker: &Checker<'_>, span: Span
         .is_some_and(word_fact_looks_like_quoted_pipeline)
 }
 
-fn word_fact_looks_like_quoted_pipeline(fact: &crate::WordFact<'_>) -> bool {
+fn word_fact_looks_like_quoted_pipeline(fact: crate::WordOccurrenceRef<'_, '_>) -> bool {
     fact.classification().quote == WordQuote::FullyQuoted
         && fact.classification().is_fixed_literal()
         && fact

--- a/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
@@ -49,7 +49,7 @@ pub fn suspicious_bracket_glob(checker: &mut Checker) {
                 .iter()
                 .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
                 .filter(|fact| supports_suspicious_bracket_glob_context(fact.expansion_context()))
-                .flat_map(|fact| word_suspicious_bracket_glob_spans(fact.word(), source)),
+                .flat_map(|fact| fact.suspicious_bracket_glob_spans(source)),
         )
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
@@ -80,14 +80,13 @@ fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &
         .collect()
 }
 
-fn word_fact_tilde_span(fact: &crate::WordFact<'_>, source: &str) -> Option<Span> {
+fn word_fact_tilde_span(fact: crate::WordOccurrenceRef<'_, '_>, source: &str) -> Option<Span> {
     let classification = fact.classification();
     (classification.quote != WordQuote::Unquoted && classification.is_fixed_literal())
         .then(|| {
-            let word = fact.word();
             fact.static_text()
                 .filter(|text| text.starts_with("~/"))
-                .and_then(|_| quoted_tilde_span(word.span, source))
+                .and_then(|_| quoted_tilde_span(fact.span(), source))
         })
         .flatten()
 }

--- a/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
@@ -1,8 +1,6 @@
 use rustc_hash::FxHashSet;
 
-use crate::{
-    Checker, ExpansionContext, FactSpan, Rule, Violation, word_unquoted_glob_pattern_spans,
-};
+use crate::{Checker, ExpansionContext, FactSpan, Rule, Violation};
 
 pub struct UnquotedGlobsInFind;
 
@@ -41,10 +39,7 @@ pub fn unquoted_globs_in_find(checker: &mut Checker) {
             fact.unquoted_command_substitution_spans()
                 .iter()
                 .copied()
-                .chain(word_unquoted_glob_pattern_spans(
-                    fact.word(),
-                    checker.source(),
-                ))
+                .chain(fact.unquoted_glob_pattern_spans(checker.source()))
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/portability/brace_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/brace_expansion.rs
@@ -31,9 +31,7 @@ pub fn brace_expansion(checker: &mut Checker) {
                 )
             )
         })
-        .flat_map(|fact| fact.word().brace_syntax().iter().copied())
-        .filter(|brace| brace.expands())
-        .map(|brace| brace.span)
+        .flat_map(|fact| fact.brace_expansion_spans())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || BraceExpansion);

--- a/crates/shuck-linter/src/rules/portability/nested_zsh_substitution.rs
+++ b/crates/shuck-linter/src/rules/portability/nested_zsh_substitution.rs
@@ -1,5 +1,5 @@
 use super::targets_non_zsh_shell;
-use crate::{Checker, Rule, Violation, word_nested_zsh_substitution_spans};
+use crate::{Checker, Rule, Violation};
 
 pub struct NestedZshSubstitution;
 
@@ -22,7 +22,7 @@ pub fn nested_zsh_substitution(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| word_nested_zsh_substitution_spans(fact.word()))
+        .flat_map(|fact| fact.nested_zsh_substitution_spans())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || NestedZshSubstitution);

--- a/crates/shuck-linter/src/rules/portability/zsh_flag_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_flag_expansion.rs
@@ -1,5 +1,5 @@
 use super::targets_non_zsh_shell;
-use crate::{Checker, Rule, Violation, word_zsh_flag_modifier_spans};
+use crate::{Checker, Rule, Violation};
 
 pub struct ZshFlagExpansion;
 
@@ -22,7 +22,7 @@ pub fn zsh_flag_expansion(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| word_zsh_flag_modifier_spans(fact.word()))
+        .flat_map(|fact| fact.zsh_flag_modifier_spans())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ZshFlagExpansion);

--- a/crates/shuck-linter/src/rules/portability/zsh_nested_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_nested_expansion.rs
@@ -1,5 +1,5 @@
 use super::targets_non_zsh_shell;
-use crate::{Checker, Rule, Violation, word_zsh_nested_expansion_spans};
+use crate::{Checker, Rule, Violation};
 
 pub struct ZshNestedExpansion;
 
@@ -22,7 +22,7 @@ pub fn zsh_nested_expansion(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| word_zsh_nested_expansion_spans(fact.word()))
+        .flat_map(|fact| fact.zsh_nested_expansion_spans())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ZshNestedExpansion);

--- a/crates/shuck-linter/src/rules/portability/zsh_parameter_flag.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_parameter_flag.rs
@@ -24,9 +24,7 @@ pub fn zsh_parameter_flag(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| {
-            parameter_flag_spans(fact.word().span.slice(checker.source()), fact.word().span)
-        })
+        .flat_map(|fact| parameter_flag_spans(fact.span().slice(checker.source()), fact.span()))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ZshParameterFlag);

--- a/crates/shuck-linter/src/rules/portability/zsh_prompt_bracket.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_prompt_bracket.rs
@@ -24,9 +24,7 @@ pub fn zsh_prompt_bracket(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| {
-            prompt_bracket_spans(fact.word().span.slice(checker.source()), fact.word().span)
-        })
+        .flat_map(|fact| prompt_bracket_spans(fact.span().slice(checker.source()), fact.span()))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ZshPromptBracket);

--- a/crates/shuck-linter/src/rules/style/default_value_in_colon_assign.rs
+++ b/crates/shuck-linter/src/rules/style/default_value_in_colon_assign.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashSet;
 
-use crate::{Checker, ExpansionContext, Rule, Violation, word_unquoted_assign_default_spans};
+use crate::{Checker, ExpansionContext, Rule, Violation};
 
 pub struct DefaultValueInColonAssign;
 
@@ -28,7 +28,7 @@ pub fn default_value_in_colon_assign(checker: &mut Checker) {
         .facts()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| colon_command_ids.contains(&fact.command_id()))
-        .flat_map(|fact| word_unquoted_assign_default_spans(fact.word()))
+        .flat_map(|fact| fact.unquoted_assign_default_spans())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || DefaultValueInColonAssign);

--- a/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
+++ b/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Checker, ExpansionContext, Rule, Violation, word_nested_dynamic_double_quote_spans,
-    word_unquoted_scalar_between_double_quoted_segments_spans,
-};
+use crate::{Checker, ExpansionContext, Rule, Violation};
 
 pub struct DoubleQuoteNesting;
 
@@ -53,9 +50,9 @@ pub fn double_quote_nesting(checker: &mut Checker) {
 
             let host_substitution_spans = fact.command_substitution_spans();
 
-            word_unquoted_scalar_between_double_quoted_segments_spans(fact.word(), &candidate_spans)
+            fact.unquoted_scalar_between_double_quoted_segments_spans(&candidate_spans)
                 .into_iter()
-                .chain(word_nested_dynamic_double_quote_spans(fact.word()))
+                .chain(fact.nested_dynamic_double_quote_spans())
                 .filter(|span| {
                     !host_substitution_spans
                         .iter()

--- a/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
+++ b/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
@@ -1,6 +1,4 @@
-use crate::{
-    Checker, ExpansionContext, Rule, Violation, WordFactHostKind, WordQuote,
-};
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactHostKind, WordQuote};
 
 pub struct GlobAssignedToVariable;
 

--- a/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
+++ b/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
@@ -1,6 +1,5 @@
 use crate::{
     Checker, ExpansionContext, Rule, Violation, WordFactHostKind, WordQuote,
-    word_unquoted_glob_pattern_spans,
 };
 
 pub struct GlobAssignedToVariable;
@@ -26,9 +25,9 @@ pub fn glob_assigned_to_variable(checker: &mut Checker) {
                 .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue),
         )
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
-        .filter(|fact| !checker.facts().is_compound_assignment_value_word(fact))
+        .filter(|fact| !checker.facts().is_compound_assignment_value_word(*fact))
         .filter(|fact| fact.classification().quote != WordQuote::FullyQuoted)
-        .filter(|fact| !word_unquoted_glob_pattern_spans(fact.word(), source).is_empty())
+        .filter(|fact| !fact.unquoted_glob_pattern_spans(source).is_empty())
         .map(|fact| fact.span())
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/style/literal_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, word_standalone_literal_backslash_span};
+use crate::{Checker, ExpansionContext, Rule, Violation};
 
 pub struct LiteralBackslash;
 
@@ -21,9 +21,9 @@ pub fn literal_backslash(checker: &mut Checker) {
         .iter()
         .filter(|fact| is_relevant_word_context(fact.expansion_context()))
         .filter(|fact| !fact.is_nested_word_command())
-        .filter(|fact| !is_command_name_word(facts, fact))
-        .filter(|fact| !is_unalias_argument(facts, fact))
-        .filter_map(|fact| word_standalone_literal_backslash_span(fact.word(), source))
+        .filter(|fact| !is_command_name_word(facts, *fact))
+        .filter(|fact| !is_unalias_argument(facts, *fact))
+        .filter_map(|fact| fact.standalone_literal_backslash_span(source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || LiteralBackslash);
@@ -42,7 +42,7 @@ fn is_relevant_word_context(context: Option<ExpansionContext>) -> bool {
 
 fn is_command_name_word<'a>(
     facts: &'a crate::facts::LinterFacts<'a>,
-    fact: &crate::facts::WordFact<'a>,
+    fact: crate::facts::WordOccurrenceRef<'_, 'a>,
 ) -> bool {
     facts
         .command(fact.command_id())
@@ -52,7 +52,7 @@ fn is_command_name_word<'a>(
 
 fn is_unalias_argument<'a>(
     facts: &'a crate::facts::LinterFacts<'a>,
-    fact: &crate::facts::WordFact<'a>,
+    fact: crate::facts::WordOccurrenceRef<'_, 'a>,
 ) -> bool {
     fact.expansion_context() == Some(ExpansionContext::CommandArgument)
         && facts

--- a/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
+++ b/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
@@ -1,6 +1,4 @@
-use crate::{
-    Checker, ExpansionContext, Rule, Violation, word_folded_positional_at_splat_span_in_source,
-};
+use crate::{Checker, ExpansionContext, Rule, Violation};
 
 pub struct PositionalArgsInString;
 
@@ -21,9 +19,7 @@ pub fn positional_args_in_string(checker: &mut Checker) {
     ]
     .into_iter()
     .flat_map(|context| checker.facts().expansion_word_facts(context))
-    .filter_map(|fact| {
-        word_folded_positional_at_splat_span_in_source(fact.word(), checker.source())
-    })
+    .filter_map(|fact| fact.folded_positional_at_splat_span_in_source(checker.source()))
     .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || PositionalArgsInString);

--- a/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
@@ -27,8 +27,7 @@ pub fn unquoted_array_split(checker: &mut Checker) {
                 .chain(fact.unquoted_array_expansion_spans().iter().copied())
                 .collect::<Vec<_>>();
             let command_substitution_spans = fact.command_substitution_spans();
-            fact.word()
-                .parts_with_spans()
+            fact.parts_with_spans()
                 .filter_map(|(part, part_span)| {
                     candidate_spans
                         .contains(&part_span)

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -1,4 +1,6 @@
-use crate::{Checker, ExpansionContext, Rule, ShellDialect, Violation, WordFact, WordFactHostKind};
+use crate::{
+    Checker, ExpansionContext, Rule, ShellDialect, Violation, WordFactHostKind, WordOccurrenceRef,
+};
 
 pub struct UnquotedCommandSubstitution;
 
@@ -66,7 +68,7 @@ pub fn unquoted_command_substitution(checker: &mut Checker) {
 
 fn should_report_unquoted_command_substitution(
     checker: &Checker,
-    fact: &WordFact<'_>,
+    fact: WordOccurrenceRef<'_, '_>,
     span: shuck_ast::Span,
     arithmetic_spans: &[shuck_ast::Span],
     pgrep_spans: &[shuck_ast::Span],

--- a/crates/shuck-linter/src/rules/style/unquoted_dollar_star.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_dollar_star.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFact, word_unquoted_star_splat_spans};
+use crate::{Checker, ExpansionContext, Rule, Violation, WordOccurrenceRef};
 
 pub struct UnquotedDollarStar;
 
@@ -28,8 +28,8 @@ pub fn unquoted_dollar_star(checker: &mut Checker) {
     checker.report_all_dedup(spans, || UnquotedDollarStar);
 }
 
-fn unquoted_star_splat_spans(fact: &WordFact<'_>) -> Vec<shuck_ast::Span> {
-    word_unquoted_star_splat_spans(fact.word())
+fn unquoted_star_splat_spans(fact: WordOccurrenceRef<'_, '_>) -> Vec<shuck_ast::Span> {
+    fact.unquoted_star_splat_spans()
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2,8 +2,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     Checker, ExpansionContext, Rule, SafeValueIndex, SafeValueQuery, ShellDialect, Violation,
-    WordFact, word_unquoted_assign_default_spans, word_unquoted_star_parameter_spans,
-    word_use_replacement_spans,
+    WordOccurrenceRef,
 };
 
 pub struct UnquotedExpansion;
@@ -73,7 +72,7 @@ fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool 
 fn report_word_expansions(
     spans: &mut Vec<shuck_ast::Span>,
     safe_values: &mut SafeValueIndex<'_>,
-    fact: &WordFact<'_>,
+    fact: WordOccurrenceRef<'_, '_>,
     context: ExpansionContext,
     in_colon_command: bool,
 ) {
@@ -82,27 +81,26 @@ fn report_word_expansions(
     }
 
     let scalar_spans = fact.scalar_expansion_spans();
-    let array_spans = fact.unquoted_array_expansion_spans();
     let assign_default_spans = if in_colon_command && context == ExpansionContext::CommandArgument {
-        word_unquoted_assign_default_spans(fact.word())
+        fact.unquoted_assign_default_spans()
     } else {
         Default::default()
     };
-    let use_replacement_spans = word_use_replacement_spans(fact.word());
-    let star_spans = word_unquoted_star_parameter_spans(fact.word(), array_spans);
+    let use_replacement_spans = fact.use_replacement_spans();
+    let star_spans = fact.unquoted_star_parameter_spans();
     if scalar_spans.is_empty() && star_spans.is_empty() {
         return;
     }
     if context == ExpansionContext::CommandName
         && !fact.has_literal_affixes()
-        && fact.word().parts.len() == 1
+        && fact.parts_len() == 1
     {
         return;
     }
     let query = SafeValueQuery::from_context(context)
         .expect("checked expansion context should map to a safe-value query");
 
-    for (part, part_span) in fact.word().parts_with_spans() {
+    for (part, part_span) in fact.parts_with_spans() {
         let report_unquoted_star = star_spans.contains(&part_span);
         if !scalar_spans.contains(&part_span) && !report_unquoted_star {
             continue;

--- a/crates/shuck-linter/src/rules/style/unquoted_word_between_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_word_between_quotes.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation, word_unquoted_word_after_single_quoted_segment_spans};
+use crate::{Checker, Rule, Violation};
 
 pub struct UnquotedWordBetweenQuotes;
 
@@ -18,7 +18,7 @@ pub fn unquoted_word_between_quotes(checker: &mut Checker) {
         .facts()
         .word_facts()
         .iter()
-        .flat_map(|fact| word_unquoted_word_after_single_quoted_segment_spans(fact.word(), source))
+        .flat_map(|fact| fact.unquoted_word_after_single_quoted_segment_spans(source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || UnquotedWordBetweenQuotes);


### PR DESCRIPTION
## What changed

This refactors the `shuck-linter` word-fact pipeline from per-occurrence `WordFact` storage into shared `WordNode` data plus lightweight `WordOccurrence` records.

It also:
- moves heavy word-derived payload behind lazy `OnceCell` caches
- interns word nodes by span and stores occurrence IDs in the fact indexes
- replaces eager array-assignment split post-processing with lazy occurrence-level computation
- updates rule-facing access to use `WordOccurrenceRef` helpers instead of the old crate-private raw-word escape hatch

## Why

The old model stored a lot of repeated per-word metadata across occurrences and eagerly built heavy derived state during fact construction. That was showing up as the main checker-owned allocation hotspot.

This change deduplicates word-intrinsic data, keeps occurrence records smaller, and forces rules/tests onto narrower fact queries so the word/fact pipeline is less allocation-heavy and less coupled to raw AST words.

## Impact

- reduces checker-owned allocation pressure in the word/fact pipeline
- preserves existing rule behavior while tightening the facts API boundary
- keeps heavy derived data lazy and memoized instead of building it unconditionally

## Validation

- `cargo check -p shuck-linter`
- `cargo test -p shuck-linter`
- `make test`
