### PR TITLE
docs: prepare repo for public OSS release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for contributing to shuck!
+
+Before opening this PR, please confirm:
+
+- [ ] You have read CONTRIBUTING.md and CLEAN_ROOM.md.
+- [ ] The PR title follows Conventional Commits (e.g. `feat(linter): add C042`, `fix(parser): handle nested heredocs`). The title is what lands on `main` and drives release-please.
+- [ ] No ShellCheck source, wiki content, or verbatim diagnostic text has been copied into this change.
+-->
+
+## Summary
+
+<!-- What does this change do, and why? Link the issue it closes if applicable. -->
+
+## Changes
+
+<!-- Bullet the user-visible or structural changes. -->
+-
+-
+
+## Test plan
+
+<!-- How did you verify this works? Tick what applies; add commands you ran. -->
+- [ ] `make check` (fmt + clippy + udeps)
+- [ ] `make test`
+- [ ] `make test-large-corpus` (for rule changes that affect conformance)
+- [ ] Added or updated unit / integration / insta snapshot tests
+- [ ] Manually exercised the CLI where relevant
+
+## Notes for reviewers
+
+<!-- Anything non-obvious: trade-offs, follow-ups, known limitations. -->

--- a/CLEAN_ROOM.md
+++ b/CLEAN_ROOM.md
@@ -1,6 +1,4 @@
-# AGENTS.md
-
-## Clean-Room Policy
+# Clean-Room Policy
 
 This project is a clean-room reimplementation of ShellCheck. To preserve the integrity of the independent authoring process, the following rules **must** be followed at all times.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the project maintainers by opening a report at <https://github.com/ewhauser/shuck/security/advisories/new>. (GitHub's private vulnerability reporting is used as a private channel for both security and conduct reports until a dedicated address is set up.) All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing to Shuck! This guide covers how to build, test, and add lint rules.
 
+By participating in this project you agree to abide by its [Code of Conduct](CODE_OF_CONDUCT.md). Please also read [CLEAN_ROOM.md](CLEAN_ROOM.md) before looking at ShellCheck internals — shuck is a clean-room reimplementation and contributions must preserve that.
+
 ## Prerequisites
 
 - **Rust** stable toolchain (pinned in `rust-toolchain.toml`; includes `rustfmt` and `clippy`)

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Disable caching with `--no-cache` or remove a project's cache entries with `shuc
 
 Shuck builds on ideas and inspiration from several excellent open-source projects. This section is a thank-you to those communities — it does not imply endorsement, affiliation, or any formal relationship between shuck and these projects.
 
-- **[bashkit](https://github.com/everruns/bashkit)** — Source of the bash lexer and parser that powers shuck-parser.
+- **[bashkit](https://github.com/everruns/bashkit)** — shuck-parser was originally forked from bashkit's bash lexer and parser; it has since evolved substantially to meet the needs of a linter (comment and trivia preservation, error recovery, multi-dialect parse views, extended AST coverage).
 - **[Ruff](https://github.com/astral-sh/ruff)** — Linter architecture inspiration, particularly around caching, rule organization, and diagnostic output.
 - **[ShellCheck](https://github.com/koalaman/shellcheck)** — An amazing project and the original source of inspiration for shuck. ShellCheck set the standard for shell script analysis.
 - **[gbash](https://github.com/ewhauser/gbash)** — A lot of lessons learned from this earlier project carried forward into shuck.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,7 @@ Shuck is pre-1.0. Only the latest published release receives security updates. I
 
 **Please do not open a public GitHub issue for security problems.**
 
-Report vulnerabilities privately through one of the following:
-
-1. **GitHub private vulnerability reporting** — [open a report](https://github.com/ewhauser/shuck/security/advisories/new) on this repository. This is the preferred channel.
-2. **Email** — `ewhauser@gmail.com`.
+Report vulnerabilities privately via GitHub private vulnerability reporting — [open a report](https://github.com/ewhauser/shuck/security/advisories/new) on this repository.
 
 Please include:
 


### PR DESCRIPTION
## Summary

Closes a batch of OSS release-readiness gaps identified in an audit of docs, clean-room policy, and public contact paths. All changes are docs / project-meta — no code or CI is touched.

## Changes

- **CODE_OF_CONDUCT.md** — add Contributor Covenant 2.1 (text downloaded from the upstream EthicalSource repo; Hugo frontmatter stripped).
- **.github/pull_request_template.md** — new template prompting for Conventional Commits, clean-room compliance, and a test plan checklist.
- **CONTRIBUTING.md** — link new contributors to both the Code of Conduct and the clean-room policy up front.
- **CLEAN_ROOM.md** — fix the H1 (was a `# AGENTS.md` copy-paste) so the file actually reads as the clean-room policy.
- **README.md** — reframe the bashkit acknowledgement as "originally forked from bashkit; has since evolved substantially" with examples of the divergence, instead of implying current upstream parity.
- **SECURITY.md / CODE_OF_CONDUCT.md** — remove the personal Gmail contact; route vulnerability and conduct reports through GitHub private vulnerability reporting. A dedicated address can replace this later.

## Test plan

- [x] `make check` (fmt + clippy + udeps) — no Rust changes, but sanity-checked
- [x] Visual diff: rendered `CODE_OF_CONDUCT.md`, PR template, and README to confirm formatting
- [x] Verified no remaining `ewhauser@gmail.com` references in the tree (`grep -r`)

## Follow-ups (not in this PR)

- Stand up a dedicated `security@` / `conduct@` address and update both files.
- Higher-priority release readiness items from the audit remain (unwrap density in library crates, workspace `[lints]` table, docs.rs metadata, MSRV CI job, CLI `examples/`).