### PR TITLE
fix(linter): report unread loop variables in C001

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -147,13 +147,12 @@ fn is_reportable_unused_assignment(kind: BindingKind, attributes: BindingAttribu
     match kind {
         BindingKind::Assignment
         | BindingKind::ArrayAssignment
+        | BindingKind::LoopVariable
         | BindingKind::ReadTarget
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
         | BindingKind::ArithmeticAssignment => true,
-        // ShellCheck's default SC2034 behavior skips plain loop counters.
-        BindingKind::LoopVariable => false,
         BindingKind::AppendAssignment | BindingKind::ParameterDefaultAssignment => false,
         BindingKind::Declaration(_) => {
             attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
@@ -319,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    fn ignores_unused_for_loop_counters() {
+    fn reports_unused_for_loop_counters() {
         let source = "\
 #!/bin/bash
 unused=1
@@ -329,9 +328,24 @@ done
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
-        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.slice(source), "unused");
+        assert_eq!(diagnostics[1].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.slice(source), "i");
+    }
+
+    #[test]
+    fn body_reads_keep_loop_counters_live() {
+        let source = "\
+#!/bin/bash
+for i in {0..5}; do
+  printf '%s\\n' \"$i\"
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert!(diagnostics.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report unread `for` loop variables as `C001`/`SC2034` findings
- keep loop variables suppressed when the loop body actually reads them
- update the rule tests to cover both behaviors

## Why
Shuck already tracked loop variables in the unused-assignment family at the semantic layer, but the linter rule filtered `BindingKind::LoopVariable` out of the reportable set entirely. That meant reproductions like `for i in {0..5}; do ...; done` missed `SC2034` even when `i` was never read in the loop body.

## Impact
This brings `C001` into line with ShellCheck for unread loop iterator variables without changing the existing behavior for loop variables that are actually consumed.

## Validation
- `cargo test -p shuck-linter rules::correctness::unused_assignment::tests -- --nocapture`
- `cargo test -p shuck-linter unused_assignment -- --nocapture`
- `make ensure-cache && make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001` (completed with `implementation_diffs=0`; the run still reports 3 unrelated parse harness failures in the corpus suite)