### PR TITLE
Add global config and color CLI options

### DIFF
--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -4,9 +4,12 @@ use std::path::PathBuf;
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 use clap::error::ErrorKind;
-use clap::{Args as ClapArgs, Parser, Subcommand, ValueEnum};
+use clap::{
+    Args as ClapArgs, ColorChoice, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
+};
 use shuck_formatter::{IndentStyle, ShellDialect};
 
+use crate::config::{ConfigArgumentParser, ConfigArguments, SingleConfigArgument};
 use crate::format_settings::FormatSettingsPatch;
 
 const STYLES: Styles = Styles::styled()
@@ -58,6 +61,16 @@ pub enum CheckOutputFormatArg {
     Concise,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum TerminalColor {
+    /// Display colors if the output goes to an interactive terminal.
+    Auto,
+    /// Always display colors.
+    Always,
+    /// Never display colors.
+    Never,
+}
+
 #[derive(Debug, Parser)]
 #[command(name = "shuck")]
 #[command(about = "Shell checker CLI for shuck")]
@@ -82,6 +95,33 @@ struct ExperimentalCli {
 
 #[derive(Debug, Clone, ClapArgs)]
 struct GlobalArgs {
+    /// Either a path to a TOML configuration file (`shuck.toml`), or a TOML
+    /// `<KEY> = <VALUE>` pair (such as you might find in a `shuck.toml`
+    /// configuration file) overriding a specific configuration option.
+    /// Overrides of individual settings using this option always take
+    /// precedence over all configuration files, including configuration files
+    /// that were also specified using `--config`.
+    #[arg(
+        long,
+        action = clap::ArgAction::Append,
+        value_name = "CONFIG_OPTION",
+        value_parser = ConfigArgumentParser,
+        global = true,
+        help_heading = "Global options"
+    )]
+    config: Vec<SingleConfigArgument>,
+    /// Ignore all configuration files.
+    #[arg(long, global = true, help_heading = "Global options")]
+    isolated: bool,
+    /// Control when colored output is used.
+    #[arg(
+        long,
+        value_enum,
+        value_name = "WHEN",
+        global = true,
+        help_heading = "Global options"
+    )]
+    color: Option<TerminalColor>,
     /// Path to the cache directory.
     #[arg(
         long,
