### PR TITLE
Fix parser and formatter fuzz regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,8 @@ dependencies = [
  "shuck-ast",
  "shuck-benchmark",
  "shuck-format",
+ "shuck-indexer",
+ "shuck-linter",
  "shuck-parser",
  "similar",
 ]
@@ -1606,6 +1608,7 @@ dependencies = [
  "shuck-ast",
  "shuck-indexer",
  "shuck-parser",
+ "smallvec",
  "tempfile",
 ]
 

--- a/crates/shuck-formatter/Cargo.toml
+++ b/crates/shuck-formatter/Cargo.toml
@@ -19,4 +19,6 @@ shuck-parser = { workspace = true }
 
 [dev-dependencies]
 shuck-benchmark = { workspace = true }
+shuck-indexer = { workspace = true }
+shuck-linter = { workspace = true }
 similar = { workspace = true }

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -174,8 +174,19 @@ fn ensure_single_trailing_newline(output: &mut String) {
         output.pop();
     }
     if !output.ends_with('\n') {
+        if trailing_backslash_count(output) % 2 == 1 {
+            output.push('\\');
+        }
         output.push('\n');
     }
+}
+
+fn trailing_backslash_count(text: &str) -> usize {
+    text.as_bytes()
+        .iter()
+        .rev()
+        .take_while(|byte| **byte == b'\\')
+        .count()
 }
 
 fn map_parse_error(error: ParseError) -> FormatError {
@@ -199,6 +210,9 @@ mod tests {
 
     use shuck_ast::{AssignmentValue, Command};
     use shuck_benchmark::TEST_FILES;
+    use shuck_indexer::Indexer;
+    use shuck_linter::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_result};
+    use shuck_parser::ShellDialect as ParseShellDialect;
 
     use super::*;
 
@@ -237,6 +251,33 @@ mod tests {
         let once = format_to_string(source, path, options);
         let twice = format_to_string(&once, path, options);
         assert_eq!(once, twice);
+    }
+
+    fn lint_source_posix_strict(source: &str, path: &Path) -> Vec<Diagnostic> {
+        let parse_result = Parser::with_dialect(source, ParseShellDialect::Posix).parse();
+        assert!(
+            !parse_result.is_err(),
+            "strict parse failed for {}: {}",
+            path.display(),
+            parse_result.strict_error()
+        );
+        let indexer = Indexer::new(source, &parse_result);
+        let settings = LinterSettings::default().with_analyzed_paths([path.to_path_buf()]);
+        lint_file_at_path_with_parse_result(
+            &parse_result,
+            source,
+            &indexer,
+            &settings,
+            None,
+            Some(path),
+        )
+    }
+
+    fn diagnostic_count(diagnostics: &[Diagnostic], code: &str) -> usize {
+        diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code() == code)
+            .count()
     }
 
     #[test]
@@ -1558,6 +1599,39 @@ print hidden &!
             source,
             Some(Path::new("fuzz.sh")),
             &ShellFormatOptions::default(),
+        );
+    }
+
+    #[test]
+    fn keeps_trailing_backslash_pipeline_reproducer_parseable() {
+        let source = "cat foo | \\\\t foo | \\";
+        let path = Some(Path::new("fuzz.sh"));
+        let options = ShellFormatOptions::default();
+
+        let once = format_to_string(source, path, &options);
+        let twice = format_source(&once, path, &options).unwrap_or_else(|err| {
+            panic!("second format pass failed: {err}\nformatted source:\n{once:?}")
+        });
+        let twice = match twice {
+            FormattedSource::Unchanged => once.clone(),
+            FormattedSource::Formatted(formatted) => formatted,
+        };
+
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn does_not_introduce_unused_assignment_for_backslash_heredoc_reproducer() {
+        let source = "cat foo E\r\nnnnnnnnnn1jn \\\ncat=,EOlo\nEOF\n";
+        let path = Path::new("fuzz.sh");
+        let formatted = format_to_string(source, Some(path), &ShellFormatOptions::default());
+
+        let original_c001 = diagnostic_count(&lint_source_posix_strict(source, path), "C001");
+        let formatted_c001 = diagnostic_count(&lint_source_posix_strict(&formatted, path), "C001");
+
+        assert!(
+            formatted_c001 <= original_c001,
+            "formatter introduced extra C001 diagnostics: original={original_c001}, formatted={formatted_c001}\nformatted source:\n{formatted:?}"
         );
     }
 }

