### PR TITLE
Handle unmapped compat selectors and uppercase optional checks

### DIFF
--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -14,6 +14,7 @@ pub struct Checker<'a> {
     facts: LinterFacts<'a>,
     rules: &'a RuleSet,
     shell: ShellDialect,
+    report_environment_style_names: bool,
     file_context: &'a FileContext,
     first_parse_error: Option<(usize, usize)>,
     diagnostics: Vec<Diagnostic>,
@@ -46,6 +47,7 @@ impl<'a> Checker<'a> {
         indexer: &'a Indexer,
         rules: &'a RuleSet,
         shell: ShellDialect,
+        report_environment_style_names: bool,
         file_context: &'a FileContext,
         first_parse_error: Option<(usize, usize)>,
     ) -> Self {
@@ -58,6 +60,7 @@ impl<'a> Checker<'a> {
             facts: LinterFacts::build(file, source, semantic, indexer, file_context),
             rules,
             shell,
+            report_environment_style_names,
             file_context,
             first_parse_error,
             diagnostics: Vec::new(),
@@ -95,6 +98,10 @@ impl<'a> Checker<'a> {
 
     pub fn shell(&self) -> ShellDialect {
         self.shell
+    }
+
+    pub fn report_environment_style_names(&self) -> bool {
+        self.report_environment_style_names
     }
 
     pub fn file_context(&self) -> &'a FileContext {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -248,6 +248,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
         indexer,
         &settings.rules,
         shell,
+        settings.report_environment_style_names,
         &file_context,
         first_parse_error,
     );
@@ -2834,6 +2835,34 @@ printf '%s %s\\n' \"$foo\" \"$Foo_BAR\"
             diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.message.contains("Foo_BAR"))
+        );
+    }
+
+    #[test]
+    fn undefined_variable_can_report_environment_style_names_when_requested() {
+        let source = "\
+#!/bin/sh
+printf '%s %s\\n' \"$FOO\" \"$XDG_CONFIG_HOME\"
+";
+        let diagnostics = lint(
+            source,
+            &LinterSettings {
+                rules: RuleSet::from_iter([Rule::UndefinedVariable]),
+                report_environment_style_names: true,
+                ..LinterSettings::default()
+            },
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("FOO"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("XDG_CONFIG_HOME"))
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -55,7 +55,7 @@ pub fn undefined_variable(checker: &mut Checker) {
             checker,
             reference,
             VariableReferenceFilter {
-                suppress_environment_style_names: true,
+                suppress_environment_style_names: !checker.report_environment_style_names(),
             },
         ) {
             continue;

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -16,6 +16,7 @@ pub struct LinterSettings {
     pub shell: ShellDialect,
     pub analyzed_paths: Option<Arc<FxHashSet<PathBuf>>>,
     pub per_file_ignores: Arc<CompiledPerFileIgnoreList>,
+    pub report_environment_style_names: bool,
 }
 
 impl Default for LinterSettings {
@@ -26,6 +27,7 @@ impl Default for LinterSettings {
             shell: ShellDialect::Unknown,
             analyzed_paths: None,
             per_file_ignores: Arc::new(CompiledPerFileIgnoreList::default()),
+            report_environment_style_names: false,
         }
     }
 }

--- a/crates/shuck/src/shellcheck_compat/mod.rs
+++ b/crates/shuck/src/shellcheck_compat/mod.rs
@@ -953,7 +953,6 @@ fn lint_with_context(
         analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
         per_file_ignores: Default::default(),
         report_environment_style_names: options.report_environment_style_names,
-        per_file_ignores: Default::default(),
     };
 
     let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result(

--- a/crates/shuck/src/shellcheck_compat/mod.rs
+++ b/crates/shuck/src/shellcheck_compat/mod.rs
@@ -314,7 +314,27 @@ struct CompatOptions {
     source_paths: Vec<String>,
     files: Vec<PathBuf>,
     enabled_rules: RuleSet,
+    report_environment_style_names: bool,
     shellcheck_map: ShellCheckCodeMap,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct CompatOptionalState {
+    check_unassigned_uppercase: bool,
+}
+
+impl CompatOptionalState {
+    fn enable(&mut self, check_name: &str) {
+        if check_name == "check-unassigned-uppercase" {
+            self.check_unassigned_uppercase = true;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedCompatSelection {
+    rules: RuleSet,
+    optional_state: CompatOptionalState,
 }
 
 #[derive(Debug, Clone)]
@@ -618,7 +638,7 @@ fn resolve_options(
     }
 
     let shellcheck_map = ShellCheckCodeMap::default();
-    let enabled_rules = resolve_rule_selection(&shellcheck_map, &cli, &config)?;
+    let selection = resolve_rule_selection(&shellcheck_map, &cli, &config)?;
 
     let files = cli
         .files
@@ -652,11 +672,12 @@ fn resolve_options(
         },
         files,
         enabled_rules: apply_extended_analysis(
-            enabled_rules,
+            selection.rules,
             cli.extended_analysis
                 .or(config.extended_analysis)
                 .unwrap_or(true),
         ),
+        report_environment_style_names: selection.optional_state.check_unassigned_uppercase,
         shellcheck_map,
     })
 }
@@ -665,11 +686,12 @@ fn resolve_rule_selection(
     shellcheck_map: &ShellCheckCodeMap,
     cli: &ParsedCompatCli,
     config: &CompatConfig,
-) -> Result<RuleSet, CompatCliError> {
+) -> Result<ResolvedCompatSelection, CompatCliError> {
     let mut rules = shellcheck_map
         .mappings()
         .map(|(_, rule)| rule)
         .collect::<RuleSet>();
+    let mut optional_state = CompatOptionalState::default();
 
     let mut requested_optional = config.enable_checks.clone();
     requested_optional.extend(cli.enable_checks.clone());
@@ -679,6 +701,7 @@ fn resolve_rule_selection(
                 for check in OPTIONAL_CHECKS.iter().filter(|check| check.supported) {
                     let optional_rules = check.rules.iter().copied().collect::<RuleSet>();
                     rules = rules.union(&optional_rules);
+                    optional_state.enable(check.name);
                 }
                 continue;
             }
@@ -695,6 +718,7 @@ fn resolve_rule_selection(
 
             let optional_rules = check.rules.iter().copied().collect::<RuleSet>();
             rules = rules.union(&optional_rules);
+            optional_state.enable(check.name);
         }
     }
 
@@ -708,7 +732,10 @@ fn resolve_rule_selection(
         rules = rules.subtract(&excluded);
     }
 
-    Ok(rules)
+    Ok(ResolvedCompatSelection {
+        rules,
+        optional_state,
+    })
 }
 
 fn combined_codes(config_codes: &[String], cli_codes: &[String]) -> Vec<String> {
@@ -727,14 +754,27 @@ fn rules_for_codes(
     for code in codes {
         let resolved = shellcheck_map.resolve_all(code);
         if resolved.is_empty() {
-            return Err(CompatCliError::usage(
-                4,
-                format!("shellcheck code `{code}` is not implemented by this compatibility mode"),
-            ));
+            if !is_valid_shellcheck_code(code) {
+                return Err(CompatCliError::usage(
+                    4,
+                    format!(
+                        "shellcheck code `{code}` is not implemented by this compatibility mode"
+                    ),
+                ));
+            }
+            continue;
         }
         rules.extend(resolved);
     }
     Ok(rules.into_iter().collect())
+}
+
+fn is_valid_shellcheck_code(code: &str) -> bool {
+    code.strip_prefix("SC")
+        .or_else(|| code.strip_prefix("sc"))
+        .unwrap_or(code)
+        .parse::<u32>()
+        .is_ok()
 }
 
 fn apply_extended_analysis(mut rules: RuleSet, enabled: bool) -> RuleSet {
@@ -911,6 +951,8 @@ fn lint_with_context(
         severity_overrides: Default::default(),
         shell,
         analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
+        per_file_ignores: Default::default(),
+        report_environment_style_names: options.report_environment_style_names,
         per_file_ignores: Default::default(),
     };
 

--- a/crates/shuck/src/shellcheck_compat/optional.rs
+++ b/crates/shuck/src/shellcheck_compat/optional.rs
@@ -55,9 +55,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         name: "check-unassigned-uppercase",
         description: "Adds uppercase-variable coverage to unset-variable style checks.",
         example: "echo $VAR",
-        guidance: "Initialize the uppercase name before reading it, or choose a different check set.",
-        rules: &[],
-        supported: false,
+        guidance: "Initialize the uppercase name before reading it when it is not inherited from the environment.",
+        rules: &[Rule::UndefinedVariable],
+        supported: true,
     },
     OptionalCheck {
         name: "deprecate-which",

--- a/crates/shuck/tests/oracle_shellcheck_cli.rs
+++ b/crates/shuck/tests/oracle_shellcheck_cli.rs
@@ -139,6 +139,35 @@ fn oracle_option_acceptance_and_rejection_match_exit_codes() {
 
 #[test]
 #[ignore]
+fn oracle_unknown_sc_selectors_match_shellcheck_behavior() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let include_args = vec!["--norc", "--include=SC9999", "-f", "json1", "x.sh"];
+    let include_sc = run_shellcheck(&include_args, tempdir.path());
+    let include_compat = run_compat(&include_args, tempdir.path());
+    assert_eq!(include_sc.status.code(), include_compat.status.code());
+    assert_eq!(
+        json1_comment_shapes(&include_sc),
+        json1_comment_shapes(&include_compat)
+    );
+
+    let exclude_args = vec!["--norc", "--exclude=SC9999", "-f", "json1", "x.sh"];
+    let exclude_sc = run_shellcheck(&exclude_args, tempdir.path());
+    let exclude_compat = run_compat(&exclude_args, tempdir.path());
+    assert_eq!(exclude_sc.status.code(), exclude_compat.status.code());
+    assert_eq!(
+        json1_comment_shapes(&exclude_sc),
+        json1_comment_shapes(&exclude_compat)
+    );
+}
+
+#[test]
+#[ignore]
 fn oracle_enable_checks_match_shellcheck_exit_codes() {
     if !shellcheck_available() {
         return;
@@ -175,6 +204,32 @@ fn oracle_enable_checks_match_shellcheck_exit_codes() {
             "{args:?}"
         );
     }
+}
+
+#[test]
+#[ignore]
+fn oracle_check_unassigned_uppercase_matches_shellcheck() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $VAR\n").unwrap();
+
+    let args = vec![
+        "--norc",
+        "--enable=check-unassigned-uppercase",
+        "-f",
+        "json1",
+        "x.sh",
+    ];
+    let shellcheck = run_shellcheck(&args, tempdir.path());
+    let compat = run_compat(&args, tempdir.path());
+    assert_eq!(shellcheck.status.code(), compat.status.code());
+    assert_eq!(
+        json1_comment_shapes(&shellcheck),
+        json1_comment_shapes(&compat)
+    );
 }
 
 #[test]

--- a/crates/shuck/tests/shellcheck_compat.rs
+++ b/crates/shuck/tests/shellcheck_compat.rs
@@ -140,6 +140,37 @@ fn compat_include_and_severity_filter_work_on_sc_codes() {
 }
 
 #[test]
+fn compat_include_unknown_sc_code_is_accepted_as_empty_selection() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let output = run_compat(
+        ["--norc", "-f", "json1", "--include=SC9999", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(json1_comments(&output), Vec::<Value>::new());
+}
+
+#[test]
+fn compat_exclude_unknown_sc_code_is_ignored() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
+
+    let output = run_compat(
+        ["--norc", "-f", "json1", "--exclude=SC9999", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let ordered_codes = json1_comments(&output)
+        .into_iter()
+        .map(|comment| comment["code"].as_u64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ordered_codes, vec![2154, 2086]);
+}
+
+#[test]
 fn compat_accepts_busybox_shell_alias() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("x.sh"), "echo hi\n").unwrap();
@@ -234,6 +265,24 @@ fn compat_enable_all_is_accepted() {
 }
 
 #[test]
+fn compat_enable_all_includes_check_unassigned_uppercase() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $VAR\n").unwrap();
+
+    let output = run_compat(
+        ["--norc", "--enable=all", "-f", "json1", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let ordered_codes = json1_comments(&output)
+        .into_iter()
+        .map(|comment| comment["code"].as_u64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ordered_codes, vec![2154, 2086]);
+}
+
+#[test]
 fn compat_accepts_named_unimplemented_optional_checks_as_noops() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();
@@ -257,6 +306,31 @@ fn compat_accepts_named_unimplemented_optional_checks_as_noops() {
                 .any(|comment| comment["code"].as_u64() == Some(2154))
         );
     }
+}
+
+#[test]
+fn compat_check_unassigned_uppercase_enables_sc2154_on_uppercase_names() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $VAR\n").unwrap();
+
+    let output = run_compat(
+        [
+            "--norc",
+            "--enable=check-unassigned-uppercase",
+            "-f",
+            "json1",
+            "x.sh",
+        ]
+        .as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let ordered_codes = json1_comments(&output)
+        .into_iter()
+        .map(|comment| comment["code"].as_u64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ordered_codes, vec![2154, 2086]);
 }
 
 #[test]

--- a/crates/shuck/tests/zsh_option_state.rs
+++ b/crates/shuck/tests/zsh_option_state.rs
@@ -151,6 +151,7 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
         &indexer,
         &rules,
         ShellDialect::Zsh,
+        false,
         &file_context,
         None,
     );


### PR DESCRIPTION
## Summary
- treat unmapped but syntactically valid `SCxxxx` include/exclude selectors as no-ops in ShellCheck compat mode
- implement the `check-unassigned-uppercase` optional check by allowing compat to opt into reporting environment-style names for `SC2154`
- add local and oracle coverage for the new selector behavior and optional check

## Testing
- cargo test -p shuck-linter undefined_variable_can_report_environment_style_names_when_requested
- cargo test -p shuck --test shellcheck_compat
- cargo test -p shuck --test oracle_shellcheck_cli -- --ignored --nocapture
- cargo clippy --workspace --all-targets --all-features --offline -- -D warnings