### PR TITLE
chore: tighten unwrap policy enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shuck"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1507,14 +1507,14 @@ dependencies = [
 
 [[package]]
 name = "shuck-ast"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "compact_str",
 ]
 
 [[package]]
 name = "shuck-benchmark"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion",
  "serde",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "shuck-cache"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bincode",
  "serde",
@@ -1541,14 +1541,14 @@ dependencies = [
 
 [[package]]
 name = "shuck-format"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "unicode-width 0.2.2",
 ]
 
 [[package]]
 name = "shuck-formatter"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "shuck-ast",
  "shuck-benchmark",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "shuck-indexer"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "shuck-ast",
  "shuck-parser",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "shuck-linter"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "globset",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "shuck-parser"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "memchr",
  "serde",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "shuck-semantic"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bitflags 2.11.0",
  "rustc-hash",

--- a/crates/shuck-ast/src/lib.rs
+++ b/crates/shuck-ast/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! AST, token, and span types shared across the Shuck workspace.
 //!

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! Shared benchmark fixtures and helpers for the shuck workspace.
 

--- a/crates/shuck-cache/src/lib.rs
+++ b/crates/shuck-cache/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! File-oriented cache keys and persistent package caches for Shuck.
 //!

--- a/crates/shuck-format/src/lib.rs
+++ b/crates/shuck-format/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! Generic document and pretty-printing primitives used by `shuck-formatter`.
 //!

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 //! Shell formatting entrypoints built on top of `shuck-parser` and `shuck-format`.
 //!
 //! Most callers will use [`format_source`] for source text or [`format_file_ast`] when they

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! Positional and structural indexes over parsed shell scripts.
 //!

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! Linting and fix application for shell scripts parsed by the Shuck toolchain.
 //!

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1381,7 +1381,10 @@ impl<'a> Lexer<'a> {
     /// or just a regular word starting with a digit
     fn read_word_or_fd_redirect(&mut self) -> Option<LexedToken<'a>> {
         if let Some(first_digit) = self.peek_char().filter(|ch| ch.is_ascii_digit()) {
-            let fd: i32 = first_digit.to_digit(10).unwrap() as i32;
+            let fd: i32 = first_digit
+                .to_digit(10)
+                .expect("peeked ASCII digit should convert to a base-10 digit")
+                as i32;
 
             match (self.second_char(), self.third_char()) {
                 (Some('>'), Some('>')) => {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2,16 +2,19 @@
 //!
 //! The parser is recursive descent and produces `shuck-ast` syntax trees while also collecting
 //! recovery diagnostics and lightweight syntax facts needed by downstream tooling.
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
-// Parser uses chars().next().unwrap() after validating character presence.
-// This is safe because we check bounds before accessing.
-#![allow(clippy::unwrap_used)]
-
+// Arithmetic parsing uses raw unwraps only after cursor checks guarantee the next token exists.
+#[allow(clippy::unwrap_used)]
 mod arithmetic;
+// Command parsing uses raw unwraps only after token-kind checks guarantee source-backed text.
+#[allow(clippy::unwrap_used)]
 mod commands;
 mod heredocs;
 mod lexer;
 mod redirects;
+// Word parsing uses raw unwraps only after cursor and segment checks guarantee bounds safety.
+#[allow(clippy::unwrap_used)]
 mod words;
 
 use std::{
@@ -6302,7 +6305,8 @@ impl<'a> Parser<'a> {
         chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
         cursor: &mut Position,
     ) -> char {
-        Self::next_word_char(chars, cursor).unwrap()
+        Self::next_word_char(chars, cursor)
+            .expect("word parser should only consume characters that were already peeked")
     }
 
     fn consume_word_char_if(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! Semantic analysis for shell scripts parsed by Shuck.
 //!

--- a/crates/shuck/src/discover.rs
+++ b/crates/shuck/src/discover.rs
@@ -239,11 +239,18 @@ fn collect_directory_parallel(
     let mut visitor = ShellFilesVisitorBuilder::new(input, cwd, exclude_matcher, &state);
     walker.visit(&mut visitor);
 
-    if let Some(error) = state.error.into_inner().unwrap() {
+    if let Some(error) = state
+        .error
+        .into_inner()
+        .map_err(|_| anyhow!("parallel discovery error state mutex poisoned"))?
+    {
         return Err(error);
     }
 
-    let mut matched_paths = state.matched_paths.into_inner().unwrap();
+    let mut matched_paths = state
+        .matched_paths
+        .into_inner()
+        .map_err(|_| anyhow!("parallel discovery matched-path state mutex poisoned"))?;
     matched_paths.sort();
     for matched_path in matched_paths {
         add_file(
@@ -310,12 +317,11 @@ impl ExplicitIgnoreCache {
             self.matchers.insert(key.clone(), gitignore);
         }
 
-        Ok(!self
+        let matcher = self
             .matchers
             .get(&key)
-            .unwrap()
-            .matched_path_or_any_parents(path, false)
-            .is_ignore())
+            .expect("gitignore matcher should be cached for the computed key");
+        Ok(!matcher.matched_path_or_any_parents(path, false).is_ignore())
     }
 }
 
@@ -486,15 +492,12 @@ impl ParallelVisitor for ShellFilesVisitor<'_> {
 impl Drop for ShellFilesVisitor<'_> {
     fn drop(&mut self) {
         if !self.local_paths.is_empty() {
-            self.state
-                .matched_paths
-                .lock()
-                .unwrap()
-                .append(&mut self.local_paths);
+            let mut matched_paths = lock_or_recover(&self.state.matched_paths);
+            matched_paths.append(&mut self.local_paths);
         }
 
         if let Some(error) = self.local_error.take() {
-            let mut state_error = self.state.error.lock().unwrap();
+            let mut state_error = lock_or_recover(&self.state.error);
             if state_error.is_none() {
                 *state_error = Some(error);
             }
@@ -554,6 +557,13 @@ pub(crate) fn display_path(path: &Path, cwd: &Path) -> PathBuf {
     path.strip_prefix(cwd)
         .map(Path::to_path_buf)
         .unwrap_or_else(|_| normalize_path(path))
+}
+
+fn lock_or_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 pub(crate) fn normalize_path(path: &Path) -> PathBuf {

--- a/crates/shuck/src/lib.rs
+++ b/crates/shuck/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! Library entrypoints for the `shuck` CLI.
 //!

--- a/crates/shuck/src/main.rs
+++ b/crates/shuck/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
+
 use std::io::Write;
 use std::process::ExitCode;
 


### PR DESCRIPTION
## Summary
This tightens the workspace `unwrap()` policy without fighting parser invariants.

## What changed
- enabled `clippy::unwrap_used` on non-parser crate roots outside tests
- moved parser unwrap allowances from a blanket module-level exemption to documented submodule-scoped allowances
- replaced a couple of standalone parser `unwrap()` calls with invariant-focused `expect(...)`
- removed production raw `unwrap()` usage from discovery parallel state handling by recovering poisoned mutexes or returning explicit errors

## Why
The workspace still had a mix of undocumented raw `unwrap()` usage in production code. Most remaining parser call sites are invariant-driven and performance-sensitive, but the policy itself was too broad and discovery still had avoidable runtime-path unwraps.

## Impact
- makes non-test unwrap usage visible to clippy across the non-parser crates
- documents where parser invariants justify scoped unwrap allowances
- hardens discovery error handling without changing public APIs

## Root cause
The parser had a blanket `allow(clippy::unwrap_used)` at the module root, and non-parser crates were not consistently enforcing the lint. That made it easy for production-path unwraps to persist without clear justification.

## Validation
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `make test`
- `cargo test -p shuck-parser`
