### PR TITLE
Add safe-fix metadata to rule specs

### DIFF
--- a/docs/rules/C001.yaml
+++ b/docs/rules/C001.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A variable is assigned but never read later, so the statement has no effect on the script's behavior.
 rationale: Remove dead assignments, or export the value if a child process needs it.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-003.yaml
   shell_checks_example: examples/003.sh

--- a/docs/rules/C001.yaml
+++ b/docs/rules/C001.yaml
@@ -12,7 +12,7 @@ shells:
 description: A variable is assigned but never read later, so the statement has no effect on the script's behavior.
 rationale: Remove dead assignments, or export the value if a child process needs it.
 safe_fix: false
-fix_description: null
+fix_description: "Rename the reported unused assignment target to `_`."
 source:
   shell_checks_rule: rules/SH-003.yaml
   shell_checks_example: examples/003.sh

--- a/docs/rules/C002.yaml
+++ b/docs/rules/C002.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A sourced file path built at runtime is harder to analyze and easier to drift from the real dependency graph.
 rationale: Keep loaded file names literal when possible, or make sure every possible source target is included in analysis.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-025.yaml
   shell_checks_example: examples/025.sh

--- a/docs/rules/C003.yaml
+++ b/docs/rules/C003.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A script loads another file directly, but that dependency is not part of the analyzed input set.
 rationale: Pass sourced files to the linter together with the script, or avoid hidden file dependencies.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-026.yaml
   shell_checks_example: examples/026.sh

--- a/docs/rules/C004.yaml
+++ b/docs/rules/C004.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The script changes directories without checking whether the move succeeded.
 rationale: Treat directory changes as fallible and branch on the result before continuing.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-027.yaml
   shell_checks_example: examples/027.sh

--- a/docs/rules/C005.yaml
+++ b/docs/rules/C005.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A dollar-sign sequence is wrapped in single quotes, so it stays literal text instead of expanding.
 rationale: Use double quotes when you intend the shell to expand a variable-like value.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-036.yaml
   shell_checks_example: examples/036.sh

--- a/docs/rules/C005.yaml
+++ b/docs/rules/C005.yaml
@@ -12,7 +12,7 @@ shells:
 description: A dollar-sign sequence is wrapped in single quotes, so it stays literal text instead of expanding.
 rationale: Use double quotes when you intend the shell to expand a variable-like value.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the reported single-quoted fragment as an equivalently escaped double-quoted fragment."
 source:
   shell_checks_rule: rules/SH-036.yaml
   shell_checks_example: examples/036.sh

--- a/docs/rules/C006.yaml
+++ b/docs/rules/C006.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The script reads a variable that is never initialized in the file.
 rationale: Initialize the value first or guard the read so typos and missing setup do not pass silently.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-039.yaml
   shell_checks_example: examples/039.sh

--- a/docs/rules/C007.yaml
+++ b/docs/rules/C007.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Sending raw `find` output into `xargs` assumes file names stay simple and whitespace-free."
 rationale: Use a null-delimited handoff or another safer iteration pattern when file paths may contain spaces or newlines.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-041.yaml
   shell_checks_example: examples/041.sh

--- a/docs/rules/C007.yaml
+++ b/docs/rules/C007.yaml
@@ -12,7 +12,7 @@ shells:
 description: "Sending raw `find` output into `xargs` assumes file names stay simple and whitespace-free."
 rationale: Use a null-delimited handoff or another safer iteration pattern when file paths may contain spaces or newlines.
 safe_fix: false
-fix_description: null
+fix_description: "Make the `find | xargs` handoff NUL-delimited by adding `-print0` to `find` and `-0` to `xargs` wherever they are missing."
 source:
   shell_checks_rule: rules/SH-041.yaml
   shell_checks_example: examples/041.sh

--- a/docs/rules/C008.yaml
+++ b/docs/rules/C008.yaml
@@ -12,7 +12,7 @@ shells:
 description: Expansions inside a double-quoted trap body resolve when the trap is set instead of when it runs.
 rationale: Use single-quoted trap commands when you need values to be evaluated at signal time rather than at definition time.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the enclosing fully double-quoted trap action as an equivalently escaped single-quoted trap action."
 source:
   shell_checks_rule: rules/SH-042.yaml
   shell_checks_example: examples/042.sh

--- a/docs/rules/C008.yaml
+++ b/docs/rules/C008.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Expansions inside a double-quoted trap body resolve when the trap is set instead of when it runs.
 rationale: Use single-quoted trap commands when you need values to be evaluated at signal time rather than at definition time.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-042.yaml
   shell_checks_example: examples/042.sh

--- a/docs/rules/C009.yaml
+++ b/docs/rules/C009.yaml
@@ -12,7 +12,7 @@ shells:
 description: Quoting the pattern on the right side of bash's regex match changes how the match is interpreted.
 rationale: Leave the regular expression unquoted when you want bash to treat it as a pattern rather than a literal string.
 safe_fix: false
-fix_description: null
+fix_description: "Remove the surrounding quotes from the right-hand operand of the `[[ ... =~ ... ]]` regex test."
 source:
   shell_checks_rule: rules/SH-043.yaml
   shell_checks_example: examples/043.sh

--- a/docs/rules/C009.yaml
+++ b/docs/rules/C009.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Quoting the pattern on the right side of bash's regex match changes how the match is interpreted.
 rationale: Leave the regular expression unquoted when you want bash to treat it as a pattern rather than a literal string.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-043.yaml
   shell_checks_example: examples/043.sh

--- a/docs/rules/C010.yaml
+++ b/docs/rules/C010.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Mixing `&&` and `||` can make the fallback depend on the middle command's exit status."
 rationale: "Use an explicit `if` when you need clear branch selection instead of a short-circuit chain."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-045.yaml
   shell_checks_example: examples/045.sh

--- a/docs/rules/C011.yaml
+++ b/docs/rules/C011.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A loop over command output can turn records into whitespace-delimited words instead of preserving each original line.
 rationale: Read data with a line-aware loop or redirect so the shell does not reshape it into separate words.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-046.yaml
   shell_checks_example: examples/046.sh

--- a/docs/rules/C012.yaml
+++ b/docs/rules/C012.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An unguarded wildcard can turn into command arguments that begin with a dash after pathname expansion.
 rationale: Put a safe separator or a more explicit file-selection step in front of wildcard-expanded path lists.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-048.yaml
   shell_checks_example: examples/048.sh

--- a/docs/rules/C012.yaml
+++ b/docs/rules/C012.yaml
@@ -12,7 +12,7 @@ shells:
 description: An unguarded wildcard can turn into command arguments that begin with a dash after pathname expansion.
 rationale: Put a safe separator or a more explicit file-selection step in front of wildcard-expanded path lists.
 safe_fix: false
-fix_description: null
+fix_description: "Prefix the flagged wildcard argument with `./`."
 source:
   shell_checks_rule: rules/SH-048.yaml
   shell_checks_example: examples/048.sh

--- a/docs/rules/C013.yaml
+++ b/docs/rules/C013.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Expanding `find` output in a `for` loop loses pathname boundaries and re-splits file names."
 rationale: "Feed `find` results to a consumer that understands line or NUL boundaries instead of shell word splitting."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-049.yaml
   shell_checks_example: examples/049.sh

--- a/docs/rules/C014.yaml
+++ b/docs/rules/C014.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "In bash, `local` is only valid inside a function body and is not meaningful at script scope."
 rationale: Move the declaration into a function or use a regular assignment when working at top level.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-052.yaml
   shell_checks_example: examples/052.sh

--- a/docs/rules/C015.yaml
+++ b/docs/rules/C015.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A redirection attached to sudo still happens in the current shell before privilege escalation.
 rationale: Move the redirection into the privileged command itself, or pipe data through a helper such as tee when only the write needs elevation.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-060.yaml
   shell_checks_example: examples/060.sh

--- a/docs/rules/C016.yaml
+++ b/docs/rules/C016.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A closing control keyword appears without a matching block opener.
 rationale: Remove the unmatched keyword or add the corresponding opener and body.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-065.yaml
   shell_checks_example: examples/065.sh

--- a/docs/rules/C017.yaml
+++ b/docs/rules/C017.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A test that compares only fixed literals cannot react to runtime data and usually adds no value.
 rationale: Compare values that come from the script's inputs or variables instead of hard-coded text when the condition is meant to branch.
+safe_fix: true
+fix_description: "Fold the fixed-literal comparison to its known boolean result and simplify the enclosing test or conditional."
 source:
   shell_checks_rule: rules/SH-069.yaml
   shell_checks_example: examples/069.sh

--- a/docs/rules/C018.yaml
+++ b/docs/rules/C018.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A loop-control command at top level has nowhere to break from and just stops script execution.
 rationale: Keep loop-control commands inside the loop they are meant to manage.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-070.yaml
   shell_checks_example: examples/070.sh

--- a/docs/rules/C019.yaml
+++ b/docs/rules/C019.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A unary string check on a hard-coded word never reflects changing input.
 rationale: Test a variable or path that can change, or drop the check if the literal is intentional.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-072.yaml
   shell_checks_example: examples/072.sh

--- a/docs/rules/C019.yaml
+++ b/docs/rules/C019.yaml
@@ -12,7 +12,7 @@ shells:
 description: A unary string check on a hard-coded word never reflects changing input.
 rationale: Test a variable or path that can change, or drop the check if the literal is intentional.
 safe_fix: false
-fix_description: null
+fix_description: "Replace the constant unary string-test operand with an explicit empty or non-empty literal that preserves the current result, such as `-z \"\"`, `-z x`, `-n \"\"`, or `-n x`."
 source:
   shell_checks_rule: rules/SH-072.yaml
   shell_checks_example: examples/072.sh

--- a/docs/rules/C020.yaml
+++ b/docs/rules/C020.yaml
@@ -12,7 +12,7 @@ shells:
 description: A one-word test on a fixed literal does not ask a runtime question and is always decided the same way.
 rationale: Check a variable, path, or explicit comparison instead of a bare literal.
 safe_fix: false
-fix_description: null
+fix_description: "Replace the bare test term with `\"\"` or `x` so it keeps the same false or true result inside the surrounding test."
 source:
   shell_checks_rule: rules/SH-073.yaml
   shell_checks_example: examples/073.sh

--- a/docs/rules/C020.yaml
+++ b/docs/rules/C020.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A one-word test on a fixed literal does not ask a runtime question and is always decided the same way.
 rationale: Check a variable, path, or explicit comparison instead of a bare literal.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-073.yaml
   shell_checks_example: examples/073.sh

--- a/docs/rules/C021.yaml
+++ b/docs/rules/C021.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A case statement on a fixed literal is redundant because the subject never varies.
 rationale: Switch on a variable or collapse the branch if the outcome is predetermined.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-074.yaml
   shell_checks_example: examples/074.sh

--- a/docs/rules/C022.yaml
+++ b/docs/rules/C022.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An empty test expression has no meaningful operand and cannot describe a runtime condition.
 rationale: Populate the test with the value you intended to check or drop the empty expression.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-075.yaml
   shell_checks_example: examples/075.sh

--- a/docs/rules/C023.yaml
+++ b/docs/rules/C023.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A leading zero can change how the shell interprets a numeric literal in arithmetic.
 rationale: Use an unpadded decimal literal unless you explicitly want octal semantics.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-078.yaml
   shell_checks_example: examples/078.sh

--- a/docs/rules/C023.yaml
+++ b/docs/rules/C023.yaml
@@ -12,7 +12,7 @@ shells:
 description: A leading zero can change how the shell interprets a numeric literal in arithmetic.
 rationale: Use an unpadded decimal literal unless you explicitly want octal semantics.
 safe_fix: false
-fix_description: null
+fix_description: "Remove the leading zeroes from the arithmetic literal, leaving a single `0` if needed."
 source:
   shell_checks_rule: rules/SH-078.yaml
   shell_checks_example: examples/078.sh

--- a/docs/rules/C024.yaml
+++ b/docs/rules/C024.yaml
@@ -12,7 +12,7 @@ shells:
 description: A space after `=` breaks an assignment into separate shell words.
 rationale: "Write assignments without spaces around `=` so the shell keeps parsing them as assignments."
 safe_fix: false
-fix_description: null
+fix_description: "Delete the whitespace immediately after `=` so the assignment becomes one shell word."
 source:
   shell_checks_rule: rules/SH-084.yaml
   shell_checks_example: examples/084.sh

--- a/docs/rules/C024.yaml
+++ b/docs/rules/C024.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A space after `=` breaks an assignment into separate shell words.
 rationale: "Write assignments without spaces around `=` so the shell keeps parsing them as assignments."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-084.yaml
   shell_checks_example: examples/084.sh

--- a/docs/rules/C025.yaml
+++ b/docs/rules/C025.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Refers to the tenth positional parameter without braces.
 rationale: Use braces when addressing arguments above nine.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-086.yaml
   shell_checks_example: examples/086.sh

--- a/docs/rules/C025.yaml
+++ b/docs/rules/C025.yaml
@@ -12,7 +12,7 @@ shells:
 description: Refers to the tenth positional parameter without braces.
 rationale: Use braces when addressing arguments above nine.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the reported positional parameter in braces, for example `$10` to `${10}`."
 source:
   shell_checks_rule: rules/SH-086.yaml
   shell_checks_example: examples/086.sh

--- a/docs/rules/C027.yaml
+++ b/docs/rules/C027.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A loop-closing `done` is missing a separator before it.
 rationale: "Insert a semicolon or newline before `done`, or quote it if it is meant literally."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-091.yaml
   shell_checks_example: examples/091.sh

--- a/docs/rules/C030.yaml
+++ b/docs/rules/C030.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A test bracket is closed without surrounding space.
 rationale: "Keep spaces around `[` and `]` in test expressions."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-098.yaml
   shell_checks_example: examples/098.sh

--- a/docs/rules/C030.yaml
+++ b/docs/rules/C030.yaml
@@ -12,7 +12,7 @@ shells:
 description: A test bracket is closed without surrounding space.
 rationale: "Keep spaces around `[` and `]` in test expressions."
 safe_fix: false
-fix_description: null
+fix_description: "Insert a space before the trailing `]` in the reported unary test operand."
 source:
   shell_checks_rule: rules/SH-098.yaml
   shell_checks_example: examples/098.sh

--- a/docs/rules/C031.yaml
+++ b/docs/rules/C031.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A test expression is missing the space before `]`, which ShellCheck flags as a bracket-spacing issue."
 rationale: Keep the test minimal and omit the closing-space mistake so the example isolates this warning.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-100.yaml
   shell_checks_example: examples/100.sh

--- a/docs/rules/C031.yaml
+++ b/docs/rules/C031.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A test expression is missing the space before `]`, which ShellCheck flags as a bracket-spacing issue."
 rationale: Keep the test minimal and omit the closing-space mistake so the example isolates this warning.
 safe_fix: false
-fix_description: null
+fix_description: "Insert a space before the trailing `]` in the test operand."
 source:
   shell_checks_rule: rules/SH-100.yaml
   shell_checks_example: examples/100.sh

--- a/docs/rules/C032.yaml
+++ b/docs/rules/C032.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The `[` test starts without the expected spacing."
 rationale: Add the missing spaces around the test brackets.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-102.yaml
   shell_checks_example: examples/102.sh

--- a/docs/rules/C032.yaml
+++ b/docs/rules/C032.yaml
@@ -12,7 +12,7 @@ shells:
 description: "The `[` test starts without the expected spacing."
 rationale: Add the missing spaces around the test brackets.
 safe_fix: false
-fix_description: null
+fix_description: "Insert a space after `[` so the test starts as `[ ! ... ]`."
 source:
   shell_checks_rule: rules/SH-102.yaml
   shell_checks_example: examples/102.sh

--- a/docs/rules/C033.yaml
+++ b/docs/rules/C033.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The here-doc terminator is indented instead of starting at column 1.
 rationale: Align the terminator flush-left so the shell can recognize the end marker.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-104.yaml
   shell_checks_example: examples/104.sh

--- a/docs/rules/C033.yaml
+++ b/docs/rules/C033.yaml
@@ -12,7 +12,7 @@ shells:
 description: The here-doc terminator is indented instead of starting at column 1.
 rationale: Align the terminator flush-left so the shell can recognize the end marker.
 safe_fix: false
-fix_description: null
+fix_description: "Remove the leading indentation from the reported here-doc terminator line so it starts at column 1."
 source:
   shell_checks_rule: rules/SH-104.yaml
   shell_checks_example: examples/104.sh

--- a/docs/rules/C034.yaml
+++ b/docs/rules/C034.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: "An `if` block is opened without a matching `fi`."
 rationale: "Close the conditional with `fi` or rewrite the control flow so it is complete."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-105.yaml
   shell_checks_example: examples/105.sh

--- a/docs/rules/C035.yaml
+++ b/docs/rules/C035.yaml
@@ -12,7 +12,7 @@ shells:
 description: "An `if` block is left without its closing `fi`, which ShellCheck reports as an unmatched conditional."
 rationale: "Stop the script after the `then` body so the only issue is the missing terminator."
 safe_fix: false
-fix_description: null
+fix_description: "Append a closing `fi` at end of file."
 source:
   shell_checks_rule: rules/SH-106.yaml
   shell_checks_example: examples/106.sh

--- a/docs/rules/C035.yaml
+++ b/docs/rules/C035.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "An `if` block is left without its closing `fi`, which ShellCheck reports as an unmatched conditional."
 rationale: "Stop the script after the `then` body so the only issue is the missing terminator."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-106.yaml
   shell_checks_example: examples/106.sh

--- a/docs/rules/C036.yaml
+++ b/docs/rules/C036.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A malformed `[` test leaves ShellCheck unable to finish parsing the expression."
 rationale: Fix the test syntax first, or keep the test on one line so ShellCheck can continue checking the rest of the script.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-109.yaml
   shell_checks_example: examples/109.sh

--- a/docs/rules/C037.yaml
+++ b/docs/rules/C037.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A malformed `[` test expression leaves ShellCheck at a parser recovery boundary."
 rationale: Correct the test syntax before relying on any other static checks.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-110.yaml
   shell_checks_example: examples/110.sh

--- a/docs/rules/C038.yaml
+++ b/docs/rules/C038.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "An `if` starts on the same line as `else` instead of using `elif`."
 rationale: "Collapse the nested form into a single `elif` branch."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-112.yaml
   shell_checks_example: examples/112.sh

--- a/docs/rules/C039.yaml
+++ b/docs/rules/C039.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A double-quoted string is opened inside another quoted string and ShellCheck thinks it was never closed.
 rationale: "Avoid embedding raw shell code inside an `echo` string; use a here-doc or escape the nested quotes explicitly."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-113.yaml
   shell_checks_example: examples/113.sh

