### PR TITLE
fix(main): reduce duplicate C001 reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "shuck-ast",
  "shuck-indexer",
  "shuck-parser",
+ "smallvec",
  "tempfile",
 ]
 

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2288,6 +2288,7 @@ fn collect_binding_values<'a>(
     semantic: &SemanticModel,
     source: &str,
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
+    binding_target_spans: &mut FxHashMap<BindingId, Span>,
 ) {
     let assignments = match command {
         Command::Simple(simple) if simple.name.span.slice(source).is_empty() => &simple.assignments,
@@ -2309,6 +2310,7 @@ fn collect_binding_values<'a>(
             assignment.target.name_span,
         ) {
             binding_values.insert(binding_id, BindingValueFact::scalar(word));
+            binding_target_spans.insert(binding_id, assignment_target_span(assignment));
         }
     }
 
@@ -2325,6 +2327,7 @@ fn collect_binding_values<'a>(
             assignment.target.name_span,
         ) {
             binding_values.insert(binding_id, BindingValueFact::scalar(word));
+            binding_target_spans.insert(binding_id, assignment_target_span(assignment));
         }
     }
 

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -309,6 +309,14 @@ impl<'a> LinterFactsBuilder<'a> {
             }
         }
 
+        for binding in self.semantic.bindings() {
+            if let shuck_semantic::BindingOrigin::ArithmeticAssignment { target_span, .. } =
+                &binding.origin
+            {
+                binding_target_spans.entry(binding.id).or_insert(*target_span);
+            }
+        }
+
         let substitution_facts =
             build_substitution_facts(&commands, &command_ids_by_span, self.source);
         for (fact, substitutions) in commands.iter_mut().zip(substitution_facts) {

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -50,6 +50,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut if_condition_command_ids = FxHashSet::default();
         let mut elif_condition_command_ids = FxHashSet::default();
         let mut binding_values = FxHashMap::default();
+        let mut binding_target_spans = FxHashMap::default();
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
         let mut ifs_literal_backslash_assignment_value_spans = Vec::new();
@@ -103,6 +104,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 self.semantic,
                 self.source,
                 &mut binding_values,
+                &mut binding_target_spans,
             );
             collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
             collect_comma_array_assignment_spans(
@@ -522,6 +524,7 @@ impl<'a> LinterFactsBuilder<'a> {
             if_condition_command_ids,
             elif_condition_command_ids,
             binding_values,
+            binding_target_spans,
             broken_assoc_key_spans,
             comma_array_assignment_spans,
             ifs_literal_backslash_assignment_value_spans,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -10,6 +10,7 @@ pub struct LinterFacts<'a> {
     if_condition_command_ids: FxHashSet<CommandId>,
     elif_condition_command_ids: FxHashSet<CommandId>,
     binding_values: FxHashMap<BindingId, BindingValueFact<'a>>,
+    binding_target_spans: FxHashMap<BindingId, Span>,
     broken_assoc_key_spans: Vec<Span>,
     comma_array_assignment_spans: Vec<Span>,
     ifs_literal_backslash_assignment_value_spans: Vec<Span>,
@@ -210,6 +211,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn binding_value(&self, binding_id: BindingId) -> Option<&BindingValueFact<'a>> {
         self.binding_values.get(&binding_id)
+    }
+
+    pub(crate) fn binding_target_span(&self, binding_id: BindingId) -> Option<Span> {
+        self.binding_target_spans.get(&binding_id).copied()
     }
 
     pub(crate) fn binding_values(&self) -> &FxHashMap<BindingId, BindingValueFact<'a>> {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -2813,6 +2813,32 @@ z=$(ls layout.*.h | cut -d. -f2 | xargs echo)
 }
 
 #[test]
+fn builds_docker_ps_substitution_facts_without_pgrep_exemptions() {
+    let source = "\
+#!/bin/bash
+docker inspect -f '{{ if ne \"true\" (index .Config.Labels \"com.dokku.devcontainer\") }}{{.ID}} {{ end }}' $(docker ps -q)
+";
+
+    with_facts(source, None, |_, facts| {
+        let substitution = facts
+            .commands()
+            .iter()
+            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .find(|fact| fact.span().slice(source) == "$(docker ps -q)")
+            .expect("expected docker ps substitution fact");
+
+        assert_eq!(
+            substitution.host_kind(),
+            SubstitutionHostKind::CommandArgument
+        );
+        assert!(substitution.unquoted_in_host());
+        assert!(substitution.body_has_commands());
+        assert!(!substitution.body_is_pgrep_lookup());
+        assert!(!substitution.body_is_seq_utility());
+    });
+}
+
+#[test]
 fn tracks_backtick_syntax_in_substitution_facts() {
     let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1415,6 +1415,34 @@ main
 }
 
 #[test]
+fn reports_caller_local_shadowing_after_assoc_declaration_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+helper() {
+  map[$key]=1
+}
+main() {
+  local key=name
+  declare -A map
+  unset map
+  local map
+  helper
+}
+main
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(spans, vec!["$key"]);
+    });
+}
+
+#[test]
 fn ignores_repeated_dynamic_scope_associative_assignment_subscripts_for_dollar_in_arithmetic() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1668,6 +1668,31 @@ fn builds_word_facts_for_filename_builder_command_substitutions() {
 }
 
 #[test]
+fn builds_word_facts_for_docker_inspect_command_substitutions() {
+    let source = "\
+#!/bin/bash
+docker inspect -f '{{ if ne \"true\" (index .Config.Labels \"com.dokku.devcontainer\") }}{{.ID}} {{ end }}' $(docker ps -q)
+";
+
+    with_facts(source, None, |_, facts| {
+        let fact = facts
+            .expansion_word_facts(ExpansionContext::CommandArgument)
+            .find(|fact| fact.span().slice(source) == "$(docker ps -q)")
+            .expect("expected docker inspect argument fact");
+
+        assert_eq!(
+            fact.unquoted_command_substitution_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(docker ps -q)"],
+            "parts: {:?}",
+            fact.word().parts
+        );
+    });
+}
+
+#[test]
 fn builds_word_facts_for_quoted_all_elements_array_expansions() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2593,15 +2593,70 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             return *result;
         }
 
-        let visible = if let Some(binding) =
-            self.prior_visible_binding_for_subscript(owner_name, subscript.span())
+        let visible = if let Some(visible) =
+            self.assoc_binding_visible_in_nearest_scope(owner_name, owner_name_span, subscript)
         {
-            binding.attributes.contains(BindingAttributes::ASSOC)
+            visible
         } else {
             self.assoc_binding_visible_from_named_callers(owner_name, subscript.span())
         };
         self.assoc_binding_visibility_memo.insert(key, visible);
         visible
+    }
+
+    fn assoc_binding_visible_in_nearest_scope(
+        &self,
+        owner_name: &Name,
+        owner_name_span: Option<Span>,
+        subscript: &Subscript,
+    ) -> Option<bool> {
+        let offset = owner_name_span
+            .map(|span| span.start.offset)
+            .unwrap_or(subscript.span().start.offset);
+        let current_scope = self.semantic.scope_at(subscript.span().start.offset);
+        let bindings = self.semantic.bindings_for(owner_name);
+        if let Some(visible) = self.assoc_binding_visible_in_scope(
+            bindings,
+            current_scope,
+            offset,
+            true,
+        ) {
+            return Some(visible);
+        }
+
+        self.semantic
+            .ancestor_scopes(current_scope)
+            .skip(1)
+            .find_map(|scope| self.assoc_binding_visible_in_scope(bindings, scope, offset, false))
+    }
+
+    fn assoc_binding_visible_in_scope(
+        &self,
+        bindings: &[BindingId],
+        scope: ScopeId,
+        offset: usize,
+        current_scope: bool,
+    ) -> Option<bool> {
+        let mut saw_binding = false;
+        let mut saw_assoc = false;
+
+        for binding_id in bindings {
+            let binding = self.semantic.binding(*binding_id);
+            if binding.scope != scope || binding.span.start.offset >= offset {
+                continue;
+            }
+            if current_scope && !binding_blocks_same_scope_assoc_lookup(binding) {
+                continue;
+            }
+
+            saw_binding = true;
+            if binding.attributes.contains(BindingAttributes::ASSOC) {
+                saw_assoc = true;
+                break;
+            }
+        }
+
+        saw_binding.then_some(saw_assoc)
     }
 
     fn assoc_binding_visible_from_named_callers(&self, owner_name: &Name, span: Span) -> bool {
@@ -2635,16 +2690,6 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
 
         false
-    }
-
-    fn prior_visible_binding_for_subscript(
-        &self,
-        owner_name: &Name,
-        span: Span,
-    ) -> Option<&shuck_semantic::Binding> {
-        let current_scope = self.semantic.scope_at(span.start.offset);
-        self.semantic
-            .visible_binding_for_assoc_lookup(owner_name, current_scope, span)
     }
 
     fn visible_binding_for_caller_assoc_lookup(
@@ -2682,6 +2727,17 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             &mut self.arithmetic.dollar_in_arithmetic_spans,
         );
     }
