### PR TITLE
Add shuck ignore generation for check

### DIFF
--- a/crates/shuck-linter/Cargo.toml
+++ b/crates/shuck-linter/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools"]
 benchmarking = []
 
 [dependencies]
+anyhow = { workspace = true }
 rustc-hash = "2"
 smallvec.workspace = true
 thiserror = { workspace = true }
@@ -24,7 +25,6 @@ shuck-parser = { path = "../shuck-parser" }
 [dev-dependencies]
 insta = { workspace = true }
 test-case = { workspace = true }
-anyhow = { workspace = true }
 tempfile = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -80,8 +80,9 @@ pub use rules::common::word::{
 pub use settings::LinterSettings;
 pub use shell::ShellDialect;
 pub use suppression::{
-    ShellCheckCodeMap, SuppressionAction, SuppressionDirective, SuppressionIndex,
-    SuppressionSource, first_statement_line, parse_directives,
+    AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,
+    SuppressionDirective, SuppressionIndex, SuppressionSource, add_ignores_to_path,
+    first_statement_line, parse_directives,
 };
 pub use violation::Violation;
 

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -11,7 +11,7 @@ use super::ShellCheckCodeMap;
 /// A parsed suppression directive from a comment.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SuppressionDirective {
-    /// The action: disable or disable-file.
+    /// The action: disable, disable-file, or ignore.
     pub action: SuppressionAction,
     /// Which directive syntax produced this.
     pub source: SuppressionSource,
@@ -27,6 +27,7 @@ pub struct SuppressionDirective {
 pub enum SuppressionAction {
     Disable,
     DisableFile,
+    Ignore,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -607,6 +608,8 @@ fn parse_shuck_action(value: &str) -> Option<SuppressionAction> {
         Some(SuppressionAction::Disable)
     } else if value.eq_ignore_ascii_case("disable-file") {
         Some(SuppressionAction::DisableFile)
+    } else if value.eq_ignore_ascii_case("ignore") {
+        Some(SuppressionAction::Ignore)
     } else {
         None
     }
@@ -671,6 +674,20 @@ mod tests {
 
         assert_eq!(directives.len(), 1);
         assert_eq!(directives[0].action, SuppressionAction::Disable);
+        assert_eq!(directives[0].source, SuppressionSource::Shuck);
+        assert_eq!(
+            directives[0].codes,
+            vec![Rule::UndefinedVariable, Rule::UnquotedExpansion]
+        );
+        assert_eq!(directives[0].line, 1);
+    }
+
+    #[test]
+    fn parses_shuck_ignore_directives_on_inline_lines() {
+        let directives = directives("echo $foo # shuck: ignore=C006,S001 # legacy\n");
+
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].action, SuppressionAction::Ignore);
         assert_eq!(directives[0].source, SuppressionSource::Shuck);
         assert_eq!(
             directives[0].codes,
@@ -1012,6 +1029,7 @@ foreach item (1 2) { # shellcheck disable=SC2086
     fn ignores_malformed_and_unknown_directives() {
         let source = "\
 # shuck: disable=
+# shuck: ignore=
 # shuck: foobar=C001
 # shuck disable=C001
 # shuck: enable=SH-039

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -36,6 +36,7 @@ impl SuppressionIndex {
                     .or_insert_with(RuleSuppressionIndex::default);
                 match directive.action {
                     SuppressionAction::DisableFile => index.whole_file = true,
+                    SuppressionAction::Ignore => index.lines.push(directive.line),
                     SuppressionAction::Disable => {
                         if directive.line < first_stmt_line {
                             index.whole_file = true;
@@ -49,6 +50,8 @@ impl SuppressionIndex {
         }
 
         for index in by_rule.values_mut() {
+            index.lines.sort_unstable();
+            index.lines.dedup();
             index
                 .ranges
                 .sort_unstable_by_key(|range| (range.start_line, range.end_line));
@@ -77,12 +80,17 @@ pub fn first_statement_line(file: &File) -> Option<u32> {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct RuleSuppressionIndex {
     whole_file: bool,
+    lines: Vec<u32>,
     ranges: Vec<LineRange>,
 }
 
 impl RuleSuppressionIndex {
     fn is_suppressed(&self, line: u32) -> bool {
         if self.whole_file {
+            return true;
+        }
+
+        if self.lines.binary_search(&line).is_ok() {
             return true;
         }
 
@@ -517,6 +525,20 @@ echo $foo
         assert!(!index.is_suppressed(Rule::UndefinedVariable, 2));
         assert!(index.is_suppressed(Rule::UndefinedVariable, 4));
         assert!(!index.is_suppressed(Rule::UndefinedVariable, 5));
+    }
+
+    #[test]
+    fn applies_shuck_ignore_only_to_the_directive_line() {
+        let source = "\
+foo='a b'
+echo $foo # shuck: ignore=C006
+echo $foo
+";
+        let index = suppression_index(source);
+
+        assert!(!index.is_suppressed(Rule::UndefinedVariable, 1));
+        assert!(index.is_suppressed(Rule::UndefinedVariable, 2));
+        assert!(!index.is_suppressed(Rule::UndefinedVariable, 3));
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/mod.rs
+++ b/crates/shuck-linter/src/suppression/mod.rs
@@ -1,8 +1,10 @@
 mod directive;
 mod index;
+mod rewrite;
 mod shellcheck_map;
 
 pub(crate) use directive::shellcheck_directive_can_apply_to_following_command;
 pub use directive::{SuppressionAction, SuppressionDirective, SuppressionSource, parse_directives};
 pub use index::{SuppressionIndex, first_statement_line};
+pub use rewrite::{AddIgnoreParseError, AddIgnoreResult, add_ignores_to_path};
 pub use shellcheck_map::ShellCheckCodeMap;

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -253,6 +253,10 @@ fn build_ignore_edit(
         });
     }
 
+    if line_ends_with_continuation(line_range, source) {
+        return None;
+    }
+
     let insertion_offset = inline_comment_insertion_offset(line_range, source);
     Some(IgnoreEdit {
         range: TextRange::new(insertion_offset, insertion_offset),
@@ -405,6 +409,14 @@ fn inline_comment_insertion_offset(line_range: TextRange, source: &str) -> TextS
         end = TextSize::new(end.to_u32() - 1);
     }
     end
+}
+
+fn line_ends_with_continuation(line_range: TextRange, source: &str) -> bool {
+    line_range
+        .slice(source)
+        .strip_suffix('\r')
+        .unwrap_or(line_range.slice(source))
+        .ends_with('\\')
 }
 
 fn join_codes(rules: &[Rule]) -> String {
@@ -574,6 +586,16 @@ mod tests {
     #[test]
     fn leaves_existing_trailing_comments_unsupported() {
         let source = "#!/bin/bash\necho $foo # existing comment\n";
+        let (result, updated) = run_add_ignore(source, None);
+
+        assert_eq!(result.directives_added, 0);
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(updated, source);
+    }
+
+    #[test]
+    fn leaves_continuation_lines_unsupported() {
+        let source = "#!/bin/bash\necho $foo \\\n&& echo ok\n";
         let (result, updated) = run_add_ignore(source, None);
 
         assert_eq!(result.directives_added, 0);

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -246,9 +246,10 @@ fn build_ignore_edit(
     }
 
     if let Some(directive) = existing_ignore {
-        return (directive.range.slice(source) != comment).then_some(IgnoreEdit {
+        let replacement = preserve_trailing_carriage_return(directive.range.slice(source), comment);
+        return (directive.range.slice(source) != replacement).then_some(IgnoreEdit {
             range: directive.range,
-            replacement: comment,
+            replacement,
         });
     }
 
@@ -257,6 +258,13 @@ fn build_ignore_edit(
         range: TextRange::new(insertion_offset, insertion_offset),
         replacement: format!("  {comment}"),
     })
+}
+
+fn preserve_trailing_carriage_return(existing: &str, mut replacement: String) -> String {
+    if existing.ends_with('\r') {
+        replacement.push('\r');
+    }
+    replacement
 }
 
 fn existing_ignore_reason<'a>(
@@ -592,6 +600,20 @@ mod tests {
         assert_eq!(
             updated,
             "#!/bin/bash\r\necho $foo  # shuck: ignore=C006\r\n"
+        );
+    }
+
+    #[test]
+    fn preserves_crlf_line_endings_when_rewriting_existing_ignores() {
+        let settings =
+            LinterSettings::for_rules([Rule::UndefinedVariable, Rule::UnquotedExpansion]);
+        let source = "#!/bin/bash\r\necho $foo  # shuck: ignore=S001 # legacy\r\n";
+        let (result, updated) = run_add_ignore_with_settings(source, &settings, None);
+
+        assert_eq!(result.directives_added, 1);
+        assert_eq!(
+            updated,
+            "#!/bin/bash\r\necho $foo  # shuck: ignore=C006, S001 # legacy\r\n"
         );
     }
 

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use rustc_hash::FxHashMap;
-use shuck_ast::TextRange;
+use shuck_ast::{TextRange, TextSize};
 use shuck_indexer::Indexer;
 use shuck_parser::{
     Error as ParseError, ShellDialect as ParseShellDialect, ShellProfile,
@@ -99,6 +99,7 @@ pub fn add_ignores_to_path(
 struct AnalyzedSource {
     directives: Vec<SuppressionDirective>,
     diagnostics: Vec<Diagnostic>,
+    strict_parse_error: Option<AddIgnoreParseError>,
     parse_error: Option<AddIgnoreParseError>,
     indexer: Indexer,
 }
@@ -133,21 +134,22 @@ fn analyze_source(
         suppression_index.as_ref(),
         Some(path),
     );
-    let parse_error = raw_parse_error(&parse_result, &diagnostics);
+    let strict_parse_error = strict_parse_error(&parse_result);
+    let parse_error = strict_parse_error
+        .clone()
+        .filter(|_| diagnostics.is_empty());
 
     AnalyzedSource {
         directives,
         diagnostics,
+        strict_parse_error,
         parse_error,
         indexer,
     }
 }
 
-fn raw_parse_error(
-    parse_result: &ParseResult,
-    diagnostics: &[Diagnostic],
-) -> Option<AddIgnoreParseError> {
-    if !parse_result.is_err() || !diagnostics.is_empty() {
+fn strict_parse_error(parse_result: &ParseResult) -> Option<AddIgnoreParseError> {
+    if !parse_result.is_err() {
         return None;
     }
 
@@ -250,8 +252,9 @@ fn build_ignore_edit(
         });
     }
 
+    let insertion_offset = inline_comment_insertion_offset(line_range, source);
     Some(IgnoreEdit {
-        range: TextRange::new(line_range.end(), line_range.end()),
+        range: TextRange::new(insertion_offset, insertion_offset),
         replacement: format!("  {comment}"),
     })
 }
@@ -283,7 +286,7 @@ fn edit_is_valid(
     line: usize,
     line_diagnostics: &[Diagnostic],
 ) -> bool {
-    if candidate.parse_error != current.parse_error {
+    if candidate.strict_parse_error != current.strict_parse_error {
         return false;
     }
 
@@ -316,26 +319,41 @@ fn edit_is_valid(
         return false;
     }
 
-    diagnostics_are_subset(&current.diagnostics, &candidate.diagnostics)
+    diagnostics_match_after_removing_targets(
+        &current.diagnostics,
+        &candidate.diagnostics,
+        line_diagnostics,
+    )
 }
 
-fn diagnostics_are_subset(current: &[Diagnostic], candidate: &[Diagnostic]) -> bool {
-    let mut counts = FxHashMap::default();
-    for key in current.iter().map(DiagnosticKey::new) {
-        *counts.entry(key).or_insert(0usize) += 1;
-    }
+fn diagnostics_match_after_removing_targets(
+    current: &[Diagnostic],
+    candidate: &[Diagnostic],
+    removed: &[Diagnostic],
+) -> bool {
+    let mut current_counts = diagnostic_counts(current);
+    let removed_counts = diagnostic_counts(removed);
 
-    for key in candidate.iter().map(DiagnosticKey::new) {
-        let Some(count) = counts.get_mut(&key) else {
+    for (key, removed_count) in removed_counts {
+        let Some(current_count) = current_counts.get_mut(&key) else {
             return false;
         };
-        if *count == 0 {
+        if *current_count < removed_count {
             return false;
         }
-        *count -= 1;
+        *current_count -= removed_count;
     }
 
-    true
+    current_counts.retain(|_, count| *count > 0);
+    current_counts == diagnostic_counts(candidate)
+}
+
+fn diagnostic_counts(diagnostics: &[Diagnostic]) -> FxHashMap<DiagnosticKey, usize> {
+    let mut counts = FxHashMap::default();
+    for key in diagnostics.iter().map(DiagnosticKey::new) {
+        *counts.entry(key).or_insert(0usize) += 1;
+    }
+    counts
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -369,6 +387,16 @@ fn apply_edit(source: &str, edit: &IgnoreEdit) -> String {
     output.push_str(&edit.replacement);
     output.push_str(&source[end..]);
     output
+}
+
+fn inline_comment_insertion_offset(line_range: TextRange, source: &str) -> TextSize {
+    let mut end = line_range.end();
+    if usize::from(end) > usize::from(line_range.start())
+        && source.as_bytes()[usize::from(end) - 1] == b'\r'
+    {
+        end = TextSize::new(end.to_u32() - 1);
+    }
+    end
 }
 
 fn join_codes(rules: &[Rule]) -> String {
@@ -553,5 +581,63 @@ mod tests {
         assert!(result.diagnostics.is_empty());
         assert!(result.parse_error.is_some());
         assert_eq!(updated, "#!/bin/bash\necho \"unterminated\n");
+    }
+
+    #[test]
+    fn preserves_crlf_line_endings_when_appending_ignores() {
+        let source = "#!/bin/bash\r\necho $foo\r\n";
+        let (result, updated) = run_add_ignore(source, None);
+
+        assert_eq!(result.directives_added, 1);
+        assert_eq!(
+            updated,
+            "#!/bin/bash\r\necho $foo  # shuck: ignore=C006\r\n"
+        );
+    }
+
+    #[test]
+    fn rejects_candidate_edits_that_introduce_parse_errors() {
+        let settings = LinterSettings::for_rule(Rule::UndefinedVariable);
+        let shellcheck_map = ShellCheckCodeMap::default();
+        let path = Path::new("script.sh");
+        let current_source = "#!/bin/bash\necho $foo\necho $bar\n";
+        let candidate_source =
+            "#!/bin/bash\necho $foo  # shuck: ignore=C006\necho $bar\necho \"unterminated\n";
+
+        let current = analyze_source(path, current_source, &settings, &shellcheck_map);
+        let candidate = analyze_source(path, candidate_source, &settings, &shellcheck_map);
+        let line_diagnostics = current
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.span.start.line == 2)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert!(current.strict_parse_error.is_none());
+        assert!(candidate.parse_error.is_none());
+        assert!(candidate.strict_parse_error.is_some());
+        assert!(!edit_is_valid(&current, &candidate, 2, &line_diagnostics));
+    }
+
+    #[test]
+    fn rejects_candidate_edits_that_change_unrelated_diagnostics() {
+        let settings = LinterSettings::for_rule(Rule::UndefinedVariable);
+        let shellcheck_map = ShellCheckCodeMap::default();
+        let path = Path::new("script.sh");
+        let current_source = "#!/bin/bash\necho $foo\necho $bar\n";
+        let candidate_source = "#!/bin/bash\necho $foo  # shuck: ignore=C006\necho ok\n";
+
+        let current = analyze_source(path, current_source, &settings, &shellcheck_map);
+        let candidate = analyze_source(path, candidate_source, &settings, &shellcheck_map);
+        let line_diagnostics = current
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.span.start.line == 2)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_eq!(current.diagnostics.len(), 2);
+        assert_eq!(candidate.diagnostics.len(), 0);
+        assert!(!edit_is_valid(&current, &candidate, 2, &line_diagnostics));
     }
 }

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -1,0 +1,557 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rustc_hash::FxHashMap;
+use shuck_ast::TextRange;
+use shuck_indexer::Indexer;
+use shuck_parser::{
+    Error as ParseError, ShellDialect as ParseShellDialect, ShellProfile,
+    parser::{ParseResult, Parser},
+};
+
+use crate::{Diagnostic, LinterSettings, Rule, ShellDialect, lint_file_at_path_with_parse_result};
+
+use super::{
+    ShellCheckCodeMap, SuppressionAction, SuppressionDirective, SuppressionIndex,
+    SuppressionSource, first_statement_line, parse_directives,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddIgnoreResult {
+    pub directives_added: usize,
+    pub diagnostics: Vec<Diagnostic>,
+    pub parse_error: Option<AddIgnoreParseError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddIgnoreParseError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+pub fn add_ignores_to_path(
+    path: &Path,
+    settings: &LinterSettings,
+    reason: Option<&str>,
+) -> Result<AddIgnoreResult> {
+    let shellcheck_map = ShellCheckCodeMap::default();
+    let mut source =
+        fs::read_to_string(path).with_context(|| format!("read source from {}", path.display()))?;
+    let mut analysis = analyze_source(path, &source, settings, &shellcheck_map);
+    let mut directives_added = 0usize;
+
+    let target_lines = analysis
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.span.start.line)
+        .collect::<BTreeSet<_>>();
+
+    for line in target_lines {
+        analysis = analyze_source(path, &source, settings, &shellcheck_map);
+        let line_diagnostics = analysis
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.span.start.line == line)
+            .cloned()
+            .collect::<Vec<_>>();
+        if line_diagnostics.is_empty() {
+            continue;
+        }
+
+        let Some(edit) = build_ignore_edit(
+            &source,
+            &analysis,
+            line,
+            &line_diagnostics,
+            reason,
+            &shellcheck_map,
+        ) else {
+            continue;
+        };
+
+        let candidate_source = apply_edit(&source, &edit);
+        let candidate_analysis = analyze_source(path, &candidate_source, settings, &shellcheck_map);
+        if !edit_is_valid(&analysis, &candidate_analysis, line, &line_diagnostics) {
+            continue;
+        }
+
+        source = candidate_source;
+        analysis = candidate_analysis;
+        directives_added += 1;
+    }
+
+    if directives_added > 0 {
+        fs::write(path, source.as_bytes())
+            .with_context(|| format!("write updated source to {}", path.display()))?;
+    }
+
+    Ok(AddIgnoreResult {
+        directives_added,
+        diagnostics: analysis.diagnostics,
+        parse_error: analysis.parse_error,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AnalyzedSource {
+    directives: Vec<SuppressionDirective>,
+    diagnostics: Vec<Diagnostic>,
+    parse_error: Option<AddIgnoreParseError>,
+    indexer: Indexer,
+}
+
+fn analyze_source(
+    path: &Path,
+    source: &str,
+    settings: &LinterSettings,
+    shellcheck_map: &ShellCheckCodeMap,
+) -> AnalyzedSource {
+    let shell = resolve_shell(settings, source, Some(path));
+    let parse_result = parse_for_lint(source, shell);
+    let indexer = Indexer::new(source, &parse_result);
+    let directives = parse_directives(
+        source,
+        &parse_result.file,
+        indexer.comment_index(),
+        shellcheck_map,
+    );
+    let suppression_index = (!directives.is_empty()).then(|| {
+        SuppressionIndex::new(
+            &directives,
+            &parse_result.file,
+            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
+        )
+    });
+    let diagnostics = lint_file_at_path_with_parse_result(
+        &parse_result,
+        source,
+        &indexer,
+        settings,
+        suppression_index.as_ref(),
+        Some(path),
+    );
+    let parse_error = raw_parse_error(&parse_result, &diagnostics);
+
+    AnalyzedSource {
+        directives,
+        diagnostics,
+        parse_error,
+        indexer,
+    }
+}
+
+fn raw_parse_error(
+    parse_result: &ParseResult,
+    diagnostics: &[Diagnostic],
+) -> Option<AddIgnoreParseError> {
+    if !parse_result.is_err() || !diagnostics.is_empty() {
+        return None;
+    }
+
+    let ParseError::Parse {
+        message,
+        line,
+        column,
+    } = parse_result.strict_error();
+    Some(AddIgnoreParseError {
+        message: message.clone(),
+        line,
+        column,
+    })
+}
+
+fn resolve_shell(
+    settings: &LinterSettings,
+    source: &str,
+    source_path: Option<&Path>,
+) -> ShellDialect {
+    if settings.shell == ShellDialect::Unknown {
+        ShellDialect::infer(source, source_path)
+    } else {
+        settings.shell
+    }
+}
+
+fn inferred_shell_profile(shell: ShellDialect) -> ShellProfile {
+    let dialect = match shell {
+        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => ParseShellDialect::Posix,
+        ShellDialect::Mksh => ParseShellDialect::Mksh,
+        ShellDialect::Zsh => ParseShellDialect::Zsh,
+        ShellDialect::Unknown | ShellDialect::Bash => ParseShellDialect::Bash,
+    };
+    ShellProfile::native(dialect)
+}
+
+fn parse_for_lint(source: &str, shell: ShellDialect) -> ParseResult {
+    Parser::with_profile(source, inferred_shell_profile(shell)).parse()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IgnoreEdit {
+    range: TextRange,
+    replacement: String,
+}
+
+fn build_ignore_edit(
+    source: &str,
+    analysis: &AnalyzedSource,
+    line: usize,
+    diagnostics: &[Diagnostic],
+    reason: Option<&str>,
+    shellcheck_map: &ShellCheckCodeMap,
+) -> Option<IgnoreEdit> {
+    let line_range = analysis.indexer.line_index().line_range(line, source)?;
+    let mut line_rules = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule)
+        .collect::<Vec<_>>();
+    line_rules.sort_unstable_by_key(|rule| rule.code());
+    line_rules.dedup();
+    let existing_ignore = analysis.directives.iter().find(|directive| {
+        directive.source == SuppressionSource::Shuck
+            && directive.action == SuppressionAction::Ignore
+            && usize::try_from(directive.line).ok() == Some(line)
+    });
+
+    let mut merged_rules = existing_ignore
+        .map(|directive| directive.codes.clone())
+        .unwrap_or_default();
+    for rule in line_rules {
+        if !merged_rules.contains(&rule) {
+            merged_rules.push(rule);
+        }
+    }
+    merged_rules.sort_unstable_by_key(|rule| rule.code());
+    merged_rules.dedup();
+
+    let comment_reason = reason
+        .filter(|reason| !reason.is_empty())
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+        .or_else(|| {
+            existing_ignore.and_then(|directive| {
+                existing_ignore_reason(directive.range.slice(source), shellcheck_map)
+            })
+        });
+
+    let mut comment = format!("# shuck: ignore={}", join_codes(&merged_rules));
+    if let Some(comment_reason) = comment_reason {
+        comment.push_str(" # ");
+        comment.push_str(comment_reason);
+    }
+
+    if let Some(directive) = existing_ignore {
+        return (directive.range.slice(source) != comment).then_some(IgnoreEdit {
+            range: directive.range,
+            replacement: comment,
+        });
+    }
+
+    Some(IgnoreEdit {
+        range: TextRange::new(line_range.end(), line_range.end()),
+        replacement: format!("  {comment}"),
+    })
+}
+
+fn existing_ignore_reason<'a>(
+    comment_text: &'a str,
+    shellcheck_map: &ShellCheckCodeMap,
+) -> Option<&'a str> {
+    let body = strip_comment_prefix(comment_text);
+    let remainder = strip_prefix_ignore_ascii_case(body, "shuck:")?;
+    let (without_reason, reason) = remainder
+        .split_once('#')
+        .map_or((remainder, None), |(before, after)| {
+            (before, Some(after.trim()))
+        });
+    let (action, codes) = without_reason.split_once('=')?;
+    if parse_shuck_action(action.trim()) != Some(SuppressionAction::Ignore)
+        || parse_codes(codes, |code| resolve_suppression_code(code, shellcheck_map)).is_empty()
+    {
+        return None;
+    }
+
+    reason.filter(|reason| !reason.is_empty())
+}
+
+fn edit_is_valid(
+    current: &AnalyzedSource,
+    candidate: &AnalyzedSource,
+    line: usize,
+    line_diagnostics: &[Diagnostic],
+) -> bool {
+    if candidate.parse_error != current.parse_error {
+        return false;
+    }
+
+    let line = match u32::try_from(line) {
+        Ok(line) => line,
+        Err(_) => return false,
+    };
+    let mut target_rules = line_diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule)
+        .collect::<Vec<_>>();
+    target_rules.sort_unstable_by_key(|rule| rule.code());
+    target_rules.dedup();
+    let recognized = candidate.directives.iter().any(|directive| {
+        directive.source == SuppressionSource::Shuck
+            && directive.action == SuppressionAction::Ignore
+            && directive.line == line
+            && target_rules
+                .iter()
+                .all(|rule| directive.codes.iter().any(|candidate| candidate == rule))
+    });
+    if !recognized {
+        return false;
+    }
+
+    if candidate.diagnostics.iter().any(|diagnostic| {
+        diagnostic.span.start.line == usize::try_from(line).unwrap_or_default()
+            && target_rules.contains(&diagnostic.rule)
+    }) {
+        return false;
+    }
+
+    diagnostics_are_subset(&current.diagnostics, &candidate.diagnostics)
+}
+
+fn diagnostics_are_subset(current: &[Diagnostic], candidate: &[Diagnostic]) -> bool {
+    let mut counts = FxHashMap::default();
+    for key in current.iter().map(DiagnosticKey::new) {
+        *counts.entry(key).or_insert(0usize) += 1;
+    }
+
+    for key in candidate.iter().map(DiagnosticKey::new) {
+        let Some(count) = counts.get_mut(&key) else {
+            return false;
+        };
+        if *count == 0 {
+            return false;
+        }
+        *count -= 1;
+    }
+
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DiagnosticKey {
+    rule: Rule,
+    start_line: usize,
+    start_column: usize,
+    end_line: usize,
+    end_column: usize,
+    message: String,
+}
+
+impl DiagnosticKey {
+    fn new(diagnostic: &Diagnostic) -> Self {
+        Self {
+            rule: diagnostic.rule,
+            start_line: diagnostic.span.start.line,
+            start_column: diagnostic.span.start.column,
+            end_line: diagnostic.span.end.line,
+            end_column: diagnostic.span.end.column,
+            message: diagnostic.message.clone(),
+        }
+    }
+}
+
+fn apply_edit(source: &str, edit: &IgnoreEdit) -> String {
+    let mut output = String::with_capacity(source.len() + edit.replacement.len());
+    let start = usize::from(edit.range.start());
+    let end = usize::from(edit.range.end());
+    output.push_str(&source[..start]);
+    output.push_str(&edit.replacement);
+    output.push_str(&source[end..]);
+    output
+}
+
+fn join_codes(rules: &[Rule]) -> String {
+    let mut rendered = String::new();
+    for (index, rule) in rules.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str(", ");
+        }
+        rendered.push_str(rule.code());
+    }
+    rendered
+}
+
+fn strip_comment_prefix(text: &str) -> &str {
+    text.trim_start().trim_start_matches('#').trim_start()
+}
+
+fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    let candidate = text.get(..prefix.len())?;
+    candidate
+        .eq_ignore_ascii_case(prefix)
+        .then(|| &text[prefix.len()..])
+}
+
+fn parse_shuck_action(value: &str) -> Option<SuppressionAction> {
+    if value.eq_ignore_ascii_case("disable") {
+        Some(SuppressionAction::Disable)
+    } else if value.eq_ignore_ascii_case("disable-file") {
+        Some(SuppressionAction::DisableFile)
+    } else if value.eq_ignore_ascii_case("ignore") {
+        Some(SuppressionAction::Ignore)
+    } else {
+        None
+    }
+}
+
+fn parse_codes(value: &str, mut resolve: impl FnMut(&str) -> Vec<Rule>) -> Vec<Rule> {
+    value
+        .split(',')
+        .flat_map(|code| {
+            let code = code.trim();
+            if code.is_empty() {
+                Vec::new()
+            } else {
+                resolve(code)
+            }
+        })
+        .collect()
+}
+
+fn resolve_suppression_code(code: &str, shellcheck_map: &ShellCheckCodeMap) -> Vec<Rule> {
+    let mut rules = resolve_rule_code(code).into_iter().collect::<Vec<_>>();
+    for rule in shellcheck_map.resolve_all(code) {
+        if !rules.contains(&rule) {
+            rules.push(rule);
+        }
+    }
+    rules
+}
+
+fn resolve_rule_code(code: &str) -> Option<Rule> {
+    crate::code_to_rule(code).or_else(|| {
+        let upper = code.to_ascii_uppercase();
+        (upper != code)
+            .then(|| crate::code_to_rule(&upper))
+            .flatten()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::Rule;
+
+    fn run_add_ignore_with_settings(
+        source: &str,
+        settings: &LinterSettings,
+        reason: Option<&str>,
+    ) -> (AddIgnoreResult, String) {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("script.sh");
+        fs::write(&path, source).unwrap();
+
+        let result = add_ignores_to_path(&path, settings, reason).unwrap();
+        let updated = fs::read_to_string(&path).unwrap();
+
+        (result, updated)
+    }
+
+    fn run_add_ignore(source: &str, reason: Option<&str>) -> (AddIgnoreResult, String) {
+        run_add_ignore_with_settings(source, &LinterSettings::default(), reason)
+    }
+
+    #[test]
+    fn adds_inline_ignore_for_single_line_diagnostic() {
+        let (result, updated) = run_add_ignore("#!/bin/bash\necho $foo\n", None);
+
+        assert_eq!(result.directives_added, 1);
+        assert!(result.diagnostics.is_empty());
+        assert!(result.parse_error.is_none());
+        assert_eq!(updated, "#!/bin/bash\necho $foo  # shuck: ignore=C006\n");
+    }
+
+    #[test]
+    fn merges_multiple_codes_on_a_single_line() {
+        let settings =
+            LinterSettings::for_rules([Rule::UndefinedVariable, Rule::UnquotedExpansion]);
+        let source = "#!/bin/bash\necho $foo\n";
+        let (result, updated) = run_add_ignore_with_settings(source, &settings, None);
+
+        assert_eq!(result.directives_added, 1);
+        assert_eq!(
+            updated,
+            "#!/bin/bash\necho $foo  # shuck: ignore=C006, S001\n"
+        );
+    }
+
+    #[test]
+    fn merges_with_existing_ignore_and_preserves_reason() {
+        let settings =
+            LinterSettings::for_rules([Rule::UndefinedVariable, Rule::UnquotedExpansion]);
+        let source = "#!/bin/bash\necho $foo  # shuck: ignore=S001 # legacy\n";
+        let (result, updated) = run_add_ignore_with_settings(source, &settings, None);
+
+        assert_eq!(result.directives_added, 1);
+        assert_eq!(
+            updated,
+            "#!/bin/bash\necho $foo  # shuck: ignore=C006, S001 # legacy\n"
+        );
+    }
+
+    #[test]
+    fn replaces_existing_reason_when_cli_reason_is_provided() {
+        let settings =
+            LinterSettings::for_rules([Rule::UndefinedVariable, Rule::UnquotedExpansion]);
+        let source = "#!/bin/bash\necho $foo  # shuck: ignore=S001 # legacy\n";
+        let (result, updated) =
+            run_add_ignore_with_settings(source, &settings, Some("intentional"));
+
+        assert_eq!(result.directives_added, 1);
+        assert_eq!(
+            updated,
+            "#!/bin/bash\necho $foo  # shuck: ignore=C006, S001 # intentional\n"
+        );
+    }
+
+    #[test]
+    fn is_idempotent_after_adding_ignore() {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("script.sh");
+        fs::write(&path, "#!/bin/bash\necho $foo\n").unwrap();
+
+        let first = add_ignores_to_path(&path, &LinterSettings::default(), None).unwrap();
+        let second = add_ignores_to_path(&path, &LinterSettings::default(), None).unwrap();
+        let updated = fs::read_to_string(&path).unwrap();
+
+        assert_eq!(first.directives_added, 1);
+        assert_eq!(second.directives_added, 0);
+        assert!(second.diagnostics.is_empty());
+        assert_eq!(updated, "#!/bin/bash\necho $foo  # shuck: ignore=C006\n");
+    }
+
+    #[test]
+    fn leaves_existing_trailing_comments_unsupported() {
+        let source = "#!/bin/bash\necho $foo # existing comment\n";
+        let (result, updated) = run_add_ignore(source, None);
+
+        assert_eq!(result.directives_added, 0);
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(updated, source);
+    }
+
+    #[test]
+    fn keeps_raw_parse_errors_as_remaining_failures() {
+        let (result, updated) = run_add_ignore("#!/bin/bash\necho \"unterminated\n", None);
+
+        assert_eq!(result.directives_added, 0);
+        assert!(result.diagnostics.is_empty());
+        assert!(result.parse_error.is_some());
+        assert_eq!(updated, "#!/bin/bash\necho \"unterminated\n");
+    }
+}

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -206,6 +206,18 @@ pub struct CheckCommand {
     /// Apply unsafe fixes.
     #[arg(long = "unsafe-fixes")]
     pub unsafe_fixes: bool,
+    /// Enable automatic additions of shuck ignore directives to failing lines.
+    /// Optionally provide a reason to append after the codes.
+    #[arg(
+        long = "add-ignore",
+        value_name = "REASON",
+        default_missing_value = "",
+        num_args = 0..=1,
+        require_equals = true,
+        conflicts_with = "fix",
+        conflicts_with = "unsafe_fixes",
+    )]
+    pub add_ignore: Option<String>,
     /// Choose the text output format for reported diagnostics.
     #[arg(long = "output-format", value_enum, default_value_t = CheckOutputFormatArg::Full)]
     pub output_format: CheckOutputFormatArg,
@@ -447,6 +459,47 @@ pub struct CleanCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn parse_check<I, T>(args: I) -> CheckCommand
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let parsed = StableCli::try_parse_from(args).unwrap();
+        match Args::from_stable(parsed).unwrap().command {
+            Command::Check(command) => command,
+            command => panic!("expected check command, got {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_add_ignore_without_reason() {
+        let command = parse_check(["shuck", "check", "--add-ignore"]);
+
+        assert_eq!(command.add_ignore, Some(String::new()));
+    }
+
+    #[test]
+    fn parses_add_ignore_with_reason() {
+        let command = parse_check(["shuck", "check", "--add-ignore=legacy"]);
+
+        assert_eq!(command.add_ignore.as_deref(), Some("legacy"));
+    }
+
+    #[test]
+    fn rejects_add_noqa_alias() {
+        let error = StableCli::try_parse_from(["shuck", "check", "--add-noqa=legacy"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn rejects_add_ignore_with_fix_flags() {
+        let error =
+            StableCli::try_parse_from(["shuck", "check", "--add-ignore", "--fix"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
 
     #[test]
     fn check_file_selection_negative_flags_override_positive_flags() {

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -317,9 +317,12 @@ fn run_add_ignore_with_cwd(
         &args.paths,
         cwd,
         &DiscoveryOptions {
+            exclude_patterns: args.file_selection.exclude.clone(),
+            extend_exclude_patterns: args.file_selection.extend_exclude.clone(),
+            respect_gitignore: args.respect_gitignore(),
+            force_exclude: args.force_exclude(),
             parallel: false,
             cache_root: Some(cache_root.to_path_buf()),
-            ..DiscoveryOptions::default()
         },
         cache_root,
         true,

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -39,18 +39,7 @@ impl CheckReport {
         if exit_non_zero_on_fix && self.fixes_applied > 0 {
             return ExitStatus::Failure;
         }
-        let has_fatal = self.diagnostics.iter().any(|d| match &d.kind {
-            DisplayedDiagnosticKind::ParseError => true,
-            DisplayedDiagnosticKind::Lint { severity, .. } => severity == "error",
-        });
-        if has_fatal {
-            return ExitStatus::Failure;
-        }
-        if self.diagnostics.is_empty() || exit_zero {
-            ExitStatus::Success
-        } else {
-            ExitStatus::Failure
-        }
+        diagnostics_exit_status(&self.diagnostics, exit_zero)
     }
 }
 
@@ -61,12 +50,23 @@ struct AddIgnoreReport {
 }
 
 impl AddIgnoreReport {
-    fn exit_status(&self) -> ExitStatus {
-        if self.diagnostics.is_empty() {
-            ExitStatus::Success
-        } else {
-            ExitStatus::Failure
-        }
+    fn exit_status(&self, exit_zero: bool) -> ExitStatus {
+        diagnostics_exit_status(&self.diagnostics, exit_zero)
+    }
+}
+
+fn diagnostics_exit_status(diagnostics: &[DisplayedDiagnostic], exit_zero: bool) -> ExitStatus {
+    let has_fatal = diagnostics.iter().any(|d| match &d.kind {
+        DisplayedDiagnosticKind::ParseError => true,
+        DisplayedDiagnosticKind::Lint { severity, .. } => severity == "error",
+    });
+    if has_fatal {
+        return ExitStatus::Failure;
+    }
+    if diagnostics.is_empty() || exit_zero {
+        ExitStatus::Success
+    } else {
+        ExitStatus::Failure
     }
 }
 
@@ -169,7 +169,7 @@ pub(crate) fn check(args: CheckCommand, cache_dir: Option<&Path>) -> Result<Exit
             );
         }
         print_diagnostics(&report.diagnostics, args.output_format)?;
-        return Ok(report.exit_status());
+        return Ok(report.exit_status(args.exit_zero));
     }
 
     let report = run_check_with_cwd(&args, &cwd, &cache_root)?;

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use shuck_cache::{CacheKey, CacheKeyHasher};
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    LinterSettings, ShellCheckCodeMap, ShellDialect, SuppressionIndex, first_statement_line,
-    parse_directives,
+    LinterSettings, ShellCheckCodeMap, ShellDialect, SuppressionIndex, add_ignores_to_path,
+    first_statement_line, parse_directives,
 };
 use shuck_parser::{
     Error as ParseError,
@@ -47,6 +47,22 @@ impl CheckReport {
             return ExitStatus::Failure;
         }
         if self.diagnostics.is_empty() || exit_zero {
+            ExitStatus::Success
+        } else {
+            ExitStatus::Failure
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct AddIgnoreReport {
+    diagnostics: Vec<DisplayedDiagnostic>,
+    directives_added: usize,
+}
+
+impl AddIgnoreReport {
+    fn exit_status(&self) -> ExitStatus {
+        if self.diagnostics.is_empty() {
             ExitStatus::Success
         } else {
             ExitStatus::Failure
@@ -128,6 +144,34 @@ struct FileCheckResult {
 pub(crate) fn check(args: CheckCommand, cache_dir: Option<&Path>) -> Result<ExitStatus> {
     let cwd = std::env::current_dir()?;
     let cache_root = resolve_cache_root(&cwd, cache_dir)?;
+    if let Some(raw_reason) = args.add_ignore.as_deref() {
+        if raw_reason.contains(['\n', '\r']) {
+            return Err(anyhow!(
+                "--add-ignore <reason> cannot contain newline characters"
+            ));
+        }
+
+        let report = run_add_ignore_with_cwd(
+            &args,
+            &cwd,
+            &cache_root,
+            (!raw_reason.is_empty()).then_some(raw_reason),
+        )?;
+        if report.directives_added > 0 {
+            let s = if report.directives_added == 1 {
+                ""
+            } else {
+                "s"
+            };
+            eprintln!(
+                "Added {} shuck ignore directive{s}.",
+                report.directives_added
+            );
+        }
+        print_diagnostics(&report.diagnostics, args.output_format)?;
+        return Ok(report.exit_status());
+    }
+
     let report = run_check_with_cwd(&args, &cwd, &cache_root)?;
     print_report(&report, args.output_format)?;
     Ok(report.exit_status(args.exit_zero, args.exit_non_zero_on_fix))
@@ -137,10 +181,17 @@ fn print_report(
     report: &CheckReport,
     output_format: crate::args::CheckOutputFormatArg,
 ) -> Result<()> {
+    print_diagnostics(&report.diagnostics, output_format)
+}
+
+fn print_diagnostics(
+    diagnostics: &[DisplayedDiagnostic],
+    output_format: crate::args::CheckOutputFormatArg,
+) -> Result<()> {
     let mut stdout = BufWriter::new(io::stdout().lock());
     print_report_to(
         &mut stdout,
-        &report.diagnostics,
+        diagnostics,
         output_format,
         colored::control::SHOULD_COLORIZE.should_colorize(),
     )?;
@@ -254,6 +305,80 @@ fn run_check_with_cwd(args: &CheckCommand, cwd: &Path, cache_root: &Path) -> Res
     Ok(report)
 }
 
+fn run_add_ignore_with_cwd(
+    args: &CheckCommand,
+    cwd: &Path,
+    cache_root: &Path,
+    reason: Option<&str>,
+) -> Result<AddIgnoreReport> {
+    let include_source = matches!(args.output_format, crate::args::CheckOutputFormatArg::Full);
+    let settings = EffectiveCheckSettings::default();
+    let runs = prepare_project_runs::<CheckCacheData, EffectiveCheckSettings, _>(
+        &args.paths,
+        cwd,
+        &DiscoveryOptions {
+            parallel: false,
+            cache_root: Some(cache_root.to_path_buf()),
+            ..DiscoveryOptions::default()
+        },
+        cache_root,
+        true,
+        b"project-cache-key",
+        |_| Ok(settings.clone()),
+    )?;
+    let base_linter_settings = LinterSettings::default();
+
+    let mut report = AddIgnoreReport::default();
+
+    for run in runs {
+        let analyzed_paths = run
+            .files
+            .iter()
+            .map(|file| file.absolute_path.clone())
+            .collect::<Vec<_>>();
+        let linter_settings = base_linter_settings
+            .clone()
+            .with_analyzed_paths(analyzed_paths);
+
+        for file in run.files {
+            let result = add_ignores_to_path(&file.absolute_path, &linter_settings, reason)?;
+            report.directives_added += result.directives_added;
+            if result.parse_error.is_none() && result.diagnostics.is_empty() {
+                continue;
+            }
+
+            let source = include_source
+                .then(|| read_shared_source(&file.absolute_path))
+                .transpose()?;
+            if let Some(error) = result.parse_error {
+                report.diagnostics.push(DisplayedDiagnostic {
+                    path: file.display_path.clone(),
+                    span: DisplaySpan::point(error.line, error.column),
+                    message: error.message,
+                    kind: DisplayedDiagnosticKind::ParseError,
+                    source: source.clone(),
+                });
+            }
+            push_lint_diagnostics(
+                &mut report.diagnostics,
+                &file.display_path,
+                &result.diagnostics,
+                source,
+            );
+        }
+    }
+
+    report.diagnostics.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then(left.span.start.line.cmp(&right.span.start.line))
+            .then(left.span.start.column.cmp(&right.span.start.column))
+            .then(left.message.cmp(&right.message))
+    });
+
+    Ok(report)
+}
+
 pub(crate) fn benchmark_check_paths(
     cwd: &Path,
     paths: &[PathBuf],
@@ -263,6 +388,7 @@ pub(crate) fn benchmark_check_paths(
         &CheckCommand {
             fix: false,
             unsafe_fixes: false,
+            add_ignore: None,
             no_cache: true,
             output_format,
             paths: paths.to_vec(),
@@ -417,6 +543,29 @@ fn push_cached_lint_diagnostics(
     }
 }
 
+fn push_lint_diagnostics(
+    displayed: &mut Vec<DisplayedDiagnostic>,
+    path: &Path,
+    diagnostics: &[shuck_linter::Diagnostic],
+    source: Option<Arc<str>>,
+) {
+    for diagnostic in diagnostics {
+        displayed.push(DisplayedDiagnostic {
+            path: path.to_path_buf(),
+            span: DisplaySpan::new(
+                DisplayPosition::new(diagnostic.span.start.line, diagnostic.span.start.column),
+                DisplayPosition::new(diagnostic.span.end.line, diagnostic.span.end.column),
+            ),
+            message: diagnostic.message.clone(),
+            kind: DisplayedDiagnosticKind::Lint {
+                code: diagnostic.code().to_owned(),
+                severity: diagnostic.severity.as_str().to_owned(),
+            },
+            source: source.clone(),
+        });
+    }
+}
+
 fn read_shared_source(path: &Path) -> Result<Arc<str>> {
     Ok(Arc::<str>::from(fs::read_to_string(path)?))
 }
@@ -460,6 +609,7 @@ mod tests {
         CheckCommand {
             fix: false,
             unsafe_fixes: false,
+            add_ignore: None,
             no_cache,
             output_format,
             paths: Vec::new(),

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -106,6 +106,8 @@ fn check_help_includes_add_ignore_flag() {
         .stdout(predicate::str::contains("shuck ignore directives"))
         .stdout(predicate::str::contains("--add-noqa").not());
 }
+
+#[test]
 fn format_subcommand_requires_experimental_env() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.arg("format");

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -325,6 +325,25 @@ fn check_add_ignore_respects_exit_zero_for_warning_leftovers() {
 }
 
 #[test]
+fn check_add_ignore_leaves_continuation_lines_failing() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    let source = "#!/bin/bash\necho $foo \\\n&& echo ok\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--add-ignore", "--output-format", "concise"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("error[C006]"))
+        .stderr(predicate::str::is_empty());
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
+}
+
+#[test]
 fn check_add_ignore_respects_force_exclude_for_explicit_files() {
     let tempdir = tempdir().unwrap();
     let script = tempdir.path().join("ignored.sh");

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -299,6 +299,30 @@ fn check_add_ignore_leaves_uneditable_trailing_comment_lines_failing() {
 }
 
 #[test]
+fn check_add_ignore_respects_exit_zero_for_warning_leftovers() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    let source = "#!/bin/bash\nunused=1 # existing comment\necho ok\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path()).args([
+        "check",
+        "--add-ignore",
+        "--exit-zero",
+        "--output-format",
+        "concise",
+    ]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("warning[C001]"))
+        .stderr(predicate::str::is_empty());
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
+}
+
+#[test]
 fn inline_shuck_ignore_suppresses_only_its_own_line() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -97,6 +97,15 @@ fn format_help_shows_file_selection_options() {
 }
 
 #[test]
+fn check_help_includes_add_ignore_flag() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.args(["check", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("--add-ignore"))
+        .stdout(predicate::str::contains("shuck ignore directives"))
+        .stdout(predicate::str::contains("--add-noqa").not());
+}
 fn format_subcommand_requires_experimental_env() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.arg("format");
@@ -188,6 +197,123 @@ fn check_concise_output_preserves_legacy_one_line_format() {
     cmd.assert()
         .code(1)
         .stdout("warn.sh:2:1: warning[C001] variable `unused` is assigned but never used\n");
+}
+
+#[test]
+fn check_add_ignore_writes_inline_shuck_ignore() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    fs::write(&script, "#!/bin/bash\necho $foo\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--add-ignore"]);
+    cmd.assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::contains("Added 1 shuck ignore directive."));
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "#!/bin/bash\necho $foo  # shuck: ignore=C006\n"
+    );
+}
+
+#[test]
+fn check_rejects_add_noqa_alias() {
+    let tempdir = tempdir().unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--add-noqa=legacy"]);
+    cmd.assert()
+        .code(2)
+        .stderr(predicate::str::contains("unexpected argument '--add-noqa'"));
+}
+
+#[test]
+fn check_add_ignore_merges_existing_ignore_and_preserves_reason() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    fs::write(
+        &script,
+        "#!/bin/bash\necho $foo  # shuck: ignore=S001 # legacy\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--add-ignore"]);
+    cmd.assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::contains("Added 1 shuck ignore directive."));
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "#!/bin/bash\necho $foo  # shuck: ignore=C006, S001 # legacy\n"
+    );
+}
+
+#[test]
+fn check_add_ignore_reports_remaining_parse_errors() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("broken.sh");
+    fs::write(&script, "#!/bin/bash\necho \"unterminated\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--add-ignore"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("error[parse-error]:"))
+        .stderr(predicate::str::is_empty());
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "#!/bin/bash\necho \"unterminated\n"
+    );
+}
+
+#[test]
+fn check_add_ignore_leaves_uneditable_trailing_comment_lines_failing() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    let source = "#!/bin/bash\necho $foo # existing comment\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--add-ignore", "--output-format", "concise"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("error[C006]"))
+        .stderr(predicate::str::is_empty());
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
+}
+
+#[test]
+fn inline_shuck_ignore_suppresses_only_its_own_line() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\necho $foo  # shuck: ignore=C006\necho $bar\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    cmd.assert()
+        .code(1)
+        .stdout("warn.sh:3:6: error[C006] variable `bar` is referenced before assignment\n");
 }
 
 #[test]

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -325,6 +325,31 @@ fn check_add_ignore_respects_exit_zero_for_warning_leftovers() {
 }
 
 #[test]
+fn check_add_ignore_respects_force_exclude_for_explicit_files() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("ignored.sh");
+    let source = "#!/bin/bash\necho $foo\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path()).args([
+        "check",
+        "--add-ignore",
+        "--exclude",
+        "ignored.sh",
+        "--force-exclude",
+        "ignored.sh",
+    ]);
+    cmd.assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::is_empty());
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
+}
+
+#[test]
 fn inline_shuck_ignore_suppresses_only_its_own_line() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/specs/006-suppressions.md
+++ b/specs/006-suppressions.md
@@ -6,13 +6,14 @@ Proposed
 
 ## Summary
 
-A suppression layer that allows users to silence specific lint diagnostics via inline comments. Suppressions are parsed from two directive formats (`# shuck:` and `# shellcheck`), built into a per-file `SuppressionIndex`, and applied as a post-hoc filter on linter output. This spec covers directive parsing, shellcheck-style scope resolution (next-command or file-wide), explicit whole-file disables, index construction, and integration with the linter from spec 005.
+A suppression layer that allows users to silence specific lint diagnostics via inline comments. Suppressions are parsed from two directive formats (`# shuck:` and `# shellcheck`), built into a per-file `SuppressionIndex`, and applied as a post-hoc filter on linter output. This spec covers directive parsing, shellcheck-style scope resolution (next-command or file-wide), exact-line native ignores, explicit whole-file disables, index construction, and integration with the linter from spec 005.
 
 ## Motivation
 
 Lint rules produce false positives. Users need a way to acknowledge and silence specific diagnostics without disabling rules globally. Shell scripts in particular carry two established suppression conventions:
 
 - **shuck native**: `# shuck: disable=C001` — supports shellcheck-style disable semantics plus explicit `disable-file`
+- **shuck native line ignore**: `# shuck: ignore=C001` — suppresses only diagnostics on the directive's own line
 - **shellcheck compatible**: `# shellcheck disable=SC2086` — widely used in existing codebases, applies to the next command only
 
 Both directive styles accept either code namespace. Native shuck codes (`C001`, `S001`, `SH-001`) and ShellCheck codes (`SC2086`, `2154`) resolve to the same underlying rules.
@@ -29,7 +30,7 @@ Following ruff's architecture, suppression filtering happens **after** the linte
 
 Case-insensitive prefix match on `shuck:`. The body after the prefix is `action=codes` where:
 
-- **action** is one of `disable` or `disable-file`
+- **action** is one of `disable`, `disable-file`, or `ignore`
 - **codes** is a comma-separated list of rule codes (e.g., `C001,S003` or `SC2086,2154`)
 - An optional reason after `#` is stripped: `# shuck: disable=C001 # legacy code`
 
@@ -38,9 +39,13 @@ Case-insensitive prefix match on `shuck:`. The body after the prefix is `action=
 echo $undefined
 
 # shuck: disable-file=S001     # file: suppress S001 for entire file
+
+echo $undefined  # shuck: ignore=C006  # line: suppress only this line
 ```
 
 `# shuck: disable=...` follows the same placement rules as shellcheck: before the first statement it becomes file-wide, otherwise it applies to the next command, including the same inline control-flow header forms that shellcheck accepts. `disable-file` remains an explicit whole-file escape hatch.
+
+`# shuck: ignore=...` is line-scoped instead. It suppresses diagnostics whose start line matches the directive's own line, and it is valid as a trailing inline comment after ordinary code. This is the directive written by `shuck check --add-ignore[=<REASON>]`.
 
 #### ShellCheck Compatible: `# shellcheck disable=<codes>`
 
@@ -72,7 +77,7 @@ echo $x                        # SC2034 NOT suppressed here
 ```rust
 /// A parsed suppression directive from a comment.
 pub struct SuppressionDirective {
-    /// The action: disable or disable-file.
+    /// The action: disable, disable-file, or ignore.
     pub action: SuppressionAction,
     /// Which directive syntax produced this.
     pub source: SuppressionSource,
@@ -88,6 +93,7 @@ pub struct SuppressionDirective {
 pub enum SuppressionAction {
     Disable,
     DisableFile,
+    Ignore,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -156,6 +162,7 @@ There are three scope types:
 | **File** | `# shellcheck disable=SC2086` before first statement | Entire file |
 | **Next-command** | `# shuck: disable=C001` after first statement | Start line through end line of the next `Stmt` AST node |
 | **Next-command** | `# shellcheck disable=SC2086` after first statement | Start line through end line of the next `Stmt` AST node |
+| **Exact-line** | `# shuck: ignore=C001` | The directive's own physical line only |
 
 ### SuppressionIndex
 
@@ -194,6 +201,8 @@ Per-rule state combining file and next-command scopes:
 struct RuleSuppressionIndex {
     /// If set, the rule is suppressed for the entire file.
     whole_file: bool,
+    /// Exact lines from native `ignore` directives.
+    lines: Vec<u32>,
     /// Line ranges from next-command suppressions.
     ranges: Vec<LineRange>,
 }
@@ -207,8 +216,9 @@ struct LineRange {
 **Query logic** (`is_suppressed`), checked in priority order:
 
 1. If `whole_file` is true → suppressed
-2. Binary search `ranges` for any range containing the query line → suppressed
-3. Otherwise → not suppressed
+2. Binary search `lines` for an exact match on the query line → suppressed
+3. Binary search `ranges` for any range containing the query line → suppressed
+4. Otherwise → not suppressed
 
 #### Building the Index
 
@@ -219,7 +229,8 @@ Construction mirrors `BuildCodeSuppressionIndex` from Go:
    - **`disable-file`** → set `whole_file = true`
    - **`disable` before first statement** → set `whole_file = true`
    - **`disable` after first statement** → find the next `Stmt` after the directive's offset via AST walk, push a `LineRange { start_line, end_line }` for that statement
-3. Sort `ranges` by `(start_line, end_line)`
+   - **`ignore`** → push the directive's own line into `lines`
+3. Sort `lines` and `ranges`
 
 **Finding the next command** for shellcheck scopes requires walking statement nodes in the AST to find the first `Stmt` whose start offset is after the directive's end offset:
 


### PR DESCRIPTION
## Summary
- add `shuck check --add-ignore[=<REASON>]` to stamp native `# shuck: ignore=...` directives
- teach suppression parsing and indexing that `ignore=` is exact-line scoped while existing `disable=` behavior stays intact
- validate rewrites in `shuck-linter`, update the suppression spec, and cover the flow with unit and integration tests

## Why
Shuck did not have a Ruff-style way to write targeted suppressions for existing failures. This adds a native flow for generating line-scoped ignores without carrying a `--add-noqa` alias.

## Testing
- cargo fmt --check
- cargo test -p shuck-linter --quiet
- cargo test -p shuck --quiet