### PR TITLE
Fix remaining formatter and linter fuzz regressions

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -1536,11 +1536,19 @@ fn emit_heredocs(
 }
 
 fn render_heredoc_tail(body_span: Span, delimiter: &str, source: &str) -> String {
+    let body = body_span.slice(source);
     let mut rendered = String::new();
     rendered.push('\n');
-    rendered.push_str(body_span.slice(source));
+    rendered.push_str(body);
+    if heredoc_body_needs_separator(body) {
+        rendered.push('\n');
+    }
     rendered.push_str(delimiter);
     rendered
+}
+
+fn heredoc_body_needs_separator(body: &str) -> bool {
+    !body.is_empty() && !body.ends_with('\n') && !body.ends_with('\r')
 }
 
 pub(crate) fn render_assignment(
@@ -2156,14 +2164,9 @@ pub(crate) fn group_attachment_span(
     let open_offset =
         source[..stmt_group_attachment_start_offset(first, source_map)].rfind(open)?;
     let sequence_end = commands
-        .last()
-        .and_then(|_| {
-            commands
-                .iter()
-                .map(|command| stmt_verbatim_span(command, source))
-                .reduce(|left, right| left.merge(right))
-        })
-        .map(|span| span.end.offset)
+        .iter()
+        .map(|command| stmt_group_attachment_end_offset(command, source_map))
+        .max()
         .unwrap_or(0);
     let end = find_group_close_offset(source, sequence_end, close)
         .map(|offset| offset + close.len_utf8())
@@ -2188,6 +2191,28 @@ fn stmt_group_attachment_start_offset(
                 .unwrap_or_else(|| stmt_verbatim_span(stmt, source).start.offset)
         }
         _ => stmt_verbatim_span(stmt, source).start.offset,
+    }
+}
+
+fn stmt_group_attachment_end_offset(
+    stmt: &Stmt,
+    source_map: &crate::comments::SourceMap<'_>,
+) -> usize {
+    let source = source_map.source();
+    match &stmt.command {
+        Command::Compound(CompoundCommand::BraceGroup(commands)) => {
+            group_attachment_span(commands.as_slice(), source_map, '{', '}')
+                .map(|span| span.end.offset)
+                .unwrap_or_else(|| stmt_verbatim_span(stmt, source).end.offset)
+        }
+        Command::Compound(CompoundCommand::Subshell(commands)) => {
+            group_attachment_span(commands.as_slice(), source_map, '(', ')')
+                .map(|span| span.end.offset)
+                .unwrap_or_else(|| stmt_verbatim_span(stmt, source).end.offset)
+        }
+        Command::Function(_) | Command::AnonymousFunction(_) => stmt_span(stmt).end.offset,
+        _ if has_heredoc(stmt) => stmt_verbatim_span(stmt, source).end.offset,
+        _ => stmt_span(stmt).end.offset,
     }
 }
 
