### PR TITLE
Add output formatter support to shuck check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,15 @@ serde_json = "1"
 serde_yaml = "0.9"
 similar = "2"
 toml = "0.8"
+quick-junit = "0.6.0"
+url = "2.5.0"
 
 # Testing
 tempfile = "3"
 memchr = "2"
 insta = "1.42"
 test-case = "3"
+roxmltree = "0.20"
 
 [profile.release]
 lto = "thin"

--- a/crates/shuck-benchmark/benches/check_command.rs
+++ b/crates/shuck-benchmark/benches/check_command.rs
@@ -39,6 +39,7 @@ fn bench_check_command(c: &mut Criterion) {
         let group_name = match output_format {
             CheckOutputFormatArg::Concise => "check_command_concise",
             CheckOutputFormatArg::Full => "check_command_full",
+            _ => unreachable!("bench only covers concise and full output"),
         };
         let mut group = c.benchmark_group(group_name);
 

--- a/crates/shuck-linter/build.rs
+++ b/crates/shuck-linter/build.rs
@@ -8,6 +8,9 @@ use serde::Deserialize;
 struct RuleMetadata {
     new_code: String,
     shellcheck_code: Option<String>,
+    description: String,
+    rationale: String,
+    fix_description: Option<String>,
 }
 
 fn parse_shellcheck_code_value(raw: &str) -> Result<Option<u32>, String> {
@@ -26,7 +29,7 @@ fn parse_shellcheck_code_value(raw: &str) -> Result<Option<u32>, String> {
     Ok(Some(number))
 }
 
-fn parse_rule_metadata(data: &str) -> Result<(String, Option<u32>), String> {
+fn parse_rule_metadata(data: &str) -> Result<(RuleMetadata, Option<u32>), String> {
     let metadata: RuleMetadata =
         serde_yaml::from_str(data).map_err(|err| format!("invalid rule metadata: {err}"))?;
 
@@ -42,7 +45,7 @@ fn parse_rule_metadata(data: &str) -> Result<(String, Option<u32>), String> {
         .transpose()?
         .flatten();
 
-    Ok((rule_code.to_owned(), shellcheck_code))
+    Ok((metadata, shellcheck_code))
 }
 
 fn main() {
@@ -59,14 +62,22 @@ fn main() {
     entries.sort();
 
     let mut mappings = Vec::new();
+    let mut metadata_rows = Vec::new();
 
     for path in entries {
         println!("cargo:rerun-if-changed={}", path.display());
         let data = fs::read_to_string(&path)
             .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
 
-        let (rule_code, shellcheck_code) =
+        let (metadata, shellcheck_code) =
             parse_rule_metadata(&data).unwrap_or_else(|err| panic!("{err} in {}", path.display()));
+        let rule_code = metadata.new_code.trim().to_owned();
+        metadata_rows.push((
+            rule_code.clone(),
+            metadata.description,
+            metadata.rationale,
+            metadata.fix_description,
+        ));
 
         let Some(shellcheck_code) = shellcheck_code else {
             continue;
@@ -84,4 +95,26 @@ fn main() {
         PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR")).join("shellcheck_map_data.rs");
     fs::write(&out_path, generated)
         .unwrap_or_else(|err| panic!("write {}: {err}", out_path.display()));
+
+    let mut metadata_generated = String::from("pub const RULE_METADATA: &[RuleMetadata] = &[\n");
+    for (rule_code, description, rationale, fix_description) in metadata_rows {
+        metadata_generated.push_str("    RuleMetadata {\n");
+        metadata_generated.push_str(&format!("        code: {:?},\n", rule_code));
+        metadata_generated.push_str(&format!("        description: {:?},\n", description));
+        metadata_generated.push_str(&format!("        rationale: {:?},\n", rationale));
+        metadata_generated.push_str(&format!(
+            "        fix_description: {},\n",
+            match fix_description {
+                Some(value) => format!("Some({value:?})"),
+                None => "None".to_owned(),
+            }
+        ));
+        metadata_generated.push_str("    },\n");
+    }
+    metadata_generated.push_str("];\n");
+
+    let metadata_out_path =
+        PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR")).join("rule_metadata_data.rs");
+    fs::write(&metadata_out_path, metadata_generated)
+        .unwrap_or_else(|err| panic!("write {}: {err}", metadata_out_path.display()));
 }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -6,6 +6,7 @@ mod facts;
 mod fix;
 mod parse_diagnostics;
 mod registry;
+mod rule_metadata;
 mod rule_selector;
 mod rule_set;
 pub mod rules;
@@ -40,6 +41,7 @@ pub use facts::{
 pub use facts::{CommandId, FactSpan, LinterFacts};
 pub use fix::{Applicability, AppliedFixes, Edit, Fix, FixAvailability, apply_fixes};
 pub use registry::{Category, Rule, code_to_rule};
+pub use rule_metadata::{RuleMetadata, rule_metadata, rule_metadata_by_code};
 pub use rule_selector::{RuleSelector, SelectorParseError};
 pub use rule_set::RuleSet;
 pub use rules::common::command::{DeclarationKind, WrapperKind};

--- a/crates/shuck-linter/src/rule_metadata.rs
+++ b/crates/shuck-linter/src/rule_metadata.rs
@@ -1,0 +1,35 @@
+use crate::{Rule, code_to_rule};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuleMetadata {
+    pub code: &'static str,
+    pub description: &'static str,
+    pub rationale: &'static str,
+    pub fix_description: Option<&'static str>,
+}
+
+include!(concat!(env!("OUT_DIR"), "/rule_metadata_data.rs"));
+
+pub fn rule_metadata(rule: Rule) -> Option<&'static RuleMetadata> {
+    rule_metadata_by_code(rule.code())
+}
+
+pub fn rule_metadata_by_code(code: &str) -> Option<&'static RuleMetadata> {
+    let rule = code_to_rule(code)?;
+    RULE_METADATA
+        .iter()
+        .find(|metadata| metadata.code == rule.code())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_rule_metadata_for_known_rules() {
+        let metadata = rule_metadata(Rule::UnusedAssignment).expect("metadata for C001");
+        assert_eq!(metadata.code, "C001");
+        assert!(metadata.description.contains("assigned"));
+        assert!(metadata.rationale.contains("dead assignments"));
+    }
+}

--- a/crates/shuck-linter/tests/build_script.rs
+++ b/crates/shuck-linter/tests/build_script.rs
@@ -24,12 +24,16 @@ mod build_script {
         let yaml = r#"
 new_code: "C001"
 shellcheck_code: SC2034
+description: Example description
+rationale: Example rationale
 "#;
 
-        assert_eq!(
-            parse_rule_metadata(yaml),
-            Ok(("C001".to_owned(), Some(2034)))
-        );
+        let (metadata, shellcheck_code) = parse_rule_metadata(yaml).unwrap();
+        assert_eq!(metadata.new_code, "C001");
+        assert_eq!(metadata.description, "Example description");
+        assert_eq!(metadata.rationale, "Example rationale");
+        assert_eq!(metadata.fix_description, None);
+        assert_eq!(shellcheck_code, Some(2034));
     }
 
     #[test]
@@ -37,12 +41,15 @@ shellcheck_code: SC2034
         let yaml = r#"
 new_code: C001
 shellcheck_code: SC2034 # compatibility code
+description: Example description
+rationale: Example rationale
 "#;
 
-        assert_eq!(
-            parse_rule_metadata(yaml),
-            Ok(("C001".to_owned(), Some(2034)))
-        );
+        let (metadata, shellcheck_code) = parse_rule_metadata(yaml).unwrap();
+        assert_eq!(metadata.new_code, "C001");
+        assert_eq!(metadata.description, "Example description");
+        assert_eq!(metadata.rationale, "Example rationale");
+        assert_eq!(shellcheck_code, Some(2034));
     }
 
     #[test]
@@ -50,8 +57,14 @@ shellcheck_code: SC2034 # compatibility code
         let yaml = r#"
 new_code: C001
 shellcheck_code: null
+description: Example description
+rationale: Example rationale
 "#;
 
-        assert_eq!(parse_rule_metadata(yaml), Ok(("C001".to_owned(), None)));
+        let (metadata, shellcheck_code) = parse_rule_metadata(yaml).unwrap();
+        assert_eq!(metadata.new_code, "C001");
+        assert_eq!(metadata.description, "Example description");
+        assert_eq!(metadata.rationale, "Example rationale");
+        assert_eq!(shellcheck_code, None);
     }
 }

--- a/crates/shuck/Cargo.toml
+++ b/crates/shuck/Cargo.toml
@@ -22,6 +22,8 @@ notify = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+quick-junit = { workspace = true }
+shuck-ast = { path = "../shuck-ast" }
 shuck-cache = { path = "../shuck-cache" }
 shuck-formatter = { path = "../shuck-formatter" }
 shuck-indexer = { path = "../shuck-indexer" }
@@ -30,16 +32,16 @@ shuck-parser = { path = "../shuck-parser" }
 shuck-semantic = { path = "../shuck-semantic" }
 similar = { workspace = true }
 toml = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2"
-insta = { workspace = true }
+insta = { workspace = true, features = ["json", "redactions"] }
 predicates = "3"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
-shuck-ast = { path = "../shuck-ast" }
 shuck-indexer = { path = "../shuck-indexer" }
 shuck-linter = { path = "../shuck-linter" }
 shuck-parser = { path = "../shuck-parser" }
@@ -47,3 +49,4 @@ shuck-semantic = { path = "../shuck-semantic" }
 tempfile = { workspace = true }
 wait-timeout = "0.2"
 walkdir = "2"
+roxmltree = { workspace = true }

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -58,8 +58,16 @@ impl From<FormatIndentStyleArg> for IndentStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum CheckOutputFormatArg {
-    Full,
     Concise,
+    Full,
+    Json,
+    JsonLines,
+    Junit,
+    Grouped,
+    Github,
+    Gitlab,
+    Rdjson,
+    Sarif,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -278,8 +286,14 @@ pub struct CheckCommand {
         conflicts_with = "unsafe_fixes",
     )]
     pub add_ignore: Option<String>,
-    /// Choose the text output format for reported diagnostics.
-    #[arg(long = "output-format", value_enum, default_value_t = CheckOutputFormatArg::Full)]
+    /// Output serialization format for violations.
+    /// The default serialization format is "full".
+    #[arg(
+        long = "output-format",
+        value_enum,
+        env = "SHUCK_OUTPUT_FORMAT",
+        default_value_t = CheckOutputFormatArg::Full
+    )]
     pub output_format: CheckOutputFormatArg,
     /// Run in watch mode by re-running whenever files change.
     #[arg(short = 'w', long, conflicts_with = "add_ignore")]
@@ -811,6 +825,25 @@ mod tests {
         let command = parse_check(["shuck", "check", "--watch"]);
 
         assert!(command.watch);
+    }
+
+    #[test]
+    fn parses_all_check_output_formats() {
+        for (raw, expected) in [
+            ("concise", CheckOutputFormatArg::Concise),
+            ("full", CheckOutputFormatArg::Full),
+            ("json", CheckOutputFormatArg::Json),
+            ("json-lines", CheckOutputFormatArg::JsonLines),
+            ("junit", CheckOutputFormatArg::Junit),
+            ("grouped", CheckOutputFormatArg::Grouped),
+            ("github", CheckOutputFormatArg::Github),
+            ("gitlab", CheckOutputFormatArg::Gitlab),
+            ("rdjson", CheckOutputFormatArg::Rdjson),
+            ("sarif", CheckOutputFormatArg::Sarif),
+        ] {
+            let command = parse_check(["shuck", "check", "--output-format", raw]);
+            assert_eq!(command.output_format, expected, "failed to parse {raw}");
+        }
     }
 
     #[test]

--- a/crates/shuck/src/commands/check.rs
+++ b/crates/shuck/src/commands/check.rs
@@ -10,6 +10,7 @@ use anyhow::{Result, anyhow};
 use notify::{RecursiveMode, Watcher, recommended_watcher};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use shuck_ast::TextSize;
 use shuck_cache::{CacheKey, CacheKeyHasher};
 use shuck_indexer::Indexer;
 use shuck_linter::{
@@ -26,7 +27,8 @@ use crate::ExitStatus;
 use crate::args::{CheckCommand, FileSelectionArgs, PatternRuleSelectorPair, RuleSelectionArgs};
 use crate::cache::resolve_cache_root;
 use crate::commands::check_output::{
-    DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
+    DisplayPosition, DisplaySpan, DisplayedApplicability, DisplayedDiagnostic,
+    DisplayedDiagnosticKind, DisplayedEdit, DisplayedFix, print_report_to,
 };
 use crate::commands::project_runner::{PendingProjectFile, prepare_project_runs};
 use crate::config::{
@@ -203,10 +205,103 @@ struct CachedLintDiagnostic {
     code: String,
     severity: String,
     message: String,
+    fix: Option<CachedLintFix>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum CachedApplicability {
+    Safe,
+    Unsafe,
+}
+
+impl From<Applicability> for CachedApplicability {
+    fn from(value: Applicability) -> Self {
+        match value {
+            Applicability::Safe => Self::Safe,
+            Applicability::Unsafe => Self::Unsafe,
+        }
+    }
+}
+
+impl From<CachedApplicability> for DisplayedApplicability {
+    fn from(value: CachedApplicability) -> Self {
+        match value {
+            CachedApplicability::Safe => Self::Safe,
+            CachedApplicability::Unsafe => Self::Unsafe,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct CachedLintFix {
+    applicability: CachedApplicability,
+    message: Option<String>,
+    edits: Vec<CachedLintEdit>,
+}
+
+impl CachedLintFix {
+    fn from_displayed(fix: &DisplayedFix) -> Self {
+        Self {
+            applicability: match fix.applicability {
+                DisplayedApplicability::Safe => CachedApplicability::Safe,
+                DisplayedApplicability::Unsafe => CachedApplicability::Unsafe,
+            },
+            message: fix.message.clone(),
+            edits: fix
+                .edits
+                .iter()
+                .map(CachedLintEdit::from_displayed)
+                .collect(),
+        }
+    }
+
+    fn to_displayed(&self) -> DisplayedFix {
+        DisplayedFix {
+            applicability: self.applicability.into(),
+            message: self.message.clone(),
+            edits: self
+                .edits
+                .iter()
+                .map(CachedLintEdit::to_displayed)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct CachedLintEdit {
+    start_line: usize,
+    start_column: usize,
+    end_line: usize,
+    end_column: usize,
+    content: String,
+}
+
+impl CachedLintEdit {
+    fn from_displayed(edit: &DisplayedEdit) -> Self {
+        Self {
+            start_line: edit.location.line,
+            start_column: edit.location.column,
+            end_line: edit.end_location.line,
+            end_column: edit.end_location.column,
+            content: edit.content.clone(),
+        }
+    }
+
+    fn to_displayed(&self) -> DisplayedEdit {
+        DisplayedEdit {
+            location: DisplayPosition::new(self.start_line, self.start_column),
+            end_location: DisplayPosition::new(self.end_line, self.end_column),
+            content: self.content.clone(),
+        }
+    }
 }
 
 impl CachedLintDiagnostic {
-    fn from_diagnostic(diagnostic: &shuck_linter::Diagnostic) -> Self {
+    fn from_diagnostic(diagnostic: &shuck_linter::Diagnostic, source: &str) -> Self {
+        let fix = displayed_fix_from_diagnostic(diagnostic, source)
+            .as_ref()
+            .map(CachedLintFix::from_displayed);
         Self {
             start_line: diagnostic.span.start.line,
             start_column: diagnostic.span.start.column,
@@ -215,6 +310,7 @@ impl CachedLintDiagnostic {
             code: diagnostic.code().to_owned(),
             severity: diagnostic.severity.as_str().to_owned(),
             message: diagnostic.message.clone(),
+            fix,
         }
     }
 }
@@ -921,6 +1017,8 @@ fn run_check_with_cwd(
                     push_cached_lint_diagnostics(
                         &mut report,
                         &file.display_path,
+                        &file.relative_path,
+                        &file.absolute_path,
                         &diagnostics,
                         source,
                     );
@@ -929,13 +1027,15 @@ fn run_check_with_cwd(
                     let source = include_source
                         .then(|| read_shared_source(&file.absolute_path))
                         .transpose()?;
-                    report.diagnostics.push(DisplayedDiagnostic {
-                        path: file.display_path,
-                        span: DisplaySpan::point(error.line, error.column),
-                        message: error.message,
-                        kind: DisplayedDiagnosticKind::ParseError,
+                    report.diagnostics.push(display_parse_error(
+                        &file.display_path,
+                        &file.relative_path,
+                        &file.absolute_path,
+                        error.line,
+                        error.column,
+                        error.message,
                         source,
-                    });
+                    ));
                 }
             }
             Ok(())
@@ -1035,22 +1135,26 @@ fn run_add_ignore_with_cwd(
                 continue;
             }
 
-            let source = include_source
-                .then(|| read_shared_source(&file.absolute_path))
-                .transpose()?;
+            let raw_source = read_shared_source(&file.absolute_path)?;
+            let source = include_source.then_some(raw_source.clone());
             if let Some(error) = result.parse_error {
-                report.diagnostics.push(DisplayedDiagnostic {
-                    path: file.display_path.clone(),
-                    span: DisplaySpan::point(error.line, error.column),
-                    message: error.message,
-                    kind: DisplayedDiagnosticKind::ParseError,
-                    source: source.clone(),
-                });
+                report.diagnostics.push(display_parse_error(
+                    &file.display_path,
+                    &file.relative_path,
+                    &file.absolute_path,
+                    error.line,
+                    error.column,
+                    error.message,
+                    source.clone(),
+                ));
             }
             push_lint_diagnostics(
                 &mut report.diagnostics,
                 &file.display_path,
+                &file.relative_path,
+                &file.absolute_path,
                 &result.diagnostics,
+                &raw_source,
                 source,
             );
         }
@@ -1158,13 +1262,15 @@ fn analyze_file(
                 line,
                 column,
             }),
-            vec![DisplayedDiagnostic {
-                path: pending.file.display_path.clone(),
-                span: DisplaySpan::point(line, column),
+            vec![display_parse_error(
+                &pending.file.display_path,
+                &pending.file.relative_path,
+                &pending.file.absolute_path,
+                line,
+                column,
                 message,
-                kind: DisplayedDiagnosticKind::ParseError,
-                source: include_source.then_some(source.clone()),
-            }],
+                include_source.then_some(source.clone()),
+            )],
         )
     } else {
         display_lint_diagnostics(&pending, &source, &diagnostics, include_source)
@@ -1222,13 +1328,15 @@ fn display_lint_diagnostics(
         CheckCacheData::Success(
             diagnostics
                 .iter()
-                .map(CachedLintDiagnostic::from_diagnostic)
+                .map(|diagnostic| CachedLintDiagnostic::from_diagnostic(diagnostic, source))
                 .collect(),
         ),
         diagnostics
             .iter()
             .map(|diagnostic| DisplayedDiagnostic {
                 path: pending.file.display_path.clone(),
+                relative_path: pending.file.relative_path.clone(),
+                absolute_path: pending.file.absolute_path.clone(),
                 span: DisplaySpan::new(
                     DisplayPosition::new(diagnostic.span.start.line, diagnostic.span.start.column),
                     DisplayPosition::new(diagnostic.span.end.line, diagnostic.span.end.column),
@@ -1238,10 +1346,99 @@ fn display_lint_diagnostics(
                     code: diagnostic.code().to_owned(),
                     severity: diagnostic.severity.as_str().to_owned(),
                 },
+                fix: displayed_fix_from_diagnostic(diagnostic, source),
                 source: diagnostic_source.clone(),
             })
             .collect(),
     )
+}
+
+fn display_parse_error(
+    display_path: &Path,
+    relative_path: &Path,
+    absolute_path: &Path,
+    line: usize,
+    column: usize,
+    message: String,
+    source: Option<Arc<str>>,
+) -> DisplayedDiagnostic {
+    DisplayedDiagnostic {
+        path: display_path.to_path_buf(),
+        relative_path: relative_path.to_path_buf(),
+        absolute_path: absolute_path.to_path_buf(),
+        span: DisplaySpan::point(line, column),
+        message,
+        kind: DisplayedDiagnosticKind::ParseError,
+        fix: None,
+        source,
+    }
+}
+
+fn displayed_fix_from_diagnostic(
+    diagnostic: &shuck_linter::Diagnostic,
+    source: &str,
+) -> Option<DisplayedFix> {
+    let fix = diagnostic.fix.as_ref()?;
+    let line_index = shuck_indexer::LineIndex::new(source);
+
+    Some(DisplayedFix {
+        applicability: match fix.applicability() {
+            Applicability::Safe => DisplayedApplicability::Safe,
+            Applicability::Unsafe => DisplayedApplicability::Unsafe,
+        },
+        message: diagnostic.fix_title.clone(),
+        edits: fix
+            .edits()
+            .iter()
+            .map(|edit| displayed_edit_from_fix(edit, &line_index, source))
+            .collect(),
+    })
+}
+
+fn displayed_edit_from_fix(
+    edit: &shuck_linter::Edit,
+    line_index: &shuck_indexer::LineIndex,
+    source: &str,
+) -> DisplayedEdit {
+    let range = edit.range();
+    let start_offset = floor_char_boundary(source, usize::from(range.start()));
+    let end_offset = ceil_char_boundary(source, usize::from(range.end()));
+
+    DisplayedEdit {
+        location: display_position_at_offset(source, line_index, start_offset),
+        end_location: display_position_at_offset(source, line_index, end_offset),
+        content: edit.content().to_owned(),
+    }
+}
+
+fn display_position_at_offset(
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    target_offset: usize,
+) -> DisplayPosition {
+    let line = line_index.line_number(TextSize::new(target_offset as u32));
+    let line_start = line_index
+        .line_start(line)
+        .map(usize::from)
+        .unwrap_or_default();
+
+    DisplayPosition::new(line, source[line_start..target_offset].chars().count() + 1)
+}
+
+fn floor_char_boundary(source: &str, offset: usize) -> usize {
+    let mut offset = offset.min(source.len());
+    while offset > 0 && !source.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn ceil_char_boundary(source: &str, offset: usize) -> usize {
+    let mut offset = offset.min(source.len());
+    while offset < source.len() && !source.is_char_boundary(offset) {
+        offset += 1;
+    }
+    offset
 }
 
 fn requested_fix_applicability(args: &CheckCommand) -> Option<Applicability> {
@@ -1257,12 +1454,16 @@ fn requested_fix_applicability(args: &CheckCommand) -> Option<Applicability> {
 fn push_cached_lint_diagnostics(
     report: &mut CheckReport,
     path: &Path,
+    relative_path: &Path,
+    absolute_path: &Path,
     diagnostics: &[CachedLintDiagnostic],
     source: Option<Arc<str>>,
 ) {
     for diagnostic in diagnostics {
         report.diagnostics.push(DisplayedDiagnostic {
             path: path.to_path_buf(),
+            relative_path: relative_path.to_path_buf(),
+            absolute_path: absolute_path.to_path_buf(),
             span: DisplaySpan::new(
                 DisplayPosition::new(diagnostic.start_line, diagnostic.start_column),
                 DisplayPosition::new(diagnostic.end_line, diagnostic.end_column),
@@ -1272,6 +1473,7 @@ fn push_cached_lint_diagnostics(
                 code: diagnostic.code.clone(),
                 severity: diagnostic.severity.clone(),
             },
+            fix: diagnostic.fix.as_ref().map(CachedLintFix::to_displayed),
             source: source.clone(),
         });
     }
@@ -1280,12 +1482,17 @@ fn push_cached_lint_diagnostics(
 fn push_lint_diagnostics(
     displayed: &mut Vec<DisplayedDiagnostic>,
     path: &Path,
+    relative_path: &Path,
+    absolute_path: &Path,
     diagnostics: &[shuck_linter::Diagnostic],
+    raw_source: &Arc<str>,
     source: Option<Arc<str>>,
 ) {
     for diagnostic in diagnostics {
         displayed.push(DisplayedDiagnostic {
             path: path.to_path_buf(),
+            relative_path: relative_path.to_path_buf(),
+            absolute_path: absolute_path.to_path_buf(),
             span: DisplaySpan::new(
                 DisplayPosition::new(diagnostic.span.start.line, diagnostic.span.start.column),
                 DisplayPosition::new(diagnostic.span.end.line, diagnostic.span.end.column),
@@ -1295,6 +1502,7 @@ fn push_lint_diagnostics(
                 code: diagnostic.code().to_owned(),
                 severity: diagnostic.severity.as_str().to_owned(),
             },
+            fix: displayed_fix_from_diagnostic(diagnostic, raw_source),
             source: source.clone(),
         });
     }
@@ -1334,6 +1542,13 @@ mod tests {
 
     fn cache_root(cwd: &Path) -> PathBuf {
         cwd.join("cache")
+    }
+
+    fn diagnostic_paths(path: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let display = PathBuf::from(path);
+        let relative = PathBuf::from(path);
+        let absolute = PathBuf::from(format!("/tmp/{path}"));
+        (display, relative, absolute)
     }
 
     fn match_paths(canonical: &Path, resolved: &Path) -> Vec<PathBuf> {
@@ -1376,6 +1591,47 @@ mod tests {
         check_args_with_format(no_cache, CheckOutputFormatArg::Full)
     }
 
+    fn lint_displayed_diagnostic(
+        path: &str,
+        span: DisplaySpan,
+        message: &str,
+        code: &str,
+        severity: &str,
+    ) -> DisplayedDiagnostic {
+        let (path, relative_path, absolute_path) = diagnostic_paths(path);
+        DisplayedDiagnostic {
+            path,
+            relative_path,
+            absolute_path,
+            span,
+            message: message.to_owned(),
+            kind: DisplayedDiagnosticKind::Lint {
+                code: code.to_owned(),
+                severity: severity.to_owned(),
+            },
+            fix: None,
+            source: None,
+        }
+    }
+
+    fn parse_displayed_diagnostic(
+        path: &str,
+        span: DisplaySpan,
+        message: &str,
+    ) -> DisplayedDiagnostic {
+        let (path, relative_path, absolute_path) = diagnostic_paths(path);
+        DisplayedDiagnostic {
+            path,
+            relative_path,
+            absolute_path,
+            span,
+            message: message.to_owned(),
+            kind: DisplayedDiagnosticKind::ParseError,
+            fix: None,
+            source: None,
+        }
+    }
+
     fn diagnostic_codes(report: &CheckReport) -> Vec<String> {
         report
             .diagnostics
@@ -1408,33 +1664,16 @@ mod tests {
 
     #[test]
     fn exit_zero_suppresses_only_non_fatal_diagnostics() {
-        let warning = DisplayedDiagnostic {
-            path: PathBuf::from("warn.sh"),
-            span: DisplaySpan::point(1, 1),
-            message: "lint".to_owned(),
-            kind: DisplayedDiagnosticKind::Lint {
-                code: "C001".to_owned(),
-                severity: "warning".to_owned(),
-            },
-            source: None,
-        };
-        let error_lint = DisplayedDiagnostic {
-            path: PathBuf::from("err.sh"),
-            span: DisplaySpan::point(1, 1),
-            message: "lint".to_owned(),
-            kind: DisplayedDiagnosticKind::Lint {
-                code: "C035".to_owned(),
-                severity: "error".to_owned(),
-            },
-            source: None,
-        };
-        let parse = DisplayedDiagnostic {
-            path: PathBuf::from("broken.sh"),
-            span: DisplaySpan::point(1, 1),
-            message: "parse".to_owned(),
-            kind: DisplayedDiagnosticKind::ParseError,
-            source: None,
-        };
+        let warning = lint_displayed_diagnostic(
+            "warn.sh",
+            DisplaySpan::point(1, 1),
+            "lint",
+            "C001",
+            "warning",
+        );
+        let error_lint =
+            lint_displayed_diagnostic("err.sh", DisplaySpan::point(1, 1), "lint", "C035", "error");
+        let parse = parse_displayed_diagnostic("broken.sh", DisplaySpan::point(1, 1), "parse");
 
         let warning_only = CheckReport {
             diagnostics: vec![warning.clone()],
@@ -1906,14 +2145,14 @@ mod tests {
 
         let report = CheckReport {
             diagnostics: vec![DisplayedDiagnostic {
-                path: PathBuf::from("script.sh"),
-                span: DisplaySpan::new(DisplayPosition::new(3, 14), DisplayPosition::new(3, 18)),
-                message: "example message".to_owned(),
-                kind: DisplayedDiagnosticKind::Lint {
-                    code: "C014".to_owned(),
-                    severity: "warning".to_owned(),
-                },
                 source: Some(Arc::<str>::from("echo ok\nvalue=$foo\nprintf '%s' $bar\n")),
+                ..lint_displayed_diagnostic(
+                    "script.sh",
+                    DisplaySpan::new(DisplayPosition::new(3, 14), DisplayPosition::new(3, 18)),
+                    "example message",
+                    "C014",
+                    "warning",
+                )
             }],
             cache_hits: 0,
             cache_misses: 0,
@@ -1940,13 +2179,11 @@ mod tests {
     #[test]
     fn report_output_stays_plain_when_colors_are_disabled() {
         let report = CheckReport {
-            diagnostics: vec![DisplayedDiagnostic {
-                path: PathBuf::from("script.sh"),
-                span: DisplaySpan::point(2, 7),
-                message: "unterminated construct".to_owned(),
-                kind: DisplayedDiagnosticKind::ParseError,
-                source: None,
-            }],
+            diagnostics: vec![parse_displayed_diagnostic(
+                "script.sh",
+                DisplaySpan::point(2, 7),
+                "unterminated construct",
+            )],
             cache_hits: 0,
             cache_misses: 0,
             fixes_applied: 0,

--- a/crates/shuck/src/commands/check_output.rs
+++ b/crates/shuck/src/commands/check_output.rs
@@ -1156,7 +1156,7 @@ mod tests {
     fn diagnostic_paths(path: &str) -> (PathBuf, PathBuf, PathBuf) {
         let display = PathBuf::from(path);
         let relative = PathBuf::from(path);
-        let absolute = PathBuf::from(format!("/tmp/{path}"));
+        let absolute = std::env::temp_dir().join(path);
         (display, relative, absolute)
     }
 

--- a/crates/shuck/src/commands/check_output.rs
+++ b/crates/shuck/src/commands/check_output.rs
@@ -1,15 +1,39 @@
+use std::collections::BTreeMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use annotate_snippets::{AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
 use colored::{ColoredString, Colorize};
+use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite, XmlString};
+use serde::Serialize;
 use shuck_indexer::LineIndex;
+use shuck_linter::{Category, RuleMetadata, code_to_rule, rule_metadata};
 
 use crate::args::CheckOutputFormatArg;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+const PARSE_ERROR_CODE: &str = "parse-error";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum DisplayedApplicability {
+    Safe,
+    Unsafe,
+}
+
+impl DisplayedApplicability {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Safe => "safe",
+            Self::Unsafe => "unsafe",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub(super) struct DisplayPosition {
     pub(super) line: usize,
     pub(super) column: usize,
@@ -38,6 +62,20 @@ impl DisplaySpan {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct DisplayedEdit {
+    pub(super) location: DisplayPosition,
+    pub(super) end_location: DisplayPosition,
+    pub(super) content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct DisplayedFix {
+    pub(super) applicability: DisplayedApplicability,
+    pub(super) message: Option<String>,
+    pub(super) edits: Vec<DisplayedEdit>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum DisplayedDiagnosticKind {
     ParseError,
@@ -47,10 +85,44 @@ pub(super) enum DisplayedDiagnosticKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct DisplayedDiagnostic {
     pub(super) path: PathBuf,
+    pub(super) relative_path: PathBuf,
+    pub(super) absolute_path: PathBuf,
     pub(super) span: DisplaySpan,
     pub(super) message: String,
     pub(super) kind: DisplayedDiagnosticKind,
+    pub(super) fix: Option<DisplayedFix>,
     pub(super) source: Option<Arc<str>>,
+}
+
+impl DisplayedDiagnostic {
+    fn code(&self) -> &str {
+        match &self.kind {
+            DisplayedDiagnosticKind::ParseError => PARSE_ERROR_CODE,
+            DisplayedDiagnosticKind::Lint { code, .. } => code,
+        }
+    }
+
+    fn severity(&self) -> &str {
+        match &self.kind {
+            DisplayedDiagnosticKind::ParseError => "error",
+            DisplayedDiagnosticKind::Lint { severity, .. } => severity,
+        }
+    }
+
+    fn relative_path_string(&self) -> String {
+        self.relative_path.display().to_string()
+    }
+
+    fn absolute_uri(&self) -> io::Result<String> {
+        url::Url::from_file_path(&self.absolute_path)
+            .map(|url| url.to_string())
+            .map_err(|()| {
+                io::Error::other(format!(
+                    "failed to convert path to file URI: {}",
+                    self.absolute_path.display()
+                ))
+            })
+    }
 }
 
 pub(super) fn print_report_to(
@@ -59,29 +131,293 @@ pub(super) fn print_report_to(
     output_format: CheckOutputFormatArg,
     use_color: bool,
 ) -> io::Result<()> {
-    for (index, diagnostic) in diagnostics.iter().enumerate() {
-        match output_format {
-            CheckOutputFormatArg::Full => {
-                if index > 0 {
-                    writeln!(writer)?;
-                }
+    match output_format {
+        CheckOutputFormatArg::Full => write_full_diagnostics(writer, diagnostics, use_color),
+        CheckOutputFormatArg::Concise => write_concise_diagnostics(writer, diagnostics, use_color),
+        CheckOutputFormatArg::Grouped => write_grouped_diagnostics(writer, diagnostics, use_color),
+        CheckOutputFormatArg::Json => write_json_diagnostics(writer, diagnostics),
+        CheckOutputFormatArg::JsonLines => write_json_lines_diagnostics(writer, diagnostics),
+        CheckOutputFormatArg::Junit => write_junit_diagnostics(writer, diagnostics),
+        CheckOutputFormatArg::Github => write_github_diagnostics(writer, diagnostics),
+        CheckOutputFormatArg::Gitlab => write_gitlab_diagnostics(writer, diagnostics),
+        CheckOutputFormatArg::Rdjson => write_rdjson_diagnostics(writer, diagnostics),
+        CheckOutputFormatArg::Sarif => write_sarif_diagnostics(writer, diagnostics),
+    }
+}
 
-                let rendered = format_full_diagnostic(diagnostic, use_color);
-                writer.write_all(rendered.as_bytes())?;
-                if !rendered.ends_with('\n') {
-                    writeln!(writer)?;
-                }
-            }
-            CheckOutputFormatArg::Concise => {
-                writeln!(
-                    writer,
-                    "{}",
-                    format_concise_diagnostic(diagnostic, use_color)
-                )?;
-            }
+fn write_full_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+    use_color: bool,
+) -> io::Result<()> {
+    for (index, diagnostic) in diagnostics.iter().enumerate() {
+        if index > 0 {
+            writeln!(writer)?;
+        }
+
+        let rendered = format_full_diagnostic(diagnostic, use_color);
+        writer.write_all(rendered.as_bytes())?;
+        if !rendered.ends_with('\n') {
+            writeln!(writer)?;
         }
     }
 
+    Ok(())
+}
+
+fn write_concise_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+    use_color: bool,
+) -> io::Result<()> {
+    for diagnostic in diagnostics {
+        writeln!(
+            writer,
+            "{}",
+            format_concise_diagnostic(diagnostic, use_color)
+        )?;
+    }
+
+    Ok(())
+}
+
+fn write_grouped_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+    use_color: bool,
+) -> io::Result<()> {
+    let mut grouped = BTreeMap::<PathBuf, Vec<&DisplayedDiagnostic>>::new();
+    for diagnostic in diagnostics {
+        grouped
+            .entry(diagnostic.path.clone())
+            .or_default()
+            .push(diagnostic);
+    }
+
+    for (index, (path, messages)) in grouped.into_iter().enumerate() {
+        if index > 0 {
+            writeln!(writer)?;
+        }
+
+        let header = paint(path.display().to_string(), use_color, |value| {
+            value.bold().underline()
+        });
+        writeln!(writer, "{header}:")?;
+
+        for diagnostic in messages {
+            let line = paint(diagnostic.span.start.line.to_string(), use_color, |value| {
+                value.cyan()
+            });
+            let column = paint(
+                diagnostic.span.start.column.to_string(),
+                use_color,
+                |value| value.cyan(),
+            );
+            writeln!(
+                writer,
+                "  {line}:{column}: {}",
+                format_diagnostic_body(diagnostic, use_color)
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_json_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+) -> io::Result<()> {
+    let values = diagnostics.iter().map(json_diagnostic).collect::<Vec<_>>();
+    serde_json::to_writer_pretty(&mut *writer, &values).map_err(io::Error::other)?;
+    writeln!(writer)?;
+    Ok(())
+}
+
+fn write_json_lines_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+) -> io::Result<()> {
+    for diagnostic in diagnostics {
+        serde_json::to_writer(&mut *writer, &json_diagnostic(diagnostic))
+            .map_err(io::Error::other)?;
+        writeln!(writer)?;
+    }
+    Ok(())
+}
+
+fn write_junit_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+) -> io::Result<()> {
+    let package = "org.shuck";
+    let mut report = Report::new("shuck");
+
+    if diagnostics.is_empty() {
+        let mut suite = TestSuite::new("shuck");
+        suite
+            .extra
+            .insert(XmlString::new("package"), XmlString::new(package));
+        let mut case = TestCase::new("No errors found", TestCaseStatus::success());
+        case.set_classname("shuck");
+        suite.add_test_case(case);
+        report.add_test_suite(suite);
+    } else {
+        let mut grouped = BTreeMap::<String, Vec<&DisplayedDiagnostic>>::new();
+        for diagnostic in diagnostics {
+            grouped
+                .entry(diagnostic.relative_path_string())
+                .or_default()
+                .push(diagnostic);
+        }
+
+        for (filename, diagnostics) in grouped {
+            let mut suite = TestSuite::new(&filename);
+            suite
+                .extra
+                .insert(XmlString::new("package"), XmlString::new(package));
+            let classname = Path::new(&filename)
+                .with_extension("")
+                .to_string_lossy()
+                .to_string();
+
+            for diagnostic in diagnostics {
+                let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
+                status.set_message(&diagnostic.message);
+                status.set_description(format!(
+                    "line {}, col {}, {}",
+                    diagnostic.span.start.line, diagnostic.span.start.column, diagnostic.message
+                ));
+
+                let mut case = TestCase::new(format!("org.shuck.{}", diagnostic.code()), status);
+                case.set_classname(&classname);
+                case.extra.insert(
+                    XmlString::new("line"),
+                    XmlString::new(diagnostic.span.start.line.to_string()),
+                );
+                case.extra.insert(
+                    XmlString::new("column"),
+                    XmlString::new(diagnostic.span.start.column.to_string()),
+                );
+                suite.add_test_case(case);
+            }
+
+            report.add_test_suite(suite);
+        }
+    }
+
+    report.serialize(&mut *writer).map_err(io::Error::other)?;
+    writeln!(writer)?;
+    Ok(())
+}
+
+fn write_github_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+) -> io::Result<()> {
+    for diagnostic in diagnostics {
+        let severity = match diagnostic.severity() {
+            "hint" | "info" => "notice",
+            "warning" => "warning",
+            _ => "error",
+        };
+        let title = escape_github_property(&format!("shuck ({})", diagnostic.code()));
+        let file = escape_github_property(&diagnostic.relative_path_string());
+        let body = escape_github_message(&format!(
+            "{}:{}:{}: {} {}",
+            diagnostic.relative_path.display(),
+            diagnostic.span.start.line,
+            diagnostic.span.start.column,
+            diagnostic.code(),
+            diagnostic.message
+        ));
+
+        write!(writer, "::{severity} title={title},file={file}")?;
+        if diagnostic.span.start.line == diagnostic.span.end.line {
+            write!(
+                writer,
+                ",line={},col={},endLine={},endColumn={}",
+                diagnostic.span.start.line,
+                diagnostic.span.start.column,
+                diagnostic.span.end.line,
+                diagnostic.span.end.column.max(diagnostic.span.start.column),
+            )?;
+        } else {
+            write!(
+                writer,
+                ",line={},endLine={}",
+                diagnostic.span.start.line, diagnostic.span.end.line
+            )?;
+        }
+        writeln!(writer, "::{body}")?;
+    }
+
+    Ok(())
+}
+
+fn write_gitlab_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+) -> io::Result<()> {
+    let values = diagnostics
+        .iter()
+        .map(gitlab_diagnostic)
+        .collect::<Vec<_>>();
+    serde_json::to_writer_pretty(&mut *writer, &values).map_err(io::Error::other)?;
+    writeln!(writer)?;
+    Ok(())
+}
+
+fn write_rdjson_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+) -> io::Result<()> {
+    let payload = RdjsonDiagnostics {
+        source: RdjsonSource {
+            name: "shuck",
+            url: env!("CARGO_PKG_REPOSITORY"),
+        },
+        severity: "WARNING",
+        diagnostics: diagnostics.iter().map(rdjson_diagnostic).collect(),
+    };
+    serde_json::to_writer_pretty(&mut *writer, &payload).map_err(io::Error::other)?;
+    writeln!(writer)?;
+    Ok(())
+}
+
+fn write_sarif_diagnostics(
+    writer: &mut dyn Write,
+    diagnostics: &[DisplayedDiagnostic],
+) -> io::Result<()> {
+    let results = diagnostics
+        .iter()
+        .map(sarif_result)
+        .collect::<io::Result<Vec<_>>>()?;
+    let mut rules = BTreeMap::<String, SarifRule>::new();
+    for diagnostic in diagnostics {
+        rules
+            .entry(diagnostic.code().to_owned())
+            .or_insert_with(|| sarif_rule(diagnostic));
+    }
+
+    let output = SarifOutput {
+        schema: "https://json.schemastore.org/sarif-2.1.0.json",
+        version: "2.1.0",
+        runs: vec![SarifRun {
+            tool: SarifTool {
+                driver: SarifDriver {
+                    name: "shuck",
+                    information_uri: env!("CARGO_PKG_REPOSITORY"),
+                    version: env!("CARGO_PKG_VERSION").to_owned(),
+                    rules: rules.into_values().collect(),
+                },
+            },
+            results,
+        }],
+    };
+
+    serde_json::to_writer_pretty(&mut *writer, &output).map_err(io::Error::other)?;
+    writeln!(writer)?;
     Ok(())
 }
 
@@ -125,7 +461,7 @@ fn format_full_header(diagnostic: &DisplayedDiagnostic, use_color: bool) -> Stri
         DisplayedDiagnosticKind::ParseError => format!(
             "{}[{}]: {}",
             paint("error".to_owned(), use_color, |value| value.red().bold()),
-            paint("parse-error".to_owned(), use_color, |value| value
+            paint(PARSE_ERROR_CODE.to_owned(), use_color, |value| value
                 .red()
                 .bold()),
             diagnostic.message
@@ -170,6 +506,22 @@ fn format_concise_diagnostic(diagnostic: &DisplayedDiagnostic, use_color: bool) 
     }
 }
 
+fn format_diagnostic_body(diagnostic: &DisplayedDiagnostic, use_color: bool) -> String {
+    match &diagnostic.kind {
+        DisplayedDiagnosticKind::ParseError => {
+            let label = paint("parse error".to_owned(), use_color, |value| {
+                value.red().bold()
+            });
+            format!("{label} {}", diagnostic.message)
+        }
+        DisplayedDiagnosticKind::Lint { code, severity } => {
+            let severity = format_severity(severity, use_color);
+            let code = paint(code.clone(), use_color, |value| value.cyan().bold());
+            format!("{severity}[{code}] {}", diagnostic.message)
+        }
+    }
+}
+
 fn format_severity(severity: &str, use_color: bool) -> String {
     paint(severity.to_owned(), use_color, |value| match severity {
         "error" => value.red().bold(),
@@ -196,6 +548,530 @@ fn annotation_type(diagnostic: &DisplayedDiagnostic) -> AnnotationType {
         DisplayedDiagnosticKind::ParseError => AnnotationType::Error,
         DisplayedDiagnosticKind::Lint { .. } => AnnotationType::Error,
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct JsonLocation {
+    row: usize,
+    column: usize,
+}
+
+impl From<DisplayPosition> for JsonLocation {
+    fn from(value: DisplayPosition) -> Self {
+        Self {
+            row: value.line,
+            column: value.column,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct JsonEdit {
+    content: String,
+    location: JsonLocation,
+    end_location: JsonLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct JsonFix {
+    applicability: &'static str,
+    message: Option<String>,
+    edits: Vec<JsonEdit>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct JsonDiagnostic {
+    code: String,
+    severity: String,
+    url: Option<String>,
+    message: String,
+    fix: Option<JsonFix>,
+    location: JsonLocation,
+    end_location: JsonLocation,
+    filename: String,
+}
+
+fn json_diagnostic(diagnostic: &DisplayedDiagnostic) -> JsonDiagnostic {
+    JsonDiagnostic {
+        code: diagnostic.code().to_owned(),
+        severity: diagnostic.severity().to_owned(),
+        url: None,
+        message: diagnostic.message.clone(),
+        fix: diagnostic.fix.as_ref().map(json_fix),
+        location: diagnostic.span.start.into(),
+        end_location: diagnostic.span.end.into(),
+        filename: diagnostic.relative_path_string(),
+    }
+}
+
+fn json_fix(fix: &DisplayedFix) -> JsonFix {
+    JsonFix {
+        applicability: fix.applicability.as_str(),
+        message: fix.message.clone(),
+        edits: fix
+            .edits
+            .iter()
+            .map(|edit| JsonEdit {
+                content: edit.content.clone(),
+                location: edit.location.into(),
+                end_location: edit.end_location.into(),
+            })
+            .collect(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct GitlabPosition {
+    line: usize,
+    column: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct GitlabPositions {
+    begin: GitlabPosition,
+    end: GitlabPosition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct GitlabLocation {
+    path: String,
+    positions: GitlabPositions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct GitlabDiagnostic {
+    description: String,
+    check_name: String,
+    severity: &'static str,
+    fingerprint: String,
+    location: GitlabLocation,
+}
+
+fn gitlab_diagnostic(diagnostic: &DisplayedDiagnostic) -> GitlabDiagnostic {
+    GitlabDiagnostic {
+        description: format!("{}: {}", diagnostic.code(), diagnostic.message),
+        check_name: diagnostic.code().to_owned(),
+        severity: gitlab_severity(diagnostic.severity()),
+        fingerprint: gitlab_fingerprint(diagnostic),
+        location: GitlabLocation {
+            path: diagnostic.relative_path_string(),
+            positions: GitlabPositions {
+                begin: GitlabPosition {
+                    line: diagnostic.span.start.line,
+                    column: diagnostic.span.start.column,
+                },
+                end: GitlabPosition {
+                    line: diagnostic.span.end.line,
+                    column: diagnostic.span.end.column,
+                },
+            },
+        },
+    }
+}
+
+fn gitlab_severity(severity: &str) -> &'static str {
+    match severity {
+        "hint" | "info" => "info",
+        "warning" => "minor",
+        "error" => "major",
+        _ => "critical",
+    }
+}
+
+fn gitlab_fingerprint(diagnostic: &DisplayedDiagnostic) -> String {
+    let mut hasher = DefaultHasher::new();
+    diagnostic.code().hash(&mut hasher);
+    diagnostic.relative_path.hash(&mut hasher);
+    diagnostic.message.hash(&mut hasher);
+    diagnostic.span.start.line.hash(&mut hasher);
+    diagnostic.span.start.column.hash(&mut hasher);
+    diagnostic.span.end.line.hash(&mut hasher);
+    diagnostic.span.end.column.hash(&mut hasher);
+    diagnostic.severity().hash(&mut hasher);
+    format!("{:x}", hasher.finish())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RdjsonSource {
+    name: &'static str,
+    url: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RdjsonDiagnostics {
+    source: RdjsonSource,
+    severity: &'static str,
+    diagnostics: Vec<RdjsonDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RdjsonCode {
+    value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RdjsonLineColumn {
+    line: usize,
+    column: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RdjsonRange {
+    start: RdjsonLineColumn,
+    end: RdjsonLineColumn,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RdjsonLocation {
+    path: String,
+    range: RdjsonRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RdjsonSuggestion {
+    range: RdjsonRange,
+    text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RdjsonDiagnostic {
+    code: RdjsonCode,
+    location: RdjsonLocation,
+    message: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    suggestions: Vec<RdjsonSuggestion>,
+}
+
+fn rdjson_diagnostic(diagnostic: &DisplayedDiagnostic) -> RdjsonDiagnostic {
+    RdjsonDiagnostic {
+        code: RdjsonCode {
+            value: diagnostic.code().to_owned(),
+            url: None,
+        },
+        location: RdjsonLocation {
+            path: diagnostic.relative_path_string(),
+            range: rdjson_range(diagnostic.span.start, diagnostic.span.end),
+        },
+        message: diagnostic.message.clone(),
+        suggestions: diagnostic
+            .fix
+            .as_ref()
+            .map(|fix| {
+                fix.edits
+                    .iter()
+                    .map(|edit| RdjsonSuggestion {
+                        range: rdjson_range(edit.location, edit.end_location),
+                        text: edit.content.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
+fn rdjson_range(start: DisplayPosition, end: DisplayPosition) -> RdjsonRange {
+    RdjsonRange {
+        start: RdjsonLineColumn {
+            line: start.line,
+            column: start.column,
+        },
+        end: RdjsonLineColumn {
+            line: end.line,
+            column: end.column,
+        },
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SarifOutput {
+    #[serde(rename = "$schema")]
+    schema: &'static str,
+    version: &'static str,
+    runs: Vec<SarifRun>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SarifRun {
+    tool: SarifTool,
+    results: Vec<SarifResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SarifTool {
+    driver: SarifDriver,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifDriver {
+    name: &'static str,
+    information_uri: &'static str,
+    version: String,
+    rules: Vec<SarifRule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRule {
+    id: String,
+    short_description: SarifMessage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    full_description: Option<SarifMessage>,
+    help: SarifMessage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    help_uri: Option<String>,
+    properties: SarifProperties,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifProperties {
+    id: String,
+    kind: String,
+    name: String,
+    #[serde(rename = "problem.severity")]
+    problem_severity: SarifLevel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifResult {
+    rule_id: String,
+    level: SarifLevel,
+    message: SarifMessage,
+    locations: Vec<SarifLocation>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    fixes: Vec<SarifFix>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SarifMessage {
+    text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifLocation {
+    physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifPhysicalLocation {
+    artifact_location: SarifArtifactLocation,
+    region: SarifRegion,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifArtifactLocation {
+    uri: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRegion {
+    start_line: usize,
+    start_column: usize,
+    end_line: usize,
+    end_column: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifFix {
+    artifact_changes: Vec<SarifArtifactChange>,
+    description: SarifDescription,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifDescription {
+    text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifArtifactChange {
+    artifact_location: SarifArtifactLocation,
+    replacements: Vec<SarifReplacement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifReplacement {
+    deleted_region: SarifRegion,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inserted_content: Option<SarifInsertedContent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifInsertedContent {
+    text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum SarifLevel {
+    Note,
+    Warning,
+    Error,
+}
+
+fn sarif_result(diagnostic: &DisplayedDiagnostic) -> io::Result<SarifResult> {
+    let uri = diagnostic.absolute_uri()?;
+    Ok(SarifResult {
+        rule_id: diagnostic.code().to_owned(),
+        level: sarif_level(diagnostic.severity()),
+        message: SarifMessage {
+            text: diagnostic.message.clone(),
+        },
+        locations: vec![SarifLocation {
+            physical_location: SarifPhysicalLocation {
+                artifact_location: SarifArtifactLocation { uri: uri.clone() },
+                region: SarifRegion {
+                    start_line: diagnostic.span.start.line,
+                    start_column: diagnostic.span.start.column,
+                    end_line: diagnostic.span.end.line,
+                    end_column: diagnostic.span.end.column.max(diagnostic.span.start.column),
+                },
+            },
+        }],
+        fixes: diagnostic
+            .fix
+            .as_ref()
+            .map(|fix| {
+                vec![SarifFix {
+                    description: SarifDescription {
+                        text: fix.message.clone(),
+                    },
+                    artifact_changes: vec![SarifArtifactChange {
+                        artifact_location: SarifArtifactLocation { uri },
+                        replacements: fix
+                            .edits
+                            .iter()
+                            .map(|edit| SarifReplacement {
+                                deleted_region: SarifRegion {
+                                    start_line: edit.location.line,
+                                    start_column: edit.location.column,
+                                    end_line: edit.end_location.line,
+                                    end_column: edit.end_location.column.max(edit.location.column),
+                                },
+                                inserted_content: (!edit.content.is_empty()).then(|| {
+                                    SarifInsertedContent {
+                                        text: edit.content.clone(),
+                                    }
+                                }),
+                            })
+                            .collect(),
+                    }],
+                }]
+            })
+            .unwrap_or_default(),
+    })
+}
+
+fn sarif_rule(diagnostic: &DisplayedDiagnostic) -> SarifRule {
+    match &diagnostic.kind {
+        DisplayedDiagnosticKind::ParseError => SarifRule {
+            id: PARSE_ERROR_CODE.to_owned(),
+            short_description: SarifMessage {
+                text: "Shell source could not be parsed".to_owned(),
+            },
+            full_description: Some(SarifMessage {
+                text: "The parser could not build a valid shell syntax tree for this file."
+                    .to_owned(),
+            }),
+            help: SarifMessage {
+                text: "Fix the reported syntax issue so analysis can continue.".to_owned(),
+            },
+            help_uri: None,
+            properties: SarifProperties {
+                id: PARSE_ERROR_CODE.to_owned(),
+                kind: "parser".to_owned(),
+                name: PARSE_ERROR_CODE.to_owned(),
+                problem_severity: SarifLevel::Error,
+            },
+        },
+        DisplayedDiagnosticKind::Lint { code, severity } => {
+            let metadata = diagnostic_rule_metadata(diagnostic);
+            let category = diagnostic_rule_category(diagnostic);
+            SarifRule {
+                id: code.clone(),
+                short_description: SarifMessage {
+                    text: metadata
+                        .map(|metadata| metadata.description.to_owned())
+                        .unwrap_or_else(|| diagnostic.message.clone()),
+                },
+                full_description: metadata.map(|metadata| SarifMessage {
+                    text: metadata.rationale.to_owned(),
+                }),
+                help: SarifMessage {
+                    text: metadata
+                        .map(|metadata| metadata.rationale.to_owned())
+                        .unwrap_or_else(|| diagnostic.message.clone()),
+                },
+                help_uri: None,
+                properties: SarifProperties {
+                    id: code.clone(),
+                    kind: category.to_owned(),
+                    name: code.clone(),
+                    problem_severity: sarif_level(severity),
+                },
+            }
+        }
+    }
+}
+
+fn sarif_level(severity: &str) -> SarifLevel {
+    match severity {
+        "hint" | "info" => SarifLevel::Note,
+        "warning" => SarifLevel::Warning,
+        _ => SarifLevel::Error,
+    }
+}
+
+fn diagnostic_rule_metadata(diagnostic: &DisplayedDiagnostic) -> Option<&'static RuleMetadata> {
+    let DisplayedDiagnosticKind::Lint { code, .. } = &diagnostic.kind else {
+        return None;
+    };
+    let rule = code_to_rule(code)?;
+    rule_metadata(rule)
+}
+
+fn diagnostic_rule_category(diagnostic: &DisplayedDiagnostic) -> &'static str {
+    let DisplayedDiagnosticKind::Lint { code, .. } = &diagnostic.kind else {
+        return "parser";
+    };
+    let Some(rule) = code_to_rule(code) else {
+        return "lint";
+    };
+    match rule.category() {
+        Category::Correctness => "correctness",
+        Category::Style => "style",
+        Category::Performance => "performance",
+        Category::Portability => "portability",
+        Category::Security => "security",
+    }
+}
+
+fn escape_github_property(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+        .replace(':', "%3A")
+        .replace(',', "%2C")
+}
+
+fn escape_github_message(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
 }
 
 struct RenderableSnippet<'a> {
@@ -277,6 +1153,13 @@ fn snippet_end_offset(line: usize, line_index: &LineIndex, source: &str) -> Opti
 mod tests {
     use super::*;
 
+    fn diagnostic_paths(path: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let display = PathBuf::from(path);
+        let relative = PathBuf::from(path);
+        let absolute = PathBuf::from(format!("/tmp/{path}"));
+        (display, relative, absolute)
+    }
+
     fn lint_diagnostic(
         path: &str,
         span: DisplaySpan,
@@ -285,16 +1168,41 @@ mod tests {
         code: &str,
         source: &str,
     ) -> DisplayedDiagnostic {
+        let (path, relative_path, absolute_path) = diagnostic_paths(path);
         DisplayedDiagnostic {
-            path: PathBuf::from(path),
+            path,
+            relative_path,
+            absolute_path,
             span,
             message: message.to_owned(),
             kind: DisplayedDiagnosticKind::Lint {
                 code: code.to_owned(),
                 severity: severity.to_owned(),
             },
+            fix: None,
             source: Some(Arc::<str>::from(source)),
         }
+    }
+
+    fn lint_diagnostic_with_fix(
+        path: &str,
+        span: DisplaySpan,
+        message: &str,
+        severity: &str,
+        code: &str,
+        source: &str,
+    ) -> DisplayedDiagnostic {
+        let mut diagnostic = lint_diagnostic(path, span, message, severity, code, source);
+        diagnostic.fix = Some(DisplayedFix {
+            applicability: DisplayedApplicability::Safe,
+            message: Some("apply example fix".to_owned()),
+            edits: vec![DisplayedEdit {
+                location: DisplayPosition::new(1, 1),
+                end_location: DisplayPosition::new(1, 5),
+                content: "echo".to_owned(),
+            }],
+        });
+        diagnostic
     }
 
     fn parse_diagnostic(
@@ -304,11 +1212,15 @@ mod tests {
         message: &str,
         source: &str,
     ) -> DisplayedDiagnostic {
+        let (path, relative_path, absolute_path) = diagnostic_paths(path);
         DisplayedDiagnostic {
-            path: PathBuf::from(path),
+            path,
+            relative_path,
+            absolute_path,
             span: DisplaySpan::point(line, column),
             message: message.to_owned(),
             kind: DisplayedDiagnosticKind::ParseError,
+            fix: None,
             source: Some(Arc::<str>::from(source)),
         }
     }
@@ -417,5 +1329,202 @@ warning[S005]: legacy backticks
             format_concise_diagnostic(&diagnostic, false),
             "script.sh:3:14: warning[C014] example message"
         );
+    }
+
+    #[test]
+    fn renders_grouped_output() {
+        let diagnostics = vec![
+            lint_diagnostic(
+                "alpha.sh",
+                DisplaySpan::point(2, 1),
+                "alpha message",
+                "warning",
+                "C001",
+                "unused=1\n",
+            ),
+            parse_diagnostic("beta.sh", 3, 4, "broken syntax", "if true\n"),
+        ];
+
+        let mut output = Vec::new();
+        print_report_to(
+            &mut output,
+            &diagnostics,
+            CheckOutputFormatArg::Grouped,
+            false,
+        )
+        .unwrap();
+
+        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @r"
+alpha.sh:
+  2:1: warning[C001] alpha message
+
+beta.sh:
+  3:4: parse error broken syntax
+");
+    }
+
+    #[test]
+    fn renders_github_output_for_multi_line_span() {
+        let diagnostics = vec![lint_diagnostic(
+            "script.sh",
+            DisplaySpan::new(DisplayPosition::new(2, 4), DisplayPosition::new(3, 9)),
+            "quoted regular expression literal",
+            "error",
+            "C010",
+            "if true; then\n  [[ $foo =~ \"bar\"\n    && $bar ]]\nfi\n",
+        )];
+
+        let mut output = Vec::new();
+        print_report_to(
+            &mut output,
+            &diagnostics,
+            CheckOutputFormatArg::Github,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "::error title=shuck (C010),file=script.sh,line=2,endLine=3::script.sh:2:4: C010 quoted regular expression literal\n",
+        );
+    }
+
+    #[test]
+    fn renders_json_output_with_fix() {
+        let diagnostics = vec![lint_diagnostic_with_fix(
+            "script.sh",
+            DisplaySpan::point(2, 1),
+            "variable is unused",
+            "warning",
+            "C001",
+            "unused=1\n",
+        )];
+
+        let mut output = Vec::new();
+        print_report_to(&mut output, &diagnostics, CheckOutputFormatArg::Json, false).unwrap();
+
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        insta::assert_json_snapshot!(value, @r#"
+        [
+          {
+            "code": "C001",
+            "end_location": {
+              "column": 1,
+              "row": 2
+            },
+            "filename": "script.sh",
+            "fix": {
+              "applicability": "safe",
+              "edits": [
+                {
+                  "content": "echo",
+                  "end_location": {
+                    "column": 5,
+                    "row": 1
+                  },
+                  "location": {
+                    "column": 1,
+                    "row": 1
+                  }
+                }
+              ],
+              "message": "apply example fix"
+            },
+            "location": {
+              "column": 1,
+              "row": 2
+            },
+            "message": "variable is unused",
+            "severity": "warning",
+            "url": null
+          }
+        ]
+        "#);
+    }
+
+    #[test]
+    fn renders_sarif_output_for_parse_error() {
+        let diagnostics = vec![parse_diagnostic(
+            "broken.sh",
+            2,
+            6,
+            "unterminated construct",
+            "#!/bin/bash\nif true\n",
+        )];
+
+        let mut output = Vec::new();
+        print_report_to(
+            &mut output,
+            &diagnostics,
+            CheckOutputFormatArg::Sarif,
+            false,
+        )
+        .unwrap();
+
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        insta::assert_json_snapshot!(value, {
+          ".runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri" => "[URI]",
+          ".runs[0].tool.driver.version" => "[VERSION]"
+        }, @r#"
+        {
+          "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+          "runs": [
+            {
+              "results": [
+                {
+                  "level": "error",
+                  "locations": [
+                    {
+                      "physicalLocation": {
+                        "artifactLocation": {
+                          "uri": "[URI]"
+                        },
+                        "region": {
+                          "endColumn": 6,
+                          "endLine": 2,
+                          "startColumn": 6,
+                          "startLine": 2
+                        }
+                      }
+                    }
+                  ],
+                  "message": {
+                    "text": "unterminated construct"
+                  },
+                  "ruleId": "parse-error"
+                }
+              ],
+              "tool": {
+                "driver": {
+                  "informationUri": "https://github.com/ewhauser/shuck",
+                  "name": "shuck",
+                  "rules": [
+                    {
+                      "fullDescription": {
+                        "text": "The parser could not build a valid shell syntax tree for this file."
+                      },
+                      "help": {
+                        "text": "Fix the reported syntax issue so analysis can continue."
+                      },
+                      "id": "parse-error",
+                      "properties": {
+                        "id": "parse-error",
+                        "kind": "parser",
+                        "name": "parse-error",
+                        "problem.severity": "error"
+                      },
+                      "shortDescription": {
+                        "text": "Shell source could not be parsed"
+                      }
+                    }
+                  ],
+                  "version": "[VERSION]"
+                }
+              }
+            }
+          ],
+          "version": "2.1.0"
+        }
+        "#);
     }
 }

--- a/crates/shuck/src/commands/check_output.rs
+++ b/crates/shuck/src/commands/check_output.rs
@@ -932,12 +932,7 @@ fn sarif_result(diagnostic: &DisplayedDiagnostic) -> io::Result<SarifResult> {
         locations: vec![SarifLocation {
             physical_location: SarifPhysicalLocation {
                 artifact_location: SarifArtifactLocation { uri: uri.clone() },
-                region: SarifRegion {
-                    start_line: diagnostic.span.start.line,
-                    start_column: diagnostic.span.start.column,
-                    end_line: diagnostic.span.end.line,
-                    end_column: diagnostic.span.end.column.max(diagnostic.span.start.column),
-                },
+                region: sarif_region(diagnostic.span.start, diagnostic.span.end),
             },
         }],
         fixes: diagnostic
@@ -954,12 +949,7 @@ fn sarif_result(diagnostic: &DisplayedDiagnostic) -> io::Result<SarifResult> {
                             .edits
                             .iter()
                             .map(|edit| SarifReplacement {
-                                deleted_region: SarifRegion {
-                                    start_line: edit.location.line,
-                                    start_column: edit.location.column,
-                                    end_line: edit.end_location.line,
-                                    end_column: edit.end_location.column.max(edit.location.column),
-                                },
+                                deleted_region: sarif_region(edit.location, edit.end_location),
                                 inserted_content: (!edit.content.is_empty()).then(|| {
                                     SarifInsertedContent {
                                         text: edit.content.clone(),
@@ -972,6 +962,19 @@ fn sarif_result(diagnostic: &DisplayedDiagnostic) -> io::Result<SarifResult> {
             })
             .unwrap_or_default(),
     })
+}
+
+fn sarif_region(start: DisplayPosition, end: DisplayPosition) -> SarifRegion {
+    SarifRegion {
+        start_line: start.line,
+        start_column: start.column,
+        end_line: end.line,
+        end_column: if start.line == end.line {
+            end.column.max(start.column)
+        } else {
+            end.column
+        },
+    }
 }
 
 fn sarif_rule(diagnostic: &DisplayedDiagnostic) -> SarifRule {
@@ -1659,5 +1662,54 @@ beta.sh:
           "version": "2.1.0"
         }
         "#);
+    }
+
+    #[test]
+    fn renders_sarif_output_with_multi_line_end_columns() {
+        let (path, relative_path, absolute_path) =
+            diagnostic_paths_with_relative("script.sh", "script.sh");
+        let diagnostic = DisplayedDiagnostic {
+            path,
+            relative_path,
+            absolute_path,
+            span: DisplaySpan::new(DisplayPosition::new(2, 20), DisplayPosition::new(3, 4)),
+            message: "quoted regular expression literal".to_owned(),
+            kind: DisplayedDiagnosticKind::Lint {
+                code: "C010".to_owned(),
+                severity: "error".to_owned(),
+            },
+            fix: Some(DisplayedFix {
+                applicability: DisplayedApplicability::Safe,
+                message: Some("rewrite expression".to_owned()),
+                edits: vec![DisplayedEdit {
+                    location: DisplayPosition::new(2, 20),
+                    end_location: DisplayPosition::new(3, 4),
+                    content: "$bar".to_owned(),
+                }],
+            }),
+            source: Some(Arc::<str>::from(
+                "if true; then\n  [[ $foo =~ \"bar\"\n    && $bar ]]\nfi\n",
+            )),
+        };
+
+        let mut output = Vec::new();
+        print_report_to(
+            &mut output,
+            std::slice::from_ref(&diagnostic),
+            CheckOutputFormatArg::Sarif,
+            false,
+        )
+        .unwrap();
+
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(
+            value["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]["endColumn"],
+            4
+        );
+        assert_eq!(
+            value["runs"][0]["results"][0]["fixes"][0]["artifactChanges"][0]["replacements"][0]["deletedRegion"]
+                ["endColumn"],
+            4
+        );
     }
 }

--- a/crates/shuck/src/commands/check_output.rs
+++ b/crates/shuck/src/commands/check_output.rs
@@ -1490,7 +1490,7 @@ beta.sh:
         let mut json_output = Vec::new();
         print_report_to(
             &mut json_output,
-            &[diagnostic.clone()],
+            std::slice::from_ref(&diagnostic),
             CheckOutputFormatArg::Json,
             false,
         )
@@ -1501,7 +1501,7 @@ beta.sh:
         let mut github_output = Vec::new();
         print_report_to(
             &mut github_output,
-            &[diagnostic.clone()],
+            std::slice::from_ref(&diagnostic),
             CheckOutputFormatArg::Github,
             false,
         )
@@ -1514,7 +1514,7 @@ beta.sh:
         let mut rdjson_output = Vec::new();
         print_report_to(
             &mut rdjson_output,
-            &[diagnostic.clone()],
+            std::slice::from_ref(&diagnostic),
             CheckOutputFormatArg::Rdjson,
             false,
         )

--- a/crates/shuck/src/commands/check_output.rs
+++ b/crates/shuck/src/commands/check_output.rs
@@ -109,8 +109,8 @@ impl DisplayedDiagnostic {
         }
     }
 
-    fn relative_path_string(&self) -> String {
-        self.relative_path.display().to_string()
+    fn display_path_string(&self) -> String {
+        self.path.display().to_string()
     }
 
     fn absolute_uri(&self) -> io::Result<String> {
@@ -266,7 +266,7 @@ fn write_junit_diagnostics(
         let mut grouped = BTreeMap::<String, Vec<&DisplayedDiagnostic>>::new();
         for diagnostic in diagnostics {
             grouped
-                .entry(diagnostic.relative_path_string())
+                .entry(diagnostic.display_path_string())
                 .or_default()
                 .push(diagnostic);
         }
@@ -322,10 +322,10 @@ fn write_github_diagnostics(
             _ => "error",
         };
         let title = escape_github_property(&format!("shuck ({})", diagnostic.code()));
-        let file = escape_github_property(&diagnostic.relative_path_string());
+        let file = escape_github_property(&diagnostic.display_path_string());
         let body = escape_github_message(&format!(
             "{}:{}:{}: {} {}",
-            diagnostic.relative_path.display(),
+            diagnostic.path.display(),
             diagnostic.span.start.line,
             diagnostic.span.start.column,
             diagnostic.code(),
@@ -600,7 +600,7 @@ fn json_diagnostic(diagnostic: &DisplayedDiagnostic) -> JsonDiagnostic {
         fix: diagnostic.fix.as_ref().map(json_fix),
         location: diagnostic.span.start.into(),
         end_location: diagnostic.span.end.into(),
-        filename: diagnostic.relative_path_string(),
+        filename: diagnostic.display_path_string(),
     }
 }
 
@@ -654,7 +654,7 @@ fn gitlab_diagnostic(diagnostic: &DisplayedDiagnostic) -> GitlabDiagnostic {
         severity: gitlab_severity(diagnostic.severity()),
         fingerprint: gitlab_fingerprint(diagnostic),
         location: GitlabLocation {
-            path: diagnostic.relative_path_string(),
+            path: diagnostic.display_path_string(),
             positions: GitlabPositions {
                 begin: GitlabPosition {
                     line: diagnostic.span.start.line,
@@ -681,7 +681,7 @@ fn gitlab_severity(severity: &str) -> &'static str {
 fn gitlab_fingerprint(diagnostic: &DisplayedDiagnostic) -> String {
     let mut hasher = DefaultHasher::new();
     diagnostic.code().hash(&mut hasher);
-    diagnostic.relative_path.hash(&mut hasher);
+    diagnostic.path.hash(&mut hasher);
     diagnostic.message.hash(&mut hasher);
     diagnostic.span.start.line.hash(&mut hasher);
     diagnostic.span.start.column.hash(&mut hasher);
@@ -751,7 +751,7 @@ fn rdjson_diagnostic(diagnostic: &DisplayedDiagnostic) -> RdjsonDiagnostic {
             url: None,
         },
         location: RdjsonLocation {
-            path: diagnostic.relative_path_string(),
+            path: diagnostic.display_path_string(),
             range: rdjson_range(diagnostic.span.start, diagnostic.span.end),
         },
         message: diagnostic.message.clone(),
@@ -1154,9 +1154,16 @@ mod tests {
     use super::*;
 
     fn diagnostic_paths(path: &str) -> (PathBuf, PathBuf, PathBuf) {
-        let display = PathBuf::from(path);
-        let relative = PathBuf::from(path);
-        let absolute = std::env::temp_dir().join(path);
+        diagnostic_paths_with_relative(path, path)
+    }
+
+    fn diagnostic_paths_with_relative(
+        display_path: &str,
+        relative_path: &str,
+    ) -> (PathBuf, PathBuf, PathBuf) {
+        let display = PathBuf::from(display_path);
+        let relative = PathBuf::from(relative_path);
+        let absolute = std::env::temp_dir().join(display_path);
         (display, relative, absolute)
     }
 
@@ -1220,6 +1227,32 @@ mod tests {
             span: DisplaySpan::point(line, column),
             message: message.to_owned(),
             kind: DisplayedDiagnosticKind::ParseError,
+            fix: None,
+            source: Some(Arc::<str>::from(source)),
+        }
+    }
+
+    fn lint_diagnostic_with_relative_path(
+        display_path: &str,
+        relative_path: &str,
+        span: DisplaySpan,
+        message: &str,
+        severity: &str,
+        code: &str,
+        source: &str,
+    ) -> DisplayedDiagnostic {
+        let (path, relative_path, absolute_path) =
+            diagnostic_paths_with_relative(display_path, relative_path);
+        DisplayedDiagnostic {
+            path,
+            relative_path,
+            absolute_path,
+            span,
+            message: message.to_owned(),
+            kind: DisplayedDiagnosticKind::Lint {
+                code: code.to_owned(),
+                severity: severity.to_owned(),
+            },
             fix: None,
             source: Some(Arc::<str>::from(source)),
         }
@@ -1440,6 +1473,106 @@ beta.sh:
           }
         ]
         "#);
+    }
+
+    #[test]
+    fn structured_outputs_use_display_paths() {
+        let diagnostic = lint_diagnostic_with_relative_path(
+            "workspace-a/script.sh",
+            "script.sh",
+            DisplaySpan::point(2, 1),
+            "variable is unused",
+            "warning",
+            "C001",
+            "unused=1\n",
+        );
+
+        let mut json_output = Vec::new();
+        print_report_to(
+            &mut json_output,
+            &[diagnostic.clone()],
+            CheckOutputFormatArg::Json,
+            false,
+        )
+        .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&json_output).unwrap();
+        assert_eq!(json[0]["filename"], "workspace-a/script.sh");
+
+        let mut github_output = Vec::new();
+        print_report_to(
+            &mut github_output,
+            &[diagnostic.clone()],
+            CheckOutputFormatArg::Github,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(github_output).unwrap(),
+            "::warning title=shuck (C001),file=workspace-a/script.sh,line=2,col=1,endLine=2,endColumn=1::workspace-a/script.sh:2:1: C001 variable is unused\n",
+        );
+
+        let mut rdjson_output = Vec::new();
+        print_report_to(
+            &mut rdjson_output,
+            &[diagnostic.clone()],
+            CheckOutputFormatArg::Rdjson,
+            false,
+        )
+        .unwrap();
+        let rdjson: serde_json::Value = serde_json::from_slice(&rdjson_output).unwrap();
+        assert_eq!(
+            rdjson["diagnostics"][0]["location"]["path"],
+            "workspace-a/script.sh"
+        );
+    }
+
+    #[test]
+    fn junit_groups_and_gitlab_fingerprints_use_display_paths() {
+        let diagnostics = vec![
+            lint_diagnostic_with_relative_path(
+                "workspace-a/script.sh",
+                "script.sh",
+                DisplaySpan::point(2, 1),
+                "first message",
+                "warning",
+                "C001",
+                "unused=1\n",
+            ),
+            lint_diagnostic_with_relative_path(
+                "workspace-b/script.sh",
+                "script.sh",
+                DisplaySpan::point(2, 1),
+                "first message",
+                "warning",
+                "C001",
+                "unused=1\n",
+            ),
+        ];
+
+        let mut junit_output = Vec::new();
+        print_report_to(
+            &mut junit_output,
+            &diagnostics,
+            CheckOutputFormatArg::Junit,
+            false,
+        )
+        .unwrap();
+        let junit = String::from_utf8(junit_output).unwrap();
+        assert!(junit.contains("testsuite name=\"workspace-a/script.sh\""));
+        assert!(junit.contains("testsuite name=\"workspace-b/script.sh\""));
+
+        let mut gitlab_output = Vec::new();
+        print_report_to(
+            &mut gitlab_output,
+            &diagnostics,
+            CheckOutputFormatArg::Gitlab,
+            false,
+        )
+        .unwrap();
+        let gitlab: serde_json::Value = serde_json::from_slice(&gitlab_output).unwrap();
+        assert_eq!(gitlab[0]["location"]["path"], "workspace-a/script.sh");
+        assert_eq!(gitlab[1]["location"]["path"], "workspace-b/script.sh");
+        assert_ne!(gitlab[0]["fingerprint"], gitlab[1]["fingerprint"]);
     }
 
     #[test]

--- a/crates/shuck/src/commands/check_output.rs
+++ b/crates/shuck/src/commands/check_output.rs
@@ -377,7 +377,7 @@ fn write_rdjson_diagnostics(
             name: "shuck",
             url: env!("CARGO_PKG_REPOSITORY"),
         },
-        severity: "WARNING",
+        severity: rdjson_payload_severity(diagnostics),
         diagnostics: diagnostics.iter().map(rdjson_diagnostic).collect(),
     };
     serde_json::to_writer_pretty(&mut *writer, &payload).map_err(io::Error::other)?;
@@ -740,6 +740,7 @@ struct RdjsonDiagnostic {
     code: RdjsonCode,
     location: RdjsonLocation,
     message: String,
+    severity: &'static str,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     suggestions: Vec<RdjsonSuggestion>,
 }
@@ -755,6 +756,7 @@ fn rdjson_diagnostic(diagnostic: &DisplayedDiagnostic) -> RdjsonDiagnostic {
             range: rdjson_range(diagnostic.span.start, diagnostic.span.end),
         },
         message: diagnostic.message.clone(),
+        severity: rdjson_severity(diagnostic.severity()),
         suggestions: diagnostic
             .fix
             .as_ref()
@@ -768,6 +770,31 @@ fn rdjson_diagnostic(diagnostic: &DisplayedDiagnostic) -> RdjsonDiagnostic {
                     .collect()
             })
             .unwrap_or_default(),
+    }
+}
+
+fn rdjson_payload_severity(diagnostics: &[DisplayedDiagnostic]) -> &'static str {
+    diagnostics
+        .iter()
+        .map(|diagnostic| rdjson_severity(diagnostic.severity()))
+        .max_by_key(|severity| rdjson_severity_rank(severity))
+        .unwrap_or("WARNING")
+}
+
+fn rdjson_severity(severity: &str) -> &'static str {
+    match severity {
+        "error" => "ERROR",
+        "hint" | "info" => "INFO",
+        _ => "WARNING",
+    }
+}
+
+fn rdjson_severity_rank(severity: &str) -> u8 {
+    match severity {
+        "ERROR" => 3,
+        "WARNING" => 2,
+        "INFO" => 1,
+        _ => 0,
     }
 }
 
@@ -1711,5 +1738,30 @@ beta.sh:
                 ["endColumn"],
             4
         );
+    }
+
+    #[test]
+    fn rdjson_preserves_error_severity() {
+        let diagnostics = vec![parse_diagnostic(
+            "broken.sh",
+            2,
+            1,
+            "unterminated construct",
+            "#!/bin/bash\nif true\n",
+        )];
+
+        let mut output = Vec::new();
+        print_report_to(
+            &mut output,
+            &diagnostics,
+            CheckOutputFormatArg::Rdjson,
+            false,
+        )
+        .unwrap();
+
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(value["severity"], "ERROR");
+        assert_eq!(value["diagnostics"][0]["severity"], "ERROR");
+        assert_eq!(value["diagnostics"][0]["code"]["value"], "parse-error");
     }
 }

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -38,6 +38,16 @@ fn enable_experimental(cmd: &mut Command) {
     cmd.env("SHUCK_EXPERIMENTAL", "1");
 }
 
+fn run_check_output(root: &Path, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, root);
+    cmd.current_dir(root).args(args).output().unwrap()
+}
+
+fn stdout_string(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).unwrap()
+}
+
 #[derive(Clone, Copy)]
 enum StreamKind {
     Stdout,
@@ -485,6 +495,244 @@ fn check_concise_output_preserves_legacy_one_line_format() {
     cmd.assert()
         .code(1)
         .stdout("warn.sh:2:1: warning[C001] variable `unused` is assigned but never used\n");
+}
+
+#[test]
+fn check_output_format_env_var_selects_json() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    let output = cmd
+        .current_dir(tempdir.path())
+        .env("SHUCK_OUTPUT_FORMAT", "json")
+        .arg("check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value[0]["filename"], "warn.sh");
+    assert_eq!(value[0]["code"], "C001");
+}
+
+#[test]
+fn check_cli_output_format_overrides_env_var() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .env("SHUCK_OUTPUT_FORMAT", "json")
+        .args(["check", "--output-format", "concise"]);
+    cmd.assert()
+        .code(1)
+        .stdout("warn.sh:2:1: warning[C001] variable `unused` is assigned but never used\n");
+}
+
+#[test]
+fn check_ruff_output_format_env_var_is_ignored() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .env("RUFF_OUTPUT_FORMAT", "json")
+        .arg("check");
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("warning[C001]:"))
+        .stdout(predicate::str::contains("\"filename\"").not());
+}
+
+#[test]
+fn check_json_output_is_valid_json() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let output = run_check_output(tempdir.path(), &["check", "--output-format", "json"]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let diagnostics = value.as_array().unwrap();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0]["filename"], "warn.sh");
+}
+
+#[test]
+fn check_json_lines_output_is_valid_json_lines() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let output = run_check_output(tempdir.path(), &["check", "--output-format", "json-lines"]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = stdout_string(&output);
+    let lines = stdout.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 1);
+    let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(value["filename"], "warn.sh");
+}
+
+#[test]
+fn check_junit_output_is_valid_xml() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let output = run_check_output(tempdir.path(), &["check", "--output-format", "junit"]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = stdout_string(&output);
+    let document = roxmltree::Document::parse(&stdout).unwrap();
+    assert_eq!(document.root_element().tag_name().name(), "testsuites");
+    assert!(
+        document
+            .descendants()
+            .any(|node| node.has_tag_name("testsuite"))
+    );
+    assert!(
+        document
+            .descendants()
+            .any(|node| node.has_tag_name("testcase"))
+    );
+}
+
+#[test]
+fn check_gitlab_output_is_valid_json() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let output = run_check_output(tempdir.path(), &["check", "--output-format", "gitlab"]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let diagnostics = value.as_array().unwrap();
+    assert_eq!(diagnostics[0]["location"]["path"], "warn.sh");
+}
+
+#[test]
+fn check_rdjson_output_is_valid_json() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let output = run_check_output(tempdir.path(), &["check", "--output-format", "rdjson"]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["source"]["name"], "shuck");
+    assert_eq!(value["diagnostics"][0]["location"]["path"], "warn.sh");
+}
+
+#[test]
+fn check_sarif_output_is_valid_json() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let output = run_check_output(tempdir.path(), &["check", "--output-format", "sarif"]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["version"], "2.1.0");
+    assert_eq!(value["runs"][0]["tool"]["driver"]["name"], "shuck");
+}
+
+#[test]
+fn check_github_output_uses_actions_annotation_format() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nunused=1\necho ok\n",
+    )
+    .unwrap();
+
+    let output = run_check_output(tempdir.path(), &["check", "--output-format", "github"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        stdout_string(&output),
+        "::warning title=shuck (C001),file=warn.sh,line=2,col=1,endLine=2,endColumn=7::warn.sh:2:1: C001 variable `unused` is assigned but never used\n",
+    );
+}
+
+#[test]
+fn check_json_output_is_identical_on_cache_hit_for_fix_payloads() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("warn.sh"),
+        "#!/bin/bash\nprintf '%s\\n' x &;\n",
+    )
+    .unwrap();
+
+    let first = run_check_output(tempdir.path(), &["check", "--output-format", "json"]);
+    assert_eq!(first.status.code(), Some(1));
+    let first_stdout = stdout_string(&first);
+    let first_value: serde_json::Value = serde_json::from_str(&first_stdout).unwrap();
+    assert!(first_value[0]["fix"].is_object());
+
+    let second = run_check_output(tempdir.path(), &["check", "--output-format", "json"]);
+    assert_eq!(second.status.code(), Some(1));
+    assert_eq!(stdout_string(&second), first_stdout);
+}
+
+#[test]
+fn check_structured_parse_error_output_is_identical_on_cache_hit() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("broken.sh"),
+        "#!/bin/bash\necho \"unterminated\n",
+    )
+    .unwrap();
+
+    let first = run_check_output(tempdir.path(), &["check", "--output-format", "sarif"]);
+    assert_eq!(first.status.code(), Some(1));
+    let first_stdout = stdout_string(&first);
+    let first_value: serde_json::Value = serde_json::from_str(&first_stdout).unwrap();
+    assert_eq!(
+        first_value["runs"][0]["results"][0]["ruleId"],
+        "parse-error"
+    );
+
+    let second = run_check_output(tempdir.path(), &["check", "--output-format", "sarif"]);
+    assert_eq!(second.status.code(), Some(1));
+    assert_eq!(stdout_string(&second), first_stdout);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Ruff-style `shuck check --output-format` support for `json`, `json-lines`, `junit`, `grouped`, `github`, `gitlab`, `rdjson`, and `sarif` while keeping `full` as the default
- carry richer normalized diagnostics and serialized fix data through the check pipeline and cache so structured output is stable on cache hits and parse errors are first-class in every formatter
- generate and expose rule description/rationale metadata from `docs/rules/*.yaml` and expand CLI/integration coverage for formatter parsing, env precedence, annotation output, and structured output validity

## Why
`shuck check` only supported `full` and `concise`, which made it hard to integrate with CI systems and tooling that expect structured formatter outputs similar to Ruff.

## Impact
This adds CI-friendly output formats, keeps existing human-readable output stable, and lets cache hits preserve the same structured payloads as fresh lint runs, including fix suggestions.

## Validation
- `cargo test -p shuck`
- `cargo test -p shuck-linter`
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
