### PR TITLE
Fix C006 spans for escaped quoted expansions

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -2280,6 +2280,24 @@ printf '%s\\n' \"${missing%%/*}\"
     }
 
     #[test]
+    fn undefined_variable_anchors_escaped_quote_parameter_expansions_to_the_parameter() {
+        let source = "\
+#!/bin/bash
+rvm_info=\"
+  uname: \\\"${_system_info}\\\"
+\"
+";
+        let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
+        assert!(diagnostics[0].message.contains("_system_info"));
+        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.column, 12);
+        assert_eq!(diagnostics[0].span.slice(source), "${_system_info}");
+    }
+
+    #[test]
     fn undefined_variable_reports_self_referential_assignments() {
         let diagnostics = lint_for_rule(
             "\

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1376,7 +1376,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 );
             }
             WordPart::Parameter(parameter) => {
-                self.visit_parameter_expansion(parameter, kind, flow, nested_regions, span);
+                self.visit_parameter_expansion(
+                    parameter,
+                    kind,
+                    flow,
+                    nested_regions,
+                    parameter.span,
+                );
             }
             WordPart::ParameterExpansion {
                 reference,
@@ -1396,7 +1402,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     },
                     flow,
                     nested_regions,
-                    span,
+                    reference.span,
                 );
                 if parameter_operator_guards_unset_reference(operator) {
                     self.guarded_parameter_refs.insert(reference_id);
@@ -1423,7 +1429,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     },
                     flow,
                     nested_regions,
-                    span,
+                    reference.span,
                 );
             }
             WordPart::ArrayAccess(reference) => {
@@ -1436,7 +1442,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     },
                     flow,
                     nested_regions,
-                    span,
+                    reference.span,
                 );
             }
             WordPart::ArrayIndices(reference) => {
@@ -1449,7 +1455,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     },
                     flow,
                     nested_regions,
-                    span,
+                    reference.span,
                 );
             }
             WordPart::PrefixMatch { prefix, .. } => {
@@ -1479,7 +1485,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     },
                     flow,
                     nested_regions,
-                    span,
+                    reference.span,
                 );
                 self.indirect_expansion_refs.insert(id);
                 if let Some(operator) = operator {
@@ -1508,7 +1514,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     },
                     flow,
                     nested_regions,
-                    span,
+                    reference.span,
                 );
                 self.visit_optional_arithmetic_expr_into(offset_ast.as_ref(), flow, nested_regions);
                 self.visit_optional_arithmetic_expr_into(length_ast.as_ref(), flow, nested_regions);
@@ -1528,7 +1534,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     },
                     flow,
                     nested_regions,
-                    span,
+                    reference.span,
                 );
                 self.visit_optional_arithmetic_expr_into(offset_ast.as_ref(), flow, nested_regions);
                 self.visit_optional_arithmetic_expr_into(length_ast.as_ref(), flow, nested_regions);
@@ -1543,7 +1549,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     },
                     flow,
                     nested_regions,
-                    span,
+                    reference.span,
                 );
             }
         }
@@ -2574,6 +2580,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     }
 
     fn add_reference(&mut self, name: &Name, kind: ReferenceKind, span: Span) -> ReferenceId {
+        let span = self.normalize_reference_span(span);
         let id = ReferenceId(self.references.len() as u32);
         let scope = self.current_scope();
         let resolved = self.resolve_reference(name, scope, span.start.offset);
@@ -2613,6 +2620,28 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let resolved_binding = resolved.map(|binding| &self.bindings[binding.index()]);
         self.observer.record_reference(reference, resolved_binding);
         id
+    }
+
+    fn normalize_reference_span(&self, span: Span) -> Span {
+        if span.end.offset >= self.source.len() {
+            return span;
+        }
+
+        let syntax = span.slice(self.source);
+        let Some(start_rel) = syntax.find("${") else {
+            return span;
+        };
+        if self.source.as_bytes().get(span.end.offset) != Some(&b'}') {
+            return span;
+        }
+
+        let start = span.start.advanced_by(&syntax[..start_rel]);
+        let end = span.end.advanced_by("}");
+        if start.offset < end.offset {
+            Span::from_positions(start, end)
+        } else {
+            span
+        }
     }
 
     fn add_parameter_default_binding(&mut self, reference: &VarRef) {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4177,6 +4177,26 @@ printf '%s\\n' \"$config_path\" \"$still_missing\"
     }
 
     #[test]
+    fn parameter_reference_spans_exclude_escaped_quotes_in_double_quoted_strings() {
+        let source = "\
+#!/bin/bash
+rvm_info=\"
+  uname: \\\"${_system_info}\\\"
+\"
+";
+        let model = model(source);
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.name == "_system_info")
+            .unwrap();
+
+        assert_eq!(reference.span.start.line, 3);
+        assert_eq!(reference.span.start.column, 12);
+        assert_eq!(reference.span.slice(source), "${_system_info}");
+    }
+
+    #[test]
     fn default_parameter_operand_reads_are_tracked() {
         let source = "\
 repo_root=$(pwd)


### PR DESCRIPTION
## Summary
- normalize semantic reference spans so escaped quotes in multiline double-quoted strings still anchor `${...}` references to the parameter expansion itself
- use parameter/reference spans consistently when recording semantic reads for expansion variants
- add semantic and linter regressions that lock the C006 anchor to `${_system_info}` in the escaped-quote case

## Root cause
The semantic builder was sometimes recording a wider enclosing word-part span instead of the concrete parameter expansion span. In strings like `\"${name}\"`, that caused the undefined-variable diagnostic to start one column early.

## Impact
This tightens C006 locations for escaped quoted expansions and reduces reviewed divergences in the targeted large-corpus comparison.

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter undefined_variable_ -- --nocapture`
- `cargo test -p shuck-semantic parameter_reference_spans_exclude_escaped_quotes_in_double_quoted_strings -- --nocapture`
- `cargo test -p shuck-parser test_nested_default_operand_keeps_quoted_right_brace_literal -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006`
