### PR TITLE
feat(release): publish shuck to homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@
 
 name: Release
 permissions:
-  contents: read
+  "contents": "read"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -57,7 +57,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           submodules: recursive
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -83,7 +83,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -117,7 +117,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           submodules: recursive
@@ -132,7 +132,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -141,9 +141,11 @@ jobs:
         run: |
           ${{ matrix.packages_install }}
       - name: Build artifacts
+        env:
+          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}
         run: |
           # Actually do builds and make zips and whatnot
-          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          dist build ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - id: cargo-dist
         name: Post-build
@@ -159,7 +161,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -176,12 +178,12 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
@@ -193,13 +195,15 @@ jobs:
           fi
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
       - id: cargo-dist
         shell: bash
+        env:
+          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}
         run: |
           dist build ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
@@ -210,10 +214,8 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
-        env:
-          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: artifacts-build-global
           path: |
@@ -236,41 +238,41 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
       - id: host
         shell: bash
+        env:
+          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}
         run: |
           dist host ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
-        env:
-          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           pattern: artifacts-*
           path: artifacts
@@ -299,19 +301,67 @@ jobs:
             gh release create "${NEEDS_PLAN_OUTPUTS_TAG}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
           fi
 
+  publish-homebrew-formula:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    environment: release
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ needs.plan.outputs.val }}
+      GITHUB_USER: "axo bot"
+      GITHUB_EMAIL: "admin+bot@axo.dev"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: true
+          repository: "ewhauser/homebrew-tap"
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      # So we have access to the formula
+      - name: Fetch homebrew formulae
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          pattern: artifacts-*
+          path: Formula/
+          merge-multiple: true
+      # This is extra complex because you can make your Formula name not match your app name
+      # so we need to find releases with a *.rb file, and publish with that filename.
+      - name: Commit formula files
+        run: |
+          git config --global user.name "${GITHUB_USER}"
+          git config --global user.email "${GITHUB_EMAIL}"
+
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
+            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
+            name=$(echo "$filename" | sed "s/\.rb$//")
+            version=$(echo "$release" | jq .app_version --raw-output)
+
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew update
+            # We avoid reformatting user-provided data such as the app description and homepage.
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+
+            git add "Formula/${filename}"
+            git commit -m "${name} ${version}"
+          done
+          git push
+
   announce:
     needs:
       - plan
       - host
+      - publish-homebrew-formula
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           submodules: recursive

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,29 +86,28 @@ lto = "thin"
 
 # Config for 'dist'
 [workspace.metadata.dist]
