### PR TITLE
Mark rules with known ShellCheck divergences in docs

### DIFF
--- a/website/app/components/docs/RuleBadge.tsx
+++ b/website/app/components/docs/RuleBadge.tsx
@@ -1,3 +1,5 @@
+import type { RuleStatus } from "@/app/lib/rules-data";
+
 const categoryColors: Record<string, string> = {
   Correctness: "bg-red-500/15 text-red-400 border-red-500/25",
   Style: "bg-blue-500/15 text-blue-400 border-blue-500/25",
@@ -27,17 +29,42 @@ export function SeverityBadge({ severity }: { severity: string }) {
   );
 }
 
-export function ImplementedBadge({ implemented }: { implemented: boolean }) {
-  if (implemented) {
-    return (
-      <span className="inline-flex items-center rounded-md border border-green-500/25 bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-400">
-        Implemented
-      </span>
-    );
-  }
+const statusStyles: Record<RuleStatus, string> = {
+  implemented: "border-green-500/25 bg-green-500/15 text-green-400",
+  implemented_with_known_shellcheck_divergences:
+    "border-yellow-500/25 bg-yellow-500/15 text-yellow-300",
+  planned: "border-fg-dim/20 bg-fg-dim/10 text-fg-secondary",
+};
+
+const statusLabels: Record<RuleStatus, string> = {
+  implemented: "Implemented",
+  implemented_with_known_shellcheck_divergences:
+    "Implemented with known ShellCheck divergences",
+  planned: "Planned",
+};
+
+export function RuleStatusBadge({ status }: { status: RuleStatus }) {
   return (
-    <span className="inline-flex items-center rounded-md border border-fg-dim/20 bg-fg-dim/10 px-1.5 py-0.5 text-xs font-medium text-fg-secondary">
-      Planned
+    <span
+      className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-xs font-medium ${statusStyles[status]}`}
+    >
+      {statusLabels[status]}
     </span>
+  );
+}
+
+export function RuleStatusDot({ status }: { status: RuleStatus }) {
+  const colors: Record<RuleStatus, string> = {
+    implemented: "bg-green-400",
+    implemented_with_known_shellcheck_divergences: "bg-yellow-300",
+    planned: "bg-fg-dim/40",
+  };
+
+  return (
+    <span
+      className={`inline-block h-2 w-2 rounded-full ${colors[status]}`}
+      title={statusLabels[status]}
+      aria-label={statusLabels[status]}
+    />
   );
 }

--- a/website/app/components/docs/RulesTable.tsx
+++ b/website/app/components/docs/RulesTable.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { Search } from "lucide-react";
 import type { RuleListItem } from "@/app/lib/rules-data";
 import { categories } from "@/app/lib/rules-data";
-import { CategoryBadge } from "./RuleBadge";
+import { RuleStatusDot } from "./RuleBadge";
 
 interface Props {
   rules: RuleListItem[];
@@ -139,11 +139,7 @@ export default function RulesTable({ rules }: Props) {
                       <span className="line-clamp-1">{rule.description}</span>
                     </td>
                     <td className="px-3 py-2 text-center">
-                      {rule.implemented ? (
-                        <span className="inline-block h-2 w-2 rounded-full bg-green-400" title="Implemented" />
-                      ) : (
-                        <span className="inline-block h-2 w-2 rounded-full bg-fg-dim/40" title="Planned" />
-                      )}
+                      <RuleStatusDot status={rule.status} />
                     </td>
                   </tr>
                 ))}

--- a/website/app/docs/rules/[code]/page.tsx
+++ b/website/app/docs/rules/[code]/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 import { codeToHtml } from "shiki";
 import { allRules, getRuleByCode } from "@/app/lib/rules-data";
-import { CategoryBadge, SeverityBadge, ImplementedBadge } from "@/app/components/docs/RuleBadge";
+import { CategoryBadge, SeverityBadge, RuleStatusBadge } from "@/app/components/docs/RuleBadge";
 
 interface Props {
   params: Promise<{ code: string }>;
@@ -67,8 +67,19 @@ export default async function RuleDetailPage({ params }: Props) {
       <div className="mb-6 flex flex-wrap gap-2">
         <CategoryBadge category={rule.category} />
         {rule.severity && <SeverityBadge severity={rule.severity} />}
-        <ImplementedBadge implemented={rule.implemented} />
+        <RuleStatusBadge status={rule.status} />
       </div>
+
+      {rule.status === "implemented_with_known_shellcheck_divergences" && (
+        <section className="mb-6 rounded-lg border border-yellow-500/25 bg-yellow-500/10 p-4">
+          <h2 className="mb-1 text-sm font-semibold text-yellow-200">ShellCheck compatibility note</h2>
+          <p className="text-sm leading-relaxed text-yellow-100/85">
+            This rule is implemented in shuck, but the large-corpus compatibility metadata tracks
+            reviewed divergences from ShellCheck for it. That is why this rule is shown in yellow
+            instead of green in the documentation.
+          </p>
+        </section>
+      )}
 
       {/* Description */}
       <section className="mb-6">
@@ -130,6 +141,14 @@ export default async function RuleDetailPage({ params }: Props) {
               <dd className="text-fg-primary">{rule.severity}</dd>
             </>
           )}
+          <dt className="text-fg-secondary">Documentation status</dt>
+          <dd className="text-fg-primary">
+            {rule.status === "implemented_with_known_shellcheck_divergences"
+              ? "Implemented with known ShellCheck divergences"
+              : rule.status === "implemented"
+                ? "Implemented"
+                : "Planned"}
+          </dd>
           <dt className="text-fg-secondary">Category</dt>
           <dd className="text-fg-primary">{rule.category}</dd>
         </dl>

--- a/website/app/docs/rules/page.tsx
+++ b/website/app/docs/rules/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { allRules, categories } from "@/app/lib/rules-data";
 import type { RuleListItem } from "@/app/lib/rules-data";
 import RulesTable from "@/app/components/docs/RulesTable";
+import { RuleStatusDot } from "@/app/components/docs/RuleBadge";
 
 export const metadata: Metadata = {
   title: "Rules",
@@ -10,21 +11,49 @@ export const metadata: Metadata = {
 };
 
 export default function RulesIndexPage() {
-  const implemented = allRules.filter((r) => r.implemented).length;
+  const fullyImplemented = allRules.filter((r) => r.status === "implemented").length;
+  const implementedWithKnownShellcheckDivergences = allRules.filter(
+    (r) => r.status === "implemented_with_known_shellcheck_divergences",
+  ).length;
+  const planned = allRules.length - fullyImplemented - implementedWithKnownShellcheckDivergences;
 
   // Strip heavy fields (rationale, examples, etc.) before sending to the client component.
-  const listRules: RuleListItem[] = allRules.map(({ code, name, category, description, implemented }) => ({
-    code, name, category, description, implemented,
-  }));
+  const listRules: RuleListItem[] = allRules.map(
+    ({ code, name, category, description, implemented, status }) => ({
+      code,
+      name,
+      category,
+      description,
+      implemented,
+      status,
+    }),
+  );
 
   return (
     <div className="max-w-5xl">
       <h1 className="mb-2 text-2xl font-bold text-fg-primary">Rules</h1>
       <p className="mb-6 text-fg-secondary">
         {allRules.length} rules across {categories.length} categories.{" "}
-        <span className="text-green-400">{implemented} implemented</span>,{" "}
-        {allRules.length - implemented} planned.
+        <span className="text-green-400">{fullyImplemented} implemented</span>,{" "}
+        <span className="text-yellow-300">
+          {implementedWithKnownShellcheckDivergences} with known ShellCheck divergences
+        </span>
+        , {planned} planned.
       </p>
+      <div className="mb-6 flex flex-wrap gap-x-4 gap-y-2 text-sm text-fg-secondary">
+        <span className="inline-flex items-center gap-2">
+          <RuleStatusDot status="implemented" />
+          Implemented
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <RuleStatusDot status="implemented_with_known_shellcheck_divergences" />
+          Implemented, with known ShellCheck divergences in corpus metadata
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <RuleStatusDot status="planned" />
+          Planned
+        </span>
+      </div>
       <Suspense>
         <RulesTable rules={listRules} />
       </Suspense>

--- a/website/app/lib/rules-data.ts
+++ b/website/app/lib/rules-data.ts
@@ -1,5 +1,10 @@
 import rulesJson from "./rules-data.generated.json";
 
+export type RuleStatus =
+  | "planned"
+  | "implemented"
+  | "implemented_with_known_shellcheck_divergences";
+
 export interface RuleData {
   code: string;
   name: string;
@@ -10,6 +15,8 @@ export interface RuleData {
   shells: string[];
   shellcheckCode: string | null;
   implemented: boolean;
+  status: RuleStatus;
+  hasKnownShellcheckDivergences: boolean;
   severity: string | null;
   examples: Array<{ kind: string; code: string }>;
 }
@@ -21,6 +28,7 @@ export interface RuleListItem {
   category: string;
   description: string;
   implemented: boolean;
+  status: RuleStatus;
 }
 
 export const allRules: RuleData[] = rulesJson as RuleData[];

--- a/website/scripts/generate-rules.ts
+++ b/website/scripts/generate-rules.ts
@@ -17,6 +17,16 @@ interface RuleYaml {
   examples?: Array<{ kind: string; code: string }>;
 }
 
+interface CorpusMetadataYaml {
+  review_all_divergences?: boolean;
+  reviewed_divergences?: unknown[];
+}
+
+export type RuleStatus =
+  | "planned"
+  | "implemented"
+  | "implemented_with_known_shellcheck_divergences";
+
 export interface RuleData {
   code: string;
   name: string;
@@ -27,6 +37,8 @@ export interface RuleData {
   shells: string[];
   shellcheckCode: string | null;
   implemented: boolean;
+  status: RuleStatus;
+  hasKnownShellcheckDivergences: boolean;
   severity: string | null;
   examples: Array<{ kind: string; code: string }>;
 }
@@ -41,6 +53,7 @@ const CATEGORY_PREFIX: Record<string, string> = {
 
 const rootDir = resolve(__dirname, "../..");
 const rulesDir = join(rootDir, "docs/rules");
+const corpusMetadataDir = join(rootDir, "crates/shuck/tests/testdata/corpus-metadata");
 const registryPath = join(rootDir, "crates/shuck-linter/src/registry.rs");
 const outPath = join(__dirname, "../app/lib/rules-data.generated.json");
 
@@ -56,6 +69,24 @@ while ((match = rulePattern.exec(registrySource)) !== null) {
   implementedRules.set(match[1], match[2]);
 }
 
+const rulesWithKnownShellcheckDivergences = new Set<string>();
+
+for (const file of readdirSync(corpusMetadataDir)) {
+  if (!file.endsWith(".yaml")) {
+    continue;
+  }
+
+  const content = readFileSync(join(corpusMetadataDir, file), "utf-8");
+  const yaml = parseYaml(content) as CorpusMetadataYaml | null;
+  const reviewedDivergences = Array.isArray(yaml?.reviewed_divergences)
+    ? yaml.reviewed_divergences
+    : [];
+
+  if (yaml?.review_all_divergences || reviewedDivergences.length > 0) {
+    rulesWithKnownShellcheckDivergences.add(file.replace(/\.yaml$/u, "").toUpperCase());
+  }
+}
+
 // Read and parse all YAML rule files
 const yamlFiles = readdirSync(rulesDir)
   .filter((f) => f.endsWith(".yaml") && f !== "validate.sh")
@@ -65,7 +96,14 @@ const rules: RuleData[] = yamlFiles.map((file) => {
   const content = readFileSync(join(rulesDir, file), "utf-8");
   const yaml = parseYaml(content) as RuleYaml;
   const code = yaml.new_code;
+  const implemented = implementedRules.has(code);
+  const hasKnownShellcheckDivergences = rulesWithKnownShellcheckDivergences.has(code);
   const severity = implementedRules.get(code) ?? null;
+  const status: RuleStatus = !implemented
+    ? "planned"
+    : hasKnownShellcheckDivergences
+      ? "implemented_with_known_shellcheck_divergences"
+      : "implemented";
 
   return {
     code,
@@ -76,7 +114,9 @@ const rules: RuleData[] = yamlFiles.map((file) => {
     rationale: yaml.rationale,
     shells: yaml.shells ?? [],
     shellcheckCode: yaml.shellcheck_code ?? null,
-    implemented: implementedRules.has(code),
+    implemented,
+    status,
+    hasKnownShellcheckDivergences,
     severity,
     examples: (yaml.examples ?? []).map((ex) => ({
       kind: ex.kind,
@@ -97,6 +137,10 @@ rules.sort((a, b) => {
 
 writeFileSync(outPath, JSON.stringify(rules, null, 2) + "\n");
 
+const implementedWithKnownShellcheckDivergences = rules.filter(
+  (rule) => rule.status === "implemented_with_known_shellcheck_divergences",
+).length;
+
 console.log(
-  `Generated ${rules.length} rules (${implementedRules.size} implemented) -> ${outPath}`,
+  `Generated ${rules.length} rules (${implementedRules.size} implemented, ${implementedWithKnownShellcheckDivergences} with known ShellCheck divergences) -> ${outPath}`,
 );


### PR DESCRIPTION
## Summary
- add a metadata-derived website rule status for implemented rules with reviewed ShellCheck divergences
- render those rules as yellow in the rules index and rule detail pages instead of green
- explain in the docs UI that yellow means the rule is implemented but has known divergence records in corpus metadata

## Why
Reviewed corpus metadata already tracks rules with known divergence from ShellCheck, but the docs site still showed every implemented rule as fully green. This makes the published rule status more honest about known compatibility gaps.

## Validation
- `pnpm generate:rules`
- `pnpm exec tsc --noEmit`
- `pnpm build`
