### PR TITLE
refactor: remove non-test unwraps

### DIFF
--- a/crates/shuck-benchmark/examples/parser_memory.rs
+++ b/crates/shuck-benchmark/examples/parser_memory.rs
@@ -246,7 +246,7 @@ fn parse_case_arg() -> Option<String> {
     }
 }
 
-fn main() {
+fn main() -> serde_json::Result<()> {
     let requested_case = parse_case_arg();
     let reports = if let Some(case_name) = requested_case {
         let Some(report) = single_case_report(&case_name) else {
@@ -261,6 +261,7 @@ fn main() {
             .collect::<Vec<_>>()
     };
 
-    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports).unwrap();
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports)?;
     println!();
+    Ok(())
 }

--- a/crates/shuck-benchmark/examples/semantic_memory.rs
+++ b/crates/shuck-benchmark/examples/semantic_memory.rs
@@ -246,7 +246,7 @@ fn parse_case_arg() -> Option<String> {
     }
 }
 
-fn main() {
+fn main() -> serde_json::Result<()> {
     let requested_case = parse_case_arg();
     let reports = if let Some(case_name) = requested_case {
         let Some(report) = single_case_report(&case_name) else {
@@ -261,6 +261,7 @@ fn main() {
             .collect::<Vec<_>>()
     };
 
-    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports).unwrap();
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports)?;
     println!();
+    Ok(())
 }

--- a/crates/shuck-parser/src/parser/arithmetic.rs
+++ b/crates/shuck-parser/src/parser/arithmetic.rs
@@ -502,7 +502,12 @@ impl<'a> ArithmeticParser<'a> {
         if self.peeked.is_none() {
             self.peeked = Some(self.lex_token()?);
         }
-        Ok(self.peeked.as_ref().unwrap())
+        self.peeked.as_ref().ok_or_else(|| {
+            self.error_at(
+                self.safe_position_at(self.index),
+                "internal arithmetic parser failed to cache lookahead token",
+            )
+        })
     }
 
     fn lex_token(&mut self) -> Result<Token> {
@@ -513,7 +518,7 @@ impl<'a> ArithmeticParser<'a> {
         }
 
         let start = self.index;
-        let ch = self.current_char().unwrap();
+        let ch = self.require_current_char()?;
 
         let token = if is_ident_start(ch) {
             self.lex_identifier_or_word(start)?
@@ -734,7 +739,7 @@ impl<'a> ArithmeticParser<'a> {
     fn scan_shell_word_end(&self, start: usize) -> Result<usize> {
         let mut index = start;
         while index < self.input.len() {
-            let ch = self.char_at(index).unwrap();
+            let ch = self.require_char_at(index)?;
             if index > start && (ch.is_whitespace() || self.is_arithmetic_boundary(ch)) {
                 break;
             }
@@ -753,7 +758,7 @@ impl<'a> ArithmeticParser<'a> {
     fn consume_single_quoted(&self, start: usize) -> Result<usize> {
         let mut index = start + 1;
         while index < self.input.len() {
-            let ch = self.char_at(index).unwrap();
+            let ch = self.require_char_at(index)?;
             index += ch.len_utf8();
             if ch == '\'' {
                 return Ok(index);
@@ -768,7 +773,7 @@ impl<'a> ArithmeticParser<'a> {
     fn consume_double_quoted(&self, start: usize) -> Result<usize> {
         let mut index = start + 1;
         while index < self.input.len() {
-            let ch = self.char_at(index).unwrap();
+            let ch = self.require_char_at(index)?;
             match ch {
                 '"' => return Ok(index + 1),
                 '\\' => index = self.consume_escape(index),
@@ -786,7 +791,7 @@ impl<'a> ArithmeticParser<'a> {
     fn consume_backticks(&self, start: usize) -> Result<usize> {
         let mut index = start + 1;
         while index < self.input.len() {
-            let ch = self.char_at(index).unwrap();
+            let ch = self.require_char_at(index)?;
             match ch {
                 '`' => return Ok(index + 1),
                 '\\' => index = self.consume_escape(index),
@@ -886,7 +891,7 @@ impl<'a> ArithmeticParser<'a> {
         let mut escaped = false;
 
         while index < self.input.len() {
-            let ch = self.char_at(index).unwrap();
+            let ch = self.require_char_at(index)?;
             if escaped {
                 escaped = false;
                 index += ch.len_utf8();
@@ -956,7 +961,7 @@ impl<'a> ArithmeticParser<'a> {
         let mut in_double = false;
 
         while index < self.input.len() {
-            let ch = self.char_at(index).unwrap();
+            let ch = self.require_char_at(index)?;
             if in_single {
                 index += ch.len_utf8();
                 if ch == '\'' {
@@ -1020,7 +1025,7 @@ impl<'a> ArithmeticParser<'a> {
         let mut in_double = false;
 
         while index < self.input.len() {
-            let ch = self.char_at(index).unwrap();
+            let ch = self.require_char_at(index)?;
             if in_single {
                 index += ch.len_utf8();
                 if ch == '\'' {
@@ -1085,7 +1090,7 @@ impl<'a> ArithmeticParser<'a> {
         let mut in_double = false;
 
         while index < self.input.len() {
-            let ch = self.char_at(index).unwrap();
+            let ch = self.require_char_at(index)?;
             if in_single {
                 index += ch.len_utf8();
                 if ch == '\'' {
@@ -1185,6 +1190,28 @@ impl<'a> ArithmeticParser<'a> {
 
     fn position_at(&self, index: usize) -> Position {
         self.base.start.advanced_by(&self.input[..index])
+    }
+
+    fn safe_position_at(&self, index: usize) -> Position {
+        let safe_index = if index <= self.input.len() && self.input.is_char_boundary(index) {
+            index
+        } else {
+            self.input.len()
+        };
+        self.position_at(safe_index)
+    }
+
+    fn require_current_char(&self) -> Result<char> {
+        self.require_char_at(self.index)
+    }
+
+    fn require_char_at(&self, index: usize) -> Result<char> {
+        self.char_at(index).ok_or_else(|| {
+            self.error_at(
+                self.safe_position_at(index),
+                "internal arithmetic parser cursor became invalid",
+            )
+        })
     }
 
     fn span_for(&self, start: usize, end: usize) -> Span {

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -4360,7 +4360,8 @@ impl<'a> Parser<'a> {
                     }
 
                     let is_literal = kind == TokenKind::LiteralWord;
-                    let word_text = self.current_source_like_word_text().unwrap();
+                    let word_text =
+                        self.current_source_like_word_text_or_error("simple command word")?;
                     let assignment_shape = (!is_literal && words.is_empty())
                         .then(|| Self::is_assignment(word_text.as_ref()));
                     let assignment_shape = assignment_shape.flatten();
@@ -4396,7 +4397,7 @@ impl<'a> Parser<'a> {
                         let saved_span = self.current_span;
                         self.advance();
                         if let Some(word) =
-                            self.try_parse_compound_array_arg(word_text.as_ref(), saved_span)
+                            self.try_parse_compound_array_arg(word_text.as_ref(), saved_span)?
                         {
                             words.push(word);
                             continue;

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -4,17 +4,11 @@
 //! recovery diagnostics and lightweight syntax facts needed by downstream tooling.
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
-// Arithmetic parsing uses raw unwraps only after cursor checks guarantee the next token exists.
-#[allow(clippy::unwrap_used)]
 mod arithmetic;
-// Command parsing uses raw unwraps only after token-kind checks guarantee source-backed text.
-#[allow(clippy::unwrap_used)]
 mod commands;
 mod heredocs;
 mod lexer;
 mod redirects;
-// Word parsing uses raw unwraps only after cursor and segment checks guarantee bounds safety.
-#[allow(clippy::unwrap_used)]
 mod words;
 
 use std::{
@@ -3473,6 +3467,17 @@ impl<'a> Parser<'a> {
             .filter(|kind| kind.is_word_like())
             .and(self.current_token.as_ref())
             .and_then(|token| self.token_source_like_word_text(token))
+    }
+
+    fn current_source_like_word_text_or_error(
+        &self,
+        context: &'static str,
+    ) -> Result<Cow<'a, str>> {
+        self.current_source_like_word_text().ok_or_else(|| {
+            self.error(format!(
+                "internal parser error: missing source text for {context}"
+            ))
+        })
     }
 
     fn keyword_from_token(token: &LexedToken<'_>) -> Option<Keyword> {

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -448,7 +448,7 @@ impl<'a> PatternParser<'a> {
     }
 
     fn is_escaped(&self, cursor: PatternCursor) -> bool {
-        let PatternSegment::Literal { text, .. } = self.segments.get(cursor.segment_index).unwrap()
+        let Some(PatternSegment::Literal { text, .. }) = self.segments.get(cursor.segment_index)
         else {
             return false;
         };
@@ -2771,9 +2771,9 @@ impl<'a> Parser<'a> {
         &mut self,
         saved_w: &str,
         saved_span: Span,
-    ) -> Option<Word> {
+    ) -> Result<Option<Word>> {
         if !self.at(TokenKind::LeftParen) {
-            return None;
+            return Ok(None);
         }
 
         let open_paren_span = self.current_span;
@@ -2788,7 +2788,7 @@ impl<'a> Parser<'a> {
                 self.advance();
             }
             let span = saved_span.merge(closing_span);
-            return Some(self.word_from_raw_text(&compound, span));
+            return Ok(Some(self.word_from_raw_text(&compound, span)));
         }
 
         self.advance(); // consume '('
@@ -2803,7 +2803,9 @@ impl<'a> Parser<'a> {
                     break;
                 }
                 Some(kind) if kind.is_word_like() => {
-                    let elem = self.current_source_like_word_text().unwrap();
+                    let elem = self.current_source_like_word_text_or_error(
+                        "compound array argument element",
+                    )?;
                     compound.push(' ');
                     compound.push_str(&elem);
                     self.advance();
@@ -2823,10 +2825,20 @@ impl<'a> Parser<'a> {
 
         if saved_span.start.offset <= span.end.offset && span.end.offset <= self.input.len() {
             let source = &self.input[saved_span.start.offset..span.end.offset];
-            return Some(self.decode_word_text(source, span, saved_span.start, true));
+            return Ok(Some(self.decode_word_text(
+                source,
+                span,
+                saved_span.start,
+                true,
+            )));
         }
 
-        Some(self.decode_word_text(&compound, span, saved_span.start, false))
+        Ok(Some(self.decode_word_text(
+            &compound,
+            span,
+            saved_span.start,
+            false,
+        )))
     }
 
     /// Parse a heredoc redirect (`<<` or `<<-`) and any trailing redirects on the same line.


### PR DESCRIPTION
## Summary
- remove non-test `unwrap()` usage from the benchmark examples and parser internals
- replace parser-side hidden unwrap assumptions with explicit invariant checks and propagated parse errors
- drop the parser module-level `clippy::unwrap_used` allowances now that the remaining runtime call sites are gone

## Why
The project is tightening unwrap policy enforcement, but a few non-test call sites still remained in compiled targets. Those sites either panicked directly or relied on broad Clippy allowances in parser modules, which made the policy harder to trust.

## Impact
This keeps the non-test lib/bin/example targets clean under `clippy::unwrap_used` without changing the public parser API. The benchmark examples now return serialization errors instead of panicking, and parser invariant failures surface as explicit internal parse errors.

## Validation
- `cargo clippy --workspace --lib --bins --examples -- -D clippy::unwrap_used`
- `cargo test -p shuck-parser --lib`
