### PR TITLE
Generate CycloneDX SBOMs in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,11 @@ jobs:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
+      - name: Install cargo-cyclonedx
+        run: |
+          if ! cargo cyclonedx --version >/dev/null 2>&1; then
+            cargo install cargo-cyclonedx --locked --version 0.5.9
+          fi
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ website/app/lib/rules-data.generated.json
 fuzz/corpus/
 fuzz/artifacts/
 fuzz/target/
+/shuck.cdx.xml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,7 @@ install-updater = false
 pr-run-mode = "skip"
 # We pin actions to commit SHAs, so skip the CI file freshness check
 allow-dirty = ["ci"]
+
+[[workspace.metadata.dist.extra-artifacts]]
+artifacts = ["shuck.cdx.xml"]
+build = ["./scripts/generate-release-sbom.sh"]

--- a/crates/shuck-parser/src/parser/arithmetic.rs
+++ b/crates/shuck-parser/src/parser/arithmetic.rs
@@ -419,10 +419,7 @@ impl<'a> ArithmeticParser<'a> {
         op_of: fn(&TokenKind) -> Option<ArithmeticBinaryOp>,
     ) -> Result<ArithmeticExprNode> {
         let mut expr = subparser(self)?;
-        loop {
-            let Some(op) = op_of(&self.peek_token()?.kind) else {
-                break;
-            };
+        while let Some(op) = op_of(&self.peek_token()?.kind) {
             self.next_token()?;
             let right = subparser(self)?;
             let span = expr.span.merge(right.span);

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -156,10 +156,7 @@ impl<'a> Parser<'a> {
 
         while let Some(kind) = self.current_token_kind {
             if Self::is_recovery_separator(kind) {
-                loop {
-                    let Some(kind) = self.current_token_kind else {
-                        break;
-                    };
+                while let Some(kind) = self.current_token_kind {
                     if !Self::is_recovery_separator(kind) {
                         break;
                     }

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3343,11 +3343,10 @@ impl<'a> Lexer<'a> {
             if in_single {
                 match ch {
                     '\'' => in_single = false,
-                    '\\' => {
-                        if chars.peek() == Some(&'"') {
-                            chars.next();
-                        }
+                    '\\' if chars.peek() == Some(&'"') => {
+                        chars.next();
                     }
+                    '\\' => {}
                     _ => {}
                 }
                 continue;

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -1131,12 +1131,20 @@ fn apply_prescan_command_effects(words: &[String], state: &mut ZshOptionState) -
     };
 
     match command {
-        "setopt" => words[args_index..]
-            .iter()
-            .fold(false, |changed, arg| state.apply_setopt(arg) || changed),
-        "unsetopt" => words[args_index..]
-            .iter()
-            .fold(false, |changed, arg| state.apply_unsetopt(arg) || changed),
+        "setopt" => {
+            let mut changed = false;
+            for arg in &words[args_index..] {
+                changed = state.apply_setopt(arg) || changed;
+            }
+            changed
+        }
+        "unsetopt" => {
+            let mut changed = false;
+            for arg in &words[args_index..] {
+                changed = state.apply_unsetopt(arg) || changed;
+            }
+            changed
+        }
         "set" => apply_prescan_set_builtin(&words[args_index..], state),
         "emulate" => apply_prescan_emulate(&words[args_index..], state),
         _ => false,

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -5666,11 +5666,10 @@ fn source_prefix_has_same_line_escaped_double_quote_fragment(
 
     while let Some(ch) = chars.next() {
         match ch {
-            '\\' if !in_single => {
-                if in_double && chars.peek() == Some(&'"') {
-                    return true;
-                }
+            '\\' if !in_single && in_double && chars.peek() == Some(&'"') => {
+                return true;
             }
+            '\\' if !in_single => {}
             '\'' if !in_double => in_single = !in_single,
             '"' if !in_single => in_double = !in_double,
             _ => {}

--- a/scripts/generate-release-sbom.sh
+++ b/scripts/generate-release-sbom.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+
+cd "$repo_root"
+
+# cargo-cyclonedx emits one SBOM per workspace crate next to each Cargo.toml.
+# Dist expects a single release artifact, so we copy the distributable crate's
+# SBOM to the repository root and clean up the temporary workspace files.
+find crates -name '*.cdx.xml' -delete
+cargo cyclonedx --manifest-path Cargo.toml --format xml -q
+cp crates/shuck/shuck.cdx.xml shuck.cdx.xml
+find crates -name '*.cdx.xml' -delete


### PR DESCRIPTION
## Summary
- add a `cargo-dist` extra artifact for `shuck.cdx.xml`
- add a small release helper that generates the SBOM with `cargo cyclonedx`
- install `cargo-cyclonedx` in the global release-artifacts job
- ignore the temporary top-level `shuck.cdx.xml` file used during release packaging

## Why
The release workflow did not publish an SBOM today. `cargo-dist` can advertise SBOM support, but in this repo setup the generated artifact needed an explicit build step so the XML is always materialized and uploaded with the release assets.

## Impact
Releases will now include a CycloneDX SBOM alongside the existing archives, installers, and checksums.

## Validation
- `bash -n scripts/generate-release-sbom.sh`
- `python3 scripts/check-release-security.py check`
- `dist build --artifacts=global --allow-dirty --output-format=json`
- verified `target/distrib/shuck.cdx.xml` is generated and non-empty