### PR TITLE
fix(linter): suppress C001 on intentional empty clears

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -437,6 +437,14 @@ mod tests {
     }
 
     #[test]
+    fn pre_use_empty_initializer_in_used_family_is_suppressed() {
+        let source = "#!/bin/bash\nfoo=\nfoo=1\n: \"$foo\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn used_non_reportable_bindings_keep_dead_branch_arms_separate() {
         let source = "#!/bin/bash\nif a; then\n  foo=1\nelif b; then\n  foo+=x\n  echo \"$foo\"\nelse\n  foo=3\nfi\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -100,7 +100,12 @@ pub fn unused_assignment(checker: &mut Checker) {
     let mut reportable_bindings = Vec::new();
     for (family, binding_ids) in unused_bindings_by_family {
         if families_with_used_bindings.contains(&family) {
-            reportable_bindings.extend(binding_ids);
+            reportable_bindings.extend(binding_ids.into_iter().filter(|binding_id| {
+                let binding = semantic.binding(*binding_id);
+                !binding
+                    .attributes
+                    .contains(BindingAttributes::EMPTY_INITIALIZER)
+            }));
             continue;
         }
 
@@ -393,6 +398,42 @@ mod tests {
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[1].span.start.line, 3);
+    }
+
+    #[test]
+    fn used_variable_empty_clear_is_suppressed() {
+        let source = "#!/bin/bash\nfoo=1\n: \"$foo\"\nfoo=\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn used_variable_quoted_empty_clear_is_suppressed() {
+        let source = "#!/bin/bash\nfoo=1\n: \"$foo\"\nfoo=\"\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn standalone_empty_initializer_is_still_reported() {
+        let source = "#!/bin/bash\nfoo=\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
+    }
+
+    #[test]
+    fn empty_clear_does_not_hide_prior_dead_reassignment() {
+        let source = "#!/bin/bash\nfoo=1\n: \"$foo\"\nfoo=2\nfoo=\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- suppress C001 for empty-string clear assignments after the variable family has already been used
- keep standalone empty initializers reportable so plain dead assignments still surface
- add regression coverage for bare clears, quoted clears, and earlier dead reassignments before a trailing clear

## Why
Shuck's family-level C001 reporting treated any later unused write as reportable once an earlier binding in the family had been read. That matched many overwrite cases, but it over-reported the common `var=` / `var=""` clear idiom that ShellCheck accepts when used to intentionally reset a variable after it has served its purpose.

## Validation
- `cargo test -p shuck-linter unused_assignment -- --nocapture`
- `cargo test -p shuck-linter`
