### PR TITLE
Support suppression aliases across directive styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Each rule has a short code (e.g., `C006`, `S001`) that appears in diagnostics an
 
 ### ShellCheck compatibility
 
-Where possible, shuck rules align with ShellCheck rules. Shuck supports ShellCheck suppression syntax (`# shellcheck disable=SC2086`) and maps ShellCheck codes to their shuck equivalents, so existing suppression comments continue to work without changes. Both suppression syntaxes accept either code namespace, so `# shuck: disable=SC2086` and `# shellcheck disable=S001` target the same rule.
+Where possible, shuck rules align with ShellCheck rules. Shuck supports ShellCheck suppression syntax (`# shellcheck disable=SC2086`) and maps ShellCheck codes to their shuck equivalents, so existing suppression comments continue to work without changes. Both suppression syntaxes accept either code namespace, and native `# shuck: disable=...` follows ShellCheck's scope rules: before the first statement it is file-wide, otherwise it applies to the next command.
 
 That said, shuck is not a port of ShellCheck. It is a clean-room reimplementation built on its own parser and analysis engine, so results will sometimes differ:
 
@@ -121,16 +121,13 @@ Compatibility is continuously validated against a large corpus of shell scripts 
 Suppress diagnostics with inline comments. Both native and ShellCheck-style directives are supported.
 
 ```sh
-# Suppress a specific rule for the next line
+# Suppress a specific rule for the next command
 # shuck:disable=C001
 unused_var="ok"
 
 # Suppress multiple rules
 # shuck:disable=C001,S001
 code_here
-
-# Re-enable a rule
-# shuck:enable=C001
 
 # Suppress for the entire file (place anywhere)
 # shuck:disable-file=S001,S002
@@ -141,6 +138,9 @@ code_here
 # Code aliases are interchangeable in either style
 # shuck: disable=SC2086
 # shellcheck disable=S001
+
+# Before the first statement, disable becomes file-wide
+# shuck: disable=S001
 ```
 
 ## File discovery

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Each rule has a short code (e.g., `C006`, `S001`) that appears in diagnostics an
 
 ### ShellCheck compatibility
 
-Where possible, shuck rules align with ShellCheck rules. Shuck supports ShellCheck suppression syntax (`# shellcheck disable=SC2086`) and maps ShellCheck codes to their shuck equivalents, so existing suppression comments continue to work without changes.
+Where possible, shuck rules align with ShellCheck rules. Shuck supports ShellCheck suppression syntax (`# shellcheck disable=SC2086`) and maps ShellCheck codes to their shuck equivalents, so existing suppression comments continue to work without changes. Both suppression syntaxes accept either code namespace, so `# shuck: disable=SC2086` and `# shellcheck disable=S001` target the same rule.
 
 That said, shuck is not a port of ShellCheck. It is a clean-room reimplementation built on its own parser and analysis engine, so results will sometimes differ:
 
@@ -137,6 +137,10 @@ code_here
 
 # ShellCheck-compatible syntax (also works)
 # shellcheck disable=SC2034,SC2086
