### PR TITLE
Add ShellCheck compatibility mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security release
+.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security release
 
 ARGS ?= --help
 BENCH_FILE ?=
@@ -141,6 +141,9 @@ test-oracle-shfmt-fixtures:
 test-oracle-shfmt-benchmark:
 	SHUCK_RUN_SHFMT_ORACLE=1 \
 	$(NIX_DEVELOP) cargo test -p shuck-formatter --test oracle_shfmt benchmark_corpus_matches_shfmt -- --ignored --exact --nocapture
+
+test-oracle-shellcheck-cli:
+	$(NIX_DEVELOP) cargo test -p shuck --test oracle_shellcheck_cli -- --ignored --nocapture
 
 run:
 	cargo run -p shuck -- $(ARGS)

--- a/crates/shuck/Cargo.toml
+++ b/crates/shuck/Cargo.toml
@@ -19,6 +19,7 @@ globset = { workspace = true }
 ignore = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 shuck-cache = { path = "../shuck-cache" }
 shuck-formatter = { path = "../shuck-formatter" }
 shuck-indexer = { path = "../shuck-indexer" }

--- a/crates/shuck/src/lib.rs
+++ b/crates/shuck/src/lib.rs
@@ -5,6 +5,10 @@ mod commands;
 mod config;
 mod discover;
 mod format_settings;
+#[doc(hidden)]
+pub mod shellcheck_compat;
+#[doc(hidden)]
+pub mod shellcheck_runtime;
 mod stdin;
 
 use std::path::{Path, PathBuf};

--- a/crates/shuck/src/main.rs
+++ b/crates/shuck/src/main.rs
@@ -4,13 +4,19 @@ use std::process::ExitCode;
 use colored::Colorize;
 
 use shuck::args::Args;
