### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -4,6 +4,7 @@
     "security:only-security-updates",
     "helpers:pinGitHubActionDigests"
   ],
+  "dependencyDashboard": false,
   "packageRules": [
     {
       "description": "Keep GitHub Action updates together so digest refreshes stay readable.",


### PR DESCRIPTION
## Summary
- Set `dependencyDashboard: false` in `.renovaterc.json5` so Renovate stops opening/maintaining the dashboard issue.

## Test plan
- [ ] Confirm Renovate closes/stops updating the dependency dashboard issue on next run.