### PR TITLE
Implement autofixes for S059, S060, S061, X012, and X052

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/portability/X012.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X012.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 : &>out
 echo ok &> /dev/null
+echo foo1&>out

--- a/crates/shuck-linter/resources/test/fixtures/portability/X012.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X012.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
 : &>out
+echo ok &> /dev/null

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
@@ -1,16 +1,22 @@
 use shuck_ast::RedirectKind;
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, RedirectFact, Rule, ShellDialect, Violation};
 
 pub struct AmpersandRedirection;
 
 impl Violation for AmpersandRedirection {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::AmpersandRedirection
     }
 
     fn message(&self) -> String {
         "use of `&>` is not portable in `sh`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite `&>` as separate stdout and stderr redirects".to_owned())
     }
 }
 
@@ -19,22 +25,62 @@ pub fn ampersand_redirection(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .flat_map(|fact| fact.redirect_facts().iter())
         .filter(|redirect| redirect.redirect().kind == RedirectKind::OutputBoth)
-        .map(|redirect| redirect.redirect().span)
+        .map(|redirect| {
+            (
+                redirect.redirect().span,
+                ampersand_redirection_fix(redirect, checker.source()),
+            )
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || AmpersandRedirection);
+    for (span, fix) in diagnostics {
+        let diagnostic = crate::Diagnostic::new(AmpersandRedirection, span);
+        if let Some(fix) = fix {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(fix));
+        } else {
+            checker.report_diagnostic_dedup(diagnostic);
+        }
+    }
+}
+
+fn ampersand_redirection_fix(redirect: &RedirectFact<'_>, source: &str) -> Option<Fix> {
+    let redirect_data = redirect.redirect();
+    if redirect_data.kind != RedirectKind::OutputBoth
+        || redirect_data.fd.is_some()
+        || redirect_data.fd_var.is_some()
+    {
+        return None;
+    }
+
+    let operator_span = redirect.operator_span();
+    if source[..operator_span.start.offset]
+        .chars()
+        .next_back()
+        .is_some_and(|ch| ch.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let target_span = redirect.target_span()?;
+
+    Some(Fix::safe_edits([
+        Edit::replacement(">", operator_span),
+        Edit::insertion(target_span.end.offset, " 2>&1"),
+    ]))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_ampersand_redirection_in_sh() {
@@ -54,6 +100,45 @@ echo ok &> /dev/null
     }
 
     #[test]
+    fn applies_safe_fix_to_plain_ampersand_redirections() {
+        let source = "\
+#!/bin/sh
+: &>out
+echo ok &> /dev/null
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AmpersandRedirection),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\n: >out 2>&1\necho ok > /dev/null 2>&1\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_digit_prefixed_ampersand_redirections_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+echo ok 2&>file
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AmpersandRedirection),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+        assert_eq!(result.fixed_diagnostics[0].span.slice(source), "&>file");
+    }
+
+    #[test]
     fn ignores_ampersand_redirection_in_bash() {
         let source = "\
 #!/bin/bash
@@ -65,5 +150,17 @@ echo ok &> /dev/null
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("portability").join("X012.sh").as_path(),
+            &LinterSettings::for_rule(Rule::AmpersandRedirection),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("X012_fix_X012.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
@@ -59,11 +59,7 @@ fn ampersand_redirection_fix(redirect: &RedirectFact<'_>, source: &str) -> Optio
     }
 
     let operator_span = redirect.operator_span();
-    if source[..operator_span.start.offset]
-        .chars()
-        .next_back()
-        .is_some_and(|ch| ch.is_ascii_digit())
-    {
+    if has_standalone_fd_prefix(source, operator_span.start.offset) {
         return None;
     }
 
@@ -73,6 +69,25 @@ fn ampersand_redirection_fix(redirect: &RedirectFact<'_>, source: &str) -> Optio
         Edit::replacement(">", operator_span),
         Edit::insertion(target_span.end.offset, " 2>&1"),
     ]))
+}
+
+fn has_standalone_fd_prefix(source: &str, operator_start: usize) -> bool {
+    let prefix = &source[..operator_start];
+    let digit_count = prefix
+        .chars()
+        .rev()
+        .take_while(|ch| ch.is_ascii_digit())
+        .count();
+    if digit_count == 0 {
+        return false;
+    }
+
+    let digit_start = prefix.len() - digit_count;
+    digit_start == 0
+        || prefix[..digit_start]
+            .chars()
+            .next_back()
+            .is_some_and(char::is_whitespace)
 }
 
 #[cfg(test)]