--- a/docs/rules/C039.yaml
+++ b/docs/rules/C039.yaml
@@ -12,7 +12,7 @@ shells:
 description: A double-quoted string is opened inside another quoted string and ShellCheck thinks it was never closed.
 rationale: "Avoid embedding raw shell code inside an `echo` string; use a here-doc or escape the nested quotes explicitly."
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the whole reopened quoted word as one consistent double-quoted string, escaping literal inner quotes and bracing embedded scalar expansions as needed."
 source:
   shell_checks_rule: rules/SH-113.yaml
   shell_checks_example: examples/113.sh

--- a/docs/rules/C040.yaml
+++ b/docs/rules/C040.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A `[` test is split across lines without the required line-continuation backslash."
 rationale: Keep the test on one line or add the backslash before the newline when you must split it.
 safe_fix: false
-fix_description: null
+fix_description: "Insert a trailing `\\` before the newline so the `[` test continues onto the following standalone `]` line."
 source:
   shell_checks_rule: rules/SH-115.yaml
   shell_checks_example: examples/115.sh

--- a/docs/rules/C040.yaml
+++ b/docs/rules/C040.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `[` test is split across lines without the required line-continuation backslash."
 rationale: Keep the test on one line or add the backslash before the newline when you must split it.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-115.yaml
   shell_checks_example: examples/115.sh

--- a/docs/rules/C041.yaml
+++ b/docs/rules/C041.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: C-style comment text is not a shell comment.
 rationale: "Use `#` comments in shell scripts instead of `/* ... */`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-121.yaml
   shell_checks_example: examples/121.sh

--- a/docs/rules/C041.yaml
+++ b/docs/rules/C041.yaml
@@ -12,7 +12,7 @@ shells:
 description: C-style comment text is not a shell comment.
 rationale: "Use `#` comments in shell scripts instead of `/* ... */`."
 safe_fix: false
-fix_description: null
+fix_description: "Insert `# ` before the reported `/*...` command so the rest of that shell line becomes a comment."
 source:
   shell_checks_rule: rules/SH-121.yaml
   shell_checks_example: examples/121.sh

--- a/docs/rules/C042.yaml
+++ b/docs/rules/C042.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A token like `&name` is parsed as a background operator followed by another command.
 rationale: Put a space after `&` when you mean backgrounding, or escape/quote a literal ampersand.
+safe_fix: true
+fix_description: "Insert a space after `&` so the background operator is explicit."
 source:
   shell_checks_rule: rules/SH-123.yaml
   shell_checks_example: examples/123.sh

--- a/docs/rules/C043.yaml
+++ b/docs/rules/C043.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Uses a malformed file-descriptor redirection
 rationale: "Write the redirection in a standard form like `2>&1`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-129.yaml
   shell_checks_example: examples/129.sh

--- a/docs/rules/C044.yaml
+++ b/docs/rules/C044.yaml
@@ -12,7 +12,7 @@ shells:
 description: Leaves a wildcard path unquoted in command position
 rationale: Quote the path or expand it explicitly before using it.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the wildcard command-path word in quotes."
 source:
   shell_checks_rule: rules/SH-130.yaml
   shell_checks_example: examples/130.sh

--- a/docs/rules/C044.yaml
+++ b/docs/rules/C044.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Leaves a wildcard path unquoted in command position
 rationale: Quote the path or expand it explicitly before using it.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-130.yaml
   shell_checks_example: examples/130.sh

--- a/docs/rules/C045.yaml
+++ b/docs/rules/C045.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Contains a patch-style marker line in shell code
 rationale: Remove patch headers from the script or turn them into comments.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-133.yaml
   shell_checks_example: examples/133.sh

--- a/docs/rules/C045.yaml
+++ b/docs/rules/C045.yaml
@@ -12,7 +12,7 @@ shells:
 description: Contains a patch-style marker line in shell code
 rationale: Remove patch headers from the script or turn them into comments.
 safe_fix: false
-fix_description: null
+fix_description: "Prefix the patch-marker line with `# ` to turn it into a shell comment."
 source:
   shell_checks_rule: rules/SH-133.yaml
   shell_checks_example: examples/133.sh

--- a/docs/rules/C046.yaml
+++ b/docs/rules/C046.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Pipes data into `kill`"
 rationale: "Collect the PIDs first, then pass them to `kill` directly."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-134.yaml
   shell_checks_example: examples/134.sh

--- a/docs/rules/C047.yaml
+++ b/docs/rules/C047.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Exit is given a nonnumeric status.
 rationale: Use a numeric code and print any message separately.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-141.yaml
   shell_checks_example: examples/141.sh

--- a/docs/rules/C048.yaml
+++ b/docs/rules/C048.yaml
@@ -12,7 +12,7 @@ shells:
 description: A case pattern is built from a variable.
 rationale: Use a direct test or a fixed pattern instead.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the reported case-pattern word as a single double-quoted word so its expansions are treated as literal text."
 source:
   shell_checks_rule: rules/SH-142.yaml
   shell_checks_example: examples/142.sh

--- a/docs/rules/C048.yaml
+++ b/docs/rules/C048.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A case pattern is built from a variable.
 rationale: Use a direct test or a fixed pattern instead.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-142.yaml
   shell_checks_example: examples/142.sh

--- a/docs/rules/C049.yaml
+++ b/docs/rules/C049.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The `||` chain can never fail."
 rationale: "Use the matching positive test or a `case`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-143.yaml
   shell_checks_example: examples/143.sh

--- a/docs/rules/C050.yaml
+++ b/docs/rules/C050.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: A redirection target is an arithmetic expansion.
 rationale: Write to a normal filename or redirect by descriptor.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-144.yaml
   shell_checks_example: examples/144.sh

--- a/docs/rules/C050.yaml
+++ b/docs/rules/C050.yaml
@@ -11,7 +11,7 @@ shells:
 description: A redirection target is an arithmetic expansion.
 rationale: Write to a normal filename or redirect by descriptor.
 safe_fix: false
-fix_description: null
+fix_description: "Remove the reported `++` or `--` operator from the arithmetic expression used as the redirection target."
 source:
   shell_checks_rule: rules/SH-144.yaml
   shell_checks_example: examples/144.sh

--- a/docs/rules/C051.yaml
+++ b/docs/rules/C051.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A later redirect makes an earlier one pointless.
 rationale: Keep only the final redirect.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-145.yaml
   shell_checks_example: examples/145.sh

--- a/docs/rules/C051.yaml
+++ b/docs/rules/C051.yaml
@@ -12,7 +12,7 @@ shells:
 description: A later redirect makes an earlier one pointless.
 rationale: Keep only the final redirect.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the earlier redirect that is overridden by the later redirect."
 source:
   shell_checks_rule: rules/SH-145.yaml
   shell_checks_example: examples/145.sh

--- a/docs/rules/C052.yaml
+++ b/docs/rules/C052.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: Assigning to the script-name parameter is rejected.
 rationale: Use a normal variable instead of the positional-zero parameter.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-146.yaml
   shell_checks_example: examples/146.sh

--- a/docs/rules/C053.yaml
+++ b/docs/rules/C053.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: Spaces around an assignment operator change the meaning.
 rationale: "Write assignments as `name=value` with no spaces."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-147.yaml
   shell_checks_example: examples/147.sh

--- a/docs/rules/C053.yaml
+++ b/docs/rules/C053.yaml
@@ -11,7 +11,7 @@ shells:
 description: Spaces around an assignment operator change the meaning.
 rationale: "Write assignments as `name=value` with no spaces."
 safe_fix: false
-fix_description: null
+fix_description: "Remove the spaces around `=` so the reported text becomes a single `name=value` assignment word."
 source:
   shell_checks_rule: rules/SH-147.yaml
   shell_checks_example: examples/147.sh

--- a/docs/rules/C054.yaml
+++ b/docs/rules/C054.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A lone `*/` token is not valid shell syntax."
 rationale: "Use `#` for comments and avoid stray comment-like delimiters."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-148.yaml
   shell_checks_example: examples/148.sh

--- a/docs/rules/C055.yaml
+++ b/docs/rules/C055.yaml
@@ -12,7 +12,7 @@ shells:
 description: A variable is being expanded inside a pattern expression.
 rationale: Make the pattern explicit and keep untrusted text out of pattern matching.
 safe_fix: false
-fix_description: null
+fix_description: "Double-quote the reported expansion inside the parameter-pattern operand so that fragment is matched literally."
 source:
   shell_checks_rule: rules/SH-152.yaml
   shell_checks_example: examples/152.sh

--- a/docs/rules/C055.yaml
+++ b/docs/rules/C055.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A variable is being expanded inside a pattern expression.
 rationale: Make the pattern explicit and keep untrusted text out of pattern matching.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-152.yaml
   shell_checks_example: examples/152.sh

--- a/docs/rules/C056.yaml
+++ b/docs/rules/C056.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Reads `$?` after a test command has already overwritten it."
 rationale: Save the status before running another command in the branch.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-155.yaml
   shell_checks_example: examples/155.sh

--- a/docs/rules/C057.yaml
+++ b/docs/rules/C057.yaml
@@ -12,7 +12,7 @@ shells:
 description: Runs a command substitution whose output is redirected away.
 rationale: Run the command directly if you only want the side effect.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the stdout redirection(s) from inside the command substitution so the substitution captures stdout again."
 source:
   shell_checks_rule: rules/SH-159.yaml
   shell_checks_example: examples/159.sh

--- a/docs/rules/C057.yaml
+++ b/docs/rules/C057.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Runs a command substitution whose output is redirected away.
 rationale: Run the command directly if you only want the side effect.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-159.yaml
   shell_checks_example: examples/159.sh

--- a/docs/rules/C058.yaml
+++ b/docs/rules/C058.yaml
@@ -12,7 +12,7 @@ shells:
 description: Runs a command substitution with redirected output in the subshell.
 rationale: Keep the redirect outside the substitution if possible.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the stdout-to-`/dev/null` redirection(s) from inside the command substitution so the substitution can capture stdout again."
 source:
   shell_checks_rule: rules/SH-160.yaml
   shell_checks_example: examples/160.sh

--- a/docs/rules/C058.yaml
+++ b/docs/rules/C058.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Runs a command substitution with redirected output in the subshell.
 rationale: Keep the redirect outside the substitution if possible.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-160.yaml
   shell_checks_example: examples/160.sh

--- a/docs/rules/C059.yaml
+++ b/docs/rules/C059.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Redirects output to a filename that shadows a known command.
 rationale: Use a distinct filename or a path prefix to avoid overwriting a command.
+safe_fix: true
+fix_description: "Prefix the redirection target with `./` to make it an explicit relative path."
 source:
   shell_checks_rule: rules/SH-165.yaml
   shell_checks_example: examples/165.sh

--- a/docs/rules/C060.yaml
+++ b/docs/rules/C060.yaml
@@ -12,7 +12,7 @@ shells:
 description: The shebang line does not start with an absolute path.
 rationale: Use an absolute interpreter path or /usr/bin/env in the shebang.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the shebang to `#!/usr/bin/env <interpreter>` using the current interpreter word’s basename and preserving any trailing shebang arguments."
 source:
   shell_checks_rule: rules/SH-166.yaml
   shell_checks_example: examples/166.sh

--- a/docs/rules/C060.yaml
+++ b/docs/rules/C060.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The shebang line does not start with an absolute path.
 rationale: Use an absolute interpreter path or /usr/bin/env in the shebang.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-166.yaml
   shell_checks_example: examples/166.sh

--- a/docs/rules/C061.yaml
+++ b/docs/rules/C061.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A template placeholder with double braces appears in command position.
 rationale: Replace the template variable before running the script.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-167.yaml
   shell_checks_example: examples/167.sh

--- a/docs/rules/C062.yaml
+++ b/docs/rules/C062.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A parameter expansion is nested inside another expansion.
 rationale: Use an intermediate variable instead of nesting expansions.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-169.yaml
   shell_checks_example: examples/169.sh

--- a/docs/rules/C063.yaml
+++ b/docs/rules/C063.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A local function definition is overwritten before any reachable direct call can resolve to it.
 rationale: Remove the dead definition, rename one version, or call it before the later local definition replaces it.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-171.yaml
   shell_checks_example: examples/171.sh

--- a/docs/rules/C063.yaml
+++ b/docs/rules/C063.yaml
@@ -12,7 +12,7 @@ shells:
 description: A local function definition is overwritten before any reachable direct call can resolve to it.
 rationale: Remove the dead definition, rename one version, or call it before the later local definition replaces it.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the earlier function definition that is overwritten before any direct call reaches it."
 source:
   shell_checks_rule: rules/SH-171.yaml
   shell_checks_example: examples/171.sh

--- a/docs/rules/C064.yaml
+++ b/docs/rules/C064.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "An if-test block is written without a `then` keyword."
 rationale: "Add `then` after the condition to form a valid if-block."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-175.yaml
   shell_checks_example: examples/175.sh

--- a/docs/rules/C065.yaml
+++ b/docs/rules/C065.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "An `else` clause appears without a preceding `then`."
 rationale: "Add `then` after the condition so that `else` is valid."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-176.yaml
   shell_checks_example: examples/176.sh

--- a/docs/rules/C066.yaml
+++ b/docs/rules/C066.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A closing brace follows a command without a semicolon or newline.
 rationale: "Add a semicolon before `}` so the shell sees the end of the group."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-177.yaml
   shell_checks_example: examples/177.sh

--- a/docs/rules/C067.yaml
+++ b/docs/rules/C067.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A function body contains no commands.
 rationale: "Add a colon or `true` as a placeholder command."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-178.yaml
   shell_checks_example: examples/178.sh

--- a/docs/rules/C068.yaml
+++ b/docs/rules/C068.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A closing brace is not preceded by a semicolon or newline.
 rationale: "Put a semicolon or newline before `}` to terminate the command."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-179.yaml
   shell_checks_example: examples/179.sh

--- a/docs/rules/C069.yaml
+++ b/docs/rules/C069.yaml
@@ -12,7 +12,7 @@ shells:
 description: A backslash-space appears right before a closing backtick.
 rationale: "Use `$( ... )` instead of backticks for cleaner quoting."
 safe_fix: false
-fix_description: null
+fix_description: "Delete the backslash before the trailing spaces at the end of the backtick command substitution."
 source:
   shell_checks_rule: rules/SH-186.yaml
   shell_checks_example: examples/186.sh

--- a/docs/rules/C069.yaml
+++ b/docs/rules/C069.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A backslash-space appears right before a closing backtick.
 rationale: "Use `$( ... )` instead of backticks for cleaner quoting."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-186.yaml
   shell_checks_example: examples/186.sh

--- a/docs/rules/C070.yaml
+++ b/docs/rules/C070.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A positional parameter is used as an arithmetic operator.
 rationale: Pass the operator as a distinct argument or use a case dispatch.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-187.yaml
   shell_checks_example: examples/187.sh

--- a/docs/rules/C071.yaml
+++ b/docs/rules/C071.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Double parentheses are used to group commands instead of arithmetic.
 rationale: "Use a subshell `( ... )` or brace group `{ ...; }` for grouping."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-188.yaml
   shell_checks_example: examples/188.sh

--- a/docs/rules/C071.yaml
+++ b/docs/rules/C071.yaml
@@ -12,7 +12,7 @@ shells:
 description: Double parentheses are used to group commands instead of arithmetic.
 rationale: "Use a subshell `( ... )` or brace group `{ ...; }` for grouping."
 safe_fix: false
-fix_description: null
+fix_description: "Insert a space after the first `(` so the leading `((` becomes `( (` and parses as a subshell group."
 source:
   shell_checks_rule: rules/SH-188.yaml
   shell_checks_example: examples/188.sh

--- a/docs/rules/C072.yaml
+++ b/docs/rules/C072.yaml
@@ -12,7 +12,7 @@ shells:
 description: A Unicode smart quote appears inside a shell string.
 rationale: Replace the Unicode quotation mark with an ASCII equivalent.
 safe_fix: false
-fix_description: null
+fix_description: "Replace each reported Unicode smart quote with the matching ASCII quote character (`'` for `‘` or `’`, `\"` for `“` or `”`)."
 source:
   shell_checks_rule: rules/SH-189.yaml
   shell_checks_example: examples/189.sh

--- a/docs/rules/C072.yaml
+++ b/docs/rules/C072.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A Unicode smart quote appears inside a shell string.
 rationale: Replace the Unicode quotation mark with an ASCII equivalent.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-189.yaml
   shell_checks_example: examples/189.sh

--- a/docs/rules/C073.yaml
+++ b/docs/rules/C073.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The shebang line is indented with leading whitespace.
 rationale: Move the shebang to column 1 so the kernel recognises it.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-191.yaml
   shell_checks_example: examples/191.sh

--- a/docs/rules/C073.yaml
+++ b/docs/rules/C073.yaml
@@ -12,7 +12,7 @@ shells:
 description: The shebang line is indented with leading whitespace.
 rationale: Move the shebang to column 1 so the kernel recognises it.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the leading whitespace before the shebang candidate line."
 source:
   shell_checks_rule: rules/SH-191.yaml
   shell_checks_example: examples/191.sh

--- a/docs/rules/C074.yaml
+++ b/docs/rules/C074.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The shebang has a space between `#` and `!`."
 rationale: "Write `#!` without a space so the kernel treats it as a shebang."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-192.yaml
   shell_checks_example: examples/192.sh

--- a/docs/rules/C074.yaml
+++ b/docs/rules/C074.yaml
@@ -12,7 +12,7 @@ shells:
 description: "The shebang has a space between `#` and `!`."
 rationale: "Write `#!` without a space so the kernel treats it as a shebang."
 safe_fix: false
-fix_description: null
+fix_description: "Delete the whitespace between `#` and `!` so the line starts with `#!`."
 source:
   shell_checks_rule: rules/SH-192.yaml
   shell_checks_example: examples/192.sh

--- a/docs/rules/C075.yaml
+++ b/docs/rules/C075.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The shebang does not appear on the first line of the file.
 rationale: Move the shebang to the very first line of the file.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-193.yaml
   shell_checks_example: examples/193.sh

--- a/docs/rules/C075.yaml
+++ b/docs/rules/C075.yaml
@@ -12,7 +12,7 @@ shells:
 description: The shebang does not appear on the first line of the file.
 rationale: Move the shebang to the very first line of the file.
 safe_fix: false
-fix_description: null
+fix_description: "Move the reported shebang line to the top of the file."
 source:
   shell_checks_rule: rules/SH-193.yaml
   shell_checks_example: examples/193.sh

--- a/docs/rules/C076.yaml
+++ b/docs/rules/C076.yaml
@@ -12,7 +12,7 @@ shells:
 description: A line continuation is followed by a commented-out argument.
 rationale: Remove the continuation backslash or uncomment the line.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the trailing backslash from the comment-only continuation line."
 source:
   shell_checks_rule: rules/SH-194.yaml
   shell_checks_example: examples/194.sh

