### PR TITLE
Add benchmark docs and website snapshots

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -3,12 +3,12 @@ name: Website
 on:
   push:
     branches: [main]
-    paths:
-      - "website/**"
-      - ".github/workflows/website.yml"
   pull_request:
     paths:
       - "website/**"
+      - "scripts/benchmarks/**"
+      - "crates/shuck-benchmark/resources/**"
+      - "Makefile"
       - ".github/workflows/website.yml"
 
 permissions:
@@ -48,7 +48,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     permissions:
       contents: read
       pages: write
@@ -63,6 +63,45 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Install benchmark dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y hyperfine shellcheck
+
+      - name: Generate CI benchmark snapshot
+        id: benchmark_snapshot
+        continue-on-error: true
+        working-directory: ${{ github.workspace }}
+        env:
+          SHUCK_BENCHMARK_OUTPUT_DIR: ${{ runner.temp }}/website-benchmarks
+        run: |
+          mkdir -p "$SHUCK_BENCHMARK_OUTPUT_DIR"
+          ./scripts/benchmarks/setup.sh hyperfine shellcheck
+          ./scripts/benchmarks/run.sh
+          python3 ./scripts/benchmarks/export_website_data.py \
+            --repo-root . \
+            --bench-dir "$SHUCK_BENCHMARK_OUTPUT_DIR" \
+            --output website/generated/benchmarks/ci-latest.json \
+            --dataset-id ci-latest \
+            --dataset-name "GitHub Actions latest main snapshot" \
+            --dataset-description "Regenerated during the GitHub Pages deploy on the latest main commit." \
+            --environment-kind ci \
+            --environment-label "GitHub Actions ubuntu-latest" \
+            --source-command "make bench-macro" \
+            --notes "This snapshot is rebuilt during every Pages deploy from the current main commit." \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+      - name: Note benchmark fallback
+        if: steps.benchmark_snapshot.outcome != 'success'
+        run: echo "Benchmark generation failed; building the site with the checked-in fallback JSON."
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ bench-macro:
 	$(NIX_DEVELOP) ./scripts/benchmarks/run.sh
 
 bench-macro-site-local: bench-macro
-	$(NIX_DEVELOP) python3 ./scripts/benchmarks/export_website_data.py --repo-root . --bench-dir .cache --output "$(BENCHMARK_WEBSITE_LOCAL_OUTPUT)" --dataset-id local-m5-max --dataset-name "Apple M5 Max checked-in snapshot" --dataset-description "Checked-in `make bench-macro` results captured on an Apple M5 Max macOS development machine." --environment-kind local --environment-label "Apple M5 Max macOS snapshot" --notes "Regenerate this checked-in snapshot on the Apple M5 Max machine when you want to refresh the website's local reference numbers."
+	$(NIX_DEVELOP) python3 ./scripts/benchmarks/export_website_data.py --repo-root . --bench-dir .cache --output "$(BENCHMARK_WEBSITE_LOCAL_OUTPUT)" --dataset-id local-m5-max --dataset-name "Apple M5 Max checked-in snapshot" --dataset-description "Checked-in make bench-macro results captured on an Apple M5 Max macOS development machine." --environment-kind local --environment-label "Apple M5 Max macOS snapshot" --notes "Regenerate this checked-in snapshot on the Apple M5 Max machine when you want to refresh the website's local reference numbers."
 
 bench-macro-single:
 	test -n "$(BENCH_FILE)"

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ LARGE_CORPUS_REPORT_DIR ?= target/large-corpus-report
 LARGE_CORPUS_REPORT_LOG ?= $(LARGE_CORPUS_REPORT_DIR)/latest.log
 LARGE_CORPUS_REPORT_HTML ?= $(LARGE_CORPUS_REPORT_DIR)/index.html
 BENCHMARK_WEBSITE_LOCAL_OUTPUT ?= website/generated/benchmarks/local-m5-max.json
+BENCHMARK_WEBSITE_BENCH_DIR ?= $(or $(SHUCK_BENCHMARK_OUTPUT_DIR),.cache)
 
 setup-hooks:
 	git config core.hooksPath .githooks
@@ -182,7 +183,7 @@ bench-macro:
 	$(NIX_DEVELOP) ./scripts/benchmarks/run.sh
 
 bench-macro-site-local: bench-macro
-	$(NIX_DEVELOP) python3 ./scripts/benchmarks/export_website_data.py --repo-root . --bench-dir .cache --output "$(BENCHMARK_WEBSITE_LOCAL_OUTPUT)" --dataset-id local-m5-max --dataset-name "Apple M5 Max checked-in snapshot" --dataset-description "Checked-in make bench-macro results captured on an Apple M5 Max macOS development machine." --environment-kind local --environment-label "Apple M5 Max macOS snapshot" --notes "Regenerate this checked-in snapshot on the Apple M5 Max machine when you want to refresh the website's local reference numbers."
+	$(NIX_DEVELOP) python3 ./scripts/benchmarks/export_website_data.py --repo-root . --bench-dir "$(BENCHMARK_WEBSITE_BENCH_DIR)" --output "$(BENCHMARK_WEBSITE_LOCAL_OUTPUT)" --dataset-id local-m5-max --dataset-name "Apple M5 Max checked-in snapshot" --dataset-description "Checked-in make bench-macro results captured on an Apple M5 Max macOS development machine." --environment-kind local --environment-label "Apple M5 Max macOS snapshot" --notes "Regenerate this checked-in snapshot on the Apple M5 Max machine when you want to refresh the website's local reference numbers."
 
 bench-macro-single:
 	test -n "$(BENCH_FILE)"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security release
+.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security release
 
 ARGS ?= --help
 BENCH_FILE ?=
@@ -25,6 +25,7 @@ SHUCK_LARGE_CORPUS_RULES ?=
 LARGE_CORPUS_REPORT_DIR ?= target/large-corpus-report
 LARGE_CORPUS_REPORT_LOG ?= $(LARGE_CORPUS_REPORT_DIR)/latest.log
 LARGE_CORPUS_REPORT_HTML ?= $(LARGE_CORPUS_REPORT_DIR)/index.html
+BENCHMARK_WEBSITE_LOCAL_OUTPUT ?= website/generated/benchmarks/local-m5-max.json
 
 setup-hooks:
 	git config core.hooksPath .githooks
@@ -179,6 +180,9 @@ bench-formatter:
 bench-macro:
 	$(NIX_DEVELOP) ./scripts/benchmarks/setup.sh hyperfine shellcheck
 	$(NIX_DEVELOP) ./scripts/benchmarks/run.sh
+
+bench-macro-site-local: bench-macro
+	$(NIX_DEVELOP) python3 ./scripts/benchmarks/export_website_data.py --repo-root . --bench-dir .cache --output "$(BENCHMARK_WEBSITE_LOCAL_OUTPUT)" --dataset-id local-m5-max --dataset-name "Apple M5 Max checked-in snapshot" --dataset-description "Checked-in `make bench-macro` results captured on an Apple M5 Max macOS development machine." --environment-kind local --environment-label "Apple M5 Max macOS snapshot" --notes "Regenerate this checked-in snapshot on the Apple M5 Max machine when you want to refresh the website's local reference numbers."
 
 bench-macro-single:
 	test -n "$(BENCH_FILE)"