--- a/crates/shuck-formatter/src/streaming.rs
+++ b/crates/shuck-formatter/src/streaming.rs
@@ -442,6 +442,14 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         self.line_start = true;
     }
 
+    fn line_continuation(&mut self) {
+        self.flush_pending_heredocs();
+        // A backslash only escapes the following LF, so CRLF here would change
+        // the command structure by leaving the carriage return behind.
+        self.push_output_str(" \\\n");
+        self.line_start = true;
+    }
+
     fn write_line_breaks(&mut self, count: usize) {
         for _ in 0..count {
             self.newline();
@@ -880,8 +888,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             .get(previous_end..next_start)
             .is_some_and(|between| between.contains('\n'))
         {
-            self.write_text(" \\");
-            self.newline();
+            self.line_continuation();
             self.write_indent_units(1);
         } else {
             self.write_space();
@@ -918,8 +925,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     .map(|(operator, _)| binary_operator(operator))
                     .unwrap_or("|");
                 if multiline {
-                    self.write_text(" \\");
-                    self.newline();
+                    self.line_continuation();
                     self.with_indent(|formatter| {
                         formatter.write_text(operator);
                         formatter.write_space();

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -5085,6 +5085,24 @@ impl<'a> Parser<'a> {
         SourceText::source(Span::from_positions(pos, pos))
     }
 
+    fn input_prefix_ends_with(&self, end_offset: usize, ch: char) -> bool {
+        self.input
+            .get(..end_offset)
+            .is_some_and(|prefix| prefix.ends_with(ch))
+    }
+
+    fn input_span_ends_with(&self, start: Position, end: Position, ch: char) -> bool {
+        self.input
+            .get(start.offset..end.offset)
+            .is_some_and(|slice| slice.ends_with(ch))
+    }
+
+    fn input_suffix_starts_with(&self, start_offset: usize, ch: char) -> bool {
+        self.input
+            .get(start_offset..)
+            .is_some_and(|suffix| suffix.starts_with(ch))
+    }
+
     fn subscript_source_text(&self, raw: &str, span: Span) -> (SourceText, Option<SourceText>) {
         if raw.len() >= 2
             && ((raw.starts_with('"') && raw.ends_with('"'))
@@ -6021,8 +6039,10 @@ impl<'a> Parser<'a> {
 
     fn source_matches(&self, span: Span, text: &str) -> bool {
         span.start.offset <= span.end.offset
-            && span.end.offset <= self.input.len()
-            && span.slice(self.input) == text
+            && self
+                .input
+                .get(span.start.offset..span.end.offset)
+                .is_some_and(|slice| slice == text)
     }
 
     fn checkpoint(&self) -> ParserCheckpoint<'a> {

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -7452,3 +7452,25 @@ fn test_parse_malformed_parameter_replacement_fuzz_regression_does_not_panic() {
     let conditional_script = format!("if [[ \"hello.world\" == {} ]]; then echo y; fi\n", input);
     let _ = Parser::new(&conditional_script).parse();
 }
+
+#[test]
+fn test_parse_arithmetic_utf8_parameter_replacement_fuzz_regression_does_not_panic() {
+    const INPUT: &str = "#!/ di[@]}\")\")#!/bin/$x)\narr=($(]x ib) echo#b;;\n#!/bi/nbash\n\narr=${in/bas\nunc(#!${in/sa\nar\0\0\0)\0\0<\0<\0=\u{2018}woin/sa\u{2019}es\0 \"two worac\ntr";
+
+    let script = format!("echo $(({}))\n", INPUT);
+    let _ = Parser::new(&script).parse();
+}
+
+#[test]
+fn test_parse_glob_utf8_parameter_replacement_fuzz_regression_does_not_panic() {
+    const INPUT: &str = "'a\0b'\nar=(\n\n{)${!f/e¢}\")\ni";
+
+    let case_script = format!(
+        "case \"test.txt\" in {}) echo match;; *) echo no;; esac\n",
+        INPUT
+    );
+    let _ = Parser::new(&case_script).parse();
+
+    let conditional_script = format!("if [[ \"hello.world\" == {} ]]; then echo y; fi\n", INPUT);
+    let _ = Parser::new(&conditional_script).parse();
+}

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4086,7 +4086,7 @@ impl<'a> Parser<'a> {
                                         (
                                             replacement,
                                             cursor.offset > 0
-                                                && self.input[..cursor.offset].ends_with('}'),
+                                                && self.input_prefix_ends_with(cursor.offset, '}'),
                                         )
                                     } else {
                                         (self.empty_source_text(cursor), false)
@@ -4094,10 +4094,8 @@ impl<'a> Parser<'a> {
                                 if !consumed_closing_brace {
                                     Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                                 }
-                                if !Span::from_positions(part_start, cursor)
-                                    .slice(self.input)
-                                    .ends_with('}')
-                                    && self.input[cursor.offset..].starts_with('}')
+                                if !self.input_span_ends_with(part_start, cursor, '}')
+                                    && self.input_suffix_starts_with(cursor.offset, '}')
                                 {
                                     cursor.advance('}');
                                 }
@@ -4356,7 +4354,7 @@ impl<'a> Parser<'a> {
                                     (
                                         replacement,
                                         cursor.offset > 0
-                                            && self.input[..cursor.offset].ends_with('}'),
+                                            && self.input_prefix_ends_with(cursor.offset, '}'),
                                     )
                                 } else {
                                     (self.empty_source_text(cursor), false)
@@ -4364,10 +4362,8 @@ impl<'a> Parser<'a> {
                             if !consumed_closing_brace {
                                 Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                             }
-                            if !Span::from_positions(part_start, cursor)
-                                .slice(self.input)
-                                .ends_with('}')
-                                && self.input[cursor.offset..].starts_with('}')
+                            if !self.input_span_ends_with(part_start, cursor, '}')
+                                && self.input_suffix_starts_with(cursor.offset, '}')
                             {
                                 cursor.advance('}');
                             }
@@ -5192,7 +5188,8 @@ impl<'a> Parser<'a> {
                             let replacement = self.read_brace_operand(chars, cursor, source_backed);
                             (
                                 replacement,
-                                cursor.offset > 0 && self.input[..cursor.offset].ends_with('}'),
+                                cursor.offset > 0
+                                    && self.input_prefix_ends_with(cursor.offset, '}'),
                             )
                         } else {
                             (self.empty_source_text(*cursor), false)
@@ -5200,13 +5197,8 @@ impl<'a> Parser<'a> {
                     if !consumed_closing_brace {
                         Self::consume_word_char_if(chars, cursor, '}');
                     }
-                    if !Span::from_positions(part_start, *cursor)
-                        .slice(self.input)
-                        .ends_with('}')
-                        && self
-                            .input
-                            .get(cursor.offset..)
-                            .is_some_and(|rest| rest.starts_with('}'))
+                    if !self.input_span_ends_with(part_start, *cursor, '}')
+                        && self.input_suffix_starts_with(cursor.offset, '}')
                     {
                         cursor.advance('}');
                     }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
  "shuck-ast",
  "shuck-indexer",
  "shuck-parser",
+ "smallvec",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- harden parser replacement parsing against invalid UTF-8 boundary slicing by using safe source access helpers
- fix formatter handling for CRLF line continuations and trailing EOF backslashes so formatting preserves shell semantics
- add focused parser and formatter regression tests for the minimized fuzz reproducers

## Root cause
The parser fuzz failures came from slicing source text at byte offsets that were not guaranteed to be UTF-8 character boundaries. The formatter fuzz failures came from emitting `\
` continuations and from turning a trailing literal backslash at EOF into a continuation when inserting a final newline.

## Validation
- `cargo fmt`
- `cargo test -p shuck-parser utf8_parameter_replacement_fuzz_regression -- --nocapture`
- `cargo test -p shuck-formatter keeps_trailing_backslash_pipeline_reproducer_parseable -- --nocapture`
- `cargo test -p shuck-formatter does_not_introduce_unused_assignment_for_backslash_heredoc_reproducer -- --nocapture`
- replayed the exact `arithmetic_fuzz`, `glob_fuzz`, `formatter_consistency_fuzz`, and `formatter_validity_fuzz` crash artifacts successfully
- `cargo fuzz run --sanitizer=none parser_fuzz -- -max_total_time=5 fuzz/corpus/parser_fuzz`
- parser Criterion compare against `main` showed no meaningful regression

Closes #380