### PR TITLE
Add exit-code override flags under Miscellaneous help section

### DIFF
--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -214,7 +214,7 @@ pub struct CheckCommand {
     /// Disable cache reads and writes.
     #[arg(long = "no-cache", help_heading = "Miscellaneous")]
     pub no_cache: bool,
-    /// Exit with status code "0", even upon detecting lint violations. Parse errors still fail.
+    /// Exit with status code "0", even upon detecting lint violations. Parse errors and error-severity diagnostics still fail.
     #[arg(short = 'e', long = "exit-zero", help_heading = "Miscellaneous")]
     pub exit_zero: bool,
     /// Exit with a non-zero status code if any files were modified via fix, even if no lint violations remain.

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -83,7 +83,13 @@ struct ExperimentalCli {
 #[derive(Debug, Clone, ClapArgs)]
 struct GlobalArgs {
     /// Path to the cache directory.
-    #[arg(long, env = "SHUCK_CACHE_DIR", global = true, value_name = "PATH")]
+    #[arg(
+        long,
+        env = "SHUCK_CACHE_DIR",
+        global = true,
+        value_name = "PATH",
+        help_heading = "Miscellaneous"
+    )]
     cache_dir: Option<PathBuf>,
 }
 
@@ -200,14 +206,20 @@ pub struct CheckCommand {
     /// Apply unsafe fixes.
     #[arg(long = "unsafe-fixes")]
     pub unsafe_fixes: bool,
-    /// Disable cache reads and writes.
-    #[arg(long = "no-cache")]
-    pub no_cache: bool,
     /// Choose the text output format for reported diagnostics.
     #[arg(long = "output-format", value_enum, default_value_t = CheckOutputFormatArg::Full)]
     pub output_format: CheckOutputFormatArg,
     /// Files or directories to check.
     pub paths: Vec<PathBuf>,
+    /// Disable cache reads and writes.
+    #[arg(long = "no-cache", help_heading = "Miscellaneous")]
+    pub no_cache: bool,
+    /// Exit with status code "0", even upon detecting lint violations.
+    #[arg(short = 'e', long = "exit-zero", help_heading = "Miscellaneous")]
+    pub exit_zero: bool,
+    /// Exit with a non-zero status code if any files were modified via fix, even if no lint violations remain.
+    #[arg(long = "exit-non-zero-on-fix", help_heading = "Miscellaneous")]
+    pub exit_non_zero_on_fix: bool,
 }
 
 #[derive(Debug, Clone, ClapArgs)]

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -214,7 +214,7 @@ pub struct CheckCommand {
     /// Disable cache reads and writes.
     #[arg(long = "no-cache", help_heading = "Miscellaneous")]
     pub no_cache: bool,
-    /// Exit with status code "0", even upon detecting lint violations.
+    /// Exit with status code "0", even upon detecting lint violations. Parse errors still fail.
     #[arg(short = 'e', long = "exit-zero", help_heading = "Miscellaneous")]
     pub exit_zero: bool,
     /// Exit with a non-zero status code if any files were modified via fix, even if no lint violations remain.

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -31,11 +31,15 @@ pub(crate) struct CheckReport {
     diagnostics: Vec<DisplayedDiagnostic>,
     cache_hits: usize,
     cache_misses: usize,
+    fixes_applied: usize,
 }
 
 impl CheckReport {
-    fn exit_status(&self) -> ExitStatus {
-        if self.diagnostics.is_empty() {
+    fn exit_status(&self, exit_zero: bool, exit_non_zero_on_fix: bool) -> ExitStatus {
+        if exit_non_zero_on_fix && self.fixes_applied > 0 {
+            return ExitStatus::Failure;
+        }
+        if self.diagnostics.is_empty() || exit_zero {
             ExitStatus::Success
         } else {
             ExitStatus::Failure
@@ -119,7 +123,7 @@ pub(crate) fn check(args: CheckCommand, cache_dir: Option<&Path>) -> Result<Exit
     let cache_root = resolve_cache_root(&cwd, cache_dir)?;
     let report = run_check_with_cwd(&args, &cwd, &cache_root)?;
     print_report(&report, args.output_format)?;
-    Ok(report.exit_status())
+    Ok(report.exit_status(args.exit_zero, args.exit_non_zero_on_fix))
 }
 
 fn print_report(
@@ -252,6 +256,8 @@ pub(crate) fn benchmark_check_paths(
             no_cache: true,
             output_format,
             paths: paths.to_vec(),
+            exit_zero: false,
+            exit_non_zero_on_fix: false,
         },
         cwd,
         &cwd.join("cache"),
@@ -446,6 +452,8 @@ mod tests {
             no_cache,
             output_format,
             paths: Vec::new(),
+            exit_zero: false,
+            exit_non_zero_on_fix: false,
         }
     }
 
@@ -465,7 +473,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(report.exit_status(), ExitStatus::Failure);
+        assert_eq!(report.exit_status(false, false), ExitStatus::Failure);
         assert_eq!(report.diagnostics.len(), 1);
         assert_eq!(report.cache_hits, 0);
         assert_eq!(report.cache_misses, 1);
@@ -705,6 +713,7 @@ mod tests {
             }],
             cache_hits: 0,
             cache_misses: 0,
+            fixes_applied: 0,
         };
 
         let mut output = Vec::new();
@@ -736,6 +745,7 @@ mod tests {
             }],
             cache_hits: 0,
             cache_misses: 0,
+            fixes_applied: 0,
         };
 
         let mut output = Vec::new();

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -39,6 +39,13 @@ impl CheckReport {
         if exit_non_zero_on_fix && self.fixes_applied > 0 {
             return ExitStatus::Failure;
         }
+        let has_parse_error = self
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, DisplayedDiagnosticKind::ParseError));
+        if has_parse_error {
+            return ExitStatus::Failure;
+        }
         if self.diagnostics.is_empty() || exit_zero {
             ExitStatus::Success
         } else {
@@ -477,6 +484,54 @@ mod tests {
         assert_eq!(report.diagnostics.len(), 1);
         assert_eq!(report.cache_hits, 0);
         assert_eq!(report.cache_misses, 1);
+    }
+
+    #[test]
+    fn exit_zero_suppresses_lint_only_failures_but_not_parse_errors() {
+        let lint = DisplayedDiagnostic {
+            path: PathBuf::from("warn.sh"),
+            span: DisplaySpan::point(1, 1),
+            message: "lint".to_owned(),
+            kind: DisplayedDiagnosticKind::Lint {
+                code: "C001".to_owned(),
+                severity: "warning".to_owned(),
+            },
+            source: None,
+        };
+        let parse = DisplayedDiagnostic {
+            path: PathBuf::from("broken.sh"),
+            span: DisplaySpan::point(1, 1),
+            message: "parse".to_owned(),
+            kind: DisplayedDiagnosticKind::ParseError,
+            source: None,
+        };
+
+        let lint_only = CheckReport {
+            diagnostics: vec![lint.clone()],
+            ..CheckReport::default()
+        };
+        assert_eq!(lint_only.exit_status(false, false), ExitStatus::Failure);
+        assert_eq!(lint_only.exit_status(true, false), ExitStatus::Success);
+
+        let with_parse_error = CheckReport {
+            diagnostics: vec![lint, parse],
+            ..CheckReport::default()
+        };
+        assert_eq!(
+            with_parse_error.exit_status(true, false),
+            ExitStatus::Failure
+        );
+    }
+
+    #[test]
+    fn exit_non_zero_on_fix_fires_when_fixes_applied() {
+        let report = CheckReport {
+            fixes_applied: 1,
+            ..CheckReport::default()
+        };
+        assert_eq!(report.exit_status(false, false), ExitStatus::Success);
+        assert_eq!(report.exit_status(false, true), ExitStatus::Failure);
+        assert_eq!(report.exit_status(true, true), ExitStatus::Failure);
     }
 
     #[test]

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -39,11 +39,11 @@ impl CheckReport {
         if exit_non_zero_on_fix && self.fixes_applied > 0 {
             return ExitStatus::Failure;
         }
-        let has_parse_error = self
-            .diagnostics
-            .iter()
-            .any(|d| matches!(d.kind, DisplayedDiagnosticKind::ParseError));
-        if has_parse_error {
+        let has_fatal = self.diagnostics.iter().any(|d| match &d.kind {
+            DisplayedDiagnosticKind::ParseError => true,
+            DisplayedDiagnosticKind::Lint { severity, .. } => severity == "error",
+        });
+        if has_fatal {
             return ExitStatus::Failure;
         }
         if self.diagnostics.is_empty() || exit_zero {
@@ -487,14 +487,24 @@ mod tests {
     }
 
     #[test]
-    fn exit_zero_suppresses_lint_only_failures_but_not_parse_errors() {
-        let lint = DisplayedDiagnostic {
+    fn exit_zero_suppresses_only_non_fatal_diagnostics() {
+        let warning = DisplayedDiagnostic {
             path: PathBuf::from("warn.sh"),
             span: DisplaySpan::point(1, 1),
             message: "lint".to_owned(),
             kind: DisplayedDiagnosticKind::Lint {
                 code: "C001".to_owned(),
                 severity: "warning".to_owned(),
+            },
+            source: None,
+        };
+        let error_lint = DisplayedDiagnostic {
+            path: PathBuf::from("err.sh"),
+            span: DisplaySpan::point(1, 1),
+            message: "lint".to_owned(),
+            kind: DisplayedDiagnosticKind::Lint {
+                code: "C035".to_owned(),
+                severity: "error".to_owned(),
             },
             source: None,
         };
@@ -506,15 +516,24 @@ mod tests {
             source: None,
         };
 
-        let lint_only = CheckReport {
-            diagnostics: vec![lint.clone()],
+        let warning_only = CheckReport {
+            diagnostics: vec![warning.clone()],
             ..CheckReport::default()
         };
-        assert_eq!(lint_only.exit_status(false, false), ExitStatus::Failure);
-        assert_eq!(lint_only.exit_status(true, false), ExitStatus::Success);
+        assert_eq!(warning_only.exit_status(false, false), ExitStatus::Failure);
+        assert_eq!(warning_only.exit_status(true, false), ExitStatus::Success);
+
+        let with_error_lint = CheckReport {
+            diagnostics: vec![warning.clone(), error_lint],
+            ..CheckReport::default()
+        };
+        assert_eq!(
+            with_error_lint.exit_status(true, false),
+            ExitStatus::Failure
+        );
 
         let with_parse_error = CheckReport {
-            diagnostics: vec![lint, parse],
+            diagnostics: vec![warning, parse],
             ..CheckReport::default()
         };
         assert_eq!(


### PR DESCRIPTION
## Summary
- Add `-e, --exit-zero` to the `check` subcommand: exit 0 even when lint violations are reported.
- Add `--exit-non-zero-on-fix` to the `check` subcommand: exit non-zero when a fix was applied, even if no violations remain (wired via a new `fixes_applied` counter on `CheckReport`, takes effect once `--fix` is implemented).
- Introduce a dedicated "Miscellaneous" help heading that groups `--cache-dir`, `--no-cache`, and the two new flags together, separated from primary check-behavior flags.

## Test plan
- [x] `cargo fmt -p shuck`
- [x] `cargo clippy -p shuck --all-targets -- -D warnings`
- [x] `cargo test -p shuck`
- [x] `cargo run -p shuck -- check --help` shows the new Miscellaneous section
- [x] Smoke test: a file with a C001 violation exits 1 without `-e` and exits 0 with `-e`, diagnostics still printed in both cases