### PR TITLE
Add file selection CLI options

### DIFF
--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -211,6 +211,8 @@ pub struct CheckCommand {
     pub output_format: CheckOutputFormatArg,
     /// Files or directories to check.
     pub paths: Vec<PathBuf>,
+    #[command(flatten)]
+    pub file_selection: FileSelectionArgs,
     /// Disable cache reads and writes.
     #[arg(long = "no-cache", help_heading = "Miscellaneous")]
     pub no_cache: bool,
@@ -220,6 +222,66 @@ pub struct CheckCommand {
     /// Exit with a non-zero status code if any files were modified via fix, even if no lint violations remain.
     #[arg(long = "exit-non-zero-on-fix", help_heading = "Miscellaneous")]
     pub exit_non_zero_on_fix: bool,
+}
+
+impl CheckCommand {
+    pub fn respect_gitignore(&self) -> bool {
+        self.file_selection.respect_gitignore()
+    }
+
+    pub fn force_exclude(&self) -> bool {
+        self.file_selection.force_exclude()
+    }
+}
+
+#[derive(Debug, Clone, Default, ClapArgs)]
+pub struct FileSelectionArgs {
+    /// List of paths, used to omit files and/or directories from analysis.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "FILE_PATTERN",
+        help_heading = "File selection"
+    )]
+    pub exclude: Vec<String>,
+    /// Like --exclude, but adds additional files and directories on top of those already excluded.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "FILE_PATTERN",
+        help_heading = "File selection"
+    )]
+    pub extend_exclude: Vec<String>,
+    /// Respect file exclusions via `.gitignore` and other standard ignore files.
+    /// Use `--no-respect-gitignore` to disable.
+    #[arg(
+        long,
+        overrides_with = "no_respect_gitignore",
+        help_heading = "File selection"
+    )]
+    pub(crate) respect_gitignore: bool,
+    #[arg(long, overrides_with = "respect_gitignore", hide = true)]
+    pub(crate) no_respect_gitignore: bool,
+    /// Enforce exclusions, even for paths passed to shuck directly on the command-line.
+    /// Use `--no-force-exclude` to disable.
+    #[arg(
+        long,
+        overrides_with = "no_force_exclude",
+        help_heading = "File selection"
+    )]
+    pub(crate) force_exclude: bool,
+    #[arg(long, overrides_with = "force_exclude", hide = true)]
+    pub(crate) no_force_exclude: bool,
+}
+
+impl FileSelectionArgs {
+    pub fn respect_gitignore(&self) -> bool {
+        resolve_bool_flag(self.respect_gitignore, self.no_respect_gitignore, true)
+    }
+
+    pub fn force_exclude(&self) -> bool {
+        resolve_bool_flag(self.force_exclude, self.no_force_exclude, false)
+    }
 }
 
 #[derive(Debug, Clone, ClapArgs)]
@@ -238,9 +300,8 @@ pub struct FormatCommand {
     /// The name of the file when reading the source from stdin.
     #[arg(long)]
     pub stdin_filename: Option<PathBuf>,
-    /// Omit files or directories matching the provided glob patterns.
-    #[arg(long, value_delimiter = ',', value_name = "GLOB")]
-    pub exclude: Vec<String>,
+    #[command(flatten)]
+    pub file_selection: FileSelectionArgs,
     /// Override the auto-discovered shell dialect used for parsing and formatting.
     #[arg(long, value_enum)]
     pub dialect: Option<FormatDialectArg>,
@@ -302,16 +363,6 @@ pub struct FormatCommand {
     /// Emit a compact minified form and drop comments.
     #[arg(long)]
     pub minify: bool,
-    /// Respect file exclusions via `.gitignore` and other standard ignore files.
-    #[arg(long, overrides_with = "no_respect_gitignore")]
-    pub(crate) respect_gitignore: bool,
-    #[arg(long, overrides_with = "respect_gitignore", hide = true)]
-    pub(crate) no_respect_gitignore: bool,
-    /// Enforce exclusions even for paths passed directly on the command line.
-    #[arg(long, overrides_with = "no_force_exclude")]
-    pub(crate) force_exclude: bool,
-    #[arg(long, overrides_with = "force_exclude", hide = true)]
-    pub(crate) no_force_exclude: bool,
 }
 
 impl FormatCommand {
@@ -356,23 +407,11 @@ impl FormatCommand {
     }
 
     pub fn respect_gitignore(&self) -> bool {
-        match (self.respect_gitignore, self.no_respect_gitignore) {
-            (false, false) | (true, false) => true,
-            (false, true) => false,
-            // Clap's `overrides_with` on these paired flags keeps only the
-            // last occurrence, so both booleans cannot remain set here.
-            (true, true) => unreachable!("clap should make this impossible"),
-        }
+        self.file_selection.respect_gitignore()
     }
 
     pub fn force_exclude(&self) -> bool {
-        match (self.force_exclude, self.no_force_exclude) {
-            (false, false) | (false, true) => false,
-            (true, false) => true,
-            // Clap's `overrides_with` on these paired flags keeps only the
-            // last occurrence, so both booleans cannot remain set here.
-            (true, true) => unreachable!("clap should make this impossible"),
-        }
+        self.file_selection.force_exclude()
     }
 }
 
@@ -388,8 +427,64 @@ fn tri_state_bool(positive: bool, negative: bool) -> Option<bool> {
     }
 }
 
