### PR TITLE
Fix C006 special-parameter parsing

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -2265,6 +2265,33 @@ printf '%s\\n' \"${!var//$'\\n'/' '}\"
     }
 
     #[test]
+    fn indirect_special_parameter_carrier_is_not_reported() {
+        let diagnostics = lint_for_rule(
+            "\
+#!/bin/bash
+set -- last
+printf '%s\\n' \"${!#}\"
+",
+            Rule::UndefinedVariable,
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn special_hash_parameter_operations_are_not_reported() {
+        let diagnostics = lint_for_rule(
+            "\
+#!/bin/bash
+printf '%s\\n' \"${##*/}\"
+",
+            Rule::UndefinedVariable,
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn undefined_variable_anchors_parameter_operator_reports_to_carrier_name() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1100,6 +1100,34 @@ fn test_parse_special_hash_parameter_prefix_removal() {
 }
 
 #[test]
+fn test_parse_length_of_special_parameters_after_hash_prefix() {
+    let input = "echo ${#-} ${#?} ${##}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+    let command = expect_simple(&script.body[0]);
+
+    let first = expect_parameter(&command.args[0]);
+    assert!(matches!(
+        &first.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { reference })
+            if reference.name.as_str() == "-"
+    ));
+
+    let second = expect_parameter(&command.args[1]);
+    assert!(matches!(
+        &second.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { reference })
+            if reference.name.as_str() == "?"
+    ));
+
+    let third = expect_parameter(&command.args[2]);
+    assert!(matches!(
+        &third.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { reference })
+            if reference.name.as_str() == "#"
+    ));
+}
+
+#[test]
 fn test_parse_special_zero_parameter_prefix_removal_inside_multiline_quote() {
     let input = "\
 usage=\"

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -8,6 +8,51 @@ fn word_part_tree_contains_variable(parts: &[WordPartNode], expected: &str) -> b
     })
 }
 
