### PR TITLE
Expand ShellCheck compatibility parity

### DIFF
--- a/crates/shuck/src/shellcheck_compat/mod.rs
+++ b/crates/shuck/src/shellcheck_compat/mod.rs
@@ -26,6 +26,7 @@ use self::optional::{OPTIONAL_CHECKS, find_optional_check};
 use self::render::{
     print_error_help, print_list_optional, print_report, print_version, usage_text,
 };
+use crate::shellcheck_runtime::{ShellCheckFix, ShellCheckReplacement};
 use crate::stdin::read_from_stdin;
 
 const COMPAT_ENV_VAR: &str = "SHUCK_SHELLCHECK_COMPAT";
@@ -154,6 +155,15 @@ impl CompatLevel {
             Self::Error => "error",
             Self::Warning => "warning",
             Self::Info | Self::Style => "note",
+        }
+    }
+
+    const fn sort_rank(self) -> u8 {
+        match self {
+            Self::Error => 0,
+            Self::Warning => 1,
+            Self::Info => 2,
+            Self::Style => 3,
         }
     }
 }
@@ -323,6 +333,7 @@ struct CompatDiagnostic {
     level: CompatLevel,
     code: u32,
     message: String,
+    fix: Option<ShellCheckFix>,
     source: Option<Arc<str>>,
 }
 
@@ -663,15 +674,12 @@ fn resolve_rule_selection(
     let mut requested_optional = config.enable_checks.clone();
     requested_optional.extend(cli.enable_checks.clone());
     if !requested_optional.is_empty() {
-        let mut unsupported = Vec::new();
         for name in requested_optional {
             if name == "all" {
-                unsupported.extend(
-                    OPTIONAL_CHECKS
-                        .iter()
-                        .filter(|check| !check.supported)
-                        .map(|check| check.name.to_owned()),
-                );
+                for check in OPTIONAL_CHECKS.iter().filter(|check| check.supported) {
+                    let optional_rules = check.rules.iter().copied().collect::<RuleSet>();
+                    rules = rules.union(&optional_rules);
+                }
                 continue;
             }
 
@@ -682,24 +690,11 @@ fn resolve_rule_selection(
                 ));
             };
             if !check.supported {
-                unsupported.push(name);
                 continue;
             }
 
             let optional_rules = check.rules.iter().copied().collect::<RuleSet>();
             rules = rules.union(&optional_rules);
-        }
-
-        if !unsupported.is_empty() {
-            unsupported.sort();
-            unsupported.dedup();
-            return Err(CompatCliError::usage(
-                4,
-                format!(
-                    "the requested optional checks are not implemented by this shellcheck compatibility mode: {}",
-                    unsupported.join(", ")
-                ),
-            ));
         }
     }
 
@@ -779,8 +774,9 @@ fn analyze_files(options: &CompatOptions, cwd: &Path) -> Result<CompatReport, Co
             .cmp(&right.file)
             .then(left.line.cmp(&right.line))
             .then(left.column.cmp(&right.column))
