### PR TITLE
Suppress SC1091 for cargo env source in fuzz-init

### DIFF
--- a/scripts/fuzz-init.sh
+++ b/scripts/fuzz-init.sh
@@ -69,7 +69,7 @@ ensure_rustup() {
   fi
 
   if [[ -r "${HOME}/.cargo/env" ]]; then
-    # shellcheck disable=SC1090
+    # shellcheck disable=SC1091
     source "${HOME}/.cargo/env"
   fi
 
@@ -89,7 +89,7 @@ ensure_rustup() {
 
   export PATH="${HOME}/.cargo/bin:${PATH}"
   if [[ -r "${HOME}/.cargo/env" ]]; then
-    # shellcheck disable=SC1090
+    # shellcheck disable=SC1091
     source "${HOME}/.cargo/env"
   fi
 


### PR DESCRIPTION
## Summary
- Switch the two `source \"\${HOME}/.cargo/env\"` suppressions in `scripts/fuzz-init.sh` from `SC1090` to `SC1091` so shuck's C003 (untracked-source-file) warning is silenced via its mapped ShellCheck code.

## Test plan
- [ ] `make check-scripts`