+
+# Code aliases are interchangeable in either style
+# shuck: disable=SC2086
+# shellcheck disable=S001
 ```
 
 ## File discovery

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -1586,36 +1586,43 @@ fn is_inline_shellcheck_directive(comment_text: &str) -> bool {
         .trim_start()
         .trim_start_matches('#')
         .trim_start();
-    let Some(remainder) = strip_prefix_ignore_ascii_case(body, "shellcheck") else {
-        return false;
-    };
-    let Some(first) = remainder.chars().next() else {
-        return false;
-    };
-    if !first.is_ascii_whitespace() {
-        return false;
+
+    if let Some(remainder) = strip_prefix_ignore_ascii_case(body, "shellcheck") {
+        let Some(first) = remainder.chars().next() else {
+            return false;
+        };
+        if !first.is_ascii_whitespace() {
+            return false;
+        }
+
+        let mut body = remainder;
+        if let Some((before, _)) = body.split_once('#') {
+            body = before;
+        }
+
+        return body.split_ascii_whitespace().any(|part| {
+            [
+                "disable=",
+                "enable=",
+                "disable-file=",
+                "source=",
+                "shell=",
+                "external-sources=",
+            ]
+            .into_iter()
+            .any(|prefix| {
+                strip_prefix_ignore_ascii_case(part, prefix)
+                    .is_some_and(|value| !value.trim().is_empty())
+            })
+        });
     }
 
-    let mut body = remainder;
-    if let Some((before, _)) = body.split_once('#') {
-        body = before;
-    }
-
-    body.split_ascii_whitespace().any(|part| {
-        [
-            "disable=",
-            "enable=",
-            "disable-file=",
-            "source=",
-            "shell=",
-            "external-sources=",
-        ]
-        .into_iter()
-        .any(|prefix| {
-            strip_prefix_ignore_ascii_case(part, prefix)
-                .is_some_and(|value| !value.trim().is_empty())
-        })
-    })
+    let Some(remainder) = strip_prefix_ignore_ascii_case(body, "shuck:") else {
+        return false;
+    };
+    let body = remainder.split_once('#').map_or(remainder, |(before, _)| before);
+    strip_prefix_ignore_ascii_case(body.trim(), "disable=")
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -36,6 +36,17 @@ mod tests {
     }
 
     #[test]
+    fn reports_inline_shuck_disable_directive() {
+        let source = "#!/bin/sh\n: # shuck: disable=C003\nfoo=1\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 3);
+        assert_eq!(diagnostics[0].span.slice(source), "#");
+    }
+
+    #[test]
     fn ignores_own_line_directive() {
         let source = "#!/bin/sh\n# shellcheck disable=2034\nfoo=1\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
@@ -70,6 +81,14 @@ mod tests {
     #[test]
     fn ignores_directive_after_semicolon_separator() {
         let source = "#!/bin/sh\ntrue; # shellcheck disable=SC2317\nfalse\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_shuck_disable_after_semicolon_separator() {
+        let source = "#!/bin/sh\ntrue; # shuck: disable=C001\nfalse\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
 
         assert!(diagnostics.is_empty());
@@ -128,6 +147,15 @@ mod tests {
     #[test]
     fn reports_keyword_like_arguments_with_trailing_directives() {
         let source = "#!/bin/sh\necho if # shellcheck disable=SC2086\necho $foo\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn reports_keyword_like_arguments_with_trailing_shuck_disable() {
+        let source = "#!/bin/sh\necho if # shuck: disable=S001\necho $foo\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
 
         assert_eq!(diagnostics.len(), 1);

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -50,7 +50,7 @@ pub fn parse_directives(
             continue;
         };
 
-        if let Some(directive) = parse_shuck_directive(&comment) {
+        if let Some(directive) = parse_shuck_directive(&comment, shellcheck_map) {
             directives.push(directive);
         } else if let Some(directive) =
             parse_shellcheck_directive(source, &comment, file, shellcheck_map)
@@ -120,7 +120,10 @@ fn is_horizontal_whitespace(text: &str) -> bool {
     text.chars().all(|ch| matches!(ch, ' ' | '\t' | '\r'))
 }
 
-fn parse_shuck_directive(comment: &NormalizedComment<'_>) -> Option<SuppressionDirective> {
+fn parse_shuck_directive(
+    comment: &NormalizedComment<'_>,
+    shellcheck_map: &ShellCheckCodeMap,
+) -> Option<SuppressionDirective> {
     let body = strip_comment_prefix(comment.text);
     let remainder = strip_prefix_ignore_ascii_case(body, "shuck:")?;
     let remainder = remainder
@@ -128,7 +131,7 @@ fn parse_shuck_directive(comment: &NormalizedComment<'_>) -> Option<SuppressionD
         .map_or(remainder, |(before, _)| before);
     let (action, codes) = remainder.split_once('=')?;
     let action = parse_shuck_action(action.trim())?;
-    let codes = parse_codes(codes, resolve_rule_code);
+    let codes = parse_codes(codes, |code| resolve_suppression_code(code, shellcheck_map));
     if codes.is_empty() {
         return None;
     }
@@ -161,7 +164,7 @@ fn parse_shellcheck_directive(
                 if code.eq_ignore_ascii_case("all") {
                     codes.extend(Rule::iter());
                 } else {
-                    codes.extend(shellcheck_map.resolve_all(code));
+                    codes.extend(resolve_suppression_code(code, shellcheck_map));
                 }
             }
         }
@@ -602,14 +605,28 @@ fn parse_shuck_action(value: &str) -> Option<SuppressionAction> {
     }
 }
 
-fn parse_codes(value: &str, mut resolve: impl FnMut(&str) -> Option<Rule>) -> Vec<Rule> {
+fn parse_codes(value: &str, mut resolve: impl FnMut(&str) -> Vec<Rule>) -> Vec<Rule> {
     value
         .split(',')
-        .filter_map(|code| {
+        .flat_map(|code| {
             let code = code.trim();
-            if code.is_empty() { None } else { resolve(code) }
+            if code.is_empty() {
+                Vec::new()
+            } else {
+                resolve(code)
+            }
         })
         .collect()
+}
+
+fn resolve_suppression_code(code: &str, shellcheck_map: &ShellCheckCodeMap) -> Vec<Rule> {
+    let mut rules = resolve_rule_code(code).into_iter().collect::<Vec<_>>();
+    for rule in shellcheck_map.resolve_all(code) {
+        if !rules.contains(&rule) {
+            rules.push(rule);
+        }
+    }
+    rules
 }
 
 fn resolve_rule_code(code: &str) -> Option<Rule> {
@@ -670,6 +687,26 @@ mod tests {
     }
 
     #[test]
+    fn parses_shellcheck_codes_in_shuck_directives() {
+        let directives = directives(
+            "\
+# shuck: disable=SC2086,2154
+# shuck: enable=SC2268
+",
+        );
+
+        assert_eq!(directives.len(), 2);
+        assert_eq!(
+            directives[0].codes,
+            vec![Rule::UnquotedExpansion, Rule::UndefinedVariable]
+        );
+        assert_eq!(
+            directives[1].codes,
+            vec![Rule::XPrefixInTest, Rule::BackslashBeforeCommand]
+        );
+    }
+
+    #[test]
     fn parses_shellcheck_directives_on_own_line_and_after_code() {
         let source = "\
 # shellcheck disable=SC2086 disable=SC2034 disable=SC7777
@@ -692,6 +729,23 @@ esac
         assert_eq!(directives[1].action, SuppressionAction::Disable);
         assert_eq!(directives[1].source, SuppressionSource::ShellCheck);
         assert_eq!(directives[1].codes, vec![Rule::UnusedAssignment]);
+    }
+
+    #[test]
+    fn parses_shuck_codes_in_shellcheck_directives() {
+        let directives = directives("# shellcheck disable=S001,SH-039,C124\n");
+
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].action, SuppressionAction::Disable);
+        assert_eq!(directives[0].source, SuppressionSource::ShellCheck);
+        assert_eq!(
+            directives[0].codes,
+            vec![
+                Rule::UnquotedExpansion,
+                Rule::UndefinedVariable,
+                Rule::UnreachableAfterExit,
+            ]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -11,7 +11,7 @@ use super::ShellCheckCodeMap;
 /// A parsed suppression directive from a comment.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SuppressionDirective {
-    /// The action: disable, enable, or disable-file.
+    /// The action: disable or disable-file.
     pub action: SuppressionAction,
     /// Which directive syntax produced this.
     pub source: SuppressionSource,
@@ -26,7 +26,6 @@ pub struct SuppressionDirective {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SuppressionAction {
     Disable,
-    Enable,
     DisableFile,
 }
 
@@ -50,7 +49,7 @@ pub fn parse_directives(
             continue;
         };
 
-        if let Some(directive) = parse_shuck_directive(&comment, shellcheck_map) {
+        if let Some(directive) = parse_shuck_directive(source, &comment, file, shellcheck_map) {
             directives.push(directive);
         } else if let Some(directive) =
             parse_shellcheck_directive(source, &comment, file, shellcheck_map)
@@ -121,7 +120,9 @@ fn is_horizontal_whitespace(text: &str) -> bool {
 }
 
 fn parse_shuck_directive(
+    source: &str,
     comment: &NormalizedComment<'_>,
+    file: &File,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Option<SuppressionDirective> {
     let body = strip_comment_prefix(comment.text);
@@ -133,6 +134,14 @@ fn parse_shuck_directive(
     let action = parse_shuck_action(action.trim())?;
     let codes = parse_codes(codes, |code| resolve_suppression_code(code, shellcheck_map));
     if codes.is_empty() {
+        return None;
+    }
+
+    if action == SuppressionAction::Disable
+        && !comment.is_own_line
+        && !shellcheck_directive_can_apply_to_following_command(source, file, comment.range)
+        && !is_case_label_directive(comment, file)
+    {
         return None;
     }
 
@@ -596,8 +605,6 @@ fn body_opener_matches(
 fn parse_shuck_action(value: &str) -> Option<SuppressionAction> {
     if value.eq_ignore_ascii_case("disable") {
         Some(SuppressionAction::Disable)
-    } else if value.eq_ignore_ascii_case("enable") {
-        Some(SuppressionAction::Enable)
     } else if value.eq_ignore_ascii_case("disable-file") {
         Some(SuppressionAction::DisableFile)
     } else {
@@ -691,7 +698,7 @@ mod tests {
         let directives = directives(
             "\
 # shuck: disable=SC2086,2154
-# shuck: enable=SC2268
+# shuck: disable-file=SC2268
 ",
         );
 
@@ -700,6 +707,7 @@ mod tests {
             directives[0].codes,
             vec![Rule::UnquotedExpansion, Rule::UndefinedVariable]
         );
+        assert_eq!(directives[1].action, SuppressionAction::DisableFile);
         assert_eq!(
             directives[1].codes,
             vec![Rule::XPrefixInTest, Rule::BackslashBeforeCommand]
@@ -760,6 +768,17 @@ echo $foo
     }
 
     #[test]
+    fn rejects_shuck_disable_directives_after_regular_code() {
+        let source = "\
+value=1 # shuck: disable=C006
+echo $foo
+";
+        let directives = directives(source);
+
+        assert!(directives.is_empty());
+    }
+
+    #[test]
     fn rejects_case_label_directives_after_same_line_commands() {
         let source = "\
 case $x in
@@ -770,6 +789,53 @@ esac
         let directives = directives(source);
 
         assert!(directives.is_empty());
+    }
+
+    #[test]
+    fn parses_shuck_disable_directives_after_control_flow_headers_and_group_openers() {
+        let source = "\
+if # shuck: disable=SC2086
+  echo $foo
+then
+  :
+fi
+if true; then { # shuck: disable=SC2086
+  echo $foo
+}; fi
+while # shuck: disable=SC2086
+  echo $foo
+do
+  :
+done
+{ # shuck: disable=SC2086
+  echo $foo
+}
+";
+        let directives = directives(source);
+
+        assert_eq!(directives.len(), 4);
+        assert!(directives.iter().all(|directive| {
+            directive.source == SuppressionSource::Shuck
+                && directive.action == SuppressionAction::Disable
+                && directive.codes == vec![Rule::UnquotedExpansion]
+        }));
+    }
+
+    #[test]
+    fn parses_shuck_disable_directives_after_case_labels() {
+        let source = "\
+case $x in
+  on) # shuck: disable=SC2086
+    echo $foo
+    ;;
+esac
+";
+        let directives = directives(source);
+
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].source, SuppressionSource::Shuck);
+        assert_eq!(directives[0].action, SuppressionAction::Disable);
+        assert_eq!(directives[0].codes, vec![Rule::UnquotedExpansion]);
     }
 
     #[test]
@@ -948,6 +1014,7 @@ foreach item (1 2) { # shellcheck disable=SC2086
 # shuck: disable=
 # shuck: foobar=C001
 # shuck disable=C001
+# shuck: enable=SH-039
 # shuck: disable=SH-039
 ";
         let directives = directives(source);

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -558,6 +558,25 @@ echo dead
     }
 
     #[test]
+    fn applies_region_disable_with_shellcheck_codes() {
+        let source = "\
+foo='a b'
+echo $foo
+# shuck: disable=SC2086
+echo $foo
+# shuck: enable=S001
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 2));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 4));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 6));
+    }
+
+    #[test]
     fn promotes_shellcheck_directives_before_the_first_statement_to_file_scope() {
         let source = "\
 #!/bin/bash
@@ -584,6 +603,20 @@ echo $foo
 
         assert!(index.is_suppressed(Rule::CompoundTestOperator, 4));
         assert!(index.is_suppressed(Rule::UnquotedExpansion, 5));
+    }
+
+    #[test]
+    fn scopes_shellcheck_disable_with_shuck_codes_to_the_next_command() {
+        let source = "\
+foo='a b'
+# shellcheck disable=S001
+echo $foo
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 4));
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -8,7 +8,7 @@ use shuck_ast::{
 use crate::Rule;
 use crate::rules::common::query;
 
-use super::{SuppressionAction, SuppressionDirective, SuppressionSource};
+use super::{SuppressionAction, SuppressionDirective};
 
 /// Per-file suppression index.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -36,9 +36,7 @@ impl SuppressionIndex {
                     .or_insert_with(RuleSuppressionIndex::default);
                 match directive.action {
                     SuppressionAction::DisableFile => index.whole_file = true,
-                    SuppressionAction::Disable
-                        if directive.source == SuppressionSource::ShellCheck =>
-                    {
+                    SuppressionAction::Disable => {
                         if directive.line < first_stmt_line {
                             index.whole_file = true;
                         } else if let Some(range) = next_command_range(file, directive.range.end())
@@ -46,14 +44,6 @@ impl SuppressionIndex {
                             index.ranges.push(range);
                         }
                     }
-                    SuppressionAction::Disable => index.events.push(RegionEvent {
-                        line: directive.line,
-                        suppressed: true,
-                    }),
-                    SuppressionAction::Enable => index.events.push(RegionEvent {
-                        line: directive.line,
-                        suppressed: false,
-                    }),
                 }
             }
         }
@@ -87,7 +77,6 @@ pub fn first_statement_line(file: &File) -> Option<u32> {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct RuleSuppressionIndex {
     whole_file: bool,
-    events: Vec<RegionEvent>,
     ranges: Vec<LineRange>,
 }
 
@@ -107,19 +96,8 @@ impl RuleSuppressionIndex {
         {
             return true;
         }
-
-        self.events
-            .partition_point(|event| event.line <= line)
-            .checked_sub(1)
-            .and_then(|index| self.events.get(index))
-            .is_some_and(|event| event.suppressed)
+        false
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct RegionEvent {
-    line: u32,
-    suppressed: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -526,20 +504,18 @@ mod tests {
     }
 
     #[test]
-    fn applies_region_disable_until_a_matching_enable() {
+    fn applies_shuck_disable_to_the_next_command() {
         let source = "\
+foo='a b'
 echo $foo
 # shuck: disable=C006
 echo $foo
-# shuck: enable=C006
 echo $foo
 ";
         let index = suppression_index(source);
 
-        assert!(!index.is_suppressed(Rule::UndefinedVariable, 1));
-        assert!(index.is_suppressed(Rule::UndefinedVariable, 2));
-        assert!(index.is_suppressed(Rule::UndefinedVariable, 3));
-        assert!(!index.is_suppressed(Rule::UndefinedVariable, 4));
+        assert!(!index.is_suppressed(Rule::UndefinedVariable, 2));
+        assert!(index.is_suppressed(Rule::UndefinedVariable, 4));
         assert!(!index.is_suppressed(Rule::UndefinedVariable, 5));
     }
 
@@ -549,31 +525,43 @@ echo $foo
 exit 0
 # shuck: disable=SH-293
 echo dead
+echo still_dead
 ";
         let index = suppression_index(source);
 
         assert!(!index.is_suppressed(Rule::UnreachableAfterExit, 1));
-        assert!(index.is_suppressed(Rule::UnreachableAfterExit, 2));
         assert!(index.is_suppressed(Rule::UnreachableAfterExit, 3));
+        assert!(!index.is_suppressed(Rule::UnreachableAfterExit, 4));
     }
 
     #[test]
-    fn applies_region_disable_with_shellcheck_codes() {
+    fn applies_shuck_disable_with_shellcheck_codes_to_the_next_command() {
         let source = "\
 foo='a b'
 echo $foo
 # shuck: disable=SC2086
 echo $foo
-# shuck: enable=S001
 echo $foo
 ";
         let index = suppression_index(source);
 
         assert!(!index.is_suppressed(Rule::UnquotedExpansion, 2));
-        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
         assert!(index.is_suppressed(Rule::UnquotedExpansion, 4));
         assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
-        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 6));
+    }
+
+    #[test]
+    fn promotes_shuck_disable_before_the_first_statement_to_file_scope() {
+        let source = "\
+#!/bin/bash
+# shuck: disable=S001
+
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 1));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 4));
     }
 
     #[test]
@@ -617,6 +605,21 @@ echo $foo
 
         assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
         assert!(!index.is_suppressed(Rule::UnquotedExpansion, 4));
+    }
+
+    #[test]
+    fn scopes_shuck_disable_after_then_header_to_the_next_command() {
+        let source = "\
+foo='a b'
+if true; then # shuck: disable=S001
+  echo $foo
+fi
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
     }
 
     #[test]

--- a/specs/006-suppressions.md
+++ b/specs/006-suppressions.md
@@ -15,6 +15,8 @@ Lint rules produce false positives. Users need a way to acknowledge and silence 
 - **shuck native**: `# shuck: disable=C001` — supports disable, enable (region toggle), and disable-file (whole-file)
 - **shellcheck compatible**: `# shellcheck disable=SC2086` — widely used in existing codebases, applies to the next command only
 