+fn resolve_bool_flag(positive: bool, negative: bool, default: bool) -> bool {
+    match (positive, negative) {
+        (false, false) => default,
+        (true, false) => true,
+        (false, true) => false,
+        // Clap's `overrides_with` on these paired flags keeps only the
+        // last occurrence, so both booleans cannot remain set here.
+        (true, true) => unreachable!("clap should make this impossible"),
+    }
+}
+
 #[derive(Debug, Clone, ClapArgs)]
 pub struct CleanCommand {
     /// Files or directories whose project caches should be removed.
     pub paths: Vec<PathBuf>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_file_selection_negative_flags_override_positive_flags() {
+        let args = Args::try_parse_from([
+            "shuck",
+            "check",
+            "--respect-gitignore",
+            "--no-respect-gitignore",
+            "--force-exclude",
+            "--no-force-exclude",
+        ])
+        .unwrap();
+
+        let Command::Check(command) = args.command else {
+            panic!("expected check command");
+        };
+
+        assert!(!command.respect_gitignore());
+        assert!(!command.force_exclude());
+    }
+
+    #[test]
+    fn check_file_selection_collects_exclude_and_extend_exclude_patterns() {
+        let args = Args::try_parse_from([
+            "shuck",
+            "check",
+            "--exclude",
+            "base.sh",
+            "--extend-exclude",
+            "extra.sh",
+        ])
+        .unwrap();
+
+        let Command::Check(command) = args.command else {
+            panic!("expected check command");
+        };
+
+        assert_eq!(command.file_selection.exclude, vec!["base.sh"]);
+        assert_eq!(command.file_selection.extend_exclude, vec!["extra.sh"]);
+    }
 }

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -166,7 +166,6 @@ fn run_check_with_cwd(args: &CheckCommand, cwd: &Path, cache_root: &Path) -> Res
             force_exclude: args.force_exclude(),
             parallel: true,
             cache_root: Some(cache_root.to_path_buf()),
-            ..DiscoveryOptions::default()
         },
         cache_root,
         args.no_cache,

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -18,7 +18,7 @@ use shuck_parser::{
 };
 
 use crate::ExitStatus;
