### PR TITLE
Improve release documentation across publishable crates

### DIFF
--- a/crates/shuck-ast/Cargo.toml
+++ b/crates/shuck-ast/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 description = "AST types for parsed shell scripts"
 keywords = ["shell", "bash", "ast", "parser"]
 categories = ["parsing", "development-tools"]
-readme = "../../README.md"
+readme = "README.md"
 
 [dependencies]
 compact_str = { workspace = true }

--- a/crates/shuck-ast/README.md
+++ b/crates/shuck-ast/README.md
@@ -1,0 +1,10 @@
+# shuck-ast
+
+`shuck-ast` defines the abstract syntax tree, token kinds, and span types shared across the
+Shuck workspace.
+
+Use this crate when you need to inspect or transform parsed shell syntax. In most cases,
+`shuck-parser` is the crate that produces these types, while `shuck-indexer`, `shuck-linter`,
+and `shuck-formatter` consume them.
+
+The API is pre-1.0 and may evolve between `0.x` releases.

--- a/crates/shuck-ast/src/lib.rs
+++ b/crates/shuck-ast/src/lib.rs
@@ -1,6 +1,9 @@
 #![warn(missing_docs)]
 
-//! AST, token, and span types for parsed bash scripts.
+//! AST, token, and span types shared across the Shuck workspace.
+//!
+//! `shuck-parser` produces these data structures, while crates such as `shuck-indexer`,
+//! `shuck-linter`, `shuck-semantic`, and `shuck-formatter` consume them.
 
 #[allow(missing_docs)]
 mod ast;

--- a/crates/shuck-cache/Cargo.toml
+++ b/crates/shuck-cache/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "File-level caching with SHA-256 content keys for shuck"
 keywords = ["cache", "shell", "linter"]
 categories = ["caching", "development-tools"]
+readme = "README.md"
 
 [dependencies]
 bincode = { version = "2", features = ["serde"] }

--- a/crates/shuck-cache/README.md
+++ b/crates/shuck-cache/README.md
@@ -1,0 +1,7 @@
+# shuck-cache
+
+`shuck-cache` provides file-oriented cache keys and on-disk package caches used by `shuck` for
+fast incremental runs.
+
+The crate is generic enough to reuse in other tooling, but it is primarily designed around the
+needs of the Shuck workspace and is still pre-1.0.

--- a/crates/shuck-cache/src/lib.rs
+++ b/crates/shuck-cache/src/lib.rs
@@ -1,7 +1,9 @@
 #![warn(missing_docs)]
 
-//! Persistent file-result caching utilities for shuck.
-
+//! File-oriented cache keys and persistent package caches for Shuck.
+//!
+//! The types in this crate power the `shuck` CLI cache, but are generic enough to reuse in other
+//! Rust tooling that wants SHA-256-based cache partitioning and serialized per-file entries.
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File};
 use std::io::{self, BufReader, Write};

--- a/crates/shuck-format/Cargo.toml
+++ b/crates/shuck-format/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "Formatting document model and pretty-printer primitives"
 keywords = ["formatter", "pretty-printer", "document"]
 categories = ["text-processing", "development-tools"]
+readme = "README.md"
 
 [dependencies]
 unicode-width = "0.2"

--- a/crates/shuck-format/README.md
+++ b/crates/shuck-format/README.md
@@ -1,0 +1,8 @@
+# shuck-format
+
+`shuck-format` is the generic document model and pretty-printing engine used by
+`shuck-formatter`.
+
+It is not shell-specific: the crate provides reusable formatting primitives such as documents,
+groups, indentation, and printing options. The API is still pre-1.0 and may change between
+`0.x` releases.

--- a/crates/shuck-format/src/lib.rs
+++ b/crates/shuck-format/src/lib.rs
@@ -1,8 +1,9 @@
 #![warn(missing_docs)]
 
-//! Formatting document model and pretty-printer primitives.
-
-#[allow(missing_docs)]
+//! Generic document and pretty-printing primitives used by `shuck-formatter`.
+//!
+//! This crate is shell-agnostic. It provides the document tree, formatter traits, and printer
+//! implementation that higher-level crates use to build language-specific formatting rules.
 mod buffer;
 #[allow(missing_docs)]
 mod format_element;
@@ -10,8 +11,8 @@ mod format_element;
 mod formatter;
 #[allow(missing_docs)]
 mod macros;
-/// Common formatting traits and helper imports.
 #[allow(missing_docs)]
+/// Re-exports commonly used when implementing [`crate::Format`] values.
 pub mod prelude;
 #[allow(missing_docs)]
 mod printer;

--- a/crates/shuck-format/src/lib.rs
+++ b/crates/shuck-format/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! This crate is shell-agnostic. It provides the document tree, formatter traits, and printer
 //! implementation that higher-level crates use to build language-specific formatting rules.
+#[allow(missing_docs)]
 mod buffer;
 #[allow(missing_docs)]
 mod format_element;
@@ -11,8 +12,8 @@ mod format_element;
 mod formatter;
 #[allow(missing_docs)]
 mod macros;
-#[allow(missing_docs)]
 /// Re-exports commonly used when implementing [`crate::Format`] values.
+#[allow(missing_docs)]
 pub mod prelude;
 #[allow(missing_docs)]
 mod printer;

--- a/crates/shuck-formatter/Cargo.toml
+++ b/crates/shuck-formatter/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "Shell script formatter with configurable style options"
 keywords = ["shell", "bash", "formatter", "code-style"]
 categories = ["text-processing", "development-tools"]
+readme = "README.md"
 
 [features]
 benchmarking = []