--- a/docs/rules/C076.yaml
+++ b/docs/rules/C076.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A line continuation is followed by a commented-out argument.
 rationale: Remove the continuation backslash or uncomment the line.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-194.yaml
   shell_checks_example: examples/194.sh

--- a/docs/rules/C077.yaml
+++ b/docs/rules/C077.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A command substitution is nested inside an arithmetic expansion.
 rationale: Assign the command output to a variable first, then use it in the arithmetic.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-195.yaml
   shell_checks_example: examples/195.sh

--- a/docs/rules/C078.yaml
+++ b/docs/rules/C078.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "An unquoted variable and glob appear in a `find -exec` command."
 rationale: "Quote variables and escape globs passed to `find`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-200.yaml
   shell_checks_example: examples/200.sh

--- a/docs/rules/C078.yaml
+++ b/docs/rules/C078.yaml
@@ -12,7 +12,7 @@ shells:
 description: "An unquoted variable and glob appear in a `find -exec` command."
 rationale: "Quote variables and escape globs passed to `find`."
 safe_fix: false
-fix_description: null
+fix_description: "Quote the entire `find -exec` argument word that contains the reported unquoted glob or command substitution."
 source:
   shell_checks_rule: rules/SH-200.yaml
   shell_checks_example: examples/200.sh

--- a/docs/rules/C080.yaml
+++ b/docs/rules/C080.yaml
@@ -12,7 +12,7 @@ shells:
 description: A glob character inside a grep pattern may be expanded by the shell.
 rationale: Quote the pattern to prevent glob expansion.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the reported grep pattern by changing each glob-style `*` to regex `.*`."
 source:
   shell_checks_rule: rules/SH-204.yaml
   shell_checks_example: examples/204.sh

--- a/docs/rules/C080.yaml
+++ b/docs/rules/C080.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A glob character inside a grep pattern may be expanded by the shell.
 rationale: Quote the pattern to prevent glob expansion.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-204.yaml
   shell_checks_example: examples/204.sh

--- a/docs/rules/C081.yaml
+++ b/docs/rules/C081.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A variable used in a string comparison may be treated as a glob.
 rationale: Quote the variable to prevent pattern matching.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-206.yaml
   shell_checks_example: examples/206.sh

--- a/docs/rules/C081.yaml
+++ b/docs/rules/C081.yaml
@@ -12,7 +12,7 @@ shells:
 description: A variable used in a string comparison may be treated as a glob.
 rationale: Quote the variable to prevent pattern matching.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the reported right-hand variable-like operand in double quotes."
 source:
   shell_checks_rule: rules/SH-206.yaml
   shell_checks_example: examples/206.sh

--- a/docs/rules/C082.yaml
+++ b/docs/rules/C082.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A backslash-escaped `!` is used in a test expression."
 rationale: "Use `!` without the backslash for negation in test."
+safe_fix: true
+fix_description: "Remove the backslash before the leading `!` in the test expression."
 source:
   shell_checks_rule: rules/SH-207.yaml
   shell_checks_example: examples/207.sh

--- a/docs/rules/C083.yaml
+++ b/docs/rules/C083.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A glob pattern inside a `find` command substitution may expand early."
 rationale: "Quote the glob or use `find -name '*.ext'` with quotes."
 safe_fix: false
-fix_description: null
+fix_description: "Quote the entire reported `find` pattern operand."
 source:
   shell_checks_rule: rules/SH-209.yaml
   shell_checks_example: examples/209.sh

--- a/docs/rules/C083.yaml
+++ b/docs/rules/C083.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A glob pattern inside a `find` command substitution may expand early."
 rationale: "Quote the glob or use `find -name '*.ext'` with quotes."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-209.yaml
   shell_checks_example: examples/209.sh

--- a/docs/rules/C084.yaml
+++ b/docs/rules/C084.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A grep regex contains characters that may be glob-expanded.
 rationale: Quote the regex argument to prevent shell expansion.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-210.yaml
   shell_checks_example: examples/210.sh

--- a/docs/rules/C084.yaml
+++ b/docs/rules/C084.yaml
@@ -12,7 +12,7 @@ shells:
 description: A grep regex contains characters that may be glob-expanded.
 rationale: Quote the regex argument to prevent shell expansion.
 safe_fix: false
-fix_description: null
+fix_description: "Quote the entire reported grep pattern word."
 source:
   shell_checks_rule: rules/SH-210.yaml
   shell_checks_example: examples/210.sh

--- a/docs/rules/C085.yaml
+++ b/docs/rules/C085.yaml
@@ -12,7 +12,7 @@ shells:
 description: Standard error is redirected before standard output is redirected.
 rationale: "Redirect stdout first, then stderr, or use `&>`."
 safe_fix: false
-fix_description: null
+fix_description: "Move the reported `2>&1` redirect to after the command's stdout-to-file redirects."
 source:
   shell_checks_rule: rules/SH-211.yaml
   shell_checks_example: examples/211.sh

--- a/docs/rules/C085.yaml
+++ b/docs/rules/C085.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Standard error is redirected before standard output is redirected.
 rationale: "Redirect stdout first, then stderr, or use `&>`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-211.yaml
   shell_checks_example: examples/211.sh

--- a/docs/rules/C086.yaml
+++ b/docs/rules/C086.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A numeric comparison uses `<` or `>` instead of `-lt` or `-gt`."
 rationale: "Use `-lt` or `-gt` for integer comparisons. Inside `[ ]`, raw `<` or `>` redirects instead of comparing; inside `[[ ]]`, they order text lexicographically."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-213.yaml
   shell_checks_example: examples/213.sh

--- a/docs/rules/C086.yaml
+++ b/docs/rules/C086.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A numeric comparison uses `<` or `>` instead of `-lt` or `-gt`."
 rationale: "Use `-lt` or `-gt` for integer comparisons. Inside `[ ]`, raw `<` or `>` redirects instead of comparing; inside `[[ ]]`, they order text lexicographically."
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported `<` or `>` operator with `-lt` or `-gt`."
 source:
   shell_checks_rule: rules/SH-213.yaml
   shell_checks_example: examples/213.sh

--- a/docs/rules/C087.yaml
+++ b/docs/rules/C087.yaml
@@ -10,6 +10,8 @@ shells:
   - dash
 description: "A `<` or `>` operator inside `[[ ]]` compares lexicographically, not numerically."
 rationale: "Use `-lt` for numeric comparison or a version-aware tool."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-214.yaml
   shell_checks_example: examples/214.sh

--- a/docs/rules/C088.yaml
+++ b/docs/rules/C088.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: "A `[[ ]]` test mixes `&&` and `||` without grouping."
 rationale: Add explicit parentheses to clarify operator precedence.
+safe_fix: true
+fix_description: "Add parentheses around the parsed `&&`/`||` subexpression to make the current grouping explicit."
 source:
   shell_checks_rule: rules/SH-215.yaml
   shell_checks_example: examples/215.sh

--- a/docs/rules/C089.yaml
+++ b/docs/rules/C089.yaml
@@ -11,7 +11,7 @@ shells:
 description: A command pipeline is quoted as a string inside a test bracket.
 rationale: Remove the quotes and use command substitution or a variable.
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported quoted pipeline literal with a quoted command substitution of the same text, for example `\"cmd | grep x\"` to `\"$(cmd | grep x)\"`."
 source:
   shell_checks_rule: rules/SH-216.yaml
   shell_checks_example: examples/216.sh

--- a/docs/rules/C089.yaml
+++ b/docs/rules/C089.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: A command pipeline is quoted as a string inside a test bracket.
 rationale: Remove the quotes and use command substitution or a variable.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-216.yaml
   shell_checks_example: examples/216.sh

--- a/docs/rules/C090.yaml
+++ b/docs/rules/C090.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A glob pattern on the right side of `==` inside `[ ]` is not expanded."
 rationale: "Use `[[ ]]` or `case` for pattern matching."
 safe_fix: false
-fix_description: null
+fix_description: "Double-quote the reported right-hand glob operand so the `[ ... ]` comparison becomes a literal string comparison."
 source:
   shell_checks_rule: rules/SH-217.yaml
   shell_checks_example: examples/217.sh

--- a/docs/rules/C090.yaml
+++ b/docs/rules/C090.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A glob pattern on the right side of `==` inside `[ ]` is not expanded."
 rationale: "Use `[[ ]]` or `case` for pattern matching."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-217.yaml
   shell_checks_example: examples/217.sh

--- a/docs/rules/C091.yaml
+++ b/docs/rules/C091.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A literal tilde inside quotes is compared instead of the expanded home path.
 rationale: "Expand the tilde outside quotes or use `$HOME`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-219.yaml
   shell_checks_example: examples/219.sh

--- a/docs/rules/C091.yaml
+++ b/docs/rules/C091.yaml
@@ -12,7 +12,7 @@ shells:
 description: A literal tilde inside quotes is compared instead of the expanded home path.
 rationale: "Expand the tilde outside quotes or use `$HOME`."
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the reported quoted `~/...` operand as a double-quoted `$HOME/...` operand."
 source:
   shell_checks_rule: rules/SH-219.yaml
   shell_checks_example: examples/219.sh

--- a/docs/rules/C092.yaml
+++ b/docs/rules/C092.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The output of a command substitution is used as a condition.
 rationale: "Remove the `$( )` wrapper and test the command exit status directly."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-220.yaml
   shell_checks_example: examples/220.sh

--- a/docs/rules/C092.yaml
+++ b/docs/rules/C092.yaml
@@ -12,7 +12,7 @@ shells:
 description: The output of a command substitution is used as a condition.
 rationale: "Remove the `$( )` wrapper and test the command exit status directly."
 safe_fix: false
-fix_description: null
+fix_description: "Remove the surrounding `$(` and `)` from the reported condition command substitution."
 source:
   shell_checks_rule: rules/SH-220.yaml
   shell_checks_example: examples/220.sh

--- a/docs/rules/C093.yaml
+++ b/docs/rules/C093.yaml
@@ -12,7 +12,7 @@ shells:
 description: A backtick command substitution is used as a command name.
 rationale: Remove the backticks and run the command directly or use a variable.
 safe_fix: false
-fix_description: null
+fix_description: "Remove the surrounding backticks from the reported command substitution so the inner command runs directly."
 source:
   shell_checks_rule: rules/SH-221.yaml
   shell_checks_example: examples/221.sh

--- a/docs/rules/C093.yaml
+++ b/docs/rules/C093.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A backtick command substitution is used as a command name.
 rationale: Remove the backticks and run the command directly or use a variable.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-221.yaml
   shell_checks_example: examples/221.sh

--- a/docs/rules/C094.yaml
+++ b/docs/rules/C094.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A command reads and writes the same file via redirection.
 rationale: "Use a temporary file or `sponge` to avoid truncating the input."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-222.yaml
   shell_checks_example: examples/222.sh

--- a/docs/rules/C095.yaml
+++ b/docs/rules/C095.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An assignment value contains a dash that may indicate a typo.
 rationale: Check whether the value was intended as a flag or comparison.
+safe_fix: true
+fix_description: "Quote the literal assignment value so it is explicitly a string."
 source:
   shell_checks_rule: rules/SH-224.yaml
   shell_checks_example: examples/224.sh

--- a/docs/rules/C096.yaml
+++ b/docs/rules/C096.yaml
@@ -12,7 +12,7 @@ shells:
 description: Bracket globs only match individual characters, not whole words or word-like lists.
 rationale: Quote bracketed text like `[appname]` when you mean it literally, or rewrite it as a real single-character pattern.
 safe_fix: false
-fix_description: null
+fix_description: "Single-quote the reported bracket-glob fragment so it is treated as literal text."
 source:
   shell_checks_rule: rules/SH-225.yaml
   shell_checks_example: examples/225.sh

--- a/docs/rules/C096.yaml
+++ b/docs/rules/C096.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Bracket globs only match individual characters, not whole words or word-like lists.
 rationale: Quote bracketed text like `[appname]` when you mean it literally, or rewrite it as a real single-character pattern.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-225.yaml
   shell_checks_example: examples/225.sh

--- a/docs/rules/C097.yaml
+++ b/docs/rules/C097.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A function that reads positional parameters is called with no arguments.
 rationale: Pass the expected arguments or guard against missing parameters.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-228.yaml
   shell_checks_example: examples/228.sh

--- a/docs/rules/C098.yaml
+++ b/docs/rules/C098.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Flags are passed to `set` without a leading dash."
 rationale: "Add a dash before the flags: `set -euo pipefail`."
+safe_fix: true
+fix_description: "Insert `--` before the first bare operand so `set` explicitly assigns positional parameters."
 source:
   shell_checks_rule: rules/SH-229.yaml
   shell_checks_example: examples/229.sh

--- a/docs/rules/C099.yaml
+++ b/docs/rules/C099.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An array slice is quoted, preventing word splitting of the elements.
 rationale: "Use `${@:N}` without surrounding double quotes if splitting is needed."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-230.yaml
   shell_checks_example: examples/230.sh

--- a/docs/rules/C099.yaml
+++ b/docs/rules/C099.yaml
@@ -12,7 +12,7 @@ shells:
 description: An array slice is quoted, preventing word splitting of the elements.
 rationale: "Use `${@:N}` without surrounding double quotes if splitting is needed."
 safe_fix: false
-fix_description: null
+fix_description: "Remove the double quotes that keep the reported all-elements array slice quoted inside the scalar assignment value."
 source:
   shell_checks_rule: rules/SH-230.yaml
   shell_checks_example: examples/230.sh

--- a/docs/rules/C100.yaml
+++ b/docs/rules/C100.yaml
@@ -12,7 +12,7 @@ shells:
 description: "`$BASH_SOURCE` is quoted without array syntax."
 rationale: "Use `${BASH_SOURCE[0]}` for the current script path."
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported quoted `$BASH_SOURCE` or `${BASH_SOURCE}` expansion with `${BASH_SOURCE[0]}`."
 source:
   shell_checks_rule: rules/SH-232.yaml
   shell_checks_example: examples/232.sh

--- a/docs/rules/C100.yaml
+++ b/docs/rules/C100.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "`$BASH_SOURCE` is quoted without array syntax."
 rationale: "Use `${BASH_SOURCE[0]}` for the current script path."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-232.yaml
   shell_checks_example: examples/232.sh

--- a/docs/rules/C101.yaml
+++ b/docs/rules/C101.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: IFS contains literal backslashes instead of separator characters.
 rationale: Backslashes stay literal in IFS. Use real separator characters, `$'...'` in bash, or `printf` when you need escapes.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-234.yaml
   shell_checks_example: examples/234.sh

--- a/docs/rules/C102.yaml
+++ b/docs/rules/C102.yaml
@@ -11,7 +11,7 @@ shells:
 description: "A glob pattern inside a unary file test may match multiple paths."
 rationale: Quote the path or use a loop to test each match.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the reported file-test operand as a single double-quoted word so the glob is treated literally."
 source:
   shell_checks_rule: rules/SH-236.yaml
   shell_checks_example: examples/236.sh

--- a/docs/rules/C102.yaml
+++ b/docs/rules/C102.yaml
@@ -10,6 +10,8 @@ shells:
   - dash
 description: "A glob pattern inside a unary file test may match multiple paths."
 rationale: Quote the path or use a loop to test each match.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-236.yaml
   shell_checks_example: examples/236.sh

--- a/docs/rules/C103.yaml
+++ b/docs/rules/C103.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `find` command uses `-o` without grouping the alternatives."
 rationale: "Add parentheses around the `-o` alternatives in `find`."
+safe_fix: true
+fix_description: "Wrap the action-bearing `find` branch in escaped parentheses to make the existing precedence explicit."
 source:
   shell_checks_rule: rules/SH-237.yaml
   shell_checks_example: examples/237.sh

--- a/docs/rules/C104.yaml
+++ b/docs/rules/C104.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A line of C or other non-shell code appears in a shell script.
 rationale: Remove the non-shell code or move it to a separate file.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-238.yaml
   shell_checks_example: examples/238.sh

--- a/docs/rules/C104.yaml
+++ b/docs/rules/C104.yaml
@@ -12,7 +12,7 @@ shells:
 description: A line of C or other non-shell code appears in a shell script.
 rationale: Remove the non-shell code or move it to a separate file.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the whole semicolon-terminated declaration-like simple command."
 source:
   shell_checks_rule: rules/SH-238.yaml
   shell_checks_example: examples/238.sh

--- a/docs/rules/C105.yaml
+++ b/docs/rules/C105.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The `export` command is called with `$@` which may not work as intended."
 rationale: Export specific variable names rather than positional parameters.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-239.yaml
   shell_checks_example: examples/239.sh

--- a/docs/rules/C106.yaml
+++ b/docs/rules/C106.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A string is appended to an array variable with `+=` and a space."
 rationale: "Use `+=()` syntax to append an element to an array."
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the append assignment to array-element form by wrapping the existing scalar RHS in `(...)`, for example `items+=\" two\"` to `items+=(\" two\")`."
 source:
   shell_checks_rule: rules/SH-241.yaml
   shell_checks_example: examples/241.sh

--- a/docs/rules/C106.yaml
+++ b/docs/rules/C106.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A string is appended to an array variable with `+=` and a space."
 rationale: "Use `+=()` syntax to append an element to an array."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-241.yaml
   shell_checks_example: examples/241.sh

--- a/docs/rules/C107.yaml
+++ b/docs/rules/C107.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A test command reads `$?` instead of checking the earlier command directly."
 rationale: "Test the command directly, or save its status before using it elsewhere."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-242.yaml
   shell_checks_example: examples/242.sh

--- a/docs/rules/C108.yaml
+++ b/docs/rules/C108.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An array-subscript operand is passed to `unset` without being kept literal.
 rationale: "Quote the whole operand, such as `unset 'arr[key]'`, so bracket text is not treated as a pattern."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-243.yaml
   shell_checks_example: examples/243.sh

--- a/docs/rules/C108.yaml
+++ b/docs/rules/C108.yaml
@@ -12,7 +12,7 @@ shells:
 description: An array-subscript operand is passed to `unset` without being kept literal.
 rationale: "Quote the whole operand, such as `unset 'arr[key]'`, so bracket text is not treated as a pattern."
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the reported `unset` operand as a single double-quoted word, for example `unset parts[$key]` to `unset \"parts[$key]\"`."
 source:
   shell_checks_rule: rules/SH-243.yaml
   shell_checks_example: examples/243.sh

--- a/docs/rules/C109.yaml
+++ b/docs/rules/C109.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `mapfile` command reads from a process substitution."
 rationale: Use a pipe or temporary file if the shell version does not support this.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-244.yaml
   shell_checks_example: examples/244.sh

