### PR TITLE
fix(linter): ignore unused for-loop counters in C001

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -164,7 +164,8 @@ fn participates_in_unused_assignment_family(
     is_reportable_unused_assignment(kind, attributes)
         || matches!(
             kind,
-            BindingKind::AppendAssignment
+            BindingKind::LoopVariable
+                | BindingKind::AppendAssignment
                 | BindingKind::ParameterDefaultAssignment
                 | BindingKind::Declaration(_)
         )
@@ -326,6 +327,23 @@ done
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.slice(source), "unused");
+    }
+
+    #[test]
+    fn used_loop_variables_keep_prior_dead_assignments_separate() {
+        let source = "\
+#!/bin/bash
+foo=1
+foo=2
+for foo in a b; do
+  printf '%s\\n' \"$foo\"
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[1].span.start.line, 3);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -142,12 +142,13 @@ fn is_reportable_unused_assignment(kind: BindingKind, attributes: BindingAttribu
     match kind {
         BindingKind::Assignment
         | BindingKind::ArrayAssignment
-        | BindingKind::LoopVariable
         | BindingKind::ReadTarget
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
         | BindingKind::ArithmeticAssignment => true,
+        // ShellCheck's default SC2034 behavior skips plain loop counters.
+        BindingKind::LoopVariable => false,
         BindingKind::AppendAssignment | BindingKind::ParameterDefaultAssignment => false,
         BindingKind::Declaration(_) => {
             attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
@@ -309,6 +310,22 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn ignores_unused_for_loop_counters() {
+        let source = "\
+#!/bin/bash
+unused=1
+for i in {0..5}; do
+  printf '%s\\n' retry
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.slice(source), "unused");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Exclude plain `for` loop counters from default C001/SC2034 reporting.
- Add a regression test covering an unused retry counter alongside a real dead assignment.

## Why
ShellCheck 0.11.0 skips plain loop counters for default SC2034 behavior, but shuck was still reporting them.

## Validation
- `cargo test -p shuck-linter unused_assignment -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10` (`implementation_diffs=0`; the overall harness still hit one unrelated existing parse mismatch in `.cache/large-corpus/scripts/juewuy__ShellCrash__scripts__starts__fw_nftables.sh`)