--- a/scripts/benchmarks/export_website_data.py
+++ b/scripts/benchmarks/export_website_data.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+
+DEFAULT_WARMUP_RUNS = 3
+DEFAULT_MEASURED_RUNS = 10
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export macro benchmark results into a website-friendly JSON payload."
+    )
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--bench-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--dataset-id", required=True)
+    parser.add_argument("--dataset-name", required=True)
+    parser.add_argument("--dataset-description", required=True)
+    parser.add_argument(
+        "--environment-kind",
+        choices=("local", "ci"),
+        required=True,
+    )
+    parser.add_argument("--environment-label", default="")
+    parser.add_argument(
+        "--source-command",
+        default="make bench-macro",
+        help="Human-readable command used to produce the benchmark exports.",
+    )
+    parser.add_argument(
+        "--notes",
+        default="",
+        help="Optional explanatory note stored alongside the methodology metadata.",
+    )
+    parser.add_argument("--run-url", default="")
+    parser.add_argument("--warmup-runs", type=int, default=DEFAULT_WARMUP_RUNS)
+    parser.add_argument("--measured-runs", type=int, default=DEFAULT_MEASURED_RUNS)
+    return parser.parse_args()
+
+
+def run_capture(args: list[str], cwd: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=cwd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout.strip()
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def detect_cpu() -> str | None:
+    system = platform.system()
+    if system == "Darwin":
+        cpu = run_capture(["sysctl", "-n", "machdep.cpu.brand_string"], cwd=Path.cwd())
+        return cpu or None
+    if system == "Linux":
+        cpuinfo = Path("/proc/cpuinfo")
+        if cpuinfo.exists():
+            for line in cpuinfo.read_text(errors="replace").splitlines():
+                if line.lower().startswith("model name"):
+                    _, _, value = line.partition(":")
+                    return value.strip() or None
+    return platform.processor() or None
+
+
+def detect_os_label() -> str:
+    system = platform.system()
+    if system == "Darwin":
+        version = platform.mac_ver()[0] or platform.release()
+        return f"macOS {version}"
+    if system == "Linux":
+        os_release = Path("/etc/os-release")
+        if os_release.exists():
+            pretty_name = None
+            for line in os_release.read_text(errors="replace").splitlines():
+                if line.startswith("PRETTY_NAME="):
+                    pretty_name = line.partition("=")[2].strip().strip('"')
+                    break
+            if pretty_name:
+                return pretty_name
+        return f"Linux {platform.release()}"
+    if system == "Windows":
+        return f"Windows {platform.release()}"
+    return platform.platform()
+
+
+def parse_shellcheck_version(output: str | None) -> str | None:
+    if not output:
+        return None
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith("version:"):
+            return stripped.partition(":")[2].strip()
+    first_line = output.splitlines()[0].strip()
+    return first_line or None
+
+
+def parse_hyperfine_version(output: str | None) -> str | None:
+    if not output:
+        return None
+    first_line = output.splitlines()[0].strip()
+    return first_line or None
+
+
+def parse_shuck_version(output: str | None) -> str | None:
+    if not output:
+        return None
+    first_line = output.splitlines()[0].strip()
+    return first_line or None
+
+
+def detect_shuck_version(repo_root: Path, shuck_bin: Path) -> str | None:
+    direct_version = parse_shuck_version(run_capture([str(shuck_bin), "--version"], cwd=repo_root))
+    if direct_version:
+        return direct_version
+
+    cargo_toml = repo_root / "crates" / "shuck" / "Cargo.toml"
+    package_match = re.search(
+        r'^version\s*=\s*"([^"]+)"',
+        cargo_toml.read_text(errors="replace"),
+        re.MULTILINE,
+    )
+    if package_match:
+        return f"shuck {package_match.group(1)}"
+
+    workspace_toml = repo_root / "Cargo.toml"
+    workspace_match = re.search(
+        r"(?ms)^\[workspace\.package\]\s+version\s*=\s*\"([^\"]+)\"",
+        workspace_toml.read_text(errors="replace"),
+    )
+    if workspace_match:
+        return f"shuck {workspace_match.group(1)}"
+    return None
+
+
+def normalize_repository_url(url: str | None) -> str | None:
+    if not url:
+        return None
+    normalized = url.strip()
+    if normalized.startswith("git@github.com:"):
+        normalized = "https://github.com/" + normalized.removeprefix("git@github.com:")
+    elif normalized.startswith("ssh://git@github.com/"):
+        normalized = "https://github.com/" + normalized.removeprefix("ssh://git@github.com/")
+
+    normalized = re.sub(r"\.git$", "", normalized)
+    if normalized.startswith("https://github.com/"):
+        return normalized
+    return None
+
+
+def detect_repository_url(repo_root: Path) -> str | None:
+    env_repo = os.environ.get("GITHUB_REPOSITORY")
+    env_server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    if env_repo:
+        return f"{env_server.rstrip('/')}/{env_repo}"
+
+    remote = run_capture(["git", "config", "--get", "remote.origin.url"], cwd=repo_root)
+    return normalize_repository_url(remote)
+
+
+def load_fixture_metadata(repo_root: Path) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    manifest_path = repo_root / "crates" / "shuck-benchmark" / "resources" / "manifest.json"
+    manifest = read_json(manifest_path)
+
+    fixtures: list[dict[str, Any]] = []
+    fixtures_by_slug: dict[str, dict[str, Any]] = {}
+    for fixture in manifest["fixtures"]:
+        local_filename = fixture["local_filename"]
+        file_path = manifest_path.parent / local_filename
+        source = file_path.read_text(errors="replace")
+        slug = Path(local_filename).stem
+        line_count = len(source.splitlines())
+        entry = {
+            "slug": slug,
+            "name": slug,
+            "fileName": Path(local_filename).name,
+            "path": local_filename,
+            "bytes": int(fixture["byte_size"]),
+            "lines": line_count,
+            "upstreamRepo": fixture["upstream_repo"],
+            "upstreamPath": fixture["upstream_path"],
+            "sourceUrl": fixture["source_url"],
+            "license": fixture["spdx_license_id"],
+            "commit": fixture["commit"],
+            "commitShort": fixture["commit"][:7],
+        }
+        fixtures.append(entry)
+        fixtures_by_slug[slug] = entry
+    return fixtures, fixtures_by_slug
+
+
+def make_measurement(tool: str, result: dict[str, Any], shuck_mean: float | None) -> dict[str, Any]:
+    times = [float(value) for value in result.get("times", [])]
+    memory_usage = [int(value) for value in result.get("memory_usage_byte", [])]
+    exit_codes = sorted({int(code) for code in result.get("exit_codes", [])})
+    mean_seconds = float(result["mean"])
+
+    relative_to_shuck = None
+    if shuck_mean and shuck_mean > 0.0:
+        relative_to_shuck = mean_seconds / shuck_mean
+
+    return {
+        "tool": tool,
+        "command": str(result.get("command", "")),
+        "meanSeconds": mean_seconds,
+        "stddevSeconds": float(result.get("stddev", 0.0)),
+        "medianSeconds": float(result.get("median", mean_seconds)),
+        "minSeconds": float(result.get("min", mean_seconds)),
+        "maxSeconds": float(result.get("max", mean_seconds)),
+        "userSeconds": float(result.get("user", 0.0)),
+        "systemSeconds": float(result.get("system", 0.0)),
+        "meanMemoryBytes": int(sum(memory_usage) / len(memory_usage)) if memory_usage else None,
+        "maxMemoryBytes": max(memory_usage) if memory_usage else None,
+        "runCount": len(times) or len(result.get("exit_codes", [])),
+        "exitCodes": exit_codes,
+        "hasFailures": any(code != 0 for code in exit_codes),
+        "relativeToShuck": relative_to_shuck,
+    }
+
+
+def load_cases(
+    bench_dir: Path,
+    fixtures: list[dict[str, Any]],
+    fixtures_by_slug: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    bench_paths = list(bench_dir.glob("bench-*.json"))
+    raw_cases: dict[str, list[dict[str, Any]]] = {}
+    for bench_path in bench_paths:
+        payload = read_json(bench_path)
+        case_slug = bench_path.stem.removeprefix("bench-")
+        raw_cases[case_slug] = list(payload.get("results", []))
+
+    fixture_order = {fixture["slug"]: index for index, fixture in enumerate(fixtures)}
+
+    def sort_key(slug: str) -> tuple[int, int, str]:
+        if slug == "all":
+            return (0, -1, slug)
+        return (1, fixture_order.get(slug, len(fixture_order)), slug)
+
+    cases: list[dict[str, Any]] = []
+    for slug in sorted(raw_cases, key=sort_key):
+        results = raw_cases[slug]
+        fixture = fixtures_by_slug.get(slug)
+        shuck_result = None
+        for result in results:
+            tool = str(result.get("command", "")).split("/", 1)[0]
+            if tool == "shuck":
+                shuck_result = result
+                break
+
+        shuck_mean = float(shuck_result["mean"]) if shuck_result else None
+        measurements: list[dict[str, Any]] = []
+        for result in results:
+            tool = str(result.get("command", "")).split("/", 1)[0]
+            measurements.append(make_measurement(tool, result, shuck_mean))
+        measurements.sort(key=lambda item: (item["tool"] != "shuck", item["tool"]))
+
+        entry: dict[str, Any] = {
+            "slug": slug,
+            "name": slug,
+            "kind": "aggregate" if slug == "all" else "fixture",
+            "bytes": sum(item["bytes"] for item in fixtures) if slug == "all" else (fixture["bytes"] if fixture else None),
+            "lines": sum(item["lines"] for item in fixtures) if slug == "all" else (fixture["lines"] if fixture else None),
+            "fixtureCount": len(fixtures) if slug == "all" else 1,
+            "measurements": measurements,
+        }
+        if fixture is not None:
+            entry["fixture"] = fixture
+        cases.append(entry)
+    return cases
+
+
+def build_summary(cases: list[dict[str, Any]]) -> dict[str, Any] | None:
+    aggregate = next((case for case in cases if case["slug"] == "all"), None)
+    if aggregate is None:
+        return None
+
+    shuck = next((item for item in aggregate["measurements"] if item["tool"] == "shuck"), None)
+    comparison = next((item for item in aggregate["measurements"] if item["tool"] != "shuck"), None)
+    if shuck is None:
+        return None
+
+    summary: dict[str, Any] = {
+        "aggregateCase": "all",
+        "primaryTool": "shuck",
+        "comparisonTool": comparison["tool"] if comparison else None,
+        "shuckMeanSeconds": shuck["meanSeconds"],
+        "comparisonMeanSeconds": comparison["meanSeconds"] if comparison else None,
+        "speedupRatio": None,
+        "timeSavedPct": None,
+    }
+
+    if comparison and shuck["meanSeconds"] > 0.0:
+        speedup_ratio = comparison["meanSeconds"] / shuck["meanSeconds"]
+        summary["speedupRatio"] = speedup_ratio
+        summary["timeSavedPct"] = (1.0 - (shuck["meanSeconds"] / comparison["meanSeconds"])) * 100.0
+
+    return summary
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=path.parent) as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+        temp_path = Path(handle.name)
+    temp_path.replace(path)
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    bench_dir = args.bench_dir.resolve()
+
+    fixtures, fixtures_by_slug = load_fixture_metadata(repo_root)
+    cases = load_cases(bench_dir, fixtures, fixtures_by_slug)
+    summary = build_summary(cases)
+    cpu = detect_cpu()
+    generated_at = (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+    repository_url = detect_repository_url(repo_root)
+    commit_sha = run_capture(["git", "rev-parse", "HEAD"], cwd=repo_root)
+    commit_short = commit_sha[:7] if commit_sha else None
+    commit_url = f"{repository_url}/commit/{commit_sha}" if repository_url and commit_sha else None
+
+    target_dir = Path(os.environ.get("CARGO_TARGET_DIR", repo_root / "target"))
+    shuck_bin = Path(os.environ.get("SHUCK_BENCHMARK_SHUCK_BIN", target_dir / "release" / "shuck"))
+
+    shuck_version = detect_shuck_version(repo_root, shuck_bin)
+    hyperfine_version = parse_hyperfine_version(run_capture(["hyperfine", "--version"], cwd=repo_root))
+    shellcheck_version = parse_shellcheck_version(run_capture(["shellcheck", "--version"], cwd=repo_root))
+
+    comparison_tool = summary["comparisonTool"] if summary else None
+    benchmark_mode = "compare" if comparison_tool else "shuck-only"
+    environment_label = args.environment_label.strip()
+    if not environment_label:
+        if args.environment_kind == "local" and cpu:
+            environment_label = f"{cpu} local snapshot"
+        elif args.environment_kind == "ci":
+            environment_label = "GitHub Actions CI snapshot"
+        else:
+            environment_label = "Macro benchmark snapshot"
+
+    payload = {
+        "schemaVersion": 1,
+        "available": True,
+        "id": args.dataset_id,
+        "name": args.dataset_name,
+        "description": args.dataset_description,
+        "generatedAt": generated_at,
+        "commit": {
+            "sha": commit_sha,
+            "shortSha": commit_short,
+        },
+        "links": {
+            "repositoryUrl": repository_url,
+            "commitUrl": commit_url,
+            "runUrl": args.run_url or None,
+        },
+        "environment": {
+            "kind": args.environment_kind,
+            "label": environment_label,
+            "os": detect_os_label(),
+            "arch": platform.machine(),
+            "cpu": cpu,
+            "python": platform.python_version(),
+        },
+        "toolVersions": {
+            "shuck": shuck_version,
+            "hyperfine": hyperfine_version,
+            "shellcheck": shellcheck_version,
+        },
+        "methodology": {
+            "benchmarkCommand": args.source_command,
+            "benchmarkMode": benchmark_mode,
+            "warmupRuns": args.warmup_runs,
+            "measuredRuns": args.measured_runs,
+            "ignoreFailure": True,
+            "shuckCommand": "shuck check --no-cache <fixture>",
+            "comparisonCommand": (
+                "shellcheck --severity=style <fixture>" if comparison_tool else None
+            ),
+            "notes": args.notes or None,
+        },
+        "corpus": {
+            "fixtureCount": len(fixtures),
+            "totalBytes": sum(item["bytes"] for item in fixtures),
+            "totalLines": sum(item["lines"] for item in fixtures),
+            "fixtures": fixtures,
+        },
+        "summary": summary,
+        "cases": cases,
+    }
+
+    write_json_atomic(args.output.resolve(), payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/export_website_data.py
+++ b/scripts/benchmarks/export_website_data.py
@@ -244,7 +244,12 @@ def load_cases(
     fixtures: list[dict[str, Any]],
     fixtures_by_slug: dict[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    bench_paths = list(bench_dir.glob("bench-*.json"))
+    allowed_slugs = {"all", *fixtures_by_slug.keys()}
+    bench_paths = [
+        path
+        for path in bench_dir.glob("bench-*.json")
+        if path.stem.removeprefix("bench-") in allowed_slugs
+    ]
     raw_cases: dict[str, list[dict[str, Any]]] = {}
     for bench_path in bench_paths:
         payload = read_json(bench_path)

--- a/scripts/benchmarks/test_export_website_data.py
+++ b/scripts/benchmarks/test_export_website_data.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from export_website_data import load_cases
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.benchmarks.export_website_data import load_cases
 
 
 class ExportWebsiteDataTests(unittest.TestCase):

--- a/scripts/benchmarks/test_export_website_data.py
+++ b/scripts/benchmarks/test_export_website_data.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from export_website_data import load_cases
+
+
+class ExportWebsiteDataTests(unittest.TestCase):
+    def test_load_cases_ignores_stale_fixture_exports(self) -> None:
+        fixtures = [
+            {
+                "slug": "fixture",
+                "name": "fixture",
+                "fileName": "fixture.sh",
+                "path": "files/fixture.sh",
+                "bytes": 12,
+                "lines": 2,
+                "upstreamRepo": "example/repo",
+                "upstreamPath": "fixture.sh",
+                "sourceUrl": "https://example.invalid/fixture.sh",
+                "license": "MIT",
+                "commit": "abc1234",
+                "commitShort": "abc1234",
+            }
+        ]
+        fixtures_by_slug = {fixture["slug"]: fixture for fixture in fixtures}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bench_dir = Path(temp_dir)
+            aggregate_payload = {
+                "results": [
+                    {
+                        "command": "shuck/all",
+                        "mean": 1.0,
+                        "stddev": 0.1,
+                        "median": 1.0,
+                        "min": 0.9,
+                        "max": 1.1,
+                        "exit_codes": [0],
+                    }
+                ]
+            }
+            fixture_payload = {
+                "results": [
+                    {
+                        "command": "shuck/fixture",
+                        "mean": 0.5,
+                        "stddev": 0.05,
+                        "median": 0.5,
+                        "min": 0.45,
+                        "max": 0.55,
+                        "exit_codes": [0],
+                    }
+                ]
+            }
+            stale_payload = {
+                "results": [
+                    {
+                        "command": "shuck/stale-fixture",
+                        "mean": 9.9,
+                        "stddev": 0.1,
+                        "median": 9.9,
+                        "min": 9.8,
+                        "max": 10.0,
+                        "exit_codes": [0],
+                    }
+                ]
+            }
+
+            (bench_dir / "bench-all.json").write_text(json.dumps(aggregate_payload))
+            (bench_dir / "bench-fixture.json").write_text(json.dumps(fixture_payload))
+            (bench_dir / "bench-stale-fixture.json").write_text(json.dumps(stale_payload))
+
+            cases = load_cases(bench_dir, fixtures, fixtures_by_slug)
+
+        self.assertEqual([case["slug"] for case in cases], ["all", "fixture"])
+        self.assertEqual(cases[1]["bytes"], 12)
+        self.assertEqual(cases[1]["lines"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmarks/test_makefile_bench_macro_site_local.py
+++ b/scripts/benchmarks/test_makefile_bench_macro_site_local.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class MakefileBenchMacroSiteLocalTests(unittest.TestCase):
+    def test_export_uses_configured_benchmark_output_directory(self) -> None:
+        result = subprocess.run(
+            [
+                "make",
+                "-n",
+                "bench-macro-site-local",
+                "SHUCK_BENCHMARK_OUTPUT_DIR=/tmp/bench-output",
+                "NIX_DEVELOP=",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertIn('--bench-dir "/tmp/bench-output"', result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { flattenNav, docsNavigation } from "@/app/lib/docs-navigation";
 // Map of slug paths to their MDX imports
 const pages: Record<string, () => Promise<{ default: React.ComponentType; metadata?: { title?: string; description?: string } }>> = {
   "getting-started": () => import("@/content/getting-started/index.mdx"),
+  "performance/benchmarks": () => import("@/content/performance/benchmarks"),
 };
 
 interface Props {

--- a/website/app/lib/benchmarks.test.ts
+++ b/website/app/lib/benchmarks.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { pickLatestDatasetWithCorpus, type BenchmarkDataset } from "./benchmarks";
+import {
+  describeRelativePerformance,
+  pickLatestDatasetWithCorpus,
+  type BenchmarkDataset,
+} from "./benchmarks";
 
 const baseDataset: BenchmarkDataset = {
   schemaVersion: 1,
@@ -113,4 +117,25 @@ test("pickLatestDatasetWithCorpus prefers the freshest dataset with fixtures", (
 
   assert.equal(chosen?.id, "ci");
   assert.equal(chosen?.corpus.fixtures[0]?.slug, "ci");
+});
+
+test("describeRelativePerformance reports faster ratios correctly", () => {
+  assert.equal(
+    describeRelativePerformance(1.5, "shellcheck"),
+    "1.50x faster than shellcheck",
+  );
+});
+
+test("describeRelativePerformance reports slower ratios correctly", () => {
+  assert.equal(
+    describeRelativePerformance(0.5, "shellcheck"),
+    "2.00x slower than shellcheck",
+  );
+});
+
+test("describeRelativePerformance reports ties neutrally", () => {
+  assert.equal(
+    describeRelativePerformance(1, "shellcheck"),
+    "roughly tied with shellcheck",
+  );
 });

--- a/website/app/lib/benchmarks.test.ts
+++ b/website/app/lib/benchmarks.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { pickLatestDatasetWithCorpus, type BenchmarkDataset } from "./benchmarks";
+
+const baseDataset: BenchmarkDataset = {
+  schemaVersion: 1,
+  available: true,
+  id: "base",
+  name: "Base dataset",
+  description: "test dataset",
+  generatedAt: "2026-04-20T17:00:00Z",
+  commit: {
+    sha: null,
+    shortSha: null,
+  },
+  links: {
+    repositoryUrl: null,
+    commitUrl: null,
+    runUrl: null,
+  },
+  environment: {
+    kind: "local",
+    label: "label",
+    os: "os",
+    arch: "arch",
+    cpu: null,
+    python: "3.13.0",
+  },
+  toolVersions: {
+    shuck: null,
+    hyperfine: null,
+    shellcheck: null,
+  },
+  methodology: {
+    benchmarkCommand: "make bench-macro",
+    benchmarkMode: "compare",
+    warmupRuns: 3,
+    measuredRuns: 10,
+    ignoreFailure: true,
+    shuckCommand: "shuck check --no-cache <fixture>",
+    comparisonCommand: "shellcheck --severity=style <fixture>",
+    notes: null,
+  },
+  corpus: {
+    fixtureCount: 0,
+    totalBytes: 0,
+    totalLines: 0,
+    fixtures: [],
+  },
+  summary: null,
+  cases: [],
+};
+
+test("pickLatestDatasetWithCorpus prefers the freshest dataset with fixtures", () => {
+  const localDataset: BenchmarkDataset = {
+    ...baseDataset,
+    id: "local",
+    generatedAt: "2026-04-20T17:00:00Z",
+    corpus: {
+      fixtureCount: 1,
+      totalBytes: 10,
+      totalLines: 1,
+      fixtures: [
+        {
+          slug: "local",
+          name: "local",
+          fileName: "local.sh",
+          path: "files/local.sh",
+          bytes: 10,
+          lines: 1,
+          upstreamRepo: "example/local",
+          upstreamPath: "local.sh",
+          sourceUrl: "https://example.invalid/local.sh",
+          license: "MIT",
+          commit: "abc1234",
+          commitShort: "abc1234",
+        },
+      ],
+    },
+  };
+  const ciDataset: BenchmarkDataset = {
+    ...baseDataset,
+    id: "ci",
+    generatedAt: "2026-04-20T18:00:00Z",
+    environment: {
+      ...baseDataset.environment,
+      kind: "ci",
+    },
+    corpus: {
+      fixtureCount: 1,
+      totalBytes: 20,
+      totalLines: 2,
+      fixtures: [
+        {
+          slug: "ci",
+          name: "ci",
+          fileName: "ci.sh",
+          path: "files/ci.sh",
+          bytes: 20,
+          lines: 2,
+          upstreamRepo: "example/ci",
+          upstreamPath: "ci.sh",
+          sourceUrl: "https://example.invalid/ci.sh",
+          license: "MIT",
+          commit: "def5678",
+          commitShort: "def5678",
+        },
+      ],
+    },
+  };
+
+  const chosen = pickLatestDatasetWithCorpus([localDataset, ciDataset]);
+
+  assert.equal(chosen?.id, "ci");
+  assert.equal(chosen?.corpus.fixtures[0]?.slug, "ci");
+});

--- a/website/app/lib/benchmarks.ts
+++ b/website/app/lib/benchmarks.ts
@@ -1,0 +1,172 @@
+export type BenchmarkFixture = {
+  slug: string;
+  name: string;
+  fileName: string;
+  path: string;
+  bytes: number;
+  lines: number;
+  upstreamRepo: string;
+  upstreamPath: string;
+  sourceUrl: string;
+  license: string;
+  commit: string;
+  commitShort: string;
+};
+
+export type BenchmarkMeasurement = {
+  tool: string;
+  command: string;
+  meanSeconds: number;
+  stddevSeconds: number;
+  medianSeconds: number;
+  minSeconds: number;
+  maxSeconds: number;
+  userSeconds: number;
+  systemSeconds: number;
+  meanMemoryBytes: number | null;
+  maxMemoryBytes: number | null;
+  runCount: number;
+  exitCodes: number[];
+  hasFailures: boolean;
+  relativeToShuck: number | null;
+};
+
+export type BenchmarkCase = {
+  slug: string;
+  name: string;
+  kind: "aggregate" | "fixture";
+  bytes: number | null;
+  lines: number | null;
+  fixtureCount: number;
+  measurements: BenchmarkMeasurement[];
+  fixture?: BenchmarkFixture;
+};
+
+export type BenchmarkDataset = {
+  schemaVersion: number;
+  available: boolean;
+  id: string;
+  name: string;
+  description: string;
+  generatedAt: string;
+  commit: {
+    sha: string | null;
+    shortSha: string | null;
+  };
+  links: {
+    repositoryUrl: string | null;
+    commitUrl: string | null;
+    runUrl: string | null;
+  };
+  environment: {
+    kind: "local" | "ci";
+    label: string;
+    os: string;
+    arch: string;
+    cpu: string | null;
+    python: string;
+  };
+  toolVersions: {
+    shuck: string | null;
+    hyperfine: string | null;
+    shellcheck: string | null;
+  };
+  methodology: {
+    benchmarkCommand: string;
+    benchmarkMode: "compare" | "shuck-only";
+    warmupRuns: number;
+    measuredRuns: number;
+    ignoreFailure: boolean;
+    shuckCommand: string;
+    comparisonCommand: string | null;
+    notes: string | null;
+  };
+  corpus: {
+    fixtureCount: number;
+    totalBytes: number;
+    totalLines: number;
+    fixtures: BenchmarkFixture[];
+  };
+  summary: {
+    aggregateCase: string;
+    primaryTool: string;
+    comparisonTool: string | null;
+    shuckMeanSeconds: number;
+    comparisonMeanSeconds: number | null;
+    speedupRatio: number | null;
+    timeSavedPct: number | null;
+  } | null;
+  cases: BenchmarkCase[];
+};
+
+export function getAggregateCase(dataset: BenchmarkDataset): BenchmarkCase | undefined {
+  return dataset.cases.find((candidate) => candidate.slug === "all");
+}
+
+export function getMeasurement(
+  benchmarkCase: BenchmarkCase,
+  tool: string,
+): BenchmarkMeasurement | undefined {
+  return benchmarkCase.measurements.find((candidate) => candidate.tool === tool);
+}
+
+export function getComparisonMeasurement(
+  benchmarkCase: BenchmarkCase,
+): BenchmarkMeasurement | undefined {
+  return benchmarkCase.measurements.find((candidate) => candidate.tool !== "shuck");
+}
+
+export function formatDuration(seconds: number): string {
+  if (seconds >= 1) {
+    return `${seconds.toFixed(2)} s`;
+  }
+  if (seconds >= 0.001) {
+    return `${(seconds * 1000).toFixed(1)} ms`;
+  }
+  return `${(seconds * 1000000).toFixed(1)} us`;
+}
+
+export function formatRatio(ratio: number | null | undefined): string {
+  if (!ratio || !Number.isFinite(ratio)) {
+    return "n/a";
+  }
+  if (ratio >= 100) {
+    return `${ratio.toFixed(1)}x`;
+  }
+  return `${ratio.toFixed(2)}x`;
+}
+
+export function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null) {
+    return "n/a";
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KiB`;
+  }
+  return `${bytes} B`;
+}
+
+export function formatMemory(bytes: number | null | undefined): string {
+  if (bytes == null) {
+    return "n/a";
+  }
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GiB`;
+  }
+  return formatBytes(bytes);
+}
+
+export function formatDate(isoString: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(new Date(isoString));
+}
+
+export function formatInteger(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}

--- a/website/app/lib/benchmarks.ts
+++ b/website/app/lib/benchmarks.ts
@@ -99,6 +99,17 @@ export type BenchmarkDataset = {
   cases: BenchmarkCase[];
 };
 
+export function pickLatestDatasetWithCorpus(
+  datasets: BenchmarkDataset[],
+): BenchmarkDataset | undefined {
+  return datasets
+    .filter((dataset) => dataset.corpus.fixtures.length > 0)
+    .sort(
+      (left, right) =>
+        Date.parse(right.generatedAt) - Date.parse(left.generatedAt),
+    )[0];
+}
+
 export function getAggregateCase(dataset: BenchmarkDataset): BenchmarkCase | undefined {
   return dataset.cases.find((candidate) => candidate.slug === "all");
 }

--- a/website/app/lib/benchmarks.ts
+++ b/website/app/lib/benchmarks.ts
@@ -147,6 +147,22 @@ export function formatRatio(ratio: number | null | undefined): string {
   return `${ratio.toFixed(2)}x`;
 }
 
+export function describeRelativePerformance(
+  ratio: number | null | undefined,
+  comparisonTool: string,
+): string {
+  if (!ratio || !Number.isFinite(ratio)) {
+    return "n/a";
+  }
+  if (ratio > 1) {
+    return `${formatRatio(ratio)} faster than ${comparisonTool}`;
+  }
+  if (ratio < 1) {
+    return `${formatRatio(1 / ratio)} slower than ${comparisonTool}`;
+  }
+  return `roughly tied with ${comparisonTool}`;
+}
+
 export function formatBytes(bytes: number | null | undefined): string {
   if (bytes == null) {
     return "n/a";

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -12,6 +12,12 @@ export const docsNavigation: NavItem[] = [
     ],
   },
   {
+    title: "Performance",
+    items: [
+      { title: "Benchmarks", href: "/docs/performance/benchmarks" },
+    ],
+  },
+  {
     title: "Rules",
     items: [
       { title: "All Rules", href: "/docs/rules" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -50,6 +50,12 @@ export default function Home() {
               >
                 Docs
               </Link>
+              <Link
+                href="/docs/performance/benchmarks"
+                className="text-accent hover:underline"
+              >
+                Benchmarks
+              </Link>
               <a
                 href="https://github.com/ewhauser/shuck"
                 className="text-accent hover:underline"

--- a/website/content/performance/benchmarks.tsx
+++ b/website/content/performance/benchmarks.tsx
@@ -1,0 +1,385 @@
+import localSnapshotJson from "@/generated/benchmarks/local-m5-max.json";
+import ciSnapshotJson from "@/generated/benchmarks/ci-latest.json";
+import type { BenchmarkDataset, BenchmarkMeasurement } from "@/app/lib/benchmarks";
+import {
+  formatBytes,
+  formatDate,
+  formatDuration,
+  formatInteger,
+  formatMemory,
+  formatRatio,
+  getAggregateCase,
+  getComparisonMeasurement,
+  getMeasurement,
+} from "@/app/lib/benchmarks";
+
+const localSnapshot = localSnapshotJson as BenchmarkDataset;
+const ciSnapshot = ciSnapshotJson as BenchmarkDataset;
+const snapshots = [localSnapshot, ciSnapshot];
+const corpus =
+  localSnapshot.corpus.fixtures.length > 0
+    ? localSnapshot.corpus
+    : ciSnapshot.corpus;
+
+function measurementText(measurement: BenchmarkMeasurement | undefined) {
+  if (!measurement) {
+    return "n/a";
+  }
+
+  return `${formatDuration(measurement.meanSeconds)} (+/- ${formatDuration(
+    measurement.stddevSeconds,
+  )})`;
+}
+
+function datasetLabel(dataset: BenchmarkDataset) {
+  return dataset.environment.kind === "ci" ? "CI snapshot" : "Checked-in local snapshot";
+}
+
+function OverviewTable() {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Snapshot</th>
+          <th>Environment</th>
+          <th>Commit</th>
+          <th>shuck (all)</th>
+          <th>Comparison (all)</th>
+          <th>Speedup</th>
+        </tr>
+      </thead>
+      <tbody>
+        {snapshots.map((dataset) => {
+          const aggregate = getAggregateCase(dataset);
+          const shuck = aggregate ? getMeasurement(aggregate, "shuck") : undefined;
+          const comparison = aggregate ? getComparisonMeasurement(aggregate) : undefined;
+
+          return (
+            <tr key={dataset.id}>
+              <td>
+                <strong>{dataset.name}</strong>
+                <br />
+                <span>{datasetLabel(dataset)}</span>
+              </td>
+              <td>
+                {dataset.environment.label}
+                <br />
+                <span>
+                  {dataset.environment.os} ({dataset.environment.arch})
+                </span>
+              </td>
+              <td>
+                {dataset.links.commitUrl && dataset.commit.shortSha ? (
+                  <a href={dataset.links.commitUrl}>{dataset.commit.shortSha}</a>
+                ) : (
+                  dataset.commit.shortSha ?? "n/a"
+                )}
+                <br />
+                <span>{formatDate(dataset.generatedAt)}</span>
+              </td>
+              <td>{dataset.available ? measurementText(shuck) : "not generated in this build"}</td>
+              <td>
+                {dataset.available ? measurementText(comparison) : "not generated in this build"}
+              </td>
+              <td>
+                {dataset.available ? formatRatio(dataset.summary?.speedupRatio) : "n/a"}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function SnapshotDetails({ dataset }: { dataset: BenchmarkDataset }) {
+  const aggregate = getAggregateCase(dataset);
+  const shuck = aggregate ? getMeasurement(aggregate, "shuck") : undefined;
+  const comparison = aggregate ? getComparisonMeasurement(aggregate) : undefined;
+
+  return (
+    <>
+      <h2>{dataset.name}</h2>
+      <p>{dataset.description}</p>
+
+      <table>
+        <tbody>
+          <tr>
+            <th>Environment</th>
+            <td>{dataset.environment.label}</td>
+          </tr>
+          <tr>
+            <th>OS / arch</th>
+            <td>
+              {dataset.environment.os} ({dataset.environment.arch})
+            </td>
+          </tr>
+          <tr>
+            <th>CPU</th>
+            <td>{dataset.environment.cpu ?? "Unknown"}</td>
+          </tr>
+          <tr>
+            <th>Generated</th>
+            <td>{formatDate(dataset.generatedAt)}</td>
+          </tr>
+          <tr>
+            <th>Commit</th>
+            <td>
+              {dataset.links.commitUrl && dataset.commit.shortSha ? (
+                <a href={dataset.links.commitUrl}>{dataset.commit.shortSha}</a>
+              ) : (
+                dataset.commit.shortSha ?? "n/a"
+              )}
+            </td>
+          </tr>
+          <tr>
+            <th>Runner</th>
+            <td>
+              hyperfine {dataset.methodology.warmupRuns} warmups /{" "}
+              {dataset.methodology.measuredRuns} measured runs
+            </td>
+          </tr>
+          <tr>
+            <th>shuck</th>
+            <td>{dataset.toolVersions.shuck ?? "Unknown"}</td>
+          </tr>
+          <tr>
+            <th>{comparison ? comparison.tool : "Comparison tool"}</th>
+            <td>
+              {comparison?.tool === "shellcheck"
+                ? dataset.toolVersions.shellcheck ?? "Unknown"
+                : comparison?.tool ?? "Not included"}
+            </td>
+          </tr>
+          <tr>
+            <th>Aggregate result</th>
+            <td>
+              {dataset.available && shuck
+                ? `${measurementText(shuck)}`
+                : "This build does not include a generated aggregate result."}
+            </td>
+          </tr>
+          <tr>
+            <th>Aggregate speedup</th>
+            <td>
+              {dataset.available && comparison
+                ? `${formatRatio(dataset.summary?.speedupRatio)} faster than ${comparison.tool}`
+                : "n/a"}
+            </td>
+          </tr>
+          {dataset.links.runUrl ? (
+            <tr>
+              <th>Workflow run</th>
+              <td>
+                <a href={dataset.links.runUrl}>GitHub Actions run</a>
+              </td>
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+
+      {!dataset.available ? (
+        <blockquote>
+          The checked-in placeholder was used for this build. The GitHub Pages
+          deployment on <code>main</code> regenerates the CI snapshot before exporting
+          the site.
+        </blockquote>
+      ) : null}
+    </>
+  );
+}
+
+function CaseTable({ dataset }: { dataset: BenchmarkDataset }) {
+  if (!dataset.available) {
+    return null;
+  }
+
+  return (
+    <>
+      <h3>{dataset.environment.kind === "ci" ? "Linux CI results" : "Apple M5 results"}</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Case</th>
+            <th>Size</th>
+            <th>shuck</th>
+            <th>Comparison</th>
+            <th>Speedup</th>
+            <th>Comparison RSS</th>
+          </tr>
+        </thead>
+        <tbody>
+          {dataset.cases.map((benchmarkCase) => {
+            const shuck = getMeasurement(benchmarkCase, "shuck");
+            const comparison = getComparisonMeasurement(benchmarkCase);
+            return (
+              <tr key={benchmarkCase.slug}>
+                <td>
+                  <strong>
+                    {benchmarkCase.slug === "all"
+                      ? "all"
+                      : benchmarkCase.fixture?.fileName ?? benchmarkCase.slug}
+                  </strong>
+                  <br />
+                  <span>
+                    {benchmarkCase.slug === "all"
+                      ? `${formatInteger(benchmarkCase.fixtureCount)} files in one invocation`
+                      : benchmarkCase.fixture?.upstreamRepo}
+                  </span>
+                </td>
+                <td>
+                  {formatBytes(benchmarkCase.bytes)}
+                  <br />
+                  <span>
+                    {benchmarkCase.lines != null
+                      ? `${formatInteger(benchmarkCase.lines)} lines`
+                      : "n/a"}
+                  </span>
+                </td>
+                <td>{measurementText(shuck)}</td>
+                <td>{measurementText(comparison)}</td>
+                <td>{formatRatio(comparison?.relativeToShuck)}</td>
+                <td>{formatMemory(comparison?.meanMemoryBytes)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </>
+  );
+}
+
+export default function BenchmarksDoc() {
+  return (
+    <>
+      <h1>Benchmarks</h1>
+
+      <p>
+        This page publishes the macro CLI benchmark results produced by{" "}
+        <code>make bench-macro</code>. It is intended as a technical reference for
+        engineers evaluating runtime characteristics, not as a cross-machine league
+        table.
+      </p>
+
+      <p>
+        Two datasets are shown:
+      </p>
+
+      <ul>
+        <li>
+          A checked-in Apple M5 Max snapshot generated from local benchmark exports.
+        </li>
+        <li>
+          A Linux CI snapshot regenerated during the GitHub Pages deploy on{" "}
+          <code>main</code>.
+        </li>
+      </ul>
+
+      <p>
+        Compare tools within the same snapshot. Absolute numbers across different
+        machines are useful for rough orientation only.
+      </p>
+
+      <h2>Snapshot Overview</h2>
+      <OverviewTable />
+
+      <h2>Methodology</h2>
+
+      <ul>
+        <li>
+          The runner is <code>hyperfine</code> with{" "}
+          <code>{localSnapshot.methodology.warmupRuns}</code> warmups and{" "}
+          <code>{localSnapshot.methodology.measuredRuns}</code> measured runs per case.
+        </li>
+        <li>
+          <code>shuck</code> is measured with <code>check --no-cache</code> so the
+          results reflect parsing and linting work rather than cache reuse.
+        </li>
+        <li>
+          The comparison command is{" "}
+          <code>shellcheck --severity=style &lt;fixture&gt;</code> on the same input.
+        </li>
+        <li>
+          <code>--ignore-failure</code> is intentional. These fixtures contain lint
+          findings, so non-zero exit codes are expected and the benchmark is measuring
+          runtime rather than success state.
+        </li>
+        <li>
+          Each fixture is benchmarked independently, and the <code>all</code> case
+          benchmarks one invocation over the entire vendored corpus.
+        </li>
+      </ul>
+
+      <h2>Reproducing Results</h2>
+
+      <h3>Refresh the checked-in local snapshot</h3>
+      <pre>
+        <code>make bench-macro-site-local</code>
+      </pre>
+
+      <h3>Generate a CI-style dataset manually</h3>
+      <pre>
+        <code>{`./scripts/benchmarks/setup.sh hyperfine shellcheck
+./scripts/benchmarks/run.sh
+python3 ./scripts/benchmarks/export_website_data.py \\
+  --repo-root . \\
+  --bench-dir .cache \\
+  --output website/generated/benchmarks/ci-latest.json \\
+  --dataset-id ci-latest \\
+  --dataset-name "GitHub Actions latest main snapshot" \\
+  --dataset-description "Generated during the website deploy workflow." \\
+  --environment-kind ci \\
+  --environment-label "GitHub Actions ubuntu-latest"`}</code>
+      </pre>
+
+      {snapshots.map((dataset) => (
+        <div key={dataset.id}>
+          <SnapshotDetails dataset={dataset} />
+          <CaseTable dataset={dataset} />
+        </div>
+      ))}
+
+      <h2>Benchmark Corpus</h2>
+
+      <p>
+        The benchmark corpus is vendored into the repository so every run uses the
+        same inputs. The current corpus contains {formatInteger(corpus.fixtureCount)}{" "}
+        files, {formatInteger(corpus.totalLines)} lines, and {formatBytes(corpus.totalBytes)}{" "}
+        of shell source.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Fixture</th>
+            <th>Source</th>
+            <th>Size</th>
+            <th>License</th>
+          </tr>
+        </thead>
+        <tbody>
+          {corpus.fixtures.map((fixture) => (
+            <tr key={fixture.slug}>
+              <td>
+                <strong>{fixture.fileName}</strong>
+                <br />
+                <span>{fixture.commitShort}</span>
+              </td>
+              <td>
+                <a href={fixture.sourceUrl}>{fixture.upstreamRepo}</a>
+                <br />
+                <span>{fixture.upstreamPath}</span>
+              </td>
+              <td>
+                {formatBytes(fixture.bytes)}
+                <br />
+                <span>{formatInteger(fixture.lines)} lines</span>
+              </td>
+              <td>{fixture.license}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/website/content/performance/benchmarks.tsx
+++ b/website/content/performance/benchmarks.tsx
@@ -2,6 +2,7 @@ import localSnapshotJson from "@/generated/benchmarks/local-m5-max.json";
 import ciSnapshotJson from "@/generated/benchmarks/ci-latest.json";
 import type { BenchmarkDataset, BenchmarkMeasurement } from "@/app/lib/benchmarks";
 import {
+  describeRelativePerformance,
   formatBytes,
   formatDate,
   formatDuration,
@@ -161,7 +162,10 @@ function SnapshotDetails({ dataset }: { dataset: BenchmarkDataset }) {
             <th>Aggregate speedup</th>
             <td>
               {dataset.available && comparison
-                ? `${formatRatio(dataset.summary?.speedupRatio)} faster than ${comparison.tool}`
+                ? describeRelativePerformance(
+                    dataset.summary?.speedupRatio,
+                    comparison.tool,
+                  )
                 : "n/a"}
             </td>
           </tr>

--- a/website/content/performance/benchmarks.tsx
+++ b/website/content/performance/benchmarks.tsx
@@ -11,15 +11,13 @@ import {
   getAggregateCase,
   getComparisonMeasurement,
   getMeasurement,
+  pickLatestDatasetWithCorpus,
 } from "@/app/lib/benchmarks";
 
 const localSnapshot = localSnapshotJson as BenchmarkDataset;
 const ciSnapshot = ciSnapshotJson as BenchmarkDataset;
 const snapshots = [localSnapshot, ciSnapshot];
-const corpus =
-  localSnapshot.corpus.fixtures.length > 0
-    ? localSnapshot.corpus
-    : ciSnapshot.corpus;
+const corpus = (pickLatestDatasetWithCorpus(snapshots) ?? localSnapshot).corpus;
 
 function measurementText(measurement: BenchmarkMeasurement | undefined) {
   if (!measurement) {

--- a/website/generated/benchmarks/ci-latest.json
+++ b/website/generated/benchmarks/ci-latest.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "available": false,
+  "id": "ci-latest",
+  "name": "GitHub Actions latest main snapshot",
+  "description": "A fresh Linux snapshot is generated during the GitHub Pages deploy on main. Local builds and pull request builds use this placeholder instead.",
+  "generatedAt": "2026-04-20T00:00:00Z",
+  "commit": {
+    "sha": null,
+    "shortSha": null
+  },
+  "links": {
+    "repositoryUrl": "https://github.com/ewhauser/shuck",
+    "commitUrl": null,
+    "runUrl": null
+  },
+  "environment": {
+    "kind": "ci",
+    "label": "GitHub Actions ubuntu-latest",
+    "os": "GitHub Actions",
+    "arch": "x86_64",
+    "cpu": null,
+    "python": "unknown"
+  },
+  "toolVersions": {
+    "shuck": null,
+    "hyperfine": null,
+    "shellcheck": null
+  },
+  "methodology": {
+    "benchmarkCommand": "make bench-macro",
+    "benchmarkMode": "compare",
+    "warmupRuns": 3,
+    "measuredRuns": 10,
+    "ignoreFailure": true,
+    "shuckCommand": "shuck check --no-cache <fixture>",
+    "comparisonCommand": "shellcheck --severity=style <fixture>",
+    "notes": "The website deploy on main overwrites this placeholder with a fresh benchmark snapshot."
+  },
+  "corpus": {
+    "fixtureCount": 0,
+    "totalBytes": 0,
+    "totalLines": 0,
+    "fixtures": []
+  },
+  "summary": null,
+  "cases": []
+}

--- a/website/generated/benchmarks/local-m5-max.json
+++ b/website/generated/benchmarks/local-m5-max.json
@@ -1,0 +1,486 @@
+{
+  "schemaVersion": 1,
+  "available": true,
+  "id": "local-m5-max",
+  "name": "Apple M5 Max checked-in snapshot",
+  "description": "Checked-in make bench-macro results captured on an Apple M5 Max macOS development machine.",
+  "generatedAt": "2026-04-20T17:18:44Z",
+  "commit": {
+    "sha": "919615be9bf12ddb67b0d94ad933a70fc4ca38e1",
+    "shortSha": "919615b"
+  },
+  "links": {
+    "repositoryUrl": "https://github.com/ewhauser/shuck",
+    "commitUrl": "https://github.com/ewhauser/shuck/commit/919615be9bf12ddb67b0d94ad933a70fc4ca38e1",
+    "runUrl": null
+  },
+  "environment": {
+    "kind": "local",
+    "label": "Apple M5 Max macOS snapshot",
+    "os": "macOS 26.4",
+    "arch": "arm64",
+    "cpu": "Apple M5 Max",
+    "python": "3.13.12"
+  },
+  "toolVersions": {
+    "shuck": "shuck 0.0.8",
+    "hyperfine": "hyperfine 1.20.0",
+    "shellcheck": "0.11.0"
+  },
+  "methodology": {
+    "benchmarkCommand": "make bench-macro",
+    "benchmarkMode": "compare",
+    "warmupRuns": 3,
+    "measuredRuns": 10,
+    "ignoreFailure": true,
+    "shuckCommand": "shuck check --no-cache <fixture>",
+    "comparisonCommand": "shellcheck --severity=style <fixture>",
+    "notes": "Regenerate this checked-in snapshot on the Apple M5 Max machine when you want to refresh the website's local reference numbers."
+  },
+  "corpus": {
+    "fixtureCount": 5,
+    "totalBytes": 325662,
+    "totalLines": 10671,
+    "fixtures": [
+      {
+        "slug": "homebrew-install",
+        "name": "homebrew-install",
+        "fileName": "homebrew-install.sh",
+        "path": "files/homebrew-install.sh",
+        "bytes": 33212,
+        "lines": 1175,
+        "upstreamRepo": "Homebrew/install",
+        "upstreamPath": "install.sh",
+        "sourceUrl": "https://raw.githubusercontent.com/Homebrew/install/6d5e2670d07961e7985d2079a2f0a484420f3c38/install.sh",
+        "license": "BSD-2-Clause",
+        "commit": "6d5e2670d07961e7985d2079a2f0a484420f3c38",
+        "commitShort": "6d5e267"
+      },
+      {
+        "slug": "nvm",
+        "name": "nvm",
+        "fileName": "nvm.sh",
+        "path": "files/nvm.sh",
+        "bytes": 150227,
+        "lines": 4661,
+        "upstreamRepo": "nvm-sh/nvm",
+        "upstreamPath": "nvm.sh",
+        "sourceUrl": "https://raw.githubusercontent.com/nvm-sh/nvm/977563e97ddc66facf3a8e31c6cff01d236f09bd/nvm.sh",
+        "license": "MIT",
+        "commit": "977563e97ddc66facf3a8e31c6cff01d236f09bd",
+        "commitShort": "977563e"
+      },
+      {
+        "slug": "pyenv-python-build",
+        "name": "pyenv-python-build",
+        "fileName": "pyenv-python-build.sh",
+        "path": "files/pyenv-python-build.sh",
+        "bytes": 81725,
+        "lines": 2740,
+        "upstreamRepo": "pyenv/pyenv",
+        "upstreamPath": "plugins/python-build/bin/python-build",
+        "sourceUrl": "https://raw.githubusercontent.com/pyenv/pyenv/8397a19c6467d11509dbd741cf0528f9a68a5541/plugins/python-build/bin/python-build",
+        "license": "MIT",
+        "commit": "8397a19c6467d11509dbd741cf0528f9a68a5541",
+        "commitShort": "8397a19"
+      },
+      {
+        "slug": "ruby-build",
+        "name": "ruby-build",
+        "fileName": "ruby-build.sh",
+        "path": "files/ruby-build.sh",
+        "bytes": 47738,
+        "lines": 1643,
+        "upstreamRepo": "rbenv/ruby-build",
+        "upstreamPath": "bin/ruby-build",
+        "sourceUrl": "https://raw.githubusercontent.com/rbenv/ruby-build/d099da05144d9f703c27cadd7b710f35f15dfadb/bin/ruby-build",
+        "license": "MIT",
+        "commit": "d099da05144d9f703c27cadd7b710f35f15dfadb",
+        "commitShort": "d099da0"
+      },
+      {
+        "slug": "fzf-install",
+        "name": "fzf-install",
+        "fileName": "fzf-install.sh",
+        "path": "files/fzf-install.sh",
+        "bytes": 12760,
+        "lines": 452,
+        "upstreamRepo": "junegunn/fzf",
+        "upstreamPath": "install",
+        "sourceUrl": "https://raw.githubusercontent.com/junegunn/fzf/55d5b153e627784fa43982fa3c01d0ab86ef0224/install",
+        "license": "MIT",
+        "commit": "55d5b153e627784fa43982fa3c01d0ab86ef0224",
+        "commitShort": "55d5b15"
+      }
+    ]
+  },
+  "summary": {
+    "aggregateCase": "all",
+    "primaryTool": "shuck",
+    "comparisonTool": "shellcheck",
+    "shuckMeanSeconds": 0.056213762420000014,
+    "comparisonMeanSeconds": 7.946037716719999,
+    "speedupRatio": 141.35395630257472,
+    "timeSavedPct": 99.29255605845269
+  },
+  "cases": [
+    {
+      "slug": "all",
+      "name": "all",
+      "kind": "aggregate",
+      "bytes": 325662,
+      "lines": 10671,
+      "fixtureCount": 5,
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck/all",
+          "meanSeconds": 0.056213762420000014,
+          "stddevSeconds": 0.0009287319787439515,
+          "medianSeconds": 0.05612473332000001,
+          "minSeconds": 0.054845733320000006,
+          "maxSeconds": 0.058142025320000006,
+          "userSeconds": 0.09534656,
+          "systemSeconds": 0.016890179999999998,
+          "meanMemoryBytes": 101379276,
+          "maxMemoryBytes": 101711872,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck/all",
+          "meanSeconds": 7.946037716719999,
+          "stddevSeconds": 0.5598110359003017,
+          "medianSeconds": 7.80453008732,
+          "minSeconds": 7.56744777532,
+          "maxSeconds": 9.506410025320001,
+          "userSeconds": 7.609177959999999,
+          "systemSeconds": 0.27072988000000003,
+          "meanMemoryBytes": 2751666585,
+          "maxMemoryBytes": 2751676416,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 141.35395630257472
+        }
+      ]
+    },
+    {
+      "slug": "homebrew-install",
+      "name": "homebrew-install",
+      "kind": "fixture",
+      "bytes": 33212,
+      "lines": 1175,
+      "fixtureCount": 1,
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck/homebrew-install",
+          "meanSeconds": 0.00899187172,
+          "stddevSeconds": 0.00015129288149443406,
+          "medianSeconds": 0.008989342720000001,
+          "minSeconds": 0.00875532172,
+          "maxSeconds": 0.009195237720000003,
+          "userSeconds": 0.006397959999999999,
+          "systemSeconds": 0.00389644,
+          "meanMemoryBytes": 17096704,
+          "maxMemoryBytes": 17186816,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck/homebrew-install",
+          "meanSeconds": 0.31254444251999997,
+          "stddevSeconds": 0.005089874250405611,
+          "medianSeconds": 0.30988957172,
+          "minSeconds": 0.30858390572,
+          "maxSeconds": 0.32225952972000005,
+          "userSeconds": 0.29094826000000007,
+          "systemSeconds": 0.013478239999999999,
+          "meanMemoryBytes": 177356800,
+          "maxMemoryBytes": 177356800,
+          "runCount": 10,
+          "exitCodes": [
+            0
+          ],
+          "hasFailures": false,
+          "relativeToShuck": 34.75855219607158
+        }
+      ],
+      "fixture": {
+        "slug": "homebrew-install",
+        "name": "homebrew-install",
+        "fileName": "homebrew-install.sh",
+        "path": "files/homebrew-install.sh",
+        "bytes": 33212,
+        "lines": 1175,
+        "upstreamRepo": "Homebrew/install",
+        "upstreamPath": "install.sh",
+        "sourceUrl": "https://raw.githubusercontent.com/Homebrew/install/6d5e2670d07961e7985d2079a2f0a484420f3c38/install.sh",
+        "license": "BSD-2-Clause",
+        "commit": "6d5e2670d07961e7985d2079a2f0a484420f3c38",
+        "commitShort": "6d5e267"
+      }
+    },
+    {
+      "slug": "nvm",
+      "name": "nvm",
+      "kind": "fixture",
+      "bytes": 150227,
+      "lines": 4661,
+      "fixtureCount": 1,
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck/nvm",
+          "meanSeconds": 0.0457354292,
+          "stddevSeconds": 0.0005677667589407165,
+          "medianSeconds": 0.0458767626,
+          "minSeconds": 0.0446732006,
+          "maxSeconds": 0.0464433246,
+          "userSeconds": 0.039100539999999996,
+          "systemSeconds": 0.00672812,
+          "meanMemoryBytes": 62031462,
+          "maxMemoryBytes": 62144512,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck/nvm",
+          "meanSeconds": 6.9354836333000005,
+          "stddevSeconds": 0.11518877389945285,
+          "medianSeconds": 6.927159179099999,
+          "minSeconds": 6.8097798246,
+          "maxSeconds": 7.1088154086,
+          "userSeconds": 6.64578834,
+          "systemSeconds": 0.25519751999999996,
+          "meanMemoryBytes": 2828140544,
+          "maxMemoryBytes": 2828140544,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 151.64356724348835
+        }
+      ],
+      "fixture": {
+        "slug": "nvm",
+        "name": "nvm",
+        "fileName": "nvm.sh",
+        "path": "files/nvm.sh",
+        "bytes": 150227,
+        "lines": 4661,
+        "upstreamRepo": "nvm-sh/nvm",
+        "upstreamPath": "nvm.sh",
+        "sourceUrl": "https://raw.githubusercontent.com/nvm-sh/nvm/977563e97ddc66facf3a8e31c6cff01d236f09bd/nvm.sh",
+        "license": "MIT",
+        "commit": "977563e97ddc66facf3a8e31c6cff01d236f09bd",
+        "commitShort": "977563e"
+      }
+    },
+    {
+      "slug": "pyenv-python-build",
+      "name": "pyenv-python-build",
+      "kind": "fixture",
+      "bytes": 81725,
+      "lines": 2740,
+      "fixtureCount": 1,
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck/pyenv-python-build",
+          "meanSeconds": 0.025292693319999997,
+          "stddevSeconds": 0.00030118262893321426,
+          "medianSeconds": 0.02523531402,
+          "minSeconds": 0.02489025202,
+          "maxSeconds": 0.02583454302,
+          "userSeconds": 0.020943339999999998,
+          "systemSeconds": 0.004586719999999999,
+          "meanMemoryBytes": 34956902,
+          "maxMemoryBytes": 35045376,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck/pyenv-python-build",
+          "meanSeconds": 0.033327972520000006,
+          "stddevSeconds": 0.0001556518316380431,
+          "medianSeconds": 0.03330554302000001,
+          "minSeconds": 0.03309187702000001,
+          "maxSeconds": 0.033628585020000004,
+          "userSeconds": 0.017710939999999998,
+          "systemSeconds": 0.0045320199999999995,
+          "meanMemoryBytes": 35045376,
+          "maxMemoryBytes": 35045376,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.317691718249957
+        }
+      ],
+      "fixture": {
+        "slug": "pyenv-python-build",
+        "name": "pyenv-python-build",
+        "fileName": "pyenv-python-build.sh",
+        "path": "files/pyenv-python-build.sh",
+        "bytes": 81725,
+        "lines": 2740,
+        "upstreamRepo": "pyenv/pyenv",
+        "upstreamPath": "plugins/python-build/bin/python-build",
+        "sourceUrl": "https://raw.githubusercontent.com/pyenv/pyenv/8397a19c6467d11509dbd741cf0528f9a68a5541/plugins/python-build/bin/python-build",
+        "license": "MIT",
+        "commit": "8397a19c6467d11509dbd741cf0528f9a68a5541",
+        "commitShort": "8397a19"
+      }
+    },
+    {
+      "slug": "ruby-build",
+      "name": "ruby-build",
+      "kind": "fixture",
+      "bytes": 47738,
+      "lines": 1643,
+      "fixtureCount": 1,
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck/ruby-build",
+          "meanSeconds": 0.015532289979999999,
+          "stddevSeconds": 0.0002781389001289342,
+          "medianSeconds": 0.015591306580000002,
+          "minSeconds": 0.014956723580000003,
+          "maxSeconds": 0.015951140580000002,
+          "userSeconds": 0.01242422,
+          "systemSeconds": 0.004027659999999999,
+          "meanMemoryBytes": 24802099,
+          "maxMemoryBytes": 24854528,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck/ruby-build",
+          "meanSeconds": 0.3849325230800001,
+          "stddevSeconds": 0.012766336202273723,
+          "medianSeconds": 0.38390922308000003,
+          "minSeconds": 0.37176668158000004,
+          "maxSeconds": 0.41258251558000003,
+          "userSeconds": 0.36195861999999995,
+          "systemSeconds": 0.01243726,
+          "meanMemoryBytes": 129155072,
+          "maxMemoryBytes": 129155072,
+          "runCount": 10,
+          "exitCodes": [
+            0
+          ],
+          "hasFailures": false,
+          "relativeToShuck": 24.782728340486475
+        }
+      ],
+      "fixture": {
+        "slug": "ruby-build",
+        "name": "ruby-build",
+        "fileName": "ruby-build.sh",
+        "path": "files/ruby-build.sh",
+        "bytes": 47738,
+        "lines": 1643,
+        "upstreamRepo": "rbenv/ruby-build",
+        "upstreamPath": "bin/ruby-build",
+        "sourceUrl": "https://raw.githubusercontent.com/rbenv/ruby-build/d099da05144d9f703c27cadd7b710f35f15dfadb/bin/ruby-build",
+        "license": "MIT",
+        "commit": "d099da05144d9f703c27cadd7b710f35f15dfadb",
+        "commitShort": "d099da0"
+      }
+    },
+    {
+      "slug": "fzf-install",
+      "name": "fzf-install",
+      "kind": "fixture",
+      "bytes": 12760,
+      "lines": 452,
+      "fixtureCount": 1,
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck/fzf-install",
+          "meanSeconds": 0.0064536527199999996,
+          "stddevSeconds": 0.00012962550876377166,
+          "medianSeconds": 0.006442411320000001,
+          "minSeconds": 0.00622822332,
+          "maxSeconds": 0.006649890320000001,
+          "userSeconds": 0.0044223199999999995,
+          "systemSeconds": 0.00348754,
+          "meanMemoryBytes": 12599296,
+          "maxMemoryBytes": 12599296,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck/fzf-install",
+          "meanSeconds": 0.12134578162000001,
+          "stddevSeconds": 0.0003808110910493971,
+          "medianSeconds": 0.12132647332,
+          "minSeconds": 0.12060405632000001,
+          "maxSeconds": 0.12185268132000002,
+          "userSeconds": 0.10003501999999997,
+          "systemSeconds": 0.00672394,
+          "meanMemoryBytes": 60719104,
+          "maxMemoryBytes": 60719104,
+          "runCount": 10,
+          "exitCodes": [
+            1
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 18.802651286758426
+        }
+      ],
+      "fixture": {
+        "slug": "fzf-install",
+        "name": "fzf-install",
+        "fileName": "fzf-install.sh",
+        "path": "files/fzf-install.sh",
+        "bytes": 12760,
+        "lines": 452,
+        "upstreamRepo": "junegunn/fzf",
+        "upstreamPath": "install",
+        "sourceUrl": "https://raw.githubusercontent.com/junegunn/fzf/55d5b153e627784fa43982fa3c01d0ab86ef0224/install",
+        "license": "MIT",
+        "commit": "55d5b153e627784fa43982fa3c01d0ab86ef0224",
+        "commitShort": "55d5b15"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This adds a published benchmark reference to the website docs.

- add a benchmark export script that converts `make bench-macro` JSON into a website-friendly dataset
- add checked-in local and CI benchmark snapshot JSON files for the website
- publish the benchmark reference under `Docs > Performance > Benchmarks`
- update the Pages workflow to regenerate the CI benchmark snapshot during the `main` deploy
- add a local `make bench-macro-site-local` target for refreshing the checked-in snapshot

## Why

The website can now show benchmark results that come directly from the existing macro benchmark workflow, along with reproduction details and methodology. Keeping the page under the docs section makes it read as technical reference material instead of product marketing.

## Validation

- `python3 -m py_compile scripts/benchmarks/export_website_data.py`
- `pnpm build`
- `SHUCK_WEBSITE_EXPORT=1 SHUCK_WEBSITE_BASE_PATH=/shuck NEXT_PUBLIC_SITE_URL=https://ewhauser.github.io/shuck pnpm build`
