### PR TITLE
Show shuck RSS on benchmarks page

### DIFF
--- a/website/content/performance/benchmarks.tsx
+++ b/website/content/performance/benchmarks.tsx
@@ -207,6 +207,7 @@ function CaseTable({ dataset }: { dataset: BenchmarkDataset }) {
             <th>shuck</th>
             <th>Comparison</th>
             <th>Speedup</th>
+            <th>shuck RSS</th>
             <th>Comparison RSS</th>
           </tr>
         </thead>
@@ -241,6 +242,7 @@ function CaseTable({ dataset }: { dataset: BenchmarkDataset }) {
                 <td>{measurementText(shuck)}</td>
                 <td>{measurementText(comparison)}</td>
                 <td>{formatRatio(comparison?.relativeToShuck)}</td>
+                <td>{formatMemory(shuck?.meanMemoryBytes)}</td>
                 <td>{formatMemory(comparison?.meanMemoryBytes)}</td>
               </tr>
             );


### PR DESCRIPTION
## Summary
- Add a "shuck RSS" column to the per-case benchmark table on the website so readers can compare shuck's memory footprint against the comparison tool's, not just its speed.

## Test plan
- [ ] Build the website and confirm the new column renders next to "Comparison RSS" with sensible values for each case.