### PR TITLE
Harden release metadata and CI guardrails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
+  RUST_VERSION: 1.94.1
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
@@ -83,6 +84,39 @@ jobs:
         run: cargo fetch
       - name: "Clippy"
         run: cargo clippy --workspace --all-targets --all-features --offline -- -D warnings
+
+  cargo-deny:
+    name: "cargo deny"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: "Run cargo-deny"
+        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
+        with:
+          rust-version: ${{ env.RUST_VERSION }}
+          command: "check bans licenses sources"
+          arguments: --all-features
+
+  cargo-audit:
+    name: "cargo audit"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: "Run cargo audit"
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   cargo-test-linux:
     name: "cargo test (linux)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "shuck-ast",
  "shuck-indexer",
  "shuck-parser",
+ "smallvec",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = ["crates/*"]
 [workspace.package]
 version = "0.0.10"
 edition = "2024"
+rust-version = "1.94.1"
 license = "MIT"
 authors = ["Eric Hauser"]
 repository = "https://github.com/ewhauser/shuck"

--- a/crates/shuck-ast/Cargo.toml
+++ b/crates/shuck-ast/Cargo.toml
@@ -4,6 +4,7 @@
 name = "shuck-ast"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-ast/src/lib.rs
+++ b/crates/shuck-ast/src/lib.rs
@@ -1,11 +1,21 @@
+#![warn(missing_docs)]
+
 //! AST, token, and span types for parsed bash scripts.
 
+#[allow(missing_docs)]
 mod ast;
+#[allow(missing_docs)]
 mod name;
+#[allow(missing_docs)]
 mod span;
+#[allow(missing_docs)]
 mod tokens;
 
+/// Parsed shell AST nodes and related syntax tree types.
 pub use ast::*;
+/// Identifier names used throughout the shell AST.
 pub use name::Name;
+/// Source positions, spans, and text range utilities.
 pub use span::{Position, Span, TextRange, TextSize};
+/// Token kinds emitted by the lexer.
 pub use tokens::TokenKind;

--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shuck-benchmark"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(missing_docs)]
+
+//! Shared benchmark fixtures and helpers for the shuck workspace.
+
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
@@ -5,6 +9,7 @@ use shuck_parser::parser::{ParseResult, Parser};
 #[cfg(feature = "parser-benchmarking")]
 use shuck_parser::parser::{ParseStatus, ParserBenchmarkCounters};
 
+#[allow(missing_docs)]
 /// Categorize fixtures by expected runtime so Criterion can spend
 /// more time where it is useful without making the slowest cases drag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14,6 +19,7 @@ pub enum TestCaseSpeed {
     Slow,
 }
 