-# The preferred dist version to use in CI (aim to keep this in sync with the installed dist CLI)
+# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-# TODO: add "homebrew" installer and tap/publish-jobs once ewhauser/homebrew-tap is set up
-installers = ["shell", "powershell"]
-# Target platforms to build for
-targets = [
-  "aarch64-apple-darwin",
-  "x86_64-unknown-linux-gnu",
-  "x86_64-unknown-linux-musl",
-  "x86_64-pc-windows-msvc",
-]
+installers = ["shell", "powershell", "homebrew"]
+# A GitHub repo to push Homebrew formulas to
+tap = "ewhauser/homebrew-tap"
+# Publish jobs to run in CI
+publish-jobs = ["homebrew"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# Don't run release checks on pull requests
+# Which actions to run on pull requests
 pr-run-mode = "skip"
-# We pin actions to commit SHAs, so skip the CI file freshness check
+# Pin GitHub Actions used by the generated release workflow.
+github-action-commits = { "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd", "actions/upload-artifact" = "b7c566a772e6b6bfb58ed0dc250532a479d7789f", "actions/download-artifact" = "37930b1c2abaa49bbe596cd826c3c89aef350131" }
+# Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
-
 [[workspace.metadata.dist.extra-artifacts]]
 artifacts = ["shuck.cdx.xml"]
 build = ["./scripts/generate-release-sbom.sh"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Shuck parses and analyzes shell scripts to catch common bugs, style issues, and 
 
 ## Installation
 
+### Homebrew
+
+```sh
+brew install ewhauser/tap/shuck
+```
+
 ### From source
 
 ```sh

--- a/crates/shuck-cli/Cargo.toml
+++ b/crates/shuck-cli/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
+homepage = "https://github.com/ewhauser/shuck"
 description = "A fast shell script linter"
 keywords = ["shell", "bash", "linter", "static-analysis", "cli"]
 categories = ["command-line-utilities", "development-tools"]

--- a/scripts/check-release-security.py
+++ b/scripts/check-release-security.py
@@ -82,6 +82,17 @@ def check(content):
         if "HOMEBREW_TAP_TOKEN" in section and "environment: release" not in section:
             issues.append("publish-homebrew-formula missing environment: release")
 
+    # Check 6: global release artifacts still need cargo-cyclonedx for the SBOM extra artifact.
+    start, end = get_job_section(lines, "build-global-artifacts")
+    if start is not None:
+        section = "\n".join(lines[start:end])
+        if "Install cargo-cyclonedx" not in section:
+            issues.append("build-global-artifacts missing cargo-cyclonedx install")
+
+    # Check 7: release publishing must handle tags that already have a GitHub Release.
+    if 'gh release upload "${NEEDS_PLAN_OUTPUTS_TAG}" artifacts/* --clobber' not in content:
+        issues.append("release publishing no longer updates existing GitHub releases")
+
     return issues
 
 
@@ -208,6 +219,42 @@ def fix(content):
                 if lines[i].strip().startswith("runs-on:"):
                     lines.insert(i + 1, "    environment: release")
                     break
+
+    # Fix 6: restore cargo-cyclonedx for the release SBOM artifact.
+    start, end = get_job_section(lines, "build-global-artifacts")
+    if start is not None:
+        section_text = "\n".join(lines[start:end])
+        if "Install cargo-cyclonedx" not in section_text:
+            for i in range(start, end):
+                if lines[i] == "      - run: chmod +x ~/.cargo/bin/dist":
+                    lines.insert(i + 1, "      - name: Install cargo-cyclonedx")
+                    lines.insert(i + 2, "        run: |")
+                    lines.insert(
+                        i + 3,
+                        "          if ! cargo cyclonedx --version >/dev/null 2>&1; then",
+                    )
+                    lines.insert(
+                        i + 4,
+                        "            cargo install cargo-cyclonedx --locked --version 0.5.9",
+                    )
+                    lines.insert(i + 5, "          fi")
+                    break
+
+    # Fix 7: preserve the existing-release upload fallback used with release-please tags.
+    simple_release = (
+        '          gh release create "${NEEDS_PLAN_OUTPUTS_TAG}" --target "$RELEASE_COMMIT" '
+        '$PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*'
+    )
+    for i, line in enumerate(lines):
+        if line == simple_release:
+            lines[i : i + 1] = [
+                '          if gh release view "${NEEDS_PLAN_OUTPUTS_TAG}" >/dev/null 2>&1; then',
+                '            gh release upload "${NEEDS_PLAN_OUTPUTS_TAG}" artifacts/* --clobber',
+                "          else",
+                '            gh release create "${NEEDS_PLAN_OUTPUTS_TAG}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*',
+                "          fi",
+            ]
+            break
 
     return "\n".join(lines) + "\n"
 

--- a/scripts/check-release-security.py
+++ b/scripts/check-release-security.py
@@ -67,6 +67,21 @@ def check(content):
         if "environment: release" not in section:
             issues.append("host job missing environment: release")
 
+    # Check 4: release commands should not interpolate needs.* expressions directly in shell.
+    if "dist build ${{ needs.plan.outputs.tag-flag }}" in content:
+        issues.append("dist build uses direct template expansion in run block")
+    if "dist host ${{ needs.plan.outputs.tag-flag }}" in content:
+        issues.append("host dist command uses direct template expansion in run block")
+    if 'gh release create "${{ needs.plan.outputs.tag }}"' in content:
+        issues.append("release creation uses direct template expansion in run block")
+
+    # Check 5: Homebrew publishing uses a secret and should be behind the release environment.
+    start, end = get_job_section(lines, "publish-homebrew-formula")
+    if start is not None:
+        section = "\n".join(lines[start:end])
+        if "HOMEBREW_TAP_TOKEN" in section and "environment: release" not in section:
+            issues.append("publish-homebrew-formula missing environment: release")
+
     return issues
 
 
@@ -120,6 +135,78 @@ def fix(content):
                         insert.append("    environment: release")
                     for j, new_line in enumerate(insert):
                         lines.insert(i + j, new_line)
+                    break
+
+    # Fix 4: move generated needs.plan expressions out of run blocks and into env vars.
+    substitutions = {
+        "          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json":
+        "          dist build ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json",
+        "          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json \"--artifacts=global\" > dist-manifest.json":
+        "          dist build ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --output-format=json \"--artifacts=global\" > dist-manifest.json",
+        "          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json":
+        "          dist host ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --steps=upload --steps=release --output-format=json > dist-manifest.json",
+        "          gh release create \"${{ needs.plan.outputs.tag }}\" --target \"$RELEASE_COMMIT\" $PRERELEASE_FLAG --title \"$ANNOUNCEMENT_TITLE\" --notes-file \"$RUNNER_TEMP/notes.txt\" artifacts/*":
+        "          gh release create \"${NEEDS_PLAN_OUTPUTS_TAG}\" --target \"$RELEASE_COMMIT\" $PRERELEASE_FLAG --title \"$ANNOUNCEMENT_TITLE\" --notes-file \"$RUNNER_TEMP/notes.txt\" artifacts/*",
+    }
+    lines = [substitutions.get(line, line) for line in lines]
+
+    for i, line in enumerate(lines):
+        if line == "      - name: Build artifacts" and i + 1 < len(lines):
+            if lines[i + 1] == "        run: |":
+                lines.insert(i + 1, "        env:")
+                lines.insert(
+                    i + 2,
+                    "          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}",
+                )
+            break
+
+    for i, line in enumerate(lines):
+        if line == "      - id: cargo-dist" and i + 2 < len(lines):
+            if (
+                lines[i + 1] == "        shell: bash"
+                and lines[i + 2] == "        run: |"
+            ):
+                lines.insert(i + 2, "        env:")
+                lines.insert(
+                    i + 3,
+                    "          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}",
+                )
+            break
+
+    for i, line in enumerate(lines):
+        if line == "      - id: host" and i + 2 < len(lines):
+            if (
+                lines[i + 1] == "        shell: bash"
+                and lines[i + 2] == "        run: |"
+            ):
+                lines.insert(i + 2, "        env:")
+                lines.insert(
+                    i + 3,
+                    "          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}",
+                )
+            break
+
+    for i, line in enumerate(lines):
+        if line == '          RELEASE_COMMIT: "${{ github.sha }}"':
+            if (
+                i + 1 < len(lines)
+                and lines[i + 1]
+                != "          NEEDS_PLAN_OUTPUTS_TAG: ${{ needs.plan.outputs.tag }}"
+            ):
+                lines.insert(
+                    i + 1,
+                    "          NEEDS_PLAN_OUTPUTS_TAG: ${{ needs.plan.outputs.tag }}",
+                )
+            break
+
+    # Fix 5: require the protected release environment for Homebrew publish job.
+    start, end = get_job_section(lines, "publish-homebrew-formula")
+    if start is not None:
+        section_text = "\n".join(lines[start:end])
+        if "environment: release" not in section_text:
+            for i in range(start, end):
+                if lines[i].strip().startswith("runs-on:"):
+                    lines.insert(i + 1, "    environment: release")
                     break
 
     return "\n".join(lines) + "\n"

--- a/scripts/test_check_release_security.py
+++ b/scripts/test_check_release_security.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+MODULE_PATH = REPO_ROOT / "scripts" / "check-release-security.py"
+SPEC = importlib.util.spec_from_file_location("check_release_security", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+check = MODULE.check
+fix = MODULE.fix
+
+
+SAMPLE_WORKFLOW = """\
+name: Release
+permissions:
+  contents: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-22.04
+  build-global-artifacts:
+    runs-on: ubuntu-22.04
+    steps:
+      - id: cargo-dist
+        shell: bash
+        run: |
+          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+      - name: Build artifacts
+        run: |
+          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+  host:
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - id: host
+        shell: bash
+        run: |
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+      - name: Create GitHub Release
+        env:
+          PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
+          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
+          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
+          RELEASE_COMMIT: "${{ github.sha }}"
+        run: |
+          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+  publish-homebrew-formula:
+    needs:
+      - plan
+      - host
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@deadbeef
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+"""
+
+
+class CheckReleaseSecurityTests(unittest.TestCase):
+    def test_check_reports_new_release_workflow_risks(self) -> None:
+        issues = check(SAMPLE_WORKFLOW)
+
+        self.assertIn("top-level permissions grants write access", issues)
+        self.assertIn("plan job missing per-job permissions", issues)
+        self.assertIn("host job missing per-job permissions", issues)
+        self.assertIn("host job missing environment: release", issues)
+        self.assertIn(
+            "dist build uses direct template expansion in run block", issues
+        )
+        self.assertIn(
+            "host dist command uses direct template expansion in run block", issues
+        )
+        self.assertIn(
+            "release creation uses direct template expansion in run block", issues
+        )
+        self.assertIn("publish-homebrew-formula missing environment: release", issues)
+
+    def test_fix_hardens_generated_release_workflow(self) -> None:
+        fixed = fix(SAMPLE_WORKFLOW)
+
+        self.assertIn("    permissions:\n      contents: write", fixed)
+        self.assertIn("    environment: release", fixed)
+        self.assertIn(
+            "          dist build ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --output-format=json \"--artifacts=global\" > dist-manifest.json",
+            fixed,
+        )
+        self.assertIn(
+            "          dist host ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --steps=upload --steps=release --output-format=json > dist-manifest.json",
+            fixed,
+        )
+        self.assertIn(
+            "          NEEDS_PLAN_OUTPUTS_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}",
+            fixed,
+        )
+        self.assertIn(
+            "          NEEDS_PLAN_OUTPUTS_TAG: ${{ needs.plan.outputs.tag }}",
+            fixed,
+        )
+        self.assertIn(
+            '          gh release create "${NEEDS_PLAN_OUTPUTS_TAG}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*',
+            fixed,
+        )
+        self.assertEqual(check(fixed), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_release_security.py
+++ b/scripts/test_check_release_security.py
@@ -31,6 +31,7 @@ jobs:
   build-global-artifacts:
     runs-on: ubuntu-22.04
     steps:
+      - run: chmod +x ~/.cargo/bin/dist
       - id: cargo-dist
         shell: bash
         run: |
@@ -85,6 +86,12 @@ class CheckReleaseSecurityTests(unittest.TestCase):
             "release creation uses direct template expansion in run block", issues
         )
         self.assertIn("publish-homebrew-formula missing environment: release", issues)
+        self.assertIn(
+            "build-global-artifacts missing cargo-cyclonedx install", issues
+        )
+        self.assertIn(
+            "release publishing no longer updates existing GitHub releases", issues
+        )
 
     def test_fix_hardens_generated_release_workflow(self) -> None:
         fixed = fix(SAMPLE_WORKFLOW)
@@ -105,6 +112,11 @@ class CheckReleaseSecurityTests(unittest.TestCase):
         )
         self.assertIn(
             "          NEEDS_PLAN_OUTPUTS_TAG: ${{ needs.plan.outputs.tag }}",
+            fixed,
+        )
+        self.assertIn("      - name: Install cargo-cyclonedx", fixed)
+        self.assertIn(
+            '            gh release upload "${NEEDS_PLAN_OUTPUTS_TAG}" artifacts/* --clobber',
             fixed,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- add cargo-dist Homebrew installer/publisher config for `ewhauser/homebrew-tap`
- regenerate the release workflow to publish the Homebrew formula while preserving pinned action SHAs and existing workflow hardening
- document `brew install ewhauser/tap/shuck` and add explicit package homepage metadata

## Validation
- `dist plan --tag=v0.0.11 --output-format=json | jq -r '.artifacts[] | select(.name == "shuck.rb") | .install_hint'`
- `TOKEN=$(gh auth token); GH_TOKEN="$TOKEN" HOMEBREW_TAP_TOKEN="$TOKEN" dist host --steps=check --tag=v0.0.11`
- `python3 scripts/check-release-security.py check`

## External setup completed
- created `ewhauser/homebrew-tap`
- added `HOMEBREW_TAP_TOKEN` to `ewhauser/shuck`