--- a/crates/shuck-formatter/README.md
+++ b/crates/shuck-formatter/README.md
@@ -1,0 +1,6 @@
+# shuck-formatter
+
+`shuck-formatter` formats shell scripts using the parser and AST from the Shuck workspace.
+
+It exposes formatting options, source-level formatting helpers, and AST-based formatting entry
+points. The crate powers the experimental `shuck format` command and remains pre-1.0.

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -1,4 +1,8 @@
 #![warn(missing_docs)]
+//! Shell formatting entrypoints built on top of `shuck-parser` and `shuck-format`.
+//!
+//! Most callers will use [`format_source`] for source text or [`format_file_ast`] when they
+//! already have a parsed shell AST.
 #![recursion_limit = "256"]
 
 //! Shell script formatter with configurable style options.

--- a/crates/shuck-indexer/Cargo.toml
+++ b/crates/shuck-indexer/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "Positional and structural indexes over parsed shell scripts"
 keywords = ["shell", "bash", "indexer", "static-analysis"]
 categories = ["parsing", "development-tools"]
+readme = "README.md"
 
 [dependencies]
 shuck-ast = { workspace = true }

--- a/crates/shuck-indexer/README.md
+++ b/crates/shuck-indexer/README.md
@@ -1,0 +1,7 @@
+# shuck-indexer
+
+`shuck-indexer` builds positional and structural indexes over parsed shell scripts.
+
+It sits between parsing and higher-level analysis by providing efficient lookups for lines,
+comments, quoted regions, heredocs, command substitutions, and continuation lines. The crate is
+published for downstream integrations but is still pre-1.0.

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -1,8 +1,9 @@
 #![warn(missing_docs)]
 
 //! Positional and structural indexes over parsed shell scripts.
-
-#[allow(missing_docs)]
+//!
+//! The indexer complements `shuck-parser` by building efficient lookup tables for line numbers,
+//! comments, syntactic regions, and continuation lines.
 mod comment_index;
 #[allow(missing_docs)]
 mod line_index;
@@ -28,7 +29,6 @@ pub struct Indexer {
     continuation_lines: Vec<TextSize>,
 }
 
-#[allow(missing_docs)]
 impl Indexer {
     /// Build an index from parser output and the original source text.
     pub fn new(source: &str, output: &ParseResult) -> Self {
@@ -45,14 +45,17 @@ impl Indexer {
         }
     }
 
+    /// The line index for the source text.
     pub fn line_index(&self) -> &LineIndex {
         &self.line_index
     }
 
+    /// The comment index extracted from the parsed file.
     pub fn comment_index(&self) -> &CommentIndex {
         &self.comment_index
     }
 
+    /// The syntactic region index for quoted, heredoc, and related spans.
     pub fn region_index(&self) -> &RegionIndex {
         &self.region_index
     }

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -7,11 +7,17 @@ use shuck_ast::{
 /// A syntactic region that affects lint rule behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegionKind {
+    /// Text inside single quotes.
     SingleQuoted,
+    /// Text inside double quotes.
     DoubleQuoted,
+    /// A heredoc body.
     Heredoc,
+    /// A command substitution such as `$(...)` or backticks.
     CommandSubstitution,
+    /// An arithmetic context such as `$((...))` or `((...))`.
     Arithmetic,
+    /// A conditional context such as `[[ ... ]]`.
     Conditional,
 }
 

--- a/crates/shuck-linter/Cargo.toml
+++ b/crates/shuck-linter/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "Lint rule engine and checker for shell scripts"
 keywords = ["shell", "bash", "linter", "static-analysis"]
 categories = ["development-tools"]
+readme = "README.md"
 
 [features]
 benchmarking = []

--- a/crates/shuck-linter/README.md
+++ b/crates/shuck-linter/README.md
@@ -1,0 +1,7 @@
+# shuck-linter
+
+`shuck-linter` contains the rule engine behind `shuck check`.
+
+It combines parser output, positional indexes, semantic analysis, suppressions, fixes, and rule
+selection into a diagnostics pipeline for shell scripts. The crate is public because it is part
+of the published Shuck toolchain, but its Rust API is still pre-1.0 and actively evolving.

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1,13 +1,14 @@
 #![warn(missing_docs)]
 
-//! Linting engine and public rule surface for shuck.
-
-#[allow(missing_docs)]
+//! Linting and fix application for shell scripts parsed by the Shuck toolchain.
+//!
+//! This crate combines parser output, semantic analysis, suppressions, and rule metadata into a
+//! diagnostics pipeline used by `shuck check`.
 mod ambient_contracts;
 #[allow(missing_docs)]
 mod checker;
-/// File-context helpers used to classify sourced and executed scripts.
 #[allow(missing_docs)]
+/// File-context classification helpers used by lint rules.
 pub mod context;
 #[allow(missing_docs)]
 mod diagnostic;
@@ -25,8 +26,8 @@ mod rule_metadata;
 mod rule_selector;
 #[allow(missing_docs)]
 mod rule_set;
-/// Built-in lint rules and rule families.
 #[allow(missing_docs)]
+/// Rule implementations and rule-oriented helper modules.
 pub mod rules;
 #[allow(missing_docs)]
 mod settings;

--- a/crates/shuck-parser/Cargo.toml
+++ b/crates/shuck-parser/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 description = "A fast, safe bash parser library"
 keywords = ["shell", "bash", "parser", "lexer"]
 categories = ["parsing", "development-tools"]
-readme = "../../README.md"
+readme = "README.md"
 
 [features]
 benchmarking = []

--- a/crates/shuck-parser/README.md
+++ b/crates/shuck-parser/README.md
@@ -1,0 +1,7 @@
+# shuck-parser
+
+`shuck-parser` is the lexer and parser library used throughout the Shuck workspace.
+
+It turns shell source into `shuck-ast` syntax trees, exposes source-backed lexical tokens, and
+lets callers choose shell dialects and zsh option profiles. The crate is pre-1.0 and may change
+between `0.x` releases.

--- a/crates/shuck-parser/src/error.rs
+++ b/crates/shuck-parser/src/error.rs
@@ -10,8 +10,11 @@ pub enum Error {
     ///
     /// When `line` and `column` are 0, the error has no source location.
     Parse {
+        /// Human-readable error message.
         message: String,
+        /// 1-based source line, or `0` when unknown.
         line: usize,
+        /// 1-based source column, or `0` when unknown.
         column: usize,
     },
 }

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -1,11 +1,14 @@
 #![warn(missing_docs)]
 
-//! Bash parser library.
+//! Shell lexer and parser APIs for the Shuck workspace.
+//!
+//! `shuck-parser` turns shell source text into `shuck-ast` syntax trees and also exposes a
+//! source-backed lexer for lower-level tooling.
 
 #[allow(missing_docs)]
 mod error;
-/// Parser entry points and low-level parser data structures.
 #[allow(missing_docs)]
+/// Parsing entrypoints, lexer types, and shell-profile configuration.
 pub mod parser;
 
 /// Error types returned by parser operations.

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -82,16 +82,24 @@ impl TokenText<'_> {
     }
 }
 