+#[allow(missing_docs)]
 impl TestCaseSpeed {
     pub fn sample_size(self) -> usize {
         match self {
@@ -25,6 +31,8 @@ impl TestCaseSpeed {
     }
 }
 
+/// Benchmark fixture source bundled with this crate.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TestFile {
     pub name: &'static str,
@@ -32,6 +40,8 @@ pub struct TestFile {
     pub speed: TestCaseSpeed,
 }
 
+/// Benchmark case made up of one or more bundled test files.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TestCase {
     pub name: &'static str,
@@ -39,6 +49,7 @@ pub struct TestCase {
     pub speed: TestCaseSpeed,
 }
 
+#[allow(missing_docs)]
 impl TestCase {
     pub fn total_bytes(self) -> u64 {
         self.files.iter().map(|file| file.source.len() as u64).sum()
@@ -59,6 +70,7 @@ fn fixture_source(bytes: &'static [u8]) -> &'static str {
     }
 }
 
+/// Built-in benchmark fixtures used by the benchmark suite.
 pub static TEST_FILES: LazyLock<Vec<TestFile>> = LazyLock::new(|| {
     vec![
         TestFile {
@@ -89,6 +101,7 @@ pub static TEST_FILES: LazyLock<Vec<TestFile>> = LazyLock::new(|| {
     ]
 });
 
+/// Returns single-file and aggregate benchmark cases derived from `TEST_FILES`.
 pub fn benchmark_cases() -> Vec<TestCase> {
     let mut cases = TEST_FILES
         .iter()
@@ -108,10 +121,12 @@ pub fn benchmark_cases() -> Vec<TestCase> {
     cases
 }
 
+/// Returns the benchmark resources directory within this crate.
 pub fn resources_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("resources")
 }
 
+/// Parses a bundled fixture with the default parser configuration.
 pub fn parse_fixture(source: &str) -> ParseResult {
     Parser::new(source).parse()
 }
@@ -136,6 +151,7 @@ pub fn parse_fixture_with_benchmark_counters(source: &str) -> CountedParseFixtur
     }
 }
 
+/// Configures the benchmark allocator used by this crate's benches.
 #[macro_export]
 macro_rules! configure_benchmark_allocator {
     () => {

--- a/crates/shuck-cache/Cargo.toml
+++ b/crates/shuck-cache/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shuck-cache"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-cache/src/lib.rs
+++ b/crates/shuck-cache/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(missing_docs)]
+
+//! Persistent file-result caching utilities for shuck.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File};
 use std::io::{self, BufReader, Write};
@@ -9,14 +13,17 @@ use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
 
+/// Legacy per-project cache directory name used by older shuck releases.
 pub const CACHE_DIR_NAME: &str = ".shuck_cache";
 
 const MAX_LAST_SEEN_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
+/// Returns the legacy cache directory that lives under a project root.
 pub fn legacy_cache_dir(project_root: &Path) -> PathBuf {
     project_root.join(CACHE_DIR_NAME)
 }
 
+/// Reads the cached project root marker stored in a legacy cache file.
 pub fn read_project_root_from_cache_file(path: &Path) -> io::Result<Option<PathBuf>> {
     let file = match File::open(path) {
         Ok(file) => file,
@@ -31,14 +38,18 @@ pub fn read_project_root_from_cache_file(path: &Path) -> io::Result<Option<PathB
     }
 }
 
+/// Trait for values that can contribute to a deterministic package cache key.
+#[allow(missing_docs)]
 pub trait CacheKey {
     fn cache_key(&self, state: &mut CacheKeyHasher);
 }
 
+/// Incremental hasher used to build structured cache keys.
 pub struct CacheKeyHasher {
     hasher: Sha256,
 }
 
+#[allow(missing_docs)]
 impl CacheKeyHasher {
     #[must_use]
     pub fn new() -> Self {
@@ -102,6 +113,7 @@ impl Default for CacheKeyHasher {
     }
 }
 
+/// Returns the hex-encoded cache key for a value.
 #[must_use]
 pub fn cache_key_hex<T: CacheKey>(value: &T) -> String {
     let mut hasher = CacheKeyHasher::new();
@@ -216,6 +228,8 @@ where
     }
 }
 
+/// File metadata used to validate cached entries against a filesystem path.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FileCacheKey {
     pub file_last_modified_ms: u128,
@@ -223,6 +237,7 @@ pub struct FileCacheKey {
     pub file_size_bytes: u64,
 }
 
+#[allow(missing_docs)]
 impl FileCacheKey {
     pub fn from_path(path: &Path) -> io::Result<Self> {
         let metadata = path.metadata()?;
@@ -271,6 +286,7 @@ struct Change<T> {
     data: T,
 }
 
+/// On-disk cache for file-scoped analysis results within a package.
 #[derive(Debug, Clone)]
 pub struct PackageCache<T> {
     path: PathBuf,
@@ -280,6 +296,7 @@ pub struct PackageCache<T> {
     last_seen_ms: u64,
 }
 
+#[allow(missing_docs)]
 impl<T> PackageCache<T>
 where
     T: Clone + Serialize + DeserializeOwned,

--- a/crates/shuck-format/Cargo.toml
+++ b/crates/shuck-format/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shuck-format"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-format/src/lib.rs
+++ b/crates/shuck-format/src/lib.rs
@@ -1,19 +1,34 @@
+#![warn(missing_docs)]
+
+//! Formatting document model and pretty-printer primitives.
+
+#[allow(missing_docs)]
 mod buffer;
+#[allow(missing_docs)]
 mod format_element;
+#[allow(missing_docs)]
 mod formatter;
+#[allow(missing_docs)]
 mod macros;
+/// Common formatting traits and helper imports.
+#[allow(missing_docs)]
 pub mod prelude;
+#[allow(missing_docs)]
 mod printer;
 
+/// Output buffers used while constructing format documents.
 pub use crate::buffer::{Buffer, VecBuffer};
+/// Formatting document elements and document construction helpers.
 pub use crate::format_element::{
     Document, FormatElement, LineMode, best_fit, group, hard_line_break, indent, soft_line_break,
     soft_line_break_or_space, space, text, token, verbatim,
 };
+/// Core formatter traits, options, and formatted output wrappers.
 pub use crate::formatter::{
     Format, FormatContext, FormatError, FormatOptions, FormatResult, Formatted, Formatter,
     SimpleFormatContext, SimpleFormatOptions,
 };
+/// Printer configuration and rendered output types.
 pub use crate::printer::{IndentStyle, LineEnding, PrintError, Printed, Printer, PrinterOptions};
 
 #[cfg(test)]

--- a/crates/shuck-formatter/Cargo.toml
+++ b/crates/shuck-formatter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shuck-formatter"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -1,18 +1,35 @@
+#![warn(missing_docs)]
 #![recursion_limit = "256"]
 
+//! Shell script formatter with configurable style options.
+
+#[allow(missing_docs)]
 mod ast_format;
+#[allow(missing_docs)]
 mod command;
+#[allow(missing_docs)]
 mod comments;
+#[allow(missing_docs)]
 mod context;
+#[allow(missing_docs)]
 mod facts;
+#[allow(missing_docs)]
 mod generated;
+#[allow(missing_docs)]
 mod options;
+#[allow(missing_docs)]
 mod prelude;
+#[allow(missing_docs)]
 mod redirect;
+#[allow(missing_docs)]
 mod script;
+#[allow(missing_docs)]
 mod shared_traits;
+#[allow(missing_docs)]
 mod simplify;
+#[allow(missing_docs)]
 mod streaming;
+#[allow(missing_docs)]
 mod word;
 
 use std::path::Path;
@@ -24,9 +41,12 @@ use shuck_parser::{Error as ParseError, parser::Parser};
 #[cfg(feature = "benchmarking")]
 use crate::facts::FormatterFacts;
 
+/// Formatter option types exposed by the shell formatter.
 pub use crate::options::{ResolvedShellFormatOptions, ShellDialect, ShellFormatOptions};
+/// Indentation styles supported by the underlying pretty-printer.
 pub use shuck_format::IndentStyle;
 
+/// Formatter specialized for shell formatting contexts.
 pub type ShellFormatter<'source, 'buf> =
     shuck_format::Formatter<context::ShellFormatContext<'source>>;
 
@@ -34,12 +54,15 @@ pub(crate) trait FormatNodeRule<N> {
     fn fmt(&self, node: &N, formatter: &mut ShellFormatter<'_, '_>) -> FormatResult<()>;
 }
 
+/// Result of formatting shell source.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FormattedSource {
     Unchanged,
     Formatted(String),
 }
 
+#[allow(missing_docs)]
 impl FormattedSource {
     #[must_use]
     pub fn is_changed(&self) -> bool {
@@ -47,6 +70,8 @@ impl FormattedSource {
     }
 }
 
+/// Errors that can occur while parsing or formatting shell source.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FormatError {
     Parse {
@@ -84,8 +109,10 @@ impl From<shuck_format::FormatError> for FormatError {
     }
 }
 
+/// Convenient result alias for shell formatting operations.
 pub type Result<T> = std::result::Result<T, FormatError>;
 
+/// Formats a shell source string using the provided options.
 pub fn format_source(
     source: &str,
     path: Option<&Path>,
@@ -116,6 +143,7 @@ pub fn source_is_formatted(
     check_file(source, parsed.file, resolved)
 }
 
+/// Formats a parsed shell file using the provided options.
 pub fn format_file_ast(
     source: &str,
     file: File,

--- a/crates/shuck-indexer/Cargo.toml
+++ b/crates/shuck-indexer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shuck-indexer"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -1,9 +1,19 @@
+#![warn(missing_docs)]
+
+//! Positional and structural indexes over parsed shell scripts.
+
+#[allow(missing_docs)]
 mod comment_index;
+#[allow(missing_docs)]
 mod line_index;
+#[allow(missing_docs)]
 mod region_index;
 
+/// Comment lookup types derived from parser output.
 pub use comment_index::{CommentIndex, IndexedComment};
+/// Line-based offset lookup utilities.
 pub use line_index::LineIndex;
+/// Structural region indexes over parsed shell source.
 pub use region_index::{RegionIndex, RegionKind};
 
 use shuck_ast::TextSize;
@@ -18,6 +28,7 @@ pub struct Indexer {
     continuation_lines: Vec<TextSize>,
 }
 
+#[allow(missing_docs)]
 impl Indexer {
     /// Build an index from parser output and the original source text.
     pub fn new(source: &str, output: &ParseResult) -> Self {

--- a/crates/shuck-linter/Cargo.toml
+++ b/crates/shuck-linter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shuck-linter"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Clone)]
 pub struct DeclarationAssignmentProbe {
-    kind: command::DeclarationKind,
+    kind: DeclarationKind,
     readonly_flag: bool,
     target_name: Box<str>,
     target_name_span: Span,
@@ -8,7 +8,7 @@ pub struct DeclarationAssignmentProbe {
 }
 
 impl DeclarationAssignmentProbe {
-    pub fn kind(&self) -> &command::DeclarationKind {
+    pub fn kind(&self) -> &DeclarationKind {
         &self.kind
     }
 
@@ -2028,9 +2028,7 @@ fn build_simple_command_declaration_assignment_probes<'a>(
     let word_groups = contiguous_word_groups(normalized.body_args());
     let readonly_flag = matches!(
         kind,
-        command::DeclarationKind::Local
-            | command::DeclarationKind::Declare
-            | command::DeclarationKind::Typeset
+        DeclarationKind::Local | DeclarationKind::Declare | DeclarationKind::Typeset
     ) && simple_command_declaration_readonly_flag(&word_groups, source);
 
     word_groups
@@ -2080,13 +2078,13 @@ fn contiguous_word_groups<'a>(words: &'a [&'a Word]) -> Vec<&'a [&'a Word]> {
     groups
 }
 
-fn simple_command_declaration_kind(name: Option<&str>) -> Option<command::DeclarationKind> {
+fn simple_command_declaration_kind(name: Option<&str>) -> Option<DeclarationKind> {
     match name? {
-        "export" => Some(command::DeclarationKind::Export),
-        "local" => Some(command::DeclarationKind::Local),
-        "declare" => Some(command::DeclarationKind::Declare),
-        "typeset" => Some(command::DeclarationKind::Typeset),
-        "readonly" => Some(command::DeclarationKind::Other("readonly".to_owned())),
+        "export" => Some(DeclarationKind::Export),
+        "local" => Some(DeclarationKind::Local),
+        "declare" => Some(DeclarationKind::Declare),
+        "typeset" => Some(DeclarationKind::Typeset),
+        "readonly" => Some(DeclarationKind::Other("readonly".to_owned())),
         _ => None,
     }
 }

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -121,7 +121,7 @@ impl<'a> CommandFact<'a> {
         self.normalized.has_wrapper(wrapper)
     }
 
-    pub fn declaration(&self) -> Option<&command::NormalizedDeclaration<'a>> {
+    pub fn declaration(&self) -> Option<&NormalizedDeclaration<'a>> {
         self.normalized.declaration.as_ref()
     }
 

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -39,7 +39,7 @@ use crate::rules::common::span::{
     expansion_part_spans, word_unbraced_variable_before_bracket_spans,
 };
 use crate::rules::common::{
-    command::{self, NormalizedCommand, WrapperKind},
+    command::{self, DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind},
     query::{self, CommandSubstitutionKind, CommandVisit, CommandWalkOptions},
     span,
     word::{

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1,28 +1,56 @@
+#![warn(missing_docs)]
+
+//! Linting engine and public rule surface for shuck.
+
+#[allow(missing_docs)]
 mod ambient_contracts;
+#[allow(missing_docs)]
 mod checker;
+/// File-context helpers used to classify sourced and executed scripts.
+#[allow(missing_docs)]
 pub mod context;
+#[allow(missing_docs)]
 mod diagnostic;
+#[allow(missing_docs)]
 mod facts;
+#[allow(missing_docs)]
 mod fix;
+#[allow(missing_docs)]
 mod parse_diagnostics;
+#[allow(missing_docs)]
 mod registry;
+#[allow(missing_docs)]
 mod rule_metadata;
+#[allow(missing_docs)]
 mod rule_selector;
+#[allow(missing_docs)]
 mod rule_set;
+/// Built-in lint rules and rule families.
+#[allow(missing_docs)]
 pub mod rules;
+#[allow(missing_docs)]
 mod settings;
+#[allow(missing_docs)]
 mod shell;
+#[allow(missing_docs)]
 mod suppression;
+#[allow(missing_docs)]
 mod violation;
 
 #[cfg(test)]
+/// Test helpers for rule and fix assertions.
+#[allow(missing_docs)]
 pub mod test;
 
+/// Primary checker API for walking facts and emitting diagnostics.
 pub use checker::Checker;
+/// File-context classification types.
 pub use context::{
     ContextRegion, ContextRegionKind, FileContext, FileContextTag, classify_file_context,
 };
+/// Rule diagnostics and severity levels.
 pub use diagnostic::{Diagnostic, Severity};
+/// Extracted structural facts available to rules and callers.
 pub use facts::{
     BacktickFragmentFact, CommandFact, CommandOptionFacts, ConditionalBareWordFact,
     ConditionalBinaryFact, ConditionalFact, ConditionalNodeFact, ConditionalOperandFact,
@@ -38,18 +66,29 @@ pub use facts::{
     WaitCommandFacts, WordFactContext, WordFactHostKind, WordOccurrence, WordOccurrenceIter,
     WordOccurrenceRef, XargsCommandFacts, leading_literal_word_prefix,
 };
+/// Fact collection types and stable identifiers into those collections.
 pub use facts::{CommandId, FactSpan, LinterFacts};
+/// Autofix types and fix application helpers.
 pub use fix::{Applicability, AppliedFixes, Edit, Fix, FixAvailability, apply_fixes};
+/// Rule identifiers, categories, and registry lookup helpers.
 pub use registry::{Category, Rule, code_to_rule};
+/// Rule metadata lookup utilities.
 pub use rule_metadata::{RuleMetadata, rule_metadata, rule_metadata_by_code};
+/// Rule selector parsing types.
 pub use rule_selector::{RuleSelector, SelectorParseError};
+/// Sets of enabled or disabled rules.
 pub use rule_set::RuleSet;
-pub use rules::common::command::{DeclarationKind, WrapperKind};
+#[allow(unused_imports)]
+pub(crate) use rules::common::command::{DeclarationKind, WrapperKind};
 pub(crate) use rules::common::expansion::{ComparablePathKey, comparable_path};
-pub use rules::common::expansion::{ExpansionContext, WordQuote};
-pub use rules::common::query::CommandSubstitutionKind;
-pub use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
-pub use rules::common::span::{
+#[allow(unused_imports)]
+pub(crate) use rules::common::expansion::{ExpansionContext, WordQuote};
+#[allow(unused_imports)]
+pub(crate) use rules::common::query::CommandSubstitutionKind;
+#[allow(unused_imports)]
+pub(crate) use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
+#[allow(unused_imports)]
+pub(crate) use rules::common::span::{
     all_elements_array_expansion_part_spans, assignment_name_span,
     case_item_suspicious_bracket_glob_spans, command_substitution_part_spans,
     conditional_array_subscript_span, conditional_extglob_span,
@@ -75,19 +114,24 @@ pub use rules::common::span::{
     word_unquoted_star_splat_spans, word_unquoted_word_after_single_quoted_segment_spans,
     word_use_replacement_spans, word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,
 };
-pub use rules::common::word::{
+#[allow(unused_imports)]
+pub(crate) use rules::common::word::{
     TestOperandClass, WordClassification, conditional_binary_op_is_string_match,
     is_shell_variable_name, static_word_text, text_is_self_contained_arithmetic_expression,
     text_looks_like_nontrivial_arithmetic_expression, word_is_standalone_status_capture,
     word_is_standalone_variable_like,
 };
+/// Linter configuration and per-file ignore types.
 pub use settings::{CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore};
+/// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;
+/// Suppression directives, shellcheck mappings, and rewrite helpers.
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,
     SuppressionDirective, SuppressionIndex, SuppressionSource, add_ignores_to_path,
     first_statement_line, parse_directives,
 };
+/// Trait implemented by rule-specific diagnostic payloads.
 pub use violation::Violation;
 
 use rustc_hash::FxHashSet;
@@ -101,8 +145,11 @@ use shuck_semantic::{
 };
 use std::path::Path;
 
+/// Combined semantic model and diagnostic output for a file analysis pass.
 pub struct AnalysisResult {
+    /// Semantic model built for the analyzed file.
     pub semantic: SemanticModel,
+    /// Diagnostics emitted by linter rules and parse checks.
     pub diagnostics: Vec<Diagnostic>,
 }
 
@@ -119,6 +166,7 @@ impl LintTraversalObserver {
 
 impl TraversalObserver for LintTraversalObserver {}
 
+/// Builds semantic facts and linter diagnostics for a parsed file.
 pub fn analyze_file(
     file: &File,
     source: &str,
@@ -162,6 +210,7 @@ pub fn benchmark_collect_word_facts(file: &File, source: &str, semantic: &Semant
     facts::benchmark_collect_word_facts(file, source, semantic)
 }
 
+/// Builds semantic facts and linter diagnostics for a parsed file at an optional source path.
 pub fn analyze_file_at_path(
     file: &File,
     source: &str,
@@ -181,6 +230,7 @@ pub fn analyze_file_at_path(
     )
 }
 
+/// Builds semantic facts and linter diagnostics with a custom source-path resolver.
 pub fn analyze_file_at_path_with_resolver(
     file: &File,
     source: &str,
@@ -317,6 +367,7 @@ fn parse_error_position(parse_result: &ParseResult) -> Option<(usize, usize)> {
         .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
 }
 
+/// Lints a parsed file and returns diagnostics only.
 pub fn lint_file(
     file: &File,
     source: &str,
@@ -327,6 +378,7 @@ pub fn lint_file(
     lint_file_at_path(file, source, indexer, settings, suppression_index, None)
 }
 
+/// Lints a parsed file located at an optional source path.
 pub fn lint_file_at_path(
     file: &File,
     source: &str,
@@ -346,6 +398,7 @@ pub fn lint_file_at_path(
     )
 }
 
+/// Lints a parsed file with a custom source-path resolver.
 pub fn lint_file_at_path_with_resolver(
     file: &File,
     source: &str,
@@ -396,6 +449,7 @@ pub fn lint_file_at_path_with_resolver(
     diagnostics
 }
 
+/// Lints an existing parse result while preserving parse-aware diagnostics.
 #[allow(clippy::too_many_arguments)]
 pub fn lint_file_at_path_with_resolver_and_parse_result(
     parse_result: &ParseResult,
@@ -449,6 +503,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
     diagnostics
 }
 
+/// Lints an existing parse result located at an optional source path.
 pub fn lint_file_at_path_with_parse_result(
     parse_result: &ParseResult,
     source: &str,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -78,13 +78,19 @@ pub use rule_metadata::{RuleMetadata, rule_metadata, rule_metadata_by_code};
 pub use rule_selector::{RuleSelector, SelectorParseError};
 /// Sets of enabled or disabled rules.
 pub use rule_set::RuleSet;
-#[allow(unused_imports)]
-pub(crate) use rules::common::command::{DeclarationKind, WrapperKind};
+/// Command normalization helper types exposed by fact APIs.
+pub use rules::common::command::{
+    DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind,
+};
 pub(crate) use rules::common::expansion::{ComparablePathKey, comparable_path};
-#[allow(unused_imports)]
-pub(crate) use rules::common::expansion::{ExpansionContext, WordQuote};
-#[allow(unused_imports)]
-pub(crate) use rules::common::query::CommandSubstitutionKind;
+/// Expansion-analysis helper types exposed by fact APIs.
+pub use rules::common::expansion::{
+    ExpansionAnalysis, ExpansionContext, ExpansionHazards, ExpansionValueShape,
+    RedirectDevNullStatus, RedirectTargetAnalysis, RedirectTargetKind, RuntimeLiteralAnalysis,
+    SubstitutionOutputIntent, WordExpansionKind, WordLiteralness, WordQuote, WordSubstitutionShape,
+};
+/// Command-substitution classification exposed by fact APIs.
+pub use rules::common::query::CommandSubstitutionKind;
 #[allow(unused_imports)]
 pub(crate) use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
 #[allow(unused_imports)]
@@ -114,12 +120,13 @@ pub(crate) use rules::common::span::{
     word_unquoted_star_splat_spans, word_unquoted_word_after_single_quoted_segment_spans,
     word_use_replacement_spans, word_zsh_flag_modifier_spans, word_zsh_nested_expansion_spans,
 };
+/// Word and test-classification types exposed by fact APIs.
+pub use rules::common::word::{TestOperandClass, WordClassification};
 #[allow(unused_imports)]
 pub(crate) use rules::common::word::{
-    TestOperandClass, WordClassification, conditional_binary_op_is_string_match,
-    is_shell_variable_name, static_word_text, text_is_self_contained_arithmetic_expression,
-    text_looks_like_nontrivial_arithmetic_expression, word_is_standalone_status_capture,
-    word_is_standalone_variable_like,
+    conditional_binary_op_is_string_match, is_shell_variable_name, static_word_text,
+    text_is_self_contained_arithmetic_expression, text_looks_like_nontrivial_arithmetic_expression,
+    word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 /// Linter configuration and per-file ignore types.
 pub use settings::{CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore};

--- a/crates/shuck-linter/src/rules/common/expansion.rs
+++ b/crates/shuck-linter/src/rules/common/expansion.rs
@@ -157,6 +157,7 @@ pub enum RedirectTargetKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
 pub enum RedirectDevNullStatus {
     DefinitelyDevNull,
     DefinitelyNotDevNull,

--- a/crates/shuck-linter/src/rules/correctness/syntax.rs
+++ b/crates/shuck-linter/src/rules/correctness/syntax.rs
@@ -1,6 +1,6 @@
 use shuck_ast::{Assignment, SimpleCommand, Word};
 
-pub use crate::static_word_text;
+pub(crate) use crate::static_word_text;
 
 fn simple_command_name(command: &SimpleCommand, source: &str) -> Option<String> {
     static_word_text(&command.name, source).map(|text| text.into_owned())

--- a/crates/shuck-linter/src/rules/mod.rs
+++ b/crates/shuck-linter/src/rules/mod.rs
@@ -1,4 +1,5 @@
-pub mod common;
+#[allow(dead_code)]
+pub(crate) mod common;
 pub mod correctness;
 pub mod performance;
 pub mod portability;

--- a/crates/shuck-linter/src/rules/style/syntax.rs
+++ b/crates/shuck-linter/src/rules/style/syntax.rs
@@ -1,6 +1,6 @@
 use shuck_ast::Command;
 
-pub use crate::static_word_text;
+pub(crate) use crate::static_word_text;
 
 pub fn is_simple_command_named(command: &Command, source: &str, name: &str) -> bool {
     match command {

--- a/crates/shuck-parser/Cargo.toml
+++ b/crates/shuck-parser/Cargo.toml
@@ -4,6 +4,7 @@
 name = "shuck-parser"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -1,7 +1,14 @@
+#![warn(missing_docs)]
+
 //! Bash parser library.
 
+#[allow(missing_docs)]
 mod error;
+/// Parser entry points and low-level parser data structures.
+#[allow(missing_docs)]
 pub mod parser;
 
+/// Error types returned by parser operations.
 pub use error::{Error, Result};
+/// Shell dialect, profile, and option types exposed by the parser.
 pub use parser::{OptionValue, ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState};

--- a/crates/shuck-semantic/Cargo.toml
+++ b/crates/shuck-semantic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shuck-semantic"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1,35 +1,62 @@
+#![warn(missing_docs)]
+
+//! Semantic analysis model for shell scripts.
+
+#[allow(missing_docs)]
 mod binding;
+#[allow(missing_docs)]
 mod builder;
+#[allow(missing_docs)]
 mod call_graph;
+#[allow(missing_docs)]
 mod cfg;
+#[allow(missing_docs)]
 mod contract;
+#[allow(missing_docs)]
 mod dataflow;
+#[allow(missing_docs)]
 mod declaration;
+#[allow(missing_docs)]
 mod reference;
+#[allow(missing_docs)]
 mod runtime;
+#[allow(missing_docs)]
 mod scope;
+#[allow(missing_docs)]
 mod source_closure;
+#[allow(missing_docs)]
 mod source_ref;
+#[allow(missing_docs)]
 mod zsh_options;
 
+/// Binding types and provenance metadata discovered during semantic analysis.
 pub use binding::{
     AssignmentValueOrigin, Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin,
     BuiltinBindingTargetKind, LoopValueOrigin,
 };
+/// Call-graph structures derived from the analyzed script.
 pub use call_graph::{CallGraph, CallSite, OverwrittenFunction};
+/// Control-flow graph types and flow-context annotations.
 pub use cfg::{BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext};
+/// Contract and build-option types used when constructing semantic models.
 pub use contract::{
     ContractCertainty, FileContract, FunctionContract, ProvidedBinding, ProvidedBindingKind,
     SemanticBuildOptions,
 };
+/// Dataflow results surfaced by the semantic analysis layer.
 pub use dataflow::{
     DeadCode, ReachingDefinitions, UninitializedCertainty, UninitializedReference,
     UnusedAssignment, UnusedReason,
 };
+/// Declaration records discovered while building the semantic model.
 pub use declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
+/// Reference types and identifiers tracked by the semantic model.
 pub use reference::{Reference, ReferenceId, ReferenceKind};
+/// Scope types and identifiers tracked by the semantic model.
 pub use scope::{FunctionScopeKind, Scope, ScopeId, ScopeKind};
+/// Shell parser option types reused by the semantic analysis layer.
 pub use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionState};
+/// Source-reference records and resolution state.
 pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution};
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -80,6 +107,7 @@ pub(crate) enum IndirectTargetHint {
     },
 }
 
+/// Synthetic read introduced by semantic modeling for later analysis passes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyntheticRead {
     pub(crate) scope: ScopeId,
@@ -87,6 +115,7 @@ pub struct SyntheticRead {
     pub(crate) name: Name,
 }
 
+#[allow(missing_docs)]
 impl SyntheticRead {
     pub fn scope(&self) -> ScopeId {
         self.scope
@@ -375,6 +404,7 @@ impl ScopeLookup {
     }
 }
 
+/// Semantic model constructed from a parsed shell file and source text.
 #[derive(Debug)]
 pub struct SemanticModel {
     shell_profile: ShellProfile,
@@ -408,6 +438,7 @@ pub struct SemanticModel {
     assoc_lookup_binding_index: OnceLock<AssocLookupBindingIndex>,
 }
 
+/// Lazy analysis view over a `SemanticModel`.
 #[derive(Debug)]
 pub struct SemanticAnalysis<'model> {
     model: &'model SemanticModel,
@@ -429,6 +460,7 @@ struct OverwriteWindow<'a> {
     unreachable: &'a FxHashSet<BlockId>,
 }
 
+#[allow(missing_docs)]
 impl SemanticModel {
     pub fn build(file: &File, source: &str, indexer: &Indexer) -> Self {
         Self::build_with_options(file, source, indexer, SemanticBuildOptions::default())
@@ -1092,6 +1124,7 @@ impl SemanticModel {
     }
 }
 
+#[allow(missing_docs)]
 impl<'model> SemanticAnalysis<'model> {
     fn new(model: &'model SemanticModel) -> Self {
         Self {

--- a/crates/shuck/Cargo.toml
+++ b/crates/shuck/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shuck"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/shuck/src/lib.rs
+++ b/crates/shuck/src/lib.rs
@@ -1,3 +1,9 @@
+#![warn(missing_docs)]
+
+//! Programmatic entry points for the `shuck` CLI.
+
+/// Command-line argument types and parsing helpers.
+#[allow(missing_docs)]
 pub mod args;
 
 mod cache;
@@ -19,6 +25,8 @@ use anyhow::Result;
 use crate::args::{Args, Command, FormatCommand, TerminalColor};
 use crate::config::ConfigArguments;
 
+/// Process exit codes returned by the CLI.
+#[allow(missing_docs)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ExitStatus {
     Success,
@@ -36,6 +44,7 @@ impl From<ExitStatus> for ExitCode {
     }
 }
 
+/// Runs the CLI with pre-parsed arguments.
 pub fn run(args: Args) -> Result<ExitStatus> {
     let Args {
         cache_dir,

--- a/crates/shuck/tests/zsh_option_state.rs
+++ b/crates/shuck/tests/zsh_option_state.rs
@@ -7,7 +7,9 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use shuck_indexer::Indexer;
-use shuck_linter::{Checker, RuleSet, ShellDialect, classify_file_context};
+use shuck_linter::{
+    Checker, ExpansionContext, RuleSet, ShellDialect, WordFactContext, classify_file_context,
+};
 use shuck_parser::parser::Parser;
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
 use shuck_semantic::{OptionValue, SemanticBuildOptions, SemanticModel, ZshOptionState};
@@ -213,7 +215,10 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
         })?;
         let word_fact = checker
             .facts()
-            .any_word_fact(target.span)
+            .word_fact(
+                target.span,
+                WordFactContext::Expansion(ExpansionContext::CommandArgument),
+            )
             .with_context(|| {
                 format!(
                     "fixture `{}` probe `{probe_id}` missing command-argument word fact",

--- a/crates/shuck/tests/zsh_option_state.rs
+++ b/crates/shuck/tests/zsh_option_state.rs
@@ -7,10 +7,7 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use shuck_indexer::Indexer;
-use shuck_linter::{
-    Checker, ExpansionContext, RuleSet, ShellDialect, WordFactContext, classify_file_context,
-    static_word_text,
-};
+use shuck_linter::{Checker, RuleSet, ShellDialect, classify_file_context};
 use shuck_parser::parser::Parser;
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
 use shuck_semantic::{OptionValue, SemanticBuildOptions, SemanticModel, ZshOptionState};
@@ -216,10 +213,7 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
         })?;
         let word_fact = checker
             .facts()
-            .word_fact(
-                target.span,
-                WordFactContext::Expansion(ExpansionContext::CommandArgument),
-            )
+            .any_word_fact(target.span)
             .with_context(|| {
                 format!(
                     "fixture `{}` probe `{probe_id}` missing command-argument word fact",
@@ -358,7 +352,7 @@ fn find_probe_command<'a>(
                 && fact
                     .body_args()
                     .first()
-                    .and_then(|word| static_word_text(word, checker.source()))
+                    .map(|word| word.render(checker.source()))
                     .as_deref()
                     == Some(probe_id)
         })

--- a/deny.toml
+++ b/deny.toml
@@ -9,12 +9,14 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",  # LLVM exception (target-lexicon via pyo3)
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0",               # notify crate
     "ISC",
     "Zlib",
     "MPL-2.0",                # Mozilla Public License 2.0 (colored crate)
     "Unicode-3.0",            # Unicode License v3 (icu_* crates)
     "CDLA-Permissive-2.0",    # Community Data License Agreement (webpki-root-certs)
     "Unicode-DFS-2016",       # Unicode Data Files and Software License (unicode_names2 via monty/ruff, --all-features only)
+    "WTFPL",                  # terminfo via clearscreen
 ]
 
 # Review unclear/dual licenses

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.94.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- declare and pin the workspace MSRV to Rust 1.94.1 across the workspace manifests and toolchain config
- add `cargo deny` and `cargo audit` jobs to CI so dependency policy and advisory checks actually run
- demote `shuck-linter` rule-common helpers from the public API and turn on `missing_docs` at the library crate roots with targeted allowances for internal modules

## Why
These changes close the release-readiness gaps called out in review before `0.1.0`:
- publishing now advertises an explicit MSRV instead of inheriting whatever stable bump lands next
- CI enforces the existing dependency-policy configuration and adds advisory scanning
- internal rule-common types stop leaking into the stable crates.io surface
- public library entry points now participate in docs linting without requiring a full internal docs sweep

## Impact
Downstream users get a declared MSRV and a smaller `shuck-linter` public surface, while maintainers get stronger CI guardrails around dependency policy, advisories, and public API docs.

## Validation
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo test --workspace --all-features`
