### PR TITLE
ci: attach archives to GitHub Releases via draft flow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,31 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # When `"draft": true` is set in .release-please-config.json, release-please
+      # creates the GitHub Release as a draft. GitHub's API does not create the
+      # underlying Git tag for draft releases until they are published, so the
+      # tag-push triggers for release.yml (cargo-dist) and crates-publish.yml
+      # would never fire, deadlocking the pipeline. Create the tag explicitly
+      # here using RELEASE_PAT so the resulting push event dispatches those
+      # workflows. (GITHUB_TOKEN pushes do not trigger other workflows; PATs do.)
+      - name: Create tag for draft release
+        if: ${{ steps.release-please.outputs.releases_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ steps.release-please.outputs.tag_name }}
+          SHA: ${{ steps.release-please.outputs.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${REPO}/git/refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; nothing to do."
+            exit 0
+          fi
+          echo "Creating tag ${TAG} -> ${SHA}"
+          gh api "repos/${REPO}/git/refs" \
+            -f "ref=refs/tags/${TAG}" \
+            -f "sha=${SHA}"
+
   # Release-please updates Cargo.toml but does not touch Cargo.lock files.
   # Refresh both lockfiles on the release PR branch so `cargo publish --locked`
   # in crates-publish.yml sees matching internal crate versions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,10 +287,13 @@ jobs:
           RELEASE_COMMIT: "${{ github.sha }}"
           NEEDS_PLAN_OUTPUTS_TAG: ${{ needs.plan.outputs.tag }}
         run: |
-          # release-please creates the GitHub Release with changelog notes.
-          # If it exists, just upload artifacts to it; otherwise create one.
+          # release-please creates the GitHub Release as a draft with changelog
+          # notes. Upload archives to the draft, then publish it — this way the
+          # release only becomes visible (and immutable) once assets are attached.
+          # If release-please hasn't created one yet, fall back to creating it here.
           if gh release view "${NEEDS_PLAN_OUTPUTS_TAG}" >/dev/null 2>&1; then
             gh release upload "${NEEDS_PLAN_OUTPUTS_TAG}" artifacts/* --clobber
+            gh release edit "${NEEDS_PLAN_OUTPUTS_TAG}" --draft=false
           else
             echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
             gh release create "${NEEDS_PLAN_OUTPUTS_TAG}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -23,6 +23,7 @@
       "component": "shuck",
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
+      "draft": true,
       "extra-files": [
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.package.version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-cli'].version" },


### PR DESCRIPTION
## Summary

- v0.0.11 shipped without cargo-dist archives because the GitHub Release was created immutable by release-please before cargo-dist could upload assets — `gh release upload --clobber` is rejected on immutable releases.
- Switch release-please to create the release as a draft (`"draft": true` in `.release-please-config.json`). Drafts are mutable.
- After cargo-dist uploads archives to the draft, run `gh release edit "$TAG" --draft=false` to publish. GitHub only marks the release immutable at that point, by which time all assets are attached.

Net flow: release PR merges → tag + draft release (hidden) → cargo-dist builds + uploads archives → draft flipped to published with full asset set → GitHub marks immutable.

The edit to `.github/workflows/release.yml` is preserved across `cargo dist generate` runs via the existing `allow-dirty = ["ci"]` in `[workspace.metadata.dist]`.

## Test plan

- [ ] Merge this PR before the pending 0.0.12 release PR (#393) so v0.0.12 exercises the new flow
- [ ] After v0.0.12 ships, verify `https://github.com/ewhauser/shuck/releases/tag/v0.0.12` has the archive assets (`shuck-*.tar.gz`, `.zip`, installers, SBOM) attached and the release body matches `CHANGELOG.md`