+Both directive styles accept either code namespace. Native shuck codes (`C001`, `S001`, `SH-001`) and ShellCheck codes (`SC2086`, `2154`) resolve to the same underlying rules.
+
 The Go frontend implements both. The Rust rewrite must preserve this behavior so users migrating from the Go tool or from shellcheck don't need to rewrite their suppression comments.
 
 Following ruff's architecture, suppression filtering happens **after** the linter produces diagnostics — the checker runs without knowledge of suppressions, and a post-processing step filters the results. This keeps the checker simple and makes suppressions independently testable.
@@ -28,7 +30,7 @@ Following ruff's architecture, suppression filtering happens **after** the linte
 Case-insensitive prefix match on `shuck:`. The body after the prefix is `action=codes` where:
 
 - **action** is one of `disable`, `enable`, or `disable-file`
-- **codes** is a comma-separated list of rule codes (e.g., `C001,S003`)
+- **codes** is a comma-separated list of rule codes (e.g., `C001,S003` or `SC2086,2154`)
 - An optional reason after `#` is stripped: `# shuck: disable=C001 # legacy code`
 
 ```shell
@@ -48,7 +50,7 @@ Case-insensitive prefix match on `shellcheck`. Additional constraints:
 - **Must be an own-line comment** — inline `# shellcheck disable=...` after code is ignored (matches shellcheck's behavior)
 - Only the `disable` action is supported
 - Supports multiple code groups: `# shellcheck disable=SC2086 disable=SC2034`