+/// Classification of one segment inside a lexed shell word.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LexedWordSegmentKind {
+    /// Unquoted or otherwise plain text.
     Plain,
+    /// Text from a single-quoted string.
     SingleQuoted,
+    /// Text from a `$'...'` string.
     DollarSingleQuoted,
+    /// Text from a double-quoted string.
     DoubleQuoted,
+    /// Text from a `$"..."` string.
     DollarDoubleQuoted,
+    /// Text composed from multiple lexical forms.
     Composite,
 }
 
+/// One segment of a lexed shell word, optionally backed by source text.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LexedWordSegment<'a> {
     kind: LexedWordSegmentKind,
@@ -147,6 +155,7 @@ impl<'a> LexedWordSegment<'a> {
         }
     }
 
+    /// Borrow this segment's cooked text.
     pub fn as_str(&self) -> &str {
         self.text.as_str()
     }
@@ -155,14 +164,17 @@ impl<'a> LexedWordSegment<'a> {
         matches!(self.text, TokenText::Borrowed(_) | TokenText::Shared { .. })
     }
 
+    /// Return the lexical classification of this segment.
     pub const fn kind(&self) -> LexedWordSegmentKind {
         self.kind
     }
 
+    /// Return the span of the inner text, if it is tracked.
     pub const fn span(&self) -> Option<Span> {
         self.span
     }
 
+    /// Return the span including surrounding quoting syntax when available.
     pub fn wrapper_span(&self) -> Option<Span> {
         self.wrapper_span.or(self.span)
     }
@@ -192,6 +204,7 @@ impl<'a> LexedWordSegment<'a> {
     }
 }
 
+/// Source-backed representation of a shell word produced by the lexer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LexedWord<'a> {
     primary_segment: LexedWordSegment<'a>,
@@ -218,14 +231,17 @@ impl<'a> LexedWord<'a> {
         self.trailing_segments.push(segment);
     }
 
+    /// Iterate over the segments that make up this word.
     pub fn segments(&self) -> impl Iterator<Item = &LexedWordSegment<'a>> {
         std::iter::once(&self.primary_segment).chain(self.trailing_segments.iter())
     }
 
+    /// Return the word text when it is represented by a single segment.
     pub fn text(&self) -> Option<&str> {
         self.single_segment().map(LexedWordSegment::as_str)
     }
 
+    /// Join all segments into an owned string.
     pub fn joined_text(&self) -> String {
         let mut text = String::new();
         for segment in self.segments() {
@@ -234,6 +250,7 @@ impl<'a> LexedWord<'a> {
         text
     }
 
+    /// Return the only segment when this word is not segmented.
     pub fn single_segment(&self) -> Option<&LexedWordSegment<'a>> {
         self.trailing_segments
             .is_empty()
@@ -278,15 +295,21 @@ impl<'a> LexedWord<'a> {
     }
 }
 
+/// Kinds of lexer error payloads attached to `TokenKind::Error`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LexerErrorKind {
+    /// Unterminated `$()` command substitution.
     CommandSubstitution,
+    /// Unterminated backtick command substitution.
     BacktickSubstitution,
+    /// Unterminated single-quoted string.
     SingleQuote,
+    /// Unterminated double-quoted string.
     DoubleQuote,
 }
 
 impl LexerErrorKind {
+    /// Human-readable message for this lexer error kind.
     pub const fn message(self) -> &'static str {
         match self {
             Self::CommandSubstitution => "unterminated command substitution",
@@ -306,9 +329,12 @@ pub(crate) enum TokenPayload<'a> {
     Error(LexerErrorKind),
 }
 
+/// Token produced by the shell lexer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LexedToken<'a> {
+    /// Token kind used by the parser.
     pub kind: TokenKind,
+    /// Source span covered by the token.
     pub span: Span,
     pub(crate) flags: TokenFlags,
     payload: TokenPayload<'a>,
@@ -448,6 +474,7 @@ impl<'a> LexedToken<'a> {
         }
     }
 
+    /// Borrow the token text when it is a single-segment word token.
     pub fn word_text(&self) -> Option<&str> {
         self.kind
             .is_word_like()
@@ -458,6 +485,7 @@ impl<'a> LexedToken<'a> {
             })
     }
 
+    /// Return an owned string containing the token's word text.
     pub fn word_string(&self) -> Option<String> {
         self.kind
             .is_word_like()
@@ -468,6 +496,7 @@ impl<'a> LexedToken<'a> {
             })
     }
 