@@ -2487,21 +2512,31 @@ pub(crate) fn rendered_stmt_end_line(
         _ if has_heredoc(stmt) => {
             span_render_end_line(stmt_verbatim_span(stmt, source), source, source_map)
         }
-        Command::Compound(CompoundCommand::Subshell(_) | CompoundCommand::BraceGroup(_)) => {
-            let end_line = span_render_end_line(stmt_format_span(stmt), source, source_map);
-            let close = match &stmt.command {
-                Command::Compound(CompoundCommand::Subshell(_)) => ')',
-                Command::Compound(CompoundCommand::BraceGroup(_)) => '}',
-                _ => unreachable!("only group compounds reach this branch"),
-            };
-            let close_line =
-                find_group_close_offset(source, stmt_format_span(stmt).end.offset, close)
-                    .map(|offset| source_map.line_number_for_offset(offset));
-            if close_line.is_some_and(|line| line > end_line) {
-                end_line + 1
-            } else {
-                end_line
+        Command::Compound(CompoundCommand::Subshell(commands)) => {
+            let mut span = group_attachment_span(commands.as_slice(), source_map, '(', ')')
+                .unwrap_or_else(|| stmt_span(stmt));
+            for redirect in &stmt.redirects {
+                span = merge_non_empty_span(span, redirect.span);
             }
+            if matches!(stmt.terminator, Some(StmtTerminator::Background(_)))
+                && let Some(terminator_span) = stmt.terminator_span
+            {
+                span = merge_non_empty_span(span, terminator_span);
+            }
+            span_render_end_line(span, source, source_map)
+        }
+        Command::Compound(CompoundCommand::BraceGroup(commands)) => {
+            let mut span = group_attachment_span(commands.as_slice(), source_map, '{', '}')
+                .unwrap_or_else(|| stmt_span(stmt));
+            for redirect in &stmt.redirects {
+                span = merge_non_empty_span(span, redirect.span);
+            }
+            if matches!(stmt.terminator, Some(StmtTerminator::Background(_)))
+                && let Some(terminator_span) = stmt.terminator_span
+            {
+                span = merge_non_empty_span(span, terminator_span);
+            }
+            span_render_end_line(span, source, source_map)
         }
         _ => span_render_end_line(stmt_format_span(stmt), source, source_map),
     }

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -226,15 +226,16 @@ mod tests {
         );
     }
 
-    fn assert_idempotent(source: &str, path: Option<&Path>, options: &ShellFormatOptions) {
-        let once = match format_source(source, path, options).unwrap() {
+    fn format_to_string(source: &str, path: Option<&Path>, options: &ShellFormatOptions) -> String {
+        match format_source(source, path, options).unwrap() {
             FormattedSource::Unchanged => source.to_string(),
             FormattedSource::Formatted(formatted) => formatted,
-        };
-        let twice = match format_source(&once, path, options).unwrap() {
-            FormattedSource::Unchanged => once.clone(),
-            FormattedSource::Formatted(formatted) => formatted,
-        };
+        }
+    }
+
+    fn assert_idempotent(source: &str, path: Option<&Path>, options: &ShellFormatOptions) {
+        let once = format_to_string(source, path, options);
+        let twice = format_to_string(&once, path, options);
         assert_eq!(once, twice);
     }
 
@@ -1451,6 +1452,33 @@ print hidden &!
     }
 
     #[test]
+    fn preserves_spacing_after_nested_multiline_subshells_before_simple_commands() {
+        assert_idempotent(
+            "(\n\t(\n\t\tfalse\n\t)\n)\ngrep \"name delta\"\n",
+            Some(Path::new("nested_multiline_subshell_then_stmt.sh")),
+            &ShellFormatOptions::default(),
+        );
+    }
+
+    #[test]
+    fn preserves_spacing_after_nested_multiline_subshells_before_other_groups() {
+        assert_idempotent(
+            "(\n\t(\n\t\tfalse\n\t)\n)\n(\n\twhile true; do\n\t\t:\n\tdone\n)\n",
+            Some(Path::new("nested_multiline_subshell_then_group.bash")),
+            &ShellFormatOptions::default(),
+        );
+    }
+
+    #[test]
+    fn preserves_spacing_after_subshells_that_end_with_function_definitions() {
+        assert_idempotent(
+            "foo() {\n\t(\n\t\tbar() {\n\t\t\techo hi\n\t\t}\n\t)\n\n\tprintf x\n}\n",
+            Some(Path::new("subshell_function_tail_gap.bash")),
+            &ShellFormatOptions::default(),
+        );
+    }
+
+    #[test]
     fn preserves_shebang_spacing_before_nested_multiline_groups_idempotently() {
         assert_idempotent(
             "#!/usr/bin/env bash\n\n(\n\t(\n\t\techo hi\n\t)\n)\n",
@@ -1495,6 +1523,40 @@ print hidden &!
         assert_idempotent(
             "[[ ! -n]]\n",
             Some(Path::new("fuzz.bash")),
+            &ShellFormatOptions::default(),
+        );
+    }
+
+    #[test]
+    fn keeps_unterminated_heredoc_closers_on_their_own_lines() {
+        let source = "x foo=1<<EOF=1<<EOF\nhi";
+        let formatted = format_to_string(
+            source,
+            Some(Path::new("fuzz.sh")),
+            &ShellFormatOptions::default(),
+        );
+
+        assert_eq!(formatted, "x foo=1 <<EOF=1 <<EOF\nhi\nEOF=1\nEOF\n");
+        assert_idempotent(
+            source,
+            Some(Path::new("fuzz.sh")),
+            &ShellFormatOptions::default(),
+        );
+    }
+
+    #[test]
+    fn preserves_body_lines_when_synthesizing_missing_heredoc_closers() {
+        let source = "d8<<EGF\nhi\nEOF";
+        let formatted = format_to_string(
+            source,
+            Some(Path::new("fuzz.sh")),
+            &ShellFormatOptions::default(),
+        );
+
+        assert_eq!(formatted, "d8 <<EGF\nhi\nEOF\nEGF\n");
+        assert_idempotent(
+            source,
+            Some(Path::new("fuzz.sh")),
             &ShellFormatOptions::default(),
         );
     }

--- a/crates/shuck-formatter/src/streaming.rs
+++ b/crates/shuck-formatter/src/streaming.rs
@@ -428,6 +428,10 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             self.push_output_str(self.line_ending());
             self.line_start = true;
             self.write_verbatim(&heredoc.body);
+            if heredoc_body_needs_separator(&heredoc.body) {
+                self.push_output_str(self.line_ending());
+                self.line_start = true;
+            }
             self.write_verbatim(&heredoc.delimiter);
         }
     }