--- a/docs/rules/C110.yaml
+++ b/docs/rules/C110.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A test expression contains `=` that looks like an assignment."
 rationale: Remove the embedded assignment from the test condition.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-246.yaml
   shell_checks_example: examples/246.sh

--- a/docs/rules/C110.yaml
+++ b/docs/rules/C110.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A test expression contains `=` that looks like an assignment."
 rationale: Remove the embedded assignment from the test condition.
 safe_fix: false
-fix_description: null
+fix_description: "Remove the leading `name=` affix from each reported quoted comparison operand, for example `\"QT6=${QT6:-no}\"` to `\"${QT6:-no}\"`."
 source:
   shell_checks_rule: rules/SH-246.yaml
   shell_checks_example: examples/246.sh

--- a/docs/rules/C111.yaml
+++ b/docs/rules/C111.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Quoting `$@` as a `[ ... ]` or `test` operand folds all arguments together."
 rationale: Use a loop or inspect the arguments one at a time instead.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-249.yaml
   shell_checks_example: examples/249.sh

--- a/docs/rules/C111.yaml
+++ b/docs/rules/C111.yaml
@@ -12,7 +12,7 @@ shells:
 description: "Quoting `$@` as a `[ ... ]` or `test` operand folds all arguments together."
 rationale: Use a loop or inspect the arguments one at a time instead.
 safe_fix: false
-fix_description: null
+fix_description: "Replace each reported positional `@` splat with the corresponding `*` form, for example `\"$@\"` to `\"$*\"` and `\"${@:-x}\"` to `\"${*:-x}\"`."
 source:
   shell_checks_rule: rules/SH-249.yaml
   shell_checks_example: examples/249.sh

--- a/docs/rules/C112.yaml
+++ b/docs/rules/C112.yaml
@@ -12,7 +12,7 @@ shells:
 description: An all-elements array expansion is used inside a `[[ ... ]]` test.
 rationale: Compare individual elements or join the array deliberately before testing it.
 safe_fix: false
-fix_description: null
+fix_description: "Replace each reported all-elements `@` expansion with the corresponding `*` form, for example `\"$@\"` to `\"$*\"` and `\"${arr[@]}\"` to `\"${arr[*]}\"`."
 source:
   shell_checks_rule: rules/SH-250.yaml
   shell_checks_example: examples/250.sh

--- a/docs/rules/C112.yaml
+++ b/docs/rules/C112.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An all-elements array expansion is used inside a `[[ ... ]]` test.
 rationale: Compare individual elements or join the array deliberately before testing it.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-250.yaml
   shell_checks_example: examples/250.sh

--- a/docs/rules/C114.yaml
+++ b/docs/rules/C114.yaml
@@ -12,7 +12,7 @@ shells:
 description: A glob pattern with an embedded variable is used in a for loop.
 rationale: "Quote the variable portion or use `find` for reliable matching."
 safe_fix: false
-fix_description: null
+fix_description: "Wrap each reported unquoted expansion prefix in double quotes."
 source:
   shell_checks_rule: rules/SH-254.yaml
   shell_checks_example: examples/254.sh

--- a/docs/rules/C114.yaml
+++ b/docs/rules/C114.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A glob pattern with an embedded variable is used in a for loop.
 rationale: "Quote the variable portion or use `find` for reliable matching."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-254.yaml
   shell_checks_example: examples/254.sh

--- a/docs/rules/C116.yaml
+++ b/docs/rules/C116.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A numeric string is used as a variable name in an assignment.
 rationale: Use a valid variable name that starts with a letter or underscore.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-258.yaml
   shell_checks_example: examples/258.sh

--- a/docs/rules/C117.yaml
+++ b/docs/rules/C117.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `+` character precedes a variable assignment."
 rationale: "Remove the leading `+` or use valid assignment syntax."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-259.yaml
   shell_checks_example: examples/259.sh

--- a/docs/rules/C118.yaml
+++ b/docs/rules/C118.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An arithmetic expansion inside a conditional test is malformed.
 rationale: "Close the `[[ ]]` properly and use `$(( ))` correctly."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-284.yaml
   shell_checks_example: examples/284.sh

--- a/docs/rules/C119.yaml
+++ b/docs/rules/C119.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A redirect placed before a pipe only affects the left-hand side.
 rationale: Place the redirect after the full pipeline or use a subshell.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-285.yaml
   shell_checks_example: examples/285.sh

--- a/docs/rules/C119.yaml
+++ b/docs/rules/C119.yaml
@@ -12,7 +12,7 @@ shells:
 description: A redirect placed before a pipe only affects the left-hand side.
 rationale: Place the redirect after the full pipeline or use a subshell.
 safe_fix: false
-fix_description: null
+fix_description: "Move the reported stdout redirect from the left pipeline segment to the end of the full pipeline, preserving its operator and target."
 source:
   shell_checks_rule: rules/SH-285.yaml
   shell_checks_example: examples/285.sh

--- a/docs/rules/C120.yaml
+++ b/docs/rules/C120.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "An `expr` string helper is used instead of shell string operations."
 rationale: Prefer shell builtins or parameter expansion over `expr` string helpers.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-287.yaml
   shell_checks_example: examples/287.sh

--- a/docs/rules/C121.yaml
+++ b/docs/rules/C121.yaml
@@ -10,7 +10,7 @@ shells:
 description: "A `[[ ... ]]` numeric comparison uses text instead of a number."
 rationale: "Use `=` or `!=` for text comparisons, or expand arithmetic expressions explicitly before comparing numerically."
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the surrounding `[[ ... -eq/-ne ... ]]` comparison to `=` or `!=` and quote any reported unquoted string-like operand."
 source:
   shell_checks_rule: rules/SH-288.yaml
   shell_checks_example: examples/288.sh

--- a/docs/rules/C121.yaml
+++ b/docs/rules/C121.yaml
@@ -9,6 +9,8 @@ shells:
   - ksh
 description: "A `[[ ... ]]` numeric comparison uses text instead of a number."
 rationale: "Use `=` or `!=` for text comparisons, or expand arithmetic expressions explicitly before comparing numerically."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-288.yaml
   shell_checks_example: examples/288.sh

--- a/docs/rules/C122.yaml
+++ b/docs/rules/C122.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The `-a` flag inside `[[ ]]` is ambiguous in POSIX sh."
 rationale: "Use `-e` for file existence or `&&` for boolean conjunction."
+safe_fix: true
+fix_description: "Replace unary `-a` with `-e` inside the `[[ ... ]]` test."
 source:
   shell_checks_rule: rules/SH-290.yaml
   shell_checks_example: examples/290.sh

--- a/docs/rules/C123.yaml
+++ b/docs/rules/C123.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A function references a positional parameter that is never passed by callers.
 rationale: Pass the expected arguments at every call site.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-292.yaml
   shell_checks_example: examples/292.sh

--- a/docs/rules/C124.yaml
+++ b/docs/rules/C124.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Code appears after all branches exit, making it unreachable.
 rationale: Remove the dead code or restructure the control flow.
+safe_fix: true
+fix_description: "Delete the unreachable statement or definition."
 source:
   shell_checks_rule: rules/SH-293.yaml
   shell_checks_example: examples/293.sh

--- a/docs/rules/C125.yaml
+++ b/docs/rules/C125.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Code changes back with `cd` instead of isolating the directory change."
 rationale: "Run directory-sensitive work in a subshell so the caller's working directory is restored automatically."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-295.yaml
   shell_checks_example: examples/295.sh

--- a/docs/rules/C126.yaml
+++ b/docs/rules/C126.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A `continue` statement appears inside a function but outside a loop."
 rationale: "Use `return` instead of `continue` to exit the function early."
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported `continue` keyword with `return`, preserving any numeric argument."
 source:
   shell_checks_rule: rules/SH-296.yaml
   shell_checks_example: examples/296.sh

--- a/docs/rules/C126.yaml
+++ b/docs/rules/C126.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `continue` statement appears inside a function but outside a loop."
 rationale: "Use `return` instead of `continue` to exit the function early."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-296.yaml
   shell_checks_example: examples/296.sh

--- a/docs/rules/C127.yaml
+++ b/docs/rules/C127.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A here-document is opened without a consuming command.
 rationale: "Prefix the here-doc with a command like `cat` or `:` if the text is intentional."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-298.yaml
   shell_checks_example: examples/298.sh

--- a/docs/rules/C127.yaml
+++ b/docs/rules/C127.yaml
@@ -12,7 +12,7 @@ shells:
 description: A here-document is opened without a consuming command.
 rationale: "Prefix the here-doc with a command like `cat` or `:` if the text is intentional."
 safe_fix: false
-fix_description: null
+fix_description: "Delete the unused here-document redirect and its body."
 source:
   shell_checks_rule: rules/SH-298.yaml
   shell_checks_example: examples/298.sh

--- a/docs/rules/C128.yaml
+++ b/docs/rules/C128.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A case glob pattern may shadow a later arm.
 rationale: Reorder case arms so more specific patterns come first.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-301.yaml
   shell_checks_example: examples/301.sh

--- a/docs/rules/C128.yaml
+++ b/docs/rules/C128.yaml
@@ -12,7 +12,7 @@ shells:
 description: A case glob pattern may shadow a later arm.
 rationale: Reorder case arms so more specific patterns come first.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the reported shadowing case-pattern alternative; if that leaves the arm with no patterns, delete the arm."
 source:
   shell_checks_rule: rules/SH-301.yaml
   shell_checks_example: examples/301.sh

--- a/docs/rules/C129.yaml
+++ b/docs/rules/C129.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A default case label appears before a glob that also matches it.
 rationale: Put the default or catch-all pattern last.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-302.yaml
   shell_checks_example: examples/302.sh

--- a/docs/rules/C129.yaml
+++ b/docs/rules/C129.yaml
@@ -12,7 +12,7 @@ shells:
 description: A default case label appears before a glob that also matches it.
 rationale: Put the default or catch-all pattern last.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the reported shadowed case-pattern alternative; if it is the arm's only pattern, delete the arm."
 source:
   shell_checks_rule: rules/SH-302.yaml
   shell_checks_example: examples/302.sh

--- a/docs/rules/C130.yaml
+++ b/docs/rules/C130.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "An assignment stores shell-style quotes or escapes that later expansion will not re-parse."
 rationale: Build argv with arrays, `set --`, or helper functions instead of storing shell quoting in a scalar.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-307.yaml
   shell_checks_example: examples/307.sh

--- a/docs/rules/C131.yaml
+++ b/docs/rules/C131.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An unquoted expansion reuses a variable that stores shell-style quoting or escapes.
 rationale: Build argv with arrays, `set --`, or helper functions instead of storing quoting syntax in a scalar.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-308.yaml
   shell_checks_example: examples/308.sh

--- a/docs/rules/C132.yaml
+++ b/docs/rules/C132.yaml
@@ -12,7 +12,7 @@ shells:
 description: A later expansion in the same command still reads the shell's earlier value instead of the preceding prefix assignment.
 rationale: Prefix assignments only reach the spawned command environment after the shell has already expanded the rest of the command line.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the command by moving each leading prefix assignment onto its own standalone assignment statement immediately before the command."
 source:
   shell_checks_rule: rules/SH-310.yaml
   shell_checks_example: examples/310.sh

--- a/docs/rules/C132.yaml
+++ b/docs/rules/C132.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A later expansion in the same command still reads the shell's earlier value instead of the preceding prefix assignment.
 rationale: Prefix assignments only reach the spawned command environment after the shell has already expanded the rest of the command line.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-310.yaml
   shell_checks_example: examples/310.sh

--- a/docs/rules/C133.yaml
+++ b/docs/rules/C133.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An array variable is converted to a flat string then used as a string.
 rationale: Keep the array intact or explicitly join it with a delimiter.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-311.yaml
   shell_checks_example: examples/311.sh

--- a/docs/rules/C134.yaml
+++ b/docs/rules/C134.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A getopts option string contains an option not handled in the case statement.
 rationale: Add a case arm for each option in the getopts string.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-312.yaml
   shell_checks_example: examples/312.sh

--- a/docs/rules/C135.yaml
+++ b/docs/rules/C135.yaml
@@ -12,7 +12,7 @@ shells:
 description: A case arm handles an option not listed in the getopts string.
 rationale: Add the missing option to the getopts string or remove the case arm.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the reported undeclared case-pattern alternative; if it is the arm's only pattern or an invalid multi-character pattern, delete the whole arm."
 source:
   shell_checks_rule: rules/SH-313.yaml
   shell_checks_example: examples/313.sh

--- a/docs/rules/C135.yaml
+++ b/docs/rules/C135.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A case arm handles an option not listed in the getopts string.
 rationale: Add the missing option to the getopts string or remove the case arm.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-313.yaml
   shell_checks_example: examples/313.sh

--- a/docs/rules/C136.yaml
+++ b/docs/rules/C136.yaml
@@ -12,7 +12,7 @@ shells:
 description: A `local` statement assigns from a variable defined earlier on the same line.
 rationale: Split the declarations onto separate lines so each has the correct value.
 safe_fix: false
-fix_description: null
+fix_description: "Split the declaration into sequential declaration commands, one assignment operand per command, preserving the original declaration keyword and options."
 source:
   shell_checks_rule: rules/SH-314.yaml
   shell_checks_example: examples/314.sh

--- a/docs/rules/C136.yaml
+++ b/docs/rules/C136.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A `local` statement assigns from a variable defined earlier on the same line.
 rationale: Split the declarations onto separate lines so each has the correct value.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-314.yaml
   shell_checks_example: examples/314.sh

--- a/docs/rules/C137.yaml
+++ b/docs/rules/C137.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A Unicode smart single-quote appears inside a single-quoted string.
 rationale: Replace the Unicode quotation mark with an ASCII apostrophe.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-315.yaml
   shell_checks_example: examples/315.sh

--- a/docs/rules/C137.yaml
+++ b/docs/rules/C137.yaml
@@ -12,7 +12,7 @@ shells:
 description: A Unicode smart single-quote appears inside a single-quoted string.
 rationale: Replace the Unicode quotation mark with an ASCII apostrophe.
 safe_fix: false
-fix_description: null
+fix_description: "Replace each reported Unicode smart single quote with the shell-safe ASCII apostrophe sequence `'\\''` inside the surrounding single-quoted word."
 source:
   shell_checks_rule: rules/SH-315.yaml
   shell_checks_example: examples/315.sh

--- a/docs/rules/C138.yaml
+++ b/docs/rules/C138.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A heredoc starts but never gets a closing marker.
 rationale: Add the matching end line before the file ends.
+safe_fix: true
+fix_description: "Append the pending heredoc closing marker(s) at EOF in source order."
 source:
   shell_checks_rule: rules/SH-318.yaml
   shell_checks_example: examples/318.sh

--- a/docs/rules/C139.yaml
+++ b/docs/rules/C139.yaml
@@ -12,7 +12,7 @@ shells:
 description: An assignment-like word has stray spaces around `=`.
 rationale: Keep assignment syntax tight with no spaces around `=`.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the whitespace around the reported `=` word so the declaration operand becomes a single `name=value` assignment."
 source:
   shell_checks_rule: rules/SH-319.yaml
   shell_checks_example: examples/319.sh

--- a/docs/rules/C139.yaml
+++ b/docs/rules/C139.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An assignment-like word has stray spaces around `=`.
 rationale: Keep assignment syntax tight with no spaces around `=`.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-319.yaml
   shell_checks_example: examples/319.sh

--- a/docs/rules/C140.yaml
+++ b/docs/rules/C140.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A variable name starts with an invalid character.
 rationale: Use a valid shell identifier on the left side of `=`.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-320.yaml
   shell_checks_example: examples/320.sh

--- a/docs/rules/C141.yaml
+++ b/docs/rules/C141.yaml
@@ -12,7 +12,7 @@ shells:
 description: A loop body is opened but never closed.
 rationale: Finish the `do` block with `done`.
 safe_fix: false
-fix_description: null
+fix_description: "Append one closing `done` at end of file."
 source:
   shell_checks_rule: rules/SH-321.yaml
   shell_checks_example: examples/321.sh

--- a/docs/rules/C141.yaml
+++ b/docs/rules/C141.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A loop body is opened but never closed.
 rationale: Finish the `do` block with `done`.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-321.yaml
   shell_checks_example: examples/321.sh

--- a/docs/rules/C142.yaml
+++ b/docs/rules/C142.yaml
@@ -12,7 +12,7 @@ shells:
 description: An unfinished `for` loop triggers ShellCheck 1062 when it reaches EOF without a matching `done`.
 rationale: Include the loop body but omit only the closing `done` so ShellCheck reports just the missing terminator.
 safe_fix: false
-fix_description: null
+fix_description: "Append one closing `done` at end of file."
 source:
   shell_checks_rule: rules/SH-322.yaml
   shell_checks_example: examples/322.sh

--- a/docs/rules/C142.yaml
+++ b/docs/rules/C142.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An unfinished `for` loop triggers ShellCheck 1062 when it reaches EOF without a matching `done`.
 rationale: Include the loop body but omit only the closing `done` so ShellCheck reports just the missing terminator.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-322.yaml
   shell_checks_example: examples/322.sh

--- a/docs/rules/C143.yaml
+++ b/docs/rules/C143.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Else branch has no body
 rationale: Put a command before the final fi.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-327.yaml
   shell_checks_example: examples/327.sh

--- a/docs/rules/C144.yaml
+++ b/docs/rules/C144.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The here-document closer appears on the same line as content instead of by itself.
 rationale: Put the here-doc terminator on a line by itself.
+safe_fix: true
+fix_description: "Append the exact heredoc delimiter on its own new line after the current body text."
 source:
   shell_checks_rule: rules/SH-332.yaml
   shell_checks_example: examples/332.sh

--- a/docs/rules/C145.yaml
+++ b/docs/rules/C145.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The heredoc closing marker is only a near match.
 rationale: Use the exact unquoted marker text on the closing line.
+safe_fix: true
+fix_description: "Append the exact unquoted heredoc delimiter on its own new line after the current body text."
 source:
   shell_checks_rule: rules/SH-333.yaml
   shell_checks_example: examples/333.sh

--- a/docs/rules/C146.yaml
+++ b/docs/rules/C146.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An `until` loop skips the `do` keyword.
 rationale: Insert `do` before the loop body.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-334.yaml
   shell_checks_example: examples/334.sh

--- a/docs/rules/C148.yaml
+++ b/docs/rules/C148.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An associative-array key is missing its closing bracket.
 rationale: Finish the key before assigning its value.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-337.yaml
   shell_checks_example: examples/337.sh