+}
+
+fn binding_blocks_same_scope_assoc_lookup(binding: &shuck_semantic::Binding) -> bool {
+    binding.attributes.contains(BindingAttributes::LOCAL)
+        || !matches!(
+            binding.kind,
+            shuck_semantic::BindingKind::Assignment
+                | shuck_semantic::BindingKind::AppendAssignment
+                | shuck_semantic::BindingKind::ArrayAssignment
+                | shuck_semantic::BindingKind::ArithmeticAssignment
+        )
 }
 
 fn pattern_has_glob_structure(pattern: &Pattern, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2637,10 +2637,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         offset: usize,
         current_scope: bool,
     ) -> Option<bool> {
-        let mut saw_binding = false;
-        let mut saw_assoc = false;
-
-        for binding_id in bindings {
+        for binding_id in bindings.iter().rev() {
             let binding = self.semantic.binding(*binding_id);
             if binding.scope != scope || binding.span.start.offset >= offset {
                 continue;
@@ -2649,14 +2646,10 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 continue;
             }
 
-            saw_binding = true;
-            if binding.attributes.contains(BindingAttributes::ASSOC) {
-                saw_assoc = true;
-                break;
-            }
+            return Some(binding.attributes.contains(BindingAttributes::ASSOC));
         }
 
-        saw_binding.then_some(saw_assoc)
+        None
     }
 
     fn assoc_binding_visible_from_named_callers(&self, owner_name: &Name, span: Span) -> bool {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2610,46 +2610,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         owner_name_span: Option<Span>,
         subscript: &Subscript,
     ) -> Option<bool> {
-        let offset = owner_name_span
-            .map(|span| span.start.offset)
-            .unwrap_or(subscript.span().start.offset);
+        let lookup_span = owner_name_span.unwrap_or(subscript.span());
         let current_scope = self.semantic.scope_at(subscript.span().start.offset);
-        let bindings = self.semantic.bindings_for(owner_name);
-        if let Some(visible) = self.assoc_binding_visible_in_scope(
-            bindings,
-            current_scope,
-            offset,
-            true,
-        ) {
-            return Some(visible);
-        }
-
         self.semantic
-            .ancestor_scopes(current_scope)
-            .skip(1)
-            .find_map(|scope| self.assoc_binding_visible_in_scope(bindings, scope, offset, false))
-    }
-
-    fn assoc_binding_visible_in_scope(
-        &self,
-        bindings: &[BindingId],
-        scope: ScopeId,
-        offset: usize,
-        current_scope: bool,
-    ) -> Option<bool> {
-        for binding_id in bindings.iter().rev() {
-            let binding = self.semantic.binding(*binding_id);
-            if binding.scope != scope || binding.span.start.offset >= offset {
-                continue;
-            }
-            if current_scope && !binding_blocks_same_scope_assoc_lookup(binding) {
-                continue;
-            }
-
-            return Some(binding.attributes.contains(BindingAttributes::ASSOC));
-        }
-
-        None
+            .visible_binding_for_assoc_lookup(owner_name, current_scope, lookup_span)
+            .map(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
     }
 
     fn assoc_binding_visible_from_named_callers(&self, owner_name: &Name, span: Span) -> bool {
@@ -2720,17 +2685,6 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             &mut self.arithmetic.dollar_in_arithmetic_spans,
         );
     }
-}
-
-fn binding_blocks_same_scope_assoc_lookup(binding: &shuck_semantic::Binding) -> bool {
-    binding.attributes.contains(BindingAttributes::LOCAL)
-        || !matches!(
-            binding.kind,
-            shuck_semantic::BindingKind::Assignment
-                | shuck_semantic::BindingKind::AppendAssignment
-                | shuck_semantic::BindingKind::ArrayAssignment
-                | shuck_semantic::BindingKind::ArithmeticAssignment
-        )
 }
 
 fn pattern_has_glob_structure(pattern: &Pattern, source: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -24,7 +24,7 @@ pub fn unused_assignment(checker: &mut Checker) {
     let semantic = checker.semantic();
     let unused_bindings = checker.semantic_analysis().unused_assignments();
     let unused_binding_ids = unused_bindings.iter().copied().collect::<HashSet<_>>();
-    let mut families_with_used_reportable_bindings = HashSet::new();
+    let mut families_with_used_bindings = HashSet::new();
     let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();
     let mut last_unused_binding_by_family = HashMap::new();
 
@@ -33,12 +33,12 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        if !is_reportable_unused_assignment(binding.kind, binding.attributes) {
+        if !participates_in_unused_assignment_family(binding.kind, binding.attributes) {
             continue;
         }
 
         if !unused_binding_ids.contains(&binding.id) {
-            families_with_used_reportable_bindings.insert(binding_family_key(semantic, binding));
+            families_with_used_bindings.insert(binding_family_key(semantic, binding));
         }
     }
 
@@ -77,7 +77,7 @@ pub fn unused_assignment(checker: &mut Checker) {
 
     let mut reportable_bindings = Vec::new();
     for (family, binding_ids) in unused_bindings_by_family {
-        if families_with_used_reportable_bindings.contains(&family) {
+        if families_with_used_bindings.contains(&family) {
             reportable_bindings.extend(binding_ids);
             continue;
         }
@@ -132,6 +132,17 @@ fn is_reportable_unused_assignment(kind: BindingKind, attributes: BindingAttribu
         }
         BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref => false,
     }
+}
+
+fn participates_in_unused_assignment_family(
+    kind: BindingKind,
+    attributes: BindingAttributes,
+) -> bool {
+    is_reportable_unused_assignment(kind, attributes)
+        || matches!(
+            kind,
+            BindingKind::AppendAssignment | BindingKind::ParameterDefaultAssignment
+        )
 }
 
 fn binding_follows_in_source(
@@ -264,5 +275,15 @@ mod tests {
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[1].span.start.line, 3);
+    }
+
+    #[test]
+    fn used_non_reportable_bindings_keep_dead_branch_arms_separate() {
+        let source = "#!/bin/bash\nif a; then\n  foo=1\nelif b; then\n  foo+=x\n  echo \"$foo\"\nelse\n  foo=3\nfi\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.start.line, 8);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -349,6 +349,16 @@ mod tests {
     }
 
     #[test]
+    fn unused_uninitialized_local_branches_do_not_hide_dead_assignments() {
+        let source =
+            "#!/bin/bash\nf(){\n  if a; then\n    foo=1\n  else\n    local foo\n  fi\n}\nf\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 4);
+    }
+
+    #[test]
     fn unused_uninitialized_declarations_do_not_split_linear_chains() {
         let source = "#!/bin/bash\nf(){\n  local foo\n  foo=1\n  foo=2\n}\nf\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -359,6 +359,14 @@ mod tests {
     }
 
     #[test]
+    fn branch_local_uninitialized_declarations_keep_prior_defs_live() {
+        let source = "#!/bin/bash\nf(){\n  foo=1\n  if cond; then\n    local foo\n  fi\n  echo \"$foo\"\n}\nf\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn unused_uninitialized_declarations_do_not_split_linear_chains() {
         let source = "#!/bin/bash\nf(){\n  local foo\n  foo=1\n  foo=2\n}\nf\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -29,7 +29,16 @@ pub fn unused_assignment(checker: &mut Checker) {
     let mut families_with_used_bindings = HashSet::new();
     let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();
     let mut last_unused_binding_by_family = HashMap::new();
-    let mut family_scopes = HashMap::new();
+    let mut family_scopes = HashMap::with_capacity(semantic.bindings().len());
+
+    for binding in semantic.bindings() {
+        if binding.name.as_str() == "_" {
+            continue;
+        }
+
+        let scope = binding_family_scope(semantic, &family_scopes, binding);
+        family_scopes.insert(binding.id, scope);
+    }
 
     for binding in semantic.bindings() {
         if binding.name.as_str() == "_" {
@@ -41,11 +50,7 @@ pub fn unused_assignment(checker: &mut Checker) {
         }
 
         if !unused_binding_ids.contains(&binding.id) {
-            families_with_used_bindings.insert(binding_family_key(
-                semantic,
-                &mut family_scopes,
-                binding,
-            ));
+            families_with_used_bindings.insert(binding_family_key(&family_scopes, binding));
         }
     }
 
@@ -59,7 +64,7 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        let family = binding_family_key(semantic, &mut family_scopes, binding);
+        let family = binding_family_key(&family_scopes, binding);
 
         unused_bindings_by_family
             .entry(family.clone())
@@ -163,40 +168,29 @@ fn binding_follows_in_source(
 }
 
 fn binding_family_key(
-    semantic: &SemanticModel,
-    family_scopes: &mut HashMap<BindingId, Option<ScopeId>>,
+    family_scopes: &HashMap<BindingId, Option<ScopeId>>,
     binding: &Binding,
 ) -> BindingFamilyKey {
-    // `local` bindings are function-scoped, while assignments inside
-    // nonpersistent execution scopes (subshells, pipelines, command
-    // substitutions) should not collapse into the parent shell state.
-    let scope = binding_family_scope(semantic, family_scopes, binding);
-
-    (scope, binding.name.to_string())
+    (
+        family_scopes.get(&binding.id).copied().flatten(),
+        binding.name.to_string(),
+    )
 }
 
 fn binding_family_scope(
     semantic: &SemanticModel,
-    family_scopes: &mut HashMap<BindingId, Option<ScopeId>>,
+    family_scopes: &HashMap<BindingId, Option<ScopeId>>,
     binding: &Binding,
 ) -> Option<ScopeId> {
     if let Some(scope) = isolated_family_scope(semantic, binding.scope) {
         return Some(scope);
     }
 
-    if let Some(scope) = family_scopes.get(&binding.id).copied() {
-        return scope;
-    }
-
-    let scope = if binding.attributes.contains(BindingAttributes::LOCAL) {
+    if binding.attributes.contains(BindingAttributes::LOCAL) {
         Some(binding.scope)
     } else {
         inherited_local_family_scope(semantic, family_scopes, binding)
-    };
-
-    family_scopes.insert(binding.id, scope);
-
-    scope
+    }
 }
 
 fn isolated_family_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
@@ -210,13 +204,15 @@ fn isolated_family_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<Sco
 
 fn inherited_local_family_scope(
     semantic: &SemanticModel,
-    family_scopes: &mut HashMap<BindingId, Option<ScopeId>>,
+    family_scopes: &HashMap<BindingId, Option<ScopeId>>,
     binding: &Binding,
 ) -> Option<ScopeId> {
     let prior =
         semantic.previous_visible_binding(&binding.name, binding.span, Some(binding.span))?;
 
-    (prior.scope == binding.scope).then(|| binding_family_scope(semantic, family_scopes, prior))?
+    (prior.scope == binding.scope)
+        .then(|| family_scopes.get(&prior.id).copied().flatten())
+        .flatten()
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -59,7 +59,7 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        if !unused_binding_ids.contains(&binding.id) {
+        if binding_counts_as_used_family_member(binding, &unused_binding_ids) {
             families_with_used_bindings.insert(binding_family_key(&family_keys, binding.id));
         }
     }
@@ -163,8 +163,29 @@ fn participates_in_unused_assignment_family(
     is_reportable_unused_assignment(kind, attributes)
         || matches!(
             kind,
-            BindingKind::AppendAssignment | BindingKind::ParameterDefaultAssignment
+            BindingKind::AppendAssignment
+                | BindingKind::ParameterDefaultAssignment
+                | BindingKind::Declaration(_)
         )
+}
+
+fn binding_counts_as_used_family_member(
+    binding: &Binding,
+    unused_binding_ids: &HashSet<BindingId>,
+) -> bool {
+    if unused_binding_ids.contains(&binding.id) {
+        return false;
+    }
+
+    if matches!(binding.kind, BindingKind::Declaration(_))
+        && !binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED)
+    {
+        return !binding.references.is_empty();
+    }
+
+    true
 }
 
 fn binding_follows_in_source(
@@ -315,6 +336,25 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn used_uninitialized_local_declarations_keep_dead_branch_arms_separate() {
+        let source = "#!/bin/bash\nf(){\n  if a; then\n    foo=1\n  elif b; then\n    local foo\n    echo \"$foo\"\n  else\n    foo=3\n  fi\n}\nf\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[1].span.start.line, 9);
+    }
+
+    #[test]
+    fn unused_uninitialized_declarations_do_not_split_linear_chains() {
+        let source = "#!/bin/bash\nf(){\n  local foo\n  foo=1\n  foo=2\n}\nf\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 5);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -48,6 +48,10 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
+        if !is_reportable_unused_assignment(binding.kind, binding.attributes) {
+            continue;
+        }
+
         let family = binding_family_key(binding);
 
         unused_bindings_by_family
@@ -201,5 +205,14 @@ mod tests {
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[1].span.start.line, 3);
+    }
+
+    #[test]
+    fn later_non_reportable_bindings_do_not_hide_earlier_assignments() {
+        let source = "#!/bin/bash\nfoo=1\nfoo+=2\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use shuck_semantic::{BindingAttributes, BindingKind};
 
@@ -21,13 +21,35 @@ impl Violation for UnusedAssignment {
 pub fn unused_assignment(checker: &mut Checker) {
     let semantic = checker.semantic();
     let unused_bindings = checker.semantic_analysis().unused_assignments();
+    let unused_binding_ids = unused_bindings.iter().copied().collect::<HashSet<_>>();
+    let mut names_with_used_reportable_bindings = HashSet::new();
+    let mut unused_bindings_by_name = HashMap::<_, Vec<_>>::new();
     let mut last_unused_binding_by_name = HashMap::new();
+
+    for binding in semantic.bindings() {
+        if binding.name.as_str() == "_" {
+            continue;
+        }
+
+        if !is_reportable_unused_assignment(binding.kind, binding.attributes) {
+            continue;
+        }
+
+        if !unused_binding_ids.contains(&binding.id) {
+            names_with_used_reportable_bindings.insert(binding.name.clone());
+        }
+    }
 
     for binding_id in unused_bindings {
         let binding = semantic.binding(*binding_id);
         if binding.name.as_str() == "_" {
             continue;
         }
+
+        unused_bindings_by_name
+            .entry(binding.name.clone())
+            .or_default()
+            .push(*binding_id);
 
         last_unused_binding_by_name
             .entry(binding.name.clone())
@@ -45,9 +67,17 @@ pub fn unused_assignment(checker: &mut Checker) {
             .or_insert(*binding_id);
     }
 
-    let mut reportable_bindings = last_unused_binding_by_name
-        .into_values()
-        .collect::<Vec<_>>();
+    let mut reportable_bindings = Vec::new();
+    for (name, binding_ids) in unused_bindings_by_name {
+        if names_with_used_reportable_bindings.contains(&name) {
+            reportable_bindings.extend(binding_ids);
+            continue;
+        }
+
+        if let Some(binding_id) = last_unused_binding_by_name.get(&name).copied() {
+            reportable_bindings.push(binding_id);
+        }
+    }
     reportable_bindings
         .sort_unstable_by_key(|binding_id| semantic.binding(*binding_id).span.start.offset);
 

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use shuck_semantic::{Binding, BindingAttributes, BindingKind, ScopeId};
+use shuck_semantic::{Binding, BindingAttributes, BindingKind, ScopeId, ScopeKind, SemanticModel};
 
 use crate::{Checker, Rule, Violation};
 
@@ -38,7 +38,7 @@ pub fn unused_assignment(checker: &mut Checker) {
         }
 
         if !unused_binding_ids.contains(&binding.id) {
-            families_with_used_reportable_bindings.insert(binding_family_key(binding));
+            families_with_used_reportable_bindings.insert(binding_family_key(semantic, binding));
         }
     }
 
@@ -52,7 +52,7 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        let family = binding_family_key(binding);
+        let family = binding_family_key(semantic, binding);
 
         unused_bindings_by_family
             .entry(family.clone())
@@ -144,16 +144,26 @@ fn binding_follows_in_source(
         || (candidate_start == current_start && candidate_end > current_end)
 }
 
-fn binding_family_key(binding: &Binding) -> BindingFamilyKey {
-    // `local`-scoped bindings should not collapse across functions, but plain
-    // assignments still participate in the wider variable family even when
-    // they appear inside a function body.
-    let scope = binding
-        .attributes
-        .contains(BindingAttributes::LOCAL)
-        .then_some(binding.scope);
+fn binding_family_key(semantic: &SemanticModel, binding: &Binding) -> BindingFamilyKey {
+    // `local` bindings are function-scoped, while assignments inside
+    // nonpersistent execution scopes (subshells, pipelines, command
+    // substitutions) should not collapse into the parent shell state.
+    let scope = if binding.attributes.contains(BindingAttributes::LOCAL) {
+        Some(binding.scope)
+    } else {
+        isolated_family_scope(semantic, binding.scope)
+    };
 
     (scope, binding.name.to_string())
+}
+
+fn isolated_family_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
+    semantic.ancestor_scopes(scope).find(|candidate| {
+        matches!(
+            semantic.scope_kind(*candidate),
+            ScopeKind::Subshell | ScopeKind::CommandSubstitution | ScopeKind::Pipeline
+        )
+    })
 }
 
 #[cfg(test)]
@@ -214,5 +224,15 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn isolated_execution_scopes_keep_separate_dedup_families() {
+        let source = "#!/bin/bash\nfoo=1\n(foo=2)\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[1].span.start.line, 3);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use shuck_semantic::{Binding, BindingAttributes, BindingKind, ScopeId, ScopeKind, SemanticModel};
+use shuck_semantic::{
+    Binding, BindingAttributes, BindingId, BindingKind, ScopeId, ScopeKind, SemanticModel,
+};
 
 use crate::{Checker, Rule, Violation};
 
@@ -27,6 +29,7 @@ pub fn unused_assignment(checker: &mut Checker) {
     let mut families_with_used_bindings = HashSet::new();
     let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();
     let mut last_unused_binding_by_family = HashMap::new();
+    let mut family_scopes = HashMap::new();
 
     for binding in semantic.bindings() {
         if binding.name.as_str() == "_" {
@@ -38,7 +41,11 @@ pub fn unused_assignment(checker: &mut Checker) {
         }
 
         if !unused_binding_ids.contains(&binding.id) {
-            families_with_used_bindings.insert(binding_family_key(semantic, binding));
+            families_with_used_bindings.insert(binding_family_key(
+                semantic,
+                &mut family_scopes,
+                binding,
+            ));
         }
     }
 
@@ -52,7 +59,7 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        let family = binding_family_key(semantic, binding);
+        let family = binding_family_key(semantic, &mut family_scopes, binding);
 
         unused_bindings_by_family
             .entry(family.clone())
@@ -155,19 +162,41 @@ fn binding_follows_in_source(
         || (candidate_start == current_start && candidate_end > current_end)
 }
 
-fn binding_family_key(semantic: &SemanticModel, binding: &Binding) -> BindingFamilyKey {
+fn binding_family_key(
+    semantic: &SemanticModel,
+    family_scopes: &mut HashMap<BindingId, Option<ScopeId>>,
+    binding: &Binding,
+) -> BindingFamilyKey {
     // `local` bindings are function-scoped, while assignments inside
     // nonpersistent execution scopes (subshells, pipelines, command
     // substitutions) should not collapse into the parent shell state.
-    let scope = isolated_family_scope(semantic, binding.scope).or_else(|| {
-        if binding.attributes.contains(BindingAttributes::LOCAL) {
-            Some(binding.scope)
-        } else {
-            local_family_scope(semantic, binding)
-        }
-    });
+    let scope = binding_family_scope(semantic, family_scopes, binding);
 
     (scope, binding.name.to_string())
+}
+
+fn binding_family_scope(
+    semantic: &SemanticModel,
+    family_scopes: &mut HashMap<BindingId, Option<ScopeId>>,
+    binding: &Binding,
+) -> Option<ScopeId> {
+    if let Some(scope) = isolated_family_scope(semantic, binding.scope) {
+        return Some(scope);
+    }
+
+    if let Some(scope) = family_scopes.get(&binding.id).copied() {
+        return scope;
+    }
+
+    let scope = if binding.attributes.contains(BindingAttributes::LOCAL) {
+        Some(binding.scope)
+    } else {
+        inherited_local_family_scope(semantic, family_scopes, binding)
+    };
+
+    family_scopes.insert(binding.id, scope);
+
+    scope
 }
 
 fn isolated_family_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
@@ -179,22 +208,15 @@ fn isolated_family_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<Sco
     })
 }
 
-fn local_family_scope(semantic: &SemanticModel, binding: &Binding) -> Option<ScopeId> {
-    let mut probe = binding;
+fn inherited_local_family_scope(
+    semantic: &SemanticModel,
+    family_scopes: &mut HashMap<BindingId, Option<ScopeId>>,
+    binding: &Binding,
+) -> Option<ScopeId> {
+    let prior =
+        semantic.previous_visible_binding(&binding.name, binding.span, Some(binding.span))?;
 
-    loop {
-        let prior = semantic.previous_visible_binding(&probe.name, probe.span, Some(probe.span))?;
-
-        if prior.attributes.contains(BindingAttributes::LOCAL) {
-            return Some(prior.scope);
-        }
-
-        if prior.scope != probe.scope {
-            return None;
-        }
-
-        probe = prior;
-    }
+    (prior.scope == binding.scope).then(|| binding_family_scope(semantic, family_scopes, prior))?
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use shuck_semantic::{BindingAttributes, BindingKind};
 
 use crate::{Checker, Rule, Violation};
@@ -17,14 +19,40 @@ impl Violation for UnusedAssignment {
 }
 
 pub fn unused_assignment(checker: &mut Checker) {
-    let unused_bindings = checker.semantic_analysis().unused_assignments().to_vec();
+    let semantic = checker.semantic();
+    let unused_bindings = checker.semantic_analysis().unused_assignments();
+    let mut last_unused_binding_by_name = HashMap::new();
 
     for binding_id in unused_bindings {
-        let binding = checker.semantic().binding(binding_id);
-
+        let binding = semantic.binding(*binding_id);
         if binding.name.as_str() == "_" {
             continue;
         }
+
+        last_unused_binding_by_name
+            .entry(binding.name.clone())
+            .and_modify(|current_binding_id| {
+                let current = semantic.binding(*current_binding_id);
+                if binding_follows_in_source(
+                    current.span.start.offset,
+                    current.span.end.offset,
+                    binding.span.start.offset,
+                    binding.span.end.offset,
+                ) {
+                    *current_binding_id = *binding_id;
+                }
+            })
+            .or_insert(*binding_id);
+    }
+
+    let mut reportable_bindings = last_unused_binding_by_name
+        .into_values()
+        .collect::<Vec<_>>();
+    reportable_bindings
+        .sort_unstable_by_key(|binding_id| semantic.binding(*binding_id).span.start.offset);
+
+    for binding_id in reportable_bindings {
+        let binding = semantic.binding(binding_id);
 
         if !is_reportable_unused_assignment(binding.kind, binding.attributes) {
             continue;
@@ -68,6 +96,16 @@ fn is_reportable_unused_assignment(kind: BindingKind, attributes: BindingAttribu
     }
 }
 
+fn binding_follows_in_source(
+    current_start: usize,
+    current_end: usize,
+    candidate_start: usize,
+    candidate_end: usize,
+) -> bool {
+    candidate_start > current_start
+        || (candidate_start == current_start && candidate_end > current_end)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
@@ -80,5 +118,32 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "unused");
+    }
+
+    #[test]
+    fn reports_only_the_last_unused_binding_for_a_name() {
+        let source = "#!/bin/sh\nfoo=1\nfoo=2\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
+    }
+
+    #[test]
+    fn uses_source_order_when_function_bindings_share_a_name() {
+        let source = "#!/bin/bash\nf(){ foo=1; }\nfoo=2\nf\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn later_exports_suppress_the_name_family() {
+        let source = "#!/bin/sh\nfoo=1\nexport foo=2\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -6,7 +6,7 @@ use shuck_semantic::{
 
 use crate::{Checker, Rule, Violation};
 
-type BindingFamilyKey = (Option<ScopeId>, String);
+type BindingFamilyKey = (Option<ScopeId>, Option<ScopeId>, String);
 
 pub struct UnusedAssignment {
     pub name: String,
@@ -29,7 +29,7 @@ pub fn unused_assignment(checker: &mut Checker) {
     let mut families_with_used_bindings = HashSet::new();
     let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();
     let mut last_unused_binding_by_family = HashMap::new();
-    let mut family_scopes = HashMap::with_capacity(semantic.bindings().len());
+    let mut local_family_scopes = HashMap::with_capacity(semantic.bindings().len());
     let mut family_keys = HashMap::with_capacity(semantic.bindings().len());
 
     for binding in semantic.bindings() {
@@ -37,9 +37,17 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        let scope = binding_family_scope(semantic, &family_scopes, binding);
-        family_scopes.insert(binding.id, scope);
-        family_keys.insert(binding.id, (scope, binding_target_key(checker, binding)));
+        let isolated_scope = isolated_family_scope(semantic, binding.scope);
+        let local_scope = binding_local_family_scope(semantic, &local_family_scopes, binding);
+        local_family_scopes.insert(binding.id, local_scope);
+        family_keys.insert(
+            binding.id,
+            (
+                isolated_scope,
+                local_scope,
+                binding_target_key(checker, binding),
+            ),
+        );
     }
 
     for binding in semantic.bindings() {
@@ -176,7 +184,7 @@ fn binding_family_key(
     family_keys
         .get(&binding_id)
         .cloned()
-        .unwrap_or_else(|| (None, String::new()))
+        .unwrap_or_else(|| (None, None, String::new()))
 }
 
 fn binding_target_key(checker: &Checker<'_>, binding: &Binding) -> String {
@@ -187,15 +195,11 @@ fn binding_target_key(checker: &Checker<'_>, binding: &Binding) -> String {
         .unwrap_or_else(|| binding.name.to_string())
 }
 
-fn binding_family_scope(
+fn binding_local_family_scope(
     semantic: &SemanticModel,
     family_scopes: &HashMap<BindingId, Option<ScopeId>>,
     binding: &Binding,
 ) -> Option<ScopeId> {
-    if let Some(scope) = isolated_family_scope(semantic, binding.scope) {
-        return Some(scope);
-    }
-
     if binding.attributes.contains(BindingAttributes::LOCAL) {
         Some(binding.scope)
     } else {
@@ -257,6 +261,14 @@ mod tests {
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[1].span.start.line, 4);
+    }
+
+    #[test]
+    fn local_families_stay_distinct_inside_subshells() {
+        let source = "#!/bin/bash\n(f(){ local foo=1; }\ng(){ local foo=2; }\nf\ng)\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -264,6 +264,16 @@ mod tests {
     }
 
     #[test]
+    fn arithmetic_indexed_writes_do_not_collapse_to_one_report() {
+        let source = "#!/bin/bash\n(( box[1] = 1 ))\n(( box[2] = 2 ))\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[1].span.start.line, 3);
+    }
+
+    #[test]
     fn local_families_stay_distinct_inside_subshells() {
         let source = "#!/bin/bash\n(f(){ local foo=1; }\ng(){ local foo=2; }\nf\ng)\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -30,6 +30,7 @@ pub fn unused_assignment(checker: &mut Checker) {
     let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();
     let mut last_unused_binding_by_family = HashMap::new();
     let mut family_scopes = HashMap::with_capacity(semantic.bindings().len());
+    let mut family_keys = HashMap::with_capacity(semantic.bindings().len());
 
     for binding in semantic.bindings() {
         if binding.name.as_str() == "_" {
@@ -38,6 +39,7 @@ pub fn unused_assignment(checker: &mut Checker) {
 
         let scope = binding_family_scope(semantic, &family_scopes, binding);
         family_scopes.insert(binding.id, scope);
+        family_keys.insert(binding.id, (scope, binding_target_key(checker, binding)));
     }
 
     for binding in semantic.bindings() {
@@ -50,7 +52,7 @@ pub fn unused_assignment(checker: &mut Checker) {
         }
 
         if !unused_binding_ids.contains(&binding.id) {
-            families_with_used_bindings.insert(binding_family_key(&family_scopes, binding));
+            families_with_used_bindings.insert(binding_family_key(&family_keys, binding.id));
         }
     }
 
@@ -64,7 +66,7 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        let family = binding_family_key(&family_scopes, binding);
+        let family = binding_family_key(&family_keys, binding.id);
 
         unused_bindings_by_family
             .entry(family.clone())
@@ -168,13 +170,21 @@ fn binding_follows_in_source(
 }
 
 fn binding_family_key(
-    family_scopes: &HashMap<BindingId, Option<ScopeId>>,
-    binding: &Binding,
+    family_keys: &HashMap<BindingId, BindingFamilyKey>,
+    binding_id: BindingId,
 ) -> BindingFamilyKey {
-    (
-        family_scopes.get(&binding.id).copied().flatten(),
-        binding.name.to_string(),
-    )
+    family_keys
+        .get(&binding_id)
+        .cloned()
+        .unwrap_or_else(|| (None, String::new()))
+}
+
+fn binding_target_key(checker: &Checker<'_>, binding: &Binding) -> String {
+    checker
+        .facts()
+        .binding_target_span(binding.id)
+        .map(|span| span.slice(checker.source()).to_string())
+        .unwrap_or_else(|| binding.name.to_string())
 }
 
 fn binding_family_scope(
@@ -237,6 +247,16 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 3);
         assert_eq!(diagnostics[0].span.slice(source), "foo");
+    }
+
+    #[test]
+    fn unrelated_array_writes_do_not_collapse_to_one_report() {
+        let source = "#!/bin/bash\nemoji[grinning]=1\nprintf '%s\\n' \"$OTHER\"\nemoji[smile]=2\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[1].span.start.line, 4);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -148,11 +148,13 @@ fn binding_family_key(semantic: &SemanticModel, binding: &Binding) -> BindingFam
     // `local` bindings are function-scoped, while assignments inside
     // nonpersistent execution scopes (subshells, pipelines, command
     // substitutions) should not collapse into the parent shell state.
-    let scope = if binding.attributes.contains(BindingAttributes::LOCAL) {
-        Some(binding.scope)
-    } else {
-        isolated_family_scope(semantic, binding.scope)
-    };
+    let scope = isolated_family_scope(semantic, binding.scope).or_else(|| {
+        if binding.attributes.contains(BindingAttributes::LOCAL) {
+            Some(binding.scope)
+        } else {
+            local_family_scope(semantic, binding)
+        }
+    });
 
     (scope, binding.name.to_string())
 }
@@ -164,6 +166,25 @@ fn isolated_family_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<Sco
             ScopeKind::Subshell | ScopeKind::CommandSubstitution | ScopeKind::Pipeline
         )
     })
+}
+
+fn local_family_scope(semantic: &SemanticModel, binding: &Binding) -> Option<ScopeId> {
+    let mut probe = binding;
+
+    loop {
+        let prior =
+            semantic.previous_visible_binding(&probe.name, probe.span, Some(probe.span))?;
+
+        if prior.attributes.contains(BindingAttributes::LOCAL) {
+            return Some(prior.scope);
+        }
+
+        if prior.scope != probe.scope {
+            return None;
+        }
+
+        probe = prior;
+    }
 }
 
 #[cfg(test)]
@@ -229,6 +250,16 @@ mod tests {
     #[test]
     fn isolated_execution_scopes_keep_separate_dedup_families() {
         let source = "#!/bin/bash\nfoo=1\n(foo=2)\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[1].span.start.line, 3);
+    }
+
+    #[test]
+    fn later_local_reassignments_stay_separate_across_functions() {
+        let source = "#!/bin/bash\nf(){ local foo=; foo=1; }\ng(){ local foo=; foo=2; }\nf\ng\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 2);

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -172,8 +172,7 @@ fn local_family_scope(semantic: &SemanticModel, binding: &Binding) -> Option<Sco
     let mut probe = binding;
 
     loop {
-        let prior =
-            semantic.previous_visible_binding(&probe.name, probe.span, Some(probe.span))?;
+        let prior = semantic.previous_visible_binding(&probe.name, probe.span, Some(probe.span))?;
 
         if prior.attributes.contains(BindingAttributes::LOCAL) {
             return Some(prior.scope);

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
-use shuck_semantic::{BindingAttributes, BindingKind};
+use shuck_semantic::{Binding, BindingAttributes, BindingKind, ScopeId};
 
 use crate::{Checker, Rule, Violation};
+
+type BindingFamilyKey = (Option<ScopeId>, String);
 
 pub struct UnusedAssignment {
     pub name: String,
@@ -22,9 +24,9 @@ pub fn unused_assignment(checker: &mut Checker) {
     let semantic = checker.semantic();
     let unused_bindings = checker.semantic_analysis().unused_assignments();
     let unused_binding_ids = unused_bindings.iter().copied().collect::<HashSet<_>>();
-    let mut names_with_used_reportable_bindings = HashSet::new();
-    let mut unused_bindings_by_name = HashMap::<_, Vec<_>>::new();
-    let mut last_unused_binding_by_name = HashMap::new();
+    let mut families_with_used_reportable_bindings = HashSet::new();
+    let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();
+    let mut last_unused_binding_by_family = HashMap::new();
 
     for binding in semantic.bindings() {
         if binding.name.as_str() == "_" {
@@ -36,7 +38,7 @@ pub fn unused_assignment(checker: &mut Checker) {
         }
 
         if !unused_binding_ids.contains(&binding.id) {
-            names_with_used_reportable_bindings.insert(binding.name.clone());
+            families_with_used_reportable_bindings.insert(binding_family_key(binding));
         }
     }
 
@@ -46,13 +48,15 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        unused_bindings_by_name
-            .entry(binding.name.clone())
+        let family = binding_family_key(binding);
+
+        unused_bindings_by_family
+            .entry(family.clone())
             .or_default()
             .push(*binding_id);
 
-        last_unused_binding_by_name
-            .entry(binding.name.clone())
+        last_unused_binding_by_family
+            .entry(family)
             .and_modify(|current_binding_id| {
                 let current = semantic.binding(*current_binding_id);
                 if binding_follows_in_source(
@@ -68,13 +72,13 @@ pub fn unused_assignment(checker: &mut Checker) {
     }
 
     let mut reportable_bindings = Vec::new();
-    for (name, binding_ids) in unused_bindings_by_name {
-        if names_with_used_reportable_bindings.contains(&name) {
+    for (family, binding_ids) in unused_bindings_by_family {
+        if families_with_used_reportable_bindings.contains(&family) {
             reportable_bindings.extend(binding_ids);
             continue;
         }
 
-        if let Some(binding_id) = last_unused_binding_by_name.get(&name).copied() {
+        if let Some(binding_id) = last_unused_binding_by_family.get(&family).copied() {
             reportable_bindings.push(binding_id);
         }
     }
@@ -136,6 +140,18 @@ fn binding_follows_in_source(
         || (candidate_start == current_start && candidate_end > current_end)
 }
 
+fn binding_family_key(binding: &Binding) -> BindingFamilyKey {
+    // `local`-scoped bindings should not collapse across functions, but plain
+    // assignments still participate in the wider variable family even when
+    // they appear inside a function body.
+    let scope = binding
+        .attributes
+        .contains(BindingAttributes::LOCAL)
+        .then_some(binding.scope);
+
+    (scope, binding.name.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
@@ -175,5 +191,15 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn keeps_distinct_local_scopes_separate() {
+        let source = "#!/bin/bash\nf(){ local foo=1; }\ng(){ local foo=2; }\nf\ng\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[1].span.start.line, 3);
     }
 }

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -197,6 +197,41 @@ assoc[$key/sfx]=z
     }
 
     #[test]
+    fn ignores_mixed_assoc_and_indexed_assignment_subscripts_in_branches() {
+        let source = "\
+#!/bin/bash
+f() {
+  if cond; then
+    local -A arr
+  else
+    local -a arr
+  fi
+  idx=0
+  arr[${idx}]=x
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_mixed_assoc_and_indexed_assignment_subscripts_in_linear_flow() {
+        let source = "\
+#!/bin/bash
+f() {
+  local -A arr
+  local -a arr
+  idx=0
+  arr[${idx}]=x
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_quoted_indexed_assignment_subscripts() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -232,6 +232,33 @@ f() {
     }
 
     #[test]
+    fn reports_caller_local_shadowing_after_assoc_declaration() {
+        let source = "\
+#!/bin/bash
+helper() {
+  map[$key]=1
+}
+main() {
+  local key=name
+  declare -A map
+  unset map
+  local map
+  helper
+}
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$key"]
+        );
+    }
+
+    #[test]
     fn ignores_quoted_indexed_assignment_subscripts() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -345,6 +345,29 @@ NUMJOBS=${NUMJOBS:-\" -j $(expr $(nproc) + 1) \"}
     }
 
     #[test]
+    fn reports_docker_ps_command_substitutions_in_arguments() {
+        let source = "\
+#!/bin/bash
+docker inspect -f '{{ if ne \"true\" (index .Config.Labels \"com.dokku.devcontainer\") }}{{.ID}} {{ end }}' $(docker ps -q)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(docker ps -q)"]
+        );
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 105);
+        assert_eq!(diagnostics[0].span.end.column, 120);
+    }
+
+    #[test]
     fn ignores_kill_pid_lists() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -1134,14 +1134,14 @@ fn apply_prescan_command_effects(words: &[String], state: &mut ZshOptionState) -
         "setopt" => {
             let mut changed = false;
             for arg in &words[args_index..] {
-                changed = state.apply_setopt(arg) || changed;
+                changed |= state.apply_setopt(arg);
             }
             changed
         }
         "unsetopt" => {
             let mut changed = false;
             for arg in &words[args_index..] {
-                changed = state.apply_unsetopt(arg) || changed;
+                changed |= state.apply_unsetopt(arg);
             }
             changed
         }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -5666,9 +5666,7 @@ fn source_prefix_has_same_line_escaped_double_quote_fragment(
 
     while let Some(ch) = chars.next() {
         match ch {
-            '\\' if !in_single && in_double && chars.peek() == Some(&'"') => {
-                return true;
-            }
+            '\\' if !in_single && in_double && chars.peek() == Some(&'"') => return true,
             '\\' if !in_single => {}
             '\'' if !in_double => in_single = !in_single,
             '"' if !in_single => in_double = !in_double,

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -49,6 +49,7 @@ pub enum BindingOrigin {
     },
     ArithmeticAssignment {
         definition_span: Span,
+        target_span: Span,
     },
     Declaration {
         definition_span: Span,

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2435,7 +2435,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             return;
         }
 
-        let mut function_mode = false;
+        let mut function_flag_seen = false;
+        let mut variable_flag_seen = false;
+        let mut nameref_mode = false;
         let mut parsing_options = true;
 
         for argument in args {
@@ -2455,11 +2457,25 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     if !unset_flags_are_valid(flags) {
                         return;
                     }
-                    if flags.contains('f') {
-                        function_mode = true;
-                    }
-                    if flags.contains('v') {
-                        function_mode = false;
+                    for flag in flags.chars() {
+                        match flag {
+                            'f' => {
+                                if variable_flag_seen {
+                                    return;
+                                }
+                                function_flag_seen = true;
+                            }
+                            'v' => {
+                                if function_flag_seen {
+                                    return;
+                                }
+                                variable_flag_seen = true;
+                            }
+                            'n' => {
+                                nameref_mode = true;
+                            }
+                            _ => unreachable!("invalid unset flag already filtered"),
+                        }
                     }
                     continue;
                 }
@@ -2467,8 +2483,23 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 parsing_options = false;
             }
 
-            if function_mode || !is_name(&text) {
+            if function_flag_seen || !is_name(&text) {
                 continue;
+            }
+
+            if nameref_mode {
+                let name = Name::from(text.as_str());
+                let Some(binding_id) =
+                    self.resolve_reference(&name, self.current_scope(), argument.span.start.offset)
+                else {
+                    continue;
+                };
+                let binding = &self.bindings[binding_id.index()];
+                if !binding.attributes.contains(BindingAttributes::NAMEREF)
+                    && !matches!(binding.kind, BindingKind::Nameref)
+                {
+                    continue;
+                }
             }
 
             self.cleared_variables.insert(
@@ -3883,8 +3914,7 @@ fn static_tail_text_starts_with_slash(
 
 fn unset_flags_are_valid(flags: &str) -> bool {
     !flags.is_empty()
-        && flags.chars().all(|flag| matches!(flag, 'f' | 'v'))
-        && !(flags.contains('f') && flags.contains('v'))
+        && flags.chars().all(|flag| matches!(flag, 'f' | 'v' | 'n'))
 }
 
 fn parse_source_directives(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -85,6 +85,7 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     command_bindings: FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
     command_references: FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
     source_directives: FxHashMap<usize, SourceDirectiveOverride>,
+    cleared_variables: FxHashMap<(ScopeId, Name), usize>,
     runtime: RuntimePrelude,
     completed_scopes: FxHashSet<ScopeId>,
     deferred_functions: Vec<DeferredFunction>,
@@ -155,6 +156,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             command_bindings: FxHashMap::default(),
             command_references: FxHashMap::default(),
             source_directives: parse_source_directives(source, indexer),
+            cleared_variables: FxHashMap::default(),
             runtime,
             completed_scopes: FxHashSet::default(),
             deferred_functions: Vec::new(),
@@ -2410,7 +2412,44 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     });
                 }
             }
+            "unset" => self.record_unset_variable_targets(&command.args),
             _ => {}
+        }
+    }
+
+    fn record_unset_variable_targets(&mut self, args: &[Word]) {
+        let mut function_mode = false;
+        let mut parsing_options = true;
+
+        for argument in args {
+            let Some(text) = static_word_text(argument, self.source) else {
+                continue;
+            };
+
+            if parsing_options && text == "--" {
+                parsing_options = false;
+                continue;
+            }
+
+            if parsing_options && text.starts_with('-') && text != "-" {
+                let flags = text.trim_start_matches('-');
+                if flags.contains('f') {
+                    function_mode = true;
+                }
+                if flags.contains('v') {
+                    function_mode = false;
+                }
+                continue;
+            }
+
+            if function_mode || !is_name(&text) {
+                continue;
+            }
+
+            self.cleared_variables.insert(
+                (self.current_scope(), Name::from(text.as_str())),
+                argument.span.start.offset,
+            );
         }
     }
 
@@ -2517,7 +2556,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 || (existing_binding.scope == scope
                     && existing_binding
                         .attributes
-                        .contains(BindingAttributes::LOCAL))
+                        .contains(BindingAttributes::LOCAL)
+                    && !self.binding_was_cleared_in_scope_after(
+                        name,
+                        scope,
+                        existing_binding.span.start.offset,
+                    ))
         });
 
         if reuse_existing {
@@ -2542,6 +2586,17 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
         };
         self.add_binding(name, kind, scope, span, origin, attributes);
+    }
+
+    fn binding_was_cleared_in_scope_after(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        binding_offset: usize,
+    ) -> bool {
+        self.cleared_variables
+            .get(&(scope, name.clone()))
+            .is_some_and(|cleared_offset| *cleared_offset > binding_offset)
     }
 
     fn add_binding(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2510,13 +2510,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let local_like = attributes.contains(BindingAttributes::LOCAL);
         let existing = self.resolve_reference(name, scope, span.start.offset);
 
-        if let Some(existing) = existing {
-            let existing_scope = self.bindings[existing.index()].scope;
-            if !local_like || existing_scope == scope {
-                self.add_reference(name, ReferenceKind::DeclarationName, span);
-                self.bindings[existing.index()].attributes |= attributes;
-                return;
-            }
+        if !local_like && let Some(existing) = existing {
+            self.add_reference(name, ReferenceKind::DeclarationName, span);
+            self.bindings[existing.index()].attributes |= attributes;
+            return;
         }
 
         let kind = if attributes.contains(BindingAttributes::NAMEREF) {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2442,6 +2442,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
         for argument in args {
             let Some(text) = static_word_text(argument, self.source) else {
+                if parsing_options {
+                    return;
+                }
                 parsing_options = false;
                 continue;
             };

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2510,7 +2510,18 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let local_like = attributes.contains(BindingAttributes::LOCAL);
         let existing = self.resolve_reference(name, scope, span.start.offset);
 
-        if !local_like && let Some(existing) = existing {
+        let reuse_existing = existing.is_some_and(|existing| {
+            let existing_binding = &self.bindings[existing.index()];
+
+            !local_like
+                || (existing_binding.scope == scope
+                    && existing_binding
+                        .attributes
+                        .contains(BindingAttributes::LOCAL))
+        });
+
+        if reuse_existing {
+            let existing = existing.expect("existing binding already checked");
             self.add_reference(name, ReferenceKind::DeclarationName, span);
             self.bindings[existing.index()].attributes |= attributes;
             return;

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2440,23 +2440,31 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
         for argument in args {
             let Some(text) = static_word_text(argument, self.source) else {
+                parsing_options = false;
                 continue;
             };
 
-            if parsing_options && text == "--" {
-                parsing_options = false;
-                continue;
-            }
+            if parsing_options {
+                if text == "--" {
+                    parsing_options = false;
+                    continue;
+                }
 
-            if parsing_options && text.starts_with('-') && text != "-" {
-                let flags = text.trim_start_matches('-');
-                if flags.contains('f') {
-                    function_mode = true;
+                if text.starts_with('-') && text != "-" {
+                    let flags = text.trim_start_matches('-');
+                    if !unset_flags_are_valid(flags) {
+                        return;
+                    }
+                    if flags.contains('f') {
+                        function_mode = true;
+                    }
+                    if flags.contains('v') {
+                        function_mode = false;
+                    }
+                    continue;
                 }
-                if flags.contains('v') {
-                    function_mode = false;
-                }
-                continue;
+
+                parsing_options = false;
             }
 
             if function_mode || !is_name(&text) {
@@ -3871,6 +3879,12 @@ fn static_tail_text_starts_with_slash(
     collect_static_word_text(parts, source, &mut result)
         && collect_static_word_text(trailing, source, &mut result)
         && result.starts_with('/')
+}
+
+fn unset_flags_are_valid(flags: &str) -> bool {
+    !flags.is_empty()
+        && flags.chars().all(|flag| matches!(flag, 'f' | 'v'))
+        && !(flags.contains('f') && flags.contains('v'))
 }
 
 fn parse_source_directives(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2554,14 +2554,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
             !local_like
                 || (existing_binding.scope == scope
-                    && existing_binding
-                        .attributes
-                        .contains(BindingAttributes::LOCAL)
-                    && !self.binding_was_cleared_in_scope_after(
-                        name,
-                        scope,
-                        existing_binding.span.start.offset,
-                    ))
+                    && self.has_uncleared_local_binding_in_scope(name, scope, span.start.offset))
         });
 
         if reuse_existing {
@@ -2597,6 +2590,31 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.cleared_variables
             .get(&(scope, name.clone()))
             .is_some_and(|cleared_offset| *cleared_offset > binding_offset)
+    }
+
+    fn has_uncleared_local_binding_in_scope(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> bool {
+        self.scopes[scope.index()]
+            .bindings
+            .get(name)
+            .and_then(|bindings| {
+                bindings.iter().rev().copied().find(|binding_id| {
+                    let binding = &self.bindings[binding_id.index()];
+                    binding.span.start.offset <= offset
+                        && binding.attributes.contains(BindingAttributes::LOCAL)
+                })
+            })
+            .is_some_and(|binding_id| {
+                !self.binding_was_cleared_in_scope_after(
+                    name,
+                    scope,
+                    self.bindings[binding_id.index()].span.start.offset,
+                )
+            })
     }
 
     fn add_binding(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -3913,8 +3913,7 @@ fn static_tail_text_starts_with_slash(
 }
 
 fn unset_flags_are_valid(flags: &str) -> bool {
-    !flags.is_empty()
-        && flags.chars().all(|flag| matches!(flag, 'f' | 'v' | 'n'))
+    !flags.is_empty() && flags.chars().all(|flag| matches!(flag, 'f' | 'v' | 'n'))
 }
 
 fn parse_source_directives(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -101,6 +101,16 @@ struct FlowState {
     in_subshell: bool,
     in_block: bool,
     exit_status_checked: bool,
+    conditionally_executed: bool,
+}
+
+impl FlowState {
+    fn conditional(self) -> Self {
+        Self {
+            conditionally_executed: true,
+            ..self
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -550,6 +560,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         for (index, stmt) in commands.into_iter().enumerate() {
             let mut nested = flow;
             nested.exit_status_checked = operators.get(index).is_some() || flow.exit_status_checked;
+            if index > 0 {
+                nested.conditionally_executed = true;
+            }
             recorded.push(self.visit_stmt(stmt, nested));
         }
 
@@ -582,7 +595,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         ..flow
                     },
                 );
-                let then_branch = self.visit_stmt_seq(&command.then_branch, flow);
+                let then_branch = self.visit_stmt_seq(&command.then_branch, flow.conditional());
                 let elif_branches = command
                     .elif_branches
                     .iter()
@@ -591,17 +604,17 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                             condition,
                             FlowState {
                                 exit_status_checked: true,
-                                ..flow
+                                ..flow.conditional()
                             },
                         ),
-                        body: self.visit_stmt_seq(body, flow),
+                        body: self.visit_stmt_seq(body, flow.conditional()),
                     })
                     .collect();
                 let elif_branches = self.recorded_program.push_elif_branches(elif_branches);
                 let else_branch = command
                     .else_branch
                     .as_ref()
-                    .map(|body| self.visit_stmt_seq(body, flow))
+                    .map(|body| self.visit_stmt_seq(body, flow.conditional()))
                     .unwrap_or_default();
 
                 self.record_command(
@@ -641,7 +654,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     &command.body,
                     FlowState {
                         loop_depth: flow.loop_depth + 1,
-                        ..flow
+                        ..flow.conditional()
                     },
                 );
                 self.record_command(
@@ -657,7 +670,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     &command.body,
                     FlowState {
                         loop_depth: flow.loop_depth + 1,
-                        ..flow
+                        ..flow.conditional()
                     },
                 );
                 self.record_command(
@@ -685,7 +698,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     &command.body,
                     FlowState {
                         loop_depth: flow.loop_depth + 1,
-                        ..flow
+                        ..flow.conditional()
                     },
                 );
                 self.record_command(
@@ -715,7 +728,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     &command.body,
                     FlowState {
                         loop_depth: flow.loop_depth + 1,
-                        ..flow
+                        ..flow.conditional()
                     },
                 );
                 self.record_command(
@@ -736,7 +749,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     &command.body,
                     FlowState {
                         loop_depth: flow.loop_depth + 1,
-                        ..flow
+                        ..flow.conditional()
                     },
                 );
                 self.record_command(
@@ -757,7 +770,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     &command.body,
                     FlowState {
                         loop_depth: flow.loop_depth + 1,
-                        ..flow
+                        ..flow.conditional()
                     },
                 );
                 self.record_command(
@@ -776,7 +789,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         let pattern_regions =
                             self.visit_patterns(&case.patterns, WordVisitKind::Conditional, flow);
                         let mut commands = Vec::with_capacity(case.body.len());
-                        self.visit_stmt_seq_into(&case.body, flow, &mut commands);
+                        self.visit_stmt_seq_into(&case.body, flow.conditional(), &mut commands);
                         if !pattern_regions.is_empty() {
                             if let Some(&first) = commands.first() {
                                 self.prepend_nested_regions(first, pattern_regions);
@@ -822,7 +835,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     &command.body,
                     FlowState {
                         loop_depth: flow.loop_depth + 1,
-                        ..flow
+                        ..flow.conditional()
                     },
                 );
                 self.record_command(
@@ -2319,7 +2332,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         &mut self,
         name: &Name,
         command: &shuck_ast::SimpleCommand,
-        _flow: FlowState,
+        flow: FlowState,
     ) {
         match name.as_str() {
             "read" => {
@@ -2412,12 +2425,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     });
                 }
             }
-            "unset" => self.record_unset_variable_targets(&command.args),
+            "unset" => self.record_unset_variable_targets(&command.args, flow),
             _ => {}
         }
     }
 
-    fn record_unset_variable_targets(&mut self, args: &[Word]) {
+    fn record_unset_variable_targets(&mut self, args: &[Word], flow: FlowState) {
+        if flow.conditionally_executed {
+            return;
+        }
+
         let mut function_mode = false;
         let mut parsing_options = true;
 

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2227,6 +2227,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     expr.span,
                     BindingOrigin::ArithmeticAssignment {
                         definition_span: expr.span,
+                        target_span: arithmetic_lvalue_span(
+                            &ArithmeticLvalue::Variable(name.clone()),
+                            expr.span,
+                        ),
                     },
                     BindingAttributes::empty(),
                 );
@@ -2242,6 +2246,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     span,
                     BindingOrigin::ArithmeticAssignment {
                         definition_span: span,
+                        target_span: arithmetic_lvalue_span(
+                            &ArithmeticLvalue::Indexed {
+                                name: name.clone(),
+                                index: index.clone(),
+                            },
+                            expr.span,
+                        ),
                     },
                     self.arithmetic_binding_attributes(
                         &ArithmeticLvalue::Indexed {
@@ -2282,6 +2293,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             name_span,
             BindingOrigin::ArithmeticAssignment {
                 definition_span: name_span,
+                target_span: arithmetic_lvalue_span(target, target_span),
             },
             attributes,
         );
@@ -3814,6 +3826,15 @@ fn parse_source_directive_override(text: &str, own_line: bool) -> Option<SourceD
 
 fn arithmetic_name_span(span: Span, name: &Name) -> Span {
     Span::from_positions(span.start, span.start.advanced_by(name.as_str()))
+}
+
+fn arithmetic_lvalue_span(target: &ArithmeticLvalue, span: Span) -> Span {
+    match target {
+        ArithmeticLvalue::Variable(name) => arithmetic_name_span(span, name),
+        ArithmeticLvalue::Indexed { index, .. } => {
+            Span::from_positions(span.start, index.span.end.advanced_by("]"))
+        }
+    }
 }
 
 fn is_name(value: &str) -> bool {

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -379,10 +379,12 @@ fn analyze_unused_assignments_exact(
         None
     } else {
         let (read_plans, callers_by_callee) = build_scope_read_plans(
+            context.cfg,
             context.scopes,
             context.bindings,
             context.references,
             context.synthetic_reads,
+            &exact.reference_blocks,
             &reference_name_ids,
             &synthetic_read_name_ids,
             context.call_sites,
@@ -498,6 +500,8 @@ fn analyze_unused_assignments_exact(
                     binding,
                     exact.binding_data.binding_name_ids[binding.id.index()],
                     context.bindings,
+                    context.cfg,
+                    &exact.binding_blocks,
                     read_plans,
                     &interprocedural.transitive_reads,
                     &interprocedural.future_reads,
@@ -1040,6 +1044,7 @@ enum ScopeReadEventKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ScopeReadEvent {
     offset: usize,
+    block: Option<BlockId>,
     kind: ScopeReadEventKind,
 }
 
@@ -1666,10 +1671,12 @@ fn reachable_blocks_dense(
 
 #[allow(clippy::too_many_arguments)]
 fn build_scope_read_plans(
+    cfg: &ControlFlowGraph,
     scopes: &[Scope],
     bindings: &[Binding],
     references: &[Reference],
     synthetic_reads: &[SyntheticRead],
+    reference_blocks: &[Option<BlockId>],
     reference_name_ids: &[NameId],
     synthetic_read_name_ids: &[NameId],
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
@@ -1689,6 +1696,7 @@ fn build_scope_read_plans(
         plan.direct_reads.insert(name_id.index());
         plan.events.push(ScopeReadEvent {
             offset: reference.span.start.offset,
+            block: reference_blocks[reference_index],
             kind: ScopeReadEventKind::Direct(name_id),
         });
     }
@@ -1699,6 +1707,7 @@ fn build_scope_read_plans(
         plan.direct_reads.insert(name_id.index());
         plan.events.push(ScopeReadEvent {
             offset: synthetic_read.span.start.offset,
+            block: command_block_for_span(cfg, synthetic_read.span),
             kind: ScopeReadEventKind::Direct(name_id),
         });
     }
@@ -1712,6 +1721,7 @@ fn build_scope_read_plans(
             });
             plan.events.push(ScopeReadEvent {
                 offset: call.offset,
+                block: command_block_for_span(cfg, call.span),
                 kind: ScopeReadEventKind::Call(call.callee_scope),
             });
         }
@@ -1864,25 +1874,45 @@ fn binding_has_future_reads_before_local_shadow(
     binding: &Binding,
     name_id: NameId,
     bindings: &[Binding],
+    cfg: &ControlFlowGraph,
+    binding_blocks: &[Option<BlockId>],
     read_plans: &[ScopeReadPlan],
     transitive_reads: &[DenseBitSet],
     future_reads: &[ScopeFutureReads],
     escape_reads: &[DenseBitSet],
 ) -> bool {
-    let shadow_offset = next_shadowing_local_declaration_offset(binding, bindings);
+    let shadow = next_shadowing_local_declaration(binding, bindings);
     let escape_reads_visible = read_plans[binding.scope.index()].is_function
         && escape_reads[binding.scope.index()].contains(name_id.index());
 
-    if let Some(shadow_offset) = shadow_offset {
-        escape_reads_visible
-            || future_reads_contain_after_until(
-                binding.scope,
-                binding.span.start.offset,
-                shadow_offset,
-                name_id,
-                read_plans,
-                transitive_reads,
-            )
+    if let Some(shadow) = shadow {
+        if let (Some(binding_block), Some(shadow_block)) = (
+            binding_blocks[binding.id.index()],
+            binding_blocks[shadow.id.index()],
+        ) {
+            escape_reads_visible
+                || future_reads_contain_after_without_shadow(
+                    binding.scope,
+                    binding.span.start.offset,
+                    shadow.span.start.offset,
+                    binding_block,
+                    shadow_block,
+                    name_id,
+                    read_plans,
+                    transitive_reads,
+                    cfg,
+                )
+        } else {
+            escape_reads_visible
+                || future_reads_contain_after_until(
+                    binding.scope,
+                    binding.span.start.offset,
+                    shadow.span.start.offset,
+                    name_id,
+                    read_plans,
+                    transitive_reads,
+                )
+        }
     } else {
         future_reads_contain_after(
             binding.scope,
@@ -1895,10 +1925,10 @@ fn binding_has_future_reads_before_local_shadow(
     }
 }
 
-fn next_shadowing_local_declaration_offset(
+fn next_shadowing_local_declaration<'a>(
     binding: &Binding,
-    bindings: &[Binding],
-) -> Option<usize> {
+    bindings: &'a [Binding],
+) -> Option<&'a Binding> {
     bindings
         .iter()
         .skip(binding.id.index() + 1)
@@ -1909,7 +1939,6 @@ fn next_shadowing_local_declaration_offset(
                 && matches!(candidate.kind, BindingKind::Declaration(_))
                 && candidate.attributes.contains(BindingAttributes::LOCAL)
         })
-        .map(|candidate| candidate.span.start.offset)
 }
 
 fn future_reads_contain_after_until(
@@ -1940,6 +1969,76 @@ fn future_reads_contain_after_until(
                 transitive_reads[callee_scope.index()].contains(name_id.index())
             }
         })
+}
+
+fn future_reads_contain_after_without_shadow(
+    scope: ScopeId,
+    after_offset: usize,
+    shadow_offset: usize,
+    binding_block: BlockId,
+    shadow_block: BlockId,
+    name_id: NameId,
+    read_plans: &[ScopeReadPlan],
+    transitive_reads: &[DenseBitSet],
+    cfg: &ControlFlowGraph,
+) -> bool {
+    let plan = &read_plans[scope.index()];
+    let start = plan
+        .events
+        .partition_point(|event| event.offset <= after_offset);
+
+    plan.events[start..].iter().any(|event| {
+        let uses_name = match event.kind {
+            ScopeReadEventKind::Direct(candidate) => candidate == name_id,
+            ScopeReadEventKind::Call(callee_scope) => {
+                transitive_reads[callee_scope.index()].contains(name_id.index())
+            }
+        };
+        if !uses_name {
+            return false;
+        }
+        if event.offset < shadow_offset {
+            return true;
+        }
+
+        let Some(event_block) = event.block else {
+            return true;
+        };
+        if event_block == shadow_block {
+            return false;
+        }
+
+        block_reaches_without(cfg, binding_block, event_block, shadow_block)
+    })
+}
+
+fn block_reaches_without(
+    cfg: &ControlFlowGraph,
+    start: BlockId,
+    end: BlockId,
+    avoided: BlockId,
+) -> bool {
+    if start == avoided {
+        return false;
+    }
+
+    let mut visited = DenseBitSet::new(cfg.blocks().len());
+    let mut stack = vec![start];
+
+    while let Some(block) = stack.pop() {
+        if block == avoided || visited.contains(block.index()) {
+            continue;
+        }
+        visited.insert(block.index());
+        if block == end {
+            return true;
+        }
+        for (successor, _) in cfg.successors(block) {
+            stack.push(*successor);
+        }
+    }
+
+    false
 }
 
 fn mark_reaching_defs_for_names_used(
@@ -2181,6 +2280,7 @@ mod tests {
             calls: Vec::new(),
             events: vec![ScopeReadEvent {
                 offset: 0,
+                block: None,
                 kind: ScopeReadEventKind::Direct(NameId(0)),
             }],
             is_function: false,

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1870,6 +1870,7 @@ fn future_reads_contain_after(
         || (plan.is_function && escape_reads[scope.index()].contains(name_id.index()))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn binding_has_future_reads_before_local_shadow(
     binding: &Binding,
     name_id: NameId,
@@ -1971,6 +1972,7 @@ fn future_reads_contain_after_until(
         })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn future_reads_contain_after_without_shadow(
     scope: ScopeId,
     after_offset: usize,

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1880,15 +1880,21 @@ fn future_reads_contain_after_until(
     transitive_reads: &[DenseBitSet],
 ) -> bool {
     let plan = &read_plans[scope.index()];
-    let start = plan.events.partition_point(|event| event.offset <= after_offset);
-    let end = plan.events.partition_point(|event| event.offset < before_offset);
+    let start = plan
+        .events
+        .partition_point(|event| event.offset <= after_offset);
+    let end = plan
+        .events
+        .partition_point(|event| event.offset < before_offset);
 
-    plan.events[start..end].iter().any(|event| match event.kind {
-        ScopeReadEventKind::Direct(candidate) => candidate == name_id,
-        ScopeReadEventKind::Call(callee_scope) => {
-            transitive_reads[callee_scope.index()].contains(name_id.index())
-        }
-    })
+    plan.events[start..end]
+        .iter()
+        .any(|event| match event.kind {
+            ScopeReadEventKind::Direct(candidate) => candidate == name_id,
+            ScopeReadEventKind::Call(callee_scope) => {
+                transitive_reads[callee_scope.index()].contains(name_id.index())
+            }
+        })
 }
 
 fn mark_reaching_defs_for_names_used(

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -416,9 +416,18 @@ fn analyze_unused_assignments_exact(
         let name_id = reference_name_ids[reference_index];
         let resolved_binding_id = context.resolved.get(&reference.id).copied();
 
-        if !resolved_binding_shadows_name_without_initializing(
-            resolved_binding_id.map(|binding_id| &context.bindings[binding_id.index()]),
-        ) {
+        if let Some(resolved_binding_id) = resolved_binding_id
+            && resolved_binding_shadows_name_without_initializing(Some(
+                &context.bindings[resolved_binding_id.index()],
+            ))
+        {
+            mark_reaching_defs_used_except(
+                &mut used_bindings,
+                incoming,
+                &exact.binding_data.bindings_for_name[name_id.index()],
+                resolved_binding_id,
+            );
+        } else {
             used_bindings.or_intersection_with(
                 incoming,
                 &exact.binding_data.bindings_for_name[name_id.index()],
@@ -1969,6 +1978,19 @@ fn mark_reaching_defs_for_names_used(
 ) {
     for binding_index in incoming.iter_ones() {
         if used_names.contains(binding_name_ids[binding_index].index()) {
+            used_bindings.insert(binding_index);
+        }
+    }
+}
+
+fn mark_reaching_defs_used_except(
+    used_bindings: &mut DenseBitSet,
+    incoming: &DenseBitSet,
+    candidates: &DenseBitSet,
+    excluded: BindingId,
+) {
+    for binding_index in incoming.iter_ones() {
+        if binding_index != excluded.index() && candidates.contains(binding_index) {
             used_bindings.insert(binding_index);
         }
     }

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -623,7 +623,7 @@ fn should_suppress_redundant_branch_unused_assignment(
     context: &mut RedundantBranchUnusedAssignmentContext<'_>,
 ) -> bool {
     let binding = &context.bindings[binding_id.index()];
-    if !participates_in_unused_assignment_reporting(binding.kind, binding.attributes) {
+    if !participates_in_unused_assignment_family(binding.kind, binding.attributes) {
         return false;
     }
 
@@ -634,14 +634,14 @@ fn should_suppress_redundant_branch_unused_assignment(
         return false;
     };
 
-    let mut later_reportable = later_bindings
+    let mut later_participants = later_bindings
         .iter()
         .copied()
         .filter(|candidate_id| candidate_id.index() > binding_id.index())
         .filter(|candidate_id| {
             let candidate = &context.bindings[candidate_id.index()];
             candidate.scope == binding.scope
-                && participates_in_unused_assignment_reporting(candidate.kind, candidate.attributes)
+                && participates_in_unused_assignment_family(candidate.kind, candidate.attributes)
         })
         .filter_map(|candidate_id| {
             let candidate_block = context.binding_blocks[candidate_id.index()]?;
@@ -649,7 +649,7 @@ fn should_suppress_redundant_branch_unused_assignment(
                 .then_some((candidate_id, candidate_block))
         });
 
-    let Some((next_binding_id, next_binding_block)) = later_reportable.next() else {
+    let Some((next_binding_id, next_binding_block)) = later_participants.next() else {
         return false;
     };
 
@@ -662,11 +662,18 @@ fn should_suppress_redundant_branch_unused_assignment(
         return false;
     }
 
-    if !context.unused_binding_ids.contains(&next_binding_id) {
+    let next_binding = &context.bindings[next_binding_id.index()];
+    if !context.unused_binding_ids.contains(&next_binding_id)
+        || !can_survive_unused_assignment_branch_collapse(
+            next_binding.kind,
+            next_binding.attributes,
+        )
+    {
         return false;
     }
 
-    if later_reportable.any(|(candidate_id, _)| !context.unused_binding_ids.contains(&candidate_id))
+    if later_participants
+        .any(|(candidate_id, _)| !context.unused_binding_ids.contains(&candidate_id))
     {
         return false;
     }
@@ -674,7 +681,7 @@ fn should_suppress_redundant_branch_unused_assignment(
     true
 }
 
-fn participates_in_unused_assignment_reporting(
+fn participates_in_unused_assignment_family(
     kind: BindingKind,
     _attributes: BindingAttributes,
 ) -> bool {
@@ -691,6 +698,30 @@ fn participates_in_unused_assignment_reporting(
         | BindingKind::ArithmeticAssignment
         | BindingKind::Declaration(_) => true,
         BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref => false,
+    }
+}
+
+fn can_survive_unused_assignment_branch_collapse(
+    kind: BindingKind,
+    attributes: BindingAttributes,
+) -> bool {
+    match kind {
+        BindingKind::Assignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment => true,
+        BindingKind::Declaration(_) => {
+            attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
+        }
+        BindingKind::ParameterDefaultAssignment
+        | BindingKind::AppendAssignment
+        | BindingKind::FunctionDefinition
+        | BindingKind::Imported
+        | BindingKind::Nameref => false,
     }
 }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1942,34 +1942,6 @@ fn future_reads_contain_after_until(
         })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn future_reads_contain_after_until_ignores_backwards_intervals() {
-        let plan = ScopeReadPlan {
-            direct_reads: DenseBitSet::new(1),
-            calls: Vec::new(),
-            events: vec![ScopeReadEvent {
-                offset: 0,
-                kind: ScopeReadEventKind::Direct(NameId(0)),
-            }],
-            is_function: false,
-        };
-        let transitive_reads = vec![DenseBitSet::new(1)];
-
-        assert!(!future_reads_contain_after_until(
-            ScopeId(0),
-            10,
-            5,
-            NameId(0),
-            &[plan],
-            &transitive_reads,
-        ));
-    }
-}
-
 fn mark_reaching_defs_for_names_used(
     used_bindings: &mut DenseBitSet,
     incoming: &DenseBitSet,
@@ -2196,4 +2168,32 @@ fn is_function_escape_candidate(binding: &Binding, scopes: &[Scope]) -> bool {
 
 fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
     std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn future_reads_contain_after_until_ignores_backwards_intervals() {
+        let plan = ScopeReadPlan {
+            direct_reads: DenseBitSet::new(1),
+            calls: Vec::new(),
+            events: vec![ScopeReadEvent {
+                offset: 0,
+                kind: ScopeReadEventKind::Direct(NameId(0)),
+            }],
+            is_function: false,
+        };
+        let transitive_reads = vec![DenseBitSet::new(1)];
+
+        assert!(!future_reads_contain_after_until(
+            ScopeId(0),
+            10,
+            5,
+            NameId(0),
+            &[plan],
+            &transitive_reads,
+        ));
+    }
 }

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -414,12 +414,18 @@ fn analyze_unused_assignments_exact(
 
         let incoming = &reaching_definitions.reaching_in[block_id.index()];
         let name_id = reference_name_ids[reference_index];
-        used_bindings.or_intersection_with(
-            incoming,
-            &exact.binding_data.bindings_for_name[name_id.index()],
-        );
+        let resolved_binding_id = context.resolved.get(&reference.id).copied();
 
-        let Some(resolved_binding_id) = context.resolved.get(&reference.id).copied() else {
+        if !resolved_binding_shadows_name_without_initializing(
+            resolved_binding_id.map(|binding_id| &context.bindings[binding_id.index()]),
+        ) {
+            used_bindings.or_intersection_with(
+                incoming,
+                &exact.binding_data.bindings_for_name[name_id.index()],
+            );
+        }
+
+        let Some(resolved_binding_id) = resolved_binding_id else {
             continue;
         };
         let resolved_binding = &context.bindings[resolved_binding_id.index()];
@@ -479,11 +485,12 @@ fn analyze_unused_assignments_exact(
 
         for binding in context.bindings {
             if is_function_escape_candidate(binding, context.scopes)
-                && future_reads_contain_after(
-                    binding.scope,
-                    binding.span.start.offset,
+                && binding_has_future_reads_before_local_shadow(
+                    binding,
                     exact.binding_data.binding_name_ids[binding.id.index()],
+                    context.bindings,
                     read_plans,
+                    &interprocedural.transitive_reads,
                     &interprocedural.future_reads,
                     &interprocedural.escape_reads,
                 )
@@ -669,7 +676,7 @@ fn should_suppress_redundant_branch_unused_assignment(
 
 fn participates_in_unused_assignment_reporting(
     kind: BindingKind,
-    attributes: BindingAttributes,
+    _attributes: BindingAttributes,
 ) -> bool {
     match kind {
         BindingKind::Assignment
@@ -681,12 +688,21 @@ fn participates_in_unused_assignment_reporting(
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
-        | BindingKind::ArithmeticAssignment => true,
-        BindingKind::Declaration(_) => {
-            attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
-        }
+        | BindingKind::ArithmeticAssignment
+        | BindingKind::Declaration(_) => true,
         BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref => false,
     }
+}
+
+fn resolved_binding_shadows_name_without_initializing(binding: Option<&Binding>) -> bool {
+    matches!(
+        binding,
+        Some(binding)
+            if matches!(binding.kind, BindingKind::Declaration(_))
+                && !binding
+                    .attributes
+                    .contains(BindingAttributes::DECLARATION_INITIALIZED)
+    )
 }
 
 fn block_can_reach(
@@ -1802,6 +1818,77 @@ fn future_reads_contain_after(
     let index = plan.events.partition_point(|event| event.offset <= offset);
     future_reads[scope.index()].suffix_reads[index].contains(name_id.index())
         || (plan.is_function && escape_reads[scope.index()].contains(name_id.index()))
+}
+
+fn binding_has_future_reads_before_local_shadow(
+    binding: &Binding,
+    name_id: NameId,
+    bindings: &[Binding],
+    read_plans: &[ScopeReadPlan],
+    transitive_reads: &[DenseBitSet],
+    future_reads: &[ScopeFutureReads],
+    escape_reads: &[DenseBitSet],
+) -> bool {
+    let shadow_offset = next_shadowing_local_declaration_offset(binding, bindings);
+    let escape_reads_visible = read_plans[binding.scope.index()].is_function
+        && escape_reads[binding.scope.index()].contains(name_id.index());
+
+    if let Some(shadow_offset) = shadow_offset {
+        escape_reads_visible
+            || future_reads_contain_after_until(
+                binding.scope,
+                binding.span.start.offset,
+                shadow_offset,
+                name_id,
+                read_plans,
+                transitive_reads,
+            )
+    } else {
+        future_reads_contain_after(
+            binding.scope,
+            binding.span.start.offset,
+            name_id,
+            read_plans,
+            future_reads,
+            escape_reads,
+        )
+    }
+}
+
+fn next_shadowing_local_declaration_offset(
+    binding: &Binding,
+    bindings: &[Binding],
+) -> Option<usize> {
+    bindings
+        .iter()
+        .skip(binding.id.index() + 1)
+        .find(|candidate| {
+            candidate.name == binding.name
+                && candidate.scope == binding.scope
+                && matches!(candidate.kind, BindingKind::Declaration(_))
+                && candidate.attributes.contains(BindingAttributes::LOCAL)
+        })
+        .map(|candidate| candidate.span.start.offset)
+}
+
+fn future_reads_contain_after_until(
+    scope: ScopeId,
+    after_offset: usize,
+    before_offset: usize,
+    name_id: NameId,
+    read_plans: &[ScopeReadPlan],
+    transitive_reads: &[DenseBitSet],
+) -> bool {
+    let plan = &read_plans[scope.index()];
+    let start = plan.events.partition_point(|event| event.offset <= after_offset);
+    let end = plan.events.partition_point(|event| event.offset < before_offset);
+
+    plan.events[start..end].iter().any(|event| match event.kind {
+        ScopeReadEventKind::Direct(candidate) => candidate == name_id,
+        ScopeReadEventKind::Call(callee_scope) => {
+            transitive_reads[callee_scope.index()].contains(name_id.index())
+        }
+    })
 }
 
 fn mark_reaching_defs_for_names_used(

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1896,6 +1896,7 @@ fn next_shadowing_local_declaration_offset(
         .find(|candidate| {
             candidate.name == binding.name
                 && candidate.scope == binding.scope
+                && candidate.span.start.offset > binding.span.start.offset
                 && matches!(candidate.kind, BindingKind::Declaration(_))
                 && candidate.attributes.contains(BindingAttributes::LOCAL)
         })
@@ -1910,6 +1911,10 @@ fn future_reads_contain_after_until(
     read_plans: &[ScopeReadPlan],
     transitive_reads: &[DenseBitSet],
 ) -> bool {
+    if before_offset <= after_offset {
+        return false;
+    }
+
     let plan = &read_plans[scope.index()];
     let start = plan
         .events
@@ -1926,6 +1931,34 @@ fn future_reads_contain_after_until(
                 transitive_reads[callee_scope.index()].contains(name_id.index())
             }
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn future_reads_contain_after_until_ignores_backwards_intervals() {
+        let plan = ScopeReadPlan {
+            direct_reads: DenseBitSet::new(1),
+            calls: Vec::new(),
+            events: vec![ScopeReadEvent {
+                offset: 0,
+                kind: ScopeReadEventKind::Direct(NameId(0)),
+            }],
+            is_function: false,
+        };
+        let transitive_reads = vec![DenseBitSet::new(1)];
+
+        assert!(!future_reads_contain_after_until(
+            ScopeId(0),
+            10,
+            5,
+            NameId(0),
+            &[plan],
+            &transitive_reads,
+        ));
+    }
 }
 
 fn mark_reaching_defs_for_names_used(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4491,6 +4491,56 @@ f() {
     }
 
     #[test]
+    fn name_only_local_after_dynamic_unset_option_word_reuses_existing_local_state() {
+        let source = "\
+f() {
+  local foo=1
+  local mode=-f
+  unset \"$mode\" foo
+  local foo
+  echo \"$foo\"
+}
+";
+        let model = model(source);
+        let function_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "f") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected function scope");
+
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo" && binding.scope == function_scope)
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 1);
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+
+        let expansion_reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "foo")
+            .expect("expected foo expansion");
+        let resolved_expansion = model.resolved_binding(expansion_reference.id).unwrap();
+        assert_eq!(resolved_expansion.id, foo_bindings[0].id);
+
+        let analysis = model.analysis();
+        assert!(analysis.uninitialized_references().is_empty());
+        assert!(analysis.unused_assignments().is_empty());
+    }
+
+    #[test]
     fn name_only_local_after_unset_creates_fresh_non_assoc_binding() {
         let source = "\
 main() {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4122,6 +4122,69 @@ check_status
     }
 
     #[test]
+    fn name_only_local_after_unset_creates_fresh_non_assoc_binding() {
+        let source = "\
+main() {
+  local key=name
+  declare -A map
+  unset map
+  local map
+  map[$key]=1
+}
+";
+        let model = model(source);
+        let main_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "main") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected main scope");
+        let redeclared_local = model
+            .bindings()
+            .iter()
+            .find(|binding| {
+                binding.name == "map"
+                    && binding.scope == main_scope
+                    && matches!(
+                        binding.kind,
+                        BindingKind::Declaration(DeclarationBuiltin::Local)
+                    )
+            })
+            .expect("expected redeclared local binding");
+        let array_assignment = model
+            .bindings()
+            .iter()
+            .find(|binding| {
+                binding.name == "map"
+                    && binding.scope == main_scope
+                    && binding.kind == BindingKind::ArrayAssignment
+            })
+            .expect("expected array assignment binding");
+
+        assert!(
+            !redeclared_local
+                .attributes
+                .contains(BindingAttributes::ASSOC)
+        );
+        assert_eq!(
+            model
+                .visible_binding_for_assoc_lookup(
+                    &Name::from("map"),
+                    main_scope,
+                    array_assignment.span,
+                )
+                .map(|binding| binding.id),
+            Some(redeclared_local.id)
+        );
+    }
+
+    #[test]
     fn special_command_targets_store_name_only_spans() {
         let source = "\
 read -r read_target

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -945,20 +945,15 @@ impl SemanticModel {
 
         if !source_ref_resolutions.is_empty() {
             debug_assert_eq!(source_ref_resolutions.len(), self.source_refs.len());
-            for (source_ref, resolution) in self
-                .source_refs
-                .iter_mut()
-                .zip(source_ref_resolutions)
+            for (source_ref, resolution) in self.source_refs.iter_mut().zip(source_ref_resolutions)
             {
                 source_ref.resolution = resolution;
             }
         }
         if !source_ref_explicitness.is_empty() {
             debug_assert_eq!(source_ref_explicitness.len(), self.source_refs.len());
-            for (source_ref, explicitly_provided) in self
-                .source_refs
-                .iter_mut()
-                .zip(source_ref_explicitness)
+            for (source_ref, explicitly_provided) in
+                self.source_refs.iter_mut().zip(source_ref_explicitness)
             {
                 source_ref.explicitly_provided = explicitly_provided;
             }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4122,6 +4122,51 @@ check_status
     }
 
     #[test]
+    fn name_only_local_after_local_write_reuses_existing_local_state() {
+        let source = "f() { local foo=1; foo=2; local foo; echo \"$foo\"; }\n";
+        let model = model(source);
+
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo")
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 2);
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+        assert!(
+            foo_bindings[1]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+
+        let declaration_reference = model
+            .references()
+            .iter()
+            .find(|reference| {
+                reference.kind == ReferenceKind::DeclarationName && reference.name == "foo"
+            })
+            .unwrap();
+        let resolved_declaration = model.resolved_binding(declaration_reference.id).unwrap();
+        assert_eq!(resolved_declaration.id, foo_bindings[1].id);
+
+        let expansion_reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "foo")
+            .unwrap();
+        let resolved_expansion = model.resolved_binding(expansion_reference.id).unwrap();
+        assert_eq!(resolved_expansion.id, foo_bindings[1].id);
+
+        let unused_binding_ids = model.analysis().dataflow().unused_assignment_ids().to_vec();
+        assert_eq!(unused_binding_ids, vec![foo_bindings[0].id]);
+        assert!(model.analysis().uninitialized_references().is_empty());
+    }
+
+    #[test]
     fn name_only_local_after_unset_creates_fresh_non_assoc_binding() {
         let source = "\
 main() {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4193,6 +4193,57 @@ check_status
     }
 
     #[test]
+    fn name_only_local_after_conditional_unset_reuses_existing_local_state() {
+        let source = "\
+f() {
+  local foo=1
+  if cond; then
+    unset foo
+  fi
+  local foo
+  echo \"$foo\"
+}
+";
+        let model = model(source);
+        let function_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "f") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected function scope");
+
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo" && binding.scope == function_scope)
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 1);
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+
+        let expansion_reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "foo")
+            .expect("expected foo expansion");
+        let resolved_expansion = model.resolved_binding(expansion_reference.id).unwrap();
+        assert_eq!(resolved_expansion.id, foo_bindings[0].id);
+
+        let analysis = model.analysis();
+        assert!(analysis.uninitialized_references().is_empty());
+        assert!(analysis.unused_assignments().is_empty());
+    }
+
+    #[test]
     fn name_only_local_after_unset_creates_fresh_non_assoc_binding() {
         let source = "\
 main() {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3687,6 +3687,32 @@ f
     }
 
     #[test]
+    fn branch_local_declarations_do_not_hide_dynamic_scope_reads_in_called_functions() {
+        let source = "\
+g() {
+  echo \"$foo\"
+}
+f() {
+  foo=1
+  if cond; then
+    local foo
+  fi
+  g
+}
+f
+";
+        let model = model(source);
+
+        assert!(
+            model
+                .analysis()
+                .dataflow()
+                .unused_assignment_ids()
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn linear_duplicate_assignments_with_unrelated_reads_keep_all_reported_ids() {
         let source = "\
 emoji[grinning]=1

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -948,7 +948,7 @@ impl SemanticModel {
             for (source_ref, resolution) in self
                 .source_refs
                 .iter_mut()
-                .zip(source_ref_resolutions.into_iter())
+                .zip(source_ref_resolutions)
             {
                 source_ref.resolution = resolution;
             }
@@ -958,7 +958,7 @@ impl SemanticModel {
             for (source_ref, explicitly_provided) in self
                 .source_refs
                 .iter_mut()
-                .zip(source_ref_explicitness.into_iter())
+                .zip(source_ref_explicitness)
             {
                 source_ref.explicitly_provided = explicitly_provided;
             }
@@ -968,7 +968,7 @@ impl SemanticModel {
             for (source_ref, diagnostic_class) in self
                 .source_refs
                 .iter_mut()
-                .zip(source_ref_diagnostic_classes.into_iter())
+                .zip(source_ref_diagnostic_classes)
             {
                 source_ref.diagnostic_class = diagnostic_class;
             }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3664,6 +3664,29 @@ f
     }
 
     #[test]
+    fn branch_local_uninitialized_declarations_preserve_other_reaching_defs() {
+        let source = "\
+f() {
+  foo=1
+  if cond; then
+    local foo
+  fi
+  echo \"$foo\"
+}
+f
+";
+        let model = model(source);
+
+        assert!(
+            model
+                .analysis()
+                .dataflow()
+                .unused_assignment_ids()
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn linear_duplicate_assignments_with_unrelated_reads_keep_all_reported_ids() {
         let source = "\
 emoji[grinning]=1

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4342,6 +4342,155 @@ f() {
     }
 
     #[test]
+    fn name_only_local_after_split_conflicting_unset_flags_reuses_existing_local_state() {
+        let source = "\
+f() {
+  local foo=1
+  unset -f -v foo
+  local foo
+  echo \"$foo\"
+}
+";
+        let model = model(source);
+        let function_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "f") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected function scope");
+
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo" && binding.scope == function_scope)
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 1);
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+
+        let expansion_reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "foo")
+            .expect("expected foo expansion");
+        let resolved_expansion = model.resolved_binding(expansion_reference.id).unwrap();
+        assert_eq!(resolved_expansion.id, foo_bindings[0].id);
+
+        let analysis = model.analysis();
+        assert!(analysis.uninitialized_references().is_empty());
+        assert!(analysis.unused_assignments().is_empty());
+    }
+
+    #[test]
+    fn unset_n_clears_nameref_binding_state_before_name_only_local() {
+        let source = "\
+f() {
+  local foo=1
+  local -n ref=foo
+  unset -n ref
+  local ref
+}
+";
+        let model = model(source);
+        let function_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "f") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected function scope");
+
+        let ref_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "ref" && binding.scope == function_scope)
+            .collect::<Vec<_>>();
+
+        assert!(
+            ref_bindings
+                .iter()
+                .any(|binding| matches!(binding.kind, BindingKind::Nameref))
+        );
+        let redeclared_local = ref_bindings
+            .iter()
+            .find(|binding| {
+                matches!(
+                    binding.kind,
+                    BindingKind::Declaration(DeclarationBuiltin::Local)
+                )
+            })
+            .expect("expected fresh local binding after unset -n");
+        assert!(
+            !redeclared_local
+                .attributes
+                .contains(BindingAttributes::NAMEREF)
+        );
+    }
+
+    #[test]
+    fn name_only_local_after_unset_n_plain_variable_reuses_existing_local_state() {
+        let source = "\
+f() {
+  local foo=1
+  unset -n foo
+  local foo
+  echo \"$foo\"
+}
+";
+        let model = model(source);
+        let function_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "f") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected function scope");
+
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo" && binding.scope == function_scope)
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 1);
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+
+        let expansion_reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "foo")
+            .expect("expected foo expansion");
+        let resolved_expansion = model.resolved_binding(expansion_reference.id).unwrap();
+        assert_eq!(resolved_expansion.id, foo_bindings[0].id);
+
+        let analysis = model.analysis();
+        assert!(analysis.uninitialized_references().is_empty());
+        assert!(analysis.unused_assignments().is_empty());
+    }
+
+    #[test]
     fn name_only_local_after_unset_creates_fresh_non_assoc_binding() {
         let source = "\
 main() {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3618,6 +3618,33 @@ fi
     }
 
     #[test]
+    fn used_uninitialized_local_branches_keep_each_dead_arm_reported() {
+        let source = "\
+f() {
+  if a; then
+    foo=1
+  elif b; then
+    local foo
+    echo \"$foo\"
+  else
+    foo=3
+  fi
+}
+f
+";
+        let model = model(source);
+        let assignment_bindings = model
+            .bindings_for(&Name::from("foo"))
+            .iter()
+            .copied()
+            .filter(|binding_id| matches!(model.binding(*binding_id).kind, BindingKind::Assignment))
+            .collect::<Vec<_>>();
+        let binding_ids = model.analysis().dataflow().unused_assignment_ids().to_vec();
+
+        assert_eq!(binding_ids, assignment_bindings);
+    }
+
+    #[test]
     fn linear_duplicate_assignments_with_unrelated_reads_keep_all_reported_ids() {
         let source = "\
 emoji[grinning]=1

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3640,6 +3640,30 @@ f
     }
 
     #[test]
+    fn unused_uninitialized_local_branches_do_not_hide_dead_assignments() {
+        let source = "\
+f() {
+  if a; then
+    foo=1
+  else
+    local foo
+  fi
+}
+f
+";
+        let model = model(source);
+        let assignment_binding = model
+            .bindings_for(&Name::from("foo"))
+            .iter()
+            .copied()
+            .find(|binding_id| matches!(model.binding(*binding_id).kind, BindingKind::Assignment))
+            .expect("expected assignment binding");
+        let binding_ids = model.analysis().dataflow().unused_assignment_ids().to_vec();
+
+        assert!(binding_ids.contains(&assignment_binding));
+    }
+
+    #[test]
     fn linear_duplicate_assignments_with_unrelated_reads_keep_all_reported_ids() {
         let source = "\
 emoji[grinning]=1
@@ -4027,6 +4051,51 @@ check_status
         assert_eq!(uninitialized.len(), 1);
         assert_eq!(uninitialized[0].reference, reference_id);
         assert_eq!(uninitialized[0].certainty, UninitializedCertainty::Definite);
+    }
+
+    #[test]
+    fn repeated_name_only_local_reuses_existing_same_scope_binding() {
+        let source = "f() { local foo=1; local foo; echo \"$foo\"; }\n";
+        let model = model(source);
+
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo")
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 1);
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::DECLARATION_INITIALIZED)
+        );
+
+        let declaration_reference = model
+            .references()
+            .iter()
+            .find(|reference| {
+                reference.kind == ReferenceKind::DeclarationName && reference.name == "foo"
+            })
+            .unwrap();
+        let resolved_declaration = model.resolved_binding(declaration_reference.id).unwrap();
+        assert_eq!(resolved_declaration.id, foo_bindings[0].id);
+
+        let expansion_reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "foo")
+            .unwrap();
+        let resolved_expansion = model.resolved_binding(expansion_reference.id).unwrap();
+        assert_eq!(resolved_expansion.id, foo_bindings[0].id);
+
+        let analysis = model.analysis();
+        assert!(analysis.uninitialized_references().is_empty());
+        assert!(analysis.unused_assignments().is_empty());
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4244,6 +4244,104 @@ f() {
     }
 
     #[test]
+    fn name_only_local_after_invalid_unset_flag_reuses_existing_local_state() {
+        let source = "\
+f() {
+  local foo=1
+  unset -z foo
+  local foo
+  echo \"$foo\"
+}
+";
+        let model = model(source);
+        let function_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "f") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected function scope");
+
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo" && binding.scope == function_scope)
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 1);
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+
+        let expansion_reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "foo")
+            .expect("expected foo expansion");
+        let resolved_expansion = model.resolved_binding(expansion_reference.id).unwrap();
+        assert_eq!(resolved_expansion.id, foo_bindings[0].id);
+
+        let analysis = model.analysis();
+        assert!(analysis.uninitialized_references().is_empty());
+        assert!(analysis.unused_assignments().is_empty());
+    }
+
+    #[test]
+    fn name_only_local_after_conflicting_unset_flags_reuses_existing_local_state() {
+        let source = "\
+f() {
+  local foo=1
+  unset -vf foo
+  local foo
+  echo \"$foo\"
+}
+";
+        let model = model(source);
+        let function_scope = model
+            .scopes()
+            .iter()
+            .find_map(|scope| match &scope.kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names))
+                    if names.iter().any(|name| name == "f") =>
+                {
+                    Some(scope.id)
+                }
+                _ => None,
+            })
+            .expect("expected function scope");
+
+        let foo_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo" && binding.scope == function_scope)
+            .collect::<Vec<_>>();
+        assert_eq!(foo_bindings.len(), 1);
+        assert!(
+            foo_bindings[0]
+                .attributes
+                .contains(BindingAttributes::LOCAL)
+        );
+
+        let expansion_reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "foo")
+            .expect("expected foo expansion");
+        let resolved_expansion = model.resolved_binding(expansion_reference.id).unwrap();
+        assert_eq!(resolved_expansion.id, foo_bindings[0].id);
+
+        let analysis = model.analysis();
+        assert!(analysis.uninitialized_references().is_empty());
+        assert!(analysis.unused_assignments().is_empty());
+    }
+
+    #[test]
     fn name_only_local_after_unset_creates_fresh_non_assoc_binding() {
         let source = "\
 main() {


### PR DESCRIPTION
## Summary
- deduplicate C001 diagnostics so repeated dead reassignments only report the last unused binding for a variable name
- preserve the existing reportability filters and add targeted rule tests for duplicate assignments, function/source-order cases, and export handoff behavior

## Why
Shuck was over-reporting `C001` compared to ShellCheck when the same variable was assigned multiple times without being read. In those cases the oracle typically reports one final dead assignment, while Shuck reported every rebinding.

## Validation
- `cargo test -p shuck-linter unused_assignment -- --nocapture`