-use crate::args::CheckCommand;
+use crate::args::{CheckCommand, FileSelectionArgs};
 use crate::cache::resolve_cache_root;
 use crate::commands::check_output::{
     DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
@@ -160,6 +160,10 @@ fn run_check_with_cwd(args: &CheckCommand, cwd: &Path, cache_root: &Path) -> Res
         &args.paths,
         cwd,
         &DiscoveryOptions {
+            exclude_patterns: args.file_selection.exclude.clone(),
+            extend_exclude_patterns: args.file_selection.extend_exclude.clone(),
+            respect_gitignore: args.respect_gitignore(),
+            force_exclude: args.force_exclude(),
             parallel: true,
             cache_root: Some(cache_root.to_path_buf()),
             ..DiscoveryOptions::default()
@@ -263,6 +267,7 @@ pub(crate) fn benchmark_check_paths(
             no_cache: true,
             output_format,
             paths: paths.to_vec(),
+            file_selection: FileSelectionArgs::default(),
             exit_zero: false,
             exit_non_zero_on_fix: false,
         },
@@ -459,6 +464,7 @@ mod tests {
             no_cache,
             output_format,
             paths: Vec::new(),
+            file_selection: FileSelectionArgs::default(),
             exit_zero: false,
             exit_non_zero_on_fix: false,
         }

--- a/crates/shuck/src/commands/format.rs
+++ b/crates/shuck/src/commands/format.rs
@@ -140,7 +140,8 @@ fn run_format_with_cwd(
 ) -> Result<FormatReport> {
     let cli_settings = args.format_settings_patch();
     let options = DiscoveryOptions {
-        exclude_patterns: args.exclude.clone(),
+        exclude_patterns: args.file_selection.exclude.clone(),
+        extend_exclude_patterns: args.file_selection.extend_exclude.clone(),
         respect_gitignore: args.respect_gitignore(),
         force_exclude: args.force_exclude(),
         parallel: false,
@@ -294,6 +295,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::args::FileSelectionArgs;
 
     fn make_file_read_only(path: &Path) {
         let mut permissions = fs::metadata(path).unwrap().permissions();
@@ -308,7 +310,7 @@ mod tests {
             diff: false,
             no_cache,
             stdin_filename: None,
-            exclude: Vec::new(),
+            file_selection: FileSelectionArgs::default(),
             dialect: None,
             indent_style: None,
             indent_width: None,
@@ -326,10 +328,6 @@ mod tests {
             no_never_split: false,
             simplify: false,
             minify: false,
-            respect_gitignore: false,
-            no_respect_gitignore: false,
-            force_exclude: false,
-            no_force_exclude: false,
         }
     }
 

--- a/crates/shuck/src/discover.rs
+++ b/crates/shuck/src/discover.rs
@@ -43,6 +43,7 @@ pub(crate) struct DiscoveredFile {
 #[derive(Debug, Default)]
 pub(crate) struct DiscoveryOptions {
     pub exclude_patterns: Vec<String>,
+    pub extend_exclude_patterns: Vec<String>,
     pub respect_gitignore: bool,
     pub force_exclude: bool,
     pub parallel: bool,
@@ -54,7 +55,8 @@ pub(crate) fn discover_files(
     cwd: &Path,
     options: &DiscoveryOptions,
 ) -> Result<Vec<DiscoveredFile>> {
-    let exclude_matcher = ExcludeMatcher::new(&options.exclude_patterns)?;
+    let exclude_matcher =
+        ExcludeMatcher::new(&options.exclude_patterns, &options.extend_exclude_patterns)?;
     let mut explicit_ignore_cache = ExplicitIgnoreCache::new(cwd);
 
     let resolved_inputs = if inputs.is_empty() {
@@ -573,13 +575,13 @@ struct ExcludeMatcher {
 }
 
 impl ExcludeMatcher {
-    fn new(patterns: &[String]) -> Result<Self> {
-        if patterns.is_empty() {
+    fn new(exclude_patterns: &[String], extend_exclude_patterns: &[String]) -> Result<Self> {
+        if exclude_patterns.is_empty() && extend_exclude_patterns.is_empty() {
             return Ok(Self { set: None });
         }
 
         let mut builder = GlobSetBuilder::new();
-        for pattern in patterns {
+        for pattern in exclude_patterns.iter().chain(extend_exclude_patterns) {
             let glob = Glob::new(pattern)
                 .map_err(|err| anyhow!("invalid exclude pattern `{pattern}`: {err}"))?;
             builder.add(glob);

--- a/crates/shuck/src/format_settings.rs
+++ b/crates/shuck/src/format_settings.rs
@@ -144,7 +144,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::args::FormatCommand;
+    use crate::args::{FileSelectionArgs, FormatCommand};
     use crate::config::{CONFIG_DIALECT_UNSUPPORTED_ERROR, FormatConfig};
 
     fn format_args() -> FormatCommand {
@@ -154,7 +154,7 @@ mod tests {
             diff: false,
             no_cache: false,
             stdin_filename: None,
-            exclude: Vec::new(),
+            file_selection: FileSelectionArgs::default(),
             dialect: None,
             indent_style: None,
             indent_width: None,
@@ -172,10 +172,6 @@ mod tests {
             no_never_split: false,
             simplify: false,
             minify: false,
-            respect_gitignore: false,
-            no_respect_gitignore: false,
-            force_exclude: false,
-            no_force_exclude: false,
         }
     }
 

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -70,6 +70,33 @@ fn clean_help_describes_project_cache_entries() {
 }
 
 #[test]
+fn check_help_shows_file_selection_options() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.args(["check", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("File selection"))
+        .stdout(predicate::str::contains("--exclude <FILE_PATTERN>"))
+        .stdout(predicate::str::contains("--extend-exclude <FILE_PATTERN>"))
+        .stdout(predicate::str::contains("--respect-gitignore"))
+        .stdout(predicate::str::contains("--force-exclude"));
+}
+
+#[test]
+fn format_help_shows_file_selection_options() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    enable_experimental(&mut cmd);
+    cmd.args(["format", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("File selection"))
+        .stdout(predicate::str::contains("--exclude <FILE_PATTERN>"))
+        .stdout(predicate::str::contains("--extend-exclude <FILE_PATTERN>"))
+        .stdout(predicate::str::contains("--respect-gitignore"))
+        .stdout(predicate::str::contains("--force-exclude"));
+}
+
+#[test]
 fn format_subcommand_requires_experimental_env() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.arg("format");
@@ -518,6 +545,112 @@ fn check_zsh_shebang_parses_with_inferred_zsh_dialect() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.current_dir(tempdir.path()).arg("check");
     cmd.assert().success().stdout("");
+}
+
+#[test]
+fn check_exclude_skips_walked_files_but_not_explicit_files_without_force_exclude() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("ok.sh"), "#!/bin/bash\necho ok\n").unwrap();
+    fs::write(tempdir.path().join("ignored.sh"), "#!/bin/bash\nif true\n").unwrap();
+
+    let mut walked = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut walked, tempdir.path());
+    walked
+        .current_dir(tempdir.path())
+        .args(["check", "--exclude", "ignored.sh"]);
+    walked.assert().success().stdout("");
+
+    let mut explicit = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut explicit, tempdir.path());
+    explicit
+        .current_dir(tempdir.path())
+        .args(["check", "--exclude", "ignored.sh", "ignored.sh"]);
+    explicit
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("--> ignored.sh:2:1"));
+
+    let mut forced = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut forced, tempdir.path());
+    forced.current_dir(tempdir.path()).args([
+        "check",
+        "--exclude",
+        "ignored.sh",
+        "--force-exclude",
+        "ignored.sh",
+    ]);
+    forced.assert().success().stdout("");
+}
+
+#[test]
+fn check_gitignore_and_force_exclude_flags_control_explicit_files() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join(".gitignore"), "ignored.sh\n").unwrap();
+    fs::write(tempdir.path().join("ignored.sh"), "#!/bin/bash\nif true\n").unwrap();
+
+    let mut default_walk = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut default_walk, tempdir.path());
+    default_walk.current_dir(tempdir.path()).arg("check");
+    default_walk.assert().success().stdout("");
+
+    let mut no_respect = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut no_respect, tempdir.path());
+    no_respect
+        .current_dir(tempdir.path())
+        .args(["check", "--no-respect-gitignore"]);
+    no_respect
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("--> ignored.sh:2:1"));
+
+    let mut explicit = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut explicit, tempdir.path());
+    explicit
+        .current_dir(tempdir.path())
+        .args(["check", "ignored.sh"]);
+    explicit
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("--> ignored.sh:2:1"));
+
+    let mut forced = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut forced, tempdir.path());
+    forced
+        .current_dir(tempdir.path())
+        .args(["check", "--force-exclude", "ignored.sh"]);
+    forced.assert().success().stdout("");
+}
+
+#[test]
+fn check_extend_exclude_adds_to_exclude_patterns() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("base.sh"), "#!/bin/bash\nif true\n").unwrap();
+    fs::write(tempdir.path().join("extra.sh"), "#!/bin/bash\nif true\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path()).args([
+        "check",
+        "--exclude",
+        "base.sh",
+        "--extend-exclude",
+        "extra.sh",
+    ]);
+    cmd.assert().success().stdout("");
+}
+
+#[test]
+fn check_invalid_extend_exclude_pattern_reports_discovery_error() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("ok.sh"), "#!/bin/bash\necho ok\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--extend-exclude", "["]);
+    cmd.assert()
+        .code(2)
+        .stderr(predicate::str::contains("invalid exclude pattern `[`"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add shared file-selection CLI args for `check` and `format`
- honor `--exclude`, `--extend-exclude`, `--respect-gitignore`, and `--force-exclude` in discovery
- add unit and integration coverage for help text, flag parsing, and `check` behavior

## Testing
- cargo fmt
- cargo test -p shuck --lib -- --nocapture
- cargo test -p shuck --test integration_test -- --nocapture