--- a/docs/rules/C150.yaml
+++ b/docs/rules/C150.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A variable is reassigned inside a subshell, so the update does not affect the parent shell.
 rationale: Move the assignment to the current shell or return the value explicitly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-339.yaml
   shell_checks_example: examples/339.sh

--- a/docs/rules/C151.yaml
+++ b/docs/rules/C151.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A Bash array literal uses commas, so multiple intended elements become one malformed item.
 rationale: Write Bash array elements as whitespace-separated words inside `(...)`.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-340.yaml
   shell_checks_example: examples/340.sh

--- a/docs/rules/C155.yaml
+++ b/docs/rules/C155.yaml
@@ -10,6 +10,8 @@ shells:
   - dash
 description: A value is updated inside a pipeline child shell and then read afterward.
 rationale: Keep the update in the main shell or pass the result out explicitly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-347.yaml
   shell_checks_example: examples/347.sh

--- a/docs/rules/C156.yaml
+++ b/docs/rules/C156.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A referenced variable looks like a misspelling of one that was assigned.
 rationale: Use the intended variable name consistently so expansions do not silently read an unset variable.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-351.yaml
   shell_checks_example: examples/351.sh

--- a/docs/rules/C157.yaml
+++ b/docs/rules/C157.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: The `if` keyword is concatenated with a `[` test.
 rationale: Separate the keyword and test command with whitespace so parsing stays unambiguous.
+safe_fix: true
+fix_description: "Insert a space between `if` and `[`."
 source:
   shell_checks_rule: rules/SH-353.yaml
   shell_checks_example: examples/353.sh

--- a/docs/rules/K001.yaml
+++ b/docs/rules/K001.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Using a variable-derived path with recursive `rm` can delete more than intended if the prefix collapses into a sensitive subtree."
 rationale: Require the variable path to be non-empty and constrained, or target a narrower known-safe location before deleting recursively.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-044.yaml
   shell_checks_example: examples/044.sh

--- a/docs/rules/K002.yaml
+++ b/docs/rules/K002.yaml
@@ -12,7 +12,7 @@ shells:
 description: An ssh command string can be expanded by the local shell before the remote host ever sees it.
 rationale: Keep remote command text quoted until the remote shell is meant to interpret it.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the containing fully double-quoted final remote-command argument as an equivalently escaped single-quoted shell word."
 source:
   shell_checks_rule: rules/SH-047.yaml
   shell_checks_example: examples/047.sh

--- a/docs/rules/K002.yaml
+++ b/docs/rules/K002.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An ssh command string can be expanded by the local shell before the remote host ever sees it.
 rationale: Keep remote command text quoted until the remote shell is meant to interpret it.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-047.yaml
   shell_checks_example: examples/047.sh

--- a/docs/rules/K003.yaml
+++ b/docs/rules/K003.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "`eval` is used to execute composed command text."
 rationale: "Avoid `eval`; call the command directly or pass arguments in an array."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-151.yaml
   shell_checks_example: examples/151.sh

--- a/docs/rules/K004.yaml
+++ b/docs/rules/K004.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `find -exec` or `-execdir` passes `{}` to shell command text that may mishandle filenames."
 rationale: "Use safe quoting or `-print0` with `xargs -0` instead."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-283.yaml
   shell_checks_example: examples/283.sh

--- a/docs/rules/P001.yaml
+++ b/docs/rules/P001.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Using expr to combine numbers spawns a separate process for work the shell can already do itself.
 rationale: Use shell arithmetic expansion when you only need a numeric result.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-055.yaml
   shell_checks_example: examples/055.sh

--- a/docs/rules/P002.yaml
+++ b/docs/rules/P002.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Counting matches by piping grep into wc -l adds an unnecessary command stage.
 rationale: Use grep -c when you only need the number of matching lines.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-064.yaml
   shell_checks_example: examples/064.sh

--- a/docs/rules/P002.yaml
+++ b/docs/rules/P002.yaml
@@ -12,7 +12,7 @@ shells:
 description: Counting matches by piping grep into wc -l adds an unnecessary command stage.
 rationale: Use grep -c when you only need the number of matching lines.
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported `grep ... | wc -l` pair with `grep -c ...`, preserving the `grep` arguments and removing the trailing `wc -l` segment."
 source:
   shell_checks_rule: rules/SH-064.yaml
   shell_checks_example: examples/064.sh

--- a/docs/rules/P003.yaml
+++ b/docs/rules/P003.yaml
@@ -12,7 +12,7 @@ shells:
 description: A lone test runs inside a subshell.
 rationale: Drop the parentheses and run the command directly.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the outer subshell parentheses around the reported test condition."
 source:
   shell_checks_rule: rules/SH-137.yaml
   shell_checks_example: examples/137.sh

--- a/docs/rules/P003.yaml
+++ b/docs/rules/P003.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A lone test runs inside a subshell.
 rationale: Drop the parentheses and run the command directly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-137.yaml
   shell_checks_example: examples/137.sh

--- a/docs/rules/P004.yaml
+++ b/docs/rules/P004.yaml
@@ -12,7 +12,7 @@ shells:
 description: A grouped test uses a subshell instead of braces.
 rationale: Replace the subshell parentheses with a brace group to avoid a needless fork.
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported outer subshell parentheses with a brace group, preserving the inner test list and ending the group with `; }`."
 source:
   shell_checks_rule: rules/SH-164.yaml
   shell_checks_example: examples/164.sh

--- a/docs/rules/P004.yaml
+++ b/docs/rules/P004.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A grouped test uses a subshell instead of braces.
 rationale: Replace the subshell parentheses with a brace group to avoid a needless fork.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-164.yaml
   shell_checks_example: examples/164.sh

--- a/docs/rules/S001.yaml
+++ b/docs/rules/S001.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Ordinary scalar parameter expansions such as $1, $foo, and ${foo:-fallback} can split or match path patterns when they are used unquoted in a shell word.
 rationale: Quote scalar parameter expansions in split-sensitive positions, including inside command substitutions. Array-style splats and the outer $(...) form have their own rules.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-001.yaml
   shell_checks_example: examples/001.sh

--- a/docs/rules/S001.yaml
+++ b/docs/rules/S001.yaml
@@ -12,7 +12,7 @@ shells:
 description: Ordinary scalar parameter expansions such as $1, $foo, and ${foo:-fallback} can split or match path patterns when they are used unquoted in a shell word.
 rationale: Quote scalar parameter expansions in split-sensitive positions, including inside command substitutions. Array-style splats and the outer $(...) form have their own rules.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the reported expansion in double quotes."
 source:
   shell_checks_rule: rules/SH-001.yaml
   shell_checks_example: examples/001.sh

--- a/docs/rules/S002.yaml
+++ b/docs/rules/S002.yaml
@@ -12,7 +12,7 @@ shells:
 description: Reading text without the raw-input option can change literal backslashes before later use.
 rationale: Use `read -r` when the script needs incoming text to stay intact instead of treating backslashes as escapes.
 safe_fix: false
-fix_description: null
+fix_description: "Insert `-r` immediately after the reported `read` command word."
 source:
   shell_checks_rule: rules/SH-002.yaml
   shell_checks_example: examples/002.sh

--- a/docs/rules/S002.yaml
+++ b/docs/rules/S002.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Reading text without the raw-input option can change literal backslashes before later use.
 rationale: Use `read -r` when the script needs incoming text to stay intact instead of treating backslashes as escapes.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-002.yaml
   shell_checks_example: examples/002.sh

--- a/docs/rules/S003.yaml
+++ b/docs/rules/S003.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Building loop items from raw command output lets whitespace and pathname characters change the iteration set.
 rationale: Iterate over globs, arrays, or explicit delimiters instead of splitting command output.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-004.yaml
   shell_checks_example: examples/004.sh

--- a/docs/rules/S004.yaml
+++ b/docs/rules/S004.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An unquoted command substitution such as $(...) is inserted as a shell word and its output is split before the receiving command sees it.
 rationale: Quote the substitution unless the script intentionally wants the produced text to be split. Expansions inside the substitution body are checked by the parameter and array quoting rules.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-005.yaml
   shell_checks_example: examples/005.sh

--- a/docs/rules/S004.yaml
+++ b/docs/rules/S004.yaml
@@ -12,7 +12,7 @@ shells:
 description: An unquoted command substitution such as $(...) is inserted as a shell word and its output is split before the receiving command sees it.
 rationale: Quote the substitution unless the script intentionally wants the produced text to be split. Expansions inside the substitution body are checked by the parameter and array quoting rules.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the reported `$(...)` span in double quotes."
 source:
   shell_checks_rule: rules/SH-005.yaml
   shell_checks_example: examples/005.sh

--- a/docs/rules/S005.yaml
+++ b/docs/rules/S005.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Backtick command substitution is a legacy form that is harder to nest and quote cleanly.
 rationale: "Use `$(...)` instead of backticks so substitutions stay readable and composable."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-034.yaml
   shell_checks_example: examples/034.sh

--- a/docs/rules/S006.yaml
+++ b/docs/rules/S006.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The script uses the old bracketed arithmetic form instead of the modern arithmetic expansion syntax.
 rationale: "Prefer `$((...))` for arithmetic so the expression reads like arithmetic rather than shell syntax."
+safe_fix: true
+fix_description: "Replace each legacy `$[expr]` arithmetic expansion with the equivalent `$((expr))` form."
 source:
   shell_checks_rule: rules/SH-035.yaml
   shell_checks_example: examples/035.sh

--- a/docs/rules/S007.yaml
+++ b/docs/rules/S007.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The format string for `printf` is supplied through a variable, which makes the call harder to audit."
 rationale: Keep the format string literal and pass data in later arguments.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-037.yaml
   shell_checks_example: examples/037.sh

--- a/docs/rules/S008.yaml
+++ b/docs/rules/S008.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Unquoted @-style splats such as $@, ${@:2}, and ${arr[@]} let positional parameters or array elements be split again or treated as path patterns.
 rationale: Quote @-style expansions when each argument or element should stay distinct.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-038.yaml
   shell_checks_example: examples/038.sh

--- a/docs/rules/S008.yaml
+++ b/docs/rules/S008.yaml
@@ -12,7 +12,7 @@ shells:
 description: Unquoted @-style splats such as $@, ${@:2}, and ${arr[@]} let positional parameters or array elements be split again or treated as path patterns.
 rationale: Quote @-style expansions when each argument or element should stay distinct.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the reported `@`-style expansion in double quotes."
 source:
   shell_checks_rule: rules/SH-038.yaml
   shell_checks_example: examples/038.sh

--- a/docs/rules/S009.yaml
+++ b/docs/rules/S009.yaml
@@ -12,7 +12,7 @@ shells:
 description: "An `echo` around a command substitution adds an unnecessary wrapper around output that is already available."
 rationale: "Print the command's result directly instead of wrapping it in another `echo` call."
 safe_fix: false
-fix_description: null
+fix_description: "Replace the enclosing echo wrapper with the inner command from its sole command substitution."
 source:
   shell_checks_rule: rules/SH-040.yaml
   shell_checks_example: examples/040.sh

--- a/docs/rules/S009.yaml
+++ b/docs/rules/S009.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "An `echo` around a command substitution adds an unnecessary wrapper around output that is already available."
 rationale: "Print the command's result directly instead of wrapping it in another `echo` call."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-040.yaml
   shell_checks_example: examples/040.sh

--- a/docs/rules/S010.yaml
+++ b/docs/rules/S010.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Capturing command output directly inside `export` hides the assignment step and mixes two concerns."
 rationale: Store the value first, then export it explicitly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-050.yaml
   shell_checks_example: examples/050.sh

--- a/docs/rules/S011.yaml
+++ b/docs/rules/S011.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Using `-a` or `-o` inside a single `[` expression compresses boolean logic into a form that is easy to misread."
 rationale: Split the condition into explicit branches so the intended logic stays obvious.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-051.yaml
   shell_checks_example: examples/051.sh

--- a/docs/rules/S012.yaml
+++ b/docs/rules/S012.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Piping ps into grep searches the formatted process list instead of asking for the process you want.
 rationale: Use a process-aware selector such as pgrep instead of parsing ps output.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-056.yaml
   shell_checks_example: examples/056.sh

--- a/docs/rules/S013.yaml
+++ b/docs/rules/S013.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Piping ls into grep treats a directory listing like a data format, which is brittle.
 rationale: Use shell patterns or filename-aware tools instead of parsing ls output.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-057.yaml
   shell_checks_example: examples/057.sh

--- a/docs/rules/S014.yaml
+++ b/docs/rules/S014.yaml
@@ -12,7 +12,7 @@ shells:
 description: Unquoted *-style splats such as $*, ${*}, and ${arr[*]} join values into one word and then expose the result to splitting and pathname expansion.
 rationale: Use "$@" for positional parameters, or "${arr[@]}" for arrays, when each value must stay separate.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the reported `*`-style splat expansion in double quotes."
 source:
   shell_checks_rule: rules/SH-062.yaml
   shell_checks_example: examples/062.sh

--- a/docs/rules/S014.yaml
+++ b/docs/rules/S014.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Unquoted *-style splats such as $*, ${*}, and ${arr[*]} join values into one word and then expose the result to splitting and pathname expansion.
 rationale: Use "$@" for positional parameters, or "${arr[@]}" for arrays, when each value must stay separate.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-062.yaml
   shell_checks_example: examples/062.sh

--- a/docs/rules/S015.yaml
+++ b/docs/rules/S015.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Putting a fully quoted expansion in a `for` list turns it into a single item instead of a list of fields.
 rationale: Leave the expansion unquoted when you want field splitting, or use the `@` form when you need one item per array element or positional parameter.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-063.yaml
   shell_checks_example: examples/063.sh

--- a/docs/rules/S015.yaml
+++ b/docs/rules/S015.yaml
@@ -12,7 +12,7 @@ shells:
 description: Putting a fully quoted expansion in a `for` list turns it into a single item instead of a list of fields.
 rationale: Leave the expansion unquoted when you want field splitting, or use the `@` form when you need one item per array element or positional parameter.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the double-quote characters that make the reported lone `for`-list word fully quoted."
 source:
   shell_checks_rule: rules/SH-063.yaml
   shell_checks_example: examples/063.sh

--- a/docs/rules/S016.yaml
+++ b/docs/rules/S016.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Capturing echo output through command substitution adds an unnecessary extra step.
 rationale: Use a direct emitter such as printf when building substitution output.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-066.yaml
   shell_checks_example: examples/066.sh

--- a/docs/rules/S017.yaml
+++ b/docs/rules/S017.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Building an array from an unquoted value can split one logical item into several elements.
 rationale: Quote the expansion or use a deliberate splitting step when you need multiple items.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-067.yaml
   shell_checks_example: examples/067.sh

--- a/docs/rules/S017.yaml
+++ b/docs/rules/S017.yaml
@@ -12,7 +12,7 @@ shells:
 description: Building an array from an unquoted value can split one logical item into several elements.
 rationale: Quote the expansion or use a deliberate splitting step when you need multiple items.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap each reported expansion span in double quotes inside the array-assignment word."
 source:
   shell_checks_rule: rules/SH-067.yaml
   shell_checks_example: examples/067.sh

--- a/docs/rules/S018.yaml
+++ b/docs/rules/S018.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Feeding raw command output straight into an array can break on whitespace and similar separators.
 rationale: Capture the data with a structured reader instead of arraying command output directly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-068.yaml
   shell_checks_example: examples/068.sh

--- a/docs/rules/S018.yaml
+++ b/docs/rules/S018.yaml
@@ -12,7 +12,7 @@ shells:
 description: Feeding raw command output straight into an array can break on whitespace and similar separators.
 rationale: Capture the data with a structured reader instead of arraying command output directly.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the reported command substitution span in double quotes inside the array-assignment word."
 source:
   shell_checks_rule: rules/SH-068.yaml
   shell_checks_example: examples/068.sh

--- a/docs/rules/S019.yaml
+++ b/docs/rules/S019.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Using grep's printed text as a boolean check ties control flow to formatting instead of success or failure.
 rationale: Use the command's exit status directly or test the match in a simpler way.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-071.yaml
   shell_checks_example: examples/071.sh

--- a/docs/rules/S020.yaml
+++ b/docs/rules/S020.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A loop that exits immediately is more complicated than the code it wraps.
 rationale: Replace it with the direct command sequence or a simpler conditional structure.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-076.yaml
   shell_checks_example: examples/076.sh

--- a/docs/rules/S021.yaml
+++ b/docs/rules/S021.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Folding positional parameters into a larger quoted string changes the argument shape.
 rationale: Pass literal text and positional parameters as separate arguments instead.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-077.yaml
   shell_checks_example: examples/077.sh

--- a/docs/rules/S022.yaml
+++ b/docs/rules/S022.yaml
@@ -10,7 +10,7 @@ shells:
 description: "The bash `let` builtin is an unnecessarily indirect way to perform arithmetic."
 rationale: Use arithmetic expansion or another direct arithmetic form instead.
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported bare `let` command with an arithmetic command `(( ... ))`, joining multiple `let` arguments with commas and unquoting fully quoted arithmetic operands."
 source:
   shell_checks_rule: rules/SH-079.yaml
   shell_checks_example: examples/079.sh

--- a/docs/rules/S022.yaml
+++ b/docs/rules/S022.yaml
@@ -9,6 +9,8 @@ shells:
   - ksh
 description: "The bash `let` builtin is an unnecessarily indirect way to perform arithmetic."
 rationale: Use arithmetic expansion or another direct arithmetic form instead.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-079.yaml
   shell_checks_example: examples/079.sh

--- a/docs/rules/S023.yaml
+++ b/docs/rules/S023.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A needless backslash is left in a plain word.
 rationale: Drop the escape unless the character is actually special there.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-082.yaml
   shell_checks_example: examples/082.sh

--- a/docs/rules/S023.yaml
+++ b/docs/rules/S023.yaml
@@ -12,7 +12,7 @@ shells:
 description: A needless backslash is left in a plain word.
 rationale: Drop the escape unless the character is actually special there.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the backslash before the reported character."
 source:
   shell_checks_rule: rules/SH-082.yaml
   shell_checks_example: examples/082.sh

--- a/docs/rules/S024.yaml
+++ b/docs/rules/S024.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Includes a literal backslash inside a quoted shell string.
 rationale: Use a quoting form that preserves the intended literal text.
+safe_fix: true
+fix_description: "Move the trailing backslash out of the single-quoted fragment as an escaped backslash."
 source:
   shell_checks_rule: rules/SH-087.yaml
   shell_checks_example: examples/087.sh

--- a/docs/rules/S025.yaml
+++ b/docs/rules/S025.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A backslash before a normal letter gets treated as plain text.
 rationale: Only escape characters that need it, or quote the word instead.