@@ -1937,6 +1941,10 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
         self.write_indent_units(levels);
     }
+}
+
+fn heredoc_body_needs_separator(body: &str) -> bool {
+    !body.is_empty() && !body.ends_with('\n') && !body.ends_with('\r')
 }
 
 fn raw_redirect_source_slice<'a>(redirect: &Redirect, source: &'a str) -> Option<&'a str> {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -86,7 +86,7 @@ pub use suppression::{
 pub use violation::Violation;
 
 use rustc_hash::FxHashSet;
-use shuck_ast::{File, TextSize};
+use shuck_ast::{File, Position, Span, TextSize};
 use shuck_indexer::Indexer;
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
@@ -250,6 +250,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
     );
     let mut diagnostics = observer.into_diagnostics();
     diagnostics.extend(checker.check());
+    sanitize_diagnostic_spans(&mut diagnostics, source);
     for diagnostic in &mut diagnostics {
         if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
             diagnostic.severity = severity;
@@ -371,6 +372,7 @@ pub fn lint_file_at_path_with_resolver(
         &settings.rules,
         shell,
     ));
+    sanitize_diagnostic_spans(&mut diagnostics, source);
 
     for diagnostic in &mut diagnostics {
         if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
@@ -420,6 +422,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
         &settings.rules,
         shell,
     ));
+    sanitize_diagnostic_spans(&mut diagnostics, source);
 
     for diagnostic in &mut diagnostics {
         if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
@@ -471,6 +474,58 @@ fn filter_suppressed_diagnostics(
 
         !suppression_index.is_suppressed(diagnostic.rule, line)
     });