-            .then(left.code.cmp(&right.code))
-            .then(left.message.cmp(&right.message))
+            .then(left.end_line.cmp(&right.end_line))
+            .then(left.end_column.cmp(&right.end_column))
+            .then(left.level.sort_rank().cmp(&right.level.sort_rank()))
     });
 
     Ok(CompatReport {
@@ -1023,6 +1019,13 @@ fn map_diagnostic(
 ) -> Option<CompatDiagnostic> {
     let code = shellcheck_map.code_for_rule(diagnostic.rule)?;
     let level = level_for_diagnostic(diagnostic.rule, diagnostic.severity, code);
+    let fix = compat_fix_for_diagnostic(
+        code,
+        diagnostic.span.start.line,
+        diagnostic.span.start.column,
+        diagnostic.span.end.line,
+        diagnostic.span.end.column,
+    );
     threshold.allows(level).then(|| CompatDiagnostic {
         file: display_path(path, cwd),
         line: diagnostic.span.start.line,
@@ -1032,7 +1035,39 @@ fn map_diagnostic(
         level,
         code,
         message: diagnostic.message,
+        fix,
         source: Some(source),
+    })
+}
+
+fn compat_fix_for_diagnostic(
+    code: u32,
+    start_line: usize,
+    start_column: usize,
+    end_line: usize,
+    end_column: usize,
+) -> Option<ShellCheckFix> {
+    (code == 2086).then(|| ShellCheckFix {
+        replacements: vec![
+            ShellCheckReplacement {
+                line: start_line,
+                end_line: start_line,
+                column: start_column,
+                end_column: start_column,
+                precedence: 7,
+                insertion_point: "afterEnd".to_owned(),
+                replacement: "\"".to_owned(),
+            },
+            ShellCheckReplacement {
+                line: end_line,
+                end_line,
+                column: end_column,
+                end_column,
+                precedence: 7,
+                insertion_point: "beforeStart".to_owned(),
+                replacement: "\"".to_owned(),
+            },
+        ],
     })
 }
 

--- a/crates/shuck/src/shellcheck_compat/render.rs
+++ b/crates/shuck/src/shellcheck_compat/render.rs
@@ -1,15 +1,17 @@
 use std::cmp::min;
+use std::collections::BTreeMap;
 use std::io::{self, ErrorKind, Write};
 
 use colored::Colorize;
 use serde::Serialize;
+use similar::TextDiff;
 
 use super::{
     CompatCliError, CompatDiagnostic, CompatFormat, CompatLevel, CompatOptions, CompatReport,
     use_color,
 };
 use crate::shellcheck_compat::optional::OptionalCheck;
-use crate::shellcheck_runtime::{ShellCheckDiagnostic, ShellCheckFix};
+use crate::shellcheck_runtime::ShellCheckDiagnostic;
 
 pub fn usage_text() -> String {
     [
@@ -74,6 +76,11 @@ pub fn print_report(report: &CompatReport, options: &CompatOptions) -> Result<()
         CompatFormat::Tty => render_tty(report, options),
     };
 
+    if options.format == CompatFormat::Diff && rendered == no_auto_fix_diff_message() {
+        let mut stderr = io::stderr().lock();
+        return write_rendered(&mut stderr, &rendered);
+    }
+
     let mut stdout = io::stdout().lock();
     write_rendered(&mut stdout, &rendered)
 }
@@ -90,7 +97,7 @@ fn write_rendered<W: Write>(writer: &mut W, rendered: &str) -> Result<(), Compat
 }
 
 fn render_checkstyle(report: &CompatReport) -> String {
-    let mut files = std::collections::BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
+    let mut files = BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
     for diagnostic in &report.diagnostics {
         files.entry(&diagnostic.file).or_default().push(diagnostic);
     }
@@ -116,31 +123,133 @@ fn render_checkstyle(report: &CompatReport) -> String {
 }
 
 fn render_diff(report: &CompatReport) -> String {
-    let mut files = std::collections::BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
+    if report.diagnostics.is_empty() {
+        return String::new();
+    }
+
+    struct FileDiffInput<'a> {
+        source: &'a str,
+        replacements: Vec<&'a crate::shellcheck_runtime::ShellCheckReplacement>,
+    }
+
+    let mut files = BTreeMap::<&str, FileDiffInput<'_>>::new();
     for diagnostic in &report.diagnostics {
-        files.entry(&diagnostic.file).or_default().push(diagnostic);
+        let Some(fix) = diagnostic.fix.as_ref() else {
+            continue;
+        };
+        let Some(source) = diagnostic.source.as_deref() else {
+            continue;
+        };
+        files
+            .entry(&diagnostic.file)
+            .and_modify(|entry| entry.replacements.extend(fix.replacements.iter()))
+            .or_insert_with(|| FileDiffInput {
+                source,
+                replacements: fix.replacements.iter().collect(),
+            });
+    }
+
+    if files.is_empty() {
+        return no_auto_fix_diff_message();
     }
 
     let mut output = String::new();
-    for (file, diagnostics) in files {
-        if diagnostics.is_empty() {
+    for (file, file_input) in files {
+        let Some(fixed_source) = apply_replacements(file_input.source, &file_input.replacements)
+        else {
+            continue;
+        };
+        if fixed_source == file_input.source {
             continue;
         }
-        if !output.is_empty() {
-            output.push('\n');
-        }
-        output.push_str(&format!("--- {file}\n+++ {file}\n"));
-        output.push_str("@@ compatibility mode @@\n");
-        for diagnostic in diagnostics {
-            output.push_str(&format!(
-                "# SC{:04} ({}) {}\n",
-                diagnostic.code,
-                diagnostic.level.as_str(),
-                diagnostic.message
-            ));
-        }
+
+        output.push_str(
+            &TextDiff::from_lines(file_input.source, &fixed_source)
+                .unified_diff()
+                .header(&format!("a/{file}"), &format!("b/{file}"))
+                .to_string(),
+        );
+        output.push('\n');
     }
+
+    if output.is_empty() {
+        return no_auto_fix_diff_message();
+    }
+
     output
+}
+
+fn no_auto_fix_diff_message() -> String {
+    "Issues were detected, but none were auto-fixable. Use another format to see them.\n".to_owned()
+}
+
+fn apply_replacements(
+    source: &str,
+    replacements: &[&crate::shellcheck_runtime::ShellCheckReplacement],
+) -> Option<String> {
+    let mut edits = replacements
+        .iter()
+        .map(|replacement| {
+            replacement_offset(source, replacement)
+                .map(|offset| (offset, replacement.replacement.as_str()))
+        })
+        .collect::<Option<Vec<_>>>()?;
+    edits.sort_by(|left, right| right.0.cmp(&left.0).then(right.1.cmp(left.1)));
+
+    let mut output = source.to_owned();
+    for (offset, replacement) in edits {
+        output.insert_str(offset, replacement);
+    }
+    Some(output)
+}
+
+fn replacement_offset(
+    source: &str,
+    replacement: &crate::shellcheck_runtime::ShellCheckReplacement,
+) -> Option<usize> {
+    match replacement.insertion_point.as_str() {
+        "beforeStart" => byte_offset_for_line_column(source, replacement.line, replacement.column),
+        "afterEnd" => {
+            byte_offset_for_line_column(source, replacement.end_line, replacement.end_column)
+        }
+        _ => None,
+    }
+}
+
+fn byte_offset_for_line_column(source: &str, line_number: usize, column: usize) -> Option<usize> {
+    if line_number == 0 {
+        return None;
+    }
+
+    let mut line_start = 0usize;
+    for (index, segment) in source.split_inclusive('\n').enumerate() {
+        if index + 1 == line_number {
+            let line = segment.strip_suffix('\n').unwrap_or(segment);
+            return byte_offset_in_line(line, column).map(|offset| line_start + offset);
+        }
+        line_start += segment.len();
+    }
+
+    if line_number == 1 && source.is_empty() {
+        return byte_offset_in_line("", column);
+    }
+
+    None
+}
+
+fn byte_offset_in_line(line: &str, column: usize) -> Option<usize> {
+    let target_chars = column.checked_sub(1)?;
+    let char_count = line.chars().count();
+    if target_chars > char_count {
+        return None;
+    }
+    if target_chars == char_count {
+        return Some(line.len());
+    }
+
+    line.char_indices()
+        .nth(target_chars)
+        .map(|(offset, _)| offset)
 }
 
 fn render_gcc(report: &CompatReport) -> String {
@@ -179,7 +288,7 @@ fn render_json1(report: &CompatReport) -> Result<String, CompatCliError> {
 fn render_tty(report: &CompatReport, options: &CompatOptions) -> String {
     let use_color = use_color(options.color);
     let mut output = String::new();
-    let mut grouped = std::collections::BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
+    let mut grouped = BTreeMap::<&str, Vec<&CompatDiagnostic>>::new();
     for diagnostic in &report.diagnostics {
         grouped
             .entry(&diagnostic.file)
@@ -192,7 +301,7 @@ fn render_tty(report: &CompatReport, options: &CompatOptions) -> String {
             continue;
         }
 
-        let mut by_line = std::collections::BTreeMap::<usize, Vec<&CompatDiagnostic>>::new();
+        let mut by_line = BTreeMap::<usize, Vec<&CompatDiagnostic>>::new();
         for diagnostic in diagnostics {
             by_line.entry(diagnostic.line).or_default().push(diagnostic);
         }
@@ -270,7 +379,7 @@ fn to_shellcheck_diagnostics(report: &CompatReport) -> Vec<ShellCheckDiagnostic>
             end_column: diagnostic.end_column.max(diagnostic.column),
             level: diagnostic.level.as_str().to_owned(),
             message: diagnostic.message.clone(),
-            fix: None::<ShellCheckFix>,
+            fix: diagnostic.fix.clone(),
         })
         .collect()
 }
@@ -281,9 +390,9 @@ fn collect_links(report: &CompatReport, count: usize) -> Vec<String> {
     }
 
     let mut links = Vec::new();
-    let mut seen = std::collections::BTreeSet::new();
+    let mut seen = BTreeMap::new();
     for diagnostic in &report.diagnostics {
-        if seen.insert(diagnostic.code) {
+        if seen.insert(diagnostic.code, ()).is_none() {
             links.push(format!(
                 "https://www.shellcheck.net/wiki/SC{:04} -- {}",
                 diagnostic.code,

--- a/crates/shuck/tests/oracle_shellcheck_cli.rs
+++ b/crates/shuck/tests/oracle_shellcheck_cli.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 use std::fs;
-use std::process::{Command, Output};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
 
 use serde_json::Value;
 use tempfile::tempdir;
@@ -29,6 +31,37 @@ fn run_compat(args: &[&str], cwd: &std::path::Path) -> Output {
         .unwrap()
 }
 
+fn run_with_stdin(mut command: Command, stdin: &str) -> Output {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn run_shellcheck_stdin(args: &[&str], cwd: &Path, stdin: &str) -> Output {
+    let mut command = Command::new("shellcheck");
+    command.args(args).current_dir(cwd);
+    run_with_stdin(command, stdin)
+}
+
+fn run_compat_stdin(args: &[&str], cwd: &Path, stdin: &str) -> Output {
+    let mut command = Command::new(assert_cmd::cargo::cargo_bin("shuck"));
+    command
+        .env("SHUCK_SHELLCHECK_COMPAT", "1")
+        .args(args)
+        .current_dir(cwd);
+    run_with_stdin(command, stdin)
+}
+
 fn json1_codes(output: &Output) -> BTreeSet<u64> {
     let value: Value = serde_json::from_slice(&output.stdout).unwrap();
     value["comments"]
@@ -37,6 +70,30 @@ fn json1_codes(output: &Output) -> BTreeSet<u64> {
         .iter()
         .filter_map(|entry| entry["code"].as_u64())
         .collect()
+}
+
+fn json1_comments(output: &Output) -> Vec<Value> {
+    serde_json::from_slice::<Value>(&output.stdout).unwrap()["comments"]
+        .as_array()
+        .unwrap()
+        .clone()
+}
+
+fn json1_comment_shapes(output: &Output) -> Vec<Value> {
+    json1_comments(output)
+        .into_iter()
+        .map(|mut comment| {
+            comment.as_object_mut().unwrap().remove("message");
+            comment
+        })
+        .collect()
+}
+
+fn comment_by_code<'a>(comments: &'a [Value], code: u64) -> &'a Value {
+    comments
+        .iter()
+        .find(|comment| comment["code"].as_u64() == Some(code))
+        .unwrap()
 }
 
 #[test]
@@ -78,6 +135,46 @@ fn oracle_option_acceptance_and_rejection_match_exit_codes() {
     let severity_sc = run_shellcheck(&["--severity=banana"], cwd.path());
     let severity_compat = run_compat(&["--severity=banana"], cwd.path());
     assert_eq!(severity_sc.status.code(), severity_compat.status.code());
+}
+
+#[test]
+#[ignore]
+fn oracle_enable_checks_match_shellcheck_exit_codes() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let enable_all_args = vec!["--norc", "--enable=all", "-f", "json1", "x.sh"];
+    let shellcheck_enable_all = run_shellcheck(&enable_all_args, tempdir.path());
+    let compat_enable_all = run_compat(&enable_all_args, tempdir.path());
+    assert_eq!(
+        shellcheck_enable_all.status.code(),
+        compat_enable_all.status.code(),
+        "{enable_all_args:?}"
+    );
+
+    for args in [
+        vec!["--norc", "--enable=add-default-case", "-f", "json1", "x.sh"],
+        vec![
+            "--norc",
+            "--enable=useless-use-of-cat",
+            "-f",
+            "json1",
+            "x.sh",
+        ],
+    ] {
+        let shellcheck = run_shellcheck(&args, tempdir.path());
+        let compat = run_compat(&args, tempdir.path());
+        assert_eq!(shellcheck.status.code(), compat.status.code(), "{args:?}");
+        assert_eq!(
+            json1_comment_shapes(&shellcheck),
+            json1_comment_shapes(&compat),
+            "{args:?}"
+        );
+    }
 }
 
 #[test]
@@ -145,4 +242,121 @@ fn oracle_output_formats_stay_structurally_valid() {
     let tty_stdout = String::from_utf8_lossy(&tty_compat.stdout);
     assert!(tty_stdout.contains("SC2154"));
     assert!(tty_stdout.contains("For more information"));
+}
+
+#[test]
+#[ignore]
+fn oracle_json1_order_matches_shellcheck_for_shared_spans() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo $bar\n").unwrap();
+
+    let shellcheck = run_shellcheck(&["--norc", "-f", "json1", "x.sh"], tempdir.path());
+    let compat = run_compat(&["--norc", "-f", "json1", "x.sh"], tempdir.path());
+    assert_eq!(shellcheck.status.code(), compat.status.code());
+
+    let shellcheck_order = json1_comments(&shellcheck)
+        .into_iter()
+        .map(|comment| {
+            (
+                comment["code"].as_u64().unwrap(),
+                comment["level"].as_str().unwrap().to_owned(),
+                comment["line"].as_u64().unwrap(),
+                comment["column"].as_u64().unwrap(),
+                comment["endColumn"].as_u64().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let compat_order = json1_comments(&compat)
+        .into_iter()
+        .map(|comment| {
+            (
+                comment["code"].as_u64().unwrap(),
+                comment["level"].as_str().unwrap().to_owned(),
+                comment["line"].as_u64().unwrap(),
+                comment["column"].as_u64().unwrap(),
+                comment["endColumn"].as_u64().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(shellcheck_order, compat_order);
+}
+
+#[test]
+#[ignore]
+fn oracle_json1_sc2086_fix_shape_matches_shellcheck() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/sh\nprintf %s prefix${name}suffix\n",
+    )
+    .unwrap();
+
+    let shellcheck = run_shellcheck(&["--norc", "-f", "json1", "x.sh"], tempdir.path());
+    let compat = run_compat(&["--norc", "-f", "json1", "x.sh"], tempdir.path());
+    assert_eq!(shellcheck.status.code(), compat.status.code());
+
+    let shellcheck_fix = comment_by_code(&json1_comments(&shellcheck), 2086)["fix"].clone();
+    let compat_fix = comment_by_code(&json1_comments(&compat), 2086)["fix"].clone();
+    assert_eq!(shellcheck_fix, compat_fix);
+}
+
+#[test]
+#[ignore]
+fn oracle_diff_behavior_matches_shellcheck_for_fixable_and_unfixable_inputs() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("fixable.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+    fs::write(
+        tempdir.path().join("unfixable.sh"),
+        "#!/bin/bash\nprintf '%s\\n' x &;\n",
+    )
+    .unwrap();
+
+    let shellcheck_fixable =
+        run_shellcheck(&["--norc", "-f", "diff", "fixable.sh"], tempdir.path());
+    let compat_fixable = run_compat(&["--norc", "-f", "diff", "fixable.sh"], tempdir.path());
+    assert_eq!(
+        shellcheck_fixable.status.code(),
+        compat_fixable.status.code()
+    );
+    assert_eq!(shellcheck_fixable.stdout, compat_fixable.stdout);
+
+    let shellcheck_unfixable =
+        run_shellcheck(&["--norc", "-f", "diff", "unfixable.sh"], tempdir.path());
+    let compat_unfixable = run_compat(&["--norc", "-f", "diff", "unfixable.sh"], tempdir.path());
+    assert_eq!(
+        shellcheck_unfixable.status.code(),
+        compat_unfixable.status.code()
+    );
+    assert_eq!(shellcheck_unfixable.stdout, compat_unfixable.stdout);
+}
+
+#[test]
+#[ignore]
+fn oracle_stdin_json1_shape_matches_shellcheck() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    let stdin = "#!/bin/sh\necho $foo\n";
+
+    let shellcheck = run_shellcheck_stdin(&["--norc", "-f", "json1", "-"], tempdir.path(), stdin);
+    let compat = run_compat_stdin(&["--norc", "-f", "json1", "-"], tempdir.path(), stdin);
+    assert_eq!(shellcheck.status.code(), compat.status.code());
+    assert_eq!(
+        json1_comment_shapes(&shellcheck),
+        json1_comment_shapes(&compat)
+    );
 }

--- a/crates/shuck/tests/oracle_shellcheck_cli.rs
+++ b/crates/shuck/tests/oracle_shellcheck_cli.rs
@@ -89,7 +89,7 @@ fn json1_comment_shapes(output: &Output) -> Vec<Value> {
         .collect()
 }
 
-fn comment_by_code<'a>(comments: &'a [Value], code: u64) -> &'a Value {
+fn comment_by_code(comments: &[Value], code: u64) -> &Value {
     comments
         .iter()
         .find(|comment| comment["code"].as_u64() == Some(code))

--- a/crates/shuck/tests/shellcheck_compat.rs
+++ b/crates/shuck/tests/shellcheck_compat.rs
@@ -1,13 +1,34 @@
 use std::fs;
+use std::path::Path;
+use std::process::Output;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serde_json::Value;
 use tempfile::tempdir;
 
 fn compat_cmd() -> Command {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.env("SHUCK_SHELLCHECK_COMPAT", "1");
     cmd
+}
+
+fn run_compat(args: &[&str], cwd: &Path) -> Output {
+    compat_cmd().current_dir(cwd).args(args).output().unwrap()
+}
+
+fn json1_comments(output: &Output) -> Vec<Value> {
+    serde_json::from_slice::<Value>(&output.stdout).unwrap()["comments"]
+        .as_array()
+        .unwrap()
+        .clone()
+}
+
+fn comment_by_code<'a>(comments: &'a [Value], code: u64) -> &'a Value {
+    comments
+        .iter()
+        .find(|comment| comment["code"].as_u64() == Some(code))
+        .unwrap()
 }
 
 #[test]
@@ -186,4 +207,160 @@ fn compat_dash_path_reads_from_stdin() {
         .stdout(predicate::str::contains("\"file\":\"-\""))
         .stdout(predicate::str::contains("\"code\":2086"))
         .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn compat_enable_all_is_accepted() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let output = run_compat(
+        ["--norc", "--enable=all", "-f", "json1", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    assert!(
+        comments
+            .iter()
+            .any(|comment| comment["code"].as_u64() == Some(2086))
+    );
+    assert!(
+        comments
+            .iter()
+            .any(|comment| comment["code"].as_u64() == Some(2154))
+    );
+}
+
+#[test]
+fn compat_accepts_named_unimplemented_optional_checks_as_noops() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    for check in ["add-default-case", "useless-use-of-cat"] {
+        let output = run_compat(
+            ["--norc", "--enable", check, "-f", "json1", "x.sh"].as_slice(),
+            tempdir.path(),
+        );
+        assert_eq!(output.status.code(), Some(1), "optional check {check}");
+
+        let comments = json1_comments(&output);
+        assert!(
+            comments
+                .iter()
+                .any(|comment| comment["code"].as_u64() == Some(2086))
+        );
+        assert!(
+            comments
+                .iter()
+                .any(|comment| comment["code"].as_u64() == Some(2154))
+        );
+    }
+}
+
+#[test]
+fn compat_json1_orders_higher_severity_before_lower_severity_at_same_span() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let output = run_compat(["--norc", "-f", "json1", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    let ordered_codes = comments
+        .iter()
+        .map(|comment| comment["code"].as_u64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ordered_codes, vec![2154, 2086]);
+}
+
+#[test]
+fn compat_json1_emits_sc2086_fix_payload_for_plain_expansions() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let output = run_compat(["--norc", "-f", "json1", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    let sc2086 = comment_by_code(&comments, 2086);
+    let replacements = sc2086["fix"]["replacements"].as_array().unwrap();
+    assert_eq!(replacements.len(), 2);
+    assert_eq!(replacements[0]["column"].as_u64(), Some(6));
+    assert_eq!(replacements[0]["endColumn"].as_u64(), Some(6));
+    assert_eq!(replacements[0]["insertionPoint"].as_str(), Some("afterEnd"));
+    assert_eq!(replacements[0]["replacement"].as_str(), Some("\""));
+    assert_eq!(replacements[1]["column"].as_u64(), Some(10));
+    assert_eq!(replacements[1]["endColumn"].as_u64(), Some(10));
+    assert_eq!(
+        replacements[1]["insertionPoint"].as_str(),
+        Some("beforeStart")
+    );
+    assert_eq!(replacements[1]["replacement"].as_str(), Some("\""));
+}
+
+#[test]
+fn compat_json1_emits_sc2086_fix_payload_for_mixed_words() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/sh\nprintf %s prefix${name}suffix\n",
+    )
+    .unwrap();
+
+    let output = run_compat(["--norc", "-f", "json1", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    let sc2086 = comment_by_code(&comments, 2086);
+    let replacements = sc2086["fix"]["replacements"].as_array().unwrap();
+    assert_eq!(replacements.len(), 2);
+    assert_eq!(replacements[0]["column"].as_u64(), Some(17));
+    assert_eq!(replacements[0]["endColumn"].as_u64(), Some(17));
+    assert_eq!(replacements[0]["insertionPoint"].as_str(), Some("afterEnd"));
+    assert_eq!(replacements[1]["column"].as_u64(), Some(24));
+    assert_eq!(replacements[1]["endColumn"].as_u64(), Some(24));
+    assert_eq!(
+        replacements[1]["insertionPoint"].as_str(),
+        Some("beforeStart")
+    );
+}
+
+#[test]
+fn compat_diff_reports_when_diagnostics_are_not_auto_fixable() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/bash\nprintf '%s\\n' x &;\n",
+    )
+    .unwrap();
+
+    let output = run_compat(["--norc", "-f", "diff", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.is_empty());
+    assert_eq!(
+        stderr,
+        "Issues were detected, but none were auto-fixable. Use another format to see them.\n"
+    );
+    assert!(!stderr.contains("@@ compatibility mode @@"));
+    assert!(!stderr.contains("--- x.sh"));
+}
+
+#[test]
+fn compat_diff_emits_unified_patch_for_fixable_sc2086() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let output = run_compat(["--norc", "-f", "diff", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--- a/x.sh"));
+    assert!(stdout.contains("+++ b/x.sh"));
+    assert!(stdout.contains("-echo $foo"));
+    assert!(stdout.contains("+echo \"$foo\""));
 }

--- a/crates/shuck/tests/shellcheck_compat.rs
+++ b/crates/shuck/tests/shellcheck_compat.rs
@@ -24,7 +24,7 @@ fn json1_comments(output: &Output) -> Vec<Value> {
         .clone()
 }
 
-fn comment_by_code<'a>(comments: &'a [Value], code: u64) -> &'a Value {
+fn comment_by_code(comments: &[Value], code: u64) -> &Value {
     comments
         .iter()
         .find(|comment| comment["code"].as_u64() == Some(code))


### PR DESCRIPTION
## Summary
- accept listed ShellCheck optional checks in compatibility mode, treating unimplemented ones as no-ops instead of usage errors
- sort compatibility diagnostics in ShellCheck-style location and severity order
- emit ShellCheck-shaped `SC2086` fix payloads plus ShellCheck-aligned `diff` output, including the non-fixable fallback on `stderr`
- add stronger local and oracle coverage for `--enable`, `json1` ordering/fix payloads, `diff`, and stdin behavior

## Why
The initial ShellCheck compatibility entrypoint landed the basic surface, but it still diverged in a few important places that users can observe directly:
- some `--enable` inputs were rejected even though ShellCheck accepts them
- `json1` ordering and fix metadata were not fully aligned for shared cases
- `diff` output did not follow ShellCheck's patch and fallback behavior closely enough

## Impact
Users invoking `shuck` as `shellcheck` now get a closer match for supported compatibility-mode flows, especially for CI and tooling that depend on stable `json1` ordering, `SC2086` fix payloads, or ShellCheck-style `diff` behavior.

## Root Cause
The compat layer was still treating optional checks as a support matrix gate, ordering diagnostics by code instead of ShellCheck-style severity within a span, and rendering `diff` as a placeholder view rather than through fix application.

## Validation
- `cargo test -p shuck --test shellcheck_compat`
- `cargo test -p shuck --test oracle_shellcheck_cli -- --ignored --nocapture`