+fn collect_bourne_parameter_names(parts: &[WordPartNode], names: &mut Vec<String>) {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => collect_bourne_parameter_names(parts, names),
+            WordPart::Parameter(parameter) => {
+                let name = match &parameter.syntax {
+                    ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access {
+                        reference,
+                    })
+                    | ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length {
+                        reference,
+                    })
+                    | ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Indices {
+                        reference,
+                    })
+                    | ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Indirect {
+                        reference,
+                        ..
+                    })
+                    | ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+                        reference,
+                        ..
+                    })
+                    | ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Slice {
+                        reference,
+                        ..
+                    })
+                    | ParameterExpansionSyntax::Bourne(
+                        BourneParameterExpansion::Transformation { reference, .. },
+                    ) => Some(reference.name.to_string()),
+                    ParameterExpansionSyntax::Bourne(BourneParameterExpansion::PrefixMatch {
+                        prefix,
+                        ..
+                    }) => Some(prefix.to_string()),
+                    ParameterExpansionSyntax::Zsh(_) => None,
+                };
+                if let Some(name) = name {
+                    names.push(name);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 #[test]
 fn test_current_word_cache_tracks_token_changes() {
     let input = "\"$foo\" bar\n";
@@ -1007,6 +1052,76 @@ fn test_parse_word_fragment_rebases_indirect_operator_spans() {
     assert_eq!(replacement.slice(source), "' '");
     assert_eq!(replacement_word_ast.render_syntax(source), "' '");
     assert_eq!(replacement_word_ast.span.slice(source), "' '");
+}
+
+#[test]
+fn test_parse_indirect_special_hash_parameter() {
+    let input = "echo ${!#}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+    let command = expect_simple(&script.body[0]);
+    let parameter = expect_parameter(&command.args[0]);
+
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Indirect {
+        reference,
+        operator,
+        operand,
+        ..
+    }) = &parameter.syntax
+    else {
+        panic!("expected indirect special-parameter expansion");
+    };
+
+    assert_eq!(reference.name.as_str(), "#");
+    assert!(operator.is_none());
+    assert!(operand.is_none());
+}
+
+#[test]
+fn test_parse_special_hash_parameter_prefix_removal() {
+    let input = "echo ${##*/}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+    let command = expect_simple(&script.body[0]);
+    let parameter = expect_parameter(&command.args[0]);
+
+    let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+        reference,
+        operator,
+        ..
+    }) = &parameter.syntax
+    else {
+        panic!("expected special-parameter operation expansion");
+    };
+
+    assert_eq!(reference.name.as_str(), "#");
+    match operator {
+        ParameterOp::RemovePrefixShort { pattern } => assert_eq!(pattern.render(input), "*/"),
+        other => panic!("expected short prefix removal, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parse_special_zero_parameter_prefix_removal_inside_multiline_quote() {
+    let input = "\
+usage=\"
+Example:
+  ${0##*/} github_repository
+Terraform:
+  data \\\"external\\\" \\\"github_repos\\\" {
+    program = [\\\"/path/to/${0##*/}\\\", \\\"github_repository\\\"]
+  }
+usage: ${0##*/} <resource_type>
+\"
+";
+    let script = Parser::new(input).parse().unwrap().file;
+    let command = expect_simple(&script.body[0]);
+    let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+
+    let mut names = Vec::new();
+    collect_bourne_parameter_names(&word.parts, &mut names);
+
+    assert_eq!(names, vec!["0", "0", "0"]);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3768,6 +3768,29 @@ impl<'a> Parser<'a> {
                         continue;
                     }
 
+                    if matches!(
+                        chars.peek().copied(),
+                        Some(':' | '-' | '=' | '+' | '?' | '#' | '%' | '/' | '^' | ',' | '}')
+                    ) {
+                        let raw_part = self.parse_parameter_tail_without_subscript(
+                            &mut chars,
+                            &mut cursor,
+                            source_backed,
+                            part_start,
+                            brace_body_start,
+                            "#",
+                        );
+                        let part = self.parameter_word_part_from_legacy(
+                            raw_part,
+                            part_start,
+                            cursor,
+                            source_backed,
+                        );
+                        Self::push_word_part(parts, part, part_start, cursor);
+                        current_start = cursor;
+                        continue;
+                    }
+
                     if self.zsh_parameter_requires_fallback(&mut chars) {
                         let tail = self.read_brace_operand(&mut chars, &mut cursor, source_backed);
                         let raw_body = self.prefixed_parameter_raw_body(
@@ -3846,7 +3869,7 @@ impl<'a> Parser<'a> {
                         continue;
                     }
 
-                    let var_name = Self::read_word_while(&mut chars, &mut cursor, |c| {
+                    let mut var_name = Self::read_word_while(&mut chars, &mut cursor, |c| {
                         !matches!(
                             c,
                             '}' | '['
@@ -3864,6 +3887,15 @@ impl<'a> Parser<'a> {
                                 | ','
                         )
                     });
+
+                    if var_name.is_empty()
+                        && matches!(
+                            chars.peek().copied(),
+                            Some('?' | '#' | '@' | '*' | '!' | '$' | '-')
+                        )
+                    {
+                        var_name.push(Self::next_word_char_unwrap(&mut chars, &mut cursor));
+                    }
 
                     let subscript = if Self::consume_word_char_if(&mut chars, &mut cursor, '[') {
                         let (index, raw_index) =
@@ -4466,259 +4498,15 @@ impl<'a> Parser<'a> {
                     continue;
                 }
 
-                let part = if let Some(c) = chars.peek().copied() {
-                    match c {
-                        ':' => {
-                            if self.zsh_parameter_suffix_looks_like_modifier(&mut chars) {
-                                let tail =
-                                    self.read_brace_operand(&mut chars, &mut cursor, source_backed);
-                                let raw_body = self.prefixed_parameter_raw_body(
-                                    &var_name,
-                                    brace_body_start,
-                                    tail,
-                                    source_backed,
-                                );
-                                let parameter =
-                                    self.zsh_parameter_word_part(raw_body, part_start, cursor);
-                                Self::push_word_part(parts, parameter, part_start, cursor);
-                                current_start = cursor;
-                                continue;
-                            }
-
-                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            match chars.peek() {
-                                Some(&'-') | Some(&'=') | Some(&'+') | Some(&'?') => {
-                                    let op_char =
-                                        Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                                    let operand = self.read_brace_operand(
-                                        &mut chars,
-                                        &mut cursor,
-                                        source_backed,
-                                    );
-                                    let operator = match op_char {
-                                        '-' => ParameterOp::UseDefault,
-                                        '=' => ParameterOp::AssignDefault,
-                                        '+' => ParameterOp::UseReplacement,
-                                        '?' => ParameterOp::Error,
-                                        _ => unreachable!(),
-                                    };
-                                    self.parameter_expansion_word_part(
-                                        self.parameter_var_ref(
-                                            part_start, "${", &var_name, None, cursor,
-                                        ),
-                                        operator,
-                                        Some(operand),
-                                        true,
-                                    )
-                                }
-                                _ => {
-                                    let (offset, length) = self.read_parameter_slice_parts(
-                                        &mut chars,
-                                        &mut cursor,
-                                        source_backed,
-                                    );
-                                    Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                    self.substring_word_part(
-                                        self.parameter_var_ref(
-                                            part_start, "${", &var_name, None, cursor,
-                                        ),
-                                        offset,
-                                        length,
-                                    )
-                                }
-                            }
-                        }
-                        '-' | '=' | '+' | '?' => {
-                            let op_char = Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            let operand =
-                                self.read_brace_operand(&mut chars, &mut cursor, source_backed);
-                            let operator = match op_char {
-                                '-' => ParameterOp::UseDefault,
-                                '=' => ParameterOp::AssignDefault,
-                                '+' => ParameterOp::UseReplacement,
-                                '?' => ParameterOp::Error,
-                                _ => unreachable!(),
-                            };
-                            self.parameter_expansion_word_part(
-                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
-                                operator,
-                                Some(operand),
-                                false,
-                            )
-                        }
-                        '#' => {
-                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            let longest = Self::consume_word_char_if(&mut chars, &mut cursor, '#');
-                            let operand_text =
-                                self.read_brace_operand(&mut chars, &mut cursor, source_backed);
-                            let pattern = self.pattern_from_source_text(&operand_text);
-                            let operator = if longest {
-                                ParameterOp::RemovePrefixLong { pattern }
-                            } else {
-                                ParameterOp::RemovePrefixShort { pattern }
-                            };
-                            self.parameter_expansion_word_part(
-                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
-                                operator,
-                                None,
-                                false,
-                            )
-                        }
-                        '%' => {
-                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            let longest = Self::consume_word_char_if(&mut chars, &mut cursor, '%');
-                            let operand_text =
-                                self.read_brace_operand(&mut chars, &mut cursor, source_backed);
-                            let pattern = self.pattern_from_source_text(&operand_text);
-                            let operator = if longest {
-                                ParameterOp::RemoveSuffixLong { pattern }
-                            } else {
-                                ParameterOp::RemoveSuffixShort { pattern }
-                            };
-                            self.parameter_expansion_word_part(
-                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
-                                operator,
-                                None,
-                                false,
-                            )
-                        }
-                        '/' => {
-                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            let replace_all =
-                                Self::consume_word_char_if(&mut chars, &mut cursor, '/');
-                            let pattern_text = self.read_replacement_pattern(
-                                &mut chars,
-                                &mut cursor,
-                                source_backed,
-                            );
-                            let pattern = self.pattern_from_source_text(&pattern_text);
-                            let (replacement, consumed_closing_brace) =
-                                if Self::consume_word_char_if(&mut chars, &mut cursor, '/') {
-                                    let replacement = self.read_brace_operand(
-                                        &mut chars,
-                                        &mut cursor,
-                                        source_backed,
-                                    );
-                                    (
-                                        replacement,
-                                        cursor.offset > 0
-                                            && self.input[..cursor.offset].ends_with('}'),
-                                    )
-                                } else {
-                                    (self.empty_source_text(cursor), false)
-                                };
-                            if !consumed_closing_brace {
-                                Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                            }
-                            if !Span::from_positions(part_start, cursor)
-                                .slice(self.input)
-                                .ends_with('}')
-                                && self.input[cursor.offset..].starts_with('}')
-                            {
-                                cursor.advance('}');
-                            }
-                            let operator = if replace_all {
-                                ParameterOp::ReplaceAll {
-                                    pattern,
-                                    replacement_word_ast: self
-                                        .parse_source_text_as_word(&replacement),
-                                    replacement,
-                                }
-                            } else {
-                                ParameterOp::ReplaceFirst {
-                                    pattern,
-                                    replacement_word_ast: self
-                                        .parse_source_text_as_word(&replacement),
-                                    replacement,
-                                }
-                            };
-                            self.parameter_expansion_word_part(
-                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
-                                operator,
-                                None,
-                                false,
-                            )
-                        }
-                        '^' => {
-                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            let operator =
-                                if Self::consume_word_char_if(&mut chars, &mut cursor, '^') {
-                                    ParameterOp::UpperAll
-                                } else {
-                                    ParameterOp::UpperFirst
-                                };
-                            let operand =
-                                if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
-                                    None
-                                } else {
-                                    Some(self.read_brace_operand(
-                                        &mut chars,
-                                        &mut cursor,
-                                        source_backed,
-                                    ))
-                                };
-                            self.parameter_expansion_word_part(
-                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
-                                operator,
-                                operand,
-                                false,
-                            )
-                        }
-                        ',' => {
-                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            let operator =
-                                if Self::consume_word_char_if(&mut chars, &mut cursor, ',') {
-                                    ParameterOp::LowerAll
-                                } else {
-                                    ParameterOp::LowerFirst
-                                };
-                            let operand =
-                                if Self::consume_word_char_if(&mut chars, &mut cursor, '}') {
-                                    None
-                                } else {
-                                    Some(self.read_brace_operand(
-                                        &mut chars,
-                                        &mut cursor,
-                                        source_backed,
-                                    ))
-                                };
-                            self.parameter_expansion_word_part(
-                                self.parameter_var_ref(part_start, "${", &var_name, None, cursor),
-                                operator,
-                                operand,
-                                false,
-                            )
-                        }
-                        '@' => {
-                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            if chars.peek().is_some() {
-                                let operator = Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                                Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                WordPart::Transformation {
-                                    reference: self.parameter_var_ref(
-                                        part_start, "${", &var_name, None, cursor,
-                                    ),
-                                    operator,
-                                }
-                            } else {
-                                Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                WordPart::Variable(var_name.into())
-                            }
-                        }
-                        '}' => {
-                            Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                            WordPart::Variable(var_name.into())
-                        }
-                        _ => {
-                            while let Some(&next) = chars.peek() {
-                                let consumed = Self::next_word_char_unwrap(&mut chars, &mut cursor);
-                                if next == '}' || consumed == '}' {
-                                    break;
-                                }
-                            }
-                            WordPart::Variable(var_name.into())
-                        }
-                    }
+                let part = if chars.peek().is_some() {
+                    self.parse_parameter_tail_without_subscript(
+                        &mut chars,
+                        &mut cursor,
+                        source_backed,
+                        part_start,
+                        brace_body_start,
+                        &var_name,
+                    )
                 } else {
                     WordPart::Variable(var_name.into())
                 };
@@ -5270,6 +5058,228 @@ impl<'a> Parser<'a> {
             length,
             length_ast,
             length_word_ast,
+        }
+    }
+
+    fn parse_parameter_tail_without_subscript(
+        &mut self,
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+        cursor: &mut Position,
+        source_backed: bool,
+        part_start: Position,
+        brace_body_start: Position,
+        var_name: &str,
+    ) -> WordPart {
+        if let Some(c) = chars.peek().copied() {
+            match c {
+                ':' => {
+                    if self.zsh_parameter_suffix_looks_like_modifier(chars) {
+                        let tail = self.read_brace_operand(chars, cursor, source_backed);
+                        let raw_body = self.prefixed_parameter_raw_body(
+                            var_name,
+                            brace_body_start,
+                            tail,
+                            source_backed,
+                        );
+                        return self.zsh_parameter_word_part(raw_body, part_start, *cursor);
+                    }
+
+                    Self::next_word_char_unwrap(chars, cursor);
+                    match chars.peek() {
+                        Some(&'-') | Some(&'=') | Some(&'+') | Some(&'?') => {
+                            let op_char = Self::next_word_char_unwrap(chars, cursor);
+                            let operand = self.read_brace_operand(chars, cursor, source_backed);
+                            let operator = match op_char {
+                                '-' => ParameterOp::UseDefault,
+                                '=' => ParameterOp::AssignDefault,
+                                '+' => ParameterOp::UseReplacement,
+                                '?' => ParameterOp::Error,
+                                _ => unreachable!(),
+                            };
+                            self.parameter_expansion_word_part(
+                                self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                                operator,
+                                Some(operand),
+                                true,
+                            )
+                        }
+                        _ => {
+                            let (offset, length) =
+                                self.read_parameter_slice_parts(chars, cursor, source_backed);
+                            Self::consume_word_char_if(chars, cursor, '}');
+                            self.substring_word_part(
+                                self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                                offset,
+                                length,
+                            )
+                        }
+                    }
+                }
+                '-' | '=' | '+' | '?' => {
+                    let op_char = Self::next_word_char_unwrap(chars, cursor);
+                    let operand = self.read_brace_operand(chars, cursor, source_backed);
+                    let operator = match op_char {
+                        '-' => ParameterOp::UseDefault,
+                        '=' => ParameterOp::AssignDefault,
+                        '+' => ParameterOp::UseReplacement,
+                        '?' => ParameterOp::Error,
+                        _ => unreachable!(),
+                    };
+                    self.parameter_expansion_word_part(
+                        self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                        operator,
+                        Some(operand),
+                        false,
+                    )
+                }
+                '#' => {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    let longest = Self::consume_word_char_if(chars, cursor, '#');
+                    let operand_text = self.read_brace_operand(chars, cursor, source_backed);
+                    let pattern = self.pattern_from_source_text(&operand_text);
+                    let operator = if longest {
+                        ParameterOp::RemovePrefixLong { pattern }
+                    } else {
+                        ParameterOp::RemovePrefixShort { pattern }
+                    };
+                    self.parameter_expansion_word_part(
+                        self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                        operator,
+                        None,
+                        false,
+                    )
+                }
+                '%' => {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    let longest = Self::consume_word_char_if(chars, cursor, '%');
+                    let operand_text = self.read_brace_operand(chars, cursor, source_backed);
+                    let pattern = self.pattern_from_source_text(&operand_text);
+                    let operator = if longest {
+                        ParameterOp::RemoveSuffixLong { pattern }
+                    } else {
+                        ParameterOp::RemoveSuffixShort { pattern }
+                    };
+                    self.parameter_expansion_word_part(
+                        self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                        operator,
+                        None,
+                        false,
+                    )
+                }
+                '/' => {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    let replace_all = Self::consume_word_char_if(chars, cursor, '/');
+                    let pattern_text = self.read_replacement_pattern(chars, cursor, source_backed);
+                    let pattern = self.pattern_from_source_text(&pattern_text);
+                    let (replacement, consumed_closing_brace) =
+                        if Self::consume_word_char_if(chars, cursor, '/') {
+                            let replacement = self.read_brace_operand(chars, cursor, source_backed);
+                            (
+                                replacement,
+                                cursor.offset > 0 && self.input[..cursor.offset].ends_with('}'),
+                            )
+                        } else {
+                            (self.empty_source_text(*cursor), false)
+                        };
+                    if !consumed_closing_brace {
+                        Self::consume_word_char_if(chars, cursor, '}');
+                    }
+                    if !Span::from_positions(part_start, *cursor)
+                        .slice(self.input)
+                        .ends_with('}')
+                        && self.input[cursor.offset..].starts_with('}')
+                    {
+                        cursor.advance('}');
+                    }
+                    let operator = if replace_all {
+                        ParameterOp::ReplaceAll {
+                            pattern,
+                            replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                            replacement,
+                        }
+                    } else {
+                        ParameterOp::ReplaceFirst {
+                            pattern,
+                            replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                            replacement,
+                        }
+                    };
+                    self.parameter_expansion_word_part(
+                        self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                        operator,
+                        None,
+                        false,
+                    )
+                }
+                '^' => {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    let operator = if Self::consume_word_char_if(chars, cursor, '^') {
+                        ParameterOp::UpperAll
+                    } else {
+                        ParameterOp::UpperFirst
+                    };
+                    let operand = if Self::consume_word_char_if(chars, cursor, '}') {
+                        None
+                    } else {
+                        Some(self.read_brace_operand(chars, cursor, source_backed))
+                    };
+                    self.parameter_expansion_word_part(
+                        self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                        operator,
+                        operand,
+                        false,
+                    )
+                }
+                ',' => {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    let operator = if Self::consume_word_char_if(chars, cursor, ',') {
+                        ParameterOp::LowerAll
+                    } else {
+                        ParameterOp::LowerFirst
+                    };
+                    let operand = if Self::consume_word_char_if(chars, cursor, '}') {
+                        None
+                    } else {
+                        Some(self.read_brace_operand(chars, cursor, source_backed))
+                    };
+                    self.parameter_expansion_word_part(
+                        self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                        operator,
+                        operand,
+                        false,
+                    )
+                }
+                '@' => {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    if chars.peek().is_some() {
+                        let operator = Self::next_word_char_unwrap(chars, cursor);
+                        Self::consume_word_char_if(chars, cursor, '}');
+                        WordPart::Transformation {
+                            reference: self
+                                .parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                            operator,
+                        }
+                    } else {
+                        Self::consume_word_char_if(chars, cursor, '}');
+                        WordPart::Variable(var_name.into())
+                    }
+                }
+                '}' => {
+                    Self::next_word_char_unwrap(chars, cursor);
+                    WordPart::Variable(var_name.into())
+                }
+                _ => {
+                    while let Some(&next) = chars.peek() {
+                        let consumed = Self::next_word_char_unwrap(chars, cursor);
+                        if next == '}' || consumed == '}' {
+                            break;
+                        }
+                    }
+                    WordPart::Variable(var_name.into())
+                }
+            }
+        } else {
+            WordPart::Variable(var_name.into())
         }
     }
 

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3768,10 +3768,22 @@ impl<'a> Parser<'a> {
                         continue;
                     }
 
-                    if matches!(
-                        chars.peek().copied(),
-                        Some(':' | '-' | '=' | '+' | '?' | '#' | '%' | '/' | '^' | ',' | '}')
-                    ) {
+                    let parses_as_special_parameter_length =
+                        chars.peek().copied().is_some_and(|ch| {
+                            matches!(ch, '?' | '#' | '@' | '*' | '!' | '$' | '-')
+                                || ch.is_ascii_digit()
+                        }) && {
+                            let mut lookahead = chars.clone();
+                            lookahead.next();
+                            matches!(lookahead.next(), Some('}'))
+                        };
+
+                    if !parses_as_special_parameter_length
+                        && matches!(
+                            chars.peek().copied(),
+                            Some(':' | '-' | '=' | '+' | '?' | '#' | '%' | '/' | '^' | ',')
+                        )
+                    {
                         let raw_part = self.parse_parameter_tail_without_subscript(
                             &mut chars,
                             &mut cursor,


### PR DESCRIPTION
## What changed

This fixes a parser/root-cause bug behind several reviewed `C006` divergences.

- parse special-parameter forms like `${!#}` and `${##*/}` correctly instead of turning them into bogus undefined-variable carriers
- add parser regressions for indirect `#` handling, special `#` prefix removal, and multiline quoted `${0##*/}` cases
- add `C006` regressions to confirm these forms no longer report undefined-variable warnings

## Why

`C006` is driven by parser + semantic reference extraction. For certain special-parameter expansions, Shuck was constructing the wrong carrier name before the linter ever ran.

That produced bad diagnostics like:

- an empty variable name for `${!#}`
- synthetic names like `#*/` for `${##*/}`

Fixing this in the parser keeps the AST/reference model correct for all downstream rules instead of papering over it in `C006`.

## Impact

- removes false-positive `C006` warnings for special-parameter expansions
- keeps the undefined-variable suite green
- reduces the targeted `C006` large-corpus reviewed divergence count from 181 to 177

## Root cause

The legacy parameter-expansion decoding path was treating `#` forms too eagerly as length expansions and did not accept special parameters like `#` as valid indirect-expansion carriers.

That caused incorrect carrier extraction in forms such as `${!#}` and `${##*/}`, especially when they appeared inside larger quoted strings.

## Validation

- `cargo test -p shuck-parser special_hash -- --nocapture`
- `cargo test -p shuck-parser multiline_quote -- --nocapture`
- `cargo test -p shuck-linter undefined_variable -- --nocapture`
- `cargo test -p shuck-linter indirect_special_parameter_carrier_is_not_reported -- --nocapture`
- `cargo test -p shuck-linter special_hash_parameter_operations_are_not_reported -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006`
