### PR TITLE
Clarify clean cache help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ shuck --cache-dir .tmp/shuck-cache check .
 
 ```sh
 # Remove cache entries for the current project
-shuck clean .
+shuck clean
 ```
 
 ## Output
@@ -156,7 +156,7 @@ Shuck caches lint results per file in a shared cache root outside the project tr
 
 Override the cache root with `--cache-dir` or `SHUCK_CACHE_DIR`.
 
-Disable caching with `--no-cache` or remove the current project's cache entries with `shuck clean`.
+Disable caching with `--no-cache` or remove a project's cache entries with `shuck clean [PATH]`.
 
 ## Acknowledgements
 

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -93,7 +93,7 @@ enum StableCommand {
     Check(CheckCommand),
     #[command(hide = true)]
     Format(FormatCommand),
-    /// Remove shuck caches under the provided paths.
+    /// Remove shuck cache entries for the provided paths' projects.
     Clean(CleanCommand),
 }
 
@@ -103,7 +103,7 @@ enum ExperimentalCommand {
     Check(CheckCommand),
     /// Format shell files.
     Format(FormatCommand),
-    /// Remove shuck caches under the provided paths.
+    /// Remove shuck cache entries for the provided paths' projects.
     Clean(CleanCommand),
 }
 
@@ -179,7 +179,7 @@ pub enum Command {
     Check(CheckCommand),
     /// Format shell files.
     Format(FormatCommand),
-    /// Remove shuck caches under the provided paths.
+    /// Remove shuck cache entries for the provided paths' projects.
     Clean(CleanCommand),
 }
 

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -56,6 +56,20 @@ fn help_shows_format_when_experimental_enabled() {
 }
 
 #[test]
+fn clean_help_describes_project_cache_entries() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.args(["clean", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Remove shuck cache entries for the provided paths' projects",
+        ))
+        .stdout(predicate::str::contains(
+            "Files or directories whose project caches should be removed",
+        ));
+}
+
+#[test]
 fn format_subcommand_requires_experimental_env() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.arg("format");


### PR DESCRIPTION
## Summary
- update the `clean` subcommand help text to describe removing project cache entries instead of caches "under" the provided paths
- refresh the README examples to reflect shared-cache cleanup semantics and the default `shuck clean` usage from the current project
- add an integration test that locks in the `clean --help` wording

## Why
The cache now lives in a shared cache root, so the old help text implied behavior that no longer matches how `clean` works. The command still resolves the provided paths to project roots and removes those projects' cache entries from the shared cache while pruning legacy local cache directories.

## Validation
- `cargo test -p shuck clean_ -- --nocapture`
