### PR TITLE
fix(semantic): keep or-fallback reachable after conditional exit

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2407,9 +2407,10 @@ fn annotate_conditional_assignment_shortcuts<'a>(
     lists: &[ListFact<'a>],
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
 ) {
-    for list in lists.iter().filter(|list| {
-        list.mixed_short_circuit_kind() == Some(MixedShortCircuitKind::AssignmentTernary)
-    }) {
+    for list in lists
+        .iter()
+        .filter(|list| list_has_conditional_assignment_shortcuts(list))
+    {
         for segment in list.segments() {
             let Some(target) = segment.assignment_target() else {
                 continue;
@@ -2427,4 +2428,22 @@ fn annotate_conditional_assignment_shortcuts<'a>(
             }
         }
     }
+}
+
+fn list_has_conditional_assignment_shortcuts(list: &ListFact<'_>) -> bool {
+    if list.mixed_short_circuit_kind() == Some(MixedShortCircuitKind::AssignmentTernary) {
+        return true;
+    }
+
+    let [_, then_branch, else_branch] = list.segments() else {
+        return false;
+    };
+    let [first_operator, second_operator] = list.operators() else {
+        return false;
+    };
+
+    first_operator.op() == shuck_ast::BinaryOp::And
+        && second_operator.op() == shuck_ast::BinaryOp::Or
+        && then_branch.assignment_target().is_some()
+        && then_branch.assignment_target() == else_branch.assignment_target()
 }

--- a/crates/shuck-linter/src/facts/tests/assignments.rs
+++ b/crates/shuck-linter/src/facts/tests/assignments.rs
@@ -73,7 +73,13 @@ fn indexes_loop_bindings_from_for_words() {
 
 #[test]
 fn marks_conditional_assignment_shortcuts_on_binding_values() {
-    let source = "#!/bin/bash\ntrue && w='-w' || w=''\nif true; then flag='-f'; else flag=''; fi\n";
+    let source = "\
+#!/bin/bash
+check() { return 0; }
+true && w='-w' || w=''
+check && opt='-o' || opt=''
+if true; then flag='-f'; else flag=''; fi
+";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
     let semantic = SemanticModel::build(&output.file, source, &indexer);
@@ -92,6 +98,19 @@ fn marks_conditional_assignment_shortcuts_on_binding_values() {
         })
         .collect::<Vec<_>>();
     assert_eq!(shortcut_bindings, vec![true, true]);
+
+    let command_shortcut_bindings = semantic
+        .bindings_for(&Name::from("opt"))
+        .iter()
+        .copied()
+        .map(|binding_id| {
+            facts
+                .binding_value(binding_id)
+                .expect("expected opt binding value fact")
+                .conditional_assignment_shortcut()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(command_shortcut_bindings, vec![true, true]);
 
     let flag_bindings = semantic
         .bindings_for(&Name::from("flag"))

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3707,6 +3707,29 @@ f
     }
 
     #[test]
+    fn unreachable_after_exit_ignores_fallback_after_conditional_exit() {
+        let source = "\
+#!/bin/bash
+run && exit 0 || sleep 15
+";
+        let diagnostics = lint(source, &LinterSettings::default());
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.rule == Rule::ChainedTestBranches)
+                .count(),
+            1
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.rule != Rule::UnreachableAfterExit),
+            "diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
     fn unused_assignment_respects_disabled_rule() {
         let diagnostics = lint(
             "#!/bin/sh\nfoo=1\n",

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -686,31 +686,45 @@ impl<'a> GraphBuilder<'a> {
         rest: RecordedListItemRange,
         loops: &[LoopTarget],
     ) -> SequenceResult {
-        let mut current = self.build_command(first, loops);
+        let current = self.build_command(first, loops);
         let entry = current.entry;
-        let mut shortcut_exits = Vec::new();
+        let mut success_exits = current.exits.clone();
+        let mut failure_exits = current.exits;
 
         for item in self.program.list_items(rest) {
             let next = self.build_command(item.command, loops);
+            let (triggering_exits, edge_kind) = match item.operator {
+                RecordedListOperator::And => (&success_exits, EdgeKind::ConditionalTrue),
+                RecordedListOperator::Or => (&failure_exits, EdgeKind::ConditionalFalse),
+            };
+
             if let Some(next_entry) = next.entry {
-                for exit in &current.exits {
-                    let edge = match item.operator {
-                        RecordedListOperator::And => EdgeKind::ConditionalTrue,
-                        RecordedListOperator::Or => EdgeKind::ConditionalFalse,
-                    };
-                    self.add_edge(*exit, next_entry, edge);
+                for exit in triggering_exits {
+                    self.add_edge(*exit, next_entry, edge_kind);
                 }
             }
 
-            shortcut_exits.extend(current.exits.clone());
-            current = SequenceResult {
-                entry,
-                exits: next.exits,
+            let next_reachable = next.entry.is_some() && !triggering_exits.is_empty();
+            let (next_success_exits, mut next_failure_exits) = if next_reachable {
+                (next.exits.clone(), next.exits)
+            } else {
+                (Vec::new(), Vec::new())
             };
+
+            match item.operator {
+                RecordedListOperator::And => {
+                    append_unique_block_ids(&mut failure_exits, &next_failure_exits);
+                    success_exits = next_success_exits;
+                }
+                RecordedListOperator::Or => {
+                    append_unique_block_ids(&mut success_exits, &next_success_exits);
+                    failure_exits = std::mem::take(&mut next_failure_exits);
+                }
+            }
         }
 
-        let mut exits = current.exits;
-        exits.extend(shortcut_exits);
+        let mut exits = success_exits;
+        append_unique_block_ids(&mut exits, &failure_exits);
         self.wrap_sequence_with_command_header(command, SequenceResult { entry, exits }, loops)
     }
 
@@ -1055,4 +1069,12 @@ fn compute_unreachable(
         .iter()
         .filter_map(|block| (!visited.contains_key(&block.id)).then_some(block.id))
         .collect()
+}
+
+fn append_unique_block_ids(target: &mut Vec<BlockId>, source: &[BlockId]) {
+    for &block in source {
+        if !target.contains(&block) {
+            target.push(block);
+        }
+    }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5325,6 +5325,18 @@ printf '%s\\n' \"$cache_dir\"
     }
 
     #[test]
+    fn conditional_exit_keeps_or_fallback_reachable() {
+        let source = "run && exit 0 || echo fallback\n";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
     fn deferred_function_bodies_resolve_later_file_scope_bindings() {
         let source = "f() { echo $X; }\nX=1\nf\n";
         let model = model(source);


### PR DESCRIPTION
## Summary
- fix logical-list CFG exit propagation so `A && exit 0 || B` keeps the `||` fallback reachable when `A` fails
- keep unreachable-code reporting focused on truly dead code instead of conditional short-circuit branches
- add semantic and linter regressions that cover the false positive and preserve the mixed-chain warning

## Root Cause
The CFG builder flattened `&&` / `||` chains but treated earlier exits as unconditional shortcuts out of the whole list. In `A && exit 0 || B`, that caused the false branch from `A` to bypass `B`, so the semantic dead-code analysis incorrectly marked the fallback as unreachable.

## Validation
- `cargo test -p shuck-semantic conditional_exit_keeps_or_fallback_reachable`
- `cargo test -p shuck-semantic dead_code -- --nocapture`
- `cargo test -p shuck-linter unreachable_after_exit_ -- --nocapture`
- `cargo run -q -p shuck-cli -- check <temp repro>`
