### PR TITLE
Add rule selection support for shuck check

### DIFF
--- a/crates/shuck-linter/Cargo.toml
+++ b/crates/shuck-linter/Cargo.toml
@@ -14,6 +14,7 @@ benchmarking = []
 
 [dependencies]
 anyhow = { workspace = true }
+globset = { workspace = true }
 rustc-hash = "2"
 smallvec.workspace = true
 thiserror = { workspace = true }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -79,7 +79,7 @@ pub use rules::common::word::{
     text_looks_like_nontrivial_arithmetic_expression, word_is_standalone_status_capture,
     word_is_standalone_variable_like,
 };
-pub use settings::LinterSettings;
+pub use settings::{CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore};
 pub use shell::ShellDialect;
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,
@@ -262,6 +262,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
     if let Some(suppression_index) = suppression_index {
         filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
     }
+    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
 
     diagnostics
         .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
@@ -384,6 +385,7 @@ pub fn lint_file_at_path_with_resolver(
     if let Some(suppression_index) = suppression_index {
         filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
     }
+    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
 
     diagnostics
         .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
@@ -436,6 +438,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
     if let Some(suppression_index) = suppression_index {
         filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
     }
+    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
 
     diagnostics
         .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
@@ -477,6 +480,19 @@ fn filter_suppressed_diagnostics(
 
         !suppression_index.is_suppressed(diagnostic.rule, line)
     });
+}
+
+fn filter_per_file_ignored_diagnostics(
+    diagnostics: &mut Vec<Diagnostic>,
+    settings: &LinterSettings,
+    source_path: Option<&Path>,
+) {
+    let ignored_rules = settings.per_file_ignored_rules(source_path);
+    if ignored_rules.is_empty() {
+        return;
+    }
+
+    diagnostics.retain(|diagnostic| !ignored_rules.contains(diagnostic.rule));
 }
 
 #[cold]

--- a/crates/shuck-linter/src/rule_set.rs
+++ b/crates/shuck-linter/src/rule_set.rs
@@ -30,6 +30,14 @@ impl RuleSet {
         self.0[word] &= !(1u64 << bit);
     }
 