-- Codes are shellcheck `SC` codes, mapped to shuck codes via a resolution table
+- Codes can be shellcheck `SC` codes or shuck-native codes. ShellCheck codes are mapped to shuck rules via a resolution table, and shuck codes resolve through the native registry.
 
 Scope depends on position:
 

--- a/specs/006-suppressions.md
+++ b/specs/006-suppressions.md
@@ -6,13 +6,13 @@ Proposed
 
 ## Summary
 
-A suppression layer that allows users to silence specific lint diagnostics via inline comments. Suppressions are parsed from two directive formats (`# shuck:` and `# shellcheck`), built into a per-file `SuppressionIndex`, and applied as a post-hoc filter on linter output. This spec covers directive parsing, scope resolution (line, region, file), index construction, and integration with the linter from spec 005.
+A suppression layer that allows users to silence specific lint diagnostics via inline comments. Suppressions are parsed from two directive formats (`# shuck:` and `# shellcheck`), built into a per-file `SuppressionIndex`, and applied as a post-hoc filter on linter output. This spec covers directive parsing, shellcheck-style scope resolution (next-command or file-wide), explicit whole-file disables, index construction, and integration with the linter from spec 005.
 
 ## Motivation
 
 Lint rules produce false positives. Users need a way to acknowledge and silence specific diagnostics without disabling rules globally. Shell scripts in particular carry two established suppression conventions:
 