@@ -88,15 +103,17 @@ mod tests {
 #!/bin/sh
 : &>out
 echo ok &> /dev/null
+echo foo1&>out
 ";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::AmpersandRedirection),
         );
 
-        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics.len(), 3);
         assert_eq!(diagnostics[0].span.slice(source), "&>out");
         assert_eq!(diagnostics[1].span.slice(source), "&> /dev/null");
+        assert_eq!(diagnostics[2].span.slice(source), "&>out");
     }
 
     #[test]
@@ -105,6 +122,7 @@ echo ok &> /dev/null
 #!/bin/sh
 : &>out
 echo ok &> /dev/null
+echo foo1&>out
 ";
         let result = test_snippet_with_fix(
             source,
@@ -112,10 +130,10 @@ echo ok &> /dev/null
             Applicability::Safe,
         );
 
-        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(result.fixes_applied, 3);
         assert_eq!(
             result.fixed_source,
-            "#!/bin/sh\n: >out 2>&1\necho ok > /dev/null 2>&1\n"
+            "#!/bin/sh\n: >out 2>&1\necho ok > /dev/null 2>&1\necho foo1>out 2>&1\n"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
@@ -5,7 +5,7 @@ use crate::{
 pub struct FunctionKeywordInSh;
 
 impl Violation for FunctionKeywordInSh {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
 
     fn rule() -> Rule {
         Rule::FunctionKeywordInSh
@@ -32,10 +32,11 @@ pub fn function_keyword_in_sh(checker: &mut Checker) {
         .filter(|header| header.uses_function_keyword() && header.has_trailing_parens())
         .map(|header| {
             let span = header.function_span_in_source(checker.source());
-            let fix = function_keyword_in_sh_fix(header)
-                .expect("X052 diagnostics should expose function keyword and name spans");
-
-            crate::Diagnostic::new(FunctionKeywordInSh, span).with_fix(fix)
+            let diagnostic = crate::Diagnostic::new(FunctionKeywordInSh, span);
+            match function_keyword_in_sh_fix(header) {
+                Some(fix) => diagnostic.with_fix(fix),
+                None => diagnostic,
+            }
         })
         .collect::<Vec<_>>();
 
@@ -145,6 +146,28 @@ function greet { :; }
         assert_eq!(result.fixes_applied, 0);
         assert_eq!(result.fixed_source, source);
         assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_dynamic_function_names_without_panicking_or_fixing() {
+        let source = "\
+#!/bin/sh
+function $0_error() { :; }
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionKeywordInSh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+        assert_eq!(
+            result.fixed_diagnostics[0].span.slice(source),
+            "function $0_error() { :; }"
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
@@ -1,14 +1,22 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{
+    Checker, Edit, Fix, FixAvailability, FunctionHeaderFact, Rule, ShellDialect, Violation,
+};
 
 pub struct FunctionKeywordInSh;
 
 impl Violation for FunctionKeywordInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::FunctionKeywordInSh
     }
 
     fn message(&self) -> String {
         "`function` with trailing `()` is not portable in `sh` scripts".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the leading `function` keyword".to_owned())
     }
 }
 
@@ -17,21 +25,41 @@ pub fn function_keyword_in_sh(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .function_headers()
         .iter()
         .filter(|header| header.uses_function_keyword() && header.has_trailing_parens())
-        .map(|header| header.function_span_in_source(checker.source()))
+        .map(|header| {
+            let span = header.function_span_in_source(checker.source());
+            let fix = function_keyword_in_sh_fix(header)
+                .expect("X052 diagnostics should expose function keyword and name spans");
+
+            crate::Diagnostic::new(FunctionKeywordInSh, span).with_fix(fix)
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || FunctionKeywordInSh);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn function_keyword_in_sh_fix(header: &FunctionHeaderFact<'_>) -> Option<Fix> {
+    let keyword_span = header.function_keyword_span()?;
+    let (_, name_span) = header.static_name_entry()?;
+
+    Some(Fix::safe_edit(Edit::deletion_at(
+        keyword_span.start.offset,
+        name_span.start.offset,
+    )))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn reports_function_keyword_with_parens_over_full_function_span() {
@@ -76,5 +104,58 @@ function greet() { :; }
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_safe_fix_to_function_keyword_with_parens() {
+        let source = "\
+#!/bin/sh
+function greet()
+{
+  printf '%s\\n' hi
+}
+function   spaced() { :; }
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionKeywordInSh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\ngreet()\n{\n  printf '%s\\n' hi\n}\nspaced() { :; }\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_function_keyword_without_parens_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+function greet { :; }
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionKeywordInSh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("portability").join("X052.sh").as_path(),
+            &LinterSettings::for_rule(Rule::FunctionKeywordInSh),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("X052_fix_X052.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__ampersand_redirection__tests__X012_fix_X012.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__ampersand_redirection__tests__X012_fix_X012.sh.snap
@@ -1,0 +1,36 @@
+---
+source: crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
+---
+Diagnostics:
+X012 use of `&>` is not portable in `sh`
+ --> <source>:2:3
+  |
+2 | : &>out
+  |
+
+X012 use of `&>` is not portable in `sh`
+ --> <source>:3:9
+  |
+3 | echo ok &> /dev/null
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,3 +1,3 @@
+ #!/bin/sh
+-: &>out
+-echo ok &> /dev/null
++: >out 2>&1
++echo ok > /dev/null 2>&1
+
+Fixed source:
+#!/bin/sh
+: >out 2>&1
+echo ok > /dev/null 2>&1
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__ampersand_redirection__tests__X012_fix_X012.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__ampersand_redirection__tests__X012_fix_X012.sh.snap
@@ -14,23 +14,32 @@ X012 use of `&>` is not portable in `sh`
 3 | echo ok &> /dev/null
   |
 
+X012 use of `&>` is not portable in `sh`
+ --> <source>:4:10
+  |
+4 | echo foo1&>out
+  |
 
-Applied fixes: 2
+
+Applied fixes: 3
 
 Diff:
 --- before
 +++ after
-@@ -1,3 +1,3 @@
+@@ -1,4 +1,4 @@
  #!/bin/sh
 -: &>out
 -echo ok &> /dev/null
+-echo foo1&>out
 +: >out 2>&1
 +echo ok > /dev/null 2>&1
++echo foo1>out 2>&1
 
 Fixed source:
 #!/bin/sh
 : >out 2>&1
 echo ok > /dev/null 2>&1
+echo foo1>out 2>&1
 
 Remaining diagnostics:
 <none>

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__function_keyword_in_sh__tests__X052_fix_X052.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__function_keyword_in_sh__tests__X052_fix_X052.sh.snap
@@ -1,0 +1,40 @@
+---
+source: crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
+---
+Diagnostics:
+X052 `function` with trailing `()` is not portable in `sh` scripts
+ --> <source>:4:1
+  |
+4 | function with_parens()
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ 
+ # Should trigger: function keyword with parens in sh
+-function with_parens()
++with_parens()
+ {
+   :
+ }
+
+Fixed source:
+#!/bin/sh
+
+# Should trigger: function keyword with parens in sh
+with_parens()
+{
+  :
+}
+
+# Should not trigger: function keyword without parens belongs to X004
+function keyword_only { :; }
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X012_X012.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X012_X012.sh.snap
@@ -12,3 +12,9 @@ X012 use of `&>` is not portable in `sh`
   |
 3 | echo ok &> /dev/null
   |
+
+X012 use of `&>` is not portable in `sh`
+ --> <source>:4:10
+  |
+4 | echo foo1&>out
+  |

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X012_X012.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X012_X012.sh.snap
@@ -1,9 +1,14 @@
 ---
 source: crates/shuck-linter/src/rules/portability/mod.rs
-assertion_line: 19
 ---
 X012 use of `&>` is not portable in `sh`
  --> <source>:2:3
   |
 2 | : &>out
+  |
+
+X012 use of `&>` is not portable in `sh`
+ --> <source>:3:9
+  |
+3 | echo ok &> /dev/null
   |

--- a/crates/shuck-linter/src/rules/style/deprecated_tempfile_command.rs
+++ b/crates/shuck-linter/src/rules/style/deprecated_tempfile_command.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct DeprecatedTempfileCommand;
 
 impl Violation for DeprecatedTempfileCommand {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::DeprecatedTempfileCommand
     }
 
     fn message(&self) -> String {
         "use `mktemp` instead of `tempfile`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite `tempfile` as `mktemp`".to_owned())
     }
 }
 
@@ -21,13 +27,20 @@ pub fn deprecated_tempfile_command(checker: &mut Checker) {
         .filter_map(|fact| fact.body_name_word().map(|word| word.span))
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || DeprecatedTempfileCommand);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(DeprecatedTempfileCommand, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement("mktemp", span))),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_plain_tempfile_invocations() {
@@ -64,5 +77,57 @@ alias tempfile=mktemp
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_plain_tempfile_invocations() {
+        let source = "\
+#!/bin/sh
+tempfile -n \"$TMPDIR/Xauthority\"
+tempfile
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DeprecatedTempfileCommand),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nmktemp -n \"$TMPDIR/Xauthority\"\nmktemp\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_wrapped_tempfile_invocations_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+command tempfile -n \"$TMPDIR/Xauthority\"
+sudo tempfile -n \"$TMPDIR/Xauthority\"
+alias tempfile=mktemp
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DeprecatedTempfileCommand),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S059.sh").as_path(),
+            &LinterSettings::for_rule(Rule::DeprecatedTempfileCommand),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("S059_fix_S059.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/egrep_deprecated.rs
+++ b/crates/shuck-linter/src/rules/style/egrep_deprecated.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct EgrepDeprecated;
 
 impl Violation for EgrepDeprecated {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::EgrepDeprecated
     }
 
     fn message(&self) -> String {
         "use `grep -E` instead of `egrep`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite `egrep` as `grep -E`".to_owned())
     }
 }
 
@@ -21,13 +27,20 @@ pub fn egrep_deprecated(checker: &mut Checker) {
         .filter_map(|fact| fact.body_name_word().map(|word| word.span))
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || EgrepDeprecated);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(EgrepDeprecated, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement("grep -E", span))),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_plain_egrep_invocations() {
@@ -58,5 +71,57 @@ grep -E foo file
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EgrepDeprecated));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_plain_egrep_invocations() {
+        let source = "\
+#!/bin/sh
+egrep foo file
+egrep
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EgrepDeprecated),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\ngrep -E foo file\ngrep -E\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_wrapped_egrep_invocations_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+command egrep foo file
+sudo egrep foo file
+grep -E foo file
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EgrepDeprecated),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S060.sh").as_path(),
+            &LinterSettings::for_rule(Rule::EgrepDeprecated),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("S060_fix_S060.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/fgrep_deprecated.rs
+++ b/crates/shuck-linter/src/rules/style/fgrep_deprecated.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct FgrepDeprecated;
 
 impl Violation for FgrepDeprecated {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::FgrepDeprecated
     }
 
     fn message(&self) -> String {
         "use `grep -F` instead of `fgrep`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite `fgrep` as `grep -F`".to_owned())
     }
 }
 
@@ -21,13 +27,20 @@ pub fn fgrep_deprecated(checker: &mut Checker) {
         .filter_map(|fact| fact.body_name_word().map(|word| word.span))
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || FgrepDeprecated);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(FgrepDeprecated, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement("grep -F", span))),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_plain_fgrep_invocations() {
@@ -58,5 +71,57 @@ grep -F foo file
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FgrepDeprecated));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_plain_fgrep_invocations() {
+        let source = "\
+#!/bin/sh
+fgrep foo file
+fgrep
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FgrepDeprecated),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\ngrep -F foo file\ngrep -F\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_wrapped_fgrep_invocations_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+command fgrep foo file
+sudo fgrep foo file
+grep -F foo file
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FgrepDeprecated),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S061.sh").as_path(),
+            &LinterSettings::for_rule(Rule::FgrepDeprecated),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("S061_fix_S061.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__deprecated_tempfile_command__tests__S059_fix_S059.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__deprecated_tempfile_command__tests__S059_fix_S059.sh.snap
@@ -1,0 +1,42 @@
+---
+source: crates/shuck-linter/src/rules/style/deprecated_tempfile_command.rs
+---
+Diagnostics:
+S059 use `mktemp` instead of `tempfile`
+ --> <source>:2:1
+  |
+2 | tempfile -n "$TMPDIR/Xauthority"
+  |
+
+S059 use `mktemp` instead of `tempfile`
+ --> <source>:3:1
+  |
+3 | tempfile
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+-tempfile -n "$TMPDIR/Xauthority"
+-tempfile
++mktemp -n "$TMPDIR/Xauthority"
++mktemp
+ command tempfile -n "$TMPDIR/Xauthority"
+ sudo tempfile -n "$TMPDIR/Xauthority"
+ alias tempfile=mktemp
+
+Fixed source:
+#!/bin/sh
+mktemp -n "$TMPDIR/Xauthority"
+mktemp
+command tempfile -n "$TMPDIR/Xauthority"
+sudo tempfile -n "$TMPDIR/Xauthority"
+alias tempfile=mktemp
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__egrep_deprecated__tests__S060_fix_S060.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__egrep_deprecated__tests__S060_fix_S060.sh.snap
@@ -1,0 +1,43 @@
+---
+source: crates/shuck-linter/src/rules/style/egrep_deprecated.rs
+assertion_line: 124
+---
+Diagnostics:
+S060 use `grep -E` instead of `egrep`
+ --> <source>:2:1
+  |
+2 | egrep foo file
+  |
+
+S060 use `grep -E` instead of `egrep`
+ --> <source>:3:1
+  |
+3 | egrep
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+-egrep foo file
+-egrep
++grep -E foo file
++grep -E
+ command egrep foo file
+ sudo egrep foo file
+ grep -E foo file
+
+Fixed source:
+#!/bin/sh
+grep -E foo file
+grep -E
+command egrep foo file
+sudo egrep foo file
+grep -E foo file
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__fgrep_deprecated__tests__S061_fix_S061.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__fgrep_deprecated__tests__S061_fix_S061.sh.snap
@@ -1,0 +1,43 @@
+---
+source: crates/shuck-linter/src/rules/style/fgrep_deprecated.rs
+assertion_line: 124
+---
+Diagnostics:
+S061 use `grep -F` instead of `fgrep`
+ --> <source>:2:1
+  |
+2 | fgrep foo file
+  |
+
+S061 use `grep -F` instead of `fgrep`
+ --> <source>:3:1
+  |
+3 | fgrep
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+-fgrep foo file
+-fgrep
++grep -F foo file
++grep -F
+ command fgrep foo file
+ sudo fgrep foo file
+ grep -F foo file
+
+Fixed source:
+#!/bin/sh
+grep -F foo file
+grep -F
+command fgrep foo file
+sudo fgrep foo file
+grep -F foo file
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -332,6 +332,42 @@ fn check_unsafe_fixes_applies_safe_s074_fix() {
 }
 
 #[test]
+fn check_fix_leaves_unsafe_s060_file_unchanged() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    let source = "#!/bin/sh\negrep foo file\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--fix", "--select", "S060"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("warning[S060]:"));
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
+}
+
+#[test]
+fn check_unsafe_fixes_applies_s060_fix() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    fs::write(&script, "#!/bin/sh\negrep foo file\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--unsafe-fixes", "--select", "S060"]);
+    cmd.assert().success().stdout("");
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "#!/bin/sh\ngrep -E foo file\n"
+    );
+}
+
+#[test]
 fn check_cli_select_replaces_config_selection() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -368,6 +368,42 @@ fn check_unsafe_fixes_applies_s060_fix() {
 }
 
 #[test]