+}
+
+fn sanitize_diagnostic_spans(diagnostics: &mut [Diagnostic], source: &str) {
+    for diagnostic in diagnostics {
+        diagnostic.span = sanitize_span(diagnostic.span, source);
+    }
+}
+
+fn sanitize_span(span: Span, source: &str) -> Span {
+    let len = source.len();
+    let raw_start = span.start.offset.min(len);
+    let raw_end = span.end.offset.min(len);
+    let (start_offset, end_offset) = if raw_start <= raw_end {
+        (
+            floor_char_boundary(source, raw_start),
+            ceil_char_boundary(source, raw_end),
+        )
+    } else {
+        (
+            floor_char_boundary(source, raw_end),
+            ceil_char_boundary(source, raw_start),
+        )
+    };
+
+    Span::from_positions(
+        position_at_offset(source, start_offset),
+        position_at_offset(source, end_offset),
+    )
+}
+
+fn position_at_offset(source: &str, target_offset: usize) -> Position {
+    let mut position = Position::new();
+    for ch in source[..target_offset].chars() {
+        position.advance(ch);
+    }
+    position
+}
+
+fn floor_char_boundary(source: &str, offset: usize) -> usize {
+    let mut offset = offset.min(source.len());
+    while offset > 0 && !source.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn ceil_char_boundary(source: &str, offset: usize) -> usize {
+    let mut offset = offset.min(source.len());
+    while offset < source.len() && !source.is_char_boundary(offset) {
+        offset += 1;
+    }
+    offset
 }
 
 #[cfg(test)]
@@ -1209,6 +1264,90 @@ END
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn recovered_lint_diagnostics_keep_valid_spans_for_fuzz_regression() {
+        let source = concat!(
+            "$~h) echo help; exit 0 ;;\n",
+            "  esac\n",
+            "done\n",
+            "\n",
+            "# Should not trigger: one arm can handle m   a) alg=le are correlated.\n",
+            "while g$OPTARG ;;\n",
+            "    d) domain=$eultiple options.\n",
+            "while ge}opts ':ab' opt; do\n",
+            "  case \"$opt\" in\n",
+            "   | ) ba: ;;\n",
+            "  esac\n",
+            "doneJ\n",
+            "# Shou#!/bin/sh\n",
+            "\n",
+            "# Should trigger: getopts declares -o, but the matching case never handles itld not trigger: only cases over the getopts variab.\n",
+            "while getopts ':a:d:o:h' OPT; do\n",
+            "  case \"$OPT\" in\n",
+            "    a) alg=le are correlated.\n",
+            "while g$OPTARG ;;\n",
+            "    d) domain=$etoptA "
+        );
+        let cases = [
+            (Some(Path::new("fuzz.sh")), ParseDialect::Posix),
+            (Some(Path::new("fuzz.bash")), ParseDialect::Bash),
+            (Some(Path::new("fuzz.mksh")), ParseDialect::Mksh),
+            (Some(Path::new("fuzz.zsh")), ParseDialect::Zsh),
+            (None, ParseDialect::Posix),
+            (None, ParseDialect::Bash),
+            (None, ParseDialect::Mksh),
+            (None, ParseDialect::Zsh),
+        ];
+
+        for (path, dialect) in cases {
+            let parse_result = Parser::with_dialect(source, dialect).parse();
+            let indexer = Indexer::new(source, &parse_result);
+            let diagnostics = lint_file_at_path_with_parse_result(
+                &parse_result,
+                source,
+                &indexer,
+                &LinterSettings::default(),
+                None,
+                path,
+            );
+
+            for diagnostic in diagnostics {
+                assert!(
+                    diagnostic.span.start.offset <= diagnostic.span.end.offset,
+                    "invalid span ordering for {} with path {:?} and dialect {:?}: {:?}",
+                    diagnostic.code(),
+                    path,
+                    dialect,
+                    diagnostic.span
+                );
+                assert!(
+                    diagnostic.span.end.offset <= source.len(),
+                    "span end out of bounds for {} with path {:?} and dialect {:?}: {:?}",
+                    diagnostic.code(),
+                    path,
+                    dialect,
+                    diagnostic.span
+                );
+                assert!(
+                    source.is_char_boundary(diagnostic.span.start.offset),
+                    "span start not on char boundary for {} with path {:?} and dialect {:?}: {:?}",
+                    diagnostic.code(),
+                    path,
+                    dialect,
+                    diagnostic.span
+                );
+                assert!(
+                    source.is_char_boundary(diagnostic.span.end.offset),
+                    "span end not on char boundary for {} with path {:?} and dialect {:?}: {:?}",
+                    diagnostic.code(),
+                    path,
+                    dialect,
+                    diagnostic.span
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -87,7 +87,7 @@ pub use violation::Violation;
 
 use rustc_hash::FxHashSet;
 use shuck_ast::{File, Position, Span, TextSize};
-use shuck_indexer::Indexer;
+use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
 use shuck_semantic::{
@@ -250,7 +250,6 @@ fn analyze_file_at_path_with_resolver_and_shell(
     );
     let mut diagnostics = observer.into_diagnostics();
     diagnostics.extend(checker.check());
-    sanitize_diagnostic_spans(&mut diagnostics, source);
     for diagnostic in &mut diagnostics {
         if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
             diagnostic.severity = severity;
@@ -372,7 +371,6 @@ pub fn lint_file_at_path_with_resolver(
         &settings.rules,
         shell,
     ));
-    sanitize_diagnostic_spans(&mut diagnostics, source);
 
     for diagnostic in &mut diagnostics {
         if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
@@ -422,7 +420,9 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
         &settings.rules,
         shell,
     ));
-    sanitize_diagnostic_spans(&mut diagnostics, source);
+    if parse_result.is_err() {
+        sanitize_diagnostic_spans_cold(&mut diagnostics, source, indexer);
+    }
 
     for diagnostic in &mut diagnostics {
         if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
@@ -476,13 +476,31 @@ fn filter_suppressed_diagnostics(
     });
 }
 
-fn sanitize_diagnostic_spans(diagnostics: &mut [Diagnostic], source: &str) {
+#[cold]
+#[inline(never)]
+fn sanitize_diagnostic_spans_cold(diagnostics: &mut [Diagnostic], source: &str, indexer: &Indexer) {
     for diagnostic in diagnostics {
-        diagnostic.span = sanitize_span(diagnostic.span, source);
+        diagnostic.span = sanitize_span(diagnostic.span, source, indexer.line_index());
     }
 }
 
-fn sanitize_span(span: Span, source: &str) -> Span {
+#[cold]
+fn sanitize_span(span: Span, source: &str, line_index: &LineIndex) -> Span {
+    if span.start.offset <= span.end.offset
+        && span.end.offset <= source.len()
+        && source.is_char_boundary(span.start.offset)
+        && source.is_char_boundary(span.end.offset)
+    {
+        return span;
+    }
+
+    let offsets_are_bounded = span.start.offset <= source.len() && span.end.offset <= source.len();
+    let offsets_are_aligned =
+        source.is_char_boundary(span.start.offset) && source.is_char_boundary(span.end.offset);
+    if offsets_are_bounded && offsets_are_aligned && span.start.offset > span.end.offset {
+        return Span::from_positions(span.end, span.start);
+    }
+
     let len = source.len();
     let raw_start = span.start.offset.min(len);
     let raw_end = span.end.offset.min(len);
@@ -499,19 +517,27 @@ fn sanitize_span(span: Span, source: &str) -> Span {
     };
 
     Span::from_positions(
-        position_at_offset(source, start_offset),
-        position_at_offset(source, end_offset),
+        position_at_offset(source, line_index, start_offset),
+        position_at_offset(source, line_index, end_offset),
     )
 }
 
-fn position_at_offset(source: &str, target_offset: usize) -> Position {
-    let mut position = Position::new();
-    for ch in source[..target_offset].chars() {
-        position.advance(ch);
+#[cold]
+fn position_at_offset(source: &str, line_index: &LineIndex, target_offset: usize) -> Position {
+    let line = line_index.line_number(TextSize::new(target_offset as u32));
+    let line_start = line_index
+        .line_start(line)
+        .map(usize::from)
+        .unwrap_or_default();
+
+    Position {
+        line,
+        column: source[line_start..target_offset].chars().count() + 1,
+        offset: target_offset,
     }
-    position
 }
 
+#[cold]
 fn floor_char_boundary(source: &str, offset: usize) -> usize {
     let mut offset = offset.min(source.len());
     while offset > 0 && !source.is_char_boundary(offset) {
@@ -520,6 +546,7 @@ fn floor_char_boundary(source: &str, offset: usize) -> usize {
     offset
 }
 
+#[cold]
 fn ceil_char_boundary(source: &str, offset: usize) -> usize {
     let mut offset = offset.min(source.len());
     while offset < source.len() && !source.is_char_boundary(offset) {

--- a/fuzz/fuzz_targets/lexer_fuzz.rs
+++ b/fuzz/fuzz_targets/lexer_fuzz.rs
@@ -4,15 +4,18 @@
 
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
+mod common;
 
-fuzz_target!(|data: &[u8]| {
-    if let Ok(input) = std::str::from_utf8(data) {
-        if input.len() > 1_000_000 {
-            return;
-        }
+use libfuzzer_sys::{Corpus, fuzz_target};
 
-        let mut lexer = shuck_parser::parser::Lexer::new(input);
-        while lexer.next_lexed_token().is_some() {}
-    }
+fuzz_target!(|data: &[u8]| -> Corpus {
+    let input = match common::filtered_input(data) {
+        Ok(input) => input,
+        Err(reject) => return reject,
+    };
+
+    let mut lexer = shuck_parser::parser::Lexer::new(input);
+    while lexer.next_lexed_token().is_some() {}
+
+    Corpus::Keep
 });

--- a/fuzz/fuzz_targets/parser_fuzz.rs
+++ b/fuzz/fuzz_targets/parser_fuzz.rs
@@ -4,15 +4,18 @@
 
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
+mod common;
 
-fuzz_target!(|data: &[u8]| {
-    if let Ok(input) = std::str::from_utf8(data) {
-        if input.len() > 1_000_000 {
-            return;
-        }
+use libfuzzer_sys::{Corpus, fuzz_target};
 
-        let parser = shuck_parser::parser::Parser::new(input);
-        let _ = parser.parse();
-    }
+fuzz_target!(|data: &[u8]| -> Corpus {
+    let input = match common::filtered_input(data) {
+        Ok(input) => input,
+        Err(reject) => return reject,
+    };
+
+    let parser = shuck_parser::parser::Parser::new(input);
+    let _ = parser.parse();
+
+    Corpus::Keep
 });


### PR DESCRIPTION
## Summary
- fix formatter fuzz regressions around unterminated heredocs and multiline grouped-command spacing
- sanitize recovered linter diagnostic spans so malformed reversed spans do not escape
- route the legacy parser and lexer fuzzers through the shared filtered-input path to avoid seeded-corpus OOMs

## Root cause
The formatter had a couple of edge cases where synthesized heredoc closing structure and multiline group boundary tracking were not stable under reformatting. The linter could also forward recovered spans without normalizing invalid ranges first. Separately, the older parser and lexer fuzz targets were still accepting much larger inputs than the newer shared harness path, which let seeded corpora drive excessive memory use.

## Validation
- `cargo test -p shuck-formatter -p shuck-linter`
- replayed the saved `formatter_consistency_fuzz`, `formatter_validity_fuzz`, `linter_no_panic_fuzz`, and `parser_fuzz` artifacts with `-runs=1`
- `cargo build -p shuck`
- `python3 ./scripts/fuzz_cli.py --shuck-bin ./target/debug/shuck --dialect sh --profile full --count 100 --seed 100 --workers 4 --artifact-dir fuzz/artifacts/cli-smoke3-sh`
- `python3 ./scripts/fuzz_cli.py --shuck-bin ./target/debug/shuck --dialect bash --profile full --count 100 --seed 100 --workers 4 --artifact-dir fuzz/artifacts/cli-smoke3-bash`