@@ -116,6 +156,8 @@ enum ExperimentalCommand {
 #[derive(Debug, Clone)]
 pub struct Args {
     pub cache_dir: Option<PathBuf>,
+    pub(crate) config: ConfigArguments,
+    pub(crate) color: Option<TerminalColor>,
     pub command: Command,
 }
 
@@ -134,9 +176,10 @@ impl Args {
         T: Into<OsString> + Clone,
     {
         if experimental_enabled() {
-            ExperimentalCli::try_parse_from(itr).map(Into::into)
+            let parsed = parse_with_color::<ExperimentalCli, _, _>(itr)?;
+            Self::from_experimental(parsed)
         } else {
-            let parsed = StableCli::try_parse_from(itr)?;
+            let parsed = parse_with_color::<StableCli, _, _>(itr)?;
             Self::from_stable(parsed)
         }
     }
@@ -144,7 +187,14 @@ impl Args {
 
 impl Args {
     fn from_stable(value: StableCli) -> Result<Self, clap::Error> {
-        let command = match value.command {
+        let StableCli { global, command } = value;
+        let GlobalArgs {
+            cache_dir,
+            config,
+            isolated,
+            color,
+        } = global;
+        let command = match command {
             StableCommand::Check(command) => Command::Check(command),
             StableCommand::Format(_) => {
                 return Err(clap::Error::raw(
@@ -158,24 +208,33 @@ impl Args {
         };
 
         Ok(Self {
-            cache_dir: value.global.cache_dir,
+            cache_dir,
+            config: ConfigArguments::from_cli(config, isolated)?,
+            color,
             command,
         })
     }
-}
 
-impl From<ExperimentalCli> for Args {
-    fn from(value: ExperimentalCli) -> Self {
-        let command = match value.command {
+    fn from_experimental(value: ExperimentalCli) -> Result<Self, clap::Error> {
+        let ExperimentalCli { global, command } = value;
+        let GlobalArgs {
+            cache_dir,
+            config,
+            isolated,
+            color,
+        } = global;
+        let command = match command {
             ExperimentalCommand::Check(command) => Command::Check(command),
             ExperimentalCommand::Format(command) => Command::Format(command),
             ExperimentalCommand::Clean(command) => Command::Clean(command),
         };
 
-        Self {
-            cache_dir: value.global.cache_dir,
+        Ok(Self {
+            cache_dir,
+            config: ConfigArguments::from_cli(config, isolated)?,
+            color,
             command,
-        }
+        })
     }
 }
 
@@ -244,6 +303,60 @@ impl CheckCommand {
     pub fn force_exclude(&self) -> bool {
         self.file_selection.force_exclude()
     }
+}
+
+fn parse_with_color<Cli, I, T>(itr: I) -> Result<Cli, clap::Error>
+where
+    Cli: CommandFactory + FromArgMatches,
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let args = itr.into_iter().map(Into::into).collect::<Vec<_>>();
+    let mut command = Cli::command().color(command_color_choice(&args));
+    let matches = command.try_get_matches_from_mut(args)?;
+    Cli::from_arg_matches(&matches)
+}
+
+fn command_color_choice(args: &[OsString]) -> ColorChoice {
+    match preparse_color(args) {
+        Some(ColorChoice::Always) => ColorChoice::Always,
+        Some(ColorChoice::Never) => ColorChoice::Never,
+        Some(ColorChoice::Auto) | None => {
+            if std::env::var_os("FORCE_COLOR").is_some_and(|value| !value.is_empty()) {
+                ColorChoice::Always
+            } else {
+                ColorChoice::Auto
+            }
+        }
+    }
+}
+
+fn preparse_color(args: &[OsString]) -> Option<ColorChoice> {
+    let mut expect_value = false;
+    let mut color = None;
+
+    for argument in args.iter().skip(1) {
+        if expect_value {
+            let value = argument.to_string_lossy();
+            color = value.parse().ok();
+            expect_value = false;
+            continue;
+        }
+
+        let argument = argument.to_string_lossy();
+        if argument == "--" {
+            break;
+        }
+        if argument == "--color" {
+            expect_value = true;
+            continue;
+        }
+        if let Some(value) = argument.strip_prefix("--color=") {
+            color = value.parse().ok();
+        }
+    }
+
+    color
 }
 
 #[derive(Debug, Clone, Default, ClapArgs)]
@@ -459,6 +572,83 @@ pub struct CleanCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::builder::TypedValueParser;
+
+    #[test]
+    fn global_config_override_is_available_after_subcommand() {
+        let command = StableCli::command();
+        let override_argument = crate::config::ConfigArgumentParser
+            .parse_ref(
+                &command,
+                None,
+                std::ffi::OsStr::new("format.indent-width = 2"),
+            )
+            .unwrap();
+
+        let args = Args::try_parse_from(["shuck", "check", "--config", "format.indent-width = 2"])
+            .unwrap();
+
+        assert_eq!(
+            args.config,
+            ConfigArguments::from_cli(vec![override_argument], false).unwrap()
+        );
+    }
+
+    #[test]
+    fn explicit_config_file_and_inline_override_both_parse_globally() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let config_path = tempdir.path().join("shuck.toml");
+        std::fs::write(&config_path, "[format]\nfunction-next-line = false\n").unwrap();
+        let command = StableCli::command();
+        let override_argument = crate::config::ConfigArgumentParser
+            .parse_ref(
+                &command,
+                None,
+                std::ffi::OsStr::new("format.function-next-line = true"),
+            )
+            .unwrap();
+
+        let args = Args::try_parse_from([
+            "shuck",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--config",
+            "format.function-next-line = true",
+            "check",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args.config,
+            ConfigArguments::from_cli(
+                vec![
+                    SingleConfigArgument::FilePath(config_path),
+                    override_argument
+                ],
+                false,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn global_color_can_be_parsed_before_subcommand() {
+        let args = Args::try_parse_from(["shuck", "--color", "never", "check"]).unwrap();
+        assert_eq!(args.color, Some(TerminalColor::Never));
+    }
+
+    #[test]
+    fn preparse_color_uses_last_value() {
+        assert_eq!(
+            preparse_color(&[
+                OsString::from("shuck"),
+                OsString::from("--color=always"),
+                OsString::from("--color"),
+                OsString::from("never"),
+            ]),
+            Some(ColorChoice::Never)
+        );
+    }
 
     fn parse_check<I, T>(args: I) -> CheckCommand
     where

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -213,6 +213,7 @@ fn run_check_with_cwd(args: &CheckCommand, cwd: &Path, cache_root: &Path) -> Res
             force_exclude: args.force_exclude(),
             parallel: true,
             cache_root: Some(cache_root.to_path_buf()),
+            use_config_roots: true,
         },
         cache_root,
         args.no_cache || fix_applicability.is_some(),

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -24,6 +24,7 @@ use crate::commands::check_output::{
     DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
 };
 use crate::commands::project_runner::{PendingProjectFile, prepare_project_runs};
+use crate::config::ConfigArguments;
 use crate::discover::DiscoveryOptions;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -142,7 +143,11 @@ struct FileCheckResult {
     fixes_applied: usize,
 }
 
-pub(crate) fn check(args: CheckCommand, cache_dir: Option<&Path>) -> Result<ExitStatus> {
+pub(crate) fn check(
+    args: CheckCommand,
+    config_arguments: &ConfigArguments,
+    cache_dir: Option<&Path>,
+) -> Result<ExitStatus> {
     let cwd = std::env::current_dir()?;
     let cache_root = resolve_cache_root(&cwd, cache_dir)?;
     if let Some(raw_reason) = args.add_ignore.as_deref() {
@@ -154,6 +159,7 @@ pub(crate) fn check(args: CheckCommand, cache_dir: Option<&Path>) -> Result<Exit
 
         let report = run_add_ignore_with_cwd(
             &args,
+            config_arguments,
             &cwd,
             &cache_root,
             (!raw_reason.is_empty()).then_some(raw_reason),
@@ -173,7 +179,7 @@ pub(crate) fn check(args: CheckCommand, cache_dir: Option<&Path>) -> Result<Exit
         return Ok(report.exit_status(args.exit_zero));
     }
 
-    let report = run_check_with_cwd(&args, &cwd, &cache_root)?;
+    let report = run_check_with_cwd(&args, config_arguments, &cwd, &cache_root)?;
     print_report(&report, args.output_format)?;
     Ok(report.exit_status(args.exit_zero, args.exit_non_zero_on_fix))
 }
@@ -199,7 +205,12 @@ fn print_diagnostics(
     Ok(())
 }
 
-fn run_check_with_cwd(args: &CheckCommand, cwd: &Path, cache_root: &Path) -> Result<CheckReport> {
+fn run_check_with_cwd(
+    args: &CheckCommand,
+    config_arguments: &ConfigArguments,
+    cwd: &Path,
+    cache_root: &Path,
+) -> Result<CheckReport> {
     let include_source = matches!(args.output_format, crate::args::CheckOutputFormatArg::Full);
     let fix_applicability = requested_fix_applicability(args);
     let settings = EffectiveCheckSettings::default();
@@ -213,7 +224,7 @@ fn run_check_with_cwd(args: &CheckCommand, cwd: &Path, cache_root: &Path) -> Res
             force_exclude: args.force_exclude(),
             parallel: true,
             cache_root: Some(cache_root.to_path_buf()),
-            use_config_roots: true,
+            use_config_roots: config_arguments.use_config_roots(),
         },
         cache_root,
         args.no_cache || fix_applicability.is_some(),
@@ -306,6 +317,7 @@ fn run_check_with_cwd(args: &CheckCommand, cwd: &Path, cache_root: &Path) -> Res
 
 fn run_add_ignore_with_cwd(
     args: &CheckCommand,
+    config_arguments: &ConfigArguments,
     cwd: &Path,
     cache_root: &Path,
     reason: Option<&str>,
@@ -322,6 +334,7 @@ fn run_add_ignore_with_cwd(
             force_exclude: args.force_exclude(),
             parallel: false,
             cache_root: Some(cache_root.to_path_buf()),
+            use_config_roots: config_arguments.use_config_roots(),
         },
         cache_root,
         true,
@@ -398,6 +411,7 @@ pub(crate) fn benchmark_check_paths(
             exit_zero: false,
             exit_non_zero_on_fix: false,
         },
+        &ConfigArguments::default(),
         cwd,
         &cwd.join("cache"),
     )?;
@@ -618,6 +632,7 @@ mod tests {
 
     use super::*;
     use crate::args::CheckOutputFormatArg;
+    use crate::config::ConfigArguments;
 
     fn pending_project_file(path: &Path, project_root: &Path) -> PendingProjectFile {
         PendingProjectFile {
@@ -669,6 +684,7 @@ mod tests {
 
         let report = run_check_with_cwd(
             &check_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
@@ -758,6 +774,7 @@ mod tests {
 
         let report = run_check_with_cwd(
             &check_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
@@ -802,12 +819,14 @@ mod tests {
 
         let first = run_check_with_cwd(
             &check_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
         .unwrap();
         let second = run_check_with_cwd(
             &check_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
@@ -827,6 +846,7 @@ mod tests {
 
         let first = run_check_with_cwd(
             &check_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
@@ -839,6 +859,7 @@ mod tests {
 
         let second = run_check_with_cwd(
             &check_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
@@ -855,6 +876,7 @@ mod tests {
 
         let report = run_check_with_cwd(
             &check_args(true),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
@@ -873,6 +895,7 @@ mod tests {
 
         let report = run_check_with_cwd(
             &check_args(true),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
@@ -896,13 +919,25 @@ mod tests {
         fs::write(&second, "#!/bin/bash\necho ok\n").unwrap();
 
         let cache_root = cache_root(tempdir.path());
-        let initial = run_check_with_cwd(&check_args(false), tempdir.path(), &cache_root).unwrap();
+        let initial = run_check_with_cwd(
+            &check_args(false),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root,
+        )
+        .unwrap();
         assert_eq!(initial.cache_hits, 0);
         assert_eq!(initial.cache_misses, 2);
 
         fs::write(&second, "#!/bin/bash\nif true\n").unwrap();
 
-        let rerun = run_check_with_cwd(&check_args(false), tempdir.path(), &cache_root).unwrap();
+        let rerun = run_check_with_cwd(
+            &check_args(false),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root,
+        )
+        .unwrap();
         assert_eq!(rerun.cache_hits, 1);
         assert_eq!(rerun.cache_misses, 1);
         assert_eq!(rerun.diagnostics.len(), 1);
@@ -917,6 +952,7 @@ mod tests {
 
         let report = run_check_with_cwd(
             &check_args(true),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
@@ -943,8 +979,13 @@ mod tests {
             paths: vec![PathBuf::from("."), PathBuf::from("dup.sh")],
             ..check_args(true)
         };
-        let report =
-            run_check_with_cwd(&args, tempdir.path(), &cache_root(tempdir.path())).unwrap();
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
 
         assert_eq!(report.cache_hits, 0);
         assert_eq!(report.cache_misses, 1);
@@ -959,7 +1000,13 @@ mod tests {
         fs::write(tempdir.path().join("ok.sh"), "#!/bin/bash\necho ok\n").unwrap();
         fs::write(cache_root.join("broken.sh"), "#!/bin/bash\nif true\n").unwrap();
 
-        let report = run_check_with_cwd(&check_args(false), tempdir.path(), &cache_root).unwrap();
+        let report = run_check_with_cwd(
+            &check_args(false),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root,
+        )
+        .unwrap();
 
         assert!(report.diagnostics.is_empty());
         assert!(!tempdir.path().join(".shuck_cache").exists());
@@ -1043,12 +1090,14 @@ mod tests {
 
         let first = run_check_with_cwd(
             &check_args_with_format(false, CheckOutputFormatArg::Full),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )
         .unwrap();
         let second = run_check_with_cwd(
             &check_args_with_format(false, CheckOutputFormatArg::Full),
+            &ConfigArguments::default(),
             tempdir.path(),
             &cache_root(tempdir.path()),
         )

--- a/crates/shuck/src/commands/clean.rs
+++ b/crates/shuck/src/commands/clean.rs
@@ -10,9 +10,13 @@ use shuck_cache::{legacy_cache_dir, read_project_root_from_cache_file};
 use crate::ExitStatus;
 use crate::args::CleanCommand;
 use crate::cache::resolve_cache_root;
-use crate::config::resolve_project_root_for_input;
+use crate::config::{ConfigArguments, resolve_project_root_for_input};
 
-pub(crate) fn clean(args: CleanCommand, cache_dir: Option<&Path>) -> Result<ExitStatus> {
+pub(crate) fn clean(
+    args: CleanCommand,
+    config_arguments: &ConfigArguments,
+    cache_dir: Option<&Path>,
+) -> Result<ExitStatus> {
     let cwd = std::env::current_dir()?;
     let cache_root = resolve_cache_root(&cwd, cache_dir)?;
     let inputs = if args.paths.is_empty() {
@@ -33,7 +37,7 @@ pub(crate) fn clean(args: CleanCommand, cache_dir: Option<&Path>) -> Result<Exit
     let mut roots = BTreeSet::new();
     let mut canonical_roots = BTreeSet::new();
     for input in inputs {
-        let root = resolve_project_root_for_input(&input)?;
+        let root = resolve_project_root_for_input(&input, config_arguments.use_config_roots())?;
         let canonical_root =
             fs::canonicalize(&root).with_context(|| format!("canonicalize {}", root.display()))?;
         canonical_roots.insert(canonical_root);

--- a/crates/shuck/src/commands/format.rs
+++ b/crates/shuck/src/commands/format.rs
@@ -14,6 +14,7 @@ use crate::ExitStatus;
 use crate::args::FormatCommand;
 use crate::cache::resolve_cache_root;
 use crate::commands::project_runner::{PendingProjectFile, prepare_project_runs};
+use crate::config::ConfigArguments;
 use crate::discover::DiscoveryOptions;
 use crate::format_settings::{ResolvedFormatSettings, resolve_project_format_settings};
 
@@ -83,11 +84,15 @@ struct ParseCacheFailure {
     column: usize,
 }
 
-pub(crate) fn format(args: FormatCommand, cache_dir: Option<&Path>) -> Result<ExitStatus> {
+pub(crate) fn format(
+    args: FormatCommand,
+    config_arguments: &ConfigArguments,
+    cache_dir: Option<&Path>,
+) -> Result<ExitStatus> {
     let cwd = std::env::current_dir()?;
     let mode = FormatMode::from_cli(&args);
     let cache_root = resolve_cache_root(&cwd, cache_dir)?;
-    let report = run_format_with_cwd(&args, &cwd, &cache_root, mode)?;
+    let report = run_format_with_cwd(&args, config_arguments, &cwd, &cache_root, mode)?;
     print_report(&report)?;
     Ok(report.exit_status(mode))
 }
@@ -134,6 +139,7 @@ fn print_report(report: &FormatReport) -> Result<()> {
 
 fn run_format_with_cwd(
     args: &FormatCommand,
+    config_arguments: &ConfigArguments,
     cwd: &Path,
     cache_root: &Path,
     mode: FormatMode,
@@ -146,6 +152,7 @@ fn run_format_with_cwd(
         force_exclude: args.force_exclude(),
         parallel: false,
         cache_root: Some(cache_root.to_path_buf()),
+        use_config_roots: config_arguments.use_config_roots(),
     };
     let runs = prepare_project_runs::<FormatCacheData, ResolvedFormatSettings, _>(
         &args.files,
@@ -154,7 +161,13 @@ fn run_format_with_cwd(
         cache_root,
         args.no_cache,
         b"project-format-cache-key",
-        |project_root| resolve_project_format_settings(&project_root.storage_root, cli_settings),
+        |project_root| {
+            resolve_project_format_settings(
+                &project_root.storage_root,
+                config_arguments,
+                cli_settings,
+            )
+        },
     )?;
     let mut report = FormatReport::default();
 
@@ -296,6 +309,7 @@ mod tests {
 
     use super::*;
     use crate::args::FileSelectionArgs;
+    use crate::config::ConfigArguments;
 
     fn make_file_read_only(path: &Path) {
         let mut permissions = fs::metadata(path).unwrap().permissions();
@@ -338,6 +352,7 @@ mod tests {
 
         let report = run_format_with_cwd(
             &format_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Write,
@@ -357,6 +372,7 @@ mod tests {
 
         let first = run_format_with_cwd(
             &format_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Write,
@@ -364,6 +380,7 @@ mod tests {
         .unwrap();
         let second = run_format_with_cwd(
             &format_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Write,
@@ -384,6 +401,7 @@ mod tests {
 
         let first = run_format_with_cwd(
             &format_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Write,
@@ -397,6 +415,7 @@ mod tests {
 
         let second = run_format_with_cwd(
             &format_args(false),
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Write,
@@ -414,6 +433,7 @@ mod tests {
 
         let report = run_format_with_cwd(
             &format_args(true),
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Write,
@@ -437,6 +457,7 @@ mod tests {
 
         let report = run_format_with_cwd(
             &args,
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Check,
@@ -458,6 +479,7 @@ mod tests {
 
         let first = run_format_with_cwd(
             &args,
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Check,
@@ -465,6 +487,7 @@ mod tests {
         .unwrap();
         let second = run_format_with_cwd(
             &args,
+            &ConfigArguments::default(),
             tempdir.path(),
             &tempdir.path().join("cache"),
             FormatMode::Check,

--- a/crates/shuck/src/commands/format_stdin.rs
+++ b/crates/shuck/src/commands/format_stdin.rs
@@ -7,19 +7,28 @@ use shuck_formatter::{FormatError, FormattedSource, format_source, source_is_for
 use crate::ExitStatus;
 use crate::args::FormatCommand;
 use crate::commands::format::{FormatMode, unified_diff, write_parse_error_line};
-use crate::config::{resolve_project_root_for_file, resolve_project_root_for_input};
+use crate::config::{
+    ConfigArguments, resolve_project_root_for_file, resolve_project_root_for_input,
+};
 use crate::format_settings::resolve_project_format_settings;
 use crate::stdin::read_from_stdin;
 
-pub(crate) fn format_stdin(args: FormatCommand) -> Result<ExitStatus> {
+pub(crate) fn format_stdin(
+    args: FormatCommand,
+    config_arguments: &ConfigArguments,
+) -> Result<ExitStatus> {
     let mode = FormatMode::from_cli(&args);
     let source = read_from_stdin()?;
     let path = args.stdin_filename.as_deref();
     let display_path = display_path(path);
     let cwd = std::env::current_dir()?;
-    let project_root = stdin_project_root(path, &cwd)?;
-    let options = resolve_project_format_settings(&project_root, args.format_settings_patch())?
-        .to_shell_format_options();
+    let project_root = stdin_project_root(path, &cwd, config_arguments.use_config_roots())?;
+    let options = resolve_project_format_settings(
+        &project_root,
+        config_arguments,
+        args.format_settings_patch(),
+    )?
+    .to_shell_format_options();
 
     if matches!(mode, FormatMode::Check) {
         return match source_is_formatted(&source, path, &options) {
@@ -81,7 +90,7 @@ fn display_path(path: Option<&Path>) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("<stdin>"))
 }
 
-fn stdin_project_root(path: Option<&Path>, cwd: &Path) -> Result<PathBuf> {
+fn stdin_project_root(path: Option<&Path>, cwd: &Path, use_config_roots: bool) -> Result<PathBuf> {
     match path {
         Some(path) => {
             let path = if path.is_absolute() {
@@ -89,8 +98,8 @@ fn stdin_project_root(path: Option<&Path>, cwd: &Path) -> Result<PathBuf> {
             } else {
                 cwd.join(path)
             };
-            Ok(resolve_project_root_for_file(&path, cwd)?)
+            Ok(resolve_project_root_for_file(&path, cwd, use_config_roots)?)
         }
-        None => Ok(resolve_project_root_for_input(cwd)?),
+        None => Ok(resolve_project_root_for_input(cwd, use_config_roots)?),
     }
 }

--- a/crates/shuck/src/config.rs
+++ b/crates/shuck/src/config.rs
@@ -1,8 +1,12 @@
+use std::ffi::OsStr;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use anyhow::{Context, Result, anyhow};
+use clap::builder::{TypedValueParser, ValueParserFactory};
+use clap::error::{ContextKind, ContextValue, ErrorKind};
 use serde::Deserialize;
 
 use crate::discover::normalize_path;
@@ -10,14 +14,26 @@ use crate::format_settings::{FormatSettingsPatch, parse_config_indent_style};
 
 const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
 pub(crate) const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
+const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["format"];
+const CONFIG_OVERRIDE_FORMAT_KEYS: &[&str] = &[
+    "dialect",
+    "indent-style",
+    "indent-width",
+    "binary-next-line",
+    "switch-case-indent",
+    "space-redirects",
+    "keep-padding",
+    "function-next-line",
+    "never-split",
+];
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
 pub(crate) struct ShuckConfig {
     pub format: FormatConfig,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub(crate) struct FormatConfig {
     pub dialect: Option<toml::Value>,
@@ -31,30 +47,162 @@ pub(crate) struct FormatConfig {
     pub never_split: Option<bool>,
 }
 
-pub(crate) fn resolve_project_root_for_input(input: &Path) -> io::Result<PathBuf> {
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct ConfigArguments {
+    isolated: bool,
+    config_file: Option<PathBuf>,
+    overrides: ShuckConfig,
+}
+
+impl ConfigArguments {
+    pub(crate) fn from_cli(
+        config_options: Vec<SingleConfigArgument>,
+        isolated: bool,
+    ) -> std::result::Result<Self, clap::Error> {
+        let mut config_file: Option<PathBuf> = None;
+        let mut overrides = ShuckConfig::default();
+
+        for option in config_options {
+            match option {
+                SingleConfigArgument::SettingsOverride(config_override) => {
+                    overrides.apply_overrides(config_override);
+                }
+                SingleConfigArgument::FilePath(path) => {
+                    if isolated {
+                        return Err(clap::Error::raw(
+                            ErrorKind::ArgumentConflict,
+                            format!(
+                                "\
+The argument `--config={}` cannot be used with `--isolated`
+
+  tip: You cannot specify a configuration file and also specify `--isolated`,
+       as `--isolated` causes shuck to ignore all configuration files.
+       For more information, try `--help`.
+",
+                                path.display()
+                            ),
+                        ));
+                    }
+
+                    if let Some(existing) = &config_file {
+                        return Err(clap::Error::raw(
+                            ErrorKind::ArgumentConflict,
+                            format!(
+                                "\
+You cannot specify more than one configuration file on the command line.
+
+  tip: remove either `--config={}` or `--config={}`.
+       For more information, try `--help`.
+",
+                                existing.display(),
+                                path.display()
+                            ),
+                        ));
+                    }
+
+                    config_file = Some(path);
+                }
+            }
+        }
+
+        Ok(Self {
+            isolated,
+            config_file,
+            overrides,
+        })
+    }
+
+    pub(crate) fn use_config_roots(&self) -> bool {
+        !self.isolated && self.config_file.is_none()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum SingleConfigArgument {
+    FilePath(PathBuf),
+    SettingsOverride(ShuckConfig),
+}
+
+#[derive(Clone)]
+pub(crate) struct ConfigArgumentParser;
+
+impl ValueParserFactory for SingleConfigArgument {
+    type Parser = ConfigArgumentParser;
+
+    fn value_parser() -> Self::Parser {
+        ConfigArgumentParser
+    }
+}
+
+impl TypedValueParser for ConfigArgumentParser {
+    type Value = SingleConfigArgument;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &OsStr,
+    ) -> std::result::Result<Self::Value, clap::Error> {
+        let path = PathBuf::from(value);
+        if path.is_file() {
+            return Ok(SingleConfigArgument::FilePath(path));
+        }
+
+        let Some(value) = value.to_str() else {
+            return Err(clap::Error::new(ErrorKind::InvalidUtf8));
+        };
+
+        parse_config_override(value)
+            .map(SingleConfigArgument::SettingsOverride)
+            .map_err(|detail| invalid_config_argument(cmd, arg, value, &detail))
+    }
+}
+
+pub(crate) fn resolve_project_root_for_input(
+    input: &Path,
+    use_config_roots: bool,
+) -> io::Result<PathBuf> {
     let base_dir = base_dir_for_input(input)?;
-    Ok(find_config_root(&base_dir)?.unwrap_or(base_dir))
+    if use_config_roots {
+        Ok(find_config_root(&base_dir)?.unwrap_or(base_dir))
+    } else {
+        Ok(base_dir)
+    }
 }
 
 pub(crate) fn resolve_project_root_for_file(
     file: &Path,
     fallback_start: &Path,
+    use_config_roots: bool,
 ) -> io::Result<PathBuf> {
     let start = file
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| fallback_start.to_path_buf());
-    Ok(find_config_root(&start)?.unwrap_or_else(|| normalize_path(fallback_start)))
+    if use_config_roots {
+        Ok(find_config_root(&start)?.unwrap_or_else(|| normalize_path(fallback_start)))
+    } else {
+        Ok(normalize_path(fallback_start))
+    }
 }
 
-pub(crate) fn load_project_config(project_root: &Path) -> Result<ShuckConfig> {
-    let Some(config_path) = config_path_for_root(project_root)? else {
-        return Ok(ShuckConfig::default());
+pub(crate) fn load_project_config(
+    project_root: &Path,
+    config_arguments: &ConfigArguments,
+) -> Result<ShuckConfig> {
+    let mut config = if config_arguments.isolated {
+        ShuckConfig::default()
+    } else if let Some(config_path) = &config_arguments.config_file {
+        load_config_file(config_path)?
+    } else {
+        let Some(config_path) = config_path_for_root(project_root)? else {
+            return Ok(config_arguments.overrides.clone());
+        };
+        load_config_file(&config_path)?
     };
 
-    let source = fs::read_to_string(&config_path)
-        .with_context(|| format!("read {}", config_path.display()))?;
-    toml::from_str(&source).with_context(|| format!("parse {}", config_path.display()))
+    config.apply_overrides(config_arguments.overrides.clone());
+    Ok(config)
 }
 
 impl FormatConfig {
@@ -81,6 +229,130 @@ impl FormatConfig {
             minify: None,
         })
     }
+}
+
+impl ShuckConfig {
+    fn apply_overrides(&mut self, overrides: ShuckConfig) {
+        self.format.apply_overrides(overrides.format);
+    }
+}
+
+impl FormatConfig {
+    fn apply_overrides(&mut self, overrides: FormatConfig) {
+        if overrides.dialect.is_some() {
+            self.dialect = overrides.dialect;
+        }
+        if overrides.indent_style.is_some() {
+            self.indent_style = overrides.indent_style;
+        }
+        if overrides.indent_width.is_some() {
+            self.indent_width = overrides.indent_width;
+        }
+        if overrides.binary_next_line.is_some() {
+            self.binary_next_line = overrides.binary_next_line;
+        }
+        if overrides.switch_case_indent.is_some() {
+            self.switch_case_indent = overrides.switch_case_indent;
+        }
+        if overrides.space_redirects.is_some() {
+            self.space_redirects = overrides.space_redirects;
+        }
+        if overrides.keep_padding.is_some() {
+            self.keep_padding = overrides.keep_padding;
+        }
+        if overrides.function_next_line.is_some() {
+            self.function_next_line = overrides.function_next_line;
+        }
+        if overrides.never_split.is_some() {
+            self.never_split = overrides.never_split;
+        }
+    }
+}
+
+fn load_config_file(config_path: &Path) -> Result<ShuckConfig> {
+    let source = fs::read_to_string(config_path)
+        .with_context(|| format!("read {}", config_path.display()))?;
+    toml::from_str(&source).with_context(|| format!("parse {}", config_path.display()))
+}
+
+fn parse_config_override(value: &str) -> std::result::Result<ShuckConfig, String> {
+    let table = toml::Table::from_str(value).map_err(|err| err.to_string())?;
+    validate_override_table(&table)?;
+    toml::from_str(value).map_err(|err: toml::de::Error| err.to_string())
+}
+
+fn validate_override_table(table: &toml::Table) -> std::result::Result<(), String> {
+    for key in table.keys() {
+        if !CONFIG_OVERRIDE_ROOT_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported config option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_ROOT_KEYS.join(", ")
+            ));
+        }
+    }
+
+    if let Some(format_value) = table.get("format") {
+        let format = format_value
+            .as_table()
+            .ok_or_else(|| "`format` must be a TOML table".to_owned())?;
+        for key in format.keys() {
+            if !CONFIG_OVERRIDE_FORMAT_KEYS.contains(&key.as_str()) {
+                return Err(format!(
+                    "unsupported `[format]` option `{key}`; expected one of: {}",
+                    CONFIG_OVERRIDE_FORMAT_KEYS.join(", ")
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn invalid_config_argument(
+    cmd: &clap::Command,
+    arg: Option<&clap::Arg>,
+    value: &str,
+    detail: &str,
+) -> clap::Error {
+    use std::fmt::Write as _;
+
+    let mut error = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+    if let Some(arg) = arg {
+        error.insert(
+            ContextKind::InvalidArg,
+            ContextValue::String(arg.to_string()),
+        );
+    }
+    error.insert(
+        ContextKind::InvalidValue,
+        ContextValue::String(value.to_owned()),
+    );
+
+    let mut tip = "\
+A `--config` flag must either be a path to a `.toml` configuration file
+       or a TOML `<KEY> = <VALUE>` pair overriding a specific configuration
+       option"
+        .to_owned();
+
+    if Path::new(value)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("toml"))
+        && !value.contains('=')
+    {
+        let _ = write!(
+            &mut tip,
+            "\n\nIt looks like you were trying to pass a path to a configuration file.\nThe path `{value}` does not point to a configuration file."
+        );
+    } else {
+        let _ = write!(&mut tip, "\n\n{detail}");
+    }
+
+    error.insert(
+        ContextKind::Suggested,
+        ContextValue::StyledStrs(vec![tip.into()]),
+    );
+    error
 }
 
 fn base_dir_for_input(input: &Path) -> io::Result<PathBuf> {
@@ -135,4 +407,123 @@ fn config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn inline_config_overrides_validate_supported_keys() {
+        let config = parse_config_override("format.indent-width = 2").unwrap();
+        assert_eq!(config.format.indent_width, Some(2));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_root_keys() {
+        let err = parse_config_override("check.embedded = false").unwrap_err();
+        assert!(err.contains("unsupported config option `check`"));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_format_keys() {
+        let err = parse_config_override("format.line-length = 88").unwrap_err();
+        assert!(err.contains("unsupported `[format]` option `line-length`"));
+    }
+
+    #[test]
+    fn config_arguments_allow_multiple_inline_overrides_with_last_one_winning() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(
+                    parse_config_override("format.indent-width = 2").unwrap(),
+                ),
+                SingleConfigArgument::SettingsOverride(
+                    parse_config_override("format.indent-width = 4").unwrap(),
+                ),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(loaded.format.indent_width, Some(4));
+    }
+
+    #[test]
+    fn isolated_rejects_explicit_config_files() {
+        let tempdir = tempdir().unwrap();
+        let config_path = tempdir.path().join("shuck.toml");
+        fs::write(&config_path, "[format]\n").unwrap();
+
+        let err =
+            ConfigArguments::from_cli(vec![SingleConfigArgument::FilePath(config_path)], true)
+                .unwrap_err();
+
+        assert!(err.to_string().contains("cannot be used with `--isolated`"));
+    }
+
+    #[test]
+    fn explicit_config_file_replaces_discovered_project_config() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[format]\nfunction-next-line = false\n",
+        )
+        .unwrap();
+
+        let explicit = tempdir.path().join("override.toml");
+        fs::write(&explicit, "[format]\nfunction-next-line = true\n").unwrap();
+
+        let config =
+            ConfigArguments::from_cli(vec![SingleConfigArgument::FilePath(explicit)], false)
+                .unwrap();
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+
+        assert_eq!(loaded.format.function_next_line, Some(true));
+    }
+
+    #[test]
+    fn isolated_only_uses_inline_overrides() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[format]\nfunction-next-line = true\n",
+        )
+        .unwrap();
+
+        let config = ConfigArguments::from_cli(
+            vec![SingleConfigArgument::SettingsOverride(
+                parse_config_override("format.indent-width = 2").unwrap(),
+            )],
+            true,
+        )
+        .unwrap();
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+
+        assert_eq!(loaded.format.function_next_line, None);
+        assert_eq!(loaded.format.indent_width, Some(2));
+    }
+
+    #[test]
+    fn project_root_resolution_can_ignore_config_roots() {
+        let tempdir = tempdir().unwrap();
+        let nested = tempdir.path().join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(tempdir.path().join("shuck.toml"), "[format]\n").unwrap();
+
+        assert_eq!(
+            resolve_project_root_for_input(&nested, true).unwrap(),
+            tempdir.path()
+        );
+        assert_eq!(
+            resolve_project_root_for_input(&nested, false).unwrap(),
+            nested
+        );
+    }
 }

--- a/crates/shuck/src/discover.rs
+++ b/crates/shuck/src/discover.rs
@@ -40,7 +40,7 @@ pub(crate) struct DiscoveredFile {
     pub project_root: ProjectRoot,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct DiscoveryOptions {
     pub exclude_patterns: Vec<String>,
     pub extend_exclude_patterns: Vec<String>,
@@ -48,6 +48,21 @@ pub(crate) struct DiscoveryOptions {
     pub force_exclude: bool,
     pub parallel: bool,
     pub cache_root: Option<PathBuf>,
+    pub use_config_roots: bool,
+}
+
+impl Default for DiscoveryOptions {
+    fn default() -> Self {
+        Self {
+            exclude_patterns: Vec::new(),
+            extend_exclude_patterns: Vec::new(),
+            respect_gitignore: false,
+            force_exclude: false,
+            parallel: false,
+            cache_root: None,
+            use_config_roots: true,
+        }
+    }
 }
 
 pub(crate) fn discover_files(
@@ -82,7 +97,7 @@ pub(crate) fn discover_files(
             continue;
         }
 
-        let storage_root = resolve_project_root_for_input(&input)
+        let storage_root = resolve_project_root_for_input(&input, options.use_config_roots)
             .with_context(|| format!("resolve project root for {}", input.display()))?;
         let canonical_root = fs::canonicalize(&storage_root)
             .with_context(|| format!("canonicalize {}", storage_root.display()))?;
@@ -134,7 +149,14 @@ fn collect_input(
             .parent()
             .map(Path::to_path_buf)
             .unwrap_or_else(|| PathBuf::from("."));
-        add_file(input, cwd, &fallback_start, project_root, files)?;
+        add_file(
+            input,
+            cwd,
+            &fallback_start,
+            project_root,
+            options.use_config_roots,
+            files,
+        )?;
     }
 
     Ok(())
@@ -161,6 +183,7 @@ fn collect_directory(
             cwd,
             project_root,
             exclude_matcher,
+            options.use_config_roots,
             &mut builder,
             files,
         );
@@ -183,7 +206,14 @@ fn collect_directory(
             continue;
         }
 
-        add_file(path, cwd, input, project_root, files)?;
+        add_file(
+            path,
+            cwd,
+            input,
+            project_root,
+            options.use_config_roots,
+            files,
+        )?;
     }
 
     Ok(())
@@ -194,6 +224,7 @@ fn collect_directory_parallel(
     cwd: &Path,
     project_root: &ProjectRoot,
     exclude_matcher: &ExcludeMatcher,
+    use_config_roots: bool,
     builder: &mut WalkBuilder,
     files: &mut BTreeMap<PathBuf, DiscoveredFile>,
 ) -> Result<()> {
@@ -215,7 +246,14 @@ fn collect_directory_parallel(
     let mut matched_paths = state.matched_paths.into_inner().unwrap();
     matched_paths.sort();
     for matched_path in matched_paths {
-        add_file(&matched_path, cwd, input, project_root, files)?;
+        add_file(
+            &matched_path,
+            cwd,
+            input,
+            project_root,
+            use_config_roots,
+            files,
+        )?;
     }
 
     Ok(())
@@ -469,11 +507,12 @@ pub(crate) fn add_file(
     cwd: &Path,
     fallback_start: &Path,
     default_project_root: &ProjectRoot,
+    use_config_roots: bool,
     files: &mut BTreeMap<PathBuf, DiscoveredFile>,
 ) -> Result<()> {
     let absolute_path =
         fs::canonicalize(path).with_context(|| format!("canonicalize {}", path.display()))?;
-    let storage_root = resolve_project_root_for_file(path, fallback_start)
+    let storage_root = resolve_project_root_for_file(path, fallback_start, use_config_roots)
         .with_context(|| format!("resolve project root for {}", path.display()))?;
     let canonical_root = fs::canonicalize(&storage_root)
         .with_context(|| format!("canonicalize {}", storage_root.display()))?;

--- a/crates/shuck/src/format_settings.rs
+++ b/crates/shuck/src/format_settings.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, anyhow};
 use shuck_cache::{CacheKey, CacheKeyHasher};
 use shuck_formatter::{IndentStyle, ShellDialect, ShellFormatOptions};
 
-use crate::config::load_project_config;
+use crate::config::{ConfigArguments, load_project_config};
 
 const CLI_INDENT_WIDTH_ERROR: &str = "`--indent-width` must be at least 1";
 const CONFIG_INDENT_WIDTH_ERROR: &str = "`[format].indent-width` must be at least 1";
@@ -98,9 +98,10 @@ impl ResolvedFormatSettings {
 
 pub(crate) fn resolve_project_format_settings(
     project_root: &Path,
+    config_arguments: &ConfigArguments,
     cli_patch: FormatSettingsPatch,
 ) -> Result<ResolvedFormatSettings> {
-    let config = load_project_config(project_root)?;
+    let config = load_project_config(project_root, config_arguments)?;
     let config_patch = config.format.to_patch()?;
 
     let mut settings = ResolvedFormatSettings::default();
@@ -228,8 +229,12 @@ mod tests {
         args.function_next_line = true;
         args.indent_width = Some(4);
 
-        let settings =
-            resolve_project_format_settings(tempdir.path(), args.format_settings_patch()).unwrap();
+        let settings = resolve_project_format_settings(
+            tempdir.path(),
+            &ConfigArguments::default(),
+            args.format_settings_patch(),
+        )
+        .unwrap();
         let options = settings.to_shell_format_options();
 
         assert!(options.function_next_line());

--- a/crates/shuck/src/lib.rs
+++ b/crates/shuck/src/lib.rs
@@ -45,7 +45,7 @@ pub fn run(args: Args) -> Result<ExitStatus> {
     }
 
     match command {
-        Command::Check(command) => commands::check::check(command, cache_dir.as_deref()),
+        Command::Check(command) => commands::check::check(command, &config, cache_dir.as_deref()),
         Command::Format(command) => format(command, &config, cache_dir.as_deref()),
         Command::Clean(command) => commands::clean::clean(command, &config, cache_dir.as_deref()),
     }

--- a/crates/shuck/src/lib.rs
+++ b/crates/shuck/src/lib.rs
@@ -12,7 +12,8 @@ use std::process::ExitCode;
 
 use anyhow::Result;
 
-use crate::args::{Args, Command, FormatCommand};
+use crate::args::{Args, Command, FormatCommand, TerminalColor};
+use crate::config::ConfigArguments;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ExitStatus {
@@ -32,11 +33,21 @@ impl From<ExitStatus> for ExitCode {
 }
 
 pub fn run(args: Args) -> Result<ExitStatus> {
-    let Args { cache_dir, command } = args;
+    let Args {
+        cache_dir,
+        config,
+        color,
+        command,
+    } = args;
+
+    if let Some(color_override) = colored_override(color, std::env::var_os("FORCE_COLOR")) {
+        colored::control::set_override(color_override);
+    }
+
     match command {
         Command::Check(command) => commands::check::check(command, cache_dir.as_deref()),
-        Command::Format(command) => format(command, cache_dir.as_deref()),
-        Command::Clean(command) => commands::clean::clean(command, cache_dir.as_deref()),
+        Command::Format(command) => format(command, &config, cache_dir.as_deref()),
+        Command::Clean(command) => commands::clean::clean(command, &config, cache_dir.as_deref()),
     }
 }
 
@@ -49,14 +60,18 @@ pub fn benchmark_check_paths(
     commands::check::benchmark_check_paths(cwd, paths, output_format)
 }
 
-fn format(mut args: FormatCommand, cache_dir: Option<&Path>) -> Result<ExitStatus> {
+fn format(
+    mut args: FormatCommand,
+    config_arguments: &ConfigArguments,
+    cache_dir: Option<&Path>,
+) -> Result<ExitStatus> {
     let stdin = is_stdin(&args.files, args.stdin_filename.as_deref());
     args.files = resolve_default_files(args.files, stdin);
 
     if stdin {
-        commands::format_stdin::format_stdin(args)
+        commands::format_stdin::format_stdin(args, config_arguments)
     } else {
-        commands::format::format(args, cache_dir)
+        commands::format::format(args, config_arguments, cache_dir)
     }
 }
 
@@ -77,5 +92,40 @@ fn resolve_default_files(files: Vec<PathBuf>, is_stdin: bool) -> Vec<PathBuf> {
         }
     } else {
         files
+    }
+}
+
+fn colored_override(
+    color: Option<TerminalColor>,
+    env_force_color: Option<std::ffi::OsString>,
+) -> Option<bool> {
+    match color {
+        Some(TerminalColor::Always) => Some(true),
+        Some(TerminalColor::Never) => Some(false),
+        Some(TerminalColor::Auto) | None => {
+            env_force_color.map(|force_color| !force_color.is_empty())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn force_color_env_is_respected() {
+        assert_eq!(colored_override(None, Some("1".into())), Some(true));
+    }
+
+    #[test]
+    fn cli_color_overrides_force_color_env() {
+        assert_eq!(
+            colored_override(Some(TerminalColor::Never), Some("1".into())),
+            Some(false)
+        );
+        assert_eq!(
+            colored_override(Some(TerminalColor::Always), None),
+            Some(true)
+        );
     }
 }

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -39,6 +39,9 @@ fn help_shows_commands() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("check"))
+        .stdout(predicate::str::contains("--config <CONFIG_OPTION>"))
+        .stdout(predicate::str::contains("--isolated"))
+        .stdout(predicate::str::contains("--color <WHEN>"))
         .stdout(predicate::str::contains("Format shell files").not())
         .stdout(predicate::str::contains("clean"));
 }
@@ -105,6 +108,22 @@ fn check_help_includes_add_ignore_flag() {
         .stdout(predicate::str::contains("--add-ignore"))
         .stdout(predicate::str::contains("shuck ignore directives"))
         .stdout(predicate::str::contains("--add-noqa").not());
+}
+
+#[test]
+fn config_file_and_isolated_conflict() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("shuck.toml"), "[format]\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.current_dir(tempdir.path())
+        .arg("--isolated")
+        .arg("--config")
+        .arg("shuck.toml")
+        .arg("check");
+    cmd.assert()
+        .code(2)
+        .stderr(predicate::str::contains("cannot be used with `--isolated`"));
 }
 
 #[test]
@@ -1026,6 +1045,79 @@ fn format_honors_project_config_and_cli_overrides_it() {
 }
 
 #[test]
+fn format_honors_explicit_global_config_file() {
+    let tempdir = tempdir().unwrap();
+    let config_path = tempdir.path().join("override.toml");
+    fs::write(&config_path, "[format]\nfunction-next-line = true\n").unwrap();
+    let script = tempdir.path().join("fn.sh");
+    fs::write(&script, "foo(){\necho hi\n}\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    enable_experimental(&mut cmd);
+    cmd.current_dir(tempdir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("format");
+    cmd.assert().success().stdout("");
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "foo()\n{\n\techo hi\n}\n"
+    );
+}
+
+#[test]
+fn format_inline_global_config_override_beats_global_config_file() {
+    let tempdir = tempdir().unwrap();
+    let config_path = tempdir.path().join("override.toml");
+    fs::write(&config_path, "[format]\nfunction-next-line = false\n").unwrap();
+    let script = tempdir.path().join("fn.sh");
+    fs::write(&script, "foo(){\necho hi\n}\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    enable_experimental(&mut cmd);
+    cmd.current_dir(tempdir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--config")
+        .arg("format.function-next-line = true")
+        .arg("format");
+    cmd.assert().success().stdout("");
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "foo()\n{\n\techo hi\n}\n"
+    );
+}
+
+#[test]
+fn format_isolated_ignores_discovered_project_config() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[format]\nfunction-next-line = true\n",
+    )
+    .unwrap();
+    let script = tempdir.path().join("fn.sh");
+    fs::write(&script, "foo(){\necho hi\n}\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    enable_experimental(&mut cmd);
+    cmd.current_dir(tempdir.path())
+        .arg("--isolated")
+        .arg("format");
+    cmd.assert().success().stdout("");
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "foo() {\n\techo hi\n}\n"
+    );
+}
+
+#[test]
 fn format_prefers_nested_project_config_for_explicit_files() {
     let tempdir = tempdir().unwrap();
     let nested = tempdir.path().join("nested");
@@ -1172,4 +1264,35 @@ fn clean_only_removes_selected_project_entries_from_shared_cache() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     assert_eq!(remaining_entries.len(), 1);
+}
+
+#[test]
+fn check_color_always_forces_ansi_output() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("broken.sh"), "#!/bin/bash\nif true\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.current_dir(tempdir.path())
+        .arg("--color")
+        .arg("always")
+        .arg("check");
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("\u{1b}["));
+}
+
+#[test]
+fn check_color_never_overrides_force_color_env() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("broken.sh"), "#!/bin/bash\nif true\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.current_dir(tempdir.path())
+        .env("FORCE_COLOR", "1")
+        .arg("--color")
+        .arg("never")
+        .arg("check");
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("\u{1b}[").not());
 }

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -1267,6 +1267,45 @@ fn clean_only_removes_selected_project_entries_from_shared_cache() {
 }
 
 #[test]
+fn check_and_clean_share_config_root_mode_for_explicit_config_files() {
+    let tempdir = tempdir().unwrap();
+    let cache_dir = tempdir.path().join("shared-cache");
+    let override_config = tempdir.path().join("override.toml");
+    let nested = tempdir.path().join("nested");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(&override_config, "[format]\n").unwrap();
+    fs::write(
+        nested.join("shuck.toml"),
+        "[format]\nfunction-next-line = true\n",
+    )
+    .unwrap();
+    fs::write(nested.join("broken.sh"), "#!/bin/bash\nif true\n").unwrap();
+
+    let mut check = Command::cargo_bin("shuck").unwrap();
+    check
+        .current_dir(tempdir.path())
+        .arg("--cache-dir")
+        .arg(&cache_dir)
+        .arg("--config")
+        .arg(&override_config)
+        .arg("check");
+    check.assert().code(1);
+    assert!(cache_dir.exists());
+
+    let mut clean = Command::cargo_bin("shuck").unwrap();
+    clean
+        .current_dir(tempdir.path())
+        .arg("--cache-dir")
+        .arg(&cache_dir)
+        .arg("--config")
+        .arg(&override_config)
+        .arg("clean");
+    clean.assert().success();
+
+    assert!(!cache_dir.exists());
+}
+
+#[test]
 fn check_color_always_forces_ansi_output() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("broken.sh"), "#!/bin/bash\nif true\n").unwrap();


### PR DESCRIPTION
## Summary
Add `--config`, `--isolated`, and `--color` as global `shuck` CLI options.

## What changed
- add global parsing for `--config <CONFIG_OPTION>` with support for one explicit config file plus inline TOML overrides
- add `--isolated` handling so discovered config files are ignored while inline overrides still work
- add `--color <WHEN>` support for help output, diagnostics, and fatal errors
- thread config precedence through formatter config loading, stdin formatting, project-root discovery, and cache-cleaning flows
- add unit and integration coverage for config precedence, isolated behavior, and forced color output

## Why
The CLI already had project config discovery and color-aware rendering in a few places, but it did not expose Ruff-style global controls for overriding config, disabling config discovery, or forcing terminal colors.

## Impact
Users can now apply one-off config overrides consistently across commands, opt out of config discovery when needed, and explicitly control colored output for local runs and automation.

## Validation
- `cargo test -p shuck`