+safe_fix: true
+fix_description: "Delete the leading backslash from the two-character literal word."
 source:
   shell_checks_rule: rules/SH-088.yaml
   shell_checks_example: examples/088.sh

--- a/docs/rules/S028.yaml
+++ b/docs/rules/S028.yaml
@@ -12,7 +12,7 @@ shells:
 description: A quote is syntactically closed, but the following character makes ShellCheck flag it as suspicious.
 rationale: Restructure the string generation so the closing quote is unambiguous, or move the embedded script text to a here-doc.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the surrounding split word as one double-quoted word, escaping literal inner quotes and bracing embedded scalar expansions as needed."
 source:
   shell_checks_rule: rules/SH-114.yaml
   shell_checks_example: examples/114.sh

--- a/docs/rules/S028.yaml
+++ b/docs/rules/S028.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A quote is syntactically closed, but the following character makes ShellCheck flag it as suspicious.
 rationale: Restructure the string generation so the closing quote is unambiguous, or move the embedded script text to a here-doc.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-114.yaml
   shell_checks_example: examples/114.sh

--- a/docs/rules/S029.yaml
+++ b/docs/rules/S029.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Literal braces appear where bash may treat them as expansion syntax.
 rationale: Quote the text so the braces stay literal.
+safe_fix: true
+fix_description: "Escape each reported literal brace with a backslash."
 source:
   shell_checks_rule: rules/SH-116.yaml
   shell_checks_example: examples/116.sh

--- a/docs/rules/S030.yaml
+++ b/docs/rules/S030.yaml
@@ -12,7 +12,7 @@ shells:
 description: Trailing whitespace on a here-doc terminator makes the marker sloppy.
 rationale: End the delimiter line cleanly with no extra spaces.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the trailing spaces or tabs after the reported here-doc delimiter line."
 source:
   shell_checks_rule: rules/SH-119.yaml
   shell_checks_example: examples/119.sh

--- a/docs/rules/S030.yaml
+++ b/docs/rules/S030.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Trailing whitespace on a here-doc terminator makes the marker sloppy.
 rationale: End the delimiter line cleanly with no extra spaces.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-119.yaml
   shell_checks_example: examples/119.sh

--- a/docs/rules/S031.yaml
+++ b/docs/rules/S031.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A shellcheck directive placed after code is ignored.
 rationale: Put directives on their own comment line before the command.
+safe_fix: true
+fix_description: "Move the inline shellcheck directive onto its own comment line immediately before the current command line."
 source:
   shell_checks_rule: rules/SH-120.yaml
   shell_checks_example: examples/120.sh

--- a/docs/rules/S032.yaml
+++ b/docs/rules/S032.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Assigns a bare command-like word as a value without quotes.
 rationale: Quote the literal text if you mean a command name, or use `$(...)` if you meant to capture command output.
+safe_fix: true
+fix_description: "Quote the fixed literal assignment value."
 source:
   shell_checks_rule: rules/SH-128.yaml
   shell_checks_example: examples/128.sh

--- a/docs/rules/S033.yaml
+++ b/docs/rules/S033.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Attaches a here-doc to `echo`"
 rationale: Use a command that reads standard input, or print the text directly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-135.yaml
   shell_checks_example: examples/135.sh

--- a/docs/rules/S033.yaml
+++ b/docs/rules/S033.yaml
@@ -12,7 +12,7 @@ shells:
 description: "Attaches a here-doc to `echo`"
 rationale: Use a command that reads standard input, or print the text directly.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the here-doc redirect and its attached here-doc body from the reported `echo` command."
 source:
   shell_checks_rule: rules/SH-135.yaml
   shell_checks_example: examples/135.sh

--- a/docs/rules/S034.yaml
+++ b/docs/rules/S034.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Uses arithmetic expansion inside an array subscript.
 rationale: Use a plain arithmetic index expression there.
+safe_fix: true
+fix_description: "Remove the redundant `$((...))` wrapper from the indexed array subscript."
 source:
   shell_checks_rule: rules/SH-157.yaml
   shell_checks_example: examples/157.sh

--- a/docs/rules/S035.yaml
+++ b/docs/rules/S035.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Uses a long arithmetic expansion in an assignment.
 rationale: Break complex math into smaller steps if it gets hard to read.
+safe_fix: true
+fix_description: "Remove the outer redundant parentheses from the arithmetic expansion body."
 source:
   shell_checks_rule: rules/SH-161.yaml
   shell_checks_example: examples/161.sh

--- a/docs/rules/S036.yaml
+++ b/docs/rules/S036.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "Uses `read` without extra options."
 rationale: Provide the needed options explicitly for the input you expect.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-163.yaml
   shell_checks_example: examples/163.sh

--- a/docs/rules/S037.yaml
+++ b/docs/rules/S037.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Extra spaces between echo arguments are collapsed by the shell.
 rationale: Quote the spaced text or use printf for precise formatting.
+safe_fix: true
+fix_description: "Collapse the repeated spaces between `echo` arguments to a single separator space."
 source:
   shell_checks_rule: rules/SH-168.yaml
   shell_checks_example: examples/168.sh

--- a/docs/rules/S038.yaml
+++ b/docs/rules/S038.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Returns the exit status that the function would already propagate.
 rationale: Omit the explicit return when the last command status is the desired result.
+safe_fix: true
+fix_description: "Delete the trailing `return $?` command."
 source:
   shell_checks_rule: rules/SH-170.yaml
   shell_checks_example: examples/170.sh

--- a/docs/rules/S039.yaml
+++ b/docs/rules/S039.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A backslash sequence inside single quotes is treated literally.
 rationale: Use double quotes or $'...' if backslash escapes are intended.
+safe_fix: true
+fix_description: "Rewrite the single-quoted fragment as an equivalently escaped double-quoted fragment."
 source:
   shell_checks_rule: rules/SH-172.yaml
   shell_checks_example: examples/172.sh

--- a/docs/rules/S040.yaml
+++ b/docs/rules/S040.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A shell word contains \n, \r, or \t text that stays literal.
 rationale: Use printf or an actual control character when whitespace is intended.
+safe_fix: false
+fix_description: null
 examples:
   - kind: invalid
     code: |

--- a/docs/rules/S041.yaml
+++ b/docs/rules/S041.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A function body is a bare compound command instead of a brace group.
 rationale: "Wrap the function body in `{ ... }` for portability."
+safe_fix: true
+fix_description: "Wrap the existing compound function body in `{ ...; }` without changing the inner command."
 source:
   shell_checks_rule: rules/SH-181.yaml
   shell_checks_example: examples/181.sh

--- a/docs/rules/S042.yaml
+++ b/docs/rules/S042.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Setting IFS to `=` with `IFS==` looks like a comparison."
 rationale: "Quote the delimiter or use `IFS='='` to avoid ambiguity."
+safe_fix: true
+fix_description: "Rewrite `IFS==` as `IFS='='`."
 source:
   shell_checks_rule: rules/SH-185.yaml
   shell_checks_example: examples/185.sh

--- a/docs/rules/S043.yaml
+++ b/docs/rules/S043.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: The script has no shebang and starts with a comment.
 rationale: "Add a `#!/bin/bash` or `#!/bin/sh` shebang as the first line."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-190.yaml
   shell_checks_example: examples/190.sh

--- a/docs/rules/S044.yaml
+++ b/docs/rules/S044.yaml
@@ -9,6 +9,8 @@ shells:
   - ksh
 description: A plain echo-to-sed rewrite can be folded into shell-native substitution.
 rationale: Prefer the shell's built-in rewrite features over spawning sed for a single inline edit.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-196.yaml
   shell_checks_example: examples/196.sh

--- a/docs/rules/S045.yaml
+++ b/docs/rules/S045.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A dollar sign is used before a variable name inside shell arithmetic."
 rationale: "Omit the `$` prefix; variables expand implicitly in arithmetic contexts."
+safe_fix: true
+fix_description: "Remove the redundant `$` prefix or `${...}` wrapper from arithmetic variable references."
 source:
   shell_checks_rule: rules/SH-197.yaml
   shell_checks_example: examples/197.sh

--- a/docs/rules/S046.yaml
+++ b/docs/rules/S046.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The output of `ls` is piped into another command."
 rationale: "Use a glob or `find` instead of parsing `ls` output."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-198.yaml
   shell_checks_example: examples/198.sh

--- a/docs/rules/S047.yaml
+++ b/docs/rules/S047.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Command substitution captures ls output for processing.
 rationale: Use a glob or find to avoid parsing ls output.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-199.yaml
   shell_checks_example: examples/199.sh

--- a/docs/rules/S049.yaml
+++ b/docs/rules/S049.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A `tr` character class is passed without quoting."
 rationale: "Quote the `tr` operands to prevent shell interpretation."
 safe_fix: false
-fix_description: null
+fix_description: "Remove the outer `[` and `]` from the reported `tr` set operand, keeping any surrounding quotes."
 source:
   shell_checks_rule: rules/SH-203.yaml
   shell_checks_example: examples/203.sh

--- a/docs/rules/S049.yaml
+++ b/docs/rules/S049.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `tr` character class is passed without quoting."
 rationale: "Quote the `tr` operands to prevent shell interpretation."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-203.yaml
   shell_checks_example: examples/203.sh

--- a/docs/rules/S050.yaml
+++ b/docs/rules/S050.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An unquoted word continues immediately after single-quoted text.
 rationale: Keep the intended word inside single quotes instead of reopening it unquoted.
+safe_fix: true
+fix_description: "Wrap the reported unquoted literal fragment in single quotes so the adjacent pieces stay one literal word."
 source:
   shell_checks_rule: rules/SH-205.yaml
   shell_checks_example: examples/205.sh

--- a/docs/rules/S051.yaml
+++ b/docs/rules/S051.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `tr` character class is not quoted and may be expanded as a glob."
 rationale: "Quote the `[:upper:]` and `[:lower:]` arguments."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-208.yaml
   shell_checks_example: examples/208.sh

--- a/docs/rules/S051.yaml
+++ b/docs/rules/S051.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A `tr` character class is not quoted and may be expanded as a glob."
 rationale: "Quote the `[:upper:]` and `[:lower:]` arguments."
 safe_fix: false
-fix_description: null
+fix_description: "Wrap the reported `tr` character-class operand in single quotes."
 source:
   shell_checks_rule: rules/SH-208.yaml
   shell_checks_example: examples/208.sh

--- a/docs/rules/S052.yaml
+++ b/docs/rules/S052.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A variable expansion is not quoted inside a `[ -n ... ]` test."
 rationale: Quote the variable to avoid syntax errors when it is empty.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap each reported unquoted scalar expansion in double quotes."
 source:
   shell_checks_rule: rules/SH-212.yaml
   shell_checks_example: examples/212.sh

--- a/docs/rules/S052.yaml
+++ b/docs/rules/S052.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A variable expansion is not quoted inside a `[ -n ... ]` test."
 rationale: Quote the variable to avoid syntax errors when it is empty.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-212.yaml
   shell_checks_example: examples/212.sh

--- a/docs/rules/S053.yaml
+++ b/docs/rules/S053.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A flag is repeated in the shebang line.
 rationale: Remove the duplicate flag from the shebang.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-223.yaml
   shell_checks_example: examples/223.sh

--- a/docs/rules/S054.yaml
+++ b/docs/rules/S054.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The `su` command is used without `-l` or `-c`."
 rationale: "Use `su -l user` or `su -c 'command' user` to start a proper login shell."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-227.yaml
   shell_checks_example: examples/227.sh

--- a/docs/rules/S055.yaml
+++ b/docs/rules/S055.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A glob pattern is assigned to a variable without quoting.
 rationale: Quote the assignment or expand the glob explicitly.
+safe_fix: true
+fix_description: "Single-quote the unquoted glob fragment in the assignment value so the stored pattern remains literal."
 source:
   shell_checks_rule: rules/SH-231.yaml
   shell_checks_example: examples/231.sh

--- a/docs/rules/S056.yaml
+++ b/docs/rules/S056.yaml
@@ -12,7 +12,7 @@ shells:
 description: An alias definition contains an expansion that resolves while the alias is being declared.
 rationale: Escape the expansion or move the logic into a function so it is evaluated when the alias is used.
 safe_fix: false
-fix_description: null
+fix_description: "Rewrite the containing alias definition as a single-quoted shell word, escaping any embedded single quotes so the expansion text stays literal."
 source:
   shell_checks_rule: rules/SH-233.yaml
   shell_checks_example: examples/233.sh

--- a/docs/rules/S056.yaml
+++ b/docs/rules/S056.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An alias definition contains an expansion that resolves while the alias is being declared.
 rationale: Escape the expansion or move the logic into a function so it is evaluated when the alias is used.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-233.yaml
   shell_checks_example: examples/233.sh

--- a/docs/rules/S057.yaml
+++ b/docs/rules/S057.yaml
@@ -12,7 +12,7 @@ shells:
 description: A function definition is embedded inside an alias string.
 rationale: Define the function separately and alias only the call.
 safe_fix: false
-fix_description: null
+fix_description: "Replace the alias definition with its literal alias body so the embedded function definition becomes real shell code."
 source:
   shell_checks_rule: rules/SH-235.yaml
   shell_checks_example: examples/235.sh

--- a/docs/rules/S057.yaml
+++ b/docs/rules/S057.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A function definition is embedded inside an alias string.
 rationale: Define the function separately and alias only the call.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-235.yaml
   shell_checks_example: examples/235.sh

--- a/docs/rules/S058.yaml
+++ b/docs/rules/S058.yaml
@@ -12,7 +12,7 @@ shells:
 description: A variable path is not quoted in a directory creation command.
 rationale: Quote the variable to handle paths with spaces.
 safe_fix: false
-fix_description: null
+fix_description: "Wrap each reported unquoted path expansion in double quotes."
 source:
   shell_checks_rule: rules/SH-240.yaml
   shell_checks_example: examples/240.sh

--- a/docs/rules/S058.yaml
+++ b/docs/rules/S058.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A variable path is not quoted in a directory creation command.
 rationale: Quote the variable to handle paths with spaces.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-240.yaml
   shell_checks_example: examples/240.sh

--- a/docs/rules/S059.yaml
+++ b/docs/rules/S059.yaml
@@ -12,7 +12,7 @@ shells:
 description: "The deprecated `tempfile` command is used to create a temporary file."
 rationale: "Use `mktemp` instead of `tempfile`."
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported `tempfile` command name with `mktemp`."
 source:
   shell_checks_rule: rules/SH-245.yaml
   shell_checks_example: examples/245.sh

--- a/docs/rules/S059.yaml
+++ b/docs/rules/S059.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The deprecated `tempfile` command is used to create a temporary file."
 rationale: "Use `mktemp` instead of `tempfile`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-245.yaml
   shell_checks_example: examples/245.sh

--- a/docs/rules/S060.yaml
+++ b/docs/rules/S060.yaml
@@ -12,7 +12,7 @@ shells:
 description: "The `egrep` command is used instead of `grep -E`."
 rationale: "Replace `egrep` with `grep -E` as egrep is deprecated."
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported `egrep` command word with `grep -E`."
 source:
   shell_checks_rule: rules/SH-247.yaml
   shell_checks_example: examples/247.sh

--- a/docs/rules/S060.yaml
+++ b/docs/rules/S060.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The `egrep` command is used instead of `grep -E`."
 rationale: "Replace `egrep` with `grep -E` as egrep is deprecated."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-247.yaml
   shell_checks_example: examples/247.sh

--- a/docs/rules/S061.yaml
+++ b/docs/rules/S061.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The `fgrep` command is used instead of `grep -F`."
 rationale: "Replace `fgrep` with `grep -F` as fgrep is deprecated."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-248.yaml
   shell_checks_example: examples/248.sh

--- a/docs/rules/S061.yaml
+++ b/docs/rules/S061.yaml
@@ -12,7 +12,7 @@ shells:
 description: "The `fgrep` command is used instead of `grep -F`."
 rationale: "Replace `fgrep` with `grep -F` as fgrep is deprecated."
 safe_fix: false
-fix_description: null
+fix_description: "Replace the reported `fgrep` command word with `grep -F`."
 source:
   shell_checks_rule: rules/SH-248.yaml
   shell_checks_example: examples/248.sh

--- a/docs/rules/S062.yaml
+++ b/docs/rules/S062.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A colon-assign expansion provides a default without quoting.
 rationale: Quote the default value to prevent word splitting.
+safe_fix: true
+fix_description: "Wrap the `${name=...}` or `${name:=...}` expansion in double quotes when it is passed to `:`."
 source:
   shell_checks_rule: rules/SH-251.yaml
   shell_checks_example: examples/251.sh

--- a/docs/rules/S063.yaml
+++ b/docs/rules/S063.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A symbolic link target uses a relative path with many `../` segments."
 rationale: Use an absolute path or verify the relative target resolves correctly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-252.yaml
   shell_checks_example: examples/252.sh

--- a/docs/rules/S064.yaml
+++ b/docs/rules/S064.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "The `-i` flag for `xargs` is deprecated."
 rationale: "Use `-I{}` instead of `-i` with `xargs`."
+safe_fix: true
+fix_description: "Rewrite deprecated `xargs -i` forms to the equivalent `xargs -I...` form, preserving any inline replacement string and using `{}` for bare `-i`."
 source:
   shell_checks_rule: rules/SH-255.yaml
   shell_checks_example: examples/255.sh

--- a/docs/rules/S065.yaml
+++ b/docs/rules/S065.yaml
@@ -12,7 +12,7 @@ shells:
 description: "A test comparison uses the `x$var` idiom for empty-string safety."
 rationale: "Use proper quoting instead of the legacy `x` prefix trick."
 safe_fix: false
-fix_description: null
+fix_description: "Remove the leading `x` or `X` from both operands of the reported string comparison and double-quote the rewritten operands."
 source:
   shell_checks_rule: rules/SH-256.yaml
   shell_checks_example: examples/256.sh

--- a/docs/rules/S065.yaml
+++ b/docs/rules/S065.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A test comparison uses the `x$var` idiom for empty-string safety."
 rationale: "Use proper quoting instead of the legacy `x` prefix trick."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-256.yaml
   shell_checks_example: examples/256.sh

--- a/docs/rules/S066.yaml
+++ b/docs/rules/S066.yaml
@@ -12,7 +12,7 @@ shells:
 description: "Both `local` and `declare` are used together in one statement."
 rationale: "Use either `local` or `declare`, not both."
 safe_fix: false
-fix_description: null
+fix_description: "Delete the reported `local` or `declare` operand from the declaration statement."
 source:
   shell_checks_rule: rules/SH-289.yaml
   shell_checks_example: examples/289.sh

--- a/docs/rules/S066.yaml
+++ b/docs/rules/S066.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Both `local` and `declare` are used together in one statement."
 rationale: "Use either `local` or `declare`, not both."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-289.yaml
   shell_checks_example: examples/289.sh

