### PR TITLE
Speed up large-corpus hotspot analysis

### DIFF
--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -69,3 +69,7 @@ harness = false
 [[bench]]
 name = "check_command"
 harness = false
+
+[[bench]]
+name = "large_corpus_hotspots"
+harness = false

--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -1,0 +1,463 @@
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
+use shuck_benchmark::configure_benchmark_allocator;
+use shuck_indexer::Indexer;
+use shuck_linter::{
+    LinterSettings, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
+    benchmark_collect_word_facts, first_statement_line,
+    lint_file_at_path_with_resolver_and_parse_result, parse_directives,
+};
+use shuck_parser::parser::{ParseResult, Parser};
+use shuck_semantic::{SemanticBuildOptions, SemanticModel, SourcePathResolver};
+
+configure_benchmark_allocator!();
+
+const LARGE_CORPUS_ROOT_ENV: &str = "SHUCK_LARGE_CORPUS_ROOT";
+const LARGE_CORPUS_CACHE_DIR_NAME: &str = ".cache/large-corpus";
+const AIRGEDDON_FIXTURE_NAME: &str = "v1s1t0r1sh3r3__airgeddon__airgeddon.sh";
+const LANGUAGE_STRINGS_FIXTURE_NAME: &str = "v1s1t0r1sh3r3__airgeddon__language_strings.sh";
+
+static LARGE_CORPUS_FIXTURES: OnceLock<Result<Arc<LoadedLargeCorpusFixtures>, String>> =
+    OnceLock::new();
+
+#[derive(Debug, Clone)]
+struct LargeCorpusFixture {
+    label: &'static str,
+    path: PathBuf,
+    cache_rel_path: PathBuf,
+    shell: String,
+    source: String,
+}
+
+impl LargeCorpusFixture {
+    fn bytes(&self) -> u64 {
+        self.source.len() as u64
+    }
+}
+
+#[derive(Debug)]
+struct LoadedLargeCorpusFixtures {
+    airgeddon: Arc<LargeCorpusFixture>,
+    language_strings: Arc<LargeCorpusFixture>,
+    resolver: Arc<LargeCorpusPathResolver>,
+}
+
+#[derive(Debug)]
+struct LargeCorpusPathResolver {
+    cache_rel_by_path: HashMap<PathBuf, PathBuf>,
+    path_by_cache_rel: HashMap<PathBuf, PathBuf>,
+}
+
+impl LargeCorpusPathResolver {
+    fn new(fixtures: &[Arc<LargeCorpusFixture>]) -> Self {
+        let mut cache_rel_by_path = HashMap::new();
+        let mut path_by_cache_rel = HashMap::new();
+
+        for fixture in fixtures {
+            let canonical_path =
+                fs::canonicalize(&fixture.path).unwrap_or_else(|_| fixture.path.clone());
+            cache_rel_by_path.insert(fixture.path.clone(), fixture.cache_rel_path.clone());
+            cache_rel_by_path.insert(canonical_path.clone(), fixture.cache_rel_path.clone());
+            path_by_cache_rel.insert(fixture.cache_rel_path.clone(), canonical_path);
+        }
+
+        Self {
+            cache_rel_by_path,
+            path_by_cache_rel,
+        }
+    }
+}
+
+impl SourcePathResolver for LargeCorpusPathResolver {
+    fn resolve_candidate_paths(&self, source_path: &Path, candidate: &str) -> Vec<PathBuf> {
+        let Some(source_cache_rel_path) = self.cache_rel_by_path.get(source_path) else {
+            return Vec::new();
+        };
+
+        let mut resolved = Vec::new();
+        let mut seen = HashSet::new();
+        for candidate_cache_rel_path in [
+            resolve_large_corpus_candidate_cache_rel_path(source_cache_rel_path, candidate),
+            resolve_large_corpus_repo_relative_candidate_cache_rel_path(
+                source_cache_rel_path,
+                candidate,
+            ),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if let Some(path) = self.path_by_cache_rel.get(&candidate_cache_rel_path)
+                && seen.insert(path.clone())
+            {
+                resolved.push(path.clone());
+            }
+        }
+
+        resolved
+    }
+}
+
+struct PreparedWordFactsInput {
+    source: String,
+    parse_result: ParseResult,
+    indexer: Indexer,
+    semantic: SemanticModel,
+}
+
+fn large_corpus_fixtures() -> Result<&'static Arc<LoadedLargeCorpusFixtures>, &'static str> {
+    LARGE_CORPUS_FIXTURES
+        .get_or_init(load_large_corpus_hotspot_fixtures)
+        .as_ref()
+        .map_err(|message| message.as_str())
+}
+
+fn load_large_corpus_hotspot_fixtures() -> Result<Arc<LoadedLargeCorpusFixtures>, String> {
+    let corpus_dir = resolve_large_corpus_root().ok_or_else(|| {
+        format!(
+            "large corpus not found; set {LARGE_CORPUS_ROOT_ENV}, populate ./{LARGE_CORPUS_CACHE_DIR_NAME}, or place ../shell-checks next to the repo"
+        )
+    })?;
+    let scripts_dir = corpus_dir.join("scripts");
+
+    let airgeddon = Arc::new(load_large_corpus_fixture(
+        &scripts_dir,
+        AIRGEDDON_FIXTURE_NAME,
+        "airgeddon",
+    )?);
+    let language_strings = Arc::new(load_large_corpus_fixture(
+        &scripts_dir,
+        LANGUAGE_STRINGS_FIXTURE_NAME,
+        "language_strings",
+    )?);
+    let resolver = Arc::new(LargeCorpusPathResolver::new(&[
+        Arc::clone(&airgeddon),
+        Arc::clone(&language_strings),
+    ]));
+
+    Ok(Arc::new(LoadedLargeCorpusFixtures {
+        airgeddon,
+        language_strings,
+        resolver,
+    }))
+}
+
+fn resolve_large_corpus_root() -> Option<PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir
+        .ancestors()
+        .nth(2)
+        .expect("crates/shuck-benchmark should live two levels below repo root");
+
+    let root_hint = env::var(LARGE_CORPUS_ROOT_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let candidates = root_hint.map(|hint| vec![hint]).unwrap_or_else(|| {
+        vec![
+            repo_root.join(LARGE_CORPUS_CACHE_DIR_NAME),
+            repo_root.join("..").join("shell-checks"),
+        ]
+    });
+
+    candidates
+        .into_iter()
+        .find_map(|candidate| normalize_large_corpus_root(&candidate))
+}
+
+fn normalize_large_corpus_root(root: &Path) -> Option<PathBuf> {
+    if !root.is_dir() {
+        return None;
+    }
+
+    let repo_corpus = root.join("corpus");
+    if corpus_dir_looks_valid(&repo_corpus) {
+        return Some(repo_corpus);
+    }
+    if corpus_dir_looks_valid(root) {
+        return Some(root.to_path_buf());
+    }
+
+    None
+}
+
+fn corpus_dir_looks_valid(root: &Path) -> bool {
+    root.join("scripts").is_dir()
+}
+
+fn load_large_corpus_fixture(
+    scripts_dir: &Path,
+    file_name: &str,
+    label: &'static str,
+) -> Result<LargeCorpusFixture, String> {
+    let path = scripts_dir.join(file_name);
+    let source = fs::read_to_string(&path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let shell = resolve_large_corpus_shell(&path, source.as_bytes());
+
+    Ok(LargeCorpusFixture {
+        label,
+        cache_rel_path: PathBuf::from(file_name),
+        path,
+        shell,
+        source,
+    })
+}
+
+fn resolve_large_corpus_shell(path: &Path, source: &[u8]) -> String {
+    let source = String::from_utf8_lossy(source);
+    let source = source.strip_prefix('\u{feff}').unwrap_or(source.as_ref());
+    let trimmed_first_line = source
+        .lines()
+        .next()
+        .map(|line| line.trim_start().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if trimmed_first_line.starts_with("#compdef") || trimmed_first_line.starts_with("#autoload") {
+        return "zsh".into();
+    }
+
+    match ShellDialect::infer(source, Some(path)) {
+        ShellDialect::Bash => "bash".into(),
+        ShellDialect::Ksh | ShellDialect::Mksh => "ksh".into(),
+        ShellDialect::Zsh => "zsh".into(),
+        ShellDialect::Sh | ShellDialect::Dash => "sh".into(),
+        ShellDialect::Unknown => "sh".into(),
+    }
+}
+
+fn parser_dialect_for_large_corpus_shell(shell: &str) -> shuck_parser::ShellDialect {
+    match ShellDialect::from_name(shell) {
+        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => {
+            shuck_parser::ShellDialect::Posix
+        }
+        ShellDialect::Mksh => shuck_parser::ShellDialect::Mksh,
+        ShellDialect::Zsh => shuck_parser::ShellDialect::Zsh,
+        ShellDialect::Unknown | ShellDialect::Bash => shuck_parser::ShellDialect::Bash,
+    }
+}
+
+fn shell_profile_for_large_corpus_shell(shell: &str) -> shuck_parser::ShellProfile {
+    shuck_parser::ShellProfile::native(parser_dialect_for_large_corpus_shell(shell))
+}
+
+fn parse_large_corpus_fixture(fixture: &LargeCorpusFixture) -> ParseResult {
+    Parser::with_dialect(
+        &fixture.source,
+        parser_dialect_for_large_corpus_shell(&fixture.shell),
+    )
+    .parse()
+}
+
+fn prepare_word_facts_input(
+    fixture: &LargeCorpusFixture,
+    resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+) -> PreparedWordFactsInput {
+    let parse_result = parse_large_corpus_fixture(fixture);
+    let indexer = Indexer::new(&fixture.source, &parse_result);
+    let semantic = SemanticModel::build_with_options(
+        &parse_result.file,
+        &fixture.source,
+        &indexer,
+        SemanticBuildOptions {
+            source_path: Some(&fixture.path),
+            source_path_resolver: resolver,
+            file_entry_contract: None,
+            analyzed_paths: None,
+            shell_profile: Some(shell_profile_for_large_corpus_shell(&fixture.shell)),
+        },
+    );
+
+    PreparedWordFactsInput {
+        source: fixture.source.clone(),
+        parse_result,
+        indexer,
+        semantic,
+    }
+}
+
+fn lint_large_corpus_fixture(
+    fixture: &LargeCorpusFixture,
+    resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+) -> usize {
+    let settings = LinterSettings::default()
+        .with_shell(ShellDialect::from_name(&fixture.shell))
+        .with_analyzed_paths([fixture.path.clone()]);
+    let parse_result = parse_large_corpus_fixture(fixture);
+    let indexer = Indexer::new(&fixture.source, &parse_result);
+    let shellcheck_map = ShellCheckCodeMap::default();
+    let directives = parse_directives(
+        &fixture.source,
+        &parse_result.file,
+        indexer.comment_index(),
+        &shellcheck_map,
+    );
+    let suppression_index = (!directives.is_empty()).then(|| {
+        SuppressionIndex::new(
+            &directives,
+            &parse_result.file,
+            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
+        )
+    });
+
+    let diagnostics = lint_file_at_path_with_resolver_and_parse_result(
+        &parse_result,
+        &fixture.source,
+        &indexer,
+        &settings,
+        suppression_index.as_ref(),
+        Some(&fixture.path),
+        resolver,
+    );
+
+    black_box(diagnostics.len())
+}
+
+fn build_large_corpus_word_facts(input: &PreparedWordFactsInput) -> usize {
+    black_box(
+        benchmark_collect_word_facts(&input.parse_result.file, &input.source, &input.semantic)
+            + input.indexer.comment_index().comments().len(),
+    )
+}
+
+fn resolve_large_corpus_candidate_cache_rel_path(
+    source_cache_rel_path: &Path,
+    candidate: &str,
+) -> Option<PathBuf> {
+    let candidate_path = Path::new(candidate);
+    if candidate_path.is_absolute() {
+        return None;
+    }
+
+    let mut resolved = source_cache_rel_path
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    let mut saw_component = false;
+
+    for component in candidate_path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !resolved.pop() {
+                    return None;
+                }
+                saw_component = true;
+            }
+            std::path::Component::Normal(part) => {
+                resolved.push(part);
+                saw_component = true;
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => return None,
+        }
+    }
+
+    saw_component.then_some(resolved)
+}
+
+fn resolve_large_corpus_repo_relative_candidate_cache_rel_path(
+    source_cache_rel_path: &Path,
+    candidate: &str,
+) -> Option<PathBuf> {
+    if source_cache_rel_path.components().count() != 1 {
+        return None;
+    }
+
+    let source_name = source_cache_rel_path.file_name()?.to_str()?;
+    let mut source_parts = source_name.split("__");
+    let owner = source_parts.next()?;
+    let repo = source_parts.next()?;
+
+    let candidate_path = Path::new(candidate);
+    if candidate_path.is_absolute() {
+        return None;
+    }
+
+    let mut flattened = Vec::new();
+    for component in candidate_path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => return None,
+            std::path::Component::Normal(part) => {
+                flattened.push(part.to_string_lossy().into_owned());
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => return None,
+        }
+    }
+
+    (!flattened.is_empty())
+        .then(|| PathBuf::from(format!("{owner}__{repo}__{}", flattened.join("__"))))
+}
+
+fn bench_large_corpus_linter(c: &mut Criterion) {
+    let Ok(fixtures) = large_corpus_fixtures() else {
+        let Err(message) = large_corpus_fixtures() else {
+            unreachable!();
+        };
+        eprintln!("skipping large corpus hotspot benches: {message}");
+        return;
+    };
+
+    let mut group = c.benchmark_group("large_corpus_linter");
+    group.sample_size(10);
+
+    for fixture in [&fixtures.airgeddon, &fixtures.language_strings] {
+        group.throughput(Throughput::Bytes(fixture.bytes()));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(fixture.label),
+            fixture,
+            |b, fixture| {
+                let resolver = fixtures.resolver.clone();
+                b.iter(|| {
+                    lint_large_corpus_fixture(
+                        fixture,
+                        Some(resolver.as_ref() as &(dyn SourcePathResolver + Send + Sync)),
+                    )
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_large_corpus_word_facts(c: &mut Criterion) {
+    let Ok(fixtures) = large_corpus_fixtures() else {
+        let Err(message) = large_corpus_fixtures() else {
+            unreachable!();
+        };
+        eprintln!("skipping large corpus hotspot benches: {message}");
+        return;
+    };
+
+    let mut group = c.benchmark_group("large_corpus_word_facts");
+    group.sample_size(10);
+    group.throughput(Throughput::Bytes(fixtures.language_strings.bytes()));
+    group.bench_with_input(
+        BenchmarkId::from_parameter(fixtures.language_strings.label),
+        &fixtures.language_strings,
+        |b, fixture| {
+            b.iter_batched(
+                || prepare_word_facts_input(fixture, None),
+                |input| {
+                    black_box(build_large_corpus_word_facts(&input));
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_large_corpus_linter,
+    bench_large_corpus_word_facts
+);
+criterion_main!(benches);

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -58,6 +58,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut word_occurrences = Vec::new();
         let mut compound_assignment_value_word_spans = FxHashSet::default();
         let mut array_assignment_split_word_ids = Vec::new();
+        let mut assoc_binding_visibility_memo = FxHashMap::default();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut case_pattern_expansion_spans = Vec::new();
         let mut pattern_literal_spans = Vec::new();
@@ -140,6 +141,7 @@ impl<'a> LinterFactsBuilder<'a> {
                     word_occurrences: &mut word_occurrences,
                     compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
                     array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
+                    assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
                     case_pattern_expansion_spans: &mut case_pattern_expansion_spans,
                     pattern_literal_spans: &mut pattern_literal_spans,
                     arithmetic: &mut arithmetic_summary,
@@ -498,12 +500,25 @@ impl<'a> LinterFactsBuilder<'a> {
                 &word_index,
                 source,
             );
+        let innermost_command_ids_by_offset = build_innermost_command_ids_by_offset(
+            &commands,
+            commands
+                .iter()
+                .map(|command| command.span().start.offset)
+                .collect(),
+        );
+        let command_parent_ids = build_command_parent_ids(&commands);
+        let command_dominance_barrier_flags =
+            build_command_dominance_barrier_flags(&commands);
 
         LinterFacts {
             source,
             commands,
             structural_command_ids,
             command_ids_by_span,
+            innermost_command_ids_by_offset,
+            command_parent_ids,
+            command_dominance_barrier_flags,
             if_condition_command_ids,
             elif_condition_command_ids,
             binding_values,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -574,10 +574,69 @@ fn command_fact<'a>(commands: &'a [CommandFact<'a>], id: CommandId) -> &'a Comma
     &commands[id.index()]
 }
 
+fn build_command_parent_ids(commands: &[CommandFact<'_>]) -> Vec<Option<CommandId>> {
+    let mut command_spans = commands
+        .iter()
+        .map(|command| (command.span(), command.id()))
+        .collect::<Vec<_>>();
+    if command_spans
+        .windows(2)
+        .any(|window| compare_command_offset_entries(window[0], window[1]).is_gt())
+    {
+        command_spans.sort_unstable_by(|left, right| compare_command_offset_entries(*left, *right));
+    }
+
+    let mut parent_ids = vec![None; commands.len()];
+    let mut active_commands = Vec::<OpenParentCommand>::new();
+
+    for (span, id) in command_spans {
+        while active_commands
+            .last()
+            .is_some_and(|candidate| candidate.end_offset < span.end.offset)
+        {
+            active_commands.pop();
+        }
+
+        parent_ids[id.index()] = active_commands.last().map(|command| command.id);
+        active_commands.push(OpenParentCommand {
+            id,
+            end_offset: span.end.offset,
+        });
+    }
+
+    parent_ids
+}
+
+fn build_command_dominance_barrier_flags(commands: &[CommandFact<'_>]) -> Vec<bool> {
+    commands
+        .iter()
+        .map(|fact| match fact.command() {
+            Command::Binary(_) => true,
+            Command::Compound(compound) => !matches!(
+                compound,
+                CompoundCommand::BraceGroup(_)
+                    | CompoundCommand::Arithmetic(_)
+                    | CompoundCommand::Time(_)
+            ),
+            Command::Simple(_)
+            | Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => false,
+        })
+        .collect()
+}
+
 fn sort_and_dedup_spans(spans: &mut Vec<Span>) {
     let mut seen = FxHashSet::default();
     spans.retain(|span| seen.insert(FactSpan::new(*span)));
     spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OpenParentCommand {
+    id: CommandId,
+    end_offset: usize,
 }
 
 fn trim_trailing_whitespace_span(span: Span, source: &str) -> Span {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -4,6 +4,9 @@ pub struct LinterFacts<'a> {
     structural_command_ids: Vec<CommandId>,
     #[cfg_attr(not(test), allow(dead_code))]
     command_ids_by_span: CommandLookupIndex,
+    innermost_command_ids_by_offset: FxHashMap<usize, Option<CommandId>>,
+    command_parent_ids: Vec<Option<CommandId>>,
+    command_dominance_barrier_flags: Vec<bool>,
     if_condition_command_ids: FxHashSet<CommandId>,
     elif_condition_command_ids: FxHashSet<CommandId>,
     binding_values: FxHashMap<BindingId, BindingValueFact<'a>>,
@@ -170,6 +173,29 @@ impl<'a> LinterFacts<'a> {
 
     pub fn command(&self, id: CommandId) -> &CommandFact<'a> {
         &self.commands[id.index()]
+    }
+
+    pub fn innermost_command_at(&self, offset: usize) -> Option<&CommandFact<'a>> {
+        self.innermost_command_id_at(offset).map(|id| self.command(id))
+    }
+
+    pub fn innermost_command_id_at(&self, offset: usize) -> Option<CommandId> {
+        precomputed_command_id_for_offset(&self.innermost_command_ids_by_offset, offset)
+    }
+
+    pub fn command_parent_id(&self, id: CommandId) -> Option<CommandId> {
+        self.command_parent_ids.get(id.index()).copied().flatten()
+    }
+
+    pub fn command_parent(&self, id: CommandId) -> Option<&CommandFact<'a>> {
+        self.command_parent_id(id).map(|parent_id| self.command(parent_id))
+    }
+
+    pub fn command_is_dominance_barrier(&self, id: CommandId) -> bool {
+        self.command_dominance_barrier_flags
+            .get(id.index())
+            .copied()
+            .unwrap_or(false)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -922,6 +922,84 @@ unset parts[\"$key\"] plain \"parts[safe]\" 'parts[also_safe]' nums[1]
 }
 
 #[test]
+fn precomputes_command_containment_and_barrier_flags_for_nested_commands() {
+    let source = "\
+#!/bin/bash
+if init_if; then
+  { brace_inner; }
+fi
+left && right
+time timed
+";
+
+    with_facts(source, None, |_, facts| {
+        let init_if = facts
+            .commands()
+            .iter()
+            .find(|fact| fact.effective_name_is("init_if"))
+            .expect("expected init_if command");
+        let brace_inner = facts
+            .commands()
+            .iter()
+            .find(|fact| fact.effective_name_is("brace_inner"))
+            .expect("expected brace_inner command");
+        let timed = facts
+            .commands()
+            .iter()
+            .find(|fact| fact.effective_name_is("timed"))
+            .expect("expected timed command");
+        let binary = facts
+            .commands()
+            .iter()
+            .find(|fact| matches!(fact.command(), shuck_ast::Command::Binary(_)))
+            .expect("expected binary command");
+
+        let init_parent = facts
+            .command_parent(init_if.id())
+            .expect("expected if parent");
+        assert!(matches!(
+            init_parent.command(),
+            shuck_ast::Command::Compound(shuck_ast::CompoundCommand::If(_))
+        ));
+        assert!(facts.command_is_dominance_barrier(init_parent.id()));
+
+        let brace_parent = facts
+            .command_parent(brace_inner.id())
+            .expect("expected brace-group parent");
+        assert!(matches!(
+            brace_parent.command(),
+            shuck_ast::Command::Compound(shuck_ast::CompoundCommand::BraceGroup(_))
+        ));
+        assert!(!facts.command_is_dominance_barrier(brace_parent.id()));
+
+        let timed_parent = facts
+            .command_parent(timed.id())
+            .expect("expected time parent");
+        assert!(matches!(
+            timed_parent.command(),
+            shuck_ast::Command::Compound(shuck_ast::CompoundCommand::Time(_))
+        ));
+        assert!(!facts.command_is_dominance_barrier(timed_parent.id()));
+        assert!(facts.command_is_dominance_barrier(binary.id()));
+
+        let brace_offset = source.find("brace_inner").expect("brace_inner offset");
+        let right_offset = source.find("right").expect("right offset");
+        assert_eq!(
+            facts
+                .innermost_command_at(brace_offset)
+                .and_then(|fact| fact.effective_name()),
+            Some("brace_inner")
+        );
+        assert_eq!(
+            facts
+                .innermost_command_at(right_offset)
+                .and_then(|fact| fact.effective_name()),
+            Some("right")
+        );
+    });
+}
+
+#[test]
 fn collects_prefix_match_spans_from_unset_operands() {
     let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1495,6 +1495,7 @@ pub(crate) fn benchmark_collect_word_facts(
     let mut word_occurrences = Vec::new();
     let mut compound_assignment_value_word_spans = FxHashSet::default();
     let mut array_assignment_split_word_ids = Vec::new();
+    let mut assoc_binding_visibility_memo = FxHashMap::default();
     let mut case_pattern_expansion_spans = Vec::new();
     let mut pattern_literal_spans = Vec::new();
     let mut arithmetic_summary = ArithmeticFactSummary::default();
@@ -1531,6 +1532,7 @@ pub(crate) fn benchmark_collect_word_facts(
                 word_occurrences: &mut word_occurrences,
                 compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
                 array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
+                assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
                 case_pattern_expansion_spans: &mut case_pattern_expansion_spans,
                 pattern_literal_spans: &mut pattern_literal_spans,
                 arithmetic: &mut arithmetic_summary,
@@ -1571,6 +1573,8 @@ struct WordFactOutputs<'out, 'a> {
     word_occurrences: &'out mut Vec<WordOccurrence>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
+    assoc_binding_visibility_memo:
+        &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     case_pattern_expansion_spans: &'out mut Vec<Span>,
     pattern_literal_spans: &'out mut Vec<Span>,
     arithmetic: &'out mut ArithmeticFactSummary,
@@ -1624,6 +1628,8 @@ struct WordFactCollector<'out, 'a, 'norm> {
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
+    assoc_binding_visibility_memo:
+        &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     seen: FxHashSet<(FactSpan, WordFactContext, WordFactHostKind)>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     case_pattern_expansion_spans: &'out mut Vec<Span>,
@@ -1653,6 +1659,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             word_node_ids_by_span: outputs.word_node_ids_by_span,
             word_occurrences: outputs.word_occurrences,
             array_assignment_split_word_ids: outputs.array_assignment_split_word_ids,
+            assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
             seen: FxHashSet::default(),
             compound_assignment_value_word_spans: outputs.compound_assignment_value_word_spans,
             case_pattern_expansion_spans: outputs.case_pattern_expansion_spans,
@@ -2548,7 +2555,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     }
 
     fn subscript_uses_index_arithmetic_semantics(
-        &self,
+        &mut self,
         owner_name: Option<&Name>,
         owner_name_span: Option<Span>,
         subscript: Option<&Subscript>,
@@ -2571,18 +2578,30 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     }
 
     fn assoc_binding_visible_for_subscript(
-        &self,
+        &mut self,
         owner_name: &Name,
         owner_name_span: Option<Span>,
         subscript: &Subscript,
     ) -> bool {
-        if let Some(binding) =
-            self.prior_visible_binding_for_subscript(owner_name, owner_name_span, subscript.span())
-        {
-            return binding.attributes.contains(BindingAttributes::ASSOC);
+        let current_scope = self.semantic.scope_at(subscript.span().start.offset);
+        let key = (
+            owner_name.clone(),
+            current_scope,
+            owner_name_span.map(FactSpan::new),
+        );
+        if let Some(result) = self.assoc_binding_visibility_memo.get(&key) {
+            return *result;
         }
 
-        self.assoc_binding_visible_from_named_callers(owner_name, subscript.span())
+        let visible = if let Some(binding) =
+            self.prior_visible_binding_for_subscript(owner_name, subscript.span())
+        {
+            binding.attributes.contains(BindingAttributes::ASSOC)
+        } else {
+            self.assoc_binding_visible_from_named_callers(owner_name, subscript.span())
+        };
+        self.assoc_binding_visibility_memo.insert(key, visible);
+        visible
     }
 
     fn assoc_binding_visible_from_named_callers(&self, owner_name: &Name, span: Span) -> bool {
@@ -2621,24 +2640,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     fn prior_visible_binding_for_subscript(
         &self,
         owner_name: &Name,
-        owner_name_span: Option<Span>,
         span: Span,
     ) -> Option<&shuck_semantic::Binding> {
         let current_scope = self.semantic.scope_at(span.start.offset);
         self.semantic
-            .bindings_for(owner_name)
-            .iter()
-            .rev()
-            .copied()
-            .find(|binding_id| {
-                self.semantic.binding_visible_at(*binding_id, span)
-                    && self.binding_blocks_caller_assoc_lookup(
-                        *binding_id,
-                        current_scope,
-                        owner_name_span,
-                    )
-            })
-            .map(|binding_id| self.semantic.binding(binding_id))
+            .visible_binding_for_assoc_lookup(owner_name, current_scope, span)
     }
 
     fn visible_binding_for_caller_assoc_lookup(
@@ -2648,46 +2654,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     ) -> Option<&shuck_semantic::Binding> {
         let current_scope = self.semantic.scope_at(span.start.offset);
         self.semantic
-            .bindings_for(owner_name)
-            .iter()
-            .rev()
-            .copied()
-            .find(|binding_id| {
-                self.semantic.binding_visible_at(*binding_id, span)
-                    && self.binding_blocks_caller_assoc_lookup(*binding_id, current_scope, None)
-            })
-            .map(|binding_id| self.semantic.binding(binding_id))
-    }
-
-    fn binding_blocks_caller_assoc_lookup(
-        &self,
-        binding_id: shuck_semantic::BindingId,
-        current_scope: shuck_semantic::ScopeId,
-        owner_name_span: Option<Span>,
-    ) -> bool {
-        let binding = self.semantic.binding(binding_id);
-        if owner_name_span.is_some_and(|owner_span| binding.span == owner_span)
-            && matches!(
-                binding.kind,
-                shuck_semantic::BindingKind::Assignment
-                    | shuck_semantic::BindingKind::AppendAssignment
-                    | shuck_semantic::BindingKind::ArrayAssignment
-                    | shuck_semantic::BindingKind::ArithmeticAssignment
-            )
-        {
-            return false;
-        }
-        if binding.scope != current_scope || binding.attributes.contains(BindingAttributes::LOCAL) {
-            return true;
-        }
-
-        !matches!(
-            binding.kind,
-            shuck_semantic::BindingKind::Assignment
-                | shuck_semantic::BindingKind::AppendAssignment
-                | shuck_semantic::BindingKind::ArrayAssignment
-                | shuck_semantic::BindingKind::ArithmeticAssignment
-        )
+            .visible_binding_for_assoc_lookup(owner_name, current_scope, span)
     }
 
     fn named_function_scope_names(&self, offset: usize) -> Option<&[Name]> {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -4,8 +4,8 @@ use shuck_ast::{
     RedirectKind, SourceText, Span, VarRef, Word, WordPart, WordPartNode,
 };
 use shuck_semantic::{
-    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, ContractCertainty,
-    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
+    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, LoopValueOrigin, ScopeId,
+    ScopeKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
 };
 use shuck_semantic::{BindingId, BlockId, ReferenceId, ReferenceKind};
 
@@ -74,6 +74,8 @@ pub struct SafeValueIndex<'a> {
     maybe_uninitialized_refs: FxHashSet<FactSpan>,
     memo: FxHashMap<(FactSpan, SafeValueQuery), bool>,
     visiting: FxHashSet<(FactSpan, SafeValueQuery)>,
+    helper_binding_memo: FxHashMap<(Name, ScopeId, FactSpan), Box<[BindingId]>>,
+    helper_binding_visiting: FxHashSet<(Name, ScopeId, FactSpan)>,
 }
 
 impl<'a> SafeValueIndex<'a> {
@@ -98,6 +100,8 @@ impl<'a> SafeValueIndex<'a> {
             maybe_uninitialized_refs,
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
+            helper_binding_memo: FxHashMap::default(),
+            helper_binding_visiting: FxHashSet::default(),
         }
     }
 
@@ -326,7 +330,7 @@ impl<'a> SafeValueIndex<'a> {
         })
     }
 
-    fn safe_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
+    fn safe_bindings_for_name(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
         let mut bindings = self.analysis.reaching_bindings_for_name(name, at);
         if bindings.len() == 1 {
             let mut expanded = self
@@ -347,23 +351,25 @@ impl<'a> SafeValueIndex<'a> {
         bindings
     }
 
-    fn called_helper_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
+    fn called_helper_bindings_for_name(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
         let scope = self.semantic.scope_at(at.start.offset);
-        let mut seen = FxHashSet::default();
-        let mut bindings = self.called_helper_bindings_before(name, scope, at, &mut seen);
+        let mut bindings = self.called_helper_bindings_before(name, scope, at);
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         bindings.dedup();
         bindings
     }
 
     fn called_helper_bindings_before(
-        &self,
+        &mut self,
         name: &Name,
         scope: ScopeId,
         at: Span,
-        seen: &mut FxHashSet<(ScopeId, usize, usize)>,
     ) -> Vec<BindingId> {
-        if !seen.insert((scope, at.start.offset, at.end.offset)) {
+        let key = (name.clone(), scope, FactSpan::new(at));
+        if let Some(cached) = self.helper_binding_memo.get(&key) {
+            return cached.to_vec();
+        }
+        if !self.helper_binding_visiting.insert(key.clone()) {
             return Vec::new();
         }
 
@@ -372,20 +378,23 @@ impl<'a> SafeValueIndex<'a> {
             .into_iter()
             .collect::<FxHashSet<_>>();
 
-        if let Some(caller_bindings) = self.helper_bindings_reaching_all_callers(name, scope, seen)
-        {
+        if let Some(caller_bindings) = self.helper_bindings_reaching_all_callers(name, scope) {
             bindings.extend(caller_bindings);
         }
 
-        seen.remove(&(scope, at.start.offset, at.end.offset));
-        bindings.into_iter().collect()
+        self.helper_binding_visiting.remove(&key);
+        let mut bindings = bindings.into_iter().collect::<Vec<_>>();
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.dedup();
+        self.helper_binding_memo
+            .insert(key, bindings.clone().into_boxed_slice());
+        bindings
     }
 
     fn helper_bindings_reaching_all_callers(
-        &self,
+        &mut self,
         name: &Name,
         scope: ScopeId,
-        seen: &mut FxHashSet<(ScopeId, usize, usize)>,
     ) -> Option<FxHashSet<BindingId>> {
         let function_kind = self.named_function_kind(scope)?;
         let mut caller_sites = Vec::new();
@@ -407,7 +416,7 @@ impl<'a> SafeValueIndex<'a> {
         for site in caller_sites {
             saw_caller = true;
             let branch = self
-                .called_helper_bindings_before(name, site.scope, site.span, seen)
+                .called_helper_bindings_before(name, site.scope, site.span)
                 .into_iter()
                 .collect::<FxHashSet<_>>();
             if branch.is_empty() {
@@ -462,41 +471,40 @@ impl<'a> SafeValueIndex<'a> {
         }
         let _ = name;
 
-        !self.facts.commands().iter().any(|fact| {
-            let outer = fact.span();
-            outer.start.offset < call_span.start.offset
-                && call_span.end.offset <= outer.end.offset
-                && outer.end.offset <= at.start.offset
-                && match fact.command() {
-                    shuck_ast::Command::Binary(_) => true,
-                    shuck_ast::Command::Compound(compound) => !matches!(
-                        compound,
-                        shuck_ast::CompoundCommand::BraceGroup(_)
-                            | shuck_ast::CompoundCommand::Arithmetic(_)
-                            | shuck_ast::CompoundCommand::Time(_)
-                    ),
-                    shuck_ast::Command::Simple(_)
-                    | shuck_ast::Command::Builtin(_)
-                    | shuck_ast::Command::Decl(_)
-                    | shuck_ast::Command::Function(_)
-                    | shuck_ast::Command::AnonymousFunction(_) => false,
-                }
-        })
+        let Some(mut command_id) = self.facts.innermost_command_id_at(call_span.start.offset)
+        else {
+            return true;
+        };
+        while self.facts.command(command_id).span() != call_span {
+            let Some(parent_id) = self.facts.command_parent_id(command_id) else {
+                return true;
+            };
+            command_id = parent_id;
+        }
+
+        let mut current = self.facts.command_parent_id(command_id);
+        while let Some(command_id) = current {
+            let command = self.facts.command(command_id);
+            if command.span().end.offset > at.start.offset {
+                break;
+            }
+            if command.span().start.offset < call_span.start.offset
+                && self.facts.command_is_dominance_barrier(command_id)
+            {
+                return false;
+            }
+            current = self.facts.command_parent_id(command_id);
+        }
+
+        true
     }
 
     fn helper_scopes_definitely_providing_name(&self, name: &Name) -> Vec<ScopeId> {
-        self.semantic
-            .scopes()
+        self.analysis
+            .definite_provider_scopes(name)
             .iter()
-            .filter_map(|scope| matches!(scope.kind, ScopeKind::Function(_)).then_some(scope.id))
-            .filter(|scope| {
-                self.analysis
-                    .summarize_scope_provided_bindings(*scope)
-                    .iter()
-                    .any(|binding| {
-                        binding.name == *name && binding.certainty == ContractCertainty::Definite
-                    })
-            })
+            .copied()
+            .filter(|scope| matches!(self.semantic.scope(*scope).kind, ScopeKind::Function(_)))
             .collect()
     }
 

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -248,6 +248,24 @@ fn previous_visible_binding_id_from_slice(
         .find(|binding_id| ignored_binding_span != Some(all_bindings[binding_id.index()].span))
 }
 
+fn insert_binding_id_sorted(
+    bindings: &mut Vec<BindingId>,
+    all_bindings: &[Binding],
+    id: BindingId,
+) {
+    let target = &all_bindings[id.index()];
+    let insertion = bindings.partition_point(|candidate_id| {
+        let candidate = &all_bindings[candidate_id.index()];
+        candidate.span.start.offset < target.span.start.offset
+            || (candidate.span.start.offset == target.span.start.offset
+                && candidate.span.end.offset < target.span.end.offset)
+            || (candidate.span.start.offset == target.span.start.offset
+                && candidate.span.end.offset == target.span.end.offset
+                && candidate.id.index() < target.id.index())
+    });
+    bindings.insert(insertion, id);
+}
+
 #[derive(Debug)]
 struct AssocLookupBindingIndex {
     blocking_bindings_by_scope: Vec<FxHashMap<Name, Box<[BindingId]>>>,
@@ -776,20 +794,25 @@ impl SemanticModel {
             references: Vec::new(),
             attributes,
         });
-        self.binding_index
-            .entry(provided.name.clone())
-            .or_default()
-            .push(id);
-        self.scopes[scope.index()]
-            .bindings
-            .entry(provided.name.clone())
-            .or_default()
-            .push(id);
-        if provided.kind == ProvidedBindingKind::Function {
-            self.functions
+        insert_binding_id_sorted(
+            self.binding_index.entry(provided.name.clone()).or_default(),
+            &self.bindings,
+            id,
+        );
+        insert_binding_id_sorted(
+            self.scopes[scope.index()]
+                .bindings
                 .entry(provided.name.clone())
-                .or_default()
-                .push(id);
+                .or_default(),
+            &self.bindings,
+            id,
+        );
+        if provided.kind == ProvidedBindingKind::Function {
+            insert_binding_id_sorted(
+                self.functions.entry(provided.name.clone()).or_default(),
+                &self.bindings,
+                id,
+            );
         }
         if let Some(command_span) = command_span {
             self.command_bindings
@@ -3342,6 +3365,58 @@ shadow() {
                 .map(|binding| binding.id),
             Some(shadow_local)
         );
+    }
+
+    #[test]
+    fn imported_entry_bindings_insert_in_visibility_order() {
+        let source = "\
+#!/bin/bash
+value=local
+echo $value
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build_with_options(
+            &output.file,
+            source,
+            &indexer,
+            SemanticBuildOptions {
+                file_entry_contract: Some(FileContract {
+                    required_reads: Vec::new(),
+                    provided_bindings: vec![ProvidedBinding::new(
+                        Name::from("value"),
+                        ProvidedBindingKind::Variable,
+                        ContractCertainty::Definite,
+                    )],
+                    provided_functions: Vec::new(),
+                }),
+                ..SemanticBuildOptions::default()
+            },
+        );
+        let value_bindings = model.bindings_for(&Name::from("value"));
+
+        assert_eq!(value_bindings.len(), 2);
+        assert!(matches!(
+            model.binding(value_bindings[0]).kind,
+            BindingKind::Imported
+        ));
+        assert!(matches!(
+            model.binding(value_bindings[1]).kind,
+            BindingKind::Assignment
+        ));
+
+        let value_reference = model
+            .references()
+            .iter()
+            .find(|reference| {
+                reference.name.as_str() == "value" && reference.span.slice(source) == "$value"
+            })
+            .expect("expected value reference");
+
+        assert!(matches!(
+            model.visible_binding(&Name::from("value"), value_reference.span),
+            Some(binding) if binding.kind == BindingKind::Assignment
+        ));
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -218,6 +218,47 @@ fn is_in_named_function_scope(scopes: &[Scope], scope: ScopeId, name: &Name) -> 
     })
 }
 
+fn assignment_like_binding(kind: BindingKind) -> bool {
+    matches!(
+        kind,
+        BindingKind::Assignment
+            | BindingKind::AppendAssignment
+            | BindingKind::ArrayAssignment
+            | BindingKind::ArithmeticAssignment
+    )
+}
+
+fn binding_blocks_same_scope_assoc_lookup(binding: &Binding) -> bool {
+    binding.attributes.contains(BindingAttributes::LOCAL) || !assignment_like_binding(binding.kind)
+}
+
+fn previous_visible_binding_id_from_slice(
+    all_bindings: &[Binding],
+    bindings: &[BindingId],
+    offset: usize,
+    ignored_binding_span: Option<Span>,
+) -> Option<BindingId> {
+    let candidate_count = bindings
+        .partition_point(|binding_id| all_bindings[binding_id.index()].span.start.offset <= offset);
+
+    bindings[..candidate_count]
+        .iter()
+        .rev()
+        .copied()
+        .find(|binding_id| ignored_binding_span != Some(all_bindings[binding_id.index()].span))
+}
+
+#[derive(Debug)]
+struct AssocLookupBindingIndex {
+    blocking_bindings_by_scope: Vec<FxHashMap<Name, Box<[BindingId]>>>,
+}
+
+#[derive(Debug)]
+struct ScopeProvidedBindingIndex {
+    provided_bindings_by_scope: Vec<Box<[ProvidedBinding]>>,
+    definite_provider_scopes_by_name: FxHashMap<Name, Box<[ScopeId]>>,
+}
+
 #[derive(Debug)]
 struct ScopeLookup {
     children: Vec<Box<[ScopeId]>>,
@@ -317,6 +358,7 @@ pub struct SemanticModel {
     import_origins_by_binding: FxHashMap<BindingId, Vec<PathBuf>>,
     heuristic_unused_assignments: Vec<BindingId>,
     zsh_option_analysis: Option<ZshOptionAnalysis>,
+    assoc_lookup_binding_index: OnceLock<AssocLookupBindingIndex>,
 }
 
 #[derive(Debug)]
@@ -329,6 +371,7 @@ pub struct SemanticAnalysis<'model> {
     uninitialized_references: OnceLock<Vec<UninitializedReference>>,
     dead_code: OnceLock<Vec<DeadCode>>,
     overwritten_functions: OnceLock<Vec<OverwrittenFunction>>,
+    scope_provided_binding_index: OnceLock<ScopeProvidedBindingIndex>,
 }
 
 struct OverwriteWindow<'a> {
@@ -405,6 +448,7 @@ impl SemanticModel {
             import_origins_by_binding: FxHashMap::default(),
             heuristic_unused_assignments: built.heuristic_unused_assignments,
             zsh_option_analysis,
+            assoc_lookup_binding_index: OnceLock::new(),
         }
     }
 
@@ -478,18 +522,7 @@ impl SemanticModel {
     }
 
     pub fn visible_binding(&self, name: &Name, at: Span) -> Option<&Binding> {
-        let scope = self.scope_at(at.start.offset);
-        for scope in self.ancestor_scopes(scope) {
-            if let Some(bindings) = self.scopes[scope.index()].bindings.get(name) {
-                for binding in bindings.iter().rev() {
-                    let binding = &self.bindings[binding.index()];
-                    if binding.span.start.offset <= at.start.offset {
-                        return Some(binding);
-                    }
-                }
-            }
-        }
-        None
+        self.previous_visible_binding(name, at, None)
     }
 
     #[doc(hidden)]
@@ -499,6 +532,44 @@ impl SemanticModel {
             && self
                 .ancestor_scopes(self.scope_at(at.start.offset))
                 .any(|scope| scope == binding.scope)
+    }
+
+    #[doc(hidden)]
+    pub fn previous_visible_binding(
+        &self,
+        name: &Name,
+        at: Span,
+        ignored_binding_span: Option<Span>,
+    ) -> Option<&Binding> {
+        let scope = self.scope_at(at.start.offset);
+        self.previous_visible_binding_id_in_scope_chain(
+            name,
+            scope,
+            at.start.offset,
+            ignored_binding_span,
+        )
+        .map(|binding_id| self.binding(binding_id))
+    }
+
+    #[doc(hidden)]
+    pub fn visible_binding_for_assoc_lookup(
+        &self,
+        name: &Name,
+        current_scope: ScopeId,
+        at: Span,
+    ) -> Option<&Binding> {
+        if let Some(binding_id) =
+            self.previous_assoc_lookup_binding_id_in_scope(current_scope, name, at.start.offset)
+        {
+            return Some(self.binding(binding_id));
+        }
+
+        self.ancestor_scopes(current_scope)
+            .skip(1)
+            .find_map(|scope| {
+                self.previous_visible_binding_id_in_scope(scope, name, at.start.offset, None)
+            })
+            .map(|binding_id| self.binding(binding_id))
     }
 
     pub fn defined_anywhere(&self, name: &Name) -> bool {
@@ -589,6 +660,79 @@ impl SemanticModel {
 
     pub fn ancestor_scopes(&self, scope: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
         std::iter::successors(Some(scope), move |scope| self.scopes[scope.index()].parent)
+    }
+
+    fn previous_visible_binding_id_in_scope_chain(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+        ignored_binding_span: Option<Span>,
+    ) -> Option<BindingId> {
+        self.ancestor_scopes(scope).find_map(|scope_id| {
+            self.previous_visible_binding_id_in_scope(scope_id, name, offset, ignored_binding_span)
+        })
+    }
+
+    fn previous_visible_binding_id_in_scope(
+        &self,
+        scope: ScopeId,
+        name: &Name,
+        offset: usize,
+        ignored_binding_span: Option<Span>,
+    ) -> Option<BindingId> {
+        let bindings = self.scopes[scope.index()].bindings.get(name)?;
+        previous_visible_binding_id_from_slice(
+            &self.bindings,
+            bindings,
+            offset,
+            ignored_binding_span,
+        )
+    }
+
+    fn previous_assoc_lookup_binding_id_in_scope(
+        &self,
+        scope: ScopeId,
+        name: &Name,
+        offset: usize,
+    ) -> Option<BindingId> {
+        let bindings = self
+            .assoc_lookup_binding_index()
+            .blocking_bindings_by_scope
+            .get(scope.index())
+            .and_then(|bindings_by_name| bindings_by_name.get(name))?;
+        previous_visible_binding_id_from_slice(&self.bindings, bindings, offset, None)
+    }
+
+    fn assoc_lookup_binding_index(&self) -> &AssocLookupBindingIndex {
+        self.assoc_lookup_binding_index.get_or_init(|| {
+            let blocking_bindings_by_scope = self
+                .scopes
+                .iter()
+                .map(|scope| {
+                    let mut bindings_by_name = FxHashMap::default();
+                    for (name, bindings) in &scope.bindings {
+                        let filtered = bindings
+                            .iter()
+                            .copied()
+                            .filter(|binding_id| {
+                                binding_blocks_same_scope_assoc_lookup(
+                                    &self.bindings[binding_id.index()],
+                                )
+                            })
+                            .collect::<Vec<_>>();
+                        if !filtered.is_empty() {
+                            bindings_by_name.insert(name.clone(), filtered.into_boxed_slice());
+                        }
+                    }
+                    bindings_by_name
+                })
+                .collect();
+
+            AssocLookupBindingIndex {
+                blocking_bindings_by_scope,
+            }
+        })
     }
 
     pub fn flow_context_at(&self, span: &Span) -> Option<&FlowContext> {
@@ -889,6 +1033,7 @@ impl<'model> SemanticAnalysis<'model> {
             uninitialized_references: OnceLock::new(),
             dead_code: OnceLock::new(),
             overwritten_functions: OnceLock::new(),
+            scope_provided_binding_index: OnceLock::new(),
         }
     }
 
@@ -1064,11 +1209,26 @@ impl<'model> SemanticAnalysis<'model> {
     }
 
     #[doc(hidden)]
+    pub fn scope_provided_bindings(&self, scope: ScopeId) -> &[ProvidedBinding] {
+        self.scope_provided_binding_index()
+            .provided_bindings_by_scope
+            .get(scope.index())
+            .map(Box::as_ref)
+            .unwrap_or(&[])
+    }
+
+    #[doc(hidden)]
+    pub fn definite_provider_scopes(&self, name: &Name) -> &[ScopeId] {
+        self.scope_provided_binding_index()
+            .definite_provider_scopes_by_name
+            .get(name)
+            .map(Box::as_ref)
+            .unwrap_or(&[])
+    }
+
+    #[doc(hidden)]
     pub fn summarize_scope_provided_bindings(&self, scope: ScopeId) -> Vec<ProvidedBinding> {
-        let cfg = self.cfg();
-        let exact = self.exact_variable_dataflow();
-        let context = self.model.dataflow_context(cfg);
-        dataflow::summarize_scope_provided_bindings(&context, exact, scope)
+        self.scope_provided_bindings(scope).to_vec()
     }
 
     pub(crate) fn summarize_scope_provided_functions(
@@ -1079,6 +1239,40 @@ impl<'model> SemanticAnalysis<'model> {
         let exact = self.exact_variable_dataflow();
         let context = self.model.dataflow_context(cfg);
         dataflow::summarize_scope_provided_functions(&context, exact, scope)
+    }
+
+    fn scope_provided_binding_index(&self) -> &ScopeProvidedBindingIndex {
+        self.scope_provided_binding_index.get_or_init(|| {
+            let cfg = self.cfg();
+            let exact = self.exact_variable_dataflow();
+            let context = self.model.dataflow_context(cfg);
+            let mut provided_bindings_by_scope = Vec::with_capacity(self.model.scopes.len());
+            let mut definite_provider_scopes_by_name = FxHashMap::<Name, Vec<ScopeId>>::default();
+
+            for scope in self.model.scopes.iter().map(|scope| scope.id) {
+                let provided_bindings =
+                    dataflow::summarize_scope_provided_bindings(&context, exact, scope);
+                for binding in &provided_bindings {
+                    if binding.certainty == ContractCertainty::Definite {
+                        definite_provider_scopes_by_name
+                            .entry(binding.name.clone())
+                            .or_default()
+                            .push(scope);
+                    }
+                }
+                provided_bindings_by_scope.push(provided_bindings.into_boxed_slice());
+            }
+
+            let definite_provider_scopes_by_name = definite_provider_scopes_by_name
+                .into_iter()
+                .map(|(name, scopes)| (name, scopes.into_boxed_slice()))
+                .collect();
+
+            ScopeProvidedBindingIndex {
+                provided_bindings_by_scope,
+                definite_provider_scopes_by_name,
+            }
+        })
     }
 
     fn overwrite_call_site_resolves_to_binding(
@@ -2988,6 +3182,25 @@ foo() {
 
         assert_eq!(bundle_ptr, function_ptr);
         assert_eq!(bundle_ptr, reused_ptr);
+        let cfg = analysis.cfg();
+        let exact = analysis.exact_variable_dataflow();
+        let context = model.dataflow_context(cfg);
+        assert_eq!(
+            analysis.scope_provided_bindings(ScopeId(0)),
+            dataflow::summarize_scope_provided_bindings(&context, exact, ScopeId(0)).as_slice()
+        );
+        assert_eq!(
+            analysis.scope_provided_bindings(foo_scope),
+            dataflow::summarize_scope_provided_bindings(&context, exact, foo_scope).as_slice()
+        );
+        assert_eq!(
+            analysis.definite_provider_scopes(&Name::from("outer")),
+            &[ScopeId(0)]
+        );
+        assert_eq!(
+            analysis.definite_provider_scopes(&Name::from("inner")),
+            &[foo_scope]
+        );
         assert_eq!(
             root_bindings
                 .iter()
@@ -3008,6 +3221,126 @@ foo() {
                 .map(|binding| binding.name.to_string())
                 .collect::<Vec<_>>(),
             vec!["foo"]
+        );
+    }
+
+    #[test]
+    fn previous_visible_binding_can_ignore_the_current_assignment_span() {
+        let model = model(
+            "\
+#!/bin/bash
+value=outer
+f() {
+  local value=inner
+  value=next
+}
+",
+        );
+        let binding_ids = model.bindings_for(&Name::from("value"));
+        let local = model.binding(binding_ids[1]);
+        let current = model.binding(binding_ids[2]);
+
+        assert_eq!(
+            model
+                .visible_binding(&Name::from("value"), current.span)
+                .map(|binding| binding.id),
+            Some(current.id)
+        );
+        assert_eq!(
+            model
+                .previous_visible_binding(&Name::from("value"), current.span, Some(current.span))
+                .map(|binding| binding.id),
+            Some(local.id)
+        );
+    }
+
+    #[test]
+    fn assoc_lookup_binding_prefers_visible_assoc_declarations_and_respects_local_shadowing() {
+        let model = model(
+            "\
+#!/bin/bash
+declare -A map
+helper() {
+  map[$key]=1
+}
+shadow() {
+  local map
+  map[$key]=2
+}
+",
+        );
+        let helper_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "helper") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected helper scope");
+        let shadow_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "shadow") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected shadow scope");
+        let helper_assignment = model
+            .bindings_for(&Name::from("map"))
+            .iter()
+            .copied()
+            .find(|binding_id| {
+                let binding = model.binding(*binding_id);
+                binding.scope == helper_scope && binding.kind == BindingKind::ArrayAssignment
+            })
+            .expect("expected helper assignment binding");
+        let shadow_local = model
+            .bindings_for(&Name::from("map"))
+            .iter()
+            .copied()
+            .find(|binding_id| {
+                let binding = model.binding(*binding_id);
+                binding.scope == shadow_scope
+                    && matches!(binding.kind, BindingKind::Declaration(_))
+                    && binding.attributes.contains(BindingAttributes::LOCAL)
+            })
+            .expect("expected shadowing local binding");
+        let shadow_assignment = model
+            .bindings_for(&Name::from("map"))
+            .iter()
+            .copied()
+            .find(|binding_id| {
+                let binding = model.binding(*binding_id);
+                binding.scope == shadow_scope && binding.kind == BindingKind::ArrayAssignment
+            })
+            .expect("expected shadow assignment binding");
+
+        assert!(
+            model
+                .visible_binding_for_assoc_lookup(
+                    &Name::from("map"),
+                    helper_scope,
+                    model.binding(helper_assignment).span,
+                )
+                .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+        );
+        assert_eq!(
+            model
+                .visible_binding_for_assoc_lookup(
+                    &Name::from("map"),
+                    shadow_scope,
+                    model.binding(shadow_assignment).span,
+                )
+                .map(|binding| binding.id),
+            Some(shadow_local)
         );
     }
 


### PR DESCRIPTION
## What changed

This speeds up the large-corpus hotspots that were causing the `airgeddon` fixtures to dominate runtime.

The main changes are:
- cache per-scope provided-binding summaries and reverse definite-provider scope lookups in `SemanticAnalysis`
- memoize helper-binding reachability in `SafeValueIndex`
- replace the linear command scan in helper call dominance checks with precomputed command containment and parent lookup facts
- add direct previous-visible-binding and assoc-lookup helpers in `SemanticModel`
- use the direct assoc lookup path plus a shared memo in the word-facts builder
- add a dedicated Criterion bench for the large-corpus hotspot fixtures without vendoring the corpus files

## Why

`airgeddon.sh` was spending most of its time in `unquoted_expansion -> SafeValueIndex`, especially repeated helper-provider analysis and recursive helper reachability work.

`language_strings.sh` was dominated by associative-array subscript analysis, repeatedly rescanning visible bindings for the same name across thousands of assignments.

## Impact

Targeted large-corpus timing on the two real fixtures improved from:

- `30s` timeout run before: `airgeddon.sh` timed out at `30.001s`, `language_strings.sh` took `11.527s`
- `30s` timeout run after: `airgeddon.sh` took `4.476s`, `language_strings.sh` took `2.348s`
- generous-timeout run before: `airgeddon.sh` took `54.910s`, `language_strings.sh` took `11.963s`
- generous-timeout run after: `airgeddon.sh` took `4.039s`, `language_strings.sh` took `2.349s`

Criterion against the saved baseline showed:

- `large_corpus_linter/airgeddon`: about `-10.0%`
- `large_corpus_linter/language_strings`: about `-69.3%`
- `large_corpus_word_facts/language_strings`: about `-95.7%`

## Validation

- `cargo fmt`
- `cargo test -p shuck-semantic tests::scope_summary_queries_reuse_exact_variable_dataflow_bundle`
- `cargo test -p shuck-semantic tests::previous_visible_binding_can_ignore_the_current_assignment_span`
- `cargo test -p shuck-semantic tests::assoc_lookup_binding_prefers_visible_assoc_declarations_and_respects_local_shadowing`
- `cargo test -p shuck-linter facts::tests::commands::precomputes_command_containment_and_barrier_flags_for_nested_commands`
- `cargo test -p shuck-linter facts::tests::surface::ignores_globally_declared_associative_assignment_subscripts_for_dollar_in_arithmetic`
- `cargo test -p shuck-linter facts::tests::surface::reports_shadowing_local_subscripts_even_when_callers_have_assoc_bindings`
- `cargo test -p shuck-linter helper_initialized_bindings_stay_safe_when_all_callers_provide_distinct_values`
- `cargo test -p shuck-linter helper_initialized_bindings_do_not_leak_across_distinct_callers`
- targeted large-corpus timing runs with `SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=30` and `=120`
- `cargo bench -p shuck-benchmark --bench large_corpus_hotspots -- --baseline=large-corpus-before --noplot`
