### PR TITLE
ci(website): deploy only on published releases

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,8 +1,8 @@
 name: Website
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
   pull_request:
     paths:
       - "website/**"
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
@@ -45,7 +46,7 @@ jobs:
         run: pnpm build
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'release'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -63,10 +64,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: false
 
       - name: Install Rust toolchain
         run: rustup show
@@ -91,12 +93,12 @@ jobs:
             --bench-dir "$SHUCK_BENCHMARK_OUTPUT_DIR" \
             --output website/generated/benchmarks/ci-latest.json \
             --dataset-id ci-latest \
-            --dataset-name "GitHub Actions latest main snapshot" \
-            --dataset-description "Regenerated during the GitHub Pages deploy on the latest main commit." \
+            --dataset-name "GitHub Actions latest release snapshot" \
+            --dataset-description "Regenerated during the GitHub Pages deploy for the latest published release." \
             --environment-kind ci \
             --environment-label "GitHub Actions ubuntu-latest" \
             --source-command "make bench-macro" \
-            --notes "This snapshot is rebuilt during every Pages deploy from the current main commit." \
+            --notes "This snapshot is rebuilt during every Pages deploy for the latest published release." \
             --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Note benchmark fallback

--- a/website/content/performance/benchmarks.tsx
+++ b/website/content/performance/benchmarks.tsx
@@ -183,8 +183,8 @@ function SnapshotDetails({ dataset }: { dataset: BenchmarkDataset }) {
       {!dataset.available ? (
         <blockquote>
           The checked-in placeholder was used for this build. The GitHub Pages
-          deployment on <code>main</code> regenerates the CI snapshot before exporting
-          the site.
+          deployment for the latest published release regenerates the CI snapshot
+          before exporting the site.
         </blockquote>
       ) : null}
     </>
@@ -274,8 +274,8 @@ export default function BenchmarksDoc() {
           A checked-in Apple M5 Max snapshot generated from local benchmark exports.
         </li>
         <li>
-          A Linux CI snapshot regenerated during the GitHub Pages deploy on{" "}
-          <code>main</code>.
+          A Linux CI snapshot regenerated during the GitHub Pages deploy for the
+          latest published release.
         </li>
       </ul>
 
@@ -330,8 +330,8 @@ python3 ./scripts/benchmarks/export_website_data.py \\
   --bench-dir .cache \\
   --output website/generated/benchmarks/ci-latest.json \\
   --dataset-id ci-latest \\
-  --dataset-name "GitHub Actions latest main snapshot" \\
-  --dataset-description "Generated during the website deploy workflow." \\
+  --dataset-name "GitHub Actions latest release snapshot" \\
+  --dataset-description "Generated during the website deploy workflow for the latest published release." \\
   --environment-kind ci \\
   --environment-label "GitHub Actions ubuntu-latest"`}</code>
       </pre>

--- a/website/generated/benchmarks/ci-latest.json
+++ b/website/generated/benchmarks/ci-latest.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "available": false,
   "id": "ci-latest",
-  "name": "GitHub Actions latest main snapshot",
-  "description": "A fresh Linux snapshot is generated during the GitHub Pages deploy on main. Local builds and pull request builds use this placeholder instead.",
+  "name": "GitHub Actions latest release snapshot",
+  "description": "A fresh Linux snapshot is generated during the GitHub Pages deploy for the latest published release. Local builds and pull request builds use this placeholder instead.",
   "generatedAt": "2026-04-20T00:00:00Z",
   "commit": {
     "sha": null,
@@ -35,7 +35,7 @@
     "ignoreFailure": true,
     "shuckCommand": "shuck check --no-cache <fixture>",
     "comparisonCommand": "shellcheck --severity=style <fixture>",
-    "notes": "The website deploy on main overwrites this placeholder with a fresh benchmark snapshot."
+    "notes": "The website deploy for the latest published release overwrites this placeholder with a fresh benchmark snapshot."
   },
   "corpus": {
     "fixtureCount": 0,


### PR DESCRIPTION
## Summary
- trigger the website workflow only for published GitHub releases instead of every push to `main`
- check out the release tag ref during website builds and deploys so Pages is built from the released commit
- update the benchmark placeholder copy to describe the release-based refresh cadence

## Why
The website deploy was running after every PR merge to `main`, even though the desired behavior is to publish the site only when a release is actually published. That also made the benchmark snapshot copy talk about `main` deploys instead of releases.

## Impact
This keeps PR website validation in place, but limits GitHub Pages publishes and CI benchmark refreshes to real release events.

## Validation
- `git diff --check`
- `pnpm build` (in `website/`)