--- a/docs/rules/S067.yaml
+++ b/docs/rules/S067.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A grep pattern starts with `*`, which reads like a shell glob instead of a regex.
 rationale: "Use `.*text` to match any prefix in regex mode, or escape a literal `*` if that character is part of the pattern."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-294.yaml
   shell_checks_example: examples/294.sh

--- a/docs/rules/S068.yaml
+++ b/docs/rules/S068.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Numeric signal identifiers are used in a trap command.
 rationale: Use symbolic signal names for clarity and portability.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-297.yaml
   shell_checks_example: examples/297.sh

--- a/docs/rules/S069.yaml
+++ b/docs/rules/S069.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A getopts case handler has no branch for invalid option flags.
 rationale: Add a catch-all branch or an explicit `\?` arm so unexpected flags do not fall through the getopts dispatch.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-300.yaml
   shell_checks_example: examples/300.sh

--- a/docs/rules/S070.yaml
+++ b/docs/rules/S070.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A double-quoted variable sits between unquoted text inside a larger double-quoted string.
 rationale: Escape inner quotes or restructure the string to avoid split quoting.
+safe_fix: true
+fix_description: "Merge the reopened double-quoted segments into one quoted word, adding braces around the embedded expansion when needed."
 source:
   shell_checks_rule: rules/SH-306.yaml
   shell_checks_example: examples/306.sh

--- a/docs/rules/S071.yaml
+++ b/docs/rules/S071.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A command-prefix assignment is reused later in the same command even though later expansions still see the older shell value.
 rationale: Prefix assignments are passed to the invoked command after the shell finishes expanding the rest of the command. Assign the variable earlier or use the intended value directly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-309.yaml
   shell_checks_example: examples/309.sh

--- a/docs/rules/S072.yaml
+++ b/docs/rules/S072.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A control operator starts a new line instead of ending the previous one.
 rationale: Put `&&` at the end of the previous line or keep the command on one line.
+safe_fix: true
+fix_description: "Move the leading `&&`, `||`, or `|` to the end of the previous line."
 source:
   shell_checks_rule: rules/SH-329.yaml
   shell_checks_example: examples/329.sh

--- a/docs/rules/S073.yaml
+++ b/docs/rules/S073.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A `<<-` heredoc uses spaces before its closing marker.
 rationale: Use tabs for the indented marker, or use plain `<<`.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-330.yaml
   shell_checks_example: examples/330.sh

--- a/docs/rules/S073.yaml
+++ b/docs/rules/S073.yaml
@@ -12,7 +12,7 @@ shells:
 description: A `<<-` heredoc uses spaces before its closing marker.
 rationale: Use tabs for the indented marker, or use plain `<<`.
 safe_fix: false
-fix_description: null
+fix_description: "Delete the leading spaces before the reported `<<-` closing marker so only tabs, if any, remain before the delimiter."
 source:
   shell_checks_rule: rules/SH-330.yaml
   shell_checks_example: examples/330.sh

--- a/docs/rules/S074.yaml
+++ b/docs/rules/S074.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A backgrounded command is followed immediately by `;`.
 rationale: End the command with `&` by itself.
+safe_fix: true
+fix_description: "Delete the semicolon that immediately follows the background `&`."
 source:
   shell_checks_rule: rules/SH-335.yaml
   shell_checks_example: examples/335.sh

--- a/docs/rules/S075.yaml
+++ b/docs/rules/S075.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Multiple commands append to the same file with separate redirections.
 rationale: Group the commands and apply one trailing >> redirection for clearer, more efficient output handling.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-349.yaml
   shell_checks_example: examples/349.sh

--- a/docs/rules/S076.yaml
+++ b/docs/rules/S076.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: One argument is assembled from alternating quoted and bare fragments.
 rationale: Use a single explicit word form so the intended text is obvious.
+safe_fix: true
+fix_description: "Rewrite the whole word as one consistent quoted form, escaping literal quote fragments as needed."
 source:
   shell_checks_rule: rules/SH-350.yaml
   shell_checks_example: examples/350.sh

--- a/docs/rules/S077.yaml
+++ b/docs/rules/S077.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An unbraced variable expansion is immediately followed by `[` text.
 rationale: Wrap the expansion in braces so the following bracket text is unambiguous.
+safe_fix: true
+fix_description: "Wrap the variable expansion in braces before the adjacent `[` text."
 source:
   shell_checks_rule: rules/SH-354.yaml
   shell_checks_example: examples/354.sh

--- a/docs/rules/X001.yaml
+++ b/docs/rules/X001.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The `[[ ... ]]` conditional form is not portable to `/bin/sh`.
 rationale: Use portable `[` or `test`, or switch the script to a shell that supports `[[ ... ]]`.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-006.yaml
   shell_checks_example: examples/006.sh

--- a/docs/rules/X002.yaml
+++ b/docs/rules/X002.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The `==` comparison operator inside `[` is not portable in POSIX shells.
 rationale: Use `=` when writing tests for `/bin/sh`.
+safe_fix: true
+fix_description: "Replace each reported `==` comparison operator with `=`."
 source:
   shell_checks_rule: rules/SH-007.yaml
   shell_checks_example: examples/007.sh

--- a/docs/rules/X003.yaml
+++ b/docs/rules/X003.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: Using `local` in a function ties the script to shells that implement function-scoped variables.
 rationale: Avoid `local` in `/bin/sh`, or require a shell that provides it.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-008.yaml
   shell_checks_example: examples/008.sh

--- a/docs/rules/X004.yaml
+++ b/docs/rules/X004.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses the `function` keyword without trailing `()`, which is not part of portable `sh` syntax.
 rationale: Define shell functions with the plain `name() { ...; }` form when portability matters.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-009.yaml
   shell_checks_example: examples/009.sh

--- a/docs/rules/X005.yaml
+++ b/docs/rules/X005.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: The `case` statement uses a bash-only fallthrough marker that portable `sh` does not understand.
 rationale: Keep `case` branches to POSIX syntax unless the script is explicitly targeting bash.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-010.yaml
   shell_checks_example: examples/010.sh

--- a/docs/rules/X006.yaml
+++ b/docs/rules/X006.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script relies on process substitution, which is not available in standard `sh`.
 rationale: Replace process substitution with a pipe, temporary file, or another portable data flow.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-011.yaml
   shell_checks_example: examples/011.sh

--- a/docs/rules/X007.yaml
+++ b/docs/rules/X007.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses ANSI C-style quoting, which is a shell extension rather than POSIX syntax.
 rationale: Use ordinary shell quoting and explicit escaping when the script needs to stay portable.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-012.yaml
   shell_checks_example: examples/012.sh

--- a/docs/rules/X008.yaml
+++ b/docs/rules/X008.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses the standalone arithmetic command form, which is not defined by POSIX `sh`.
 rationale: Use a portable arithmetic approach or switch to a shell that supports this command form.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-013.yaml
   shell_checks_example: examples/013.sh

--- a/docs/rules/X009.yaml
+++ b/docs/rules/X009.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script relies on `select`, which is a shell-specific menu loop rather than portable `sh` syntax.
 rationale: Build the menu flow with basic shell loops if the script must run in `sh`.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-014.yaml
   shell_checks_example: examples/014.sh

--- a/docs/rules/X010.yaml
+++ b/docs/rules/X010.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script depends on brace expansion, which portable `sh` does not expand.
 rationale: Spell out the values explicitly or generate them in a loop instead of using braces.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-015.yaml
   shell_checks_example: examples/015.sh

--- a/docs/rules/X011.yaml
+++ b/docs/rules/X011.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script feeds data with a here-string, which is a bash-style redirection.
 rationale: Use a pipe or temporary file when the same input needs to work in portable shell code.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-016.yaml
   shell_checks_example: examples/016.sh

--- a/docs/rules/X012.yaml
+++ b/docs/rules/X012.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses combined stdout-and-stderr redirection syntax that portable `sh` does not provide.
 rationale: Redirect stdout and stderr separately when you need the code to stay portable.
+safe_fix: true
+fix_description: "Replace `&>target` with `>target 2>&1`."
 source:
   shell_checks_rule: rules/SH-017.yaml
   shell_checks_example: examples/017.sh

--- a/docs/rules/X013.yaml
+++ b/docs/rules/X013.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script assigns a shell array, which is not part of standard `sh`.
 rationale: Use separate variables or positional parameters instead of array assignment in portable shell.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-018.yaml
   shell_checks_example: examples/018.sh

--- a/docs/rules/X014.yaml
+++ b/docs/rules/X014.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses a co-process, which is a shell extension rather than POSIX `sh`.
 rationale: Use ordinary background jobs and pipes if the script must remain portable.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-019.yaml
   shell_checks_example: examples/019.sh

--- a/docs/rules/X015.yaml
+++ b/docs/rules/X015.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script relies on `let`, which portable `sh` does not define.
 rationale: Prefer arithmetic expansion or another portable arithmetic mechanism instead.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-020.yaml
   shell_checks_example: examples/020.sh

--- a/docs/rules/X016.yaml
+++ b/docs/rules/X016.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses `declare`, which is not available in portable `sh`.
 rationale: Use plain assignments or shell features that your target shell actually supports.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-021.yaml
   shell_checks_example: examples/021.sh

--- a/docs/rules/X017.yaml
+++ b/docs/rules/X017.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script depends on trapping `ERR`, `DEBUG`, or `RETURN`, which are shell-specific rather than POSIX behavior.
 rationale: Check command statuses explicitly and avoid shell-specific trap hooks in portable code.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-022.yaml
   shell_checks_example: examples/022.sh

--- a/docs/rules/X018.yaml
+++ b/docs/rules/X018.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses indirect parameter expansion, which is a bash extension.
 rationale: Reshape the data flow so the script can name the target variable directly.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-023.yaml
   shell_checks_example: examples/023.sh

--- a/docs/rules/X019.yaml
+++ b/docs/rules/X019.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses a direct array reference, which portable `sh` does not support.
 rationale: Use separate variables or positional parameters instead of array references in portable shell.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-024.yaml
   shell_checks_example: examples/024.sh

--- a/docs/rules/X020.yaml
+++ b/docs/rules/X020.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script opens a file descriptor with a brace-based redirection form that portable sh does not support.
 rationale: Use a fixed descriptor or a shell that supports this redirection syntax.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-028.yaml
   shell_checks_example: examples/028.sh

--- a/docs/rules/X021.yaml
+++ b/docs/rules/X021.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: The script enables pipeline failure handling with a shell option that portable sh does not define.
 rationale: Check command statuses explicitly in sh, or switch to a shell that supports this option.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-029.yaml
   shell_checks_example: examples/029.sh

--- a/docs/rules/X022.yaml
+++ b/docs/rules/X022.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script uses a shell builtin option that portable sh does not provide.
 rationale: Avoid shell builtin option forms that POSIX sh does not define, or require a shell that guarantees them.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-030.yaml
   shell_checks_example: examples/030.sh

--- a/docs/rules/X023.yaml
+++ b/docs/rules/X023.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script slices a parameter with a bash-only substring form.
 rationale: Use a POSIX-safe transformation or require bash for substring slicing.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-031.yaml
   shell_checks_example: examples/031.sh

--- a/docs/rules/X024.yaml
+++ b/docs/rules/X024.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script modifies a parameter's case with a bash-only expansion form.
 rationale: Perform case conversion in another step, or target a shell that supports case-modification expansion.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-032.yaml
   shell_checks_example: examples/032.sh

--- a/docs/rules/X025.yaml
+++ b/docs/rules/X025.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: The script performs parameter replacement with a bash-only expansion form.
 rationale: Use a different transformation path, or switch to bash for this replacement syntax.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-033.yaml
   shell_checks_example: examples/033.sh

--- a/docs/rules/X026.yaml
+++ b/docs/rules/X026.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `$(< file)` shortcut reads a file with bash-specific syntax instead of portable shell syntax."
 rationale: "Use a portable read pattern when the script is meant to run under `sh`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-053.yaml
   shell_checks_example: examples/053.sh

--- a/docs/rules/X027.yaml
+++ b/docs/rules/X027.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: Echo flags make output formatting depend on the shell's own implementation choices.
 rationale: "Use `printf` when the script needs predictable formatting."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-054.yaml
   shell_checks_example: examples/054.sh

--- a/docs/rules/X028.yaml
+++ b/docs/rules/X028.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A lower-case range in tr can depend on locale and may not cover the characters you expect.
 rationale: Use explicit character classes or a fixed character list when mapping characters.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-058.yaml
   shell_checks_example: examples/058.sh

--- a/docs/rules/X029.yaml
+++ b/docs/rules/X029.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An upper-case range in tr can depend on locale and may not cover the characters you expect.
 rationale: Use explicit character classes or a fixed character list when mapping characters.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-059.yaml
   shell_checks_example: examples/059.sh

--- a/docs/rules/X030.yaml
+++ b/docs/rules/X030.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: Backslash sequences in echo depend on shell behavior and may not print as intended.
 rationale: Use printf when the text needs predictable escape handling.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-061.yaml
   shell_checks_example: examples/061.sh

--- a/docs/rules/X031.yaml
+++ b/docs/rules/X031.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "A POSIX shell script is relying on `source`, which is not part of the portable shell vocabulary."
 rationale: "Use the portable dot command when you need to include another file, or switch to bash intentionally if you want `source`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-080.yaml
   shell_checks_example: examples/080.sh

--- a/docs/rules/X032.yaml
+++ b/docs/rules/X032.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "A POSIX shell script is using bash's `%q` `printf` conversion."
 rationale: "Keep `printf` format strings within POSIX features when targeting `sh`, or run the script under bash if you need `%q`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-081.yaml
   shell_checks_example: examples/081.sh

--- a/docs/rules/X033.yaml
+++ b/docs/rules/X033.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: "A POSIX sh script uses a bash-style `[[ ... ]]` test in an `elif` clause."
 rationale: "Use a portable `[` test or switch the script to bash."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-093.yaml
   shell_checks_example: examples/093.sh

--- a/docs/rules/X035.yaml
+++ b/docs/rules/X035.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A POSIX `sh` function is written with parameter syntax that ShellCheck rejects."
 rationale: "Use the portable `name() { ...; }` form and read arguments through `$1`, `$2`, and so on."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-107.yaml
   shell_checks_example: examples/107.sh

--- a/docs/rules/X036.yaml
+++ b/docs/rules/X036.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A zsh-only redirection operator appears in a POSIX shell script.
 rationale: Use portable redirections instead of the zsh operator.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-108.yaml
   shell_checks_example: examples/108.sh

--- a/docs/rules/X037.yaml
+++ b/docs/rules/X037.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A grouped case pattern uses non-POSIX shell syntax.
 rationale: Spell out the alternatives with plain case patterns or use bash.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-111.yaml
   shell_checks_example: examples/111.sh

--- a/docs/rules/X038.yaml
+++ b/docs/rules/X038.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Zsh-style conditional bracing is not portable shell syntax.
 rationale: "Use standard `if ...; then ...; fi` structure instead."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-124.yaml
   shell_checks_example: examples/124.sh

--- a/docs/rules/X039.yaml
+++ b/docs/rules/X039.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Zsh `always` blocks are not valid shell syntax."
 rationale: Rewrite the flow using normal shell constructs.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-125.yaml
   shell_checks_example: examples/125.sh

--- a/docs/rules/X040.yaml
+++ b/docs/rules/X040.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Uses array-style subscripting in a POSIX shell test
 rationale: Use a portable test or a shell that actually supports arrays.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-126.yaml
   shell_checks_example: examples/126.sh

--- a/docs/rules/X041.yaml
+++ b/docs/rules/X041.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: Uses array-style subscripting inside a shell condition
 rationale: Rewrite it with portable parameter handling or a real array-capable shell.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-127.yaml
   shell_checks_example: examples/127.sh

--- a/docs/rules/X042.yaml
+++ b/docs/rules/X042.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: A sourced file is invoked with extra words.
 rationale: Keep the source path simple and quote dynamic pieces.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-140.yaml
   shell_checks_example: examples/140.sh

--- a/docs/rules/X043.yaml
+++ b/docs/rules/X043.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: This uses a zsh-only parameter expansion form.
 rationale: Switch to a shell that supports the syntax or rewrite it portably.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-153.yaml
   shell_checks_example: examples/153.sh

--- a/docs/rules/X044.yaml
+++ b/docs/rules/X044.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: Nested zsh-style expansion syntax is not portable to sh.
 rationale: Replace the nested expansion with plain shell logic.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-154.yaml
   shell_checks_example: examples/154.sh

--- a/docs/rules/X045.yaml
+++ b/docs/rules/X045.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "Uses `+=` append assignment in a shell mode that does not guarantee it."
 rationale: Rewrite it as an ordinary assignment or explicit string append.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-158.yaml
   shell_checks_example: examples/158.sh

--- a/docs/rules/X046.yaml
+++ b/docs/rules/X046.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: An extended glob pattern appears inside a test expression.
 rationale: Rewrite the condition with a portable pattern or a `case` statement.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-174.yaml
   shell_checks_example: examples/174.sh

--- a/docs/rules/X047.yaml
+++ b/docs/rules/X047.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A `for` loop binds more than one variable per iteration."
 rationale: Use a single loop variable and unpack values inside the body.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-180.yaml
   shell_checks_example: examples/180.sh

--- a/docs/rules/X048.yaml
+++ b/docs/rules/X048.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A case pattern uses extended-glob parenthesized alternation.
 rationale: Use separate case arms or a portable glob pattern.
+safe_fix: true
+fix_description: "Expand the embedded parenthesized alternation into equivalent whole `case` patterns separated by `|`."
 source:
   shell_checks_rule: rules/SH-182.yaml
   shell_checks_example: examples/182.sh

--- a/docs/rules/X049.yaml
+++ b/docs/rules/X049.yaml
@@ -10,6 +10,8 @@ shells:
   - ksh
 description: A zsh prompt escape is used inside a POSIX shell script.
 rationale: Use ANSI escape sequences instead of zsh prompt formatting.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-183.yaml
   shell_checks_example: examples/183.sh

--- a/docs/rules/X050.yaml
+++ b/docs/rules/X050.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: "A csh-style `set` assignment appears in a POSIX shell script."
 rationale: Use standard variable assignment syntax for sh.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-184.yaml
   shell_checks_example: examples/184.sh

--- a/docs/rules/X051.yaml
+++ b/docs/rules/X051.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A zsh-style nested parameter expansion is used in a POSIX script.
 rationale: Use intermediate variables instead of nested expansions.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-218.yaml
   shell_checks_example: examples/218.sh

--- a/docs/rules/X052.yaml
+++ b/docs/rules/X052.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `function` keyword is used with parentheses in a POSIX shell script."
 rationale: "Remove the `function` keyword or the parentheses for portability."