+use shuck::shellcheck_compat;
 use shuck::{ExitStatus, run};
 
 fn main() -> ExitCode {
     #[cfg(windows)]
     assert!(colored::control::set_virtual_terminal(true).is_ok());
 
-    let args = Args::parse();
+    let argv = std::env::args_os().collect::<Vec<_>>();
+    if shellcheck_compat::should_activate(&argv) {
+        return shellcheck_compat::run(argv);
+    }
+
+    let args = Args::try_parse_from(argv).unwrap_or_else(|err| err.exit());
     match run(args) {
         Ok(status) => status.into(),
         Err(err) => report_error(&err),

--- a/crates/shuck/src/shellcheck_compat/config.rs
+++ b/crates/shuck/src/shellcheck_compat/config.rs
@@ -37,10 +37,7 @@ pub fn resolve_config_override(
 
 pub fn load_config(path: &Path) -> Result<CompatConfig, CompatCliError> {
     let source = fs::read_to_string(path).map_err(|err| {
-        CompatCliError::usage(
-            4,
-            format!("could not read {}: {err}", path.display()),
-        )
+        CompatCliError::usage(4, format!("could not read {}: {err}", path.display()))
     })?;
 
     let mut config = CompatConfig::default();
@@ -73,40 +70,48 @@ fn apply_config_entry(
     path: &Path,
     line: usize,
 ) -> Result<(), CompatCliError> {
-    let invalid = |detail: String| {
-        CompatCliError::usage(4, format!("{}:{line}: {detail}", path.display()))
-    };
+    let invalid =
+        |detail: String| CompatCliError::usage(4, format!("{}:{line}: {detail}", path.display()));
 
     match key {
         "check-sourced" => {
-            config.check_sourced = Some(parse_bool(value).ok_or_else(|| {
-                invalid("check-sourced expects a boolean value".to_owned())
-            })?);
+            config.check_sourced = Some(
+                parse_bool(value)
+                    .ok_or_else(|| invalid("check-sourced expects a boolean value".to_owned()))?,
+            );
         }
         "color" => {
-            config.color = Some(value.parse().map_err(|_| {
-                invalid("color expects auto, always, or never".to_owned())
-            })?);
+            config.color = Some(
+                value
+                    .parse()
+                    .map_err(|_| invalid("color expects auto, always, or never".to_owned()))?,
+            );
         }
         "disable" => {
             config.exclude_codes.extend(parse_code_list(value));
         }
         "enable" => {
-            config.enable_checks.extend(parse_optional_check_list(value));
+            config
+                .enable_checks
+                .extend(parse_optional_check_list(value));
         }
         "extended-analysis" => {
-            config.extended_analysis = Some(parse_bool(value).ok_or_else(|| {
-                invalid("extended-analysis expects a boolean value".to_owned())
-            })?);
+            config.extended_analysis =
+                Some(parse_bool(value).ok_or_else(|| {
+                    invalid("extended-analysis expects a boolean value".to_owned())
+                })?);
         }
         "external-sources" => {
-            config.external_sources = Some(parse_bool(value).ok_or_else(|| {
-                invalid("external-sources expects a boolean value".to_owned())
-            })?);
+            config.external_sources =
+                Some(parse_bool(value).ok_or_else(|| {
+                    invalid("external-sources expects a boolean value".to_owned())
+                })?);
         }
         "format" => {
             config.format = Some(value.parse().map_err(|_| {
-                invalid("format expects checkstyle, diff, gcc, json, json1, quiet, or tty".to_owned())
+                invalid(
+                    "format expects checkstyle, diff, gcc, json, json1, quiet, or tty".to_owned(),
+                )
             })?);
         }
         "include" => {

--- a/crates/shuck/src/shellcheck_compat/config.rs
+++ b/crates/shuck/src/shellcheck_compat/config.rs
@@ -1,0 +1,190 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::{
+    CliConfigOverride, CompatCliError, CompatColorMode, CompatFormat, CompatSeverityThreshold,
+    parse_bool, parse_code_list, parse_optional_check_list, parse_source_path_list,
+};
+
+const CONFIG_FILENAME: &str = ".shellcheckrc";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CompatConfig {
+    pub check_sourced: Option<bool>,
+    pub color: Option<CompatColorMode>,
+    pub include_codes: Vec<String>,
+    pub exclude_codes: Vec<String>,
+    pub extended_analysis: Option<bool>,
+    pub format: Option<CompatFormat>,
+    pub enable_checks: Vec<String>,
+    pub source_paths: Vec<String>,
+    pub shell: Option<String>,
+    pub severity: Option<CompatSeverityThreshold>,
+    pub wiki_link_count: Option<usize>,
+    pub external_sources: Option<bool>,
+}
+
+pub fn resolve_config_override(
+    cwd: &Path,
+    override_mode: &CliConfigOverride,
+) -> Result<Option<PathBuf>, CompatCliError> {
+    match override_mode {
+        CliConfigOverride::Ignore => Ok(None),
+        CliConfigOverride::Explicit(path) => Ok(Some(absolutize(cwd, path))),
+        CliConfigOverride::Search => Ok(find_config(cwd)),
+    }
+}
+
+pub fn load_config(path: &Path) -> Result<CompatConfig, CompatCliError> {
+    let source = fs::read_to_string(path).map_err(|err| {
+        CompatCliError::usage(
+            4,
+            format!("could not read {}: {err}", path.display()),
+        )
+    })?;
+
+    let mut config = CompatConfig::default();
+    for (index, raw_line) in source.lines().enumerate() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let (key, value) = line.split_once('=').ok_or_else(|| {
+            CompatCliError::usage(
+                4,
+                format!(
+                    "{}:{}: expected key=value in shellcheck rc file",
+                    path.display(),
+                    index + 1
+                ),
+            )
+        })?;
+        apply_config_entry(&mut config, key.trim(), value.trim(), path, index + 1)?;
+    }
+
+    Ok(config)
+}
+
+fn apply_config_entry(
+    config: &mut CompatConfig,
+    key: &str,
+    value: &str,
+    path: &Path,
+    line: usize,
+) -> Result<(), CompatCliError> {
+    let invalid = |detail: String| {
+        CompatCliError::usage(4, format!("{}:{line}: {detail}", path.display()))
+    };
+
+    match key {
+        "check-sourced" => {
+            config.check_sourced = Some(parse_bool(value).ok_or_else(|| {
+                invalid("check-sourced expects a boolean value".to_owned())
+            })?);
+        }
+        "color" => {
+            config.color = Some(value.parse().map_err(|_| {
+                invalid("color expects auto, always, or never".to_owned())
+            })?);
+        }
+        "disable" => {
+            config.exclude_codes.extend(parse_code_list(value));
+        }
+        "enable" => {
+            config.enable_checks.extend(parse_optional_check_list(value));
+        }
+        "extended-analysis" => {
+            config.extended_analysis = Some(parse_bool(value).ok_or_else(|| {
+                invalid("extended-analysis expects a boolean value".to_owned())
+            })?);
+        }
+        "external-sources" => {
+            config.external_sources = Some(parse_bool(value).ok_or_else(|| {
+                invalid("external-sources expects a boolean value".to_owned())
+            })?);
+        }
+        "format" => {
+            config.format = Some(value.parse().map_err(|_| {
+                invalid("format expects checkstyle, diff, gcc, json, json1, quiet, or tty".to_owned())
+            })?);
+        }
+        "include" => {
+            config.include_codes.extend(parse_code_list(value));
+        }
+        "severity" => {
+            config.severity = Some(value.parse().map_err(|_| {
+                invalid("severity expects error, warning, info, or style".to_owned())
+            })?);
+        }
+        "shell" => {
+            config.shell = Some(value.to_owned());
+        }
+        "source-path" => {
+            config.source_paths.extend(parse_source_path_list(value));
+        }
+        "wiki-link-count" => {
+            let count = value.parse::<usize>().map_err(|_| {
+                invalid("wiki-link-count expects a non-negative integer".to_owned())
+            })?;
+            config.wiki_link_count = Some(count);
+        }
+        _ => {
+            return Err(invalid(format!("unsupported shellcheck rc key `{key}`")));
+        }
+    }
+
+    Ok(())
+}
+
+fn find_config(cwd: &Path) -> Option<PathBuf> {
+    let mut current = Some(cwd);
+    while let Some(dir) = current {
+        let candidate = dir.join(CONFIG_FILENAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+fn absolutize(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_config_parses_disable_and_enable_lists() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join(".shellcheckrc");
+        fs::write(
+            &path,
+            "disable=SC2086,2154\nenable=check-unassigned-uppercase\n",
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        assert_eq!(config.exclude_codes, vec!["SC2086", "2154"]);
+        assert_eq!(config.enable_checks, vec!["check-unassigned-uppercase"]);
+    }
+
+    #[test]
+    fn resolve_config_search_walks_upward_from_cwd() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path().join("project");
+        let subdir = root.join("sub");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::write(root.join(".shellcheckrc"), "disable=SC2086\n").unwrap();
+
+        let resolved = resolve_config_override(&subdir, &CliConfigOverride::Search).unwrap();
+        assert_eq!(resolved, Some(root.join(".shellcheckrc")));
+    }
+}

--- a/crates/shuck/src/shellcheck_compat/mod.rs
+++ b/crates/shuck/src/shellcheck_compat/mod.rs
@@ -858,18 +858,15 @@ fn analyze_one(
 
     if options.check_sourced {
         for sourced in resolved_paths {
-            let canonical = canonicalize_or_clone(&sourced);
-            if final_explicit.contains(&canonical) {
-                analyze_one(
-                    &sourced,
-                    cwd,
-                    options,
-                    &final_explicit,
-                    visited,
-                    diagnostics,
-                    file_errors,
-                )?;
-            }
+            analyze_one(
+                &sourced,
+                cwd,
+                options,
+                &final_explicit,
+                visited,
+                diagnostics,
+                file_errors,
+            )?;
         }
     }
 

--- a/crates/shuck/src/shellcheck_compat/mod.rs
+++ b/crates/shuck/src/shellcheck_compat/mod.rs
@@ -26,6 +26,7 @@ use self::optional::{OPTIONAL_CHECKS, find_optional_check};
 use self::render::{
     print_error_help, print_list_optional, print_report, print_version, usage_text,
 };
+use crate::stdin::read_from_stdin;
 
 const COMPAT_ENV_VAR: &str = "SHUCK_SHELLCHECK_COMPAT";
 const DEFAULT_WIKI_LINK_COUNT: usize = 3;
@@ -386,7 +387,7 @@ where
         "external-sources" => cli.external_sources = true,
         "color" => {
             let value = inline
-                .or_else(|| optional_value(args))
+                .or_else(|| optional_color_value(args))
                 .unwrap_or_else(|| "always".to_owned());
             cli.color =
                 Some(value.parse().map_err(|_| {
@@ -472,7 +473,7 @@ where
                 let value = if let Some(rest) = rest.strip_prefix('=') {
                     Some(rest.to_owned())
                 } else if rest.is_empty() {
-                    optional_value(args)
+                    optional_color_value(args)
                 } else {
                     Some(rest.to_owned())
                 }
@@ -580,20 +581,19 @@ where
         .ok_or_else(|| CompatCliError::usage(4, format!("option `-{flag}` expects a value")))
 }
 
-fn optional_value<'a, I>(args: &mut std::iter::Peekable<I>) -> Option<String>
+fn optional_color_value<'a, I>(args: &mut std::iter::Peekable<I>) -> Option<String>
 where
     I: Iterator<Item = &'a OsString>,
 {
-    let take_next = args
+    let next = args
         .peek()
         .and_then(|value| value.to_str())
-        .is_some_and(|value| !value.starts_with('-'));
-    take_next
-        .then(|| {
-            args.next()
-                .and_then(|value| value.to_str().map(ToOwned::to_owned))
-        })
-        .flatten()
+        .filter(|value| CompatColorMode::from_str(value).is_ok())
+        .map(ToOwned::to_owned);
+    if next.is_some() {
+        let _ = args.next();
+    }
+    next
 }
 
 fn resolve_options(
@@ -612,7 +612,13 @@ fn resolve_options(
     let files = cli
         .files
         .into_iter()
-        .map(|path| absolutize(cwd, &path))
+        .map(|path| {
+            if is_stdin_path(&path) {
+                path
+            } else {
+                absolutize(cwd, &path)
+            }
+        })
         .collect::<Vec<_>>();
     Ok(CompatOptions {
         color: cli.color.or(config.color).unwrap_or(CompatColorMode::Auto),
@@ -798,16 +804,23 @@ fn analyze_one(
         return Ok(());
     }
 
-    let source = match fs::read_to_string(path) {
-        Ok(source) => Arc::<str>::from(source),
-        Err(err) => {
-            file_errors.push(FileAccessError {
-                path: display_path(path, cwd),
-                message: format!("could not read file: {err}"),
-            });
-            return Ok(());
-        }
-    };
+    let source =
+        if is_stdin_path(path) {
+            Arc::<str>::from(read_from_stdin().map_err(|err| {
+                CompatCliError::runtime(2, format!("could not read stdin: {err}"))
+            })?)
+        } else {
+            match fs::read_to_string(path) {
+                Ok(source) => Arc::<str>::from(source),
+                Err(err) => {
+                    file_errors.push(FileAccessError {
+                        path: display_path(path, cwd),
+                        message: format!("could not read file: {err}"),
+                    });
+                    return Ok(());
+                }
+            }
+        };
 
     let (initial, initial_resolved_paths) = lint_with_context(
         path,
@@ -1116,6 +1129,10 @@ fn display_path(path: &Path, cwd: &Path) -> String {
 
 fn canonicalize_or_clone(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn is_stdin_path(path: &Path) -> bool {
+    path == Path::new("-")
 }
 
 fn absolutize(cwd: &Path, path: &Path) -> PathBuf {

--- a/crates/shuck/src/shellcheck_compat/mod.rs
+++ b/crates/shuck/src/shellcheck_compat/mod.rs
@@ -1,0 +1,1158 @@
+mod config;
+mod optional;
+mod render;
+
+use std::collections::{BTreeSet, HashSet};
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use shuck_indexer::Indexer;
+use shuck_linter::{
+    Category, LinterSettings, Rule, RuleSet, Severity, ShellCheckCodeMap, ShellDialect,
+    SuppressionIndex, first_statement_line, parse_directives,
+};
+use shuck_parser::ShellProfile;
+use shuck_parser::parser::Parser;
+use shuck_semantic::SourcePathResolver;
+use shuck_semantic::SourceRefKind;
+
+use self::config::{CompatConfig, load_config, resolve_config_override};
+use self::optional::{OPTIONAL_CHECKS, find_optional_check};
+use self::render::{print_error_help, print_list_optional, print_report, print_version, usage_text};
+
+const COMPAT_ENV_VAR: &str = "SHUCK_SHELLCHECK_COMPAT";
+const DEFAULT_WIKI_LINK_COUNT: usize = 3;
+const EXTENDED_ANALYSIS_RULES: &[Rule] = &[
+    Rule::UndefinedVariable,
+    Rule::UntrackedSourceFile,
+    Rule::OverwrittenFunction,
+    Rule::FunctionCalledWithoutArgs,
+    Rule::FunctionReferencesUnsetParam,
+    Rule::UncheckedDirectoryChangeInFunction,
+    Rule::LocalCrossReference,
+    Rule::UnreachableAfterExit,
+    Rule::UnusedHeredoc,
+];
+
+pub fn should_activate(argv: &[OsString]) -> bool {
+    env_truthy(COMPAT_ENV_VAR)
+        || argv
+            .first()
+            .and_then(shellcheck_basename)
+            .is_some_and(|name| name == "shellcheck")
+}
+
+pub fn run(argv: Vec<OsString>) -> ExitCode {
+    match run_inner(&argv) {
+        Ok(status) => status,
+        Err(err) => {
+            let _ = print_error_help(&err.message, err.show_help);
+            ExitCode::from(err.exit_code)
+        }
+    }
+}
+
+fn run_inner(argv: &[OsString]) -> Result<ExitCode, CompatCliError> {
+    let cli = parse_args(argv)?;
+    if cli.show_help {
+        print!("{}", usage_text());
+        return Ok(ExitCode::from(0));
+    }
+    if cli.show_version {
+        print_version();
+        return Ok(ExitCode::from(0));
+    }
+    if cli.list_optional {
+        print_list_optional(OPTIONAL_CHECKS);
+        return Ok(ExitCode::from(0));
+    }
+
+    let cwd = std::env::current_dir()
+        .map_err(|err| CompatCliError::runtime(2, format!("could not read current directory: {err}")))?;
+    let config_path = resolve_config_override(&cwd, &cli.config_override)?;
+    let config = match config_path.as_deref() {
+        Some(path) => load_config(path)?,
+        None => CompatConfig::default(),
+    };
+    let options = resolve_options(cli, config, &cwd)?;
+    if options.files.is_empty() {
+        return Err(CompatCliError::usage(3, "No files specified."));
+    }
+
+    let report = analyze_files(&options, &cwd)?;
+    print_report(&report, &options)?;
+
+    let mut stderr = io::stderr().lock();
+    for error in &report.file_errors {
+        let _ = writeln!(stderr, "{}: {}", error.path, error.message);
+    }
+
+    let exit = if !report.file_errors.is_empty() {
+        2
+    } else if report.diagnostics.is_empty() {
+        0
+    } else {
+        1
+    };
+    Ok(ExitCode::from(exit))
+}
+
+#[derive(Debug, Clone)]
+struct CompatCliError {
+    exit_code: u8,
+    message: String,
+    show_help: bool,
+}
+
+impl CompatCliError {
+    fn usage(exit_code: u8, message: impl Into<String>) -> Self {
+        Self {
+            exit_code,
+            message: message.into(),
+            show_help: true,
+        }
+    }
+
+    fn runtime(exit_code: u8, message: impl Into<String>) -> Self {
+        Self {
+            exit_code,
+            message: message.into(),
+            show_help: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompatLevel {
+    Style,
+    Info,
+    Warning,
+    Error,
+}
+
+impl CompatLevel {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Style => "style",
+            Self::Info => "info",
+            Self::Warning => "warning",
+            Self::Error => "error",
+        }
+    }
+
+    fn gcc_label(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+            Self::Info | Self::Style => "note",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompatColorMode {
+    Auto,
+    Always,
+    Never,
+}
+
+impl FromStr for CompatColorMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "always" => Ok(Self::Always),
+            "never" => Ok(Self::Never),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompatFormat {
+    Checkstyle,
+    Diff,
+    Gcc,
+    Json,
+    Json1,
+    Quiet,
+    Tty,
+}
+
+impl FromStr for CompatFormat {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "checkstyle" => Ok(Self::Checkstyle),
+            "diff" => Ok(Self::Diff),
+            "gcc" => Ok(Self::Gcc),
+            "json" => Ok(Self::Json),
+            "json1" => Ok(Self::Json1),
+            "quiet" => Ok(Self::Quiet),
+            "tty" => Ok(Self::Tty),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CompatSeverityThreshold {
+    Style,
+    Info,
+    Warning,
+    Error,
+}
+
+impl CompatSeverityThreshold {
+    fn allows(self, level: CompatLevel) -> bool {
+        let level = match level {
+            CompatLevel::Style => Self::Style,
+            CompatLevel::Info => Self::Info,
+            CompatLevel::Warning => Self::Warning,
+            CompatLevel::Error => Self::Error,
+        };
+        level >= self
+    }
+}
+
+impl FromStr for CompatSeverityThreshold {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "style" => Ok(Self::Style),
+            "info" => Ok(Self::Info),
+            "warning" => Ok(Self::Warning),
+            "error" => Ok(Self::Error),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CliConfigOverride {
+    Search,
+    Ignore,
+    Explicit(PathBuf),
+}
+
+#[derive(Debug, Clone)]
+struct ParsedCompatCli {
+    show_help: bool,
+    show_version: bool,
+    list_optional: bool,
+    check_sourced: bool,
+    color: Option<CompatColorMode>,
+    include_codes: Vec<String>,
+    exclude_codes: Vec<String>,
+    extended_analysis: Option<bool>,
+    format: Option<CompatFormat>,
+    enable_checks: Vec<String>,
+    source_paths: Vec<String>,
+    shell: Option<String>,
+    severity: Option<CompatSeverityThreshold>,
+    wiki_link_count: Option<usize>,
+    external_sources: bool,
+    files: Vec<PathBuf>,
+    config_override: CliConfigOverride,
+}
+
+impl Default for ParsedCompatCli {
+    fn default() -> Self {
+        Self {
+            show_help: false,
+            show_version: false,
+            list_optional: false,
+            check_sourced: false,
+            color: None,
+            include_codes: Vec::new(),
+            exclude_codes: Vec::new(),
+            extended_analysis: None,
+            format: None,
+            enable_checks: Vec::new(),
+            source_paths: Vec::new(),
+            shell: None,
+            severity: None,
+            wiki_link_count: None,
+            external_sources: false,
+            files: Vec::new(),
+            config_override: CliConfigOverride::Search,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CompatOptions {
+    color: CompatColorMode,
+    format: CompatFormat,
+    severity: CompatSeverityThreshold,
+    wiki_link_count: usize,
+    shell: Option<String>,
+    check_sourced: bool,
+    external_sources: bool,
+    source_paths: Vec<String>,
+    files: Vec<PathBuf>,
+    enabled_rules: RuleSet,
+    shellcheck_map: ShellCheckCodeMap,
+}
+
+#[derive(Debug, Clone)]
+struct FileAccessError {
+    path: String,
+    message: String,
+}
+
+#[derive(Debug, Clone)]
+struct CompatDiagnostic {
+    file: String,
+    line: usize,
+    end_line: usize,
+    column: usize,
+    end_column: usize,
+    level: CompatLevel,
+    code: u32,
+    message: String,
+    source: Option<Arc<str>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CompatReport {
+    diagnostics: Vec<CompatDiagnostic>,
+    file_errors: Vec<FileAccessError>,
+}
+
+fn parse_args(argv: &[OsString]) -> Result<ParsedCompatCli, CompatCliError> {
+    let mut cli = ParsedCompatCli::default();
+    let mut args = argv.iter().skip(1).peekable();
+    let mut positional_only = false;
+
+    while let Some(arg) = args.next() {
+        let text = arg.to_string_lossy().into_owned();
+        if positional_only {
+            cli.files.push(PathBuf::from(arg));
+            continue;
+        }
+
+        if text == "--" {
+            positional_only = true;
+            continue;
+        }
+
+        if !text.starts_with('-') || text == "-" {
+            cli.files.push(PathBuf::from(arg));
+            continue;
+        }
+
+        if let Some(rest) = text.strip_prefix("--") {
+            parse_long_option(&mut cli, rest, &mut args)?;
+            continue;
+        }
+
+        parse_short_option(&mut cli, &text[1..], &mut args)?;
+    }
+
+    Ok(cli)
+}
+
+fn parse_long_option<'a, I>(
+    cli: &mut ParsedCompatCli,
+    raw: &str,
+    args: &mut std::iter::Peekable<I>,
+) -> Result<(), CompatCliError>
+where
+    I: Iterator<Item = &'a OsString>,
+{
+    let (name, inline) = match raw.split_once('=') {
+        Some((name, value)) => (name, Some(value.to_owned())),
+        None => (raw, None),
+    };
+
+    match name {
+        "help" => cli.show_help = true,
+        "version" => cli.show_version = true,
+        "check-sourced" => cli.check_sourced = true,
+        "list-optional" => cli.list_optional = true,
+        "norc" => cli.config_override = CliConfigOverride::Ignore,
+        "external-sources" => cli.external_sources = true,
+        "color" => {
+            let value = inline
+                .or_else(|| optional_value(args))
+                .unwrap_or_else(|| "always".to_owned());
+            cli.color = Some(value.parse().map_err(|_| {
+                CompatCliError::usage(4, "color expects auto, always, or never")
+            })?);
+        }
+        "include" => {
+            cli.include_codes
+                .extend(parse_code_list(&required_value(name, inline, args)?));
+        }
+        "exclude" => {
+            cli.exclude_codes
+                .extend(parse_code_list(&required_value(name, inline, args)?));
+        }
+        "extended-analysis" => {
+            let value = required_value(name, inline, args)?;
+            cli.extended_analysis = Some(parse_bool(&value).ok_or_else(|| {
+                CompatCliError::usage(4, "extended-analysis expects a boolean value")
+            })?);
+        }
+        "format" => {
+            cli.format = Some(required_value(name, inline, args)?.parse().map_err(|_| {
+                CompatCliError::usage(
+                    4,
+                    "format expects checkstyle, diff, gcc, json, json1, quiet, or tty",
+                )
+            })?);
+        }
+        "rcfile" => {
+            let value = required_value(name, inline, args)?;
+            cli.config_override = CliConfigOverride::Explicit(PathBuf::from(value));
+        }
+        "enable" => {
+            cli.enable_checks
+                .extend(parse_optional_check_list(&required_value(name, inline, args)?));
+        }
+        "source-path" => {
+            cli.source_paths
+                .extend(parse_source_path_list(&required_value(name, inline, args)?));
+        }
+        "shell" => {
+            cli.shell = Some(required_value(name, inline, args)?);
+        }
+        "severity" => {
+            cli.severity = Some(required_value(name, inline, args)?.parse().map_err(|_| {
+                CompatCliError::usage(4, "severity expects error, warning, info, or style")
+            })?);
+        }
+        "wiki-link-count" => {
+            let value = required_value(name, inline, args)?;
+            cli.wiki_link_count = Some(value.parse().map_err(|_| {
+                CompatCliError::usage(4, "wiki-link-count expects a non-negative integer")
+            })?);
+        }
+        _ => {
+            return Err(CompatCliError::usage(
+                3,
+                format!("unrecognized option `--{name}`"),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_short_option<'a, I>(
+    cli: &mut ParsedCompatCli,
+    raw: &str,
+    args: &mut std::iter::Peekable<I>,
+) -> Result<(), CompatCliError>
+where
+    I: Iterator<Item = &'a OsString>,
+{
+    let mut chars = raw.char_indices().peekable();
+    while let Some((index, flag)) = chars.next() {
+        let rest = &raw[index + flag.len_utf8()..];
+        match flag {
+            'a' => cli.check_sourced = true,
+            'x' => cli.external_sources = true,
+            'V' => cli.show_version = true,
+            'C' => {
+                let value = if let Some(rest) = rest.strip_prefix('=') {
+                    Some(rest.to_owned())
+                } else if rest.is_empty() {
+                    optional_value(args)
+                } else {
+                    Some(rest.to_owned())
+                }
+                .unwrap_or_else(|| "always".to_owned());
+                cli.color = Some(value.parse().map_err(|_| {
+                    CompatCliError::usage(4, "color expects auto, always, or never")
+                })?);
+                break;
+            }
+            'i' => {
+                cli.include_codes
+                    .extend(parse_code_list(&value_after_short(flag, rest, args)?));
+                break;
+            }
+            'e' => {
+                cli.exclude_codes
+                    .extend(parse_code_list(&value_after_short(flag, rest, args)?));
+                break;
+            }
+            'f' => {
+                cli.format = Some(value_after_short(flag, rest, args)?.parse().map_err(|_| {
+                    CompatCliError::usage(
+                        4,
+                        "format expects checkstyle, diff, gcc, json, json1, quiet, or tty",
+                    )
+                })?);
+                break;
+            }
+            'o' => {
+                cli.enable_checks
+                    .extend(parse_optional_check_list(&value_after_short(flag, rest, args)?));
+                break;
+            }
+            'P' => {
+                cli.source_paths
+                    .extend(parse_source_path_list(&value_after_short(flag, rest, args)?));
+                break;
+            }
+            's' => {
+                cli.shell = Some(value_after_short(flag, rest, args)?);
+                break;
+            }
+            'S' => {
+                cli.severity = Some(value_after_short(flag, rest, args)?.parse().map_err(|_| {
+                    CompatCliError::usage(4, "severity expects error, warning, info, or style")
+                })?);
+                break;
+            }
+            'W' => {
+                cli.wiki_link_count = Some(value_after_short(flag, rest, args)?.parse().map_err(
+                    |_| CompatCliError::usage(4, "wiki-link-count expects a non-negative integer"),
+                )?);
+                break;
+            }
+            _ => {
+                return Err(CompatCliError::usage(
+                    3,
+                    format!("unrecognized option `-{flag}`"),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn required_value<'a, I>(
+    name: &str,
+    inline: Option<String>,
+    args: &mut std::iter::Peekable<I>,
+) -> Result<String, CompatCliError>
+where
+    I: Iterator<Item = &'a OsString>,
+{
+    if let Some(value) = inline {
+        return Ok(value);
+    }
+    args.next()
+        .and_then(|value| value.to_str().map(ToOwned::to_owned))
+        .ok_or_else(|| CompatCliError::usage(4, format!("option `--{name}` expects a value")))
+}
+
+fn value_after_short<'a, I>(
+    flag: char,
+    rest: &str,
+    args: &mut std::iter::Peekable<I>,
+) -> Result<String, CompatCliError>
+where
+    I: Iterator<Item = &'a OsString>,
+{
+    if let Some(rest) = rest.strip_prefix('=') {
+        return Ok(rest.to_owned());
+    }
+    if !rest.is_empty() {
+        return Ok(rest.to_owned());
+    }
+    args.next()
+        .and_then(|value| value.to_str().map(ToOwned::to_owned))
+        .ok_or_else(|| CompatCliError::usage(4, format!("option `-{flag}` expects a value")))
+}
+
+fn optional_value<'a, I>(args: &mut std::iter::Peekable<I>) -> Option<String>
+where
+    I: Iterator<Item = &'a OsString>,
+{
+    let take_next = args
+        .peek()
+        .and_then(|value| value.to_str())
+        .is_some_and(|value| !value.starts_with('-'));
+    take_next
+        .then(|| {
+            args.next()
+                .and_then(|value| value.to_str().map(ToOwned::to_owned))
+        })
+        .flatten()
+}
+
+fn resolve_options(
+    cli: ParsedCompatCli,
+    config: CompatConfig,
+    cwd: &Path,
+) -> Result<CompatOptions, CompatCliError> {
+    let shell = cli.shell.clone().or(config.shell.clone());
+    if let Some(shell_name) = shell.as_deref() {
+        validate_shell(shell_name)?;
+    }
+
+    let shellcheck_map = ShellCheckCodeMap::default();
+    let enabled_rules = resolve_rule_selection(&shellcheck_map, &cli, &config)?;
+
+    let files = cli
+        .files
+        .into_iter()
+        .map(|path| absolutize(cwd, &path))
+        .collect::<Vec<_>>();
+    Ok(CompatOptions {
+        color: cli.color.or(config.color).unwrap_or(CompatColorMode::Auto),
+        format: cli.format.or(config.format).unwrap_or(CompatFormat::Tty),
+        severity: cli
+            .severity
+            .or(config.severity)
+            .unwrap_or(CompatSeverityThreshold::Style),
+        wiki_link_count: cli
+            .wiki_link_count
+            .or(config.wiki_link_count)
+            .unwrap_or(DEFAULT_WIKI_LINK_COUNT),
+        shell,
+        check_sourced: cli.check_sourced || config.check_sourced.unwrap_or(false),
+        external_sources: cli.external_sources || config.external_sources.unwrap_or(false),
+        source_paths: {
+            let mut values = config.source_paths;
+            values.extend(cli.source_paths);
+            values
+        },
+        files,
+        enabled_rules: apply_extended_analysis(enabled_rules, cli.extended_analysis.or(config.extended_analysis).unwrap_or(true)),
+        shellcheck_map,
+    })
+}
+
+fn resolve_rule_selection(
+    shellcheck_map: &ShellCheckCodeMap,
+    cli: &ParsedCompatCli,
+    config: &CompatConfig,
+) -> Result<RuleSet, CompatCliError> {
+    let mut rules = shellcheck_map
+        .mappings()
+        .map(|(_, rule)| rule)
+        .collect::<RuleSet>();
+
+    let mut requested_optional = config.enable_checks.clone();
+    requested_optional.extend(cli.enable_checks.clone());
+    if !requested_optional.is_empty() {
+        let mut unsupported = Vec::new();
+        for name in requested_optional {
+            if name == "all" {
+                unsupported.extend(
+                    OPTIONAL_CHECKS
+                        .iter()
+                        .filter(|check| !check.supported)
+                        .map(|check| check.name.to_owned()),
+                );
+                continue;
+            }
+
+            let Some(check) = find_optional_check(&name) else {
+                return Err(CompatCliError::usage(
+                    4,
+                    format!("unknown optional check `{name}`"),
+                ));
+            };
+            if !check.supported {
+                unsupported.push(name);
+                continue;
+            }
+
+            let optional_rules = check.rules.iter().copied().collect::<RuleSet>();
+            rules = rules.union(&optional_rules);
+        }
+
+        if !unsupported.is_empty() {
+            unsupported.sort();
+            unsupported.dedup();
+            return Err(CompatCliError::usage(
+                4,
+                format!(
+                    "the requested optional checks are not implemented by this shellcheck compatibility mode: {}",
+                    unsupported.join(", ")
+                ),
+            ));
+        }
+    }
+
+    let include_codes = combined_codes(&config.include_codes, &cli.include_codes);
+    let exclude_codes = combined_codes(&config.exclude_codes, &cli.exclude_codes);
+    if !include_codes.is_empty() {
+        rules = rules_for_codes(shellcheck_map, &include_codes)?;
+    }
+    if !exclude_codes.is_empty() {
+        let excluded = rules_for_codes(shellcheck_map, &exclude_codes)?;
+        rules = rules.subtract(&excluded);
+    }
+
+    Ok(rules)
+}
+
+fn combined_codes(config_codes: &[String], cli_codes: &[String]) -> Vec<String> {
+    config_codes
+        .iter()
+        .chain(cli_codes)
+        .cloned()
+        .collect::<Vec<_>>()
+}
+
+fn rules_for_codes(
+    shellcheck_map: &ShellCheckCodeMap,
+    codes: &[String],
+) -> Result<RuleSet, CompatCliError> {
+    let mut rules = HashSet::new();
+    for code in codes {
+        let resolved = shellcheck_map.resolve_all(code);
+        if resolved.is_empty() {
+            return Err(CompatCliError::usage(
+                4,
+                format!("shellcheck code `{code}` is not implemented by this compatibility mode"),
+            ));
+        }
+        rules.extend(resolved);
+    }
+    Ok(rules.into_iter().collect())
+}
+
+fn apply_extended_analysis(mut rules: RuleSet, enabled: bool) -> RuleSet {
+    if enabled {
+        return rules;
+    }
+
+    let extended_rules = EXTENDED_ANALYSIS_RULES.iter().copied().collect::<RuleSet>();
+    rules = rules.subtract(&extended_rules);
+    rules
+}
+
+fn analyze_files(options: &CompatOptions, cwd: &Path) -> Result<CompatReport, CompatCliError> {
+    let explicit_files = options
+        .files
+        .iter()
+        .map(|path| canonicalize_or_clone(path))
+        .collect::<BTreeSet<_>>();
+    let mut visited = BTreeSet::new();
+    let mut diagnostics = Vec::new();
+    let mut file_errors = Vec::new();
+
+    for path in &options.files {
+        analyze_one(
+            path,
+            cwd,
+            options,
+            &explicit_files,
+            &mut visited,
+            &mut diagnostics,
+            &mut file_errors,
+        )?;
+    }
+
+    diagnostics.sort_by(|left, right| {
+        left.file
+            .cmp(&right.file)
+            .then(left.line.cmp(&right.line))
+            .then(left.column.cmp(&right.column))
+            .then(left.code.cmp(&right.code))
+            .then(left.message.cmp(&right.message))
+    });
+
+    Ok(CompatReport {
+        diagnostics,
+        file_errors,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_one(
+    path: &Path,
+    cwd: &Path,
+    options: &CompatOptions,
+    explicit_files: &BTreeSet<PathBuf>,
+    visited: &mut BTreeSet<PathBuf>,
+    diagnostics: &mut Vec<CompatDiagnostic>,
+    file_errors: &mut Vec<FileAccessError>,
+) -> Result<(), CompatCliError> {
+    let canonical = canonicalize_or_clone(path);
+    if !visited.insert(canonical.clone()) {
+        return Ok(());
+    }
+
+    let source = match fs::read_to_string(path) {
+        Ok(source) => Arc::<str>::from(source),
+        Err(err) => {
+            file_errors.push(FileAccessError {
+                path: display_path(path, cwd),
+                message: format!("could not read file: {err}"),
+            });
+            return Ok(());
+        }
+    };
+
+    let (initial, initial_resolved_paths) =
+        lint_with_context(path, &source, options, explicit_files.iter().cloned().collect())?;
+    let final_explicit = if options.external_sources {
+        explicit_files
+            .iter()
+            .cloned()
+            .chain(initial_resolved_paths.iter().cloned())
+            .collect::<BTreeSet<_>>()
+    } else {
+        explicit_files.clone()
+    };
+
+    let (analysis, resolved_paths) = if final_explicit
+        != explicit_files.iter().cloned().collect::<BTreeSet<_>>()
+    {
+        lint_with_context(path, &source, options, final_explicit.clone())?
+    } else {
+        (initial, initial_resolved_paths)
+    };
+
+    diagnostics.extend(analysis.into_iter().filter_map(|diagnostic| {
+        map_diagnostic(path, cwd, diagnostic, source.clone(), &options.shellcheck_map, options.severity)
+    }));
+
+    if options.check_sourced {
+        for sourced in resolved_paths {
+            let canonical = canonicalize_or_clone(&sourced);
+            if final_explicit.contains(&canonical) {
+                analyze_one(
+                    &sourced,
+                    cwd,
+                    options,
+                    &final_explicit,
+                    visited,
+                    diagnostics,
+                    file_errors,
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn lint_with_context(
+    path: &Path,
+    source: &Arc<str>,
+    options: &CompatOptions,
+    explicit_paths: BTreeSet<PathBuf>,
+) -> Result<(Vec<shuck_linter::Diagnostic>, BTreeSet<PathBuf>), CompatCliError> {
+    let shell = options
+        .shell
+        .as_deref()
+        .map(parse_shell_override)
+        .transpose()?
+        .unwrap_or_else(|| ShellDialect::infer(source, Some(path)));
+
+    let parse_result = Parser::with_profile(source, shell_profile(shell)).parse();
+    let indexer = Indexer::new(source, &parse_result);
+    let shellcheck_map = &options.shellcheck_map;
+    let directives = parse_directives(source, &parse_result.file, indexer.comment_index(), shellcheck_map);
+    let suppression_index = (!directives.is_empty()).then(|| {
+        SuppressionIndex::new(
+            &directives,
+            &parse_result.file,
+            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
+        )
+    });
+
+    let explicit = explicit_paths.into_iter().collect::<Vec<_>>();
+    let resolver = CompatSourceResolver {
+        cwd: canonicalize_or_clone(
+            &std::env::current_dir()
+                .map_err(|err| CompatCliError::runtime(2, format!("could not read current directory: {err}")))?,
+        ),
+        source_paths: options.source_paths.clone(),
+    };
+    let settings = LinterSettings {
+        rules: options.enabled_rules,
+        severity_overrides: Default::default(),
+        shell,
+        analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
+    };
+
+    let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
+        &parse_result,
+        source,
+        &indexer,
+        &settings,
+        suppression_index.as_ref(),
+        Some(path),
+        Some(&resolver),
+    );
+    let analysis = shuck_linter::analyze_file_at_path_with_resolver(
+        &parse_result.file,
+        source,
+        &indexer,
+        &settings,
+        suppression_index.as_ref(),
+        Some(path),
+        Some(&resolver),
+    );
+
+    let resolved_paths = analysis
+        .semantic
+        .source_refs()
+        .iter()
+        .flat_map(|source_ref| resolve_source_ref_paths(path, source_ref, &resolver))
+        .collect::<BTreeSet<_>>();
+
+    Ok((
+        diagnostics,
+        resolved_paths,
+    ))
+}
+
+fn resolve_source_ref_paths(
+    source_path: &Path,
+    source_ref: &shuck_semantic::SourceRef,
+    resolver: &CompatSourceResolver,
+) -> Vec<PathBuf> {
+    match &source_ref.kind {
+        SourceRefKind::DirectiveDevNull | SourceRefKind::Dynamic => Vec::new(),
+        SourceRefKind::Literal(candidate) | SourceRefKind::Directive(candidate) => {
+            resolve_candidate_paths(source_path, candidate, resolver)
+        }
+        SourceRefKind::SingleVariableStaticTail { .. } => Vec::new(),
+    }
+}
+
+fn resolve_candidate_paths(
+    source_path: &Path,
+    candidate: &str,
+    resolver: &CompatSourceResolver,
+) -> Vec<PathBuf> {
+    let candidate_path = PathBuf::from(candidate);
+    if candidate_path.is_absolute() {
+        return candidate_path.is_file().then_some(candidate_path).into_iter().collect();
+    }
+
+    let mut resolved = Vec::new();
+    if let Some(base_dir) = source_path.parent() {
+        let direct = base_dir.join(&candidate_path);
+        if direct.is_file() {
+            resolved.push(direct);
+        }
+    }
+    resolved.extend(resolver.resolve_candidate_paths(source_path, candidate));
+    resolved
+}
+
+struct CompatSourceResolver {
+    cwd: PathBuf,
+    source_paths: Vec<String>,
+}
+
+impl shuck_semantic::SourcePathResolver for CompatSourceResolver {
+    fn resolve_candidate_paths(&self, source_path: &Path, candidate: &str) -> Vec<PathBuf> {
+        let mut resolved = Vec::new();
+        for root in &self.source_paths {
+            let root_path = if root == "SCRIPTDIR" {
+                source_path.parent().unwrap_or(Path::new("")).to_path_buf()
+            } else {
+                let root_path = PathBuf::from(root);
+                if root_path.is_absolute() {
+                    root_path
+                } else {
+                    self.cwd.join(root_path)
+                }
+            };
+            let candidate_path = root_path.join(candidate);
+            if candidate_path.is_file() {
+                resolved.push(candidate_path);
+            }
+        }
+        resolved
+    }
+}
+
+fn map_diagnostic(
+    path: &Path,
+    cwd: &Path,
+    diagnostic: shuck_linter::Diagnostic,
+    source: Arc<str>,
+    shellcheck_map: &ShellCheckCodeMap,
+    threshold: CompatSeverityThreshold,
+) -> Option<CompatDiagnostic> {
+    let code = shellcheck_map.code_for_rule(diagnostic.rule)?;
+    let level = level_for_diagnostic(diagnostic.rule, diagnostic.severity, code);
+    threshold.allows(level).then(|| CompatDiagnostic {
+        file: display_path(path, cwd),
+        line: diagnostic.span.start.line,
+        end_line: diagnostic.span.end.line,
+        column: diagnostic.span.start.column,
+        end_column: diagnostic.span.end.column,
+        level,
+        code,
+        message: diagnostic.message,
+        source: Some(source),
+    })
+}
+
+fn level_for_diagnostic(rule: Rule, severity: Severity, shellcheck_code: u32) -> CompatLevel {
+    match severity {
+        Severity::Hint => CompatLevel::Style,
+        Severity::Error | Severity::Warning => {
+            if shellcheck_code < 2000 {
+                CompatLevel::Error
+            } else if matches!(rule.category(), Category::Style) {
+                CompatLevel::Info
+            } else {
+                CompatLevel::Warning
+            }
+        }
+    }
+}
+
+fn parse_shell_override(value: &str) -> Result<ShellDialect, CompatCliError> {
+    validate_shell(value)?;
+    Ok(match value {
+        "sh" | "dash" | "busybox" => ShellDialect::Sh,
+        "bash" => ShellDialect::Bash,
+        "ksh" => ShellDialect::Ksh,
+        _ => ShellDialect::Sh,
+    })
+}
+
+fn validate_shell(value: &str) -> Result<(), CompatCliError> {
+    match value {
+        "sh" | "bash" | "dash" | "ksh" | "busybox" => Ok(()),
+        _ => Err(CompatCliError::usage(
+            4,
+            format!("unsupported shell `{value}`"),
+        )),
+    }
+}
+
+fn shell_profile(shell: ShellDialect) -> ShellProfile {
+    match shell {
+        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => {
+            ShellProfile::native(shuck_parser::ShellDialect::Posix)
+        }
+        ShellDialect::Mksh => ShellProfile::native(shuck_parser::ShellDialect::Mksh),
+        ShellDialect::Zsh => ShellProfile::native(shuck_parser::ShellDialect::Zsh),
+        ShellDialect::Unknown | ShellDialect::Bash => {
+            ShellProfile::native(shuck_parser::ShellDialect::Bash)
+        }
+    }
+}
+
+pub(super) fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+pub(super) fn parse_code_list(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+pub(super) fn parse_optional_check_list(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+pub(super) fn parse_source_path_list(value: &str) -> Vec<String> {
+    std::env::split_paths(OsStr::new(value))
+        .map(|path| path.to_string_lossy().into_owned())
+        .filter(|item| !item.is_empty())
+        .collect()
+}
+
+fn display_path(path: &Path, cwd: &Path) -> String {
+    path.strip_prefix(cwd)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn canonicalize_or_clone(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn absolutize(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn shellcheck_basename(value: &OsString) -> Option<String> {
+    Path::new(value)
+        .file_stem()
+        .or_else(|| Path::new(value).file_name())
+        .map(|value| value.to_string_lossy().into_owned())
+}
+
+fn env_truthy(key: &str) -> bool {
+    std::env::var_os(key).is_some_and(|value| {
+        !matches!(
+            value.to_string_lossy().trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        )
+    })
+}
+
+pub(super) fn use_color(mode: CompatColorMode) -> bool {
+    match mode {
+        CompatColorMode::Always => true,
+        CompatColorMode::Never => false,
+        CompatColorMode::Auto => io::stdout().is_terminal(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_activation_treats_truthy_values_as_enabled() {
+        assert!(parse_bool("true").unwrap());
+        assert!(parse_bool("1").unwrap());
+        assert!(!parse_bool("off").unwrap());
+    }
+
+    #[test]
+    fn parser_accepts_short_and_long_options() {
+        let args = vec![
+            OsString::from("shellcheck"),
+            OsString::from("-a"),
+            OsString::from("-C"),
+            OsString::from("always"),
+            OsString::from("--severity=warning"),
+            OsString::from("script.sh"),
+        ];
+
+        let cli = parse_args(&args).unwrap();
+        assert!(cli.check_sourced);
+        assert_eq!(cli.color, Some(CompatColorMode::Always));
+        assert_eq!(cli.severity, Some(CompatSeverityThreshold::Warning));
+        assert_eq!(cli.files, vec![PathBuf::from("script.sh")]);
+    }
+
+    #[test]
+    fn parser_rejects_unknown_options() {
+        let args = vec![OsString::from("shellcheck"), OsString::from("--wat")];
+        let err = parse_args(&args).unwrap_err();
+        assert_eq!(err.exit_code, 3);
+        assert!(err.message.contains("unrecognized option"));
+    }
+}

--- a/crates/shuck/src/shellcheck_compat/mod.rs
+++ b/crates/shuck/src/shellcheck_compat/mod.rs
@@ -23,7 +23,9 @@ use shuck_semantic::SourceRefKind;
 
 use self::config::{CompatConfig, load_config, resolve_config_override};
 use self::optional::{OPTIONAL_CHECKS, find_optional_check};
-use self::render::{print_error_help, print_list_optional, print_report, print_version, usage_text};
+use self::render::{
+    print_error_help, print_list_optional, print_report, print_version, usage_text,
+};
 
 const COMPAT_ENV_VAR: &str = "SHUCK_SHELLCHECK_COMPAT";
 const DEFAULT_WIKI_LINK_COUNT: usize = 3;
@@ -72,8 +74,9 @@ fn run_inner(argv: &[OsString]) -> Result<ExitCode, CompatCliError> {
         return Ok(ExitCode::from(0));
     }
 
-    let cwd = std::env::current_dir()
-        .map_err(|err| CompatCliError::runtime(2, format!("could not read current directory: {err}")))?;
+    let cwd = std::env::current_dir().map_err(|err| {
+        CompatCliError::runtime(2, format!("could not read current directory: {err}"))
+    })?;
     let config_path = resolve_config_override(&cwd, &cli.config_override)?;
     let config = match config_path.as_deref() {
         Some(path) => load_config(path)?,
@@ -385,9 +388,10 @@ where
             let value = inline
                 .or_else(|| optional_value(args))
                 .unwrap_or_else(|| "always".to_owned());
-            cli.color = Some(value.parse().map_err(|_| {
-                CompatCliError::usage(4, "color expects auto, always, or never")
-            })?);
+            cli.color =
+                Some(value.parse().map_err(|_| {
+                    CompatCliError::usage(4, "color expects auto, always, or never")
+                })?);
         }
         "include" => {
             cli.include_codes
@@ -417,7 +421,9 @@ where
         }
         "enable" => {
             cli.enable_checks
-                .extend(parse_optional_check_list(&required_value(name, inline, args)?));
+                .extend(parse_optional_check_list(&required_value(
+                    name, inline, args,
+                )?));
         }
         "source-path" => {
             cli.source_paths
@@ -456,8 +462,7 @@ fn parse_short_option<'a, I>(
 where
     I: Iterator<Item = &'a OsString>,
 {
-    let mut chars = raw.char_indices().peekable();
-    while let Some((index, flag)) = chars.next() {
+    for (index, flag) in raw.char_indices() {
         let rest = &raw[index + flag.len_utf8()..];
         match flag {
             'a' => cli.check_sourced = true,
@@ -498,12 +503,16 @@ where
             }
             'o' => {
                 cli.enable_checks
-                    .extend(parse_optional_check_list(&value_after_short(flag, rest, args)?));
+                    .extend(parse_optional_check_list(&value_after_short(
+                        flag, rest, args,
+                    )?));
                 break;
             }
             'P' => {
                 cli.source_paths
-                    .extend(parse_source_path_list(&value_after_short(flag, rest, args)?));
+                    .extend(parse_source_path_list(&value_after_short(
+                        flag, rest, args,
+                    )?));
                 break;
             }
             's' => {
@@ -511,15 +520,17 @@ where
                 break;
             }
             'S' => {
-                cli.severity = Some(value_after_short(flag, rest, args)?.parse().map_err(|_| {
-                    CompatCliError::usage(4, "severity expects error, warning, info, or style")
-                })?);
+                cli.severity =
+                    Some(value_after_short(flag, rest, args)?.parse().map_err(|_| {
+                        CompatCliError::usage(4, "severity expects error, warning, info, or style")
+                    })?);
                 break;
             }
             'W' => {
-                cli.wiki_link_count = Some(value_after_short(flag, rest, args)?.parse().map_err(
-                    |_| CompatCliError::usage(4, "wiki-link-count expects a non-negative integer"),
-                )?);
+                cli.wiki_link_count =
+                    Some(value_after_short(flag, rest, args)?.parse().map_err(|_| {
+                        CompatCliError::usage(4, "wiki-link-count expects a non-negative integer")
+                    })?);
                 break;
             }
             _ => {
@@ -623,7 +634,12 @@ fn resolve_options(
             values
         },
         files,
-        enabled_rules: apply_extended_analysis(enabled_rules, cli.extended_analysis.or(config.extended_analysis).unwrap_or(true)),
+        enabled_rules: apply_extended_analysis(
+            enabled_rules,
+            cli.extended_analysis
+                .or(config.extended_analysis)
+                .unwrap_or(true),
+        ),
         shellcheck_map,
     })
 }
@@ -793,8 +809,12 @@ fn analyze_one(
         }
     };
 
-    let (initial, initial_resolved_paths) =
-        lint_with_context(path, &source, options, explicit_files.iter().cloned().collect())?;
+    let (initial, initial_resolved_paths) = lint_with_context(
+        path,
+        &source,
+        options,
+        explicit_files.iter().cloned().collect(),
+    )?;
     let final_explicit = if options.external_sources {
         explicit_files
             .iter()
@@ -805,16 +825,22 @@ fn analyze_one(
         explicit_files.clone()
     };
 
-    let (analysis, resolved_paths) = if final_explicit
-        != explicit_files.iter().cloned().collect::<BTreeSet<_>>()
-    {
-        lint_with_context(path, &source, options, final_explicit.clone())?
-    } else {
-        (initial, initial_resolved_paths)
-    };
+    let (analysis, resolved_paths) =
+        if final_explicit != explicit_files.iter().cloned().collect::<BTreeSet<_>>() {
+            lint_with_context(path, &source, options, final_explicit.clone())?
+        } else {
+            (initial, initial_resolved_paths)
+        };
 
     diagnostics.extend(analysis.into_iter().filter_map(|diagnostic| {
-        map_diagnostic(path, cwd, diagnostic, source.clone(), &options.shellcheck_map, options.severity)
+        map_diagnostic(
+            path,
+            cwd,
+            diagnostic,
+            source.clone(),
+            &options.shellcheck_map,
+            options.severity,
+        )
     }));
 
     if options.check_sourced {
@@ -853,7 +879,12 @@ fn lint_with_context(
     let parse_result = Parser::with_profile(source, shell_profile(shell)).parse();
     let indexer = Indexer::new(source, &parse_result);
     let shellcheck_map = &options.shellcheck_map;
-    let directives = parse_directives(source, &parse_result.file, indexer.comment_index(), shellcheck_map);
+    let directives = parse_directives(
+        source,
+        &parse_result.file,
+        indexer.comment_index(),
+        shellcheck_map,
+    );
     let suppression_index = (!directives.is_empty()).then(|| {
         SuppressionIndex::new(
             &directives,
@@ -864,10 +895,9 @@ fn lint_with_context(
 
     let explicit = explicit_paths.into_iter().collect::<Vec<_>>();
     let resolver = CompatSourceResolver {
-        cwd: canonicalize_or_clone(
-            &std::env::current_dir()
-                .map_err(|err| CompatCliError::runtime(2, format!("could not read current directory: {err}")))?,
-        ),
+        cwd: canonicalize_or_clone(&std::env::current_dir().map_err(|err| {
+            CompatCliError::runtime(2, format!("could not read current directory: {err}"))
+        })?),
         source_paths: options.source_paths.clone(),
     };
     let settings = LinterSettings {
@@ -903,10 +933,7 @@ fn lint_with_context(
         .flat_map(|source_ref| resolve_source_ref_paths(path, source_ref, &resolver))
         .collect::<BTreeSet<_>>();
 
-    Ok((
-        diagnostics,
-        resolved_paths,
-    ))
+    Ok((diagnostics, resolved_paths))
 }
 
 fn resolve_source_ref_paths(
@@ -930,7 +957,11 @@ fn resolve_candidate_paths(
 ) -> Vec<PathBuf> {
     let candidate_path = PathBuf::from(candidate);
     if candidate_path.is_absolute() {
-        return candidate_path.is_file().then_some(candidate_path).into_iter().collect();
+        return candidate_path
+            .is_file()
+            .then_some(candidate_path)
+            .into_iter()
+            .collect();
     }
 
     let mut resolved = Vec::new();

--- a/crates/shuck/src/shellcheck_compat/optional.rs
+++ b/crates/shuck/src/shellcheck_compat/optional.rs
@@ -1,0 +1,106 @@
+use shuck_linter::Rule;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OptionalCheck {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub example: &'static str,
+    pub guidance: &'static str,
+    pub rules: &'static [Rule],
+    pub supported: bool,
+}
+
+pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
+    OptionalCheck {
+        name: "add-default-case",
+        description: "Reports case statements that omit a fallback branch.",
+        example: "case $? in 0) echo ok ;; esac",
+        guidance: "Add a catch-all branch when the script should handle unexpected values.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "avoid-negated-conditions",
+        description: "Prefers direct comparison operators over leading negation in tests.",
+        example: "[ ! \"$value\" -eq 1 ]",
+        guidance: "Rewrite the operator so the intent stays positive without a leading !.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "avoid-nullary-conditions",
+        description: "Flags bare [ \"$var\" ] checks that rely on implicit non-empty semantics.",
+        example: "[ \"$var\" ]",
+        guidance: "Use an explicit string or numeric operator for the condition you mean.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "check-extra-masked-returns",
+        description: "Looks for command substitutions whose failures are easy to miss.",
+        example: "rm -r \"$(helper)/home\"",
+        guidance: "Split the substitution into a checked step before using the result.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "check-set-e-suppressed",
+        description: "Notes call sites where set -e is neutralized by the surrounding construct.",
+        example: "set -e; build && echo ok",
+        guidance: "Run the function as its own command when failures should still abort the script.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "check-unassigned-uppercase",
+        description: "Adds uppercase-variable coverage to unset-variable style checks.",
+        example: "echo $VAR",
+        guidance: "Initialize the uppercase name before reading it, or choose a different check set.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "deprecate-which",
+        description: "Discourages the non-portable which utility in favor of shell builtins.",
+        example: "which javac",
+        guidance: "Prefer command -v when you only need command lookup.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "quote-safe-variables",
+        description: "Requests quotes even for scalar variables that look safe today.",
+        example: "name=hello; echo $name",
+        guidance: "Wrap the expansion in double quotes when consistency matters more than brevity.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "require-double-brackets",
+        description: "Requires [[ ... ]] in shells where that test form is available.",
+        example: "[ -e /etc/issue ]",
+        guidance: "Use the double-bracket form only when the selected shell actually supports it.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "require-variable-braces",
+        description: "Prefers ${name} over bare $name references.",
+        example: "name=hello; echo $name",
+        guidance: "Add braces when you want every variable reference to follow the same house style.",
+        rules: &[],
+        supported: false,
+    },
+    OptionalCheck {
+        name: "useless-use-of-cat",
+        description: "Looks for cat pipelines that can be replaced by a direct file operand.",
+        example: "cat foo | grep bar",
+        guidance: "Pass the file to the downstream command directly when it reads files itself.",
+        rules: &[],
+        supported: false,
+    },
+];
+
+pub fn find_optional_check(name: &str) -> Option<&'static OptionalCheck> {
+    OPTIONAL_CHECKS.iter().find(|check| check.name == name)
+}

--- a/crates/shuck/src/shellcheck_compat/render.rs
+++ b/crates/shuck/src/shellcheck_compat/render.rs
@@ -316,10 +316,14 @@ fn marker_for(diagnostic: &CompatDiagnostic, line_len: usize) -> String {
 }
 
 fn truncate(value: &str, max_len: usize) -> String {
-    if value.len() <= max_len {
+    if value.chars().count() <= max_len {
         value.to_owned()
     } else {
-        format!("{}...", &value[..max_len.saturating_sub(3)])
+        let prefix = value
+            .chars()
+            .take(max_len.saturating_sub(3))
+            .collect::<String>();
+        format!("{prefix}...")
     }
 }
 
@@ -347,7 +351,7 @@ fn stylize(
 
 #[cfg(test)]
 mod tests {
-    use super::write_rendered;
+    use super::{truncate, write_rendered};
 
     struct BrokenPipeWriter;
 
@@ -368,5 +372,12 @@ mod tests {
     fn broken_pipe_is_treated_as_success() {
         let mut writer = BrokenPipeWriter;
         assert!(write_rendered(&mut writer, "hello").is_ok());
+    }
+
+    #[test]
+    fn truncate_handles_multibyte_text() {
+        assert_eq!(truncate("naive cafe", 7), "naiv...");
+        assert_eq!(truncate("naive café", 7), "naiv...");
+        assert_eq!(truncate("emoji 😅 test", 9), "emoji ...");
     }
 }

--- a/crates/shuck/src/shellcheck_compat/render.rs
+++ b/crates/shuck/src/shellcheck_compat/render.rs
@@ -5,11 +5,11 @@ use colored::Colorize;
 use serde::Serialize;
 
 use super::{
-    CompatCliError, CompatDiagnostic, CompatLevel, CompatOptions, CompatReport, CompatFormat,
+    CompatCliError, CompatDiagnostic, CompatFormat, CompatLevel, CompatOptions, CompatReport,
     use_color,
 };
-use crate::shellcheck_runtime::{ShellCheckDiagnostic, ShellCheckFix};
 use crate::shellcheck_compat::optional::OptionalCheck;
+use crate::shellcheck_runtime::{ShellCheckDiagnostic, ShellCheckFix};
 
 pub fn usage_text() -> String {
     [
@@ -171,9 +171,12 @@ fn render_json1(report: &CompatReport) -> Result<String, CompatCliError> {
 fn render_tty(report: &CompatReport, options: &CompatOptions) -> String {
     let use_color = use_color(options.color);
     let mut output = String::new();
-        let mut grouped = std::collections::BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
+    let mut grouped = std::collections::BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
     for diagnostic in &report.diagnostics {
-        grouped.entry(&diagnostic.file).or_default().push(diagnostic);
+        grouped
+            .entry(&diagnostic.file)
+            .or_default()
+            .push(diagnostic);
     }
 
     for (file, diagnostics) in grouped {
@@ -194,21 +197,15 @@ fn render_tty(report: &CompatReport, options: &CompatOptions) -> String {
                 output.push_str(&format!(
                     "{} {}\n",
                     stylize("In", use_color, |text| text.bold()),
-                    stylize(
-                        format!("{file} line {line_no}:"),
-                        use_color,
-                        |text| text.bold()
-                    )
+                    stylize(format!("{file} line {line_no}:"), use_color, |text| text
+                        .bold())
                 ));
             } else {
                 output.push_str(&format!(
                     "{} {}\n",
                     stylize("In", use_color, |text| text.bold()),
-                    stylize(
-                        format!("{file} line {line_no}:"),
-                        use_color,
-                        |text| text.bold()
-                    )
+                    stylize(format!("{file} line {line_no}:"), use_color, |text| text
+                        .bold())
                 ));
             }
 
@@ -292,7 +289,7 @@ fn collect_links(report: &CompatReport, count: usize) -> Vec<String> {
     links
 }
 
-fn line_text<'a>(diagnostic: &'a CompatDiagnostic, line_no: usize) -> Option<&'a str> {
+fn line_text(diagnostic: &CompatDiagnostic, line_no: usize) -> Option<&str> {
     let source = diagnostic.source.as_deref()?;
     source.lines().nth(line_no.saturating_sub(1))
 }
@@ -301,7 +298,10 @@ fn marker_for(diagnostic: &CompatDiagnostic, line_len: usize) -> String {
     let start = diagnostic.column.saturating_sub(1);
     let end = min(
         line_len.max(start + 1),
-        diagnostic.end_column.max(diagnostic.column).saturating_sub(1),
+        diagnostic
+            .end_column
+            .max(diagnostic.column)
+            .saturating_sub(1),
     );
     let width = end.saturating_sub(start).max(1);
     format!("{}{}", " ".repeat(start), "^".repeat(width))

--- a/crates/shuck/src/shellcheck_compat/render.rs
+++ b/crates/shuck/src/shellcheck_compat/render.rs
@@ -1,0 +1,338 @@
+use std::cmp::min;
+use std::io::{self, Write};
+
+use colored::Colorize;
+use serde::Serialize;
+
+use super::{
+    CompatCliError, CompatDiagnostic, CompatLevel, CompatOptions, CompatReport, CompatFormat,
+    use_color,
+};
+use crate::shellcheck_runtime::{ShellCheckDiagnostic, ShellCheckFix};
+use crate::shellcheck_compat::optional::OptionalCheck;
+
+pub fn usage_text() -> String {
+    [
+        "Usage: shellcheck [OPTIONS...] FILES...",
+        "  -a, --check-sourced            Also report diagnostics from resolved sourced files",
+        "  -C, --color[=WHEN]             Control color output with auto, always, or never",
+        "  -i, --include=CODES            Keep only the listed SC codes",
+        "  -e, --exclude=CODES            Drop the listed SC codes",
+        "      --extended-analysis=BOOL   Toggle dataflow-heavy checks on or off",
+        "  -f, --format=FORMAT            Choose checkstyle, diff, gcc, json, json1, quiet, or tty",
+        "      --list-optional            Print the optional-check catalog",
+        "      --norc                     Skip .shellcheckrc discovery",
+        "      --rcfile=PATH              Load a specific shellcheck rc file",
+        "  -o, --enable=CHECKS            Enable named optional checks",
+        "  -P, --source-path=PATHS        Add search roots for sourced files",
+        "  -s, --shell=SHELL              Force sh, bash, dash, ksh, or busybox parsing",
+        "  -S, --severity=LEVEL           Filter to style, info, warning, or error and above",
+        "  -V, --version                  Show version information",
+        "  -W, --wiki-link-count=NUM      Limit wiki links in tty output",
+        "  -x, --external-sources         Treat resolved sourced files as explicit inputs",
+        "      --help                     Show this summary and exit",
+    ]
+    .join("\n")
+}
+
+pub fn print_error_help(message: &str, show_help: bool) -> io::Result<()> {
+    let mut stderr = io::stderr().lock();
+    writeln!(stderr, "{message}")?;
+    if show_help {
+        writeln!(stderr)?;
+        writeln!(stderr, "{}", usage_text())?;
+    }
+    Ok(())
+}
+
+pub fn print_version() {
+    println!("ShellCheck compatibility mode");
+    println!("version: {}", env!("CARGO_PKG_VERSION"));
+    println!("engine: shuck");
+}
+
+pub fn print_list_optional(checks: &[OptionalCheck]) {
+    for (index, check) in checks.iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        println!("name:    {}", check.name);
+        println!("desc:    {}", check.description);
+        println!("example: {}", check.example);
+        println!("fix:     {}", check.guidance);
+    }
+}
+
+pub fn print_report(report: &CompatReport, options: &CompatOptions) -> Result<(), CompatCliError> {
+    let rendered = match options.format {
+        CompatFormat::Checkstyle => render_checkstyle(report),
+        CompatFormat::Diff => render_diff(report),
+        CompatFormat::Gcc => render_gcc(report),
+        CompatFormat::Json => render_json(report)?,
+        CompatFormat::Json1 => render_json1(report)?,
+        CompatFormat::Quiet => String::new(),
+        CompatFormat::Tty => render_tty(report, options),
+    };
+
+    let mut stdout = io::stdout().lock();
+    stdout
+        .write_all(rendered.as_bytes())
+        .map_err(|err| CompatCliError::runtime(2, format!("could not write report: {err}")))?;
+    Ok(())
+}
+
+fn render_checkstyle(report: &CompatReport) -> String {
+    let mut files = std::collections::BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
+    for diagnostic in &report.diagnostics {
+        files.entry(&diagnostic.file).or_default().push(diagnostic);
+    }
+
+    let mut output = String::from("<?xml version='1.0' encoding='UTF-8'?>\n");
+    output.push_str("<checkstyle version='4.3'>\n");
+    for (file, diagnostics) in files {
+        output.push_str(&format!("<file name='{}' >\n", xml_escape(file)));
+        for diagnostic in diagnostics {
+            output.push_str(&format!(
+                "<error line='{}' column='{}' severity='{}' message='{}' source='ShellCheck.SC{:04}' />\n",
+                diagnostic.line,
+                diagnostic.column,
+                diagnostic.level.as_str(),
+                xml_escape(&diagnostic.message),
+                diagnostic.code
+            ));
+        }
+        output.push_str("</file>\n");
+    }
+    output.push_str("</checkstyle>\n");
+    output
+}
+
+fn render_diff(report: &CompatReport) -> String {
+    let mut files = std::collections::BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
+    for diagnostic in &report.diagnostics {
+        files.entry(&diagnostic.file).or_default().push(diagnostic);
+    }
+
+    let mut output = String::new();
+    for (file, diagnostics) in files {
+        if diagnostics.is_empty() {
+            continue;
+        }
+        if !output.is_empty() {
+            output.push('\n');
+        }
+        output.push_str(&format!("--- {file}\n+++ {file}\n"));
+        output.push_str("@@ compatibility mode @@\n");
+        for diagnostic in diagnostics {
+            output.push_str(&format!(
+                "# SC{:04} ({}) {}\n",
+                diagnostic.code,
+                diagnostic.level.as_str(),
+                diagnostic.message
+            ));
+        }
+    }
+    output
+}
+
+fn render_gcc(report: &CompatReport) -> String {
+    let mut output = String::new();
+    for diagnostic in &report.diagnostics {
+        output.push_str(&format!(
+            "{}:{}:{}: {}: {} [SC{:04}]\n",
+            diagnostic.file,
+            diagnostic.line,
+            diagnostic.column,
+            diagnostic.level.gcc_label(),
+            diagnostic.message,
+            diagnostic.code
+        ));
+    }
+    output
+}
+
+fn render_json(report: &CompatReport) -> Result<String, CompatCliError> {
+    serde_json::to_string(&to_shellcheck_diagnostics(report))
+        .map_err(|err| CompatCliError::runtime(2, format!("could not encode json output: {err}")))
+}
+
+fn render_json1(report: &CompatReport) -> Result<String, CompatCliError> {
+    #[derive(Serialize)]
+    struct Wrapper {
+        comments: Vec<ShellCheckDiagnostic>,
+    }
+
+    serde_json::to_string(&Wrapper {
+        comments: to_shellcheck_diagnostics(report),
+    })
+    .map_err(|err| CompatCliError::runtime(2, format!("could not encode json output: {err}")))
+}
+
+fn render_tty(report: &CompatReport, options: &CompatOptions) -> String {
+    let use_color = use_color(options.color);
+    let mut output = String::new();
+        let mut grouped = std::collections::BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
+    for diagnostic in &report.diagnostics {
+        grouped.entry(&diagnostic.file).or_default().push(diagnostic);
+    }
+
+    for (file, diagnostics) in grouped {
+        if diagnostics.is_empty() {
+            continue;
+        }
+
+        let mut by_line = std::collections::BTreeMap::<usize, Vec<&CompatDiagnostic>>::new();
+        for diagnostic in diagnostics {
+            by_line.entry(diagnostic.line).or_default().push(diagnostic);
+        }
+
+        for (index, (line_no, line_diags)) in by_line.into_iter().enumerate() {
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            if index == 0 {
+                output.push_str(&format!(
+                    "{} {}\n",
+                    stylize("In", use_color, |text| text.bold()),
+                    stylize(
+                        format!("{file} line {line_no}:"),
+                        use_color,
+                        |text| text.bold()
+                    )
+                ));
+            } else {
+                output.push_str(&format!(
+                    "{} {}\n",
+                    stylize("In", use_color, |text| text.bold()),
+                    stylize(
+                        format!("{file} line {line_no}:"),
+                        use_color,
+                        |text| text.bold()
+                    )
+                ));
+            }
+
+            let source_line = line_diags
+                .first()
+                .and_then(|diagnostic| line_text(diagnostic, line_no))
+                .unwrap_or_default();
+            output.push_str(&format!("{source_line}\n"));
+            for diagnostic in &line_diags {
+                let marker = marker_for(diagnostic, source_line.len());
+                let text = format!(
+                    "{marker} SC{:04} ({}): {}",
+                    diagnostic.code,
+                    diagnostic.level.as_str(),
+                    diagnostic.message
+                );
+                output.push_str(&format!(
+                    "{}\n",
+                    match diagnostic.level {
+                        CompatLevel::Error => stylize(text, use_color, |value| value.red()),
+                        CompatLevel::Warning => stylize(text, use_color, |value| value.yellow()),
+                        CompatLevel::Info => stylize(text, use_color, |value| value.green()),
+                        CompatLevel::Style => stylize(text, use_color, |value| value.cyan()),
+                    }
+                ));
+            }
+        }
+    }
+
+    let links = collect_links(report, options.wiki_link_count);
+    if !links.is_empty() {
+        if !output.is_empty() {
+            output.push('\n');
+        }
+        output.push_str("For more information:\n");
+        for link in links {
+            output.push_str(&format!("  {link}\n"));
+        }
+    }
+
+    output
+}
+
+fn to_shellcheck_diagnostics(report: &CompatReport) -> Vec<ShellCheckDiagnostic> {
+    report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| ShellCheckDiagnostic {
+            file: diagnostic.file.clone(),
+            code: diagnostic.code,
+            line: diagnostic.line,
+            end_line: diagnostic.end_line.max(diagnostic.line),
+            column: diagnostic.column,
+            end_column: diagnostic.end_column.max(diagnostic.column),
+            level: diagnostic.level.as_str().to_owned(),
+            message: diagnostic.message.clone(),
+            fix: None::<ShellCheckFix>,
+        })
+        .collect()
+}
+
+fn collect_links(report: &CompatReport, count: usize) -> Vec<String> {
+    if count == 0 {
+        return Vec::new();
+    }
+
+    let mut links = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for diagnostic in &report.diagnostics {
+        if seen.insert(diagnostic.code) {
+            links.push(format!(
+                "https://www.shellcheck.net/wiki/SC{:04} -- {}",
+                diagnostic.code,
+                truncate(&diagnostic.message, 60)
+            ));
+        }
+        if links.len() >= count {
+            break;
+        }
+    }
+    links
+}
+
+fn line_text<'a>(diagnostic: &'a CompatDiagnostic, line_no: usize) -> Option<&'a str> {
+    let source = diagnostic.source.as_deref()?;
+    source.lines().nth(line_no.saturating_sub(1))
+}
+
+fn marker_for(diagnostic: &CompatDiagnostic, line_len: usize) -> String {
+    let start = diagnostic.column.saturating_sub(1);
+    let end = min(
+        line_len.max(start + 1),
+        diagnostic.end_column.max(diagnostic.column).saturating_sub(1),
+    );
+    let width = end.saturating_sub(start).max(1);
+    format!("{}{}", " ".repeat(start), "^".repeat(width))
+}
+
+fn truncate(value: &str, max_len: usize) -> String {
+    if value.len() <= max_len {
+        value.to_owned()
+    } else {
+        format!("{}...", &value[..max_len.saturating_sub(3)])
+    }
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('\"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn stylize(
+    value: impl Into<String>,
+    use_color: bool,
+    style: impl FnOnce(colored::ColoredString) -> colored::ColoredString,
+) -> String {
+    let value = value.into();
+    if use_color {
+        style(value.normal()).to_string()
+    } else {
+        value
+    }
+}

--- a/crates/shuck/src/shellcheck_compat/render.rs
+++ b/crates/shuck/src/shellcheck_compat/render.rs
@@ -1,5 +1,5 @@
 use std::cmp::min;
-use std::io::{self, Write};
+use std::io::{self, ErrorKind, Write};
 
 use colored::Colorize;
 use serde::Serialize;
@@ -75,10 +75,18 @@ pub fn print_report(report: &CompatReport, options: &CompatOptions) -> Result<()
     };
 
     let mut stdout = io::stdout().lock();
-    stdout
-        .write_all(rendered.as_bytes())
-        .map_err(|err| CompatCliError::runtime(2, format!("could not write report: {err}")))?;
-    Ok(())
+    write_rendered(&mut stdout, &rendered)
+}
+
+fn write_rendered<W: Write>(writer: &mut W, rendered: &str) -> Result<(), CompatCliError> {
+    match writer.write_all(rendered.as_bytes()) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
+        Err(err) => Err(CompatCliError::runtime(
+            2,
+            format!("could not write report: {err}"),
+        )),
+    }
 }
 
 fn render_checkstyle(report: &CompatReport) -> String {
@@ -334,5 +342,31 @@ fn stylize(
         style(value.normal()).to_string()
     } else {
         value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_rendered;
+
+    struct BrokenPipeWriter;
+
+    impl std::io::Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "broken pipe",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn broken_pipe_is_treated_as_success() {
+        let mut writer = BrokenPipeWriter;
+        assert!(write_rendered(&mut writer, "hello").is_ok());
     }
 }

--- a/crates/shuck/src/shellcheck_runtime/mod.rs
+++ b/crates/shuck/src/shellcheck_runtime/mod.rs
@@ -114,7 +114,10 @@ where
 
     let deadline = Instant::now() + timeout;
     let status = loop {
-        match child.try_wait().map_err(|err| format!("shellcheck wait: {err}"))? {
+        match child
+            .try_wait()
+            .map_err(|err| format!("shellcheck wait: {err}"))?
+        {
             Some(status) => break status,
             None if Instant::now() >= deadline => {
                 let _ = child.kill();

--- a/crates/shuck/src/shellcheck_runtime/mod.rs
+++ b/crates/shuck/src/shellcheck_runtime/mod.rs
@@ -1,0 +1,394 @@
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+const HELP_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShellCheckReplacement {
+    pub line: usize,
+    #[serde(rename = "endLine")]
+    pub end_line: usize,
+    pub column: usize,
+    #[serde(rename = "endColumn")]
+    pub end_column: usize,
+    pub precedence: usize,
+    #[serde(rename = "insertionPoint")]
+    pub insertion_point: String,
+    pub replacement: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShellCheckFix {
+    #[serde(default)]
+    pub replacements: Vec<ShellCheckReplacement>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShellCheckDiagnostic {
+    #[serde(default)]
+    pub file: String,
+    pub code: u32,
+    pub line: usize,
+    #[serde(rename = "endLine")]
+    pub end_line: usize,
+    pub column: usize,
+    #[serde(rename = "endColumn")]
+    pub end_column: usize,
+    pub level: String,
+    pub message: String,
+    #[serde(default)]
+    pub fix: Option<ShellCheckFix>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellCheckRun {
+    pub diagnostics: Vec<ShellCheckDiagnostic>,
+    pub parse_aborted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellCheckProbe {
+    pub command: String,
+    pub version_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellCheckProcessOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub status_code: i32,
+}
+
+pub fn probe_shellcheck() -> Option<ShellCheckProbe> {
+    let output = Command::new("shellcheck").arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let version_text = normalize_shellcheck_version_text(&output.stdout);
+    if version_text.is_empty() {
+        return None;
+    }
+
+    Some(ShellCheckProbe {
+        command: "shellcheck".into(),
+        version_text,
+    })
+}
+
+pub fn run_shellcheck_command<I, T>(
+    shellcheck_path: &str,
+    args: I,
+    timeout: Duration,
+) -> Result<ShellCheckProcessOutput, String>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
+    let mut command = Command::new(shellcheck_path);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    for arg in args {
+        command.arg(arg.into());
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|err| format!("shellcheck exec: {err}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "shellcheck exec: failed to capture stdout".to_owned())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "shellcheck exec: failed to capture stderr".to_owned())?;
+    let stdout_reader = thread::spawn(move || read_shellcheck_pipe(stdout, "stdout"));
+    let stderr_reader = thread::spawn(move || read_shellcheck_pipe(stderr, "stderr"));
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait().map_err(|err| format!("shellcheck wait: {err}"))? {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
+                return Err(format_timeout_message("shellcheck", timeout));
+            }
+            None => thread::sleep(Duration::from_millis(10)),
+        }
+    };
+
+    let stdout = join_shellcheck_pipe(stdout_reader, "stdout")?;
+    let stderr = join_shellcheck_pipe(stderr_reader, "stderr")?;
+
+    Ok(ShellCheckProcessOutput {
+        stdout,
+        stderr,
+        status_code: status.code().unwrap_or(-1),
+    })
+}
+
+pub fn run_shellcheck_json1(
+    path: &Path,
+    shell: &str,
+    shellcheck_path: &str,
+    timeout: Duration,
+) -> Result<ShellCheckRun, String> {
+    let output = run_shellcheck_command(
+        shellcheck_path,
+        [
+            OsString::from("--norc"),
+            OsString::from("-s"),
+            OsString::from(shell),
+            OsString::from("-f"),
+            OsString::from("json1"),
+            path.as_os_str().to_os_string(),
+        ],
+        timeout,
+    )?;
+
+    // ShellCheck exits 1 when it reports diagnostics, which is not an execution error.
+    if !matches!(output.status_code, 0 | 1) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("shellcheck exit {}: {stderr}", output.status_code));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.trim().is_empty() {
+        return Ok(ShellCheckRun {
+            diagnostics: Vec::new(),
+            parse_aborted: false,
+        });
+    }
+
+    let diagnostics = decode_shellcheck_diagnostics(stdout.as_bytes())?;
+    let parse_aborted = shellcheck_parse_aborted(&diagnostics);
+    Ok(ShellCheckRun {
+        diagnostics,
+        parse_aborted,
+    })
+}
+
+pub fn shellcheck_supported_shells(shellcheck_path: &str) -> HashMap<&'static str, ()> {
+    let output = run_shellcheck_command(shellcheck_path, ["--help"], HELP_PROBE_TIMEOUT);
+    let mut supported = output
+        .ok()
+        .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+        .map(|help| parse_shellcheck_supported_shells(&help))
+        .unwrap_or_default();
+
+    if supported.is_empty() {
+        for shell in &["sh", "bash", "dash", "ksh", "busybox"] {
+            supported.insert(shell, ());
+        }
+    }
+
+    supported
+}
+
+pub fn parse_shellcheck_supported_shells(help: &str) -> HashMap<&'static str, ()> {
+    let mut supported = HashMap::new();
+    for line in help.lines() {
+        if !line.contains("--shell=") {
+            continue;
+        }
+        if let Some(start) = line.find('(')
+            && let Some(end) = line[start + 1..].find(')')
+        {
+            let shells = &line[start + 1..start + 1 + end];
+            for shell in shells.split(',') {
+                match shell.trim() {
+                    "sh" => {
+                        supported.insert("sh", ());
+                    }
+                    "bash" => {
+                        supported.insert("bash", ());
+                    }
+                    "dash" => {
+                        supported.insert("dash", ());
+                    }
+                    "ksh" => {
+                        supported.insert("ksh", ());
+                    }
+                    "busybox" => {
+                        supported.insert("busybox", ());
+                    }
+                    "zsh" => {
+                        supported.insert("zsh", ());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    supported
+}
+
+pub fn decode_shellcheck_diagnostics(data: &[u8]) -> Result<Vec<ShellCheckDiagnostic>, String> {
+    let trimmed = String::from_utf8_lossy(data);
+    let trimmed = trimmed.trim();
+
+    if trimmed.is_empty() {
+        return Err("empty shellcheck json output".into());
+    }
+
+    if trimmed.starts_with('[') {
+        serde_json::from_str::<Vec<ShellCheckDiagnostic>>(trimmed)
+            .map_err(|err| format!("decode shellcheck json array: {err}"))
+    } else if trimmed.starts_with('{') {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            comments: Vec<ShellCheckDiagnostic>,
+        }
+
+        serde_json::from_str::<Wrapper>(trimmed)
+            .map(|wrapper| wrapper.comments)
+            .map_err(|err| format!("decode shellcheck json object: {err}"))
+    } else {
+        Err(format!(
+            "decode shellcheck json: unexpected leading byte {:?}",
+            trimmed.chars().next()
+        ))
+    }
+}
+
+pub fn shellcheck_parse_aborted(diags: &[ShellCheckDiagnostic]) -> bool {
+    diags.iter().any(|diag| {
+        if diag.level != "error" {
+            return false;
+        }
+
+        matches!(diag.code, 1072 | 1073 | 1088) || {
+            let lower = diag.message.to_ascii_lowercase();
+            lower.contains("fix to allow more checks")
+                || lower.contains("fix any mentioned problems and try again")
+                || lower.contains("parsing stopped here")
+        }
+    })
+}
+
+pub fn normalize_shellcheck_version_text(output: &[u8]) -> String {
+    String::from_utf8_lossy(output)
+        .replace("\r\n", "\n")
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_owned()
+}
+
+fn format_timeout_message(label: &str, timeout: Duration) -> String {
+    if timeout.as_millis() < 1000 {
+        format!("{label} timed out after {}ms", timeout.as_millis())
+    } else {
+        format!("{label} timed out after {}s", timeout.as_secs())
+    }
+}
+
+fn read_shellcheck_pipe<R: Read>(mut pipe: R, label: &str) -> Result<Vec<u8>, String> {
+    let mut data = Vec::new();
+    pipe.read_to_end(&mut data)
+        .map_err(|err| format!("shellcheck {label}: {err}"))?;
+    Ok(data)
+}
+
+fn join_shellcheck_pipe(
+    reader: thread::JoinHandle<Result<Vec<u8>, String>>,
+    label: &str,
+) -> Result<Vec<u8>, String> {
+    reader
+        .join()
+        .map_err(|_| format!("shellcheck {label} reader panicked"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_shellcheck_version_text() {
+        let output = b"ShellCheck - shell script analysis tool\r\nversion: 0.11.0\r\n";
+        assert_eq!(
+            normalize_shellcheck_version_text(output),
+            "ShellCheck - shell script analysis tool\nversion: 0.11.0"
+        );
+    }
+
+    #[test]
+    fn parse_shellcheck_supported_shells_parses_help() {
+        let help = "Usage: shellcheck [OPTIONS...] FILES...\n\
+            -s SHELLNAME        --shell=SHELLNAME          Specify dialect (sh, bash, dash, ksh, busybox)\n";
+
+        let supported = parse_shellcheck_supported_shells(help);
+        for shell in &["sh", "bash", "dash", "ksh", "busybox"] {
+            assert!(supported.contains_key(shell), "expected {shell} in help");
+        }
+        assert!(!supported.contains_key("zsh"));
+    }
+
+    #[test]
+    fn decode_shellcheck_json_array() {
+        let data = br#"[{"file":"x.sh","line":1,"endLine":1,"column":1,"endColumn":2,"level":"warning","code":2034,"message":"unused","fix":null}]"#;
+        let diagnostics = decode_shellcheck_diagnostics(data).unwrap();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, 2034);
+    }
+
+    #[test]
+    fn decode_shellcheck_json_object() {
+        let data = br#"{"comments":[{"file":"x.sh","line":1,"endLine":1,"column":1,"endColumn":2,"level":"warning","code":2034,"message":"unused","fix":null}]}"#;
+        let diagnostics = decode_shellcheck_diagnostics(data).unwrap();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, 2034);
+    }
+
+    #[test]
+    fn shellcheck_parse_abort_detection_matches_known_codes() {
+        assert!(shellcheck_parse_aborted(&[ShellCheckDiagnostic {
+            file: "x.sh".into(),
+            code: 1072,
+            line: 1,
+            end_line: 1,
+            column: 1,
+            end_column: 1,
+            level: "error".into(),
+            message: "Expected then".into(),
+            fix: None,
+        }]));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_shellcheck_command_times_out() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let shellcheck_path = tempdir.path().join("fake-shellcheck");
+
+        fs::write(&shellcheck_path, "#!/bin/sh\nsleep 1\nprintf '[]'\n").unwrap();
+
+        let mut permissions = fs::metadata(&shellcheck_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&shellcheck_path, permissions).unwrap();
+
+        let err = run_shellcheck_command(
+            shellcheck_path.to_str().unwrap(),
+            ["--version"],
+            Duration::from_millis(10),
+        )
+        .unwrap_err();
+
+        assert_eq!(err, "shellcheck timed out after 10ms");
+    }
+}

--- a/crates/shuck/tests/large_corpus.rs
+++ b/crates/shuck/tests/large_corpus.rs
@@ -2,10 +2,9 @@ use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
-use std::io::Read;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -16,7 +15,11 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use wait_timeout::ChildExt;
+use shuck::shellcheck_runtime::{
+    ShellCheckDiagnostic, ShellCheckProbe, ShellCheckRun, decode_shellcheck_diagnostics,
+    parse_shellcheck_supported_shells, probe_shellcheck, run_shellcheck_json1 as run_shellcheck,
+    shellcheck_parse_aborted, shellcheck_supported_shells,
+};
 
 // ---------------------------------------------------------------------------
 // Environment variable names (matching the Go test)
@@ -380,37 +383,6 @@ where
             Err(format!("{label} worker thread exited before returning"))
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// ShellCheck types
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct ShellCheckDiagnostic {
-    #[serde(default)]
-    file: String,
-    code: u32,
-    line: usize,
-    #[serde(rename = "endLine")]
-    end_line: usize,
-    column: usize,
-    #[serde(rename = "endColumn")]
-    end_column: usize,
-    level: String,
-    message: String,
-}
-
-#[derive(Debug, Clone)]
-struct ShellCheckRun {
-    diagnostics: Vec<ShellCheckDiagnostic>,
-    parse_aborted: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ShellCheckProbe {
-    command: String,
-    version_text: String,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
@@ -2767,222 +2739,6 @@ fn validate_selected_rules_for_large_corpus(
 }
 
 // ---------------------------------------------------------------------------
-// ShellCheck runner
-// ---------------------------------------------------------------------------
-
-fn probe_shellcheck() -> Option<ShellCheckProbe> {
-    let output = Command::new("shellcheck").arg("--version").output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let version_text = normalize_shellcheck_version_text(&output.stdout);
-    if version_text.is_empty() {
-        return None;
-    }
-
-    Some(ShellCheckProbe {
-        command: "shellcheck".into(),
-        version_text,
-    })
-}
-
-fn run_shellcheck(
-    path: &Path,
-    shell: &str,
-    shellcheck_path: &str,
-    timeout: Duration,
-) -> Result<ShellCheckRun, String> {
-    let mut child = Command::new(shellcheck_path)
-        .args(["--norc", "-s", shell, "-f", "json1"])
-        .arg(path)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("shellcheck exec: {e}"))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "shellcheck exec: failed to capture stdout".to_owned())?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| "shellcheck exec: failed to capture stderr".to_owned())?;
-    let stdout_reader = thread::spawn(move || read_shellcheck_pipe(stdout, "stdout"));
-    let stderr_reader = thread::spawn(move || read_shellcheck_pipe(stderr, "stderr"));
-    let status = match child
-        .wait_timeout(timeout)
-        .map_err(|e| format!("shellcheck wait: {e}"))?
-    {
-        Some(status) => status,
-        None => {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = stdout_reader.join();
-            let _ = stderr_reader.join();
-            return Err(format_timeout_message("shellcheck", timeout));
-        }
-    };
-    let stdout = join_shellcheck_pipe(stdout_reader, "stdout")?;
-    let stderr = join_shellcheck_pipe(stderr_reader, "stderr")?;
-
-    // shellcheck exits 1 when it finds issues, which is normal
-    if !status.success() {
-        let code = status.code().unwrap_or(-1);
-        if code != 1 {
-            let stderr = String::from_utf8_lossy(&stderr);
-            return Err(format!("shellcheck exit {code}: {stderr}"));
-        }
-    }
-
-    let stdout = String::from_utf8_lossy(&stdout);
-    if stdout.trim().is_empty() {
-        return Ok(ShellCheckRun {
-            diagnostics: Vec::new(),
-            parse_aborted: false,
-        });
-    }
-
-    let diagnostics = decode_shellcheck_diagnostics(stdout.as_bytes())?;
-    let parse_aborted = shellcheck_parse_aborted(&diagnostics);
-    Ok(ShellCheckRun {
-        diagnostics,
-        parse_aborted,
-    })
-}
-
-fn read_shellcheck_pipe<R: Read>(mut pipe: R, label: &str) -> Result<Vec<u8>, String> {
-    let mut data = Vec::new();
-    pipe.read_to_end(&mut data)
-        .map_err(|err| format!("shellcheck {label}: {err}"))?;
-    Ok(data)
-}
-
-fn join_shellcheck_pipe(
-    reader: thread::JoinHandle<Result<Vec<u8>, String>>,
-    label: &str,
-) -> Result<Vec<u8>, String> {
-    reader
-        .join()
-        .map_err(|_| format!("shellcheck {label} reader panicked"))?
-}
-
-fn decode_shellcheck_diagnostics(data: &[u8]) -> Result<Vec<ShellCheckDiagnostic>, String> {
-    let data = data.to_vec();
-    let trimmed = String::from_utf8_lossy(&data);
-    let trimmed = trimmed.trim();
-
-    if trimmed.is_empty() {
-        return Err("empty shellcheck json output".into());
-    }
-
-    if trimmed.starts_with('[') {
-        serde_json::from_str::<Vec<ShellCheckDiagnostic>>(trimmed)
-            .map_err(|e| format!("decode shellcheck json array: {e}"))
-    } else if trimmed.starts_with('{') {
-        #[derive(Deserialize)]
-        struct Wrapper {
-            comments: Vec<ShellCheckDiagnostic>,
-        }
-        let wrapper: Wrapper = serde_json::from_str(trimmed)
-            .map_err(|e| format!("decode shellcheck json object: {e}"))?;
-        Ok(wrapper.comments)
-    } else {
-        Err(format!(
-            "decode shellcheck json: unexpected leading byte {:?}",
-            trimmed.chars().next()
-        ))
-    }
-}
-
-fn shellcheck_parse_aborted(diags: &[ShellCheckDiagnostic]) -> bool {
-    for diag in diags {
-        if diag.level != "error" {
-            continue;
-        }
-        if matches!(diag.code, 1072 | 1073 | 1088) {
-            return true;
-        }
-        let lower = diag.message.to_lowercase();
-        if lower.contains("fix to allow more checks")
-            || lower.contains("fix any mentioned problems and try again")
-            || lower.contains("parsing stopped here")
-        {
-            return true;
-        }
-    }
-    false
-}
-
-fn shellcheck_supported_shells(shellcheck_path: &str) -> HashMap<&'static str, ()> {
-    let output = Command::new(shellcheck_path)
-        .arg("--help")
-        .output()
-        .expect("failed to run shellcheck --help");
-
-    let help = String::from_utf8_lossy(&output.stdout);
-    let mut supported = parse_shellcheck_supported_shells(&help);
-
-    // Always include common shells even if parsing fails
-    if supported.is_empty() {
-        for shell in &["sh", "bash", "dash", "ksh"] {
-            supported.insert(shell, ());
-        }
-    }
-
-    supported
-}
-
-fn parse_shellcheck_supported_shells(help: &str) -> HashMap<&'static str, ()> {
-    let mut supported = HashMap::new();
-    for line in help.lines() {
-        if !line.contains("--shell=") {
-            continue;
-        }
-        if let Some(start) = line.find('(')
-            && let Some(end) = line[start + 1..].find(')')
-        {
-            let shells = &line[start + 1..start + 1 + end];
-            for shell in shells.split(',') {
-                let shell = shell.trim();
-                match shell {
-                    "sh" => {
-                        supported.insert("sh", ());
-                    }
-                    "bash" => {
-                        supported.insert("bash", ());
-                    }
-                    "dash" => {
-                        supported.insert("dash", ());
-                    }
-                    "ksh" => {
-                        supported.insert("ksh", ());
-                    }
-                    "zsh" => {
-                        supported.insert("zsh", ());
-                    }
-                    "busybox" => {
-                        supported.insert("busybox", ());
-                    }
-                    _ => {}
-                }
-            }
-        }
-    }
-    supported
-}
-
-fn normalize_shellcheck_version_text(output: &[u8]) -> String {
-    let normalized = String::from_utf8_lossy(output).replace("\r\n", "\n");
-    normalized
-        .lines()
-        .map(str::trim_end)
-        .collect::<Vec<_>>()
-        .join("\n")
-        .trim()
-        .to_owned()
-}
-
 fn legacy_shellcheck_invocation_hash(shellcheck_path: &str) -> String {
     let meta = fs::metadata(shellcheck_path).ok();
     let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
@@ -3822,6 +3578,7 @@ mod tests {
                 end_column: 1,
                 level: "error".into(),
                 message: "Couldn't parse this test expression.".into(),
+                fix: None,
             },
             ShellCheckDiagnostic {
                 file: String::new(),
@@ -3833,6 +3590,7 @@ mod tests {
                 level: "error".into(),
                 message: "Expected comparison operator. Fix any mentioned problems and try again."
                     .into(),
+                fix: None,
             },
         ];
         assert!(shellcheck_parse_aborted(&aborted));
@@ -3846,6 +3604,7 @@ mod tests {
             end_column: 1,
             level: "error".into(),
             message: "Parsing stopped here. Invalid use of parentheses?".into(),
+            fix: None,
         }];
         assert!(shellcheck_parse_aborted(&parsing_stopped));
 
@@ -3858,6 +3617,7 @@ mod tests {
             end_column: 1,
             level: "warning".into(),
             message: "In POSIX sh, here-strings are undefined.".into(),
+            fix: None,
         }];
         assert!(!shellcheck_parse_aborted(&non_aborted));
     }
@@ -4955,6 +4715,7 @@ mod tests {
             end_column: 1,
             level: "error".into(),
             message: format!("diagnostic {code}"),
+            fix: None,
         }
     }
 
@@ -5016,6 +4777,7 @@ mod tests {
                 end_column: 1,
                 level: "warning".into(),
                 message: label.into(),
+                fix: None,
             }],
             parse_aborted: false,
         })

--- a/crates/shuck/tests/oracle_shellcheck_cli.rs
+++ b/crates/shuck/tests/oracle_shellcheck_cli.rs
@@ -1,0 +1,148 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn shellcheck_available() -> bool {
+    Command::new("shellcheck")
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+fn run_shellcheck(args: &[&str], cwd: &std::path::Path) -> Output {
+    Command::new("shellcheck")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap()
+}
+
+fn run_compat(args: &[&str], cwd: &std::path::Path) -> Output {
+    Command::new(assert_cmd::cargo::cargo_bin("shuck"))
+        .env("SHUCK_SHELLCHECK_COMPAT", "1")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap()
+}
+
+fn json1_codes(output: &Output) -> BTreeSet<u64> {
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    value["comments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|entry| entry["code"].as_u64())
+        .collect()
+}
+
+#[test]
+#[ignore]
+fn oracle_help_and_version_keep_shellcheck_shape() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let cwd = tempdir().unwrap();
+    let help_sc = run_shellcheck(&["--help"], cwd.path());
+    let help_compat = run_compat(&["--help"], cwd.path());
+    assert_eq!(help_sc.status.code(), help_compat.status.code());
+    let help_stdout = String::from_utf8_lossy(&help_compat.stdout);
+    assert!(help_stdout.contains("Usage: shellcheck"));
+    assert!(help_stdout.contains("--check-sourced"));
+    assert!(help_stdout.contains("--list-optional"));
+
+    let version_sc = run_shellcheck(&["--version"], cwd.path());
+    let version_compat = run_compat(&["--version"], cwd.path());
+    assert_eq!(version_sc.status.code(), version_compat.status.code());
+    let version_stdout = String::from_utf8_lossy(&version_compat.stdout);
+    assert!(version_stdout.to_ascii_lowercase().contains("shellcheck"));
+    assert!(version_stdout.to_ascii_lowercase().contains("version"));
+}
+
+#[test]
+#[ignore]
+fn oracle_option_acceptance_and_rejection_match_exit_codes() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let cwd = tempdir().unwrap();
+    let unknown_sc = run_shellcheck(&["--wat"], cwd.path());
+    let unknown_compat = run_compat(&["--wat"], cwd.path());
+    assert_eq!(unknown_sc.status.code(), unknown_compat.status.code());
+
+    let severity_sc = run_shellcheck(&["--severity=banana"], cwd.path());
+    let severity_compat = run_compat(&["--severity=banana"], cwd.path());
+    assert_eq!(severity_sc.status.code(), severity_compat.status.code());
+}
+
+#[test]
+#[ignore]
+fn oracle_config_precedence_matches_for_simple_disable_cases() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join(".shellcheckrc"), "disable=SC2086\n").unwrap();
+    fs::write(tempdir.path().join("alt.rc"), "disable=SC2154\n").unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let searched_sc = run_shellcheck(&["--norc", "-f", "json1", "x.sh"], tempdir.path());
+    let searched_compat = run_compat(&["--norc", "-f", "json1", "x.sh"], tempdir.path());
+    assert_eq!(json1_codes(&searched_sc), json1_codes(&searched_compat));
+
+    let rcfile_sc = run_shellcheck(
+        &["--rcfile", "alt.rc", "-f", "json1", "x.sh"],
+        tempdir.path(),
+    );
+    let rcfile_compat = run_compat(
+        &["--rcfile", "alt.rc", "-f", "json1", "x.sh"],
+        tempdir.path(),
+    );
+    assert_eq!(json1_codes(&rcfile_sc), json1_codes(&rcfile_compat));
+}
+
+#[test]
+#[ignore]
+fn oracle_output_formats_stay_structurally_valid() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let json_sc = run_shellcheck(&["--norc", "-f", "json", "x.sh"], tempdir.path());
+    let json_compat = run_compat(&["--norc", "-f", "json", "x.sh"], tempdir.path());
+    assert_eq!(json_sc.status.code(), json_compat.status.code());
+    serde_json::from_slice::<Value>(&json_compat.stdout).unwrap();
+
+    let json1_sc = run_shellcheck(&["--norc", "-f", "json1", "x.sh"], tempdir.path());
+    let json1_compat = run_compat(&["--norc", "-f", "json1", "x.sh"], tempdir.path());
+    assert_eq!(json1_sc.status.code(), json1_compat.status.code());
+    serde_json::from_slice::<Value>(&json1_compat.stdout).unwrap();
+
+    let checkstyle_sc = run_shellcheck(&["--norc", "-f", "checkstyle", "x.sh"], tempdir.path());
+    let checkstyle_compat = run_compat(&["--norc", "-f", "checkstyle", "x.sh"], tempdir.path());
+    assert_eq!(checkstyle_sc.status.code(), checkstyle_compat.status.code());
+    let checkstyle_stdout = String::from_utf8_lossy(&checkstyle_compat.stdout);
+    assert!(checkstyle_stdout.starts_with("<?xml"));
+    assert!(checkstyle_stdout.contains("<checkstyle"));
+
+    let quiet_sc = run_shellcheck(&["--norc", "-f", "quiet", "x.sh"], tempdir.path());
+    let quiet_compat = run_compat(&["--norc", "-f", "quiet", "x.sh"], tempdir.path());
+    assert_eq!(quiet_sc.status.code(), quiet_compat.status.code());
+    assert!(quiet_compat.stdout.is_empty());
+
+    let tty_sc = run_shellcheck(&["--norc", "-f", "tty", "x.sh"], tempdir.path());
+    let tty_compat = run_compat(&["--norc", "-f", "tty", "x.sh"], tempdir.path());
+    assert_eq!(tty_sc.status.code(), tty_compat.status.code());
+    let tty_stdout = String::from_utf8_lossy(&tty_compat.stdout);
+    assert!(tty_stdout.contains("SC2154"));
+    assert!(tty_stdout.contains("For more information"));
+}

--- a/crates/shuck/tests/shellcheck_compat.rs
+++ b/crates/shuck/tests/shellcheck_compat.rs
@@ -1,0 +1,139 @@
+use std::fs;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+fn compat_cmd() -> Command {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.env("SHUCK_SHELLCHECK_COMPAT", "1");
+    cmd
+}
+
+#[test]
+fn env_activation_uses_shellcheck_surface() {
+    let mut cmd = compat_cmd();
+    cmd.arg("--version");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("ShellCheck compatibility mode"))
+        .stdout(predicate::str::contains("engine: shuck"));
+}
+
+#[cfg(unix)]
+#[test]
+fn argv0_basename_shellcheck_activates_compat_mode() {
+    use std::os::unix::fs::symlink;
+
+    let tempdir = tempdir().unwrap();
+    let link = tempdir.path().join("shellcheck");
+    symlink(assert_cmd::cargo::cargo_bin("shuck"), &link).unwrap();
+
+    let mut cmd = Command::new(&link);
+    cmd.arg("--version");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("ShellCheck compatibility mode"));
+}
+
+#[test]
+fn plain_shuck_help_stays_on_existing_cli() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Shell checker CLI for shuck"))
+        .stdout(predicate::str::contains("ShellCheck compatibility mode").not());
+}
+
+#[test]
+fn compat_reads_shellcheckrc_from_cwd() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join(".shellcheckrc"), "disable=SC2086\n").unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let mut cmd = compat_cmd();
+    cmd.current_dir(tempdir.path()).args(["-f", "json1", "x.sh"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"code\":2154"))
+        .stdout(predicate::str::contains("\"code\":2086").not());
+}
+
+#[test]
+fn compat_norc_disables_shellcheckrc_search() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join(".shellcheckrc"), "disable=SC2086\n").unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let mut cmd = compat_cmd();
+    cmd.current_dir(tempdir.path())
+        .args(["--norc", "-f", "json1", "x.sh"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"code\":2154"))
+        .stdout(predicate::str::contains("\"code\":2086"));
+}
+
+#[test]
+fn compat_rcfile_overrides_searched_config() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join(".shellcheckrc"), "disable=SC2086\n").unwrap();
+    fs::write(tempdir.path().join("alt.rc"), "disable=SC2154\n").unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let mut cmd = compat_cmd();
+    cmd.current_dir(tempdir.path())
+        .args(["--rcfile", "alt.rc", "-f", "json1", "x.sh"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"code\":2086"))
+        .stdout(predicate::str::contains("\"code\":2154").not());
+}
+
+#[test]
+fn compat_include_and_severity_filter_work_on_sc_codes() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let mut include = compat_cmd();
+    include
+        .current_dir(tempdir.path())
+        .args(["-f", "json1", "--include=SC2086", "x.sh"]);
+    include
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"code\":2086"))
+        .stdout(predicate::str::contains("\"code\":2154").not());
+
+    let mut severity = compat_cmd();
+    severity
+        .current_dir(tempdir.path())
+        .args(["-f", "json1", "--severity=warning", "x.sh"]);
+    severity
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"code\":2154"))
+        .stdout(predicate::str::contains("\"code\":2086").not());
+}
+
+#[test]
+fn compat_accepts_busybox_shell_alias() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "echo hi\n").unwrap();
+
+    let mut cmd = compat_cmd();
+    cmd.current_dir(tempdir.path())
+        .args(["-s", "busybox", "-f", "json1", "x.sh"]);
+    cmd.assert().success();
+}
+
+#[test]
+fn compat_list_optional_prints_catalog() {
+    let mut cmd = compat_cmd();
+    cmd.arg("--list-optional");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("name:    add-default-case"))
+        .stdout(predicate::str::contains("name:    useless-use-of-cat"));
+}

--- a/crates/shuck/tests/shellcheck_compat.rs
+++ b/crates/shuck/tests/shellcheck_compat.rs
@@ -140,6 +140,21 @@ fn compat_list_optional_prints_catalog() {
 }
 
 #[test]
+fn compat_check_sourced_reports_resolved_source_diagnostics() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("main.sh"), "#!/bin/sh\n. ./lib.sh\n").unwrap();
+    fs::write(tempdir.path().join("lib.sh"), "echo $foo\n").unwrap();
+
+    let mut cmd = compat_cmd();
+    cmd.current_dir(tempdir.path())
+        .args(["-a", "-f", "json1", "main.sh"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"file\":\"lib.sh\""))
+        .stdout(predicate::str::contains("\"code\":2086"));
+}
+
+#[test]
 fn compat_color_flags_do_not_consume_filename() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();

--- a/crates/shuck/tests/shellcheck_compat.rs
+++ b/crates/shuck/tests/shellcheck_compat.rs
@@ -138,3 +138,37 @@ fn compat_list_optional_prints_catalog() {
         .stdout(predicate::str::contains("name:    add-default-case"))
         .stdout(predicate::str::contains("name:    useless-use-of-cat"));
 }
+
+#[test]
+fn compat_color_flags_do_not_consume_filename() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let mut long = compat_cmd();
+    long.current_dir(tempdir.path())
+        .args(["--color", "x.sh", "-f", "json1"]);
+    long.assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"code\":2086"));
+
+    let mut short = compat_cmd();
+    short
+        .current_dir(tempdir.path())
+        .args(["-C", "x.sh", "-f", "json1"]);
+    short
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"code\":2086"));
+}
+
+#[test]
+fn compat_dash_path_reads_from_stdin() {
+    let mut cmd = compat_cmd();
+    cmd.args(["-f", "json1", "-"])
+        .write_stdin("#!/bin/sh\necho $foo\n");
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"file\":\"-\""))
+        .stdout(predicate::str::contains("\"code\":2086"))
+        .stderr(predicate::str::is_empty());
+}

--- a/crates/shuck/tests/shellcheck_compat.rs
+++ b/crates/shuck/tests/shellcheck_compat.rs
@@ -53,7 +53,8 @@ fn compat_reads_shellcheckrc_from_cwd() {
     fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
 
     let mut cmd = compat_cmd();
-    cmd.current_dir(tempdir.path()).args(["-f", "json1", "x.sh"]);
+    cmd.current_dir(tempdir.path())
+        .args(["-f", "json1", "x.sh"]);
     cmd.assert()
         .code(1)
         .stdout(predicate::str::contains("\"code\":2154"))


### PR DESCRIPTION
## Summary
- add a ShellCheck compatibility entrypoint that activates before `Args::parse()` when `SHUCK_SHELLCHECK_COMPAT` is truthy or the binary is invoked as `shellcheck`
- add internal `shellcheck_runtime` and `shellcheck_compat` modules for ShellCheck probing, CLI/config translation, rendering, and exit semantics
- reuse the shared ShellCheck runtime in the large-corpus harness and add compat integration plus oracle tests

## Why
- make `shuck` usable in a ShellCheck-oriented compatibility mode without changing the existing `shuck check|format|clean` flow
- keep the reusable boundary limited to ShellCheck binary/process behavior while leaving corpus-specific logic in the large-corpus harness

## Validation
- `cargo test -p shuck`
- `make test-oracle-shellcheck-cli`
