### PR TITLE
ci: rerun release-please after draft publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,12 +3,18 @@ name: Release Please
 on:
   push:
     branches: [main]
+  # Rerun when release.yml flips a draft release to published. The first run
+  # (from the push that merged the release PR) can't see its own just-created
+  # draft via the GitHub API and proposes a stale next-version PR. The rerun
+  # sees the published release and rewrites the PR with the correct version.
+  release:
+    types: [published]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,10 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
       - name: Create or update GitHub Release
         env:
+          # Use RELEASE_PAT (not GITHUB_TOKEN) so `gh release edit --draft=false`
+          # triggers the `release: published` event in release-please.yml.
+          # GITHUB_TOKEN-driven events don't cascade to other workflows.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
           ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"


### PR DESCRIPTION
## Summary
- Add `release: types: [published]` trigger to `release-please.yml` so it reruns after `release.yml` flips a draft release to published.
- Switch `release.yml`'s "Create or update GitHub Release" step to `RELEASE_PAT`; `GITHUB_TOKEN`-driven events don't dispatch other workflows, so without this the new trigger would never fire.
- Collapse the release-please concurrency group to `${{ github.workflow }}` so push-on-main and release-published runs serialize instead of racing on the same PR branch.

## Why
When a release PR merges, `release-please-action` creates the draft GitHub Release **and** proposes the next-version PR in the same step. The just-created draft isn't reliably visible via the GitHub API at that moment (`⚠ Expected 1 releases, only found 0` in the run log), so the next-version calculation falls back to stale history and proposes the wrong version — this is why we kept seeing "0.0.11" PRs opened after shipping 0.0.12, 0.0.13, and 0.0.14.

After this change, the sequence becomes:
1. Release PR merges → release-please-action creates draft release + (possibly stale) next-version PR.
2. `release.yml` builds artifacts and publishes the draft.
3. `release: published` fires → release-please reruns with correct state and rewrites the PR to the right version.

We can't avoid the stale-PR window entirely without dropping `draft: true` (which we need so assets attach before the release becomes immutable), but this at least guarantees self-healing without relying on a subsequent unrelated push to `main`.

## Test plan
- [ ] Merge and observe the next release cycle end-to-end.
- [ ] Confirm the `release-please` PR ends up at the correct next version once `release.yml` publishes the draft (no lingering stale-version PR).
- [ ] Confirm `gh release edit --draft=false` still succeeds with `RELEASE_PAT` (same permissions as before — `contents: write`).