### PR TITLE
fix(linter): treat self-referential initializers as reads

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1879,6 +1879,20 @@ spinner
     }
 
     #[test]
+    fn self_referential_assignments_are_not_flagged_unused() {
+        let diagnostics = lint_for_rule(
+            "\
+#!/bin/sh
+foo=\"$foo\"
+bar=\"${bar:-fallback}\"
+",
+            Rule::UnusedAssignment,
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn nested_default_operand_followed_by_later_expansion_keeps_assignment_live() {
         let diagnostics = lint_for_rule(
             "\

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -129,5 +129,6 @@ bitflags! {
         const IMPORTED_FUNCTION      = 0b1000_0000_0000;
         const EMPTY_INITIALIZER      = 0b0001_0000_0000_0000;
         const IMPORTED_FILE_ENTRY    = 0b0010_0000_0000_0000;
+        const SELF_REFERENTIAL_READ  = 0b0100_0000_0000_0000;
     }
 }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1002,6 +1002,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
+        let reference_start = self.references.len();
         self.visit_var_ref_subscript_words(
             Some(&assignment.target.name),
             assignment.target.subscript.as_ref(),
@@ -1025,6 +1026,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         attributes |= assignment_binding_attributes(assignment);
         if assignment_has_empty_initializer(assignment, self.source) {
             attributes |= BindingAttributes::EMPTY_INITIALIZER;
+        }
+        if self.newly_added_references_read_name(&assignment.target.name, reference_start) {
+            attributes |= BindingAttributes::SELF_REFERENTIAL_READ;
         }
         if assignment.target.subscript.is_some()
             && !attributes.contains(BindingAttributes::ASSOC)
@@ -2253,7 +2257,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                             expr.span,
                         ),
                     },
-                    BindingAttributes::empty(),
+                    BindingAttributes::SELF_REFERENTIAL_READ,
                 );
             }
             ArithmeticExpr::Indexed { name, index } => {
@@ -2281,7 +2285,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                             index: index.clone(),
                         },
                         span.start.offset,
-                    ),
+                    ) | BindingAttributes::SELF_REFERENTIAL_READ,
                 );
             }
             _ => {}
@@ -2297,16 +2301,20 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
-        self.visit_arithmetic_lvalue_indices_into(target, flow, nested_regions);
-        let attributes = self.arithmetic_binding_attributes(target, target_span.start.offset);
         let name = match target {
             ArithmeticLvalue::Variable(name) | ArithmeticLvalue::Indexed { name, .. } => name,
         };
         let name_span = arithmetic_name_span(target_span, name);
+        let reference_start = self.references.len();
+        self.visit_arithmetic_lvalue_indices_into(target, flow, nested_regions);
+        let mut attributes = self.arithmetic_binding_attributes(target, target_span.start.offset);
         if !matches!(op, ArithmeticAssignOp::Assign) {
             self.add_reference(name, ReferenceKind::ArithmeticRead, name_span);
         }
         self.visit_arithmetic_expr_into(value, flow, nested_regions);
+        if self.newly_added_references_read_name(name, reference_start) {
+            attributes |= BindingAttributes::SELF_REFERENTIAL_READ;
+        }
         self.add_binding(
             name,
             BindingKind::ArithmeticAssignment,
@@ -2813,6 +2821,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn newly_added_references_read_name(&self, name: &Name, start: usize) -> bool {
+        self.references[start..]
+            .iter()
+            .any(|reference| reference.name == *name)
+    }
+
     fn resolve_reference(&self, name: &Name, scope: ScopeId, offset: usize) -> Option<BindingId> {
         for scope in ancestor_scopes(&self.scopes, scope) {
             let Some(bindings) = self.scopes[scope.index()].bindings.get(name) else {
@@ -2902,6 +2916,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     binding.kind,
                     BindingKind::FunctionDefinition | BindingKind::Imported
                 ) && binding.references.is_empty()
+                    && !binding
+                        .attributes
+                        .contains(BindingAttributes::SELF_REFERENTIAL_READ)
             })
             .map(|binding| binding.id)
             .collect()

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -401,7 +401,12 @@ fn analyze_unused_assignments_exact(
 
     let mut used_bindings = DenseBitSet::new(context.bindings.len());
     for binding in context.bindings {
-        if !binding.references.is_empty() || context.runtime.is_always_used_binding(&binding.name) {
+        if !binding.references.is_empty()
+            || binding
+                .attributes
+                .contains(BindingAttributes::SELF_REFERENTIAL_READ)
+            || context.runtime.is_always_used_binding(&binding.name)
+        {
             used_bindings.insert(binding.id.index());
         }
     }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5311,6 +5311,28 @@ printf '%s\\n' \"$cache_dir\"
     }
 
     #[test]
+    fn self_referential_default_initializers_are_not_reported_unused() {
+        let source = "\
+#!/bin/sh
+STATE=\"${STATE:-in_progress}\"
+DESCRIPTION=\"${DESCRIPTION:-Deployment metadata updated}\"
+";
+        let model = model_with_dialect(source, ShellDialect::Posix);
+        let unused = reportable_unused_names(&model);
+
+        assert!(
+            !unused.contains(&Name::from("STATE")),
+            "unused bindings: {:?}",
+            unused
+        );
+        assert!(
+            !unused.contains(&Name::from("DESCRIPTION")),
+            "unused bindings: {:?}",
+            unused
+        );
+    }
+
+    #[test]
     fn detects_dead_code_after_exit() {
         let source = "exit 0\necho dead\n";
         let model = model(source);


### PR DESCRIPTION
## Summary
- treat self-referential assignment initializers as reads in the semantic model
- use that signal in both heuristic and exact unused-assignment analysis
- add regression coverage for plain self-references and `${VAR:-default}` default-init cases

## Root Cause
Shuck records assignment bindings after visiting the right-hand side. That meant `foo="$foo"` and `foo="${foo:-bar}"` produced reads, but those reads never kept the new binding live for `C001`/`SC2034`.

## Validation
- `cargo test -p shuck-semantic self_referential_default_initializers_are_not_reported_unused`
- `cargo test -p shuck-semantic default_parameter_operand_reads_are_tracked`
- `cargo test -p shuck-linter self_referential_assignments_are_not_flagged_unused`
- `cargo test -p shuck-linter substring_offset_arithmetic_reads_do_not_trigger_unused_assignment`
- `SHUCK_CACHE_DIR=$(mktemp -d) cargo run -p shuck-cli -- check /Users/ewhauser/working/cadencerpm/monorepo/tools/ci/update-deployment-metadata.sh`

## Notes
- `shuck check` reused a stale cache entry on the first repro rerun, so the final CLI verification was done with a fresh `SHUCK_CACHE_DIR`.
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10` still hits an unrelated existing harness failure on `.cache/large-corpus/scripts/juewuy__ShellCrash__scripts__starts__fw_nftables.sh`.
