### PR TITLE
Document ShellCheck compatibility mode in website docs

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { flattenNav, docsNavigation } from "@/app/lib/docs-navigation";
 // Map of slug paths to their MDX imports
 const pages: Record<string, () => Promise<{ default: React.ComponentType; metadata?: { title?: string; description?: string } }>> = {
   "getting-started": () => import("@/content/getting-started/index.mdx"),
+  "shellcheck-compat": () => import("@/content/shellcheck-compat/index.mdx"),
   "performance/benchmarks": () => import("@/content/performance/benchmarks"),
 };
 

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -9,6 +9,7 @@ export const docsNavigation: NavItem[] = [
     title: "Getting Started",
     items: [
       { title: "Overview", href: "/docs/getting-started" },
+      { title: "ShellCheck Compatibility", href: "/docs/shellcheck-compat" },
     ],
   },
   {

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -5,6 +5,7 @@ An extremely fast shell script linter, written in Rust.
 - ⚡ 20x faster than ShellCheck, with built-in caching for incremental runs
 - 🐚 Multi-dialect support for bash, sh/POSIX, dash, ksh, mksh, and zsh
 - 🤝 ShellCheck suppression compatibility (`# shellcheck disable=SC2086` just works)
+- 🔄 ShellCheck CLI compatibility mode for existing editor, CI, and local workflows
 - 🔧 Fix support, for automatic error correction (`--fix` and `--unsafe-fixes`)
 - 📏 Rules across correctness, style, performance, and portability categories
 - 💾 Per-file caching to avoid re-analyzing unchanged files
@@ -39,3 +40,9 @@ echo 'echo $foo' | shuck check -
 # Apply safe fixes automatically
 shuck check --fix .
 ```
+
+## ShellCheck compatibility mode
+
+If you already have tools that invoke `shellcheck`, Shuck can expose a ShellCheck-shaped CLI without changing your primary workflow all at once.
+
+See the dedicated [ShellCheck compatibility guide](/docs/shellcheck-compat) for activation, supported flags, `.shellcheckrc` handling, and current caveats.

--- a/website/content/shellcheck-compat/index.mdx
+++ b/website/content/shellcheck-compat/index.mdx
@@ -1,0 +1,71 @@
+# ShellCheck Compatibility
+
+Shuck can expose a ShellCheck-shaped CLI for teams that want to migrate existing editor integrations, CI jobs, or local workflows without changing every call site at once.
+
+This mode is powered by Shuck's parser and linter, not by embedding ShellCheck itself. That means the interface is intentionally familiar, while the implementation continues to evolve with the rest of Shuck.
+
+## Activate compatibility mode
+
+There are two supported ways to turn the compatibility surface on:
+
+1. Invoke the binary as `shellcheck`.
+2. Set `SHUCK_SHELLCHECK_COMPAT=1` before running `shuck`.
+
+```bash
+# Make shuck available as `shellcheck`
+ln -s "$(command -v shuck)" ~/bin/shellcheck
+shellcheck --version
+
+# Or force compat mode for a single command
+SHUCK_SHELLCHECK_COMPAT=1 shuck --version
+```
+
+Compat mode only affects that invocation. Running `shuck check ...` directly still uses Shuck's native CLI.
+
+## What it supports today
+
+The compatibility surface currently covers the pieces that are most useful for migration:
+
+- Familiar `--help` and `--version` output
+- Common output formats: `tty`, `json`, `json1`, `checkstyle`, `gcc`, `diff`, and `quiet`
+- ShellCheck-style code filtering with `--include` and `--exclude`
+- Severity filtering with `--severity`
+- Source resolution controls like `--check-sourced`, `--external-sources`, and `--source-path`
+- Shell overrides for `sh`, `bash`, `dash`, `ksh`, and `busybox`
+- Optional-check discovery with `--list-optional`
+- Standard stdin usage with `-` as the input path
+
+```bash
+# Machine-readable output for editor tooling or CI
+SHUCK_SHELLCHECK_COMPAT=1 shuck -f json1 script.sh
+
+# Only keep selected SC codes
+SHUCK_SHELLCHECK_COMPAT=1 shuck --include=SC2086,SC2154 script.sh
+
+# Follow sourced files and add extra lookup roots
+SHUCK_SHELLCHECK_COMPAT=1 shuck -a -P scripts:lib main.sh
+```
+
+## `.shellcheckrc` support
+
+Compat mode searches for `.shellcheckrc` from the current working directory upward. You can keep the default search, skip it with `--norc`, or point at a specific file with `--rcfile`.
+
+Supported config keys today are `check-sourced`, `color`, `disable`, `enable`, `extended-analysis`, `external-sources`, `format`, `include`, `severity`, `shell`, `source-path`, and `wiki-link-count`.
+
+```bash
+# Use the nearest .shellcheckrc
+shellcheck script.sh
+
+# Ignore discovered config
+shellcheck --norc script.sh
+
+# Use an explicit config file
+shellcheck --rcfile ci/shellcheckrc script.sh
+```
+
+## Migration notes
+
+- Exit status follows the usual ShellCheck shape: `0` for no diagnostics, `1` when diagnostics are reported, and `2` for file or runtime errors.
+- Diagnostic codes, suppressions, and filters use `SCxxxx` identifiers, so existing `# shellcheck disable=...` comments continue to work.
+- `--list-optional` is available, but not every named optional check is implemented yet. Treat that catalog as a compatibility target rather than a guarantee that every check can already be enabled.
+- If you want Shuck-only features such as the native multi-dialect workflow or automatic fixes, use the regular [`shuck check` docs](/docs/getting-started) instead of the compatibility surface.


### PR DESCRIPTION
## Summary
- add a dedicated website docs page for ShellCheck compatibility mode
- link the new page from the getting started docs and docs sidebar
- register the route in the docs page loader so `/docs/shellcheck-compat` renders

## Why
The ShellCheck compatibility mode landed in `014a3f1e`, but the website did not explain how to activate it, what flags and config surface it supports today, or how teams should think about migrating existing ShellCheck-based workflows.

## Validation
- `pnpm build` (in `website/`)
