### PR TITLE
Move C006 file-entry contract handling into semantics

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -734,7 +734,7 @@ End
     }
 
     #[test]
-    fn ambient_build_style_contract_suppresses_void_packages_c006_noise() {
+    fn ambient_build_style_contract_keeps_uppercase_context_but_reports_lowercase_reads() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/void-packages/common/build-style/void-cross.sh"),
             "\
@@ -747,11 +747,40 @@ build
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pkgname"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pkgver"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("configure_args"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cross_gcc_configure_args"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("wrksrc"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_SRCPKGDIR"))
+        );
     }
 
     #[test]
-    fn ambient_build_style_contract_suppresses_flattened_corpus_paths() {
+    fn ambient_build_style_contract_reports_lowercase_reads_on_flattened_corpus_paths() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/scripts/void-linux__void-packages__common__build-style__void-cross.sh"),
             "\
@@ -763,11 +792,25 @@ build
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("configure_args"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("wrksrc"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_SRCPKGDIR"))
+        );
     }
 
     #[test]
-    fn ambient_pre_pkg_hook_contract_suppresses_void_packages_c006_noise() {
+    fn ambient_pre_pkg_hook_contract_keeps_uppercase_context_but_reports_lowercase_reads() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/void-packages/common/hooks/pre-pkg/99-pkglint.sh"),
             "\
@@ -789,11 +832,30 @@ hook
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pkgname"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pkgver"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_COMMONDIR"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_QUERY_XCMD"))
+        );
     }
 
     #[test]
-    fn ambient_xbps_src_shutils_contract_suppresses_void_packages_c006_noise() {
+    fn ambient_xbps_src_shutils_contract_keeps_uppercase_context_but_reports_lowercase_reads() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/void-packages/common/xbps-src/shutils/common.sh"),
             "\
@@ -805,11 +867,40 @@ helper
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pkgname"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("build_style"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_COMMONDIR"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_SRCPKGDIR"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_STATEDIR"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("NOCOLORS"))
+        );
     }
 
     #[test]
-    fn ambient_xbps_src_libexec_contract_suppresses_void_packages_c006_noise() {
+    fn ambient_xbps_src_libexec_contract_keeps_uppercase_context_but_reports_lowercase_reads() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/void-packages/common/xbps-src/libexec/build.sh"),
             "\
@@ -824,11 +915,45 @@ printf '%s\\n' \"$XBPS_TARGET\" \"$pkgname\"
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("subpackages"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("sourcepkg"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pkgname"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_LIBEXECDIR"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_CROSS_BUILD"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_STATEDIR"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("XBPS_TARGET"))
+        );
     }
 
     #[test]
