### PR TITLE
Use SmallVec in parser and semantic internals

### DIFF
--- a/crates/shuck-benchmark/examples/semantic_memory.rs
+++ b/crates/shuck-benchmark/examples/semantic_memory.rs
@@ -1,0 +1,266 @@
+use std::cell::RefCell;
+use std::process;
+
+use serde::Serialize;
+use shuck_benchmark::{benchmark_cases, parse_fixture};
+use shuck_indexer::Indexer;
+use shuck_parser::parser::ParseStatus;
+use shuck_semantic::SemanticModel;
+
+#[global_allocator]
+static GLOBAL: CountingAllocator<std::alloc::System> = CountingAllocator(std::alloc::System);
+
+const MAX_MEASURE_DEPTH: usize = 8;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Frame {
+    allocation_count: u64,
+    reallocation_count: u64,
+    total_allocated_bytes: u64,
+    total_reallocated_bytes: u64,
+    current_live_bytes: i64,
+    peak_live_bytes: u64,
+}
+
+impl Frame {
+    fn on_alloc(&mut self, size: usize) {
+        self.allocation_count += 1;
+        self.total_allocated_bytes += size as u64;
+        self.current_live_bytes += size as i64;
+        self.peak_live_bytes = self
+            .peak_live_bytes
+            .max(self.current_live_bytes.max(0) as u64);
+    }
+
+    fn on_dealloc(&mut self, size: usize) {
+        self.current_live_bytes -= size as i64;
+    }
+
+    fn on_realloc(&mut self, old_size: usize, new_size: usize) {
+        self.reallocation_count += 1;
+        self.total_reallocated_bytes += new_size as u64;
+        self.current_live_bytes += new_size as i64 - old_size as i64;
+        self.peak_live_bytes = self
+            .peak_live_bytes
+            .max(self.current_live_bytes.max(0) as u64);
+    }
+}
+
+#[derive(Debug, Default)]
+struct CounterState {
+    depth: usize,
+    frames: [Frame; MAX_MEASURE_DEPTH],
+}
+
+thread_local! {
+    static COUNTER_STATE: RefCell<CounterState> = RefCell::new(CounterState::default());
+}
+
+struct CountingAllocator<A>(A);
+
+unsafe impl<A: std::alloc::GlobalAlloc> std::alloc::GlobalAlloc for CountingAllocator<A> {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        let ptr = unsafe { self.0.alloc(layout) };
+        if !ptr.is_null() {
+            record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        record_dealloc(layout.size());
+        unsafe { self.0.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { self.0.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            record_realloc(layout.size(), new_size);
+        }
+        new_ptr
+    }
+}
+
+fn record_alloc(size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_alloc(size);
+        }
+    });
+}
+
+fn record_dealloc(size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_dealloc(size);
+        }
+    });
+}
+
+fn record_realloc(old_size: usize, new_size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_realloc(old_size, new_size);
+        }
+    });
+}
+
+fn measure<T>(f: impl FnOnce() -> T) -> (Frame, T) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        assert!(
+            state.depth + 1 < MAX_MEASURE_DEPTH,
+            "measurement nesting too deep"
+        );
+        state.depth += 1;
+        let depth = state.depth;
+        state.frames[depth] = Frame::default();
+    });
+
+    let result = f();
+
+    let frame = COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        let frame = state.frames[depth];
+        state.frames[depth] = Frame::default();
+        state.depth -= 1;
+        frame
+    });
+
+    (frame, result)
+}
+
+#[derive(Debug, Serialize)]
+struct MemoryMetrics {
+    allocation_count: u64,
+    reallocation_count: u64,
+    total_allocated_bytes: u64,
+    total_reallocated_bytes: u64,
+    peak_live_bytes: u64,
+    final_live_bytes: u64,
+}
+
+impl From<Frame> for MemoryMetrics {
+    fn from(frame: Frame) -> Self {
+        Self {
+            allocation_count: frame.allocation_count,
+            reallocation_count: frame.reallocation_count,
+            total_allocated_bytes: frame.total_allocated_bytes,
+            total_reallocated_bytes: frame.total_reallocated_bytes,
+            peak_live_bytes: frame.peak_live_bytes,
+            final_live_bytes: frame.current_live_bytes.max(0) as u64,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CaseReport {
+    case: String,
+    files: usize,
+    recovered_files: usize,
+    command_count: usize,
+    metrics: MemoryMetrics,
+}
+
+fn build_semantic(source: &str) -> (usize, usize, bool) {
+    let output = parse_fixture(source);
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic_count =
+        semantic.bindings().len() + semantic.references().len() + semantic.scopes().len();
+    (
+        semantic_count,
+        output.file.body.len(),
+        output.status != ParseStatus::Clean,
+    )
+}
+
+fn single_case_report(case_name: &str) -> Option<CaseReport> {
+    let cases = benchmark_cases();
+    let case = cases.into_iter().find(|case| case.name == case_name)?;
+
+    let (frame, (recovered_files, command_count)) = measure(|| {
+        let mut recovered_files = 0usize;
+        let mut command_count = 0usize;
+        let mut semantic_count = 0usize;
+
+        for file in case.files {
+            let (file_semantic_count, file_command_count, recovered) = build_semantic(file.source);
+            semantic_count += file_semantic_count;
+            command_count += file_command_count;
+            recovered_files += usize::from(recovered);
+        }
+
+        std::hint::black_box(semantic_count);
+        (recovered_files, command_count)
+    });
+
+    Some(CaseReport {
+        case: case.name.to_string(),
+        files: case.files.len(),
+        recovered_files,
+        command_count,
+        metrics: frame.into(),
+    })
+}
+
+fn parse_case_arg() -> Option<String> {
+    let mut args = std::env::args().skip(1);
+    let arg = args.next()?;
+
+    match arg.as_str() {
+        "--case" => {
+            let value = args.next();
+            if let Some(extra) = args.next() {
+                eprintln!("unknown argument `{extra}`");
+                process::exit(2);
+            }
+            value
+        }
+        "--help" | "-h" => {
+            eprintln!(
+                "usage: cargo run -p shuck-benchmark --example semantic_memory -- [--case NAME]"
+            );
+            process::exit(0);
+        }
+        _ => {
+            eprintln!("unknown argument `{arg}`");
+            process::exit(2);
+        }
+    }
+}
+
+fn main() {
+    let requested_case = parse_case_arg();
+    let reports = if let Some(case_name) = requested_case {
+        let Some(report) = single_case_report(&case_name) else {
+            eprintln!("unknown benchmark case `{case_name}`");
+            process::exit(2);
+        };
+        vec![report]
+    } else {
+        benchmark_cases()
+            .into_iter()
+            .filter_map(|case| single_case_report(case.name))
+            .collect::<Vec<_>>()
+    };
+
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports).unwrap();
+    println!();
+}

--- a/crates/shuck-linter/src/rules/common/expansion.rs
+++ b/crates/shuck-linter/src/rules/common/expansion.rs
@@ -1232,7 +1232,7 @@ mod tests {
         let Command::Simple(command) = &file.body[0].command else {
             panic!("expected simple command");
         };
-        command.args.clone()
+        command.args.to_vec()
     }
 
     fn analyze_argument_words(source: &str) -> Vec<ExpansionAnalysis> {

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -1,4 +1,5 @@
 use super::*;
+use smallvec::SmallVec;
 
 #[derive(Debug, Clone, Copy)]
 enum ForHeaderSurface {
@@ -1070,7 +1071,7 @@ impl<'a> Parser<'a> {
             let left_paren_span = self.current_span;
             self.advance();
 
-            let mut words = Vec::new();
+            let mut words = SmallVec::<[Word; 2]>::new();
             while !self.at(TokenKind::RightParen) {
                 if self.at(TokenKind::Newline) {
                     self.skip_newlines()?;
@@ -1296,15 +1297,15 @@ impl<'a> Parser<'a> {
 
         self.pop_depth();
         Ok(CompoundCommand::For(ForCommand {
-            targets,
-            words,
+            targets: targets.into_vec(),
+            words: words.map(SmallVec::into_vec),
             body,
             syntax,
             span: start_span.merge(end_span),
         }))
     }
 
-    fn parse_for_targets(&mut self, allow_zsh_targets: bool) -> Result<Vec<ForTarget>> {
+    fn parse_for_targets(&mut self, allow_zsh_targets: bool) -> Result<SmallVec<[ForTarget; 1]>> {
         let allow_digits = allow_zsh_targets;
         let first_target = self
             .current_for_target(allow_digits)
@@ -1312,7 +1313,7 @@ impl<'a> Parser<'a> {
         let first_word = first_target.word.clone();
         self.advance_past_word(&first_word);
 
-        let mut targets = vec![first_target];
+        let mut targets = SmallVec::from_vec(vec![first_target]);
         if !allow_zsh_targets {
             return Ok(targets);
         }
@@ -1354,8 +1355,8 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_for_word_list_until_body_separator(&mut self) -> Result<(Vec<Word>, bool)> {
-        let mut words = Vec::new();
+    fn parse_for_word_list_until_body_separator(&mut self) -> Result<(SmallVec<[Word; 2]>, bool)> {
+        let mut words = SmallVec::<[Word; 2]>::new();
         loop {
             match self.current_token_kind {
                 Some(kind)
@@ -1552,7 +1553,7 @@ impl<'a> Parser<'a> {
             let left_paren_span = self.current_span;
             self.advance();
 
-            let mut words = Vec::new();
+            let mut words = SmallVec::<[Word; 2]>::new();
             while !self.at(TokenKind::RightParen) {
                 match self.current_token_kind {
                     Some(kind) if kind.is_word_like() => {
@@ -1598,7 +1599,7 @@ impl<'a> Parser<'a> {
             let in_span = self.current_span;
             self.advance();
 
-            let mut words = Vec::new();
+            let mut words = SmallVec::<[Word; 2]>::new();
             let saw_separator = loop {
                 match self.current_token_kind {
                     _ if self.current_keyword() == Some(Keyword::Do) => break false,
@@ -1667,7 +1668,7 @@ impl<'a> Parser<'a> {
         Ok(CompoundCommand::Foreach(ForeachCommand {
             variable,
             variable_span,
-            words,
+            words: words.into_vec(),
             body,
             syntax,
             span: start_span.merge(end_span),
@@ -1700,7 +1701,7 @@ impl<'a> Parser<'a> {
         self.advance(); // consume 'in'
 
         // Parse word list until do/newline/;
-        let mut words = Vec::new();
+        let mut words = SmallVec::<[Word; 2]>::new();
         loop {
             match self.current_token_kind {
                 _ if self.current_keyword() == Some(Keyword::Do) => break,
@@ -1742,7 +1743,7 @@ impl<'a> Parser<'a> {
         Ok(CompoundCommand::Select(SelectCommand {
             variable,
             variable_span,
-            words,
+            words: words.into_vec(),
             body,
             span: start_span.merge(self.current_span),
         }))
@@ -1865,7 +1866,7 @@ impl<'a> Parser<'a> {
                     span,
                     vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
                         Box::new(body),
-                        Vec::new(),
+                        SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
                 self.current_span,
@@ -1934,7 +1935,7 @@ impl<'a> Parser<'a> {
                     span,
                     vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
                         Box::new(body),
-                        Vec::new(),
+                        SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
                 self.current_span,
@@ -1951,7 +1952,7 @@ impl<'a> Parser<'a> {
                     span,
                     vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
                         Box::new(brace_group),
-                        Vec::new(),
+                        SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
                 right_brace_span,
@@ -2004,7 +2005,7 @@ impl<'a> Parser<'a> {
                     span,
                     vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
                         Box::new(body),
-                        Vec::new(),
+                        SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
                 self.current_span,
@@ -2021,7 +2022,7 @@ impl<'a> Parser<'a> {
                     span,
                     vec![Self::lower_non_sequence_command_to_stmt(Command::Compound(
                         Box::new(brace_group),
-                        Vec::new(),
+                        SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
                 right_brace_span,
@@ -4098,8 +4099,8 @@ impl<'a> Parser<'a> {
         Ok(stmt)
     }
 
-    fn parse_anonymous_function_args(&mut self) -> Result<Vec<Word>> {
-        let mut args = Vec::new();
+    fn parse_anonymous_function_args(&mut self) -> Result<SmallVec<[Word; 2]>> {
+        let mut args = SmallVec::<[Word; 2]>::new();
         while self.current_token_kind.is_some_and(TokenKind::is_word_like) {
             let word = self
                 .take_current_word_and_advance()
@@ -4142,7 +4143,7 @@ impl<'a> Parser<'a> {
                             function_keyword_span: start_span,
                         },
                         body: Box::new(body),
-                        args,
+                        args: args.into_vec(),
                         span,
                     },
                     redirects,
@@ -4269,7 +4270,7 @@ impl<'a> Parser<'a> {
             AnonymousFunctionCommand {
                 surface: AnonymousFunctionSurface::Parens { parens_span },
                 body: Box::new(body),
-                args,
+                args: args.into_vec(),
                 span,
             },
             redirects,
@@ -4335,9 +4336,9 @@ impl<'a> Parser<'a> {
         self.check_error_token()?;
         let start_span = self.current_span;
 
-        let mut assignments = SmallAssignmentList::new();
-        let mut words = SmallWordList::new();
-        let mut redirects = Vec::with_capacity(1);
+        let mut assignments = SmallVec::<[Assignment; 1]>::new();
+        let mut words = SmallVec::<[Word; 2]>::new();
+        let mut redirects = SmallVec::<[Redirect; 1]>::new();
 
         loop {
             self.check_error_token()?;
@@ -4527,9 +4528,9 @@ impl<'a> Parser<'a> {
         if words.is_empty() && (!assignments.is_empty() || !redirects.is_empty()) {
             return Ok(Some(SimpleCommand {
                 name: Word::literal(""),
-                args: Vec::new(),
+                args: SmallVec::new(),
                 redirects,
-                assignments: assignments.into_vec(),
+                assignments,
                 span: start_span.merge(self.current_span),
             }));
         }
@@ -4538,7 +4539,6 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
 
-        let mut words = words.into_vec();
         let name = words.remove(0);
         let args = words;
 
@@ -4546,7 +4546,7 @@ impl<'a> Parser<'a> {
             name,
             args,
             redirects,
-            assignments: assignments.into_vec(),
+            assignments,
             span: start_span.merge(self.current_span),
         }))
     }
@@ -4554,7 +4554,7 @@ impl<'a> Parser<'a> {
     /// Extract fd-variable name from `{varname}` pattern in the last word.
     /// If the last word is a single literal `{identifier}`, pop it and return the name.
     /// Used for `exec {var}>file` / `exec {var}>&-` syntax.
-    fn pop_fd_var(&self, words: &mut SmallWordList) -> (Option<Name>, Option<Span>) {
+    fn pop_fd_var(&self, words: &mut SmallVec<[Word; 2]>) -> (Option<Name>, Option<Span>) {
         if let Some(last) = words.last()
             && last.parts.len() == 1
             && let WordPart::Literal(ref s) = last.parts[0].kind
@@ -4587,7 +4587,7 @@ impl<'a> Parser<'a> {
 
     fn pop_line_continuation_fd_var(
         &self,
-        words: &mut SmallWordList,
+        words: &mut SmallVec<[Word; 2]>,
     ) -> (Option<Name>, Option<Span>) {
         let Some(last) = words.last() else {
             return (None, None);

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -560,14 +560,14 @@ impl<'a> Parser<'a> {
                 assignments,
                 span,
             } = command;
-            return Command::Decl(DeclClause {
+            return Command::Decl(Box::new(DeclClause {
                 variant,
                 variant_span: name.span,
                 operands: self.classify_decl_operands(args),
                 redirects,
                 assignments,
                 span,
-            });
+            }));
         }
 
         Command::Simple(command)

--- a/crates/shuck-parser/src/parser/heredocs.rs
+++ b/crates/shuck-parser/src/parser/heredocs.rs
@@ -1,4 +1,5 @@
 use super::*;
+use smallvec::SmallVec;
 
 impl<'a> Parser<'a> {
     pub(super) fn current_static_heredoc_delimiter(&mut self) -> Option<(Word, String, bool)> {
@@ -42,7 +43,7 @@ impl<'a> Parser<'a> {
     pub(super) fn consume_heredoc_redirect(
         &mut self,
         strip_tabs: bool,
-        redirects: &mut Vec<Redirect>,
+        redirects: &mut SmallVec<[Redirect; 1]>,
         fd_var: Option<Name>,
         fd_var_span: Option<Span>,
         strict: bool,
@@ -137,7 +138,7 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_heredoc_redirect(
         &mut self,
         strip_tabs: bool,
-        redirects: &mut Vec<Redirect>,
+        redirects: &mut SmallVec<[Redirect; 1]>,
         fd_var: Option<Name>,
         fd_var_span: Option<Span>,
     ) -> Result<()> {
@@ -148,7 +149,7 @@ impl<'a> Parser<'a> {
     /// Consume redirect tokens that follow a heredoc on the same line.
     pub(super) fn collect_trailing_redirects(
         &mut self,
-        redirects: &mut Vec<Redirect>,
+        redirects: &mut SmallVec<[Redirect; 1]>,
     ) -> Result<()> {
         while self.consume_non_heredoc_redirect(redirects, None, None, false)? {}
         Ok(())

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -6,6 +6,7 @@ use std::{collections::VecDeque, ops::Range, sync::Arc};
 
 use memchr::{memchr, memchr_iter, memrchr};
 use shuck_ast::{Position, Span, TokenKind};
+use smallvec::SmallVec;
 
 use super::{ShellProfile, ZshOptionState, ZshOptionTimeline};
 
@@ -2661,7 +2662,7 @@ impl<'a> Lexer<'a> {
     fn flush_command_subst_keyword(
         current_word: &mut String,
         pending_case_headers: &mut usize,
-        case_clause_depths: &mut Vec<usize>,
+        case_clause_depths: &mut SmallVec<[usize; 4]>,
         depth: usize,
         word_started_at_command_start: &mut bool,
     ) {
@@ -2805,9 +2806,9 @@ impl<'a> Lexer<'a> {
         }
 
         let mut depth = 1;
-        let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+        let mut pending_heredocs = SmallVec::<[(String, bool); 2]>::new();
         let mut pending_case_headers = 0usize;
-        let mut case_clause_depths = Vec::new();
+        let mut case_clause_depths = SmallVec::<[usize; 4]>::new();
         let mut current_word = String::with_capacity(16);
         let mut at_command_start = true;
         let mut expecting_redirection_target = false;
@@ -4325,7 +4326,7 @@ fn scan_command_subst_backtick_segment(input: &str, start: usize) -> Option<usiz
 fn flush_scanned_command_subst_keyword(
     current_word: &mut String,
     pending_case_headers: &mut usize,
-    case_clause_depths: &mut Vec<usize>,
+    case_clause_depths: &mut SmallVec<[usize; 4]>,
     depth: usize,
     word_started_at_command_start: &mut bool,
 ) {
@@ -4357,9 +4358,9 @@ fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> 
 
     let mut index = 0usize;
     let mut depth = 1;
-    let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+    let mut pending_heredocs = SmallVec::<[(String, bool); 2]>::new();
     let mut pending_case_headers = 0usize;
-    let mut case_clause_depths = Vec::new();
+    let mut case_clause_depths = SmallVec::<[usize; 4]>::new();
     let mut current_word = String::with_capacity(16);
     let mut at_command_start = true;
     let mut expecting_redirection_target = false;

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -6518,7 +6518,7 @@ impl<'a> Parser<'a> {
                     inline_comment: None,
                     span,
                 }
-            },
+            }
             Command::Decl(command) => {
                 let command = *command;
                 Stmt {
@@ -6537,7 +6537,7 @@ impl<'a> Parser<'a> {
                     inline_comment: None,
                     span: command.span,
                 }
-            },
+            }
             Command::Compound(compound, redirects) => {
                 let span = Self::compound_span(&compound);
                 Stmt {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -236,7 +236,7 @@ struct DeclClause {
 enum Command {
     Simple(SimpleCommand),
     Builtin(BuiltinCommand),
-    Decl(DeclClause),
+    Decl(Box<DeclClause>),
     Compound(Box<CompoundCommand>, SmallVec<[Redirect; 1]>),
     Function(FunctionDef),
     AnonymousFunction(AnonymousFunctionCommand, SmallVec<[Redirect; 1]>),
@@ -6518,22 +6518,25 @@ impl<'a> Parser<'a> {
                     inline_comment: None,
                     span,
                 }
-            }
-            Command::Decl(command) => Stmt {
-                leading_comments: Vec::new(),
-                command: AstCommand::Decl(AstDeclClause {
-                    variant: command.variant,
-                    variant_span: command.variant_span,
-                    operands: command.operands.into_vec(),
-                    assignments: command.assignments.into_vec(),
+            },
+            Command::Decl(command) => {
+                let command = *command;
+                Stmt {
+                    leading_comments: Vec::new(),
+                    command: AstCommand::Decl(AstDeclClause {
+                        variant: command.variant,
+                        variant_span: command.variant_span,
+                        operands: command.operands.into_vec(),
+                        assignments: command.assignments.into_vec(),
+                        span: command.span,
+                    }),
+                    negated: false,
+                    redirects: command.redirects.into_vec(),
+                    terminator: None,
+                    terminator_span: None,
+                    inline_comment: None,
                     span: command.span,
-                }),
-                negated: false,
-                redirects: command.redirects.into_vec(),
-                terminator: None,
-                terminator_span: None,
-                inline_comment: None,
-                span: command.span,
+                }
             },
             Command::Compound(compound, redirects) => {
                 let span = Self::compound_span(&compound);

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -19,13 +19,12 @@ use std::{
     sync::Arc,
 };
 
-use memchr::{memchr, memchr2, memchr3};
-use smallvec::SmallVec;
-
 pub use lexer::{
     HeredocRead, LexedToken, LexedWord, LexedWordSegment, LexedWordSegmentKind, Lexer,
     LexerErrorKind,
 };
+use memchr::{memchr, memchr2, memchr3};
+use smallvec::SmallVec;
 
 use shuck_ast::{
     AlwaysCommand, AnonymousFunctionCommand, AnonymousFunctionSurface, ArithmeticCommand,
@@ -173,48 +172,45 @@ pub struct ParserBenchmarkCounters {
 #[derive(Debug, Clone)]
 struct SimpleCommand {
     name: Word,
-    args: Vec<Word>,
-    redirects: Vec<Redirect>,
-    assignments: Vec<Assignment>,
+    args: SmallVec<[Word; 2]>,
+    redirects: SmallVec<[Redirect; 1]>,
+    assignments: SmallVec<[Assignment; 1]>,
     span: Span,
 }
-
-type SmallWordList = SmallVec<[Word; 4]>;
-type SmallAssignmentList = SmallVec<[Assignment; 1]>;
 
 #[derive(Debug, Clone)]
 struct BreakCommand {
     depth: Option<Word>,
-    extra_args: Vec<Word>,
-    redirects: Vec<Redirect>,
-    assignments: Vec<Assignment>,
+    extra_args: SmallVec<[Word; 2]>,
+    redirects: SmallVec<[Redirect; 1]>,
+    assignments: SmallVec<[Assignment; 1]>,
     span: Span,
 }
 
 #[derive(Debug, Clone)]
 struct ContinueCommand {
     depth: Option<Word>,
-    extra_args: Vec<Word>,
-    redirects: Vec<Redirect>,
-    assignments: Vec<Assignment>,
+    extra_args: SmallVec<[Word; 2]>,
+    redirects: SmallVec<[Redirect; 1]>,
+    assignments: SmallVec<[Assignment; 1]>,
     span: Span,
 }
 
 #[derive(Debug, Clone)]
 struct ReturnCommand {
     code: Option<Word>,
-    extra_args: Vec<Word>,
-    redirects: Vec<Redirect>,
-    assignments: Vec<Assignment>,
+    extra_args: SmallVec<[Word; 2]>,
+    redirects: SmallVec<[Redirect; 1]>,
+    assignments: SmallVec<[Assignment; 1]>,
     span: Span,
 }
 
 #[derive(Debug, Clone)]
 struct ExitCommand {
     code: Option<Word>,
-    extra_args: Vec<Word>,
-    redirects: Vec<Redirect>,
-    assignments: Vec<Assignment>,
+    extra_args: SmallVec<[Word; 2]>,
+    redirects: SmallVec<[Redirect; 1]>,
+    assignments: SmallVec<[Assignment; 1]>,
     span: Span,
 }
 
@@ -230,9 +226,9 @@ enum BuiltinCommand {
 struct DeclClause {
     variant: Name,
     variant_span: Span,
-    operands: Vec<DeclOperand>,
-    redirects: Vec<Redirect>,
-    assignments: Vec<Assignment>,
+    operands: SmallVec<[DeclOperand; 2]>,
+    redirects: SmallVec<[Redirect; 1]>,
+    assignments: SmallVec<[Assignment; 1]>,
     span: Span,
 }
 
@@ -241,9 +237,9 @@ enum Command {
     Simple(SimpleCommand),
     Builtin(BuiltinCommand),
     Decl(DeclClause),
-    Compound(Box<CompoundCommand>, Vec<Redirect>),
+    Compound(Box<CompoundCommand>, SmallVec<[Redirect; 1]>),
     Function(FunctionDef),
-    AnonymousFunction(AnonymousFunctionCommand, Vec<Redirect>),
+    AnonymousFunction(AnonymousFunctionCommand, SmallVec<[Redirect; 1]>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -6430,7 +6426,9 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn lower_builtin_command(builtin: BuiltinCommand) -> (AstBuiltinCommand, Vec<Redirect>, Span) {
+    fn lower_builtin_command(
+        builtin: BuiltinCommand,
+    ) -> (AstBuiltinCommand, SmallVec<[Redirect; 1]>, Span) {
         match builtin {
             BuiltinCommand::Break(command) => {
                 let span = command.span;
@@ -6438,8 +6436,8 @@ impl<'a> Parser<'a> {
                 (
                     AstBuiltinCommand::Break(AstBreakCommand {
                         depth: command.depth,
-                        extra_args: command.extra_args,
-                        assignments: command.assignments,
+                        extra_args: command.extra_args.into_vec(),
+                        assignments: command.assignments.into_vec(),
                         span,
                     }),
                     redirects,
@@ -6452,8 +6450,8 @@ impl<'a> Parser<'a> {
                 (
                     AstBuiltinCommand::Continue(AstContinueCommand {
                         depth: command.depth,
-                        extra_args: command.extra_args,
-                        assignments: command.assignments,
+                        extra_args: command.extra_args.into_vec(),
+                        assignments: command.assignments.into_vec(),
                         span,
                     }),
                     redirects,
@@ -6466,8 +6464,8 @@ impl<'a> Parser<'a> {
                 (
                     AstBuiltinCommand::Return(AstReturnCommand {
                         code: command.code,
-                        extra_args: command.extra_args,
-                        assignments: command.assignments,
+                        extra_args: command.extra_args.into_vec(),
+                        assignments: command.assignments.into_vec(),
                         span,
                     }),
                     redirects,
@@ -6480,8 +6478,8 @@ impl<'a> Parser<'a> {
                 (
                     AstBuiltinCommand::Exit(AstExitCommand {
                         code: command.code,
-                        extra_args: command.extra_args,
-                        assignments: command.assignments,
+                        extra_args: command.extra_args.into_vec(),
+                        assignments: command.assignments.into_vec(),
                         span,
                     }),
                     redirects,
@@ -6497,12 +6495,12 @@ impl<'a> Parser<'a> {
                 leading_comments: Vec::new(),
                 command: AstCommand::Simple(AstSimpleCommand {
                     name: command.name,
-                    args: command.args,
-                    assignments: command.assignments,
+                    args: command.args.into_vec(),
+                    assignments: command.assignments.into_vec(),
                     span: command.span,
                 }),
                 negated: false,
-                redirects: command.redirects,
+                redirects: command.redirects.into_vec(),
                 terminator: None,
                 terminator_span: None,
                 inline_comment: None,
@@ -6514,7 +6512,7 @@ impl<'a> Parser<'a> {
                     leading_comments: Vec::new(),
                     command: AstCommand::Builtin(command),
                     negated: false,
-                    redirects,
+                    redirects: redirects.into_vec(),
                     terminator: None,
                     terminator_span: None,
                     inline_comment: None,
@@ -6526,12 +6524,12 @@ impl<'a> Parser<'a> {
                 command: AstCommand::Decl(AstDeclClause {
                     variant: command.variant,
                     variant_span: command.variant_span,
-                    operands: command.operands,
-                    assignments: command.assignments,
+                    operands: command.operands.into_vec(),
+                    assignments: command.assignments.into_vec(),
                     span: command.span,
                 }),
                 negated: false,
-                redirects: command.redirects,
+                redirects: command.redirects.into_vec(),
                 terminator: None,
                 terminator_span: None,
                 inline_comment: None,
@@ -6543,7 +6541,7 @@ impl<'a> Parser<'a> {
                     leading_comments: Vec::new(),
                     command: AstCommand::Compound(*compound),
                     negated: false,
-                    redirects,
+                    redirects: redirects.into_vec(),
                     terminator: None,
                     terminator_span: None,
                     inline_comment: None,
@@ -6565,7 +6563,7 @@ impl<'a> Parser<'a> {
                 span: function.span,
                 command: AstCommand::AnonymousFunction(function),
                 negated: false,
-                redirects,
+                redirects: redirects.into_vec(),
                 terminator: None,
                 terminator_span: None,
                 inline_comment: None,

--- a/crates/shuck-parser/src/parser/redirects.rs
+++ b/crates/shuck-parser/src/parser/redirects.rs
@@ -1,4 +1,5 @@
 use super::*;
+use smallvec::SmallVec;
 
 impl<'a> Parser<'a> {
     pub(super) fn fd_var_gap_allows_attachment(gap: &str) -> bool {
@@ -71,7 +72,7 @@ impl<'a> Parser<'a> {
             .and_then(LexedToken::fd_pair_value)
     }
     pub(super) fn push_redirect_both_append(
-        redirects: &mut Vec<Redirect>,
+        redirects: &mut SmallVec<[Redirect; 1]>,
         operator_span: Span,
         target: Word,
     ) {
@@ -118,7 +119,7 @@ impl<'a> Parser<'a> {
 
     pub(super) fn consume_non_heredoc_redirect(
         &mut self,
-        redirects: &mut Vec<Redirect>,
+        redirects: &mut SmallVec<[Redirect; 1]>,
         fd_var: Option<Name>,
         fd_var_span: Option<Span>,
         strict: bool,
@@ -372,8 +373,8 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub(super) fn parse_trailing_redirects(&mut self) -> Vec<Redirect> {
-        let mut redirects = Vec::new();
+    pub(super) fn parse_trailing_redirects(&mut self) -> SmallVec<[Redirect; 1]> {
+        let mut redirects = SmallVec::<[Redirect; 1]>::new();
         let mut pending_fd_var = None;
         loop {
             let current_end = self.current_span.end.offset;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -4694,7 +4694,7 @@ FOR2 eye2 IN onetwo 3; do echo $i; done
         panic!("expected final command to be a for loop");
     };
     assert_eq!(command.targets[0].name.as_deref(), Some("i"));
-    assert_eq!(command.words.as_ref().map(Vec::len), Some(3));
+    assert_eq!(command.words.as_ref().map(|words| words.len()), Some(3));
 }
 
 #[test]
@@ -4787,7 +4787,7 @@ e_ $i; done
     };
 
     assert_eq!(command.targets[0].name.as_deref(), Some("i"));
-    assert_eq!(command.words.as_ref().map(Vec::len), Some(3));
+    assert_eq!(command.words.as_ref().map(|words| words.len()), Some(3));
 
     let Some(body_stmt) = command.body.first() else {
         panic!("expected loop body command");

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1,5 +1,6 @@
 use super::*;
 use shuck_ast::ArrayValueWord;
+use smallvec::SmallVec;
 #[derive(Debug, Clone, Copy)]
 struct PatternCursor {
     segment_index: usize,
@@ -2662,9 +2663,12 @@ impl<'a> Parser<'a> {
         explicit_kind
     }
 
-    pub(super) fn classify_decl_operands(&mut self, words: Vec<Word>) -> Vec<DeclOperand> {
+    pub(super) fn classify_decl_operands(
+        &mut self,
+        words: SmallVec<[Word; 2]>,
+    ) -> SmallVec<[DeclOperand; 2]> {
         let mut explicit_array_kind = None;
-        let mut operands = Vec::with_capacity(words.len());
+        let mut operands = SmallVec::<[DeclOperand; 2]>::with_capacity(words.len());
 
         for word in words {
             if let Some(text) = self.single_literal_word_text(&word)

--- a/crates/shuck-semantic/Cargo.toml
+++ b/crates/shuck-semantic/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 bitflags = "2"
 rustc-hash = "2"
+smallvec.workspace = true
 shuck-ast = { path = "../shuck-ast" }
 shuck-indexer = { path = "../shuck-indexer" }
 shuck-parser = { path = "../shuck-parser" }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -10,6 +10,7 @@ use shuck_ast::{
 };
 use shuck_indexer::Indexer;
 use shuck_parser::{ShellProfile, ZshEmulationMode};
+use smallvec::SmallVec;
 
 use crate::binding::{
     AssignmentValueOrigin, Binding, BindingAttributes, BindingKind, BindingOrigin,
@@ -40,14 +41,14 @@ pub(crate) struct BuildOutput {
     pub(crate) scopes: Vec<Scope>,
     pub(crate) bindings: Vec<Binding>,
     pub(crate) references: Vec<Reference>,
-    pub(crate) reference_index: FxHashMap<Name, Vec<ReferenceId>>,
+    pub(crate) reference_index: FxHashMap<Name, SmallVec<[ReferenceId; 2]>>,
     pub(crate) predefined_runtime_refs: FxHashSet<ReferenceId>,
     pub(crate) guarded_parameter_refs: FxHashSet<ReferenceId>,
-    pub(crate) binding_index: FxHashMap<Name, Vec<BindingId>>,
+    pub(crate) binding_index: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     pub(crate) resolved: FxHashMap<ReferenceId, BindingId>,
     pub(crate) unresolved: Vec<ReferenceId>,
-    pub(crate) functions: FxHashMap<Name, Vec<BindingId>>,
-    pub(crate) call_sites: FxHashMap<Name, Vec<CallSite>>,
+    pub(crate) functions: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
+    pub(crate) call_sites: FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     pub(crate) call_graph: CallGraph,
     pub(crate) source_refs: Vec<SourceRef>,
     pub(crate) runtime: RuntimePrelude,
@@ -56,8 +57,8 @@ pub(crate) struct BuildOutput {
     pub(crate) indirect_expansion_refs: FxHashSet<ReferenceId>,
     pub(crate) flow_contexts: Vec<(Span, FlowContext)>,
     pub(crate) recorded_program: RecordedProgram,
-    pub(crate) command_bindings: FxHashMap<SpanKey, Vec<BindingId>>,
-    pub(crate) command_references: FxHashMap<SpanKey, Vec<ReferenceId>>,
+    pub(crate) command_bindings: FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    pub(crate) command_references: FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
     pub(crate) heuristic_unused_assignments: Vec<BindingId>,
 }
 
@@ -67,22 +68,22 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     scopes: Vec<Scope>,
     bindings: Vec<Binding>,
     references: Vec<Reference>,
-    reference_index: FxHashMap<Name, Vec<ReferenceId>>,
+    reference_index: FxHashMap<Name, SmallVec<[ReferenceId; 2]>>,
     predefined_runtime_refs: FxHashSet<ReferenceId>,
     guarded_parameter_refs: FxHashSet<ReferenceId>,
-    binding_index: FxHashMap<Name, Vec<BindingId>>,
+    binding_index: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     resolved: FxHashMap<ReferenceId, BindingId>,
     unresolved: Vec<ReferenceId>,
-    functions: FxHashMap<Name, Vec<BindingId>>,
-    call_sites: FxHashMap<Name, Vec<CallSite>>,
+    functions: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
+    call_sites: FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     source_refs: Vec<SourceRef>,
     declarations: Vec<Declaration>,
     indirect_target_hints: FxHashMap<BindingId, IndirectTargetHint>,
     indirect_expansion_refs: FxHashSet<ReferenceId>,
     flow_contexts: Vec<(Span, FlowContext)>,
     recorded_program: RecordedProgram,
-    command_bindings: FxHashMap<SpanKey, Vec<BindingId>>,
-    command_references: FxHashMap<SpanKey, Vec<ReferenceId>>,
+    command_bindings: FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    command_references: FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
     source_directives: FxHashMap<usize, SourceDirectiveOverride>,
     runtime: RuntimePrelude,
     completed_scopes: FxHashSet<ScopeId>,
@@ -332,12 +333,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 scope,
                 arg_count: command.args.len(),
             };
-            match self.call_sites.get_mut(callee.as_str()) {
-                Some(v) => v.push(call_site),
-                None => {
-                    self.call_sites.insert(callee.clone(), vec![call_site]);
-                }
-            }
+            self.call_sites
+                .entry(callee.clone())
+                .or_default()
+                .push(call_site);
 
             self.classify_special_simple_command(&callee, command, flow);
         }
@@ -510,7 +509,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         mut flow: FlowState,
     ) -> RecordedCommandId {
         flow.in_subshell = true;
-        let mut commands = Vec::new();
+        let mut commands = SmallVec::<[&Stmt; 4]>::new();
         collect_pipeline_segments(&command.left, &mut commands);
         collect_pipeline_segments(&command.right, &mut commands);
 
@@ -539,13 +538,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         command: &BinaryCommand,
         flow: FlowState,
     ) -> RecordedCommandId {
-        let mut operators = Vec::new();
-        let mut commands = Vec::new();
+        let mut operators = SmallVec::<[RecordedListOperator; 4]>::new();
+        let mut commands = SmallVec::<[&Stmt; 4]>::new();
         collect_logical_segments(&command.left, &mut commands, &mut operators);
         operators.push(recorded_list_operator(command.op));
         collect_logical_segments(&command.right, &mut commands, &mut operators);
 
-        let mut recorded = Vec::with_capacity(commands.len());
+        let mut recorded = SmallVec::<[RecordedCommandId; 4]>::with_capacity(commands.len());
         for (index, stmt) in commands.into_iter().enumerate() {
             let mut nested = flow;
             nested.exit_status_checked = operators.get(index).is_some() || flow.exit_status_checked;
@@ -2545,12 +2544,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             references: Vec::new(),
             attributes,
         });
-        match self.binding_index.get_mut(name.as_str()) {
-            Some(v) => v.push(id),
-            None => {
-                self.binding_index.insert(name.clone(), vec![id]);
-            }
-        }
+        self.binding_index.entry(name.clone()).or_default().push(id);
         match self.scopes[scope.index()].bindings.get_mut(name.as_str()) {
             Some(v) => v.push(id),
             None => {
@@ -2560,12 +2554,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
         }
         if matches!(kind, BindingKind::FunctionDefinition) {
-            match self.functions.get_mut(name.as_str()) {
-                Some(v) => v.push(id),
-                None => {
-                    self.functions.insert(name.clone(), vec![id]);
-                }
-            }
+            self.functions.entry(name.clone()).or_default().push(id);
         }
         if let Some(command) = self.command_stack.last().copied() {
             self.command_bindings
@@ -4241,7 +4230,7 @@ fn command_span_from_compound(command: &CompoundCommand) -> Span {
     }
 }
 
-fn collect_pipeline_segments<'a>(stmt: &'a Stmt, out: &mut Vec<&'a Stmt>) {
+fn collect_pipeline_segments<'a>(stmt: &'a Stmt, out: &mut SmallVec<[&'a Stmt; 4]>) {
     match &stmt.command {
         Command::Binary(command) if matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
             collect_pipeline_segments(&command.left, out);
@@ -4253,8 +4242,8 @@ fn collect_pipeline_segments<'a>(stmt: &'a Stmt, out: &mut Vec<&'a Stmt>) {
 
 fn collect_logical_segments<'a>(
     stmt: &'a Stmt,
-    commands: &mut Vec<&'a Stmt>,
-    operators: &mut Vec<RecordedListOperator>,
+    commands: &mut SmallVec<[&'a Stmt; 4]>,
+    operators: &mut SmallVec<[RecordedListOperator; 4]>,
 ) {
     match &stmt.command {
         Command::Binary(command) if matches!(command.op, BinaryOp::And | BinaryOp::Or) => {

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap;
 use shuck_ast::{CaseTerminator, Span};
 use shuck_parser::ZshEmulationMode;
+use smallvec::SmallVec;
 use std::marker::PhantomData;
 
 use crate::source_closure::SourcePathTemplate;
@@ -430,8 +431,8 @@ struct LoopTarget {
 
 struct GraphBuilder<'a> {
     program: &'a RecordedProgram,
-    command_bindings: &'a FxHashMap<SpanKey, Vec<BindingId>>,
-    command_references: &'a FxHashMap<SpanKey, Vec<ReferenceId>>,
+    command_bindings: &'a FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    command_references: &'a FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
     blocks: Vec<BasicBlock>,
     successors: FxHashMap<BlockId, Vec<(BlockId, EdgeKind)>>,
     command_blocks: FxHashMap<SpanKey, Vec<BlockId>>,
@@ -441,8 +442,8 @@ struct GraphBuilder<'a> {
 
 pub(crate) fn build_control_flow_graph(
     program: &RecordedProgram,
-    command_bindings: &FxHashMap<SpanKey, Vec<BindingId>>,
-    command_references: &FxHashMap<SpanKey, Vec<ReferenceId>>,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    command_references: &FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
 ) -> ControlFlowGraph {
     let mut builder = GraphBuilder {
         program,
@@ -976,12 +977,18 @@ impl<'a> GraphBuilder<'a> {
         self.blocks.push(BasicBlock {
             id,
             commands: vec![span],
-            bindings: self.command_bindings.get(&key).cloned().unwrap_or_default(),
+            bindings: self
+                .command_bindings
+                .get(&key)
+                .cloned()
+                .unwrap_or_default()
+                .into_vec(),
             references: self
                 .command_references
                 .get(&key)
                 .cloned()
-                .unwrap_or_default(),
+                .unwrap_or_default()
+                .into_vec(),
         });
         self.command_blocks.entry(key).or_default().push(id);
         id

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1,6 +1,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::Name;
 use shuck_ast::Span;
+use smallvec::SmallVec;
 
 use crate::runtime::RuntimePrelude;
 use crate::{
@@ -71,7 +72,7 @@ pub(crate) struct DataflowContext<'a> {
     pub(crate) predefined_runtime_refs: &'a FxHashSet<ReferenceId>,
     pub(crate) guarded_parameter_refs: &'a FxHashSet<ReferenceId>,
     pub(crate) resolved: &'a FxHashMap<ReferenceId, BindingId>,
-    pub(crate) call_sites: &'a FxHashMap<Name, Vec<CallSite>>,
+    pub(crate) call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     pub(crate) indirect_targets_by_reference: &'a FxHashMap<ReferenceId, Vec<BindingId>>,
     pub(crate) synthetic_reads: &'a [SyntheticRead],
     pub(crate) entry_bindings: &'a [BindingId],
@@ -337,12 +338,12 @@ fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
         .collect()
 }
 
-fn build_bindings_by_name(bindings: &[Binding]) -> FxHashMap<Name, Vec<BindingId>> {
-    let mut bindings_by_name = FxHashMap::default();
+fn build_bindings_by_name(bindings: &[Binding]) -> FxHashMap<Name, SmallVec<[BindingId; 2]>> {
+    let mut bindings_by_name: FxHashMap<Name, SmallVec<[BindingId; 2]>> = FxHashMap::default();
     for binding in bindings {
         bindings_by_name
             .entry(binding.name.clone())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(binding.id);
     }
     bindings_by_name
@@ -603,7 +604,7 @@ fn cfg_has_no_branching_edges(cfg: &ControlFlowGraph) -> bool {
 struct RedundantBranchUnusedAssignmentContext<'a> {
     cfg: &'a ControlFlowGraph,
     bindings: &'a [Binding],
-    bindings_by_name: &'a FxHashMap<Name, Vec<BindingId>>,
+    bindings_by_name: &'a FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     binding_blocks: &'a [Option<BlockId>],
     unreachable_blocks: &'a DenseBitSet,
     unused_binding_ids: &'a FxHashSet<BindingId>,
@@ -1615,7 +1616,7 @@ fn build_scope_read_plans(
     synthetic_reads: &[SyntheticRead],
     reference_name_ids: &[NameId],
     synthetic_read_name_ids: &[NameId],
-    call_sites: &FxHashMap<Name, Vec<CallSite>>,
+    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     name_count: usize,
 ) -> (Vec<ScopeReadPlan>, Vec<Vec<CallerReadSite>>) {
     let function_scopes = function_scopes_by_binding(scopes, bindings);
@@ -1935,7 +1936,7 @@ fn function_scopes_by_binding(
 fn resolved_calls_by_scope(
     scopes: &[Scope],
     bindings: &[Binding],
-    call_sites: &FxHashMap<Name, Vec<CallSite>>,
+    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     function_scopes: &FxHashMap<BindingId, ScopeId>,
 ) -> FxHashMap<ScopeId, Vec<ResolvedCallSite>> {
     let mut calls_by_scope: FxHashMap<ScopeId, Vec<ResolvedCallSite>> = FxHashMap::default();

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -35,6 +35,7 @@ pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceR
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Command, File, Name, Span};
 use shuck_indexer::Indexer;
+use smallvec::{Array, SmallVec};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -144,8 +145,8 @@ fn dedup_synthetic_reads(reads: Vec<SyntheticRead>) -> Vec<SyntheticRead> {
 fn build_call_graph(
     scopes: &[Scope],
     all_bindings: &[Binding],
-    functions: &FxHashMap<Name, Vec<BindingId>>,
-    call_sites: &FxHashMap<Name, Vec<CallSite>>,
+    functions: &FxHashMap<Name, SmallVec<[BindingId; 2]>>,
+    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
 ) -> CallGraph {
     let mut reachable = FxHashSet::default();
     let mut worklist = call_sites
@@ -248,13 +249,41 @@ fn previous_visible_binding_id_from_slice(
         .find(|binding_id| ignored_binding_span != Some(all_bindings[binding_id.index()].span))
 }
 
+trait BindingIdCollection {
+    fn as_slice(&self) -> &[BindingId];
+    fn insert_binding_id(&mut self, index: usize, id: BindingId);
+}
+
+impl BindingIdCollection for Vec<BindingId> {
+    fn as_slice(&self) -> &[BindingId] {
+        self
+    }
+
+    fn insert_binding_id(&mut self, index: usize, id: BindingId) {
+        self.insert(index, id);
+    }
+}
+
+impl<A> BindingIdCollection for SmallVec<A>
+where
+    A: Array<Item = BindingId>,
+{
+    fn as_slice(&self) -> &[BindingId] {
+        self
+    }
+
+    fn insert_binding_id(&mut self, index: usize, id: BindingId) {
+        self.insert(index, id);
+    }
+}
+
 fn insert_binding_id_sorted(
-    bindings: &mut Vec<BindingId>,
+    bindings: &mut impl BindingIdCollection,
     all_bindings: &[Binding],
     id: BindingId,
 ) {
     let target = &all_bindings[id.index()];
-    let insertion = bindings.partition_point(|candidate_id| {
+    let insertion = bindings.as_slice().partition_point(|candidate_id| {
         let candidate = &all_bindings[candidate_id.index()];
         candidate.span.start.offset < target.span.start.offset
             || (candidate.span.start.offset == target.span.start.offset
@@ -263,7 +292,7 @@ fn insert_binding_id_sorted(
                 && candidate.span.end.offset == target.span.end.offset
                 && candidate.id.index() < target.id.index())
     });
-    bindings.insert(insertion, id);
+    bindings.insert_binding_id(insertion, id);
 }
 
 #[derive(Debug)]
@@ -353,14 +382,14 @@ pub struct SemanticModel {
     scope_lookup: ScopeLookup,
     bindings: Vec<Binding>,
     references: Vec<Reference>,
-    reference_index: FxHashMap<Name, Vec<ReferenceId>>,
+    reference_index: FxHashMap<Name, SmallVec<[ReferenceId; 2]>>,
     predefined_runtime_refs: FxHashSet<ReferenceId>,
     guarded_parameter_refs: FxHashSet<ReferenceId>,
-    binding_index: FxHashMap<Name, Vec<BindingId>>,
+    binding_index: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     resolved: FxHashMap<ReferenceId, BindingId>,
     unresolved: Vec<ReferenceId>,
-    functions: FxHashMap<Name, Vec<BindingId>>,
-    call_sites: FxHashMap<Name, Vec<CallSite>>,
+    functions: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
+    call_sites: FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     call_graph: CallGraph,
     source_refs: Vec<SourceRef>,
     runtime: RuntimePrelude,
@@ -371,8 +400,8 @@ pub struct SemanticModel {
     entry_bindings: Vec<BindingId>,
     flow_contexts: Vec<(Span, FlowContext)>,
     recorded_program: RecordedProgram,
-    command_bindings: FxHashMap<SpanKey, Vec<BindingId>>,
-    command_references: FxHashMap<SpanKey, Vec<ReferenceId>>,
+    command_bindings: FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    command_references: FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
     import_origins_by_binding: FxHashMap<BindingId, Vec<PathBuf>>,
     heuristic_unused_assignments: Vec<BindingId>,
     zsh_option_analysis: Option<ZshOptionAnalysis>,
@@ -535,7 +564,7 @@ impl SemanticModel {
     pub fn bindings_for(&self, name: &Name) -> &[BindingId] {
         self.binding_index
             .get(name)
-            .map(Vec::as_slice)
+            .map(SmallVec::as_slice)
             .unwrap_or(&[])
     }
 
@@ -997,11 +1026,17 @@ impl SemanticModel {
     }
 
     pub fn function_definitions(&self, name: &Name) -> &[BindingId] {
-        self.functions.get(name).map(Vec::as_slice).unwrap_or(&[])
+        self.functions
+            .get(name)
+            .map(SmallVec::as_slice)
+            .unwrap_or(&[])
     }
 
     pub fn call_sites_for(&self, name: &Name) -> &[CallSite] {
-        self.call_sites.get(name).map(Vec::as_slice).unwrap_or(&[])
+        self.call_sites
+            .get(name)
+            .map(SmallVec::as_slice)
+            .unwrap_or(&[])
     }
 
     pub fn call_graph(&self) -> &CallGraph {


### PR DESCRIPTION
## Summary

This PR replaces short-lived internal `Vec` usage with direct `SmallVec` storage in the parser and semantic layers, and adds a semantic allocation harness so we can validate the change with the same measurement flow used for parser memory.

The parser now keeps tiny command, redirect, assignment, operand, and lexer scratch collections inline during parsing, and the semantic model now stores its small per-name and per-command ID lists in `SmallVec` as well. I also removed the intermediate `SmallVec` type aliases so the code uses the chosen container types directly.

## Why

A lot of these collections are usually 1-4 elements wide and get rebuilt constantly, so they were paying heap allocation overhead without getting much value from `Vec` growth behavior.

I also tested pushing `SmallVec` into the public AST, but the allocation profile got worse in total bytes and peak memory, so this PR intentionally keeps the public AST on `Vec` and limits `SmallVec` to the internal hot paths where it measured well.

## Impact

Compared to `main`, the measured allocation profile improved:

- Parser overall: allocation count `98758 -> 89680` (`-9.19%`), total allocated bytes `93265021 -> 91375469` (`-2.03%`), peak live bytes `25697818 -> 25163362` (`-2.08%`)
- Semantic overall: allocation count `153917 -> 135338` (`-12.07%`), reallocation count `18021 -> 17720` (`-1.67%`), total allocated bytes `99722798 -> 98340114` (`-1.39%`), peak live bytes `29770400 -> 29245916` (`-1.76%`)

There are small realloc regressions in a couple parser metrics, but the overall profile is still better and semantic improves consistently across the benchmark corpus.

## Validation

- `cargo test -p shuck-ast -p shuck-parser -p shuck-semantic -p shuck-linter`
- `python3 scripts/benchmarks/run_parser_memory.py --repo-root /Users/ewhauser/working/shuck --save-baseline main --release`
- `python3 scripts/benchmarks/run_parser_memory.py --repo-root /Users/ewhauser/.codex/worktrees/60cd/shuck --baseline main --release`
- `python3 scripts/benchmarks/run_parser_memory.py --repo-root <temp main worktree> --example semantic_memory --save-baseline semantic-main --release`
- `python3 scripts/benchmarks/run_parser_memory.py --repo-root /Users/ewhauser/.codex/worktrees/60cd/shuck --example semantic_memory --baseline semantic-main --release`