+safe_fix: true
+fix_description: "Delete the leading `function` keyword and keep the `name()` definition form."
 source:
   shell_checks_rule: rules/SH-226.yaml
   shell_checks_example: examples/226.sh

--- a/docs/rules/X053.yaml
+++ b/docs/rules/X053.yaml
@@ -7,6 +7,8 @@ shells:
   - bash
 description: "The variable `0` is assigned a value, which is a zsh idiom."
 rationale: "Use a regular variable name instead of `0`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-260.yaml
   shell_checks_example: examples/260.sh

--- a/docs/rules/X054.yaml
+++ b/docs/rules/X054.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "An extended glob pattern `@()` is used in a POSIX shell context."
 rationale: "Use a `case` statement or POSIX glob patterns instead."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-261.yaml
   shell_checks_example: examples/261.sh

--- a/docs/rules/X055.yaml
+++ b/docs/rules/X055.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "A `$\"string\"` locale-translated string is used in POSIX sh."
 rationale: Use plain double quotes for portability.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-262.yaml
   shell_checks_example: examples/262.sh

--- a/docs/rules/X055.yaml
+++ b/docs/rules/X055.yaml
@@ -10,7 +10,7 @@ shells:
 description: "A `$\"string\"` locale-translated string is used in POSIX sh."
 rationale: Use plain double quotes for portability.
 safe_fix: false
-fix_description: null
+fix_description: Replace the leading `$"` with a plain `"` on the reported string.
 source:
   shell_checks_rule: rules/SH-262.yaml
   shell_checks_example: examples/262.sh

--- a/docs/rules/X056.yaml
+++ b/docs/rules/X056.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "A C-style `for ((...))` loop is used in a POSIX shell script."
 rationale: "Use a `while` loop with arithmetic for portability."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-263.yaml
   shell_checks_example: examples/263.sh

--- a/docs/rules/X056.yaml
+++ b/docs/rules/X056.yaml
@@ -10,7 +10,7 @@ shells:
 description: "A C-style `for ((...))` loop is used in a POSIX shell script."
 rationale: "Use a `while` loop with arithmetic for portability."
 safe_fix: false
-fix_description: null
+fix_description: Rewrite the C-style `for ((init; cond; step))` loop as separate init code plus a `while` loop with the condition and step made explicit.
 source:
   shell_checks_rule: rules/SH-263.yaml
   shell_checks_example: examples/263.sh

--- a/docs/rules/X057.yaml
+++ b/docs/rules/X057.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The legacy `$[...]` arithmetic syntax is used in POSIX sh."
 rationale: "Use `$((...))` for arithmetic expansion."
+safe_fix: true
+fix_description: "Replace each legacy `$[expr]` arithmetic fragment with the equivalent `$((expr))` form."
 source:
   shell_checks_rule: rules/SH-264.yaml
   shell_checks_example: examples/264.sh

--- a/docs/rules/X058.yaml
+++ b/docs/rules/X058.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: "A `<` or `>` operator is used inside `[[ ]]` in a POSIX sh script."
 rationale: "Use `-lt`/`-gt` for numeric comparisons, or another portable form for string ordering."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-265.yaml
   shell_checks_example: examples/265.sh

--- a/docs/rules/X059.yaml
+++ b/docs/rules/X059.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `=~` regex match operator is used in POSIX sh."
 rationale: "Use `grep` or `case` for pattern matching in POSIX sh."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-266.yaml
   shell_checks_example: examples/266.sh

--- a/docs/rules/X060.yaml
+++ b/docs/rules/X060.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `-v` variable-is-set test is used in POSIX sh."
 rationale: "Use `[ -n \"${var+set}\" ]` for portability."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-267.yaml
   shell_checks_example: examples/267.sh

--- a/docs/rules/X060.yaml
+++ b/docs/rules/X060.yaml
@@ -10,7 +10,7 @@ shells:
 description: "The `-v` variable-is-set test is used in POSIX sh."
 rationale: "Use `[ -n \"${var+set}\" ]` for portability."
 safe_fix: false
-fix_description: null
+fix_description: Rewrite the reported variable-set test as a parameter-expansion emptiness check, for example `[[ -v name ]]` to `[ -n "${name+set}" ]`.
 source:
   shell_checks_rule: rules/SH-267.yaml
   shell_checks_example: examples/267.sh

--- a/docs/rules/X061.yaml
+++ b/docs/rules/X061.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `-a` file-existence test is used inside `[[ ]]` in POSIX sh."
 rationale: "Use `-e` instead of `-a` for file existence testing."
+safe_fix: true
+fix_description: "Replace unary `-a` with `-e` inside the `[[ ... ]]` file-existence test."
 source:
   shell_checks_rule: rules/SH-268.yaml
   shell_checks_example: examples/268.sh

--- a/docs/rules/X062.yaml
+++ b/docs/rules/X062.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: A C-style for loop with arithmetic uses bashism syntax in POSIX sh.
 rationale: Use a while loop for portable iteration.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-269.yaml
   shell_checks_example: examples/269.sh

--- a/docs/rules/X062.yaml
+++ b/docs/rules/X062.yaml
@@ -10,7 +10,7 @@ shells:
 description: A C-style for loop with arithmetic uses bashism syntax in POSIX sh.
 rationale: Use a while loop for portable iteration.
 safe_fix: false
-fix_description: null
+fix_description: Rewrite the C-style loop as a `while` loop and spell each reported `++` or `--` as an explicit arithmetic assignment.
 source:
   shell_checks_rule: rules/SH-269.yaml
   shell_checks_example: examples/269.sh

--- a/docs/rules/X063.yaml
+++ b/docs/rules/X063.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `>&` combined redirect is used in POSIX sh."
 rationale: "Use `>/dev/null 2>&1` for portable output suppression."
+safe_fix: true
+fix_description: "Expand `>& target` into `> target 2>&1` using the same fixed literal target word."
 source:
   shell_checks_rule: rules/SH-270.yaml
   shell_checks_example: examples/270.sh

--- a/docs/rules/X065.yaml
+++ b/docs/rules/X065.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "A `[^...]` negated bracket expression is used in POSIX sh."
 rationale: "Use `[!...]` for portable negation in bracket expressions."
+safe_fix: true
+fix_description: "Replace the leading `^` in each reported bracket expression with `!` to use the portable negated bracket syntax."
 source:
   shell_checks_rule: rules/SH-272.yaml
   shell_checks_example: examples/272.sh

--- a/docs/rules/X066.yaml
+++ b/docs/rules/X066.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `|&` pipe-stderr operator is used in POSIX sh."
 rationale: "Use `2>&1 |` for portable stderr piping."
+safe_fix: true
+fix_description: "Expand each `|&` operator to `2>&1 |`."
 source:
   shell_checks_rule: rules/SH-273.yaml
   shell_checks_example: examples/273.sh

--- a/docs/rules/X067.yaml
+++ b/docs/rules/X067.yaml
@@ -10,7 +10,7 @@ shells:
 description: A function name contains a hyphen, which is not portable.
 rationale: Use underscores instead of hyphens in function names.
 safe_fix: false
-fix_description: null
+fix_description: Rename the function by replacing hyphens with underscores, and update matching call sites to use the new name.
 source:
   shell_checks_rule: rules/SH-274.yaml
   shell_checks_example: examples/274.sh

--- a/docs/rules/X067.yaml
+++ b/docs/rules/X067.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: A function name contains a hyphen, which is not portable.
 rationale: Use underscores instead of hyphens in function names.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-274.yaml
   shell_checks_example: examples/274.sh

--- a/docs/rules/X068.yaml
+++ b/docs/rules/X068.yaml
@@ -9,7 +9,7 @@ shells:
 description: "The script uses `set -E` or `set -T` in POSIX sh."
 rationale: "Avoid Bash-only trap inheritance flags in `sh`, or switch to a shell that supports them."
 safe_fix: false
-fix_description: null
+fix_description: Remove the errtrace or functrace option from the reported `set` operand, deleting it or splitting any remaining clustered flags as needed.
 source:
   shell_checks_rule: rules/SH-275.yaml
   shell_checks_example: examples/275.sh

--- a/docs/rules/X068.yaml
+++ b/docs/rules/X068.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: "The script uses `set -E` or `set -T` in POSIX sh."
 rationale: "Avoid Bash-only trap inheritance flags in `sh`, or switch to a shell that supports them."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-275.yaml
   shell_checks_example: examples/275.sh

--- a/docs/rules/X069.yaml
+++ b/docs/rules/X069.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "A symbolic signal name like `SIGHUP` is used with `trap` in POSIX sh."
 rationale: "Use the numeric signal or omit the `SIG` prefix for portability."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-276.yaml
   shell_checks_example: examples/276.sh

--- a/docs/rules/X069.yaml
+++ b/docs/rules/X069.yaml
@@ -10,7 +10,7 @@ shells:
 description: "A symbolic signal name like `SIGHUP` is used with `trap` in POSIX sh."
 rationale: "Use the numeric signal or omit the `SIG` prefix for portability."
 safe_fix: false
-fix_description: null
+fix_description: Delete the leading `SIG` prefix from the reported trap signal name.
 source:
   shell_checks_rule: rules/SH-276.yaml
   shell_checks_example: examples/276.sh

--- a/docs/rules/X070.yaml
+++ b/docs/rules/X070.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "A base prefix like `10#` is used in arithmetic in POSIX sh."
 rationale: Strip leading zeros manually for portability.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-277.yaml
   shell_checks_example: examples/277.sh

--- a/docs/rules/X070.yaml
+++ b/docs/rules/X070.yaml
@@ -10,7 +10,7 @@ shells:
 description: "A base prefix like `10#` is used in arithmetic in POSIX sh."
 rationale: Strip leading zeros manually for portability.
 safe_fix: false
-fix_description: null
+fix_description: Remove the reported `base#` prefix and normalize the remaining value to plain decimal by stripping any leading zeroes first.
 source:
   shell_checks_rule: rules/SH-277.yaml
   shell_checks_example: examples/277.sh

--- a/docs/rules/X071.yaml
+++ b/docs/rules/X071.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `${!arr[*]}` array key expansion is used in POSIX sh."
 rationale: Use a loop or associative array in bash instead.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-278.yaml
   shell_checks_example: examples/278.sh

--- a/docs/rules/X072.yaml
+++ b/docs/rules/X072.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "A pattern-based `unset -v` is used in POSIX sh."
 rationale: Unset variables individually for portability.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-279.yaml
   shell_checks_example: examples/279.sh

--- a/docs/rules/X073.yaml
+++ b/docs/rules/X073.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `-o` option test is used inside `[[ ]]` in POSIX sh."
 rationale: "Check shell options with a case statement or `set -o` output."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-280.yaml
   shell_checks_example: examples/280.sh

--- a/docs/rules/X074.yaml
+++ b/docs/rules/X074.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: "The `-k` sticky-bit test is used in POSIX sh."
 rationale: "Use `stat` or `ls -l` to check the sticky bit portably."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-281.yaml
   shell_checks_example: examples/281.sh

--- a/docs/rules/X075.yaml
+++ b/docs/rules/X075.yaml
@@ -8,6 +8,8 @@ shells:
   - sh
 description: "The `-O` ownership test is used in a POSIX sh script."
 rationale: "Use `stat` or a similar portable check for file ownership."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-282.yaml
   shell_checks_example: examples/282.sh

--- a/docs/rules/X076.yaml
+++ b/docs/rules/X076.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A zsh-style parameter flag is used in POSIX sh.
 rationale: Use standard parameter expansion or sed for text substitution.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-286.yaml
   shell_checks_example: examples/286.sh

--- a/docs/rules/X077.yaml
+++ b/docs/rules/X077.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: A nested default-value expansion is used in POSIX sh.
 rationale: Use intermediate variables instead of nesting expansions.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-291.yaml
   shell_checks_example: examples/291.sh

--- a/docs/rules/X078.yaml
+++ b/docs/rules/X078.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A case pattern cannot match the subject shape produced by this shell.
 rationale: Make the subject and pattern agree on any fixed prefixes or suffixes before matching.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-299.yaml
   shell_checks_example: examples/299.sh

--- a/docs/rules/X079.yaml
+++ b/docs/rules/X079.yaml
@@ -11,6 +11,8 @@ shells:
   - ksh
 description: A zsh-style parameter index flag is used in POSIX sh.
 rationale: Extract the value with cut or awk instead of zsh subscripting.
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-303.yaml
   shell_checks_example: examples/303.sh

--- a/docs/rules/X080.yaml
+++ b/docs/rules/X080.yaml
@@ -10,7 +10,7 @@ shells:
 description: "The bash-only `source` command is used inside a function in POSIX sh."
 rationale: "Use the portable `.` (dot) command instead of `source`."
 safe_fix: false
-fix_description: null
+fix_description: Replace the leading `source` command word with `.`, leaving the remaining operands unchanged.
 source:
   shell_checks_rule: rules/SH-304.yaml
   shell_checks_example: examples/304.sh

--- a/docs/rules/X080.yaml
+++ b/docs/rules/X080.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The bash-only `source` command is used inside a function in POSIX sh."
 rationale: "Use the portable `.` (dot) command instead of `source`."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-304.yaml
   shell_checks_example: examples/304.sh

--- a/docs/rules/X081.yaml
+++ b/docs/rules/X081.yaml
@@ -9,6 +9,8 @@ shells:
   - dash
 description: "The `${*%%pattern}` longest-suffix removal is applied to `$*` in POSIX sh."
 rationale: "Assign `$*` to a variable first, then apply parameter expansion."
+safe_fix: false
+fix_description: null
 source:
   shell_checks_rule: rules/SH-305.yaml
   shell_checks_example: examples/305.sh

--- a/docs/rules/X081.yaml
+++ b/docs/rules/X081.yaml
@@ -10,7 +10,7 @@ shells:
 description: "The `${*%%pattern}` longest-suffix removal is applied to `$*` in POSIX sh."
 rationale: "Assign `$*` to a variable first, then apply parameter expansion."
 safe_fix: false
-fix_description: null
+fix_description: Assign `$*` to a temporary variable first, then apply the reported `%%pattern` suffix removal to that variable.
 source:
   shell_checks_rule: rules/SH-305.yaml
   shell_checks_example: examples/305.sh

--- a/docs/rules/validate.sh
+++ b/docs/rules/validate.sh
@@ -196,7 +196,10 @@ validate_file() {
   if ! check_yq "${file}" '(.safe_fix | type) == "!!bool"' "safe_fix must be a boolean"; then
     failed=1
   fi
-  if ! check_yq "${file}" '(.safe_fix == true and ((.fix_description | type) == "!!str") and ((.fix_description | length) > 0)) or (.safe_fix == false and .fix_description == null)' "fix_description must be a non-empty string when safe_fix is true and null when safe_fix is false"; then
+  if ! check_yq "${file}" '(((.fix_description | type) == "!!str") and ((.fix_description | length) > 0)) or (.fix_description == null)' "fix_description must be a non-empty string or null"; then
+    failed=1
+  fi
+  if ! check_yq "${file}" '(.safe_fix == false) or (((.fix_description | type) == "!!str") and ((.fix_description | length) > 0))' "fix_description must be a non-empty string when safe_fix is true"; then
     failed=1
   fi
   if ! check_yq "${file}" '((.source | type) == "!!map") and ((.source.shell_checks_rule | type) == "!!str") and ((.source.shell_checks_rule | length) > 0) and ((.source.shell_checks_example | type) == "!!str") and ((.source.shell_checks_example | length) > 0)' "source must include shell_checks_rule and shell_checks_example"; then

--- a/docs/rules/validate.sh
+++ b/docs/rules/validate.sh
@@ -153,11 +153,12 @@ check_unique_optional_field() {
 
 validate_file() {
   local file=$1
-  local basename stem legacy_code rule_path example_path doc_shells source_shells failed=0
+  local basename stem legacy_code new_code rule_path example_path doc_shells source_shells failed=0
 
   basename=$(basename "${file}")
   stem=${basename%.yaml}
   legacy_code=$(yq -r '.legacy_code' "${file}")
+  new_code=$(yq -r '.new_code' "${file}")
 
   if ! check_yq "${file}" 'type == "!!map"' "root document must be a mapping"; then
     failed=1
@@ -192,6 +193,12 @@ validate_file() {
   if ! check_yq "${file}" '((.rationale | type) == "!!str") and ((.rationale | length) > 0)' "rationale must be a non-empty string"; then
     failed=1
   fi
+  if ! check_yq "${file}" '(.safe_fix | type) == "!!bool"' "safe_fix must be a boolean"; then
+    failed=1
+  fi
+  if ! check_yq "${file}" '(.safe_fix == true and ((.fix_description | type) == "!!str") and ((.fix_description | length) > 0)) or (.safe_fix == false and .fix_description == null)' "fix_description must be a non-empty string when safe_fix is true and null when safe_fix is false"; then
+    failed=1
+  fi
   if ! check_yq "${file}" '((.source | type) == "!!map") and ((.source.shell_checks_rule | type) == "!!str") and ((.source.shell_checks_rule | length) > 0) and ((.source.shell_checks_example | type) == "!!str") and ((.source.shell_checks_example | length) > 0)' "source must include shell_checks_rule and shell_checks_example"; then
     failed=1
   fi
@@ -199,8 +206,8 @@ validate_file() {
     failed=1
   fi
 
-  if [[ "${stem}" != "${legacy_code}" ]]; then
-    printf 'ERROR %s: filename must match legacy_code (%s)\n' "${basename}" "${legacy_code}" >&2
+  if [[ "${stem}" != "${new_code}" ]]; then
+    printf 'ERROR %s: filename must match new_code (%s)\n' "${basename}" "${new_code}" >&2
     failed=1
   fi
 


### PR DESCRIPTION
## Summary
- add `safe_fix` and `fix_description` to every rule spec under `docs/rules`
- classify each rule against both its YAML and current implementation, marking 46 rules as safely fixable and 261 as not safely fixable
- update `docs/rules/validate.sh` to validate the new fields and to check filenames against `new_code`

## Why
The rule specs needed explicit metadata for whether a future fixer can apply a semantics-preserving rewrite. This change records that classification directly in the rule docs and gives the validator enough schema awareness to keep the metadata consistent.

## Impact
This gives the analyzer and future fix plumbing a rule-by-rule source of truth for safe fixes, plus short human-readable fix descriptions for the rules that qualify.

## Validation
- `python3` metadata coverage check: `missing=0 safe=46 unsafe=261 total=307`
- `yq` schema-only pass across `docs/rules/*.yaml` for `safe_fix` and `fix_description`
- full `./docs/rules/validate.sh` could not complete in this worktree because the sibling `../shell-checks` repo is not present
