### PR TITLE
Add watch mode to shuck check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,11 @@ sha2 = "0.11"
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
+clearscreen = "4.0.0"
 colored = "3"
 globset = "0.4"
 ignore = "0.4"
+notify = "8.0.0"
 
 # Serialization
 serde_json = "1"

--- a/crates/shuck/Cargo.toml
+++ b/crates/shuck/Cargo.toml
@@ -12,11 +12,13 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 annotate-snippets = { workspace = true }
 anyhow = { workspace = true }
+clearscreen = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
 etcetera = { workspace = true }
 globset = { workspace = true }
 ignore = { workspace = true }
+notify = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 shuck-cache = { path = "../shuck-cache" }

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -280,6 +280,9 @@ pub struct CheckCommand {
     /// Choose the text output format for reported diagnostics.
     #[arg(long = "output-format", value_enum, default_value_t = CheckOutputFormatArg::Full)]
     pub output_format: CheckOutputFormatArg,
+    /// Run in watch mode by re-running whenever files change.
+    #[arg(short = 'w', long, conflicts_with = "add_ignore")]
+    pub watch: bool,
     /// Files or directories to check.
     pub paths: Vec<PathBuf>,
     #[command(flatten)]
@@ -677,6 +680,20 @@ mod tests {
     }
 
     #[test]
+    fn parses_short_watch_flag() {
+        let command = parse_check(["shuck", "check", "-w"]);
+
+        assert!(command.watch);
+    }
+
+    #[test]
+    fn parses_long_watch_flag() {
+        let command = parse_check(["shuck", "check", "--watch"]);
+
+        assert!(command.watch);
+    }
+
+    #[test]
     fn rejects_add_noqa_alias() {
         let error = StableCli::try_parse_from(["shuck", "check", "--add-noqa=legacy"]).unwrap_err();
 
@@ -687,6 +704,14 @@ mod tests {
     fn rejects_add_ignore_with_fix_flags() {
         let error =
             StableCli::try_parse_from(["shuck", "check", "--add-ignore", "--fix"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn rejects_watch_with_add_ignore() {
+        let error =
+            StableCli::try_parse_from(["shuck", "check", "--watch", "--add-ignore"]).unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
     }

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -27,7 +27,9 @@ use crate::commands::check_output::{
     DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
 };
 use crate::commands::project_runner::{PendingProjectFile, prepare_project_runs};
-use crate::config::{ConfigArguments, resolve_project_root_for_input};
+use crate::config::{
+    ConfigArguments, discovered_config_path_for_root, resolve_project_root_for_input,
+};
 use crate::discover::{DEFAULT_IGNORED_DIR_NAMES, DiscoveryOptions, normalize_path};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -146,6 +148,22 @@ struct FileCheckResult {
     fixes_applied: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WatchTarget {
+    path: PathBuf,
+    recursive: bool,
+}
+
+impl WatchTarget {
+    fn recursive_mode(&self) -> RecursiveMode {
+        if self.recursive {
+            RecursiveMode::Recursive
+        } else {
+            RecursiveMode::NonRecursive
+        }
+    }
+}
+
 pub(crate) fn check(
     args: CheckCommand,
     config_arguments: &ConfigArguments,
@@ -197,11 +215,11 @@ fn watch_check(
     cwd: &Path,
     cache_root: &Path,
 ) -> Result<ExitStatus> {
-    let watch_roots = collect_watch_roots(&args.paths, cwd, config_arguments.use_config_roots())?;
+    let watch_targets = collect_watch_targets(&args.paths, config_arguments, cwd)?;
     let (tx, rx) = channel();
     let mut watcher = recommended_watcher(tx)?;
-    for root in &watch_roots {
-        watcher.watch(root, RecursiveMode::Recursive)?;
+    for target in &watch_targets {
+        watcher.watch(&target.path, target.recursive_mode())?;
     }
 
     clear_screen()?;
@@ -248,8 +266,12 @@ fn print_diagnostics(
     Ok(())
 }
 
+fn should_clear_screen(stdout_is_terminal: bool) -> bool {
+    stdout_is_terminal
+}
+
 fn clear_screen() -> Result<()> {
-    if !io::stdout().is_terminal() && !io::stderr().is_terminal() {
+    if !should_clear_screen(io::stdout().is_terminal()) {
         return Ok(());
     }
     clearscreen::clear()?;
@@ -271,49 +293,87 @@ fn effective_check_inputs(paths: &[PathBuf]) -> Vec<PathBuf> {
     }
 }
 
-fn collect_watch_roots(
+fn collect_watch_targets(
     paths: &[PathBuf],
+    config_arguments: &ConfigArguments,
     cwd: &Path,
-    use_config_roots: bool,
-) -> Result<Vec<PathBuf>> {
+) -> Result<Vec<WatchTarget>> {
     let inputs = effective_check_inputs(paths);
-    let mut roots = Vec::new();
+    let mut targets = Vec::new();
     for input in inputs {
         let resolved_input = if input.is_absolute() {
             normalize_path(&input)
         } else {
             normalize_path(&cwd.join(&input))
         };
+        let metadata = fs::metadata(&resolved_input)?;
+        let canonical_input = fs::canonicalize(&resolved_input).map_err(anyhow::Error::from)?;
 
-        roots.push(
-            fs::canonicalize(resolve_project_root_for_input(
-                &resolved_input,
-                use_config_roots,
-            )?)
-            .map_err(anyhow::Error::from)?,
-        );
+        targets.push(WatchTarget {
+            path: canonical_input,
+            recursive: metadata.is_dir(),
+        });
 
-        if fs::metadata(&resolved_input)?.is_dir() {
-            roots.push(fs::canonicalize(&resolved_input).map_err(anyhow::Error::from)?);
+        if let Some(config_path) = watch_config_target(config_arguments, cwd, &resolved_input)? {
+            targets.push(WatchTarget {
+                path: config_path,
+                recursive: false,
+            });
         }
     }
 
-    roots.sort_by(|left, right| {
-        left.components()
+    targets.sort_by(|left, right| {
+        left.path
+            .components()
             .count()
-            .cmp(&right.components().count())
-            .then_with(|| left.cmp(right))
+            .cmp(&right.path.components().count())
+            .then_with(|| right.recursive.cmp(&left.recursive))
+            .then_with(|| left.path.cmp(&right.path))
     });
 
     let mut deduped = Vec::new();
-    for root in roots {
-        if deduped.iter().any(|existing| root.starts_with(existing)) {
+    for target in targets {
+        if deduped.iter().any(|existing: &WatchTarget| {
+            existing.path == target.path
+                || (existing.recursive && target.path.starts_with(&existing.path))
+        }) {
             continue;
         }
-        deduped.push(root);
+        deduped.push(target);
     }
 
     Ok(deduped)
+}
+
+fn watch_config_target(
+    config_arguments: &ConfigArguments,
+    cwd: &Path,
+    resolved_input: &Path,
+) -> Result<Option<PathBuf>> {
+    if let Some(explicit_config) = config_arguments.explicit_config_file() {
+        let resolved_config = if explicit_config.is_absolute() {
+            normalize_path(explicit_config)
+        } else {
+            normalize_path(&cwd.join(explicit_config))
+        };
+
+        return Ok(Some(
+            fs::canonicalize(resolved_config).map_err(anyhow::Error::from)?,
+        ));
+    }
+
+    if !config_arguments.use_config_roots() {
+        return Ok(None);
+    }
+
+    let project_root = resolve_project_root_for_input(resolved_input, true)?;
+    let Some(config_path) = discovered_config_path_for_root(&project_root)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        fs::canonicalize(config_path).map_err(anyhow::Error::from)?,
+    ))
 }
 
 fn watch_event_requires_rerun(event: &notify::Event, cache_root: &Path) -> bool {
@@ -1371,27 +1431,69 @@ mod tests {
     }
 
     #[test]
-    fn collect_watch_roots_dedupes_nested_paths_and_defaults_to_current_directory() {
+    fn clear_screen_requires_terminal_stdout() {
+        assert!(should_clear_screen(true));
+        assert!(!should_clear_screen(false));
+    }
+
+    #[test]
+    fn collect_watch_targets_stay_within_requested_scope_and_watch_config_files() {
         let tempdir = tempdir().unwrap();
         let nested = tempdir.path().join("nested");
         let deeper = nested.join("deeper");
         fs::create_dir_all(&deeper).unwrap();
         fs::write(tempdir.path().join("shuck.toml"), "[format]\n").unwrap();
+        let file = nested.join("script.sh");
+        fs::write(&file, "#!/bin/bash\necho ok\n").unwrap();
 
-        let default_roots = collect_watch_roots(&[], tempdir.path()).unwrap();
+        let default_targets =
+            collect_watch_targets(&[], &ConfigArguments::default(), tempdir.path()).unwrap();
         assert_eq!(
-            default_roots,
-            vec![fs::canonicalize(tempdir.path()).unwrap()]
+            default_targets,
+            vec![WatchTarget {
+                path: fs::canonicalize(tempdir.path()).unwrap(),
+                recursive: true,
+            }]
         );
 
-        let nested_roots = collect_watch_roots(
+        let nested_targets = collect_watch_targets(
             &[PathBuf::from("nested"), PathBuf::from("nested/deeper")],
+            &ConfigArguments::default(),
             tempdir.path(),
         )
         .unwrap();
         assert_eq!(
-            nested_roots,
-            vec![fs::canonicalize(tempdir.path()).unwrap()]
+            nested_targets,
+            vec![
+                WatchTarget {
+                    path: fs::canonicalize(&nested).unwrap(),
+                    recursive: true,
+                },
+                WatchTarget {
+                    path: fs::canonicalize(tempdir.path().join("shuck.toml")).unwrap(),
+                    recursive: false,
+                },
+            ]
+        );
+
+        let file_targets = collect_watch_targets(
+            &[PathBuf::from("nested/script.sh")],
+            &ConfigArguments::default(),
+            tempdir.path(),
+        )
+        .unwrap();
+        assert_eq!(
+            file_targets,
+            vec![
+                WatchTarget {
+                    path: fs::canonicalize(tempdir.path().join("shuck.toml")).unwrap(),
+                    recursive: false,
+                },
+                WatchTarget {
+                    path: fs::canonicalize(file).unwrap(),
+                    recursive: false,
+                },
+            ]
         );
     }
 }

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -1,9 +1,12 @@
 use std::fs;
-use std::io::{self, BufWriter};
+use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::mpsc::channel;
+use std::{ffi::OsStr, io::IsTerminal};
 
 use anyhow::{Result, anyhow};
+use notify::{RecursiveMode, Watcher, recommended_watcher};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use shuck_cache::{CacheKey, CacheKeyHasher};
@@ -24,8 +27,8 @@ use crate::commands::check_output::{
     DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
 };
 use crate::commands::project_runner::{PendingProjectFile, prepare_project_runs};
-use crate::config::ConfigArguments;
-use crate::discover::DiscoveryOptions;
+use crate::config::{ConfigArguments, resolve_project_root_for_input};
+use crate::discover::{DEFAULT_IGNORED_DIR_NAMES, DiscoveryOptions, normalize_path};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct CheckReport {
@@ -150,6 +153,10 @@ pub(crate) fn check(
 ) -> Result<ExitStatus> {
     let cwd = std::env::current_dir()?;
     let cache_root = resolve_cache_root(&cwd, cache_dir)?;
+    if args.watch {
+        return watch_check(&args, config_arguments, &cwd, &cache_root);
+    }
+
     if let Some(raw_reason) = args.add_ignore.as_deref() {
         if raw_reason.contains(['\n', '\r']) {
             return Err(anyhow!(
@@ -184,6 +191,42 @@ pub(crate) fn check(
     Ok(report.exit_status(args.exit_zero, args.exit_non_zero_on_fix))
 }
 
+fn watch_check(
+    args: &CheckCommand,
+    config_arguments: &ConfigArguments,
+    cwd: &Path,
+    cache_root: &Path,
+) -> Result<ExitStatus> {
+    let watch_roots = collect_watch_roots(&args.paths, cwd, config_arguments.use_config_roots())?;
+    let (tx, rx) = channel();
+    let mut watcher = recommended_watcher(tx)?;
+    for root in &watch_roots {
+        watcher.watch(root, RecursiveMode::Recursive)?;
+    }
+
+    clear_screen()?;
+    print_watch_banner("Starting linter in watch mode...")?;
+    let report = run_check_with_cwd(args, config_arguments, cwd, cache_root)?;
+    print_report(&report, args.output_format)?;
+
+    loop {
+        match rx.recv() {
+            Ok(Ok(event)) => {
+                if !watch_event_requires_rerun(&event, cache_root) {
+                    continue;
+                }
+
+                clear_screen()?;
+                print_watch_banner("File change detected...")?;
+                let report = run_check_with_cwd(args, config_arguments, cwd, cache_root)?;
+                print_report(&report, args.output_format)?;
+            }
+            Ok(Err(error)) => return Err(error.into()),
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
 fn print_report(
     report: &CheckReport,
     output_format: crate::args::CheckOutputFormatArg,
@@ -203,6 +246,101 @@ fn print_diagnostics(
         colored::control::SHOULD_COLORIZE.should_colorize(),
     )?;
     Ok(())
+}
+
+fn clear_screen() -> Result<()> {
+    if !io::stdout().is_terminal() && !io::stderr().is_terminal() {
+        return Ok(());
+    }
+    clearscreen::clear()?;
+    Ok(())
+}
+
+fn print_watch_banner(message: &str) -> Result<()> {
+    let mut stderr = BufWriter::new(io::stderr().lock());
+    writeln!(stderr, "{message}")?;
+    stderr.flush()?;
+    Ok(())
+}
+
+fn effective_check_inputs(paths: &[PathBuf]) -> Vec<PathBuf> {
+    if paths.is_empty() {
+        vec![PathBuf::from(".")]
+    } else {
+        paths.to_vec()
+    }
+}
+
+fn collect_watch_roots(
+    paths: &[PathBuf],
+    cwd: &Path,
+    use_config_roots: bool,
+) -> Result<Vec<PathBuf>> {
+    let inputs = effective_check_inputs(paths);
+    let mut roots = Vec::new();
+    for input in inputs {
+        let resolved_input = if input.is_absolute() {
+            normalize_path(&input)
+        } else {
+            normalize_path(&cwd.join(&input))
+        };
+
+        roots.push(
+            fs::canonicalize(resolve_project_root_for_input(
+                &resolved_input,
+                use_config_roots,
+            )?)
+            .map_err(anyhow::Error::from)?,
+        );
+
+        if fs::metadata(&resolved_input)?.is_dir() {
+            roots.push(fs::canonicalize(&resolved_input).map_err(anyhow::Error::from)?);
+        }
+    }
+
+    roots.sort_by(|left, right| {
+        left.components()
+            .count()
+            .cmp(&right.components().count())
+            .then_with(|| left.cmp(right))
+    });
+
+    let mut deduped = Vec::new();
+    for root in roots {
+        if deduped.iter().any(|existing| root.starts_with(existing)) {
+            continue;
+        }
+        deduped.push(root);
+    }
+
+    Ok(deduped)
+}
+
+fn watch_event_requires_rerun(event: &notify::Event, cache_root: &Path) -> bool {
+    if event.kind.is_access() || event.kind.is_other() {
+        return false;
+    }
+
+    if event.need_rescan() {
+        return true;
+    }
+
+    event
+        .paths
+        .iter()
+        .any(|path| !watch_event_path_is_ignored(path, cache_root))
+}
+
+fn watch_event_path_is_ignored(path: &Path, cache_root: &Path) -> bool {
+    path.starts_with(cache_root)
+        || path.components().any(|component| {
+            let std::path::Component::Normal(part) = component else {
+                return false;
+            };
+            DEFAULT_IGNORED_DIR_NAMES
+                .iter()
+                .any(|name| part == OsStr::new(name))
+        })
 }
 
 fn run_check_with_cwd(
@@ -406,6 +544,7 @@ pub(crate) fn benchmark_check_paths(
             add_ignore: None,
             no_cache: true,
             output_format,
+            watch: false,
             paths: paths.to_vec(),
             file_selection: FileSelectionArgs::default(),
             exit_zero: false,
@@ -628,6 +767,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
+    use notify::event::{CreateKind, EventAttributes, ModifyKind, RemoveKind, RenameMode};
     use tempfile::tempdir;
 
     use super::*;
@@ -666,6 +806,7 @@ mod tests {
             add_ignore: None,
             no_cache,
             output_format,
+            watch: false,
             paths: Vec::new(),
             file_selection: FileSelectionArgs::default(),
             exit_zero: false,
@@ -1136,5 +1277,121 @@ mod tests {
             .as_ref()
             .expect("full output should retain source");
         assert!(Arc::ptr_eq(diagnostic_source, &source));
+    }
+
+    #[test]
+    fn watch_event_filter_ignores_access_other_ignored_dirs_and_cache_paths() {
+        let cache_root = Path::new("/tmp/shuck-cache");
+
+        assert!(!watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Access(notify::event::AccessKind::Any),
+                paths: vec![PathBuf::from("script.sh")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+        ));
+        assert!(!watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Other,
+                paths: vec![PathBuf::from("script.sh")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+        ));
+        assert!(!watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Create(CreateKind::File),
+                paths: vec![PathBuf::from(".git/hooks/post-commit")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+        ));
+        assert!(!watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Modify(ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                paths: vec![cache_root.join("entry.bin")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+        ));
+    }
+
+    #[test]
+    fn watch_event_filter_triggers_on_create_modify_remove_rename_and_rescan() {
+        let cache_root = Path::new("/tmp/shuck-cache");
+
+        assert!(watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Create(CreateKind::File),
+                paths: vec![PathBuf::from("script.sh")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+        ));
+        assert!(watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Modify(ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                paths: vec![PathBuf::from("script.sh")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+        ));
+        assert!(watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Remove(RemoveKind::File),
+                paths: vec![PathBuf::from("script.sh")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+        ));
+        assert!(watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+                paths: vec![PathBuf::from("old.sh"), PathBuf::from("new.sh")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+        ));
+
+        let mut attrs = EventAttributes::default();
+        attrs.set_flag(notify::event::Flag::Rescan);
+        assert!(watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Modify(ModifyKind::Any),
+                paths: vec![],
+                attrs,
+            },
+            cache_root,
+        ));
+    }
+
+    #[test]
+    fn collect_watch_roots_dedupes_nested_paths_and_defaults_to_current_directory() {
+        let tempdir = tempdir().unwrap();
+        let nested = tempdir.path().join("nested");
+        let deeper = nested.join("deeper");
+        fs::create_dir_all(&deeper).unwrap();
+        fs::write(tempdir.path().join("shuck.toml"), "[format]\n").unwrap();
+
+        let default_roots = collect_watch_roots(&[], tempdir.path()).unwrap();
+        assert_eq!(
+            default_roots,
+            vec![fs::canonicalize(tempdir.path()).unwrap()]
+        );
+
+        let nested_roots = collect_watch_roots(
+            &[PathBuf::from("nested"), PathBuf::from("nested/deeper")],
+            tempdir.path(),
+        )
+        .unwrap();
+        assert_eq!(
+            nested_roots,
+            vec![fs::canonicalize(tempdir.path()).unwrap()]
+        );
     }
 }

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::mpsc::channel;
+use std::sync::mpsc::{Receiver, TryRecvError, channel};
 use std::{ffi::OsStr, io::IsTerminal};
 
 use anyhow::{Result, anyhow};
@@ -150,17 +150,89 @@ struct FileCheckResult {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct WatchTarget {
-    path: PathBuf,
+    watch_path: PathBuf,
+    watch_paths: Vec<PathBuf>,
     recursive: bool,
+    match_paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+struct WatchPath {
+    resolved_path: PathBuf,
+    canonical_path: PathBuf,
 }
 
 impl WatchTarget {
+    fn recursive(path: PathBuf) -> Self {
+        Self {
+            watch_path: path.clone(),
+            watch_paths: vec![path.clone()],
+            recursive: true,
+            match_paths: vec![path],
+        }
+    }
+
+    fn file(path: PathBuf) -> Self {
+        let watch_path = path.parent().unwrap_or(&path).to_path_buf();
+        Self {
+            watch_path: watch_path.clone(),
+            watch_paths: vec![watch_path],
+            recursive: false,
+            match_paths: vec![path],
+        }
+    }
+
     fn recursive_mode(&self) -> RecursiveMode {
         if self.recursive {
             RecursiveMode::Recursive
         } else {
             RecursiveMode::NonRecursive
         }
+    }
+
+    fn matches_event_path(&self, path: &Path) -> bool {
+        if self.recursive {
+            self.match_paths
+                .iter()
+                .any(|match_path| path.starts_with(match_path))
+        } else {
+            self.match_paths.iter().any(|match_path| match_path == path)
+        }
+    }
+
+    fn add_match_path(&mut self, path: PathBuf) {
+        self.match_paths.push(path);
+        self.match_paths.sort();
+        self.match_paths.dedup();
+    }
+
+    fn add_watch_path(&mut self, path: PathBuf) {
+        self.watch_paths.push(path);
+        self.watch_paths.sort();
+        self.watch_paths.dedup();
+    }
+
+    fn merge(&mut self, other: WatchTarget) {
+        debug_assert_eq!(self.watch_path, other.watch_path);
+        debug_assert_eq!(self.recursive, other.recursive);
+
+        self.watch_paths.extend(other.watch_paths);
+        self.watch_paths.sort();
+        self.watch_paths.dedup();
+        self.match_paths.extend(other.match_paths);
+        self.match_paths.sort();
+        self.match_paths.dedup();
+    }
+
+    fn covers(&self, other: &WatchTarget) -> bool {
+        if !self.recursive {
+            return false;
+        }
+
+        other
+            .match_paths
+            .iter()
+            .all(|path| self.matches_event_path(path))
     }
 }
 
@@ -219,7 +291,9 @@ fn watch_check(
     let (tx, rx) = channel();
     let mut watcher = recommended_watcher(tx)?;
     for target in &watch_targets {
-        watcher.watch(&target.path, target.recursive_mode())?;
+        for watch_path in &target.watch_paths {
+            watcher.watch(watch_path, target.recursive_mode())?;
+        }
     }
 
     clear_screen()?;
@@ -228,20 +302,12 @@ fn watch_check(
     print_report(&report, args.output_format)?;
 
     loop {
-        match rx.recv() {
-            Ok(Ok(event)) => {
-                if !watch_event_requires_rerun(&event, cache_root) {
-                    continue;
-                }
+        wait_for_watch_rerun(&rx, cache_root, &watch_targets)?;
 
-                clear_screen()?;
-                print_watch_banner("File change detected...")?;
-                let report = run_check_with_cwd(args, config_arguments, cwd, cache_root)?;
-                print_report(&report, args.output_format)?;
-            }
-            Ok(Err(error)) => return Err(error.into()),
-            Err(error) => return Err(error.into()),
-        }
+        clear_screen()?;
+        print_watch_banner("File change detected...")?;
+        let report = run_check_with_cwd(args, config_arguments, cwd, cache_root)?;
+        print_report(&report, args.output_format)?;
     }
 }
 
@@ -309,36 +375,60 @@ fn collect_watch_targets(
         let metadata = fs::metadata(&resolved_input)?;
         let canonical_input = fs::canonicalize(&resolved_input).map_err(anyhow::Error::from)?;
 
-        targets.push(WatchTarget {
-            path: canonical_input,
-            recursive: metadata.is_dir(),
-        });
+        let mut target = if metadata.is_dir() {
+            WatchTarget::recursive(resolved_input.clone())
+        } else {
+            WatchTarget::file(resolved_input.clone())
+        };
+        if metadata.is_dir() {
+            target.add_watch_path(canonical_input.clone());
+        } else if let Some(parent) = canonical_input.parent() {
+            target.add_watch_path(parent.to_path_buf());
+        }
+        target.add_match_path(canonical_input);
+        targets.push(target);
 
         if let Some(config_path) = watch_config_target(config_arguments, cwd, &resolved_input)? {
-            targets.push(WatchTarget {
-                path: config_path,
-                recursive: false,
-            });
+            let canonical_config_parent =
+                config_path.canonical_path.parent().map(Path::to_path_buf);
+            let mut target = WatchTarget::file(config_path.resolved_path);
+            target.add_match_path(config_path.canonical_path);
+            if let Some(parent) = canonical_config_parent {
+                target.add_watch_path(parent.to_path_buf());
+            }
+            targets.push(target);
         }
     }
 
     targets.sort_by(|left, right| {
-        left.path
+        left.watch_path
             .components()
             .count()
-            .cmp(&right.path.components().count())
+            .cmp(&right.watch_path.components().count())
             .then_with(|| right.recursive.cmp(&left.recursive))
-            .then_with(|| left.path.cmp(&right.path))
+            .then_with(|| left.watch_path.cmp(&right.watch_path))
     });
 
     let mut deduped = Vec::new();
     for target in targets {
-        if deduped.iter().any(|existing: &WatchTarget| {
-            existing.path == target.path
-                || (existing.recursive && target.path.starts_with(&existing.path))
+        if let Some(existing) = deduped.iter_mut().find(|existing: &&mut WatchTarget| {
+            existing.watch_path == target.watch_path && existing.recursive == target.recursive
         }) {
+            existing.merge(target);
             continue;
         }
+
+        if deduped
+            .iter()
+            .any(|existing: &WatchTarget| existing.covers(&target))
+        {
+            continue;
+        }
+
+        if target.recursive {
+            deduped.retain(|existing| !target.covers(existing));
+        }
+
         deduped.push(target);
     }
 
@@ -349,7 +439,7 @@ fn watch_config_target(
     config_arguments: &ConfigArguments,
     cwd: &Path,
     resolved_input: &Path,
-) -> Result<Option<PathBuf>> {
+) -> Result<Option<WatchPath>> {
     if let Some(explicit_config) = config_arguments.explicit_config_file() {
         let resolved_config = if explicit_config.is_absolute() {
             normalize_path(explicit_config)
@@ -357,9 +447,10 @@ fn watch_config_target(
             normalize_path(&cwd.join(explicit_config))
         };
 
-        return Ok(Some(
-            fs::canonicalize(resolved_config).map_err(anyhow::Error::from)?,
-        ));
+        return Ok(Some(WatchPath {
+            canonical_path: fs::canonicalize(&resolved_config).map_err(anyhow::Error::from)?,
+            resolved_path: resolved_config,
+        }));
     }
 
     if !config_arguments.use_config_roots() {
@@ -371,12 +462,58 @@ fn watch_config_target(
         return Ok(None);
     };
 
-    Ok(Some(
-        fs::canonicalize(config_path).map_err(anyhow::Error::from)?,
-    ))
+    let resolved_path = normalize_path(&config_path);
+    Ok(Some(WatchPath {
+        canonical_path: fs::canonicalize(&resolved_path).map_err(anyhow::Error::from)?,
+        resolved_path,
+    }))
 }
 
-fn watch_event_requires_rerun(event: &notify::Event, cache_root: &Path) -> bool {
+fn wait_for_watch_rerun(
+    rx: &Receiver<notify::Result<notify::Event>>,
+    cache_root: &Path,
+    watch_targets: &[WatchTarget],
+) -> Result<()> {
+    loop {
+        let event = match rx.recv() {
+            Ok(Ok(event)) => event,
+            Ok(Err(error)) => return Err(error.into()),
+            Err(error) => return Err(error.into()),
+        };
+
+        if drain_watch_batch(event, rx, cache_root, watch_targets)? {
+            return Ok(());
+        }
+    }
+}
+
+fn drain_watch_batch(
+    first_event: notify::Event,
+    rx: &Receiver<notify::Result<notify::Event>>,
+    cache_root: &Path,
+    watch_targets: &[WatchTarget],
+) -> Result<bool> {
+    let mut should_rerun = watch_event_requires_rerun(&first_event, cache_root, watch_targets);
+
+    loop {
+        match rx.try_recv() {
+            Ok(Ok(event)) => {
+                should_rerun |= watch_event_requires_rerun(&event, cache_root, watch_targets);
+            }
+            Ok(Err(error)) => return Err(error.into()),
+            Err(TryRecvError::Empty) => return Ok(should_rerun),
+            Err(TryRecvError::Disconnected) => {
+                return Err(anyhow!("watch channel disconnected"));
+            }
+        }
+    }
+}
+
+fn watch_event_requires_rerun(
+    event: &notify::Event,
+    cache_root: &Path,
+    watch_targets: &[WatchTarget],
+) -> bool {
     if event.kind.is_access() || event.kind.is_other() {
         return false;
     }
@@ -388,7 +525,13 @@ fn watch_event_requires_rerun(event: &notify::Event, cache_root: &Path) -> bool 
     event
         .paths
         .iter()
-        .any(|path| !watch_event_path_is_ignored(path, cache_root))
+        .map(|path| normalize_path(path))
+        .filter(|path| !watch_event_path_is_ignored(path, cache_root))
+        .any(|path| {
+            watch_targets
+                .iter()
+                .any(|target| target.matches_event_path(&path))
+        })
 }
 
 fn watch_event_path_is_ignored(path: &Path, cache_root: &Path) -> bool {
@@ -851,6 +994,20 @@ mod tests {
 
     fn cache_root(cwd: &Path) -> PathBuf {
         cwd.join("cache")
+    }
+
+    fn match_paths(canonical: &Path, resolved: &Path) -> Vec<PathBuf> {
+        let mut paths = vec![canonical.to_path_buf(), normalize_path(resolved)];
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    fn watch_paths(canonical: &Path, resolved: &Path) -> Vec<PathBuf> {
+        let mut paths = vec![canonical.to_path_buf(), normalize_path(resolved)];
+        paths.sort();
+        paths.dedup();
+        paths
     }
 
     fn make_file_read_only(path: &Path) {
@@ -1342,6 +1499,10 @@ mod tests {
     #[test]
     fn watch_event_filter_ignores_access_other_ignored_dirs_and_cache_paths() {
         let cache_root = Path::new("/tmp/shuck-cache");
+        let watch_targets = vec![
+            WatchTarget::recursive(PathBuf::from("/workspace/project")),
+            WatchTarget::file(PathBuf::from("/workspace/config/shuck.toml")),
+        ];
 
         assert!(!watch_event_requires_rerun(
             &notify::Event {
@@ -1350,6 +1511,7 @@ mod tests {
                 attrs: EventAttributes::default(),
             },
             cache_root,
+            &watch_targets,
         ));
         assert!(!watch_event_requires_rerun(
             &notify::Event {
@@ -1358,6 +1520,7 @@ mod tests {
                 attrs: EventAttributes::default(),
             },
             cache_root,
+            &watch_targets,
         ));
         assert!(!watch_event_requires_rerun(
             &notify::Event {
@@ -1366,6 +1529,7 @@ mod tests {
                 attrs: EventAttributes::default(),
             },
             cache_root,
+            &watch_targets,
         ));
         assert!(!watch_event_requires_rerun(
             &notify::Event {
@@ -1376,46 +1540,69 @@ mod tests {
                 attrs: EventAttributes::default(),
             },
             cache_root,
+            &watch_targets,
+        ));
+        assert!(!watch_event_requires_rerun(
+            &notify::Event {
+                kind: notify::EventKind::Modify(ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                paths: vec![PathBuf::from("/workspace/config/other.txt")],
+                attrs: EventAttributes::default(),
+            },
+            cache_root,
+            &watch_targets,
         ));
     }
 
     #[test]
     fn watch_event_filter_triggers_on_create_modify_remove_rename_and_rescan() {
         let cache_root = Path::new("/tmp/shuck-cache");
+        let watch_targets = vec![
+            WatchTarget::recursive(PathBuf::from("/workspace/project")),
+            WatchTarget::file(PathBuf::from("/workspace/config/shuck.toml")),
+        ];
 
         assert!(watch_event_requires_rerun(
             &notify::Event {
                 kind: notify::EventKind::Create(CreateKind::File),
-                paths: vec![PathBuf::from("script.sh")],
+                paths: vec![PathBuf::from("/workspace/project/script.sh")],
                 attrs: EventAttributes::default(),
             },
             cache_root,
+            &watch_targets,
         ));
         assert!(watch_event_requires_rerun(
             &notify::Event {
                 kind: notify::EventKind::Modify(ModifyKind::Data(
                     notify::event::DataChange::Content,
                 )),
-                paths: vec![PathBuf::from("script.sh")],
+                paths: vec![PathBuf::from("/workspace/config/shuck.toml")],
                 attrs: EventAttributes::default(),
             },
             cache_root,
+            &watch_targets,
         ));
         assert!(watch_event_requires_rerun(
             &notify::Event {
                 kind: notify::EventKind::Remove(RemoveKind::File),
-                paths: vec![PathBuf::from("script.sh")],
+                paths: vec![PathBuf::from("/workspace/project/script.sh")],
                 attrs: EventAttributes::default(),
             },
             cache_root,
+            &watch_targets,
         ));
         assert!(watch_event_requires_rerun(
             &notify::Event {
                 kind: notify::EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
-                paths: vec![PathBuf::from("old.sh"), PathBuf::from("new.sh")],
+                paths: vec![
+                    PathBuf::from("/tmp/tempfile"),
+                    PathBuf::from("/workspace/config/shuck.toml"),
+                ],
                 attrs: EventAttributes::default(),
             },
             cache_root,
+            &watch_targets,
         ));
 
         let mut attrs = EventAttributes::default();
@@ -1427,6 +1614,7 @@ mod tests {
                 attrs,
             },
             cache_root,
+            &watch_targets,
         ));
     }
 
@@ -1451,8 +1639,16 @@ mod tests {
         assert_eq!(
             default_targets,
             vec![WatchTarget {
-                path: fs::canonicalize(tempdir.path()).unwrap(),
+                watch_path: normalize_path(tempdir.path()),
+                watch_paths: watch_paths(
+                    &fs::canonicalize(tempdir.path()).unwrap(),
+                    tempdir.path()
+                ),
                 recursive: true,
+                match_paths: match_paths(
+                    &fs::canonicalize(tempdir.path()).unwrap(),
+                    tempdir.path()
+                ),
             }]
         );
 
@@ -1466,12 +1662,22 @@ mod tests {
             nested_targets,
             vec![
                 WatchTarget {
-                    path: fs::canonicalize(&nested).unwrap(),
-                    recursive: true,
+                    watch_path: normalize_path(tempdir.path()),
+                    watch_paths: watch_paths(
+                        &fs::canonicalize(tempdir.path()).unwrap(),
+                        tempdir.path()
+                    ),
+                    recursive: false,
+                    match_paths: match_paths(
+                        &fs::canonicalize(tempdir.path().join("shuck.toml")).unwrap(),
+                        &tempdir.path().join("shuck.toml"),
+                    ),
                 },
                 WatchTarget {
-                    path: fs::canonicalize(tempdir.path().join("shuck.toml")).unwrap(),
-                    recursive: false,
+                    watch_path: normalize_path(&nested),
+                    watch_paths: watch_paths(&fs::canonicalize(&nested).unwrap(), &nested),
+                    recursive: true,
+                    match_paths: match_paths(&fs::canonicalize(&nested).unwrap(), &nested),
                 },
             ]
         );
@@ -1486,14 +1692,88 @@ mod tests {
             file_targets,
             vec![
                 WatchTarget {
-                    path: fs::canonicalize(tempdir.path().join("shuck.toml")).unwrap(),
+                    watch_path: normalize_path(tempdir.path()),
+                    watch_paths: watch_paths(
+                        &fs::canonicalize(tempdir.path()).unwrap(),
+                        tempdir.path()
+                    ),
                     recursive: false,
+                    match_paths: match_paths(
+                        &fs::canonicalize(tempdir.path().join("shuck.toml")).unwrap(),
+                        &tempdir.path().join("shuck.toml"),
+                    ),
                 },
                 WatchTarget {
-                    path: fs::canonicalize(file).unwrap(),
+                    watch_path: normalize_path(&nested),
+                    watch_paths: watch_paths(&fs::canonicalize(&nested).unwrap(), &nested),
                     recursive: false,
+                    match_paths: match_paths(&fs::canonicalize(&file).unwrap(), &file),
                 },
             ]
         );
+    }
+
+    #[test]
+    fn collect_watch_targets_merge_files_in_the_same_parent_directory() {
+        let tempdir = tempdir().unwrap();
+        let nested = tempdir.path().join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        let first = nested.join("first.sh");
+        let second = nested.join("second.sh");
+        fs::write(&first, "#!/bin/bash\necho ok\n").unwrap();
+        fs::write(&second, "#!/bin/bash\necho ok\n").unwrap();
+
+        let targets = collect_watch_targets(
+            &[
+                PathBuf::from("nested/first.sh"),
+                PathBuf::from("nested/second.sh"),
+            ],
+            &ConfigArguments::from_cli(Vec::new(), true).unwrap(),
+            tempdir.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            targets,
+            vec![WatchTarget {
+                watch_path: normalize_path(&nested),
+                watch_paths: watch_paths(&fs::canonicalize(&nested).unwrap(), &nested),
+                recursive: false,
+                match_paths: {
+                    let mut paths = vec![
+                        fs::canonicalize(&first).unwrap(),
+                        normalize_path(&first),
+                        fs::canonicalize(&second).unwrap(),
+                        normalize_path(&second),
+                    ];
+                    paths.sort();
+                    paths.dedup();
+                    paths
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn drain_watch_batch_coalesces_queued_events_before_rerunning() {
+        let cache_root = Path::new("/tmp/shuck-cache");
+        let watch_targets = vec![WatchTarget::recursive(PathBuf::from("/workspace/project"))];
+        let (tx, rx) = channel();
+
+        tx.send(Ok(notify::Event {
+            kind: notify::EventKind::Modify(ModifyKind::Data(notify::event::DataChange::Content)),
+            paths: vec![PathBuf::from("/workspace/project/ignored/.git/index")],
+            attrs: EventAttributes::default(),
+        }))
+        .unwrap();
+
+        let first = notify::Event {
+            kind: notify::EventKind::Modify(ModifyKind::Data(notify::event::DataChange::Content)),
+            paths: vec![PathBuf::from("/workspace/project/script.sh")],
+            attrs: EventAttributes::default(),
+        };
+
+        assert!(drain_watch_batch(first, &rx, cache_root, &watch_targets).unwrap());
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
     }
 }

--- a/crates/shuck/src/config.rs
+++ b/crates/shuck/src/config.rs
@@ -115,6 +115,10 @@ You cannot specify more than one configuration file on the command line.
     pub(crate) fn use_config_roots(&self) -> bool {
         !self.isolated && self.config_file.is_none()
     }
+
+    pub(crate) fn explicit_config_file(&self) -> Option<&Path> {
+        self.config_file.as_deref()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -407,6 +411,10 @@ fn config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
     }
 
     Ok(None)
+}
+
+pub(crate) fn discovered_config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
+    config_path_for_root(root)
 }
 
 #[cfg(test)]

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -1,9 +1,15 @@
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::process::{Command as ProcessCommand, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::tempdir;
+use wait_timeout::ChildExt;
 use walkdir::WalkDir;
 
 fn cache_dir(root: &Path) -> PathBuf {
@@ -30,6 +36,92 @@ fn configure_default_cache_env(cmd: &mut Command, root: &Path) {
 
 fn enable_experimental(cmd: &mut Command) {
     cmd.env("SHUCK_EXPERIMENTAL", "1");
+}
+
+#[derive(Clone, Copy)]
+enum StreamKind {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Default)]
+struct CapturedOutput {
+    stdout: String,
+    stderr: String,
+}
+
+fn spawn_output_reader<R>(
+    reader: R,
+    kind: StreamKind,
+    tx: mpsc::Sender<(StreamKind, String)>,
+) -> thread::JoinHandle<()>
+where
+    R: std::io::Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut reader = BufReader::new(reader);
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    if tx.send((kind, line)).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+fn wait_for_output<F>(
+    rx: &Receiver<(StreamKind, String)>,
+    captured: &mut CapturedOutput,
+    timeout: Duration,
+    predicate: F,
+) -> bool
+where
+    F: Fn(&CapturedOutput) -> bool,
+{
+    if predicate(captured) {
+        return true;
+    }
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return predicate(captured);
+        };
+
+        match rx.recv_timeout(remaining) {
+            Ok((kind, line)) => match kind {
+                StreamKind::Stdout => captured.stdout.push_str(&line),
+                StreamKind::Stderr => captured.stderr.push_str(&line),
+            },
+            Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => {
+                return predicate(captured);
+            }
+        }
+
+        if predicate(captured) {
+            return true;
+        }
+    }
+}
+
+fn stop_child(child: &mut std::process::Child) {
+    if child.try_wait().unwrap().is_none() {
+        let _ = child.kill();
+    }
+    if child
+        .wait_timeout(Duration::from_secs(5))
+        .unwrap()
+        .is_none()
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
 }
 
 #[test]
@@ -106,6 +198,7 @@ fn check_help_includes_add_ignore_flag() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("--add-ignore"))
+        .stdout(predicate::str::contains("-w, --watch"))
         .stdout(predicate::str::contains("shuck ignore directives"))
         .stdout(predicate::str::contains("--add-noqa").not());
 }
@@ -937,6 +1030,59 @@ fn check_invalid_extend_exclude_pattern_reports_discovery_error() {
     cmd.assert()
         .code(2)
         .stderr(predicate::str::contains("invalid exclude pattern `[`"));
+}
+
+#[test]
+fn check_watch_reruns_when_files_change() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("watch.sh");
+    fs::write(&script, "#!/bin/bash\necho ok\n").unwrap();
+
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin("shuck"));
+    child
+        .env("SHUCK_CACHE_DIR", cache_dir(tempdir.path()))
+        .current_dir(tempdir.path())
+        .args(["check", "--watch", "--output-format", "concise"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = child.spawn().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let stdout_reader = spawn_output_reader(stdout, StreamKind::Stdout, tx.clone());
+    let stderr_reader = spawn_output_reader(stderr, StreamKind::Stderr, tx);
+    let mut captured = CapturedOutput::default();
+
+    let initial_ready = wait_for_output(&rx, &mut captured, Duration::from_secs(10), |output| {
+        output.stderr.contains("Starting linter in watch mode...")
+    });
+    if !initial_ready {
+        stop_child(&mut child);
+        let _ = stdout_reader.join();
+        let _ = stderr_reader.join();
+        panic!(
+            "watch mode did not emit its startup banner\nstdout:\n{}\nstderr:\n{}",
+            captured.stdout, captured.stderr
+        );
+    }
+
+    fs::write(&script, "#!/bin/bash\nunused=1\necho ok\n").unwrap();
+
+    let rerun_ready = wait_for_output(&rx, &mut captured, Duration::from_secs(10), |output| {
+        output.stderr.contains("File change detected...")
+            && output.stdout.contains("watch.sh:2:1: warning[C001]")
+    });
+
+    stop_child(&mut child);
+    let _ = stdout_reader.join();
+    let _ = stderr_reader.join();
+
+    assert!(
+        rerun_ready,
+        "watch mode did not rerun after file changes\nstdout:\n{}\nstderr:\n{}",
+        captured.stdout, captured.stderr
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `-w, --watch` to `shuck check`
- rerun checks automatically when watched files change, with Ruff-style screen refresh behavior for terminal sessions
- cover the new watch workflow with argument, unit, help, and end-to-end integration tests

## Why
`shuck check` did not have a built-in watch mode, so iterating on shell files required re-running the command manually after every edit.

## Impact
Users can now keep `shuck check` running during development and get refreshed diagnostics whenever relevant files change. Watch mode stays lint-only by conflicting with `--add-ignore`, and it ignores cache/default ignored directories to avoid noisy reruns.

## Root Cause
The CLI only supported one-shot `check` execution; there was no file-watching loop or event filtering path wired into the command.

## Validation
- `cargo test -p shuck`