+    pub fn set(&mut self, rule: Rule, enabled: bool) {
+        if enabled {
+            self.insert(rule);
+        } else {
+            self.remove(rule);
+        }
+    }
+
     pub fn union(&self, other: &Self) -> Self {
         let mut words = [0; WORD_COUNT];
         let mut index = 0;

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -207,7 +207,7 @@ impl CompiledPerFileIgnoreList {
         self.entries.iter().fold(RuleSet::EMPTY, |ignored, entry| {
             let matches = entry.basename_matcher.is_match(file_name)
                 || entry.relative_matcher.is_match(relative_path)
-                || entry.absolute_matcher.is_match(path);
+                || matches_absolute_path(&entry.absolute_matcher, path);
             let applies = if entry.negated { !matches } else { matches };
 
             if applies {
@@ -219,11 +219,30 @@ impl CompiledPerFileIgnoreList {
     }
 }
 
+fn matches_absolute_path(matcher: &GlobMatcher, path: &Path) -> bool {
+    matcher.is_match(path)
+        || normalized_absolute_match_path(path)
+            .as_deref()
+            .is_some_and(|normalized| matcher.is_match(normalized))
+}
+
+fn normalized_absolute_match_path(path: &Path) -> Option<PathBuf> {
+    let path = path.to_string_lossy();
+
+    if let Some(stripped) = path.strip_prefix(r"\\?\UNC\") {
+        return Some(PathBuf::from(format!(r"\\{stripped}")));
+    }
+
+    path.strip_prefix(r"\\?\").map(PathBuf::from)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use tempfile::tempdir;
 
-    use super::{CompiledPerFileIgnoreList, PerFileIgnore};
+    use super::{CompiledPerFileIgnoreList, PerFileIgnore, normalized_absolute_match_path};
     use crate::{Rule, RuleSet};
 
     #[test]
@@ -249,5 +268,21 @@ mod tests {
         let ignored_rules = per_file_ignores.ignored_rules(&script_path);
 
         assert!(ignored_rules.contains(Rule::UnusedAssignment));
+    }
+
+    #[test]
+    fn strips_windows_verbatim_disk_prefixes_for_absolute_matching() {
+        assert_eq!(
+            normalized_absolute_match_path(Path::new(r"\\?\C:\repo\nested\script.sh")),
+            Some(PathBuf::from(r"C:\repo\nested\script.sh"))
+        );
+    }
+
+    #[test]
+    fn strips_windows_verbatim_unc_prefixes_for_absolute_matching() {
+        assert_eq!(
+            normalized_absolute_match_path(Path::new(r"\\?\UNC\server\share\script.sh")),
+            Some(PathBuf::from(r"\\server\share\script.sh"))
+        );
     }
 }

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -72,6 +72,7 @@ struct CompiledPerFileIgnore {
     pattern: String,
     basename_matcher: GlobMatcher,
     relative_matcher: GlobMatcher,
+    absolute_matcher: GlobMatcher,
     negated: bool,
     rules: RuleSet,
 }
@@ -171,11 +172,15 @@ impl CompiledPerFileIgnoreList {
                 let relative_matcher = Glob::new(&pattern)
                     .with_context(|| format!("invalid glob {:?}", per_file_ignore.pattern()))?
                     .compile_matcher();
+                let absolute_matcher = Glob::new(&pattern)
+                    .with_context(|| format!("invalid glob {:?}", per_file_ignore.pattern()))?
+                    .compile_matcher();
 
                 Ok(CompiledPerFileIgnore {
                     pattern: per_file_ignore.pattern().to_owned(),
                     basename_matcher,
                     relative_matcher,
+                    absolute_matcher,
                     negated,
                     rules: per_file_ignore.rules(),
                 })
@@ -201,7 +206,8 @@ impl CompiledPerFileIgnoreList {
 
         self.entries.iter().fold(RuleSet::EMPTY, |ignored, entry| {
             let matches = entry.basename_matcher.is_match(file_name)
-                || entry.relative_matcher.is_match(relative_path);
+                || entry.relative_matcher.is_match(relative_path)
+                || entry.absolute_matcher.is_match(path);
             let applies = if entry.negated { !matches } else { matches };
 
             if applies {
@@ -210,5 +216,38 @@ impl CompiledPerFileIgnoreList {
                 ignored
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{CompiledPerFileIgnoreList, PerFileIgnore};
+    use crate::{Rule, RuleSet};
+
+    #[test]
+    fn matches_absolute_per_file_ignore_patterns() {
+        let tempdir = tempdir().unwrap();
+        let project_root = tempdir.path().to_path_buf();
+        let script_path = project_root.join("nested").join("script.sh");
+        let absolute_pattern = script_path
+            .parent()
+            .unwrap()
+            .join("*.sh")
+            .to_string_lossy()
+            .into_owned();
+        let per_file_ignores = CompiledPerFileIgnoreList::resolve(
+            project_root,
+            [PerFileIgnore::new(
+                absolute_pattern,
+                RuleSet::from_iter([Rule::UnusedAssignment]),
+            )],
+        )
+        .unwrap();
+
+        let ignored_rules = per_file_ignores.ignored_rules(&script_path);
+
+        assert!(ignored_rules.contains(Rule::UnusedAssignment));
     }
 }

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -1,6 +1,9 @@
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use anyhow::{Context, Result};
+use globset::{Glob, GlobMatcher};
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -12,6 +15,7 @@ pub struct LinterSettings {
     pub severity_overrides: FxHashMap<Rule, Severity>,
     pub shell: ShellDialect,
     pub analyzed_paths: Option<Arc<FxHashSet<PathBuf>>>,
+    pub per_file_ignores: Arc<CompiledPerFileIgnoreList>,
 }
 
 impl Default for LinterSettings {
@@ -21,9 +25,64 @@ impl Default for LinterSettings {
             severity_overrides: FxHashMap::default(),
             shell: ShellDialect::Unknown,
             analyzed_paths: None,
+            per_file_ignores: Arc::new(CompiledPerFileIgnoreList::default()),
         }
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PerFileIgnore {
+    pattern: String,
+    rules: RuleSet,
+}
+
+impl PerFileIgnore {
+    pub fn new(pattern: impl Into<String>, rules: RuleSet) -> Self {
+        Self {
+            pattern: pattern.into(),
+            rules,
+        }
+    }
+
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+
+    pub const fn rules(&self) -> RuleSet {
+        self.rules
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CompiledPerFileIgnoreList {
+    project_root: PathBuf,
+    entries: Vec<CompiledPerFileIgnore>,
+}
+
+impl PartialEq for CompiledPerFileIgnoreList {
+    fn eq(&self, other: &Self) -> bool {
+        self.project_root == other.project_root && self.entries == other.entries
+    }
+}
+
+impl Eq for CompiledPerFileIgnoreList {}
+
+#[derive(Debug, Clone)]
+struct CompiledPerFileIgnore {
+    pattern: String,
+    basename_matcher: GlobMatcher,
+    relative_matcher: GlobMatcher,
+    negated: bool,
+    rules: RuleSet,
+}
+
+impl PartialEq for CompiledPerFileIgnore {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern && self.negated == other.negated && self.rules == other.rules
+    }
+}
+
+impl Eq for CompiledPerFileIgnore {}
 
 impl LinterSettings {
     pub fn for_rule(rule: Rule) -> Self {
@@ -77,5 +136,79 @@ impl LinterSettings {
                 .collect(),
         ));
         self
+    }
+
+    pub fn with_per_file_ignores(mut self, per_file_ignores: CompiledPerFileIgnoreList) -> Self {
+        self.per_file_ignores = Arc::new(per_file_ignores);
+        self
+    }
+
+    pub fn per_file_ignored_rules(&self, path: Option<&Path>) -> RuleSet {
+        path.map_or(RuleSet::EMPTY, |path| {
+            self.per_file_ignores.ignored_rules(path)
+        })
+    }
+}
+
+impl CompiledPerFileIgnoreList {
+    pub fn resolve(
+        project_root: impl Into<PathBuf>,
+        per_file_ignores: impl IntoIterator<Item = PerFileIgnore>,
+    ) -> Result<Self> {
+        let project_root = project_root.into();
+        let entries = per_file_ignores
+            .into_iter()
+            .map(|per_file_ignore| {
+                let mut pattern = per_file_ignore.pattern().to_owned();
+                let negated = pattern.starts_with('!');
+                if negated {
+                    pattern.drain(..1);
+                }
+
+                let basename_matcher = Glob::new(&pattern)
+                    .with_context(|| format!("invalid glob {:?}", per_file_ignore.pattern()))?
+                    .compile_matcher();
+                let relative_matcher = Glob::new(&pattern)
+                    .with_context(|| format!("invalid glob {:?}", per_file_ignore.pattern()))?
+                    .compile_matcher();
+
+                Ok(CompiledPerFileIgnore {
+                    pattern: per_file_ignore.pattern().to_owned(),
+                    basename_matcher,
+                    relative_matcher,
+                    negated,
+                    rules: per_file_ignore.rules(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            project_root,
+            entries,
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn ignored_rules(&self, path: &Path) -> RuleSet {
+        let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
+        let file_name = relative_path.file_name().or_else(|| path.file_name());
+        let Some(file_name) = file_name else {
+            return RuleSet::EMPTY;
+        };
+
+        self.entries.iter().fold(RuleSet::EMPTY, |ignored, entry| {
+            let matches = entry.basename_matcher.is_match(file_name)
+                || entry.relative_matcher.is_match(relative_path);
+            let applies = if entry.negated { !matches } else { matches };
+
+            if applies {
+                ignored.union(&entry.rules)
+            } else {
+                ignored
+            }
+        })
     }
 }

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -322,7 +322,7 @@ impl std::str::FromStr for PatternRuleSelectorPair {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let (pattern, selector) = value
-            .split_once(':')
+            .rsplit_once(':')
             .ok_or_else(|| "expected <FilePattern>:<RuleCode>".to_owned())?;
         let pattern = pattern.trim();
         let selector = selector.trim();
@@ -878,6 +878,19 @@ mod tests {
                 pattern: "!src/*.sh".to_owned(),
                 selector: RuleSelector::Category(shuck_linter::Category::Style),
             }]
+        );
+    }
+
+    #[test]
+    fn parses_per_file_ignore_pairs_with_colons_in_pattern() {
+        let command = parse_check(["shuck", "check", "--per-file-ignores", r"C:\repo\*.sh:C001"]);
+
+        assert_eq!(
+            command.rule_selection.per_file_ignores,
+            Some(vec![PatternRuleSelectorPair {
+                pattern: r"C:\repo\*.sh".to_owned(),
+                selector: RuleSelector::Rule(Rule::UnusedAssignment),
+            }])
         );
     }
 

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -333,11 +333,18 @@ impl std::str::FromStr for PatternRuleSelectorPair {
 
         Ok(Self {
             pattern: pattern.to_owned(),
-            selector: selector
-                .parse::<RuleSelector>()
-                .map_err(|err| err.to_string())?,
+            selector: parse_cli_rule_selector(selector)?,
         })
     }
+}
+
+fn parse_cli_rule_selector(value: &str) -> Result<RuleSelector, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err("rule selector cannot be empty".to_owned());
+    }
+
+    value.parse::<RuleSelector>().map_err(|err| err.to_string())
 }
 
 #[derive(Debug, Clone, Default, ClapArgs)]
@@ -346,6 +353,7 @@ pub struct RuleSelectionArgs {
     #[arg(
         long,
         value_delimiter = ',',
+        value_parser = parse_cli_rule_selector,
         value_name = "RULE_CODE",
         help_heading = "Rule selection",
         hide_possible_values = true
@@ -355,6 +363,7 @@ pub struct RuleSelectionArgs {
     #[arg(
         long,
         value_delimiter = ',',
+        value_parser = parse_cli_rule_selector,
         value_name = "RULE_CODE",
         help_heading = "Rule selection",
         hide_possible_values = true
@@ -364,6 +373,7 @@ pub struct RuleSelectionArgs {
     #[arg(
         long,
         value_delimiter = ',',
+        value_parser = parse_cli_rule_selector,
         value_name = "RULE_CODE",
         help_heading = "Rule selection",
         hide_possible_values = true
@@ -389,6 +399,7 @@ pub struct RuleSelectionArgs {
     #[arg(
         long,
         value_delimiter = ',',
+        value_parser = parse_cli_rule_selector,
         value_name = "RULE_CODE",
         help_heading = "Rule selection",
         hide_possible_values = true
@@ -398,6 +409,7 @@ pub struct RuleSelectionArgs {
     #[arg(
         long,
         value_delimiter = ',',
+        value_parser = parse_cli_rule_selector,
         value_name = "RULE_CODE",
         help_heading = "Rule selection",
         hide_possible_values = true
@@ -407,6 +419,7 @@ pub struct RuleSelectionArgs {
     #[arg(
         long,
         value_delimiter = ',',
+        value_parser = parse_cli_rule_selector,
         value_name = "RULE_CODE",
         help_heading = "Rule selection",
         hide_possible_values = true
@@ -892,6 +905,20 @@ mod tests {
                 selector: RuleSelector::Rule(Rule::UnusedAssignment),
             }])
         );
+    }
+
+    #[test]
+    fn rejects_empty_cli_rule_selectors() {
+        let error = StableCli::try_parse_from(["shuck", "check", "--select", ""]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn rejects_empty_cli_rule_selectors_after_value_delimiter() {
+        let error = StableCli::try_parse_from(["shuck", "check", "--select", "C001,"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -8,6 +8,7 @@ use clap::{
     Args as ClapArgs, ColorChoice, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
 };
 use shuck_formatter::{IndentStyle, ShellDialect};
+use shuck_linter::RuleSelector;
 
 use crate::config::{ConfigArgumentParser, ConfigArguments, SingleConfigArgument};
 use crate::format_settings::FormatSettingsPatch;
@@ -286,6 +287,8 @@ pub struct CheckCommand {
     /// Files or directories to check.
     pub paths: Vec<PathBuf>,
     #[command(flatten)]
+    pub rule_selection: RuleSelectionArgs,
+    #[command(flatten)]
     pub file_selection: FileSelectionArgs,
     /// Disable cache reads and writes.
     #[arg(long = "no-cache", help_heading = "Miscellaneous")]
@@ -306,6 +309,109 @@ impl CheckCommand {
     pub fn force_exclude(&self) -> bool {
         self.file_selection.force_exclude()
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatternRuleSelectorPair {
+    pub pattern: String,
+    pub selector: RuleSelector,
+}
+
+impl std::str::FromStr for PatternRuleSelectorPair {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (pattern, selector) = value
+            .split_once(':')
+            .ok_or_else(|| "expected <FilePattern>:<RuleCode>".to_owned())?;
+        let pattern = pattern.trim();
+        let selector = selector.trim();
+
+        if pattern.is_empty() || selector.is_empty() {
+            return Err("expected <FilePattern>:<RuleCode>".to_owned());
+        }
+
+        Ok(Self {
+            pattern: pattern.to_owned(),
+            selector: selector
+                .parse::<RuleSelector>()
+                .map_err(|err| err.to_string())?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, ClapArgs)]
+pub struct RuleSelectionArgs {
+    /// Comma-separated list of rule codes to enable (or ALL, to enable all rules).
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection",
+        hide_possible_values = true
+    )]
+    pub select: Option<Vec<RuleSelector>>,
+    /// Comma-separated list of rule codes to disable.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection",
+        hide_possible_values = true
+    )]
+    pub ignore: Vec<RuleSelector>,
+    /// Like --select, but adds additional rule codes on top of those already specified.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection",
+        hide_possible_values = true
+    )]
+    pub extend_select: Vec<RuleSelector>,
+    /// List of mappings from file pattern to code to exclude.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "PER_FILE_IGNORES",
+        help_heading = "Rule selection"
+    )]
+    pub per_file_ignores: Option<Vec<PatternRuleSelectorPair>>,
+    /// Like `--per-file-ignores`, but adds additional ignores on top of those already specified.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "EXTEND_PER_FILE_IGNORES",
+        help_heading = "Rule selection"
+    )]
+    pub extend_per_file_ignores: Vec<PatternRuleSelectorPair>,
+    /// List of rule codes to treat as eligible for fix. Only applicable when fix itself is enabled (e.g., via `--fix`).
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection",
+        hide_possible_values = true
+    )]
+    pub fixable: Option<Vec<RuleSelector>>,
+    /// List of rule codes to treat as ineligible for fix. Only applicable when fix itself is enabled (e.g., via `--fix`).
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection",
+        hide_possible_values = true
+    )]
+    pub unfixable: Vec<RuleSelector>,
+    /// Like --fixable, but adds additional rule codes on top of those already specified.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection",
+        hide_possible_values = true
+    )]
+    pub extend_fixable: Vec<RuleSelector>,
 }
 
 fn parse_with_color<Cli, I, T>(itr: I) -> Result<Cli, clap::Error>
@@ -576,6 +682,7 @@ pub struct CleanCommand {
 mod tests {
     use super::*;
     use clap::builder::TypedValueParser;
+    use shuck_linter::Rule;
 
     #[test]
     fn global_config_override_is_available_after_subcommand() {
@@ -691,6 +798,87 @@ mod tests {
         let command = parse_check(["shuck", "check", "--watch"]);
 
         assert!(command.watch);
+    }
+
+    #[test]
+    fn parses_rule_selection_flags() {
+        let command = parse_check([
+            "shuck",
+            "check",
+            "--select",
+            "C001",
+            "--select",
+            "S,C002",
+            "--ignore",
+            "C003,C004",
+            "--extend-select",
+            "X",
+            "--fixable",
+            "ALL",
+            "--unfixable",
+            "C001",
+            "--extend-fixable",
+            "S074",
+        ]);
+
+        assert_eq!(
+            command.rule_selection.select,
+            Some(vec![
+                RuleSelector::Rule(Rule::UnusedAssignment),
+                RuleSelector::Category(shuck_linter::Category::Style),
+                RuleSelector::Rule(Rule::DynamicSourcePath),
+            ])
+        );
+        assert_eq!(
+            command.rule_selection.ignore,
+            vec![
+                RuleSelector::Rule(Rule::UntrackedSourceFile),
+                RuleSelector::Rule(Rule::UncheckedDirectoryChange),
+            ]
+        );
+        assert_eq!(
+            command.rule_selection.extend_select,
+            vec![RuleSelector::Category(shuck_linter::Category::Portability)]
+        );
+        assert_eq!(
+            command.rule_selection.fixable,
+            Some(vec![RuleSelector::All])
+        );
+        assert_eq!(
+            command.rule_selection.unfixable,
+            vec![RuleSelector::Rule(Rule::UnusedAssignment)]
+        );
+        assert_eq!(
+            command.rule_selection.extend_fixable,
+            vec![RuleSelector::Rule(Rule::AmpersandSemicolon)]
+        );
+    }
+
+    #[test]
+    fn parses_per_file_ignore_pairs() {
+        let command = parse_check([
+            "shuck",
+            "check",
+            "--per-file-ignores",
+            "tests/*.sh:C001",
+            "--extend-per-file-ignores",
+            "!src/*.sh:S",
+        ]);
+
+        assert_eq!(
+            command.rule_selection.per_file_ignores,
+            Some(vec![PatternRuleSelectorPair {
+                pattern: "tests/*.sh".to_owned(),
+                selector: RuleSelector::Rule(Rule::UnusedAssignment),
+            }])
+        );
+        assert_eq!(
+            command.rule_selection.extend_per_file_ignores,
+            vec![PatternRuleSelectorPair {
+                pattern: "!src/*.sh".to_owned(),
+                selector: RuleSelector::Category(shuck_linter::Category::Style),
+            }]
+        );
     }
 
     #[test]

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -748,6 +748,13 @@ fn parse_rule_selectors(selectors: &[String], scope: &str) -> Result<Vec<RuleSel
     selectors
         .iter()
         .map(|selector| {
+            let selector = selector.trim();
+            if selector.is_empty() {
+                return Err(anyhow!(
+                    "invalid {scope} selector: selector cannot be empty"
+                ));
+            }
+
             selector
                 .parse::<RuleSelector>()
                 .map_err(|err| anyhow!("invalid {scope} selector `{selector}`: {err}"))
@@ -1624,6 +1631,16 @@ mod tests {
         assert_eq!(
             diagnostic_codes(&report),
             vec![Rule::UnusedAssignment.code().to_owned()]
+        );
+    }
+
+    #[test]
+    fn rejects_empty_rule_selectors() {
+        let error = parse_rule_selectors(&[String::new()], "lint.select").unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "invalid lint.select selector: selector cannot be empty"
         );
     }
 

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -12,8 +13,9 @@ use serde::{Deserialize, Serialize};
 use shuck_cache::{CacheKey, CacheKeyHasher};
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    Applicability, LinterSettings, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
-    add_ignores_to_path, first_statement_line, parse_directives,
+    Applicability, CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore, Rule, RuleSelector,
+    RuleSet, ShellCheckCodeMap, ShellDialect, SuppressionIndex, add_ignores_to_path,
+    first_statement_line, parse_directives,
 };
 use shuck_parser::{
     Error as ParseError,
@@ -21,16 +23,17 @@ use shuck_parser::{
 };
 
 use crate::ExitStatus;
-use crate::args::{CheckCommand, FileSelectionArgs};
+use crate::args::{CheckCommand, FileSelectionArgs, PatternRuleSelectorPair, RuleSelectionArgs};
 use crate::cache::resolve_cache_root;
 use crate::commands::check_output::{
     DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
 };
 use crate::commands::project_runner::{PendingProjectFile, prepare_project_runs};
 use crate::config::{
-    ConfigArguments, discovered_config_path_for_root, resolve_project_root_for_input,
+    ConfigArguments, LintConfig, discovered_config_path_for_root, load_project_config,
+    resolve_project_root_for_input,
 };
-use crate::discover::{DEFAULT_IGNORED_DIR_NAMES, DiscoveryOptions, normalize_path};
+use crate::discover::{DEFAULT_IGNORED_DIR_NAMES, DiscoveryOptions, ProjectRoot, normalize_path};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct CheckReport {
@@ -79,18 +82,44 @@ fn diagnostics_exit_status(diagnostics: &[DisplayedDiagnostic], exit_zero: bool)
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct EffectiveCheckSettings {
     enabled_rules: Vec<String>,
+    per_file_ignores: Vec<EffectivePerFileIgnore>,
 }
 
-impl Default for EffectiveCheckSettings {
-    fn default() -> Self {
-        let mut enabled_rules = LinterSettings::default()
-            .rules
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EffectivePerFileIgnore {
+    pattern: String,
+    rules: Vec<String>,
+}
+
+impl EffectiveCheckSettings {
+    fn new(enabled_rules: RuleSet, per_file_ignores: &[PerFileIgnore]) -> Self {
+        let mut enabled_rules = enabled_rules
             .iter()
             .map(|rule| rule.code().to_owned())
             .collect::<Vec<_>>();
         enabled_rules.sort();
 
-        Self { enabled_rules }
+        let mut per_file_ignores = per_file_ignores
+            .iter()
+            .map(|ignore| {
+                let mut rules = ignore
+                    .rules()
+                    .iter()
+                    .map(|rule| rule.code().to_owned())
+                    .collect::<Vec<_>>();
+                rules.sort();
+                EffectivePerFileIgnore {
+                    pattern: ignore.pattern().to_owned(),
+                    rules,
+                }
+            })
+            .collect::<Vec<_>>();
+        per_file_ignores.sort_by(|left, right| left.pattern.cmp(&right.pattern));
+
+        Self {
+            enabled_rules,
+            per_file_ignores,
+        }
     }
 }
 
@@ -98,6 +127,57 @@ impl CacheKey for EffectiveCheckSettings {
     fn cache_key(&self, state: &mut CacheKeyHasher) {
         state.write_tag(b"effective-check-settings");
         self.enabled_rules.cache_key(state);
+        self.per_file_ignores.cache_key(state);
+    }
+}
+
+impl CacheKey for EffectivePerFileIgnore {
+    fn cache_key(&self, state: &mut CacheKeyHasher) {
+        self.pattern.cache_key(state);
+        self.rules.cache_key(state);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedCheckSettings {
+    linter_settings: LinterSettings,
+    fixable_rules: RuleSet,
+    effective: EffectiveCheckSettings,
+}
+
+impl CacheKey for ResolvedCheckSettings {
+    fn cache_key(&self, state: &mut CacheKeyHasher) {
+        self.effective.cache_key(state);
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct RuleSelectionLayer {
+    select: Option<Vec<RuleSelector>>,
+    ignore: Vec<RuleSelector>,
+    extend_select: Vec<RuleSelector>,
+    per_file_ignores: Option<Vec<PerFileIgnoreSpec>>,
+    extend_per_file_ignores: Vec<PerFileIgnoreSpec>,
+    fixable: Option<Vec<RuleSelector>>,
+    unfixable: Vec<RuleSelector>,
+    extend_fixable: Vec<RuleSelector>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PerFileIgnoreSpec {
+    pattern: String,
+    selectors: Vec<RuleSelector>,
+}
+
+impl PerFileIgnoreSpec {
+    fn into_ignore(self) -> PerFileIgnore {
+        let rules = self
+            .selectors
+            .into_iter()
+            .fold(RuleSet::EMPTY, |rules, selector| {
+                rules.union(&selector.into_rule_set())
+            });
+        PerFileIgnore::new(self.pattern, rules)
     }
 }
 
@@ -546,6 +626,246 @@ fn watch_event_path_is_ignored(path: &Path, cache_root: &Path) -> bool {
         })
 }
 
+fn resolve_project_check_settings(
+    project_root: &ProjectRoot,
+    config_arguments: &ConfigArguments,
+    cli_rule_selection: &RuleSelectionArgs,
+) -> Result<ResolvedCheckSettings> {
+    let config = load_project_config(&project_root.storage_root, config_arguments)?;
+    let layers = [
+        parse_lint_config_layer(&config.lint)?,
+        parse_cli_rule_selection_layer(cli_rule_selection),
+    ];
+
+    let mut enabled_rules = LinterSettings::default_rules();
+    let mut fixable_rules = RuleSet::all();
+    let mut per_file_ignores = Vec::new();
+
+    for layer in layers {
+        enabled_rules = apply_rule_selector_layer(
+            enabled_rules,
+            layer.select.as_deref(),
+            &layer.extend_select,
+            &layer.ignore,
+        );
+        fixable_rules = apply_rule_selector_layer(
+            fixable_rules,
+            layer.fixable.as_deref(),
+            &layer.extend_fixable,
+            &layer.unfixable,
+        );
+        per_file_ignores = apply_per_file_ignore_layer(
+            per_file_ignores,
+            layer.per_file_ignores,
+            layer.extend_per_file_ignores,
+        );
+    }
+
+    let compiled_per_file_ignores = CompiledPerFileIgnoreList::resolve(
+        project_root.canonical_root.clone(),
+        per_file_ignores.clone(),
+    )?;
+    let effective = EffectiveCheckSettings::new(enabled_rules, &per_file_ignores);
+
+    Ok(ResolvedCheckSettings {
+        linter_settings: LinterSettings {
+            rules: enabled_rules,
+            per_file_ignores: Arc::new(compiled_per_file_ignores),
+            ..LinterSettings::default()
+        },
+        fixable_rules,
+        effective,
+    })
+}
+
+fn parse_lint_config_layer(lint: &LintConfig) -> Result<RuleSelectionLayer> {
+    Ok(RuleSelectionLayer {
+        select: lint
+            .select
+            .as_ref()
+            .map(|selectors| parse_rule_selectors(selectors, "lint.select"))
+            .transpose()?,
+        ignore: lint
+            .ignore
+            .as_ref()
+            .map(|selectors| parse_rule_selectors(selectors, "lint.ignore"))
+            .transpose()?
+            .unwrap_or_default(),
+        extend_select: lint
+            .extend_select
+            .as_ref()
+            .map(|selectors| parse_rule_selectors(selectors, "lint.extend-select"))
+            .transpose()?
+            .unwrap_or_default(),
+        per_file_ignores: lint
+            .per_file_ignores
+            .as_ref()
+            .map(|patterns| parse_per_file_ignore_map(patterns, "lint.per-file-ignores"))
+            .transpose()?,
+        extend_per_file_ignores: lint
+            .extend_per_file_ignores
+            .as_ref()
+            .map(|patterns| parse_per_file_ignore_map(patterns, "lint.extend-per-file-ignores"))
+            .transpose()?
+            .unwrap_or_default(),
+        fixable: lint
+            .fixable
+            .as_ref()
+            .map(|selectors| parse_rule_selectors(selectors, "lint.fixable"))
+            .transpose()?,
+        unfixable: lint
+            .unfixable
+            .as_ref()
+            .map(|selectors| parse_rule_selectors(selectors, "lint.unfixable"))
+            .transpose()?
+            .unwrap_or_default(),
+        extend_fixable: lint
+            .extend_fixable
+            .as_ref()
+            .map(|selectors| parse_rule_selectors(selectors, "lint.extend-fixable"))
+            .transpose()?
+            .unwrap_or_default(),
+    })
+}
+
+fn parse_cli_rule_selection_layer(args: &RuleSelectionArgs) -> RuleSelectionLayer {
+    RuleSelectionLayer {
+        select: args.select.clone(),
+        ignore: args.ignore.clone(),
+        extend_select: args.extend_select.clone(),
+        per_file_ignores: args
+            .per_file_ignores
+            .as_ref()
+            .map(|pairs| group_per_file_ignore_pairs(pairs)),
+        extend_per_file_ignores: group_per_file_ignore_pairs(&args.extend_per_file_ignores),
+        fixable: args.fixable.clone(),
+        unfixable: args.unfixable.clone(),
+        extend_fixable: args.extend_fixable.clone(),
+    }
+}
+
+fn parse_rule_selectors(selectors: &[String], scope: &str) -> Result<Vec<RuleSelector>> {
+    selectors
+        .iter()
+        .map(|selector| {
+            selector
+                .parse::<RuleSelector>()
+                .map_err(|err| anyhow!("invalid {scope} selector `{selector}`: {err}"))
+        })
+        .collect()
+}
+
+fn parse_per_file_ignore_map(
+    patterns: &BTreeMap<String, Vec<String>>,
+    scope: &str,
+) -> Result<Vec<PerFileIgnoreSpec>> {
+    patterns
+        .iter()
+        .map(|(pattern, selectors)| {
+            Ok(PerFileIgnoreSpec {
+                pattern: pattern.clone(),
+                selectors: parse_rule_selectors(selectors, scope)?,
+            })
+        })
+        .collect()
+}
+
+fn group_per_file_ignore_pairs(pairs: &[PatternRuleSelectorPair]) -> Vec<PerFileIgnoreSpec> {
+    let mut grouped = BTreeMap::<String, Vec<RuleSelector>>::new();
+    for pair in pairs {
+        grouped
+            .entry(pair.pattern.clone())
+            .or_default()
+            .push(pair.selector.clone());
+    }
+
+    grouped
+        .into_iter()
+        .map(|(pattern, selectors)| PerFileIgnoreSpec { pattern, selectors })
+        .collect()
+}
+
+fn apply_rule_selector_layer(
+    current: RuleSet,
+    select: Option<&[RuleSelector]>,
+    extend_select: &[RuleSelector],
+    ignore: &[RuleSelector],
+) -> RuleSet {
+    let mut specificities = select
+        .into_iter()
+        .flatten()
+        .chain(extend_select.iter())
+        .chain(ignore.iter())
+        .map(selector_specificity)
+        .collect::<Vec<_>>();
+    specificities.sort_unstable();
+    specificities.dedup();
+
+    let mut updates = HashMap::<Rule, bool>::new();
+    for specificity in specificities {
+        for selector in select
+            .into_iter()
+            .flatten()
+            .chain(extend_select.iter())
+            .filter(|selector| selector_specificity(selector) == specificity)
+        {
+            for rule in selector.into_rule_set().iter() {
+                updates.insert(rule, true);
+            }
+        }
+        for selector in ignore
+            .iter()
+            .filter(|selector| selector_specificity(selector) == specificity)
+        {
+            for rule in selector.into_rule_set().iter() {
+                updates.insert(rule, false);
+            }
+        }
+    }
+
+    if select.is_some() {
+        updates
+            .into_iter()
+            .filter_map(|(rule, enabled)| enabled.then_some(rule))
+            .collect()
+    } else {
+        let mut rules = current;
+        for (rule, enabled) in updates {
+            rules.set(rule, enabled);
+        }
+        rules
+    }
+}
+
+fn selector_specificity(selector: &RuleSelector) -> usize {
+    match selector {
+        RuleSelector::All => 0,
+        RuleSelector::Category(_) => 1,
+        RuleSelector::Prefix(prefix) => 2 + prefix.len(),
+        RuleSelector::Rule(_) => usize::MAX,
+    }
+}
+
+fn apply_per_file_ignore_layer(
+    current: Vec<PerFileIgnore>,
+    per_file_ignores: Option<Vec<PerFileIgnoreSpec>>,
+    extend_per_file_ignores: Vec<PerFileIgnoreSpec>,
+) -> Vec<PerFileIgnore> {
+    let mut per_file_ignores = per_file_ignores
+        .map(|per_file_ignores| {
+            per_file_ignores
+                .into_iter()
+                .map(PerFileIgnoreSpec::into_ignore)
+                .collect()
+        })
+        .unwrap_or(current);
+    per_file_ignores.extend(
+        extend_per_file_ignores
+            .into_iter()
+            .map(PerFileIgnoreSpec::into_ignore),
+    );
+    per_file_ignores
+}
 fn run_check_with_cwd(
     args: &CheckCommand,
     config_arguments: &ConfigArguments,
@@ -554,8 +874,7 @@ fn run_check_with_cwd(
 ) -> Result<CheckReport> {
     let include_source = matches!(args.output_format, crate::args::CheckOutputFormatArg::Full);
     let fix_applicability = requested_fix_applicability(args);
-    let settings = EffectiveCheckSettings::default();
-    let runs = prepare_project_runs::<CheckCacheData, EffectiveCheckSettings, _>(
+    let runs = prepare_project_runs::<CheckCacheData, ResolvedCheckSettings, _>(
         &args.paths,
         cwd,
         &DiscoveryOptions {
@@ -570,9 +889,10 @@ fn run_check_with_cwd(
         cache_root,
         args.no_cache || fix_applicability.is_some(),
         b"project-cache-key",
-        |_| Ok(settings.clone()),
+        |project_root| {
+            resolve_project_check_settings(project_root, config_arguments, &args.rule_selection)
+        },
     )?;
-    let base_linter_settings = LinterSettings::default();
     let shellcheck_map = ShellCheckCodeMap::default();
 
     let mut report = CheckReport::default();
@@ -583,6 +903,7 @@ fn run_check_with_cwd(
             .iter()
             .map(|file| file.absolute_path.clone())
             .collect::<Vec<_>>();
+        let project_settings = run.settings.clone();
         let pending = run.take_pending_files(|file, cached| {
             report.cache_hits += 1;
             match cached {
@@ -618,12 +939,14 @@ fn run_check_with_cwd(
             .map(|pending| {
                 analyze_file(
                     pending,
-                    &base_linter_settings
+                    &project_settings
+                        .linter_settings
                         .clone()
                         .with_analyzed_paths(analyzed_paths.clone()),
                     &shellcheck_map,
                     include_source,
                     fix_applicability,
+                    &project_settings.fixable_rules,
                 )
             })
             .collect::<Vec<_>>();
@@ -664,8 +987,7 @@ fn run_add_ignore_with_cwd(
     reason: Option<&str>,
 ) -> Result<AddIgnoreReport> {
     let include_source = matches!(args.output_format, crate::args::CheckOutputFormatArg::Full);
-    let settings = EffectiveCheckSettings::default();
-    let runs = prepare_project_runs::<CheckCacheData, EffectiveCheckSettings, _>(
+    let runs = prepare_project_runs::<CheckCacheData, ResolvedCheckSettings, _>(
         &args.paths,
         cwd,
         &DiscoveryOptions {
@@ -680,9 +1002,10 @@ fn run_add_ignore_with_cwd(
         cache_root,
         true,
         b"project-cache-key",
-        |_| Ok(settings.clone()),
+        |project_root| {
+            resolve_project_check_settings(project_root, config_arguments, &args.rule_selection)
+        },
     )?;
-    let base_linter_settings = LinterSettings::default();
 
     let mut report = AddIgnoreReport::default();
 
@@ -692,7 +1015,9 @@ fn run_add_ignore_with_cwd(
             .iter()
             .map(|file| file.absolute_path.clone())
             .collect::<Vec<_>>();
-        let linter_settings = base_linter_settings
+        let linter_settings = run
+            .settings
+            .linter_settings
             .clone()
             .with_analyzed_paths(analyzed_paths);
 
@@ -749,6 +1074,7 @@ pub(crate) fn benchmark_check_paths(
             output_format,
             watch: false,
             paths: paths.to_vec(),
+            rule_selection: RuleSelectionArgs::default(),
             file_selection: FileSelectionArgs::default(),
             exit_zero: false,
             exit_non_zero_on_fix: false,
@@ -767,6 +1093,7 @@ fn analyze_file(
     shellcheck_map: &ShellCheckCodeMap,
     include_source: bool,
     fix_applicability: Option<Applicability>,
+    fixable_rules: &RuleSet,
 ) -> Result<FileCheckResult> {
     let mut source = read_shared_source(&pending.file.absolute_path)?;
     let inferred_shell = ShellDialect::infer(&source, Some(&pending.file.absolute_path));
@@ -791,7 +1118,12 @@ fn analyze_file(
     let mut fixes_applied = 0;
 
     if let Some(applicability) = fix_applicability {
-        let applied = shuck_linter::apply_fixes(&source, &diagnostics, applicability);
+        let fixable_diagnostics = diagnostics
+            .iter()
+            .filter(|diagnostic| fixable_rules.contains(diagnostic.rule))
+            .cloned()
+            .collect::<Vec<_>>();
+        let applied = shuck_linter::apply_fixes(&source, &fixable_diagnostics, applicability);
         if applied.fixes_applied > 0 {
             source = Arc::<str>::from(applied.code);
             fs::write(&pending.file.absolute_path, &*source)?;
@@ -971,10 +1303,11 @@ mod tests {
     use std::sync::Arc;
 
     use notify::event::{CreateKind, EventAttributes, ModifyKind, RemoveKind, RenameMode};
+    use shuck_linter::{Rule, RuleSelector};
     use tempfile::tempdir;
 
     use super::*;
-    use crate::args::CheckOutputFormatArg;
+    use crate::args::{CheckOutputFormatArg, PatternRuleSelectorPair, RuleSelectionArgs};
     use crate::config::ConfigArguments;
 
     fn pending_project_file(path: &Path, project_root: &Path) -> PendingProjectFile {
@@ -1025,6 +1358,7 @@ mod tests {
             output_format,
             watch: false,
             paths: Vec::new(),
+            rule_selection: RuleSelectionArgs::default(),
             file_selection: FileSelectionArgs::default(),
             exit_zero: false,
             exit_non_zero_on_fix: false,
@@ -1033,6 +1367,17 @@ mod tests {
 
     fn check_args(no_cache: bool) -> CheckCommand {
         check_args_with_format(no_cache, CheckOutputFormatArg::Full)
+    }
+
+    fn diagnostic_codes(report: &CheckReport) -> Vec<String> {
+        report
+            .diagnostics
+            .iter()
+            .filter_map(|diagnostic| match &diagnostic.kind {
+                DisplayedDiagnosticKind::Lint { code, .. } => Some(code.clone()),
+                DisplayedDiagnosticKind::ParseError => None,
+            })
+            .collect()
     }
 
     #[test]
@@ -1146,6 +1491,173 @@ mod tests {
     }
 
     #[test]
+    fn select_replaces_default_rules() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("script.sh"),
+            "#!/bin/sh\nunused=1\nread\n",
+        )
+        .unwrap();
+
+        let mut args = check_args(true);
+        args.rule_selection = RuleSelectionArgs {
+            select: Some(vec![RuleSelector::Rule(Rule::BareRead)]),
+            ..RuleSelectionArgs::default()
+        };
+
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            diagnostic_codes(&report),
+            vec![Rule::BareRead.code().to_owned()]
+        );
+    }
+
+    #[test]
+    fn extend_select_adds_on_top_of_config_selection() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nselect = ['C001']\n",
+        )
+        .unwrap();
+        fs::write(
+            tempdir.path().join("script.sh"),
+            "#!/bin/sh\nunused=1\nread\n",
+        )
+        .unwrap();
+
+        let mut args = check_args(true);
+        args.rule_selection = RuleSelectionArgs {
+            extend_select: vec![RuleSelector::Rule(Rule::BareRead)],
+            ..RuleSelectionArgs::default()
+        };
+
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        let mut codes = diagnostic_codes(&report);
+        codes.sort();
+        assert_eq!(
+            codes,
+            vec![
+                Rule::UnusedAssignment.code().to_owned(),
+                Rule::BareRead.code().to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignore_can_trigger_parse_error_fallback() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("broken.sh"),
+            "#!/bin/sh\nif true; then\n  :\n",
+        )
+        .unwrap();
+
+        let mut args = check_args(true);
+        args.rule_selection = RuleSelectionArgs {
+            ignore: vec![RuleSelector::Rule(Rule::MissingFi)],
+            ..RuleSelectionArgs::default()
+        };
+
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert_eq!(report.diagnostics.len(), 1);
+        assert!(matches!(
+            report.diagnostics[0].kind,
+            DisplayedDiagnosticKind::ParseError
+        ));
+    }
+
+    #[test]
+    fn per_file_ignores_suppress_matching_rules_only() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("ignored.sh"),
+            "#!/bin/bash\nunused=1\necho ok\n",
+        )
+        .unwrap();
+        fs::write(
+            tempdir.path().join("kept.sh"),
+            "#!/bin/bash\nunused=1\necho ok\n",
+        )
+        .unwrap();
+
+        let mut args = check_args(true);
+        args.rule_selection = RuleSelectionArgs {
+            per_file_ignores: Some(vec![PatternRuleSelectorPair {
+                pattern: "ignored.sh".to_owned(),
+                selector: RuleSelector::Rule(Rule::UnusedAssignment),
+            }]),
+            ..RuleSelectionArgs::default()
+        };
+
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(report.diagnostics[0].path, PathBuf::from("kept.sh"));
+        assert_eq!(
+            diagnostic_codes(&report),
+            vec![Rule::UnusedAssignment.code().to_owned()]
+        );
+    }
+
+    #[test]
+    fn unfixable_rules_prevent_fix_application() {
+        let tempdir = tempdir().unwrap();
+        let script = tempdir.path().join("warn.sh");
+        let source = "#!/bin/bash\nprintf '%s\\n' x &;\n";
+        fs::write(&script, source).unwrap();
+
+        let mut args = check_args(true);
+        args.fix = true;
+        args.rule_selection = RuleSelectionArgs {
+            unfixable: vec![RuleSelector::Rule(Rule::AmpersandSemicolon)],
+            ..RuleSelectionArgs::default()
+        };
+
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert_eq!(report.fixes_applied, 0);
+        assert_eq!(fs::read_to_string(script).unwrap(), source);
+        assert_eq!(
+            diagnostic_codes(&report),
+            vec![Rule::AmpersandSemicolon.code().to_owned()]
+        );
+    }
+
+    #[test]
     fn reports_missing_fi_as_parse_error_when_parse_rule_is_disabled() {
         let tempdir = tempdir().unwrap();
         let broken_path = tempdir.path().join("broken.sh");
@@ -1158,6 +1670,7 @@ mod tests {
             &ShellCheckCodeMap::default(),
             false,
             None,
+            &RuleSet::all(),
         )
         .unwrap();
 

--- a/crates/shuck/src/config.rs
+++ b/crates/shuck/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;
 use std::io;
@@ -14,7 +15,7 @@ use crate::format_settings::{FormatSettingsPatch, parse_config_indent_style};
 
 const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
 pub(crate) const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
-const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["format"];
+const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["format", "lint"];
 const CONFIG_OVERRIDE_FORMAT_KEYS: &[&str] = &[
     "dialect",
     "indent-style",
@@ -26,11 +27,22 @@ const CONFIG_OVERRIDE_FORMAT_KEYS: &[&str] = &[
     "function-next-line",
     "never-split",
 ];
+const CONFIG_OVERRIDE_LINT_KEYS: &[&str] = &[
+    "select",
+    "ignore",
+    "extend-select",
+    "per-file-ignores",
+    "extend-per-file-ignores",
+    "fixable",
+    "unfixable",
+    "extend-fixable",
+];
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
 pub(crate) struct ShuckConfig {
     pub format: FormatConfig,
+    pub lint: LintConfig,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
@@ -45,6 +57,19 @@ pub(crate) struct FormatConfig {
     pub keep_padding: Option<bool>,
     pub function_next_line: Option<bool>,
     pub never_split: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub(crate) struct LintConfig {
+    pub select: Option<Vec<String>>,
+    pub ignore: Option<Vec<String>>,
+    pub extend_select: Option<Vec<String>>,
+    pub per_file_ignores: Option<BTreeMap<String, Vec<String>>>,
+    pub extend_per_file_ignores: Option<BTreeMap<String, Vec<String>>>,
+    pub fixable: Option<Vec<String>>,
+    pub unfixable: Option<Vec<String>>,
+    pub extend_fixable: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -65,7 +90,7 @@ impl ConfigArguments {
         for option in config_options {
             match option {
                 SingleConfigArgument::SettingsOverride(config_override) => {
-                    overrides.apply_overrides(config_override);
+                    overrides.apply_overrides(*config_override);
                 }
                 SingleConfigArgument::FilePath(path) => {
                     if isolated {
@@ -124,7 +149,7 @@ You cannot specify more than one configuration file on the command line.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum SingleConfigArgument {
     FilePath(PathBuf),
-    SettingsOverride(ShuckConfig),
+    SettingsOverride(Box<ShuckConfig>),
 }
 
 #[derive(Clone)]
@@ -157,6 +182,7 @@ impl TypedValueParser for ConfigArgumentParser {
         };
 
         parse_config_override(value)
+            .map(Box::new)
             .map(SingleConfigArgument::SettingsOverride)
             .map_err(|detail| invalid_config_argument(cmd, arg, value, &detail))
     }
@@ -238,6 +264,7 @@ impl FormatConfig {
 impl ShuckConfig {
     fn apply_overrides(&mut self, overrides: ShuckConfig) {
         self.format.apply_overrides(overrides.format);
+        self.lint.apply_overrides(overrides.lint);
     }
 }
 
@@ -273,6 +300,35 @@ impl FormatConfig {
     }
 }
 
+impl LintConfig {
+    fn apply_overrides(&mut self, overrides: LintConfig) {
+        if overrides.select.is_some() {
+            self.select = overrides.select;
+        }
+        if overrides.ignore.is_some() {
+            self.ignore = overrides.ignore;
+        }
+        if overrides.extend_select.is_some() {
+            self.extend_select = overrides.extend_select;
+        }
+        if overrides.per_file_ignores.is_some() {
+            self.per_file_ignores = overrides.per_file_ignores;
+        }
+        if overrides.extend_per_file_ignores.is_some() {
+            self.extend_per_file_ignores = overrides.extend_per_file_ignores;
+        }
+        if overrides.fixable.is_some() {
+            self.fixable = overrides.fixable;
+        }
+        if overrides.unfixable.is_some() {
+            self.unfixable = overrides.unfixable;
+        }
+        if overrides.extend_fixable.is_some() {
+            self.extend_fixable = overrides.extend_fixable;
+        }
+    }
+}
+
 fn load_config_file(config_path: &Path) -> Result<ShuckConfig> {
     let source = fs::read_to_string(config_path)
         .with_context(|| format!("read {}", config_path.display()))?;
@@ -304,6 +360,20 @@ fn validate_override_table(table: &toml::Table) -> std::result::Result<(), Strin
                 return Err(format!(
                     "unsupported `[format]` option `{key}`; expected one of: {}",
                     CONFIG_OVERRIDE_FORMAT_KEYS.join(", ")
+                ));
+            }
+        }
+    }
+
+    if let Some(lint_value) = table.get("lint") {
+        let lint = lint_value
+            .as_table()
+            .ok_or_else(|| "`lint` must be a TOML table".to_owned())?;
+        for key in lint.keys() {
+            if !CONFIG_OVERRIDE_LINT_KEYS.contains(&key.as_str()) {
+                return Err(format!(
+                    "unsupported `[lint]` option `{key}`; expected one of: {}",
+                    CONFIG_OVERRIDE_LINT_KEYS.join(", ")
                 ));
             }
         }
@@ -444,16 +514,28 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_lint_keys() {
+        let config = parse_config_override("lint.select = ['C001']").unwrap();
+        assert_eq!(config.lint.select, Some(vec!["C001".to_owned()]));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_lint_keys() {
+        let err = parse_config_override("lint.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint]` option `preview`"));
+    }
+
+    #[test]
     fn config_arguments_allow_multiple_inline_overrides_with_last_one_winning() {
         let tempdir = tempdir().unwrap();
         let config = ConfigArguments::from_cli(
             vec![
-                SingleConfigArgument::SettingsOverride(
+                SingleConfigArgument::SettingsOverride(Box::new(
                     parse_config_override("format.indent-width = 2").unwrap(),
-                ),
-                SingleConfigArgument::SettingsOverride(
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
                     parse_config_override("format.indent-width = 4").unwrap(),
-                ),
+                )),
             ],
             false,
         )
@@ -461,6 +543,26 @@ mod tests {
 
         let loaded = load_project_config(tempdir.path(), &config).unwrap();
         assert_eq!(loaded.format.indent_width, Some(4));
+    }
+
+    #[test]
+    fn lint_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.select = ['C001']").unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.select = ['C002']").unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(loaded.lint.select, Some(vec!["C002".to_owned()]));
     }
 
     #[test]
@@ -506,9 +608,9 @@ mod tests {
         .unwrap();
 
         let config = ConfigArguments::from_cli(
-            vec![SingleConfigArgument::SettingsOverride(
+            vec![SingleConfigArgument::SettingsOverride(Box::new(
                 parse_config_override("format.indent-width = 2").unwrap(),
-            )],
+            ))],
             true,
         )
         .unwrap();

--- a/crates/shuck/src/shellcheck_compat/mod.rs
+++ b/crates/shuck/src/shellcheck_compat/mod.rs
@@ -915,6 +915,7 @@ fn lint_with_context(
         severity_overrides: Default::default(),
         shell,
         analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
+        per_file_ignores: Default::default(),
     };
 
     let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result(

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -178,6 +178,27 @@ fn check_help_shows_file_selection_options() {
 }
 
 #[test]
+fn check_help_shows_rule_selection_options() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.args(["check", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Rule selection"))
+        .stdout(predicate::str::contains("--select <RULE_CODE>"))
+        .stdout(predicate::str::contains("--ignore <RULE_CODE>"))
+        .stdout(predicate::str::contains("--extend-select <RULE_CODE>"))
+        .stdout(predicate::str::contains(
+            "--per-file-ignores <PER_FILE_IGNORES>",
+        ))
+        .stdout(predicate::str::contains(
+            "--extend-per-file-ignores <EXTEND_PER_FILE_IGNORES>",
+        ))
+        .stdout(predicate::str::contains("--fixable <RULE_CODE>"))
+        .stdout(predicate::str::contains("--unfixable <RULE_CODE>"))
+        .stdout(predicate::str::contains("--extend-fixable <RULE_CODE>"));
+}
+
+#[test]
 fn format_help_shows_file_selection_options() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     enable_experimental(&mut cmd);
@@ -308,6 +329,88 @@ fn check_unsafe_fixes_applies_safe_s074_fix() {
         fs::read_to_string(script).unwrap(),
         "#!/bin/bash\nprintf '%s\\n' x &\n"
     );
+}
+
+#[test]
+fn check_cli_select_replaces_config_selection() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[lint]\nselect = ['C001']\n",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("script.sh"),
+        "#!/bin/sh\nunused=1\nread\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path()).args([
+        "check",
+        "--select",
+        "S036",
+        "--output-format",
+        "concise",
+    ]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("warning[S036]"))
+        .stdout(predicate::str::contains("warning[C001]").not());
+}
+
+#[test]
+fn check_per_file_ignores_skip_matching_files() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("ignored.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("kept.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path()).args([
+        "check",
+        "--per-file-ignores",
+        "ignored.sh:C001",
+        "--output-format",
+        "concise",
+    ]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("kept.sh:2:1: warning[C001]"))
+        .stdout(predicate::str::contains("ignored.sh:").not());
+}
+
+#[test]
+fn check_unfixable_prevents_fixing_matching_rules() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    let source = "#!/bin/bash\nprintf '%s\\n' x &;\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path()).args([
+        "check",
+        "--fix",
+        "--unfixable",
+        "S074",
+        "--output-format",
+        "concise",
+    ]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("warning[S074]"));
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Ruff-style rule selection flags to `shuck check`, including selector, per-file-ignore, and fixability controls
- add matching root-level `[lint]` config support and inline `--config "lint.* = ..."` overrides
- resolve rule selection per project root and reuse the resolved settings for normal linting, `--add-ignore`, caching, and fix filtering

## Testing
- cargo test -p shuck -- --nocapture