+fn check_fix_leaves_unsafe_s061_file_unchanged() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    let source = "#!/bin/sh\nfgrep foo file\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--fix", "--select", "S061"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("warning[S061]:"));
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
+}
+
+#[test]
+fn check_unsafe_fixes_applies_s061_fix() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    fs::write(&script, "#!/bin/sh\nfgrep foo file\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--unsafe-fixes", "--select", "S061"]);
+    cmd.assert().success().stdout("");
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "#!/bin/sh\ngrep -F foo file\n"
+    );
+}
+
+#[test]
 fn check_cli_select_replaces_config_selection() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck/tests/integration_test.rs
+++ b/crates/shuck/tests/integration_test.rs
@@ -332,6 +332,42 @@ fn check_unsafe_fixes_applies_safe_s074_fix() {
 }
 
 #[test]
+fn check_fix_leaves_unsafe_s059_file_unchanged() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    let source = "#!/bin/sh\ntempfile -n \"$TMPDIR/Xauthority\"\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--fix", "--select", "S059"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("warning[S059]:"));
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
+}
+
+#[test]
+fn check_unsafe_fixes_applies_s059_fix() {
+    let tempdir = tempdir().unwrap();
+    let script = tempdir.path().join("warn.sh");
+    fs::write(&script, "#!/bin/sh\ntempfile -n \"$TMPDIR/Xauthority\"\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--unsafe-fixes", "--select", "S059"]);
+    cmd.assert().success().stdout("");
+
+    assert_eq!(
+        fs::read_to_string(script).unwrap(),
+        "#!/bin/sh\nmktemp -n \"$TMPDIR/Xauthority\"\n"
+    );
+}
+
+#[test]
 fn check_fix_leaves_unsafe_s060_file_unchanged() {
     let tempdir = tempdir().unwrap();
     let script = tempdir.path().join("warn.sh");


### PR DESCRIPTION
## Summary

This starts the autofix backlog by wiring up the first five documented fixes that were still missing implementations.

- implement autofixes for `S059`, `S060`, `S061`, `X012`, and `X052`
- add fix snapshots and integration coverage for the new edits
- update the `X012` fixture coverage alongside the autofix work

## Why

These rules already had fix metadata in `docs/rules/`, but the linter was only reporting diagnostics and not producing edits yet. This change makes those documented fixes real so `shuck --fix` can apply them.

## Impact

Users can now automatically rewrite a handful of deprecated command and portability cases instead of fixing them by hand.

## Validation

- `cargo test --workspace`
- `make check`