### PR TITLE
ci(release): publish linux aarch64 binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tap = "ewhauser/homebrew-tap"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program


### PR DESCRIPTION
## Summary
- Add `aarch64-unknown-linux-gnu` and `aarch64-unknown-linux-musl` to the cargo-dist target list in `Cargo.toml`
- Releases will now ship native Linux arm64 artifacts (both glibc and musl) alongside the existing x86_64 and macOS builds
- Both targets build natively on GitHub's `ubuntu-22.04-arm` runners — no cross-compilation

## Test plan
- [ ] Confirm `dist plan` output includes both aarch64 linux targets with `ubuntu-22.04-arm` runner
- [ ] Next release tag produces `shuck-aarch64-unknown-linux-gnu.tar.xz` and `shuck-aarch64-unknown-linux-musl.tar.xz` assets
- [ ] Homebrew formula picks up the new linux arm64 bottle