-- **shuck native**: `# shuck: disable=C001` — supports disable, enable (region toggle), and disable-file (whole-file)
+- **shuck native**: `# shuck: disable=C001` — supports shellcheck-style disable semantics plus explicit `disable-file`
 - **shellcheck compatible**: `# shellcheck disable=SC2086` — widely used in existing codebases, applies to the next command only
 
 Both directive styles accept either code namespace. Native shuck codes (`C001`, `S001`, `SH-001`) and ShellCheck codes (`SC2086`, `2154`) resolve to the same underlying rules.
@@ -29,19 +29,18 @@ Following ruff's architecture, suppression filtering happens **after** the linte
 
 Case-insensitive prefix match on `shuck:`. The body after the prefix is `action=codes` where:
 
-- **action** is one of `disable`, `enable`, or `disable-file`
+- **action** is one of `disable` or `disable-file`
 - **codes** is a comma-separated list of rule codes (e.g., `C001,S003` or `SC2086,2154`)
 - An optional reason after `#` is stripped: `# shuck: disable=C001 # legacy code`
 
 ```shell
-# shuck: disable=C001          # region: suppress C001 from here forward
+# shuck: disable=C001          # shellcheck-style: suppress the next command
 echo $undefined
-# shuck: enable=C001           # region: re-enable C001
 
 # shuck: disable-file=S001     # file: suppress S001 for entire file
 ```
 