-    fn ambient_pycompile_trigger_contract_suppresses_void_packages_c006_noise() {
+    fn ambient_pycompile_trigger_contract_reports_lowercase_reads() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/void-packages/srcpkgs/xbps-triggers/files/pycompile"),
             "\
@@ -853,7 +978,21 @@ esac
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pycompile_dirs"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pycompile_module"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("pycompile_version"))
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -127,5 +127,6 @@ bitflags! {
         const IMPORTED_POSSIBLE      = 0b0100_0000_0000;
         const IMPORTED_FUNCTION      = 0b1000_0000_0000;
         const EMPTY_INITIALIZER      = 0b0001_0000_0000_0000;
+        const IMPORTED_FILE_ENTRY    = 0b0010_0000_0000_0000;
     }
 }

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -265,6 +265,13 @@ fn analyze_uninitialized_references_exact(
         if exact.unreachable_blocks.contains(block_id.index()) {
             continue;
         }
+        if reference_resolves_to_file_entry_contract_variable(context, reference) {
+            uninitialized_references.push(UninitializedReference {
+                reference: reference.id,
+                certainty: UninitializedCertainty::Definite,
+            });
+            continue;
+        }
         let Some(name_id) = exact.names.get(&reference.name) else {
             continue;
         };
@@ -285,6 +292,23 @@ fn analyze_uninitialized_references_exact(
     }
 
     uninitialized_references
+}
+
+fn reference_resolves_to_file_entry_contract_variable(
+    context: &DataflowContext<'_>,
+    reference: &Reference,
+) -> bool {
+    let Some(binding_id) = context.resolved.get(&reference.id).copied() else {
+        return false;
+    };
+    let binding = &context.bindings[binding_id.index()];
+    matches!(binding.kind, BindingKind::Imported)
+        && !binding
+            .attributes
+            .contains(BindingAttributes::IMPORTED_FUNCTION)
+        && binding
+            .attributes
+            .contains(BindingAttributes::IMPORTED_FILE_ENTRY)
 }
 
 fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -265,6 +265,10 @@ fn analyze_uninitialized_references_exact(
         if exact.unreachable_blocks.contains(block_id.index()) {
             continue;
         }
+        // File-entry contracts describe ambient names supplied by the caller
+        // environment, not assignments performed by this file, so a read that
+        // resolves only to such an import remains uninitialized until we see a
+        // real write in dataflow.
         if reference_resolves_to_file_entry_contract_variable(context, reference) {
             uninitialized_references.push(UninitializedReference {
                 reference: reference.id,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -772,6 +772,7 @@ impl SemanticModel {
         span: Span,
         command_span: Option<Span>,
         origin_paths: Vec<PathBuf>,
+        file_entry_contract: bool,
     ) -> BindingId {
         let mut attributes = BindingAttributes::empty();
         if provided.certainty == ContractCertainty::Possible {
@@ -779,6 +780,9 @@ impl SemanticModel {
         }
         if provided.kind == ProvidedBindingKind::Function {
             attributes |= BindingAttributes::IMPORTED_FUNCTION;
+        }
+        if file_entry_contract {
+            attributes |= BindingAttributes::IMPORTED_FILE_ENTRY;
         }
 
         let id = BindingId(self.bindings.len() as u32);
@@ -867,7 +871,14 @@ impl SemanticModel {
                 .get(&binding.name)
                 .cloned()
                 .unwrap_or_default();
-            let id = self.add_imported_binding(binding, ScopeId(0), entry_span, None, origin_paths);
+            let id = self.add_imported_binding(
+                binding,
+                ScopeId(0),
+                entry_span,
+                None,
+                origin_paths,
+                true,
+            );
             entry_bindings.push(id);
         }
 
@@ -941,6 +952,7 @@ impl SemanticModel {
                 site.span,
                 Some(site.span),
                 site.origin_paths,
+                false,
             );
         }
         self.resolve_unresolved_references();
@@ -6055,8 +6067,20 @@ printf '%s\\n' \"$flag\"
             let binding = model.resolved_binding(reference.id).unwrap();
             assert_eq!(binding.kind, BindingKind::Imported);
             assert_eq!(binding.name, name);
+            assert!(
+                binding
+                    .attributes
+                    .contains(BindingAttributes::IMPORTED_FILE_ENTRY)
+            );
         }
-        assert!(model.analysis().uninitialized_references().is_empty());
+        assert_eq!(
+            uninitialized_details(&model),
+            vec![
+                ("pkgname".to_owned(), UninitializedCertainty::Definite),
+                ("pkgver".to_owned(), UninitializedCertainty::Definite),
+                ("wrksrc".to_owned(), UninitializedCertainty::Definite),
+            ]
+        );
     }
 
     #[test]
@@ -6109,8 +6133,20 @@ build() {
             let binding = model.resolved_binding(reference.id).unwrap();
             assert_eq!(binding.kind, BindingKind::Imported);
             assert_eq!(binding.name, name);
+            assert!(
+                binding
+                    .attributes
+                    .contains(BindingAttributes::IMPORTED_FILE_ENTRY)
+            );
         }
-        assert!(model.analysis().uninitialized_references().is_empty());
+        assert_eq!(
+            uninitialized_details(&model),
+            vec![
+                ("pkgname".to_owned(), UninitializedCertainty::Definite),
+                ("pkgver".to_owned(), UninitializedCertainty::Definite),
+                ("wrksrc".to_owned(), UninitializedCertainty::Definite),
+            ]
+        );
     }
 
     #[test]
@@ -6172,8 +6208,27 @@ hook() {
             let binding = model.resolved_binding(reference.id).unwrap();
             assert_eq!(binding.kind, BindingKind::Imported);
             assert_eq!(binding.name, name);
+            assert!(
+                binding
+                    .attributes
+                    .contains(BindingAttributes::IMPORTED_FILE_ENTRY)
+            );
         }
-        assert!(model.analysis().uninitialized_references().is_empty());
+        assert_eq!(
+            uninitialized_details(&model),
+            vec![
+                (
+                    "pycompile_dirs".to_owned(),
+                    UninitializedCertainty::Definite
+                ),
+                ("pkgname".to_owned(), UninitializedCertainty::Definite),
+                (
+                    "pycompile_version".to_owned(),
+                    UninitializedCertainty::Definite
+                ),
+                ("pkgver".to_owned(), UninitializedCertainty::Definite),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

This moves the C006 file-entry contract behavior out of the linter rule and into `shuck-semantic`.

- tag imported bindings that come from file-entry contracts with explicit semantic provenance
- teach uninitialized-reference analysis to treat references resolved only through those file-entry imports as definite reads-before-assignment
- keep the `undefined_variable` rule thin again so it just consumes semantic results
- add semantic regression tests for file-entry contract cases and keep the linter ambient-contract regressions that cover the user-facing behavior

## Why

C006 was compensating in the rule layer for how file-entry ambient bindings were modeled underneath. That made the rule responsible for behavior that really belongs in semantics. Moving the decision down keeps the architecture cleaner: ambient contracts describe what bindings exist, and semantic dataflow decides whether that counts as initialization.

## Impact

This improves ShellCheck compatibility for the lower-case ambient/file-entry contract cases we were missing without reopening the uppercase environment-style noise.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic file_entry_contracts_`
- `cargo test -p shuck-linter ambient_`
- `cargo test -p shuck-linter undefined_variable_`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006`
  - compatibility summary: `blocking=2 warnings=174 fixtures=34596 unsupported_shells=862 implementation_diffs=0 mapping_issues=0 reviewed_divergences=160 harness_warnings=14 harness_failures=2`
  - remaining blockers are the same unrelated parser harness failures in `HariSekhon__DevOps-Bash-tools__lib__utils.sh` and `termux__termux-packages__scripts__utils__termux_reuse_pr_build_artifacts.sh`
