### PR TITLE
Add security rule docs for destructive patterns

### DIFF
--- a/docs/rules/K006.yaml
+++ b/docs/rules/K006.yaml
@@ -1,0 +1,24 @@
+legacy_code: SH-324
+legacy_name: rm-rootish-target
+new_category: Security
+new_code: K006
+runtime_kind: ast
+shellcheck_code: null
+shells:
+  - sh
+  - bash
+  - dash
+  - ksh
+description: A recursive `rm` aimed at a root-like path can erase an entire filesystem or home tree.
+rationale: "Require a narrower, explicitly bounded target before using recursive deletion on `/`, `~`, or home-directory roots."
+safe_fix: false
+fix_description: null
+source:
+  shell_checks_rule: rules/SH-324.yaml
+  shell_checks_example: examples/324.sh
+examples:
+  - kind: invalid
+    source: shell-checks/examples/324.sh
+    code: |
+      #!/bin/sh
+      rm -rf "$HOME"/*

--- a/docs/rules/K007.yaml
+++ b/docs/rules/K007.yaml
@@ -1,0 +1,24 @@
+legacy_code: SH-325
+legacy_name: chmod-world-writable-sensitive-path
+new_category: Security
+new_code: K007
+runtime_kind: ast
+shellcheck_code: null
+shells:
+  - sh
+  - bash
+  - dash
+  - ksh
+description: Making a sensitive path world-writable weakens the protections that path is supposed to provide.
+rationale: Keep privileged directories and credential stores restricted to the intended owner or group instead of granting universal write access.
+safe_fix: false
+fix_description: null
+source:
+  shell_checks_rule: rules/SH-325.yaml
+  shell_checks_example: examples/325.sh
+examples:
+  - kind: invalid
+    source: shell-checks/examples/325.sh
+    code: |
+      #!/bin/sh
+      chmod -R 777 ~/.ssh

--- a/docs/rules/K008.yaml
+++ b/docs/rules/K008.yaml
@@ -1,0 +1,24 @@
+legacy_code: SH-326
+legacy_name: fork-bomb-pattern
+new_category: Security
+new_code: K008
+runtime_kind: ast
+shellcheck_code: null
+shells:
+  - sh
+  - bash
+  - dash
+  - ksh
+description: The classic fork-bomb pattern recursively spawns processes until the system is exhausted.
+rationale: Remove the recursive self-pipe pattern entirely; even a copied test version can hang or crash a machine.
+safe_fix: false
+fix_description: null
+source:
+  shell_checks_rule: rules/SH-326.yaml
+  shell_checks_example: examples/326.sh
+examples:
+  - kind: invalid
+    source: shell-checks/examples/326.sh
+    code: |
+      #!/bin/sh
+      :(){ :|:& };:


### PR DESCRIPTION
## What changed

- Added doc-only security rule definitions for destructive shell patterns in `K006` through `K008`.
- Covered root-like recursive `rm` targets, world-writable sensitive paths, and the classic fork bomb pattern.

## Why

- These additions document security-focused rule candidates that fit the current `docs/rules/` catalog without implementing the runtime checks yet.

## Validation

- Ran `yq` schema sanity checks on `docs/rules/K006.yaml`, `docs/rules/K007.yaml`, and `docs/rules/K008.yaml`.
- `bash docs/rules/validate.sh` is blocked in this worktree because the sibling `../shell-checks` repository is not present.