-Shuck directives can appear anywhere — own-line or inline. Position does not affect semantics; only the action determines scope.
+`# shuck: disable=...` follows the same placement rules as shellcheck: before the first statement it becomes file-wide, otherwise it applies to the next command, including the same inline control-flow header forms that shellcheck accepts. `disable-file` remains an explicit whole-file escape hatch.
 
 #### ShellCheck Compatible: `# shellcheck disable=<codes>`
 
@@ -73,7 +72,7 @@ echo $x                        # SC2034 NOT suppressed here
 ```rust
 /// A parsed suppression directive from a comment.
 pub struct SuppressionDirective {
-    /// The action: disable, enable, or disable-file.
+    /// The action: disable or disable-file.
     pub action: SuppressionAction,
     /// Which directive syntax produced this.
     pub source: SuppressionSource,
@@ -88,7 +87,6 @@ pub struct SuppressionDirective {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SuppressionAction {
     Disable,
-    Enable,
     DisableFile,
 }
 
@@ -149,13 +147,14 @@ impl ShellCheckCodeMap {
 
 ### Suppression Scopes
 
-There are three scope types, matching the Go implementation:
+There are three scope types:
 
 | Scope | Trigger | Range |
 |-------|---------|-------|
 | **File** | `# shuck: disable-file=C001` | Entire file |