+    /// Borrow the structured word payload for word-like tokens.
     pub fn word(&self) -> Option<&LexedWord<'a>> {
         match &self.payload {
             TokenPayload::Word(word) => Some(word),
@@ -475,6 +504,7 @@ impl<'a> LexedToken<'a> {
         }
     }
 
+    /// Borrow the original source slice when the token is source-backed and uncooked.
     pub fn source_slice<'b>(&self, source: &'b str) -> Option<&'b str> {
         if !self.kind.is_word_like() || self.flags.has_cooked_text() || self.flags.is_synthetic() {
             return None;
@@ -484,6 +514,7 @@ impl<'a> LexedToken<'a> {
             .then(|| &source[self.span.start.offset..self.span.end.offset])
     }
 
+    /// Return the file-descriptor payload for redirection tokens that carry one.
     pub fn fd_value(&self) -> Option<i32> {
         match self.payload {
             TokenPayload::Fd(fd) => Some(fd),
@@ -491,6 +522,7 @@ impl<'a> LexedToken<'a> {
         }
     }
 
+    /// Return the `(source_fd, target_fd)` payload for descriptor-pair redirections.
     pub fn fd_pair_value(&self) -> Option<(i32, i32)> {
         match self.payload {
             TokenPayload::FdPair(src_fd, dst_fd) => Some((src_fd, dst_fd)),
@@ -498,6 +530,7 @@ impl<'a> LexedToken<'a> {
         }
     }
 
+    /// Return the lexer error payload when this token represents `TokenKind::Error`.
     pub fn error_kind(&self) -> Option<LexerErrorKind> {
         match self.payload {
             TokenPayload::Error(kind) => Some(kind),
@@ -509,7 +542,9 @@ impl<'a> LexedToken<'a> {
 /// Result of reading a heredoc body from the source.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HeredocRead {
+    /// Decoded heredoc content.
     pub content: String,
+    /// Source span covering the heredoc body content.
     pub content_span: Span,
 }
 
@@ -716,6 +751,7 @@ impl<'a> Lexer<'a> {
         )
     }
 
+    /// Create a new lexer using the provided shell profile.
     pub fn with_profile(input: &'a str, shell_profile: &ShellProfile) -> Self {
         let zsh_timeline = (shell_profile.dialect == super::ShellDialect::Zsh)
             .then(|| ZshOptionTimeline::build(input, shell_profile))

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -1,6 +1,7 @@
-//! Parser module for shuck
+//! Parser entrypoints, lexical types, and shell-profile configuration.
 //!
-//! Implements a recursive descent parser for bash scripts.
+//! The parser is recursive descent and produces `shuck-ast` syntax trees while also collecting
+//! recovery diagnostics and lightweight syntax facts needed by downstream tooling.
 
 // Parser uses chars().next().unwrap() after validating character presence.
 // This is safe because we check bounds before accessing.
@@ -70,23 +71,34 @@ const HARD_MAX_AST_DEPTH: usize = 100;
 /// Default maximum parser operations (matches ExecutionLimits default)
 const DEFAULT_MAX_PARSER_OPERATIONS: usize = 100_000;
 
+/// Overall outcome of a parse attempt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParseStatus {
+    /// The parse completed without recovery diagnostics.
     Clean,
+    /// The parse completed, but required recovery diagnostics.
     Recovered,
+    /// The parse failed with a terminal error.
     Fatal,
 }
 
+/// One branch separator recognized inside a zsh `case` pattern group.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZshCaseGroupPart {
+    /// Index of the owning pattern part within the parsed pattern.
     pub pattern_part_index: usize,
+    /// Source span covering the separator syntax.
     pub span: Span,
 }
 
+/// Additional parser-owned facts that are useful to downstream consumers.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SyntaxFacts {
+    /// Spans of zsh brace-style `if` bodies.
     pub zsh_brace_if_spans: Vec<Span>,
+    /// Spans of zsh `always` clauses.
     pub zsh_always_spans: Vec<Span>,
+    /// Pattern-group separators collected from zsh `case` items.
     pub zsh_case_group_parts: Vec<ZshCaseGroupPart>,
 }
 
@@ -94,22 +106,33 @@ pub struct SyntaxFacts {
 /// syntax facts collected along the way.
 #[derive(Debug, Clone)]
 pub struct ParseResult {
+    /// Parsed syntax tree for the file.
     pub file: File,
+    /// Recovery diagnostics emitted while producing the AST.
     pub diagnostics: Vec<ParseDiagnostic>,
+    /// High-level parse status.
     pub status: ParseStatus,
+    /// Terminal parse error, when recovery could not continue.
     pub terminal_error: Option<Error>,
+    /// Additional syntax facts collected during parsing.
     pub syntax_facts: SyntaxFacts,
 }
 
 impl ParseResult {
+    /// Returns `true` when the parse completed without recovery diagnostics.
     pub fn is_ok(&self) -> bool {
         self.status == ParseStatus::Clean
     }
 
+    /// Returns `true` when the parse produced recovery diagnostics or a terminal error.
     pub fn is_err(&self) -> bool {
         !self.is_ok()
     }
 
+    /// Convert this result into a strict parse error.
+    ///
+    /// If recovery diagnostics exist but no terminal error was recorded, the first recovery
+    /// diagnostic is converted into an [`Error`].
     pub fn strict_error(&self) -> Error {
         self.terminal_error.clone().unwrap_or_else(|| {
             let diagnostic = self
@@ -124,6 +147,7 @@ impl ParseResult {
         })
     }
 
+    /// Return the parse result when it is clean, otherwise panic with the strict error.
     pub fn unwrap(self) -> Self {
         if self.is_ok() {
             self
@@ -135,6 +159,7 @@ impl ParseResult {
         }
     }
 
+    /// Return the parse result when it is clean, otherwise panic with `message`.
     pub fn expect(self, message: &str) -> Self {
         if self.is_ok() {
             self
@@ -143,6 +168,7 @@ impl ParseResult {
         }
     }
 
+    /// Return the strict parse error when the result is not clean, otherwise panic.
     pub fn unwrap_err(self) -> Error {
         if self.is_err() {
             self.strict_error()
@@ -151,6 +177,8 @@ impl ParseResult {
         }
     }
 
+    /// Return the strict parse error when the result is not clean, otherwise panic with
+    /// `message`.
     pub fn expect_err(self, message: &str) -> Error {
         if self.is_err() {
             self.strict_error()
@@ -164,8 +192,11 @@ impl ParseResult {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[doc(hidden)]
 pub struct ParserBenchmarkCounters {
+    /// Number of lexer current-position lookups performed while parsing.
     pub lexer_current_position_calls: u64,
+    /// Number of parser calls that updated the current spanned token.
     pub parser_set_current_spanned_calls: u64,
+    /// Number of raw token-advance operations performed by the parser.
     pub parser_advance_raw_calls: u64,
 }
 
@@ -242,32 +273,44 @@ enum Command {
     AnonymousFunction(AnonymousFunctionCommand, SmallVec<[Redirect; 1]>),
 }
 
+/// Supported shell dialects for parsing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ShellDialect {
+    /// POSIX-style parsing used for `sh`, `dash`, and generic portable shell input.
     Posix,
+    /// mksh-specific parsing.
     Mksh,
+    /// Bash parsing.
     #[default]
     Bash,
+    /// zsh parsing.
     Zsh,
 }
 
+/// Tri-state option value used when modeling zsh option state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum OptionValue {
+    /// The option is enabled.
     On,
+    /// The option is disabled.
     Off,
+    /// The option value is unknown or differs across merged states.
     #[default]
     Unknown,
 }
 
 impl OptionValue {
+    /// Returns `true` when the option is known to be enabled.
     pub const fn is_definitely_on(self) -> bool {
         matches!(self, Self::On)
     }
 
+    /// Returns `true` when the option is known to be disabled.
     pub const fn is_definitely_off(self) -> bool {
         matches!(self, Self::Off)
     }
 
+    /// Merge two option values, preserving certainty only when they agree.
     pub const fn merge(self, other: Self) -> Self {
         match (self, other) {
             (Self::On, Self::On) => Self::On,
@@ -277,42 +320,75 @@ impl OptionValue {
     }
 }
 
+/// Target emulation mode for zsh's `emulate` behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ZshEmulationMode {
+    /// Native zsh behavior.
     Zsh,
+    /// `sh` compatibility mode.
     Sh,
+    /// `ksh` compatibility mode.
     Ksh,
+    /// `csh` compatibility mode.
     Csh,
 }
 
+/// Snapshot of zsh option state used by the parser and lexer.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ZshOptionState {
+    /// State of the `sh_word_split` option.
     pub sh_word_split: OptionValue,
+    /// State of the `glob_subst` option.
     pub glob_subst: OptionValue,
+    /// State of the `rc_expand_param` option.
     pub rc_expand_param: OptionValue,
+    /// State of the `glob` option.
     pub glob: OptionValue,
+    /// State of the `nomatch` option.
     pub nomatch: OptionValue,
+    /// State of the `null_glob` option.
     pub null_glob: OptionValue,
+    /// State of the `csh_null_glob` option.
     pub csh_null_glob: OptionValue,
+    /// State of the `extended_glob` option.
     pub extended_glob: OptionValue,
+    /// State of the `ksh_glob` option.
     pub ksh_glob: OptionValue,
+    /// State of the `sh_glob` option.
     pub sh_glob: OptionValue,
+    /// State of the `bare_glob_qual` option.
     pub bare_glob_qual: OptionValue,
+    /// State of the `glob_dots` option.
     pub glob_dots: OptionValue,
+    /// State of the `equals` option.
     pub equals: OptionValue,
+    /// State of the `magic_equal_subst` option.
     pub magic_equal_subst: OptionValue,
+    /// State of the `sh_file_expansion` option.
     pub sh_file_expansion: OptionValue,
+    /// State of the `glob_assign` option.
     pub glob_assign: OptionValue,
+    /// State of the `ignore_braces` option.
     pub ignore_braces: OptionValue,
+    /// State of the `ignore_close_braces` option.
     pub ignore_close_braces: OptionValue,
+    /// State of the `brace_ccl` option.
     pub brace_ccl: OptionValue,
+    /// State of the `ksh_arrays` option.
     pub ksh_arrays: OptionValue,
+    /// State of the `ksh_zero_subscript` option.
     pub ksh_zero_subscript: OptionValue,
+    /// State of the `short_loops` option.
     pub short_loops: OptionValue,
+    /// State of the `short_repeat` option.
     pub short_repeat: OptionValue,
+    /// State of the `rc_quotes` option.
     pub rc_quotes: OptionValue,
+    /// State of the `interactive_comments` option.
     pub interactive_comments: OptionValue,
+    /// State of the `c_bases` option.
     pub c_bases: OptionValue,
+    /// State of the `octal_zeroes` option.
     pub octal_zeroes: OptionValue,
 }
 
@@ -348,6 +424,7 @@ enum ZshOptionField {
 }
 
 impl ZshOptionState {
+    /// Default zsh option state used for native zsh parsing.
     pub const fn zsh_default() -> Self {
         Self {
             sh_word_split: OptionValue::Off,
@@ -380,6 +457,7 @@ impl ZshOptionState {
         }
     }
 
+    /// Option state implied by `emulate <mode>`.
     pub fn for_emulate(mode: ZshEmulationMode) -> Self {
         let mut state = Self::zsh_default();
         match mode {
@@ -409,10 +487,16 @@ impl ZshOptionState {
         state
     }
 
+    /// Apply a zsh `setopt`-style option name.
+    ///
+    /// Returns `true` when the option name was recognized.
     pub fn apply_setopt(&mut self, name: &str) -> bool {
         self.apply_named_option(name, true)
     }
 
+    /// Apply a zsh `unsetopt`-style option name.
+    ///
+    /// Returns `true` when the option name was recognized.
     pub fn apply_unsetopt(&mut self, name: &str) -> bool {
         self.apply_named_option(name, false)
     }
@@ -481,6 +565,7 @@ impl ZshOptionState {
         }
     }
 
+    /// Merge two option snapshots field by field.
     pub fn merge(&self, other: &Self) -> Self {
         let mut merged = Self::zsh_default();
         for field in ZshOptionField::ALL {
@@ -537,13 +622,17 @@ impl ZshOptionField {
     ];
 }
 
+/// Dialect plus optional zsh option state used to configure the lexer and parser.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShellProfile {
+    /// Shell dialect to parse.
     pub dialect: ShellDialect,
+    /// Optional zsh option state, used only for zsh parsing.
     pub options: Option<ZshOptionState>,
 }
 
 impl ShellProfile {
+    /// Build a native profile for `dialect`.
     pub fn native(dialect: ShellDialect) -> Self {
         Self {
             dialect,
@@ -551,6 +640,7 @@ impl ShellProfile {
         }
     }
 
+    /// Build a profile with explicit zsh option state.
     pub fn with_zsh_options(dialect: ShellDialect, options: ZshOptionState) -> Self {
         Self {
             dialect,
@@ -558,6 +648,7 @@ impl ShellProfile {
         }
     }
 
+    /// Borrow the zsh option state, if this profile carries one.
     pub fn zsh_options(&self) -> Option<&ZshOptionState> {
         self.options.as_ref()
     }
@@ -1361,6 +1452,7 @@ struct DialectFeatures {
 }
 
 impl ShellDialect {
+    /// Infer a shell dialect from a command or shebang name.
     pub fn from_name(name: &str) -> Self {
         match name.trim().to_ascii_lowercase().as_str() {
             "sh" | "dash" | "ksh" | "posix" => Self::Posix,
@@ -1506,7 +1598,9 @@ struct ParserCheckpoint<'a> {
 /// A parser diagnostic emitted while recovering from invalid input.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseDiagnostic {
+    /// Human-readable diagnostic message.
     pub message: String,
+    /// Source span associated with the diagnostic.
     pub span: Span,
 }
 
@@ -1758,6 +1852,7 @@ impl<'a> Parser<'a> {
         Self::with_limits_and_profile(input, max_depth, max_fuel, ShellProfile::native(dialect))
     }
 
+    /// Create a new parser with custom depth, fuel, and shell-profile settings.
     pub fn with_limits_and_profile(
         input: &'a str,
         max_depth: usize,
@@ -1857,10 +1952,12 @@ impl<'a> Parser<'a> {
         )
     }
 
+    /// Return the dialect associated with this parser.
     pub fn dialect(&self) -> ShellDialect {
         self.dialect
     }
 
+    /// Borrow the full shell profile associated with this parser.
     pub fn shell_profile(&self) -> &ShellProfile {
         &self.shell_profile
     }

--- a/crates/shuck-semantic/Cargo.toml
+++ b/crates/shuck-semantic/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "Semantic analysis model for shell scripts with scopes, bindings, and dataflow"
 keywords = ["shell", "bash", "semantic-analysis", "static-analysis"]
 categories = ["development-tools"]
+readme = "README.md"
 
 [dependencies]
 bitflags = "2"

--- a/crates/shuck-semantic/README.md
+++ b/crates/shuck-semantic/README.md
@@ -1,0 +1,7 @@
+# shuck-semantic
+
+`shuck-semantic` builds semantic models for shell scripts on top of parsed syntax.
+
+It tracks scopes, bindings, references, control-flow, source references, and selected dataflow
+facts so higher-level tooling can reason about shell behavior. The crate is published as part of
+the Shuck workspace and is still pre-1.0.

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1,8 +1,9 @@
 #![warn(missing_docs)]
 
-//! Semantic analysis model for shell scripts.
-
-#[allow(missing_docs)]
+//! Semantic analysis for shell scripts parsed by Shuck.
+//!
+//! The semantic model tracks scopes, bindings, references, control flow, and selected dataflow
+//! facts so higher-level crates can reason about shell behavior without re-traversing the AST.
 mod binding;
 #[allow(missing_docs)]
 mod builder;

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! The semantic model tracks scopes, bindings, references, control flow, and selected dataflow
 //! facts so higher-level crates can reason about shell behavior without re-traversing the AST.
+#[allow(missing_docs)]
 mod binding;
 #[allow(missing_docs)]
 mod builder;

--- a/crates/shuck/Cargo.toml
+++ b/crates/shuck/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "A fast shell script linter"
 keywords = ["shell", "bash", "linter", "static-analysis", "cli"]
 categories = ["command-line-utilities", "development-tools"]
+readme = "README.md"
 
 [dependencies]
 annotate-snippets = { workspace = true }

--- a/crates/shuck/README.md
+++ b/crates/shuck/README.md
@@ -1,0 +1,9 @@
+# shuck
+
+`shuck` is the command-line shell checker and formatter in the Shuck workspace.
+
+This crate is published so the binary, integration tests, and benchmarks can share the same
+argument parsing and command execution logic. Most users should install and run the `shuck`
+binary instead of depending on this crate directly.
+
+The Rust API is still pre-1.0 and may change between `0.x` releases.

--- a/crates/shuck/src/args.rs
+++ b/crates/shuck/src/args.rs
@@ -1,3 +1,5 @@
+//! Command-line argument types and parsing helpers for the `shuck` CLI.
+
 use std::ffi::OsString;
 use std::path::PathBuf;
 
@@ -20,12 +22,18 @@ const STYLES: Styles = Styles::styled()
     .placeholder(AnsiColor::Cyan.on_default());
 const EXPERIMENTAL_ENV_VAR: &str = "SHUCK_EXPERIMENTAL";
 
+/// Shell dialect override accepted by `shuck format`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum FormatDialectArg {
+    /// Detect the dialect from the source and file path when possible.
     Auto,
+    /// Parse and format as Bash.
     Bash,
+    /// Parse and format as a POSIX-style shell.
     Posix,
+    /// Parse and format as mksh.
     Mksh,
+    /// Parse and format as zsh.
     Zsh,
 }
 
@@ -41,9 +49,12 @@ impl From<FormatDialectArg> for ShellDialect {
     }
 }
 
+/// Indentation styles accepted by `shuck format`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum FormatIndentStyleArg {
+    /// Indent with tab characters.
     Tab,
+    /// Indent with spaces.
     Space,
 }
 
@@ -56,20 +67,32 @@ impl From<FormatIndentStyleArg> for IndentStyle {
     }
 }
 
+/// Output formats supported by `shuck check`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum CheckOutputFormatArg {
+    /// Emit one diagnostic per line.
     Concise,
+    /// Emit rich human-readable diagnostics.
     Full,
+    /// Emit a JSON array of diagnostics.
     Json,
+    /// Emit one JSON object per line.
     JsonLines,
+    /// Emit JUnit XML.
     Junit,
+    /// Emit grouped human-readable diagnostics.
     Grouped,
+    /// Emit GitHub Actions workflow commands.
     Github,
+    /// Emit GitLab code quality output.
     Gitlab,
+    /// Emit Reviewdog RDJSON.
     Rdjson,
+    /// Emit SARIF.
     Sarif,
 }
 
+/// Color preference for terminal output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum TerminalColor {
     /// Display colors if the output goes to an interactive terminal.
@@ -162,23 +185,29 @@ enum ExperimentalCommand {
     Clean(CleanCommand),
 }
 
+/// Parsed top-level arguments for the `shuck` command.
 #[derive(Debug, Clone)]
 pub struct Args {
+    /// Override for the cache root directory.
     pub cache_dir: Option<PathBuf>,
     pub(crate) config: ConfigArguments,
     pub(crate) color: Option<TerminalColor>,
+    /// The subcommand selected by the user.
     pub command: Command,
 }
 
 impl Args {
+    /// Parse arguments from the current process and exit on invalid input.
     pub fn parse() -> Self {
         Self::try_parse().unwrap_or_else(|err| err.exit())
     }
 
+    /// Parse arguments from the current process without exiting on errors.
     pub fn try_parse() -> Result<Self, clap::Error> {
         Self::try_parse_from(std::env::args_os())
     }
 
+    /// Parse arguments from an arbitrary iterator of command-line values.
     pub fn try_parse_from<I, T>(itr: I) -> Result<Self, clap::Error>
     where
         I: IntoIterator<Item = T>,
@@ -247,6 +276,7 @@ impl Args {
     }
 }
 
+/// Supported `shuck` subcommands.
 #[derive(Debug, Clone, Subcommand)]
 pub enum Command {
     /// Parse shell files and report syntax failures.
@@ -266,6 +296,7 @@ fn experimental_enabled() -> bool {
     })
 }
 
+/// Arguments for `shuck check`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct CheckCommand {
     /// Apply safe fixes.
@@ -300,8 +331,10 @@ pub struct CheckCommand {
     pub watch: bool,
     /// Files or directories to check.
     pub paths: Vec<PathBuf>,
+    /// Rule selection and suppression settings.
     #[command(flatten)]
     pub rule_selection: RuleSelectionArgs,
+    /// File discovery and exclusion settings.
     #[command(flatten)]
     pub file_selection: FileSelectionArgs,
     /// Disable cache reads and writes.
@@ -316,18 +349,23 @@ pub struct CheckCommand {
 }
 
 impl CheckCommand {
+    /// Whether standard ignore files such as `.gitignore` should be respected.
     pub fn respect_gitignore(&self) -> bool {
         self.file_selection.respect_gitignore()
     }
 
+    /// Whether excludes should also apply to explicitly passed paths.
     pub fn force_exclude(&self) -> bool {
         self.file_selection.force_exclude()
     }
 }
 
+/// A `<pattern>:<rule-selector>` mapping from the CLI.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PatternRuleSelectorPair {
+    /// Glob-style file pattern.
     pub pattern: String,
+    /// Rule selector applied to matching files.
     pub selector: RuleSelector,
 }
 
@@ -361,6 +399,7 @@ fn parse_cli_rule_selector(value: &str) -> Result<RuleSelector, String> {
     value.parse::<RuleSelector>().map_err(|err| err.to_string())
 }
 
+/// Rule-selection flags shared by `shuck check`.
 #[derive(Debug, Clone, Default, ClapArgs)]
 pub struct RuleSelectionArgs {
     /// Comma-separated list of rule codes to enable (or ALL, to enable all rules).
@@ -495,6 +534,7 @@ fn preparse_color(args: &[OsString]) -> Option<ColorChoice> {
     color
 }
 
+/// File-discovery and exclusion flags shared by multiple commands.
 #[derive(Debug, Clone, Default, ClapArgs)]
 pub struct FileSelectionArgs {
     /// List of paths, used to omit files and/or directories from analysis.
@@ -536,15 +576,18 @@ pub struct FileSelectionArgs {
 }
 
 impl FileSelectionArgs {
+    /// Resolve the effective `respect_gitignore` setting after CLI overrides.
     pub fn respect_gitignore(&self) -> bool {
         resolve_bool_flag(self.respect_gitignore, self.no_respect_gitignore, true)
     }
 
+    /// Resolve the effective `force_exclude` setting after CLI overrides.
     pub fn force_exclude(&self) -> bool {
         resolve_bool_flag(self.force_exclude, self.no_force_exclude, false)
     }
 }
 
+/// Arguments for `shuck format`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct FormatCommand {
     /// List of files or directories to format, or `-` to read from stdin.
@@ -561,6 +604,7 @@ pub struct FormatCommand {
     /// The name of the file when reading the source from stdin.
     #[arg(long)]
     pub stdin_filename: Option<PathBuf>,
+    /// File discovery and exclusion settings.
     #[command(flatten)]
     pub file_selection: FileSelectionArgs,
     /// Override the auto-discovered shell dialect used for parsing and formatting.
@@ -643,34 +687,42 @@ impl FormatCommand {
         }
     }
 
+    /// Resolve the effective `binary-next-line` formatter option.
     pub fn binary_next_line(&self) -> Option<bool> {
         tri_state_bool(self.binary_next_line, self.no_binary_next_line)
     }
 
+    /// Resolve the effective `switch-case-indent` formatter option.
     pub fn switch_case_indent(&self) -> Option<bool> {
         tri_state_bool(self.switch_case_indent, self.no_switch_case_indent)
     }
 
+    /// Resolve the effective `space-redirects` formatter option.
     pub fn space_redirects(&self) -> Option<bool> {
         tri_state_bool(self.space_redirects, self.no_space_redirects)
     }
 
+    /// Resolve the effective `keep-padding` formatter option.
     pub fn keep_padding(&self) -> Option<bool> {
         tri_state_bool(self.keep_padding, self.no_keep_padding)
     }
 
+    /// Resolve the effective `function-next-line` formatter option.
     pub fn function_next_line(&self) -> Option<bool> {
         tri_state_bool(self.function_next_line, self.no_function_next_line)
     }
 
+    /// Resolve the effective `never-split` formatter option.
     pub fn never_split(&self) -> Option<bool> {
         tri_state_bool(self.never_split, self.no_never_split)
     }
 
+    /// Whether standard ignore files such as `.gitignore` should be respected.
     pub fn respect_gitignore(&self) -> bool {
         self.file_selection.respect_gitignore()
     }
 
+    /// Whether excludes should also apply to explicitly passed paths.
     pub fn force_exclude(&self) -> bool {
         self.file_selection.force_exclude()
     }
@@ -699,6 +751,7 @@ fn resolve_bool_flag(positive: bool, negative: bool, default: bool) -> bool {
     }
 }
 
+/// Arguments for `shuck clean`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct CleanCommand {
     /// Files or directories whose project caches should be removed.

--- a/crates/shuck/src/lib.rs
+++ b/crates/shuck/src/lib.rs
@@ -1,9 +1,12 @@
 #![warn(missing_docs)]
 
-//! Programmatic entry points for the `shuck` CLI.
+//! Library entrypoints for the `shuck` CLI.
+//!
+//! This crate primarily exists so the command-line binary, tests, and benchmarks can share the
+//! same argument parsing and command execution code. Most users should invoke the `shuck` binary
+//! directly rather than depend on this library API.
 
-/// Command-line argument types and parsing helpers.
-#[allow(missing_docs)]
+/// Command-line argument types and parsing helpers for the `shuck` executable.
 pub mod args;
 
 mod cache;
@@ -25,12 +28,14 @@ use anyhow::Result;
 use crate::args::{Args, Command, FormatCommand, TerminalColor};
 use crate::config::ConfigArguments;
 
-/// Process exit codes returned by the CLI.
-#[allow(missing_docs)]
+/// Exit status returned by [`run`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ExitStatus {
+    /// The command completed successfully without reporting failures.
     Success,
+    /// The command completed, but reported lint or formatting failures.
     Failure,
+    /// The command failed due to invalid input, I/O, or another runtime error.
     Error,
 }
 
@@ -44,7 +49,7 @@ impl From<ExitStatus> for ExitCode {
     }
 }
 
-/// Runs the CLI with pre-parsed arguments.
+/// Run a parsed `shuck` command and return the resulting process status.
 pub fn run(args: Args) -> Result<ExitStatus> {
     let Args {
         cache_dir,


### PR DESCRIPTION
## Summary

Improve release-facing documentation across the publishable crates in the workspace.

- add crate-specific README files and point each publishable crate manifest at its local README
- add crate-level rustdoc for each publishable library crate
- document the highest-impact public APIs in `shuck`, `shuck-parser`, and `shuck-indexer`
- capture the lockfile update needed for the existing `shuck-semantic` dependency set

## Why

The pre-release audit showed that the workspace would publish multiple library crates to crates.io, but several of them either pointed at the top-level CLI README or exposed public APIs without enough release-facing documentation. This change makes docs.rs and crates.io metadata much more intentional before the first release.

## Impact

- `shuck`, `shuck-parser`, and `shuck-indexer` now pass `-W missing-docs`
- every publishable crate now has a crate-specific README for crates.io/docs.rs
- the remaining missing-docs work is concentrated in deeper library crates instead of the main release-facing surfaces

## Validation

- `cargo fmt`
- `cargo rustdoc -p shuck --lib -- -W missing-docs`
- `cargo rustdoc -p shuck-parser --lib -- -W missing-docs`
- `cargo rustdoc -p shuck-indexer --lib -- -W missing-docs`
- workspace sweep with `cargo rustdoc -p <crate> --lib -- -W missing-docs` for all publishable crates