+| **File** | `# shuck: disable=C001` before first statement | Entire file |
 | **File** | `# shellcheck disable=SC2086` before first statement | Entire file |
-| **Region** | `# shuck: disable=C001` | From directive line until matching `enable` or EOF |
+| **Next-command** | `# shuck: disable=C001` after first statement | Start line through end line of the next `Stmt` AST node |
 | **Next-command** | `# shellcheck disable=SC2086` after first statement | Start line through end line of the next `Stmt` AST node |
 
 ### SuppressionIndex
@@ -189,22 +188,14 @@ impl SuppressionIndex {
 
 #### RuleSuppressionIndex
 
-Per-rule state combining all three scope types:
+Per-rule state combining file and next-command scopes:
 
 ```rust
 struct RuleSuppressionIndex {
     /// If set, the rule is suppressed for the entire file.
     whole_file: bool,
-    /// Region state events, sorted by line. Used for shuck disable/enable regions.
-    events: Vec<RegionEvent>,
-    /// Line ranges from shellcheck next-command suppressions.
+    /// Line ranges from next-command suppressions.
     ranges: Vec<LineRange>,
-}
-
-struct RegionEvent {
-    line: u32,
-    /// State after this event: true = suppressed, false = not suppressed.
-    suppressed: bool,
 }
 
 struct LineRange {
@@ -217,10 +208,7 @@ struct LineRange {
 
 1. If `whole_file` is true → suppressed
 2. Binary search `ranges` for any range containing the query line → suppressed
-3. Binary search `events` for the most recent event at or before the query line; if `suppressed` is true → suppressed
-4. Otherwise → not suppressed
-
-This matches the Go implementation's `CodeSuppressionIndex.Match()` priority order: whole-file, then shellcheck ranges, then region state.
+3. Otherwise → not suppressed
 
 #### Building the Index
 
@@ -229,10 +217,8 @@ Construction mirrors `BuildCodeSuppressionIndex` from Go:
 1. Group directives by rule code
 2. For each rule, iterate its directives in source order:
    - **`disable-file`** → set `whole_file = true`
-   - **shellcheck directive before first statement** → set `whole_file = true`
-   - **shellcheck directive after first statement** → find the next `Stmt` after the directive's offset via AST walk, push a `LineRange { start_line, end_line }` for that statement
-   - **`disable`** → push `RegionEvent { line, suppressed: true }`
-   - **`enable`** → push `RegionEvent { line, suppressed: false }`
+   - **`disable` before first statement** → set `whole_file = true`
+   - **`disable` after first statement** → find the next `Stmt` after the directive's offset via AST walk, push a `LineRange { start_line, end_line }` for that statement
 3. Sort `ranges` by `(start_line, end_line)`
 
 **Finding the next command** for shellcheck scopes requires walking statement nodes in the AST to find the first `Stmt` whose start offset is after the directive's end offset:
@@ -340,9 +326,9 @@ Put directive parsing and the suppression index in `shuck-indexer` alongside `Co
 
 ### Alternative C: Support `enable` for shellcheck Directives
 
-Allow `# shellcheck enable=SC2086` to re-enable a suppressed rule, giving shellcheck directives the same region semantics as shuck directives.
+Allow `# shellcheck enable=SC2086` to re-enable a suppressed rule.
 
-**Rejected because:** ShellCheck itself doesn't support `enable`. Adding non-standard extensions to shellcheck's directive format would confuse users who expect shellcheck-compatible behavior. Users who need region toggles should use the shuck-native format.
+**Rejected because:** ShellCheck itself doesn't support `enable`. Adding non-standard extensions to shellcheck's directive format would confuse users who expect shellcheck-compatible behavior.
 
 ### Alternative D: Unused Suppression Warnings
 
@@ -357,7 +343,8 @@ Once implemented, verify with:
 - **Shuck directive parsing**: A comment `# shuck: disable=C001,S001` produces a `SuppressionDirective` with `action == Disable`, `codes == [Rule::UndefinedVariable, Rule::UnquotedExpansion]`, and `source == Shuck`.
 - **ShellCheck directive parsing**: A comment `# shellcheck disable=SC2086` on its own line maps to the correct shuck `Rule` via `ShellCheckCodeMap`. The same comment inline after code is ignored.
 - **Disable-file scope**: `# shuck: disable-file=C001` at any position causes `is_suppressed(Rule::UndefinedVariable, line)` to return true for all lines.
-- **Region scope**: `# shuck: disable=C001` on line 5 and `# shuck: enable=C001` on line 10 causes `is_suppressed` to return true for lines 5–9 and false for lines 1–4 and 10+.
+- **Shuck next-command scope**: `# shuck: disable=C001` on line 5 (after the first statement) suppresses only the lines spanned by the next `Stmt` node. A diagnostic on a subsequent statement is not suppressed.
+- **Shuck whole-file detection**: `# shuck: disable=C001` before the first statement suppresses the rule for all lines.
 - **ShellCheck next-command scope**: `# shellcheck disable=SC2086` on line 5 (after first statement) suppresses only the lines spanned by the next `Stmt` node. A diagnostic on a subsequent statement is not suppressed.
 - **ShellCheck whole-file detection**: `# shellcheck disable=SC2086` before the first statement suppresses the rule for all lines.
 - **Post-hoc filtering**: `lint_file()` with a suppression index filters out diagnostics on suppressed lines while preserving diagnostics on non-suppressed lines.


### PR DESCRIPTION
## Summary
- make native `# shuck: disable=...` follow shellcheck's scope rules instead of shuck-only region semantics
- keep both shuck and shellcheck code namespaces interchangeable in both directive styles
- update trailing-directive detection and docs to match the new shellcheck-style behavior

## Why
The current suppression behavior split along directive style: native shuck `disable` acted like a region toggle, while shellcheck `disable` acted on the next command or whole file when placed before the first statement. The goal here is to make ignores behave the same way regardless of whether the user writes shuck codes or shellcheck codes, and to model shellcheck's actual behavior rather than the older native implementation.

## Impact
After this change, native `# shuck: disable=...` is file-wide before the first statement and next-command scoped everywhere else, including the same inline control-flow header placements that shellcheck accepts. `# shuck: disable-file=...` remains the explicit whole-file escape hatch.

## Validation
- `cargo test -p shuck-linter suppression::`
- `cargo test -p shuck-linter trailing_directive`
- `cargo fmt --all --check`
- spot-checked shellcheck 0.11.0 behavior for preamble disables and next-command disables to keep shuck aligned
