### PR TITLE
feat: lint embedded GitHub Actions scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "shuck-extract"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "marked-yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "shuck-extract"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "marked-yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +508,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -636,6 +657,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -930,6 +960,17 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "marked-yaml"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a76cf4e66a8ffccfce983161b0faafe61a5ef03fe875ef2e3deb897e4e915fa"
+dependencies = [
+ "doc-comment",
+ "hashlink",
+ "yaml-rust2",
+]
 
 [[package]]
 name = "memchr"
@@ -1526,6 +1567,7 @@ dependencies = [
  "sha2 0.11.0",
  "shuck-ast",
  "shuck-cache",
+ "shuck-extract",
  "shuck-formatter",
  "shuck-indexer",
  "shuck-linter",
@@ -1537,6 +1579,14 @@ dependencies = [
  "url",
  "wait-timeout",
  "walkdir",
+]
+
+[[package]]
+name = "shuck-extract"
+version = "0.0.15"
+dependencies = [
+ "anyhow",
+ "marked-yaml",
 ]
 
 [[package]]
@@ -2354,6 +2404,17 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ shuck-linter = { path = "crates/shuck-linter", version = "0.0.17" }
 shuck-parser = { path = "crates/shuck-parser", version = "0.0.17" }
 shuck-semantic = { path = "crates/shuck-semantic", version = "0.0.17" }
 shuck-cli = { path = "crates/shuck-cli", version = "0.0.17" }
+shuck-extract = { path = "crates/shuck-extract", version = "0.0.17" }
 
 # Error handling
 thiserror = "2"
@@ -55,6 +56,7 @@ notify = "8.0.0"
 # Serialization
 serde_json = "1"
 serde_yaml = "0.9"
+marked-yaml = "0.8"
 similar = "2"
 toml = "0.8"
 quick-junit = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A shell script linter, written in Rust.
 
-Shuck parses and analyzes shell scripts to catch common bugs, style issues, and portability problems. It includes a caching layer for fast incremental runs.
+Shuck parses and analyzes shell scripts to catch common bugs, style issues, and portability problems. It also lints shell embedded in supported non-shell files such as GitHub Actions workflows. A caching layer keeps incremental runs fast.
 
 ## Features
 
@@ -11,6 +11,7 @@ Shuck parses and analyzes shell scripts to catch common bugs, style issues, and 
 - Safe and unsafe fix support for selected diagnostics
 - Multi-dialect support: bash, sh/POSIX, mksh, zsh
 - Automatic file discovery via extensions and shebang detection
+- Embedded shell extraction for GitHub Actions workflows and composite actions
 - ShellCheck suppression compatibility (`# shellcheck disable=SC2086`)
 
 ## Installation
@@ -41,6 +42,12 @@ shuck check script.sh src/
 
 # Check the current directory
 shuck check .
+
+# Check GitHub Actions workflow `run:` blocks
+shuck check .github/workflows/ci.yml
+
+# Check a composite action
+shuck check action.yml
 
 # Read from stdin
 echo 'echo $foo' | shuck check -
@@ -88,6 +95,7 @@ path:line:col: severity[CODE] message
 deploy.sh:14:1: warning[C001] variable `tmp` is assigned but never used
 deploy.sh:31:10: error[C006] undefined variable `DEPLY_ENV`
 deploy.sh:45:3: warning[S005] legacy backtick command substitution
+.github/workflows/ci.yml:12:11: warning[C001] jobs.test.steps[0].run: variable `summary` is assigned but never used
 ```
 
 ### Exit codes
@@ -150,12 +158,43 @@ code_here
 # shuck: disable=S001
 ```
 
+For embedded GitHub Actions scripts, put suppression comments inside the `run:` block as shell comments:
+
+```yaml
+- run: |
+    # shellcheck disable=SC2086
+    echo $FOO
+```
+
+YAML comments outside the `run:` scalar are not visible to the shell parser and do not suppress shell diagnostics.
+
+## Configuration
+
+Project settings live in `.shuck.toml` or `shuck.toml`.
+
+Use the `[check]` section to control embedded-script extraction:
+
+```toml
+[check]
+# Lint supported embedded shell scripts in non-shell files such as
+# GitHub Actions workflows and composite actions.
+# Default: true
+embedded = true
+```
+
 ## File discovery
 
-When given a directory, shuck recursively discovers shell scripts by:
+When given a directory, shuck recursively discovers standalone shell scripts by:
 
 1. **Extension**: `.sh`, `.bash`, `.zsh`, `.ksh`, `.dash`, `.mksh`, `.bats`
 2. **Shebang**: files starting with `#!/bin/bash`, `#!/usr/bin/env sh`, etc.
+
+Shuck also discovers embedded shell in supported non-shell files:
+
+1. **GitHub Actions workflows**: `.github/workflows/*.yml` and `.github/workflows/*.yaml`
+2. **Composite actions**: `action.yml` and `action.yaml`
+
+For GitHub Actions files, shuck lints `run:` blocks independently, remaps diagnostics back to the host YAML file, and includes the step path (for example `jobs.test.steps[0].run`) in the message. Steps that target unsupported shells such as PowerShell or `cmd` are skipped.
 
 The following directories are skipped by default: `.git`, `.hg`, `.svn`, `.jj`, `.bzr`, `.cache`, `node_modules`, `vendor`, `.shuck_cache`.
 

--- a/crates/shuck-cli/Cargo.toml
+++ b/crates/shuck-cli/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { workspace = true }
 quick-junit = { workspace = true }
 shuck-ast = { workspace = true }
 shuck-cache = { workspace = true }
+shuck-extract = { workspace = true }
 shuck-formatter = { workspace = true }
 shuck-indexer = { workspace = true }
 shuck-linter = { workspace = true }

--- a/crates/shuck-cli/README.md
+++ b/crates/shuck-cli/README.md
@@ -4,6 +4,7 @@
 
 This crate is published so the binary, integration tests, and benchmarks can share the same
 argument parsing and command execution logic. Most users should install and run the `shuck`
-binary instead of depending on this crate directly.
+binary instead of depending on this crate directly. The `check` command lints standalone shell
+files plus supported embedded shell in GitHub Actions workflow and composite-action `run:` blocks.
 
 The Rust API is still pre-1.0 and may change between `0.x` releases.

--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -167,7 +167,7 @@ struct GlobalArgs {
 
 #[derive(Debug, Subcommand)]
 enum StableCommand {
-    /// Parse shell files and report syntax failures.
+    /// Lint shell files and supported embedded shell scripts.
     Check(CheckCommand),
     #[command(hide = true)]
     Format(FormatCommand),
@@ -177,7 +177,7 @@ enum StableCommand {
 
 #[derive(Debug, Subcommand)]
 enum ExperimentalCommand {
-    /// Parse shell files and report syntax failures.
+    /// Lint shell files and supported embedded shell scripts.
     Check(CheckCommand),
     /// Format shell files.
     Format(FormatCommand),
@@ -279,7 +279,7 @@ impl Args {
 /// Supported `shuck` subcommands.
 #[derive(Debug, Clone, Subcommand)]
 pub enum Command {
-    /// Parse shell files and report syntax failures.
+    /// Lint shell files and supported embedded shell scripts.
     Check(CheckCommand),
     /// Format shell files.
     Format(FormatCommand),

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1800,6 +1800,15 @@ fn remap_embedded_column(
     host_start_column: usize,
     snippet_column: usize,
 ) -> usize {
+    let decoded_column = remap_placeholder_column(embedded, snippet_line, snippet_column);
+    remap_decoded_yaml_column(embedded, snippet_line, host_start_column, decoded_column)
+}
+
+fn remap_placeholder_column(
+    embedded: &EmbeddedScript,
+    snippet_line: usize,
+    snippet_column: usize,
+) -> usize {
     let local_column = snippet_column.saturating_sub(1);
     let mut cumulative_delta = 0isize;
 
@@ -1821,14 +1830,42 @@ fn remap_embedded_column(
         }
 
         if local_column >= substituted_start {
-            let host_start = substituted_start as isize + cumulative_delta;
+            let decoded_start = substituted_start as isize + cumulative_delta;
             let relative = local_column - substituted_start;
-            let mapped = host_start + relative.min(host_len.saturating_sub(1)) as isize;
-            return host_start_column + mapped.max(0) as usize;
+            let mapped = decoded_start + relative.min(host_len.saturating_sub(1)) as isize;
+            return mapped.max(0) as usize + 1;
         }
     }
 
-    host_start_column + (local_column as isize + cumulative_delta).max(0) as usize
+    (local_column as isize + cumulative_delta).max(0) as usize + 1
+}
+
+fn remap_decoded_yaml_column(
+    embedded: &EmbeddedScript,
+    snippet_line: usize,
+    host_start_column: usize,
+    decoded_column: usize,
+) -> usize {
+    let local_column = decoded_column.saturating_sub(1);
+    let mut cumulative_delta = 0usize;
+
+    for mapping in embedded
+        .host_column_mappings
+        .iter()
+        .filter(|mapping| mapping.line == snippet_line)
+    {
+        let mapped_start = mapping.column.saturating_sub(1);
+        if local_column > mapped_start {
+            cumulative_delta += mapping.host_columns.saturating_sub(1);
+            continue;
+        }
+
+        if local_column == mapped_start {
+            return host_start_column + mapped_start + cumulative_delta;
+        }
+    }
+
+    host_start_column + local_column + cumulative_delta
 }
 
 fn source_line_column_for_offset(source: &str, offset: usize) -> (usize, usize) {
@@ -2143,6 +2180,7 @@ jobs:
                 HostLineStart { line: 8, column: 9 },
                 HostLineStart { line: 9, column: 9 },
             ],
+            host_column_mappings: Vec::new(),
             dialect: ExtractedDialect::Bash,
             label: "jobs.test.steps[0].run".to_owned(),
             format: EmbeddedFormat::GitHubActions,
@@ -2163,6 +2201,7 @@ jobs:
             host_start_line: 7,
             host_start_column: 9,
             host_line_starts: vec![HostLineStart { line: 7, column: 9 }],
+            host_column_mappings: Vec::new(),
             dialect: ExtractedDialect::Bash,
             label: "jobs.test.steps[0].run".to_owned(),
             format: EmbeddedFormat::GitHubActions,
@@ -2190,6 +2229,7 @@ jobs:
             host_start_line: 7,
             host_start_column: 9,
             host_line_starts: vec![HostLineStart { line: 7, column: 9 }],
+            host_column_mappings: Vec::new(),
             dialect: ExtractedDialect::Bash,
             label: "jobs.test.steps[0].run".to_owned(),
             format: EmbeddedFormat::GitHubActions,
@@ -2230,6 +2270,7 @@ jobs:
                     column: 33,
                 },
             ],
+            host_column_mappings: Vec::new(),
             dialect: ExtractedDialect::Bash,
             label: "jobs.test.steps[0].run".to_owned(),
             format: EmbeddedFormat::GitHubActions,
@@ -2240,6 +2281,34 @@ jobs:
         let position = remap_embedded_position(&embedded, 2, 1);
         assert_eq!(position.line, 7);
         assert_eq!(position.column, 24);
+    }
+
+    #[test]
+    fn remaps_columns_after_non_newline_yaml_escapes() {
+        let embedded = EmbeddedScript {
+            source: "echo\tif true\n".to_owned(),
+            host_offset: 0,
+            host_start_line: 7,
+            host_start_column: 15,
+            host_line_starts: vec![HostLineStart {
+                line: 7,
+                column: 15,
+            }],
+            host_column_mappings: vec![shuck_extract::HostColumnMapping {
+                line: 1,
+                column: 5,
+                host_columns: 2,
+            }],
+            dialect: ExtractedDialect::Bash,
+            label: "jobs.test.steps[0].run".to_owned(),
+            format: EmbeddedFormat::GitHubActions,
+            placeholders: Vec::new(),
+            implicit_flags: ImplicitShellFlags::default(),
+        };
+
+        let position = remap_embedded_position(&embedded, 1, 6);
+        assert_eq!(position.line, 7);
+        assert_eq!(position.column, 21);
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -15,9 +15,9 @@ use shuck_cache::{CacheKey, CacheKeyHasher};
 use shuck_extract::{EmbeddedScript, ExtractedDialect, HostLineStart, extract_all};
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    Applicability, CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore, Rule, RuleSelector,
-    RuleSet, ShellCheckCodeMap, ShellDialect, SuppressionIndex, add_ignores_to_path,
-    first_statement_line, parse_directives,
+    AmbientShellOptions, Applicability, CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore,
+    Rule, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
+    add_ignores_to_path, first_statement_line, parse_directives,
 };
 use shuck_parser::{
     Error as ParseError,
@@ -1410,7 +1410,13 @@ fn analyze_embedded_file(
 
         let snippet_source: Arc<str> = Arc::from(embedded.source.clone());
         let parse_result = Parser::with_dialect(&snippet_source, parse_dialect).parse();
-        let linter_settings = base_linter_settings.clone().with_shell(shell_dialect);
+        let linter_settings = base_linter_settings
+            .clone()
+            .with_shell(shell_dialect)
+            .with_ambient_shell_options(AmbientShellOptions {
+                errexit: embedded.implicit_flags.errexit,
+                pipefail: embedded.implicit_flags.pipefail,
+            });
         let diagnostics = collect_lint_diagnostics(
             &pending,
             &snippet_source,

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -12,6 +12,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use shuck_ast::TextSize;
 use shuck_cache::{CacheKey, CacheKeyHasher};
+use shuck_extract::{EmbeddedScript, ExtractedDialect, extract_all};
 use shuck_indexer::Indexer;
 use shuck_linter::{
     Applicability, CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore, Rule, RuleSelector,
@@ -35,6 +36,7 @@ use crate::config::{
     ConfigArguments, LintConfig, discovered_config_path_for_root, load_project_config,
     resolve_project_root_for_input,
 };
+use crate::discover::FileKind;
 use crate::discover::{DEFAULT_IGNORED_DIR_NAMES, DiscoveryOptions, ProjectRoot, normalize_path};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -86,6 +88,7 @@ struct EffectiveCheckSettings {
     enabled_rules: Vec<String>,
     per_file_ignores: Vec<EffectivePerFileIgnore>,
     rule_options: EffectiveRuleOptions,
+    embedded_enabled: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -104,6 +107,7 @@ impl EffectiveCheckSettings {
         enabled_rules: RuleSet,
         per_file_ignores: &[PerFileIgnore],
         rule_options: &shuck_linter::LinterRuleOptions,
+        embedded_enabled: bool,
     ) -> Self {
         let mut enabled_rules = enabled_rules
             .iter()
@@ -132,6 +136,7 @@ impl EffectiveCheckSettings {
             enabled_rules,
             per_file_ignores,
             rule_options: EffectiveRuleOptions::new(rule_options),
+            embedded_enabled,
         }
     }
 }
@@ -142,6 +147,7 @@ impl CacheKey for EffectiveCheckSettings {
         self.enabled_rules.cache_key(state);
         self.per_file_ignores.cache_key(state);
         self.rule_options.cache_key(state);
+        self.embedded_enabled.cache_key(state);
     }
 }
 
@@ -175,6 +181,7 @@ struct ResolvedCheckSettings {
     linter_settings: LinterSettings,
     fixable_rules: RuleSet,
     effective: EffectiveCheckSettings,
+    embedded_enabled: bool,
 }
 
 impl CacheKey for ResolvedCheckSettings {
@@ -214,27 +221,35 @@ impl PerFileIgnoreSpec {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-enum CheckCacheData {
-    Success(Vec<CachedLintDiagnostic>),
-    ParseError(ParseCacheFailure),
+struct CheckCacheData {
+    diagnostics: Vec<CachedDisplayedDiagnostic>,
+}
+
+impl CheckCacheData {
+    fn from_displayed(diagnostics: &[DisplayedDiagnostic]) -> Self {
+        Self {
+            diagnostics: diagnostics
+                .iter()
+                .map(CachedDisplayedDiagnostic::from_displayed)
+                .collect(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct ParseCacheFailure {
-    message: String,
-    line: usize,
-    column: usize,
+enum CachedDisplayedDiagnosticKind {
+    ParseError,
+    Lint { code: String, severity: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct CachedLintDiagnostic {
+struct CachedDisplayedDiagnostic {
     start_line: usize,
     start_column: usize,
     end_line: usize,
     end_column: usize,
-    code: String,
-    severity: String,
     message: String,
+    kind: CachedDisplayedDiagnosticKind,
     fix: Option<CachedLintFix>,
 }
 
@@ -327,20 +342,24 @@ impl CachedLintEdit {
     }
 }
 
-impl CachedLintDiagnostic {
-    fn from_diagnostic(diagnostic: &shuck_linter::Diagnostic, source: &str) -> Self {
-        let fix = displayed_fix_from_diagnostic(diagnostic, source)
-            .as_ref()
-            .map(CachedLintFix::from_displayed);
+impl CachedDisplayedDiagnostic {
+    fn from_displayed(diagnostic: &DisplayedDiagnostic) -> Self {
         Self {
             start_line: diagnostic.span.start.line,
             start_column: diagnostic.span.start.column,
             end_line: diagnostic.span.end.line,
             end_column: diagnostic.span.end.column,
-            code: diagnostic.code().to_owned(),
-            severity: diagnostic.severity.as_str().to_owned(),
             message: diagnostic.message.clone(),
-            fix,
+            kind: match &diagnostic.kind {
+                DisplayedDiagnosticKind::ParseError => CachedDisplayedDiagnosticKind::ParseError,
+                DisplayedDiagnosticKind::Lint { code, severity } => {
+                    CachedDisplayedDiagnosticKind::Lint {
+                        code: code.clone(),
+                        severity: severity.clone(),
+                    }
+                }
+            },
+            fix: diagnostic.fix.as_ref().map(CachedLintFix::from_displayed),
         }
     }
 }
@@ -792,7 +811,13 @@ fn resolve_project_check_settings(
         project_root.canonical_root.clone(),
         per_file_ignores.clone(),
     )?;
-    let effective = EffectiveCheckSettings::new(enabled_rules, &per_file_ignores, &rule_options);
+    let embedded_enabled = config.check.embedded.unwrap_or(true);
+    let effective = EffectiveCheckSettings::new(
+        enabled_rules,
+        &per_file_ignores,
+        &rule_options,
+        embedded_enabled,
+    );
 
     Ok(ResolvedCheckSettings {
         linter_settings: LinterSettings {
@@ -803,6 +828,7 @@ fn resolve_project_check_settings(
         },
         fixable_rules,
         effective,
+        embedded_enabled,
     })
 }
 
@@ -1023,7 +1049,7 @@ fn run_check_with_cwd(
 ) -> Result<CheckReport> {
     let include_source = matches!(args.output_format, crate::args::CheckOutputFormatArg::Full);
     let fix_applicability = requested_fix_applicability(args);
-    let runs = prepare_project_runs::<CheckCacheData, ResolvedCheckSettings, _>(
+    let mut runs = prepare_project_runs::<CheckCacheData, ResolvedCheckSettings, _>(
         &args.paths,
         cwd,
         &DiscoveryOptions {
@@ -1046,6 +1072,12 @@ fn run_check_with_cwd(
 
     let mut report = CheckReport::default();
 
+    for run in &mut runs {
+        if !run.settings.embedded_enabled {
+            run.files.retain(|file| file.kind == FileKind::Shell);
+        }
+    }
+
     for mut run in runs {
         let analyzed_paths = run
             .files
@@ -1055,35 +1087,17 @@ fn run_check_with_cwd(
         let project_settings = run.settings.clone();
         let pending = run.take_pending_files(|file, cached| {
             report.cache_hits += 1;
-            match cached {
-                CheckCacheData::Success(diagnostics) => {
-                    let source = (include_source && !diagnostics.is_empty())
-                        .then(|| read_shared_source(&file.absolute_path))
-                        .transpose()?;
-                    push_cached_lint_diagnostics(
-                        &mut report,
-                        &file.display_path,
-                        &file.relative_path,
-                        &file.absolute_path,
-                        &diagnostics,
-                        source,
-                    );
-                }
-                CheckCacheData::ParseError(error) => {
-                    let source = include_source
-                        .then(|| read_shared_source(&file.absolute_path))
-                        .transpose()?;
-                    report.diagnostics.push(display_parse_error(
-                        &file.display_path,
-                        &file.relative_path,
-                        &file.absolute_path,
-                        error.line,
-                        error.column,
-                        error.message,
-                        source,
-                    ));
-                }
-            }
+            let source = (include_source && !cached.diagnostics.is_empty())
+                .then(|| read_shared_source(&file.absolute_path))
+                .transpose()?;
+            push_cached_diagnostics(
+                &mut report,
+                &file.display_path,
+                &file.relative_path,
+                &file.absolute_path,
+                &cached.diagnostics,
+                source,
+            );
             Ok(())
         })?;
 
@@ -1140,7 +1154,7 @@ fn run_add_ignore_with_cwd(
     reason: Option<&str>,
 ) -> Result<AddIgnoreReport> {
     let include_source = matches!(args.output_format, crate::args::CheckOutputFormatArg::Full);
-    let runs = prepare_project_runs::<CheckCacheData, ResolvedCheckSettings, _>(
+    let mut runs = prepare_project_runs::<CheckCacheData, ResolvedCheckSettings, _>(
         &args.paths,
         cwd,
         &DiscoveryOptions {
@@ -1161,6 +1175,10 @@ fn run_add_ignore_with_cwd(
     )?;
 
     let mut report = AddIgnoreReport::default();
+
+    for run in &mut runs {
+        run.files.retain(|file| file.kind == FileKind::Shell);
+    }
 
     for run in runs {
         let analyzed_paths = run
@@ -1252,6 +1270,32 @@ fn analyze_file(
     fix_applicability: Option<Applicability>,
     fixable_rules: &RuleSet,
 ) -> Result<FileCheckResult> {
+    match pending.file.kind {
+        FileKind::Shell => analyze_shell_file(
+            pending,
+            base_linter_settings,
+            shellcheck_map,
+            include_source,
+            fix_applicability,
+            fixable_rules,
+        ),
+        FileKind::Embedded => analyze_embedded_file(
+            pending,
+            base_linter_settings,
+            shellcheck_map,
+            include_source,
+        ),
+    }
+}
+
+fn analyze_shell_file(
+    pending: PendingProjectFile,
+    base_linter_settings: &LinterSettings,
+    shellcheck_map: &ShellCheckCodeMap,
+    include_source: bool,
+    fix_applicability: Option<Applicability>,
+    fixable_rules: &RuleSet,
+) -> Result<FileCheckResult> {
     let mut source = read_shared_source(&pending.file.absolute_path)?;
     let inferred_shell = ShellDialect::infer(&source, Some(&pending.file.absolute_path));
     let parse_dialect = match inferred_shell {
@@ -1271,6 +1315,7 @@ fn analyze_file(
         &parse_result,
         &linter_settings,
         shellcheck_map,
+        &pending.file.absolute_path,
     );
     let mut fixes_applied = 0;
 
@@ -1291,36 +1336,31 @@ fn analyze_file(
                 &parse_result,
                 &linter_settings,
                 shellcheck_map,
+                &pending.file.absolute_path,
             );
             fixes_applied = applied.fixes_applied;
         }
     }
 
-    let (cache_data, diagnostics) = if parse_result.is_err() && diagnostics.is_empty() {
+    let diagnostics = if parse_result.is_err() && diagnostics.is_empty() {
         let ParseError::Parse {
             message,
             line,
             column,
         } = parse_result.strict_error();
-        (
-            CheckCacheData::ParseError(ParseCacheFailure {
-                message: message.clone(),
-                line,
-                column,
-            }),
-            vec![display_parse_error(
-                &pending.file.display_path,
-                &pending.file.relative_path,
-                &pending.file.absolute_path,
-                line,
-                column,
-                message,
-                include_source.then_some(source.clone()),
-            )],
-        )
+        vec![display_parse_error(
+            &pending.file.display_path,
+            &pending.file.relative_path,
+            &pending.file.absolute_path,
+            line,
+            column,
+            message,
+            include_source.then_some(source.clone()),
+        )]
     } else {
         display_lint_diagnostics(&pending, &source, &diagnostics, include_source)
     };
+    let cache_data = CheckCacheData::from_displayed(&diagnostics);
 
     Ok(FileCheckResult {
         file: pending.file,
@@ -1331,12 +1371,102 @@ fn analyze_file(
     })
 }
 
+fn analyze_embedded_file(
+    pending: PendingProjectFile,
+    base_linter_settings: &LinterSettings,
+    shellcheck_map: &ShellCheckCodeMap,
+    include_source: bool,
+) -> Result<FileCheckResult> {
+    let host_source = read_shared_source(&pending.file.absolute_path)?;
+    let host_display_source = include_source.then_some(host_source.clone());
+    let extracted = match extract_all(&pending.file.absolute_path, host_source.as_ref()) {
+        Ok(extracted) => extracted,
+        Err(err) => {
+            let diagnostics = vec![display_parse_error(
+                &pending.file.display_path,
+                &pending.file.relative_path,
+                &pending.file.absolute_path,
+                1,
+                1,
+                err.to_string(),
+                host_display_source,
+            )];
+            return Ok(FileCheckResult {
+                file: pending.file,
+                file_key: pending.file_key,
+                cache_data: CheckCacheData::from_displayed(&diagnostics),
+                diagnostics,
+                fixes_applied: 0,
+            });
+        }
+    };
+
+    let mut displayed = Vec::new();
+
+    for embedded in extracted
+        .into_iter()
+        .filter(|embedded| embedded_supported_dialect(embedded))
+    {
+        let Some((shell_dialect, parse_dialect)) = embedded_dialects(embedded.dialect) else {
+            continue;
+        };
+
+        let snippet_source: Arc<str> = Arc::from(embedded.source.clone());
+        let parse_result = Parser::with_dialect(&snippet_source, parse_dialect).parse();
+        let linter_settings = base_linter_settings.clone().with_shell(shell_dialect);
+        let diagnostics = collect_lint_diagnostics(
+            &pending,
+            &snippet_source,
+            &parse_result,
+            &linter_settings,
+            shellcheck_map,
+            &pending.file.absolute_path,
+        )
+        .into_iter()
+        .filter(|diagnostic| embedded_rule_allowed(diagnostic.rule))
+        .collect::<Vec<_>>();
+
+        if parse_result.is_err() && diagnostics.is_empty() {
+            let ParseError::Parse {
+                message,
+                line,
+                column,
+            } = parse_result.strict_error();
+            displayed.push(remap_embedded_parse_error(
+                &pending,
+                &embedded,
+                line,
+                column,
+                prefixed_embedded_message(&embedded, &message),
+                host_display_source.clone(),
+            ));
+            continue;
+        }
+
+        displayed.extend(remap_embedded_lint_diagnostics(
+            &pending,
+            &embedded,
+            &diagnostics,
+            host_display_source.clone(),
+        ));
+    }
+
+    Ok(FileCheckResult {
+        file: pending.file,
+        file_key: pending.file_key,
+        cache_data: CheckCacheData::from_displayed(&displayed),
+        diagnostics: displayed,
+        fixes_applied: 0,
+    })
+}
+
 fn collect_lint_diagnostics(
-    pending: &PendingProjectFile,
+    _pending: &PendingProjectFile,
     source: &Arc<str>,
     parse_result: &ParseResult,
     linter_settings: &LinterSettings,
     shellcheck_map: &ShellCheckCodeMap,
+    source_path: &Path,
 ) -> Vec<shuck_linter::Diagnostic> {
     let indexer = Indexer::new(source, parse_result);
     let directives = parse_directives(
@@ -1358,7 +1488,7 @@ fn collect_lint_diagnostics(
         &indexer,
         linter_settings,
         suppression_index.as_ref(),
-        Some(&pending.file.absolute_path),
+        Some(source_path),
     )
 }
 
@@ -1367,36 +1497,28 @@ fn display_lint_diagnostics(
     source: &Arc<str>,
     diagnostics: &[shuck_linter::Diagnostic],
     include_source: bool,
-) -> (CheckCacheData, Vec<DisplayedDiagnostic>) {
+) -> Vec<DisplayedDiagnostic> {
     let diagnostic_source = (!diagnostics.is_empty() && include_source).then(|| source.clone());
 
-    (
-        CheckCacheData::Success(
-            diagnostics
-                .iter()
-                .map(|diagnostic| CachedLintDiagnostic::from_diagnostic(diagnostic, source))
-                .collect(),
-        ),
-        diagnostics
-            .iter()
-            .map(|diagnostic| DisplayedDiagnostic {
-                path: pending.file.display_path.clone(),
-                relative_path: pending.file.relative_path.clone(),
-                absolute_path: pending.file.absolute_path.clone(),
-                span: DisplaySpan::new(
-                    DisplayPosition::new(diagnostic.span.start.line, diagnostic.span.start.column),
-                    DisplayPosition::new(diagnostic.span.end.line, diagnostic.span.end.column),
-                ),
-                message: diagnostic.message.clone(),
-                kind: DisplayedDiagnosticKind::Lint {
-                    code: diagnostic.code().to_owned(),
-                    severity: diagnostic.severity.as_str().to_owned(),
-                },
-                fix: displayed_fix_from_diagnostic(diagnostic, source),
-                source: diagnostic_source.clone(),
-            })
-            .collect(),
-    )
+    diagnostics
+        .iter()
+        .map(|diagnostic| DisplayedDiagnostic {
+            path: pending.file.display_path.clone(),
+            relative_path: pending.file.relative_path.clone(),
+            absolute_path: pending.file.absolute_path.clone(),
+            span: DisplaySpan::new(
+                DisplayPosition::new(diagnostic.span.start.line, diagnostic.span.start.column),
+                DisplayPosition::new(diagnostic.span.end.line, diagnostic.span.end.column),
+            ),
+            message: diagnostic.message.clone(),
+            kind: DisplayedDiagnosticKind::Lint {
+                code: diagnostic.code().to_owned(),
+                severity: diagnostic.severity.as_str().to_owned(),
+            },
+            fix: displayed_fix_from_diagnostic(diagnostic, source),
+            source: diagnostic_source.clone(),
+        })
+        .collect()
 }
 
 fn display_parse_error(
@@ -1497,12 +1619,12 @@ fn requested_fix_applicability(args: &CheckCommand) -> Option<Applicability> {
     }
 }
 
-fn push_cached_lint_diagnostics(
+fn push_cached_diagnostics(
     report: &mut CheckReport,
     path: &Path,
     relative_path: &Path,
     absolute_path: &Path,
-    diagnostics: &[CachedLintDiagnostic],
+    diagnostics: &[CachedDisplayedDiagnostic],
     source: Option<Arc<str>>,
 ) {
     for diagnostic in diagnostics {
@@ -1515,9 +1637,14 @@ fn push_cached_lint_diagnostics(
                 DisplayPosition::new(diagnostic.end_line, diagnostic.end_column),
             ),
             message: diagnostic.message.clone(),
-            kind: DisplayedDiagnosticKind::Lint {
-                code: diagnostic.code.clone(),
-                severity: diagnostic.severity.clone(),
+            kind: match &diagnostic.kind {
+                CachedDisplayedDiagnosticKind::ParseError => DisplayedDiagnosticKind::ParseError,
+                CachedDisplayedDiagnosticKind::Lint { code, severity } => {
+                    DisplayedDiagnosticKind::Lint {
+                        code: code.clone(),
+                        severity: severity.clone(),
+                    }
+                }
             },
             fix: diagnostic.fix.as_ref().map(CachedLintFix::to_displayed),
             source: source.clone(),
@@ -1554,6 +1681,116 @@ fn push_lint_diagnostics(
     }
 }
 
+fn embedded_supported_dialect(embedded: &EmbeddedScript) -> bool {
+    !matches!(embedded.dialect, ExtractedDialect::Unsupported)
+}
+
+fn embedded_dialects(
+    dialect: ExtractedDialect,
+) -> Option<(ShellDialect, shuck_parser::ShellDialect)> {
+    match dialect {
+        ExtractedDialect::Bash => Some((ShellDialect::Bash, shuck_parser::ShellDialect::Bash)),
+        ExtractedDialect::Sh => Some((ShellDialect::Sh, shuck_parser::ShellDialect::Posix)),
+        ExtractedDialect::Unsupported => None,
+    }
+}
+
+fn embedded_rule_allowed(rule: Rule) -> bool {
+    !matches!(
+        rule,
+        Rule::NonAbsoluteShebang
+            | Rule::IndentedShebang
+            | Rule::SpaceAfterHashBang
+            | Rule::ShebangNotOnFirstLine
+            | Rule::MissingShebangLine
+            | Rule::DuplicateShebangFlag
+            | Rule::DynamicSourcePath
+            | Rule::UntrackedSourceFile
+    )
+}
+
+fn remap_embedded_lint_diagnostics(
+    pending: &PendingProjectFile,
+    embedded: &EmbeddedScript,
+    diagnostics: &[shuck_linter::Diagnostic],
+    source: Option<Arc<str>>,
+) -> Vec<DisplayedDiagnostic> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| DisplayedDiagnostic {
+            path: pending.file.display_path.clone(),
+            relative_path: pending.file.relative_path.clone(),
+            absolute_path: pending.file.absolute_path.clone(),
+            span: remap_embedded_span(
+                embedded,
+                diagnostic.span.start.line,
+                diagnostic.span.start.column,
+                diagnostic.span.end.line,
+                diagnostic.span.end.column,
+            ),
+            message: prefixed_embedded_message(embedded, &diagnostic.message),
+            kind: DisplayedDiagnosticKind::Lint {
+                code: diagnostic.code().to_owned(),
+                severity: diagnostic.severity.as_str().to_owned(),
+            },
+            fix: None,
+            source: source.clone(),
+        })
+        .collect()
+}
+
+fn remap_embedded_parse_error(
+    pending: &PendingProjectFile,
+    embedded: &EmbeddedScript,
+    line: usize,
+    column: usize,
+    message: String,
+    source: Option<Arc<str>>,
+) -> DisplayedDiagnostic {
+    let position = remap_embedded_position(embedded, line, column);
+    DisplayedDiagnostic {
+        path: pending.file.display_path.clone(),
+        relative_path: pending.file.relative_path.clone(),
+        absolute_path: pending.file.absolute_path.clone(),
+        span: DisplaySpan::point(position.line, position.column),
+        message,
+        kind: DisplayedDiagnosticKind::ParseError,
+        fix: None,
+        source,
+    }
+}
+
+fn remap_embedded_span(
+    embedded: &EmbeddedScript,
+    start_line: usize,
+    start_column: usize,
+    end_line: usize,
+    end_column: usize,
+) -> DisplaySpan {
+    DisplaySpan::new(
+        remap_embedded_position(embedded, start_line, start_column),
+        remap_embedded_position(embedded, end_line, end_column),
+    )
+}
+
+fn remap_embedded_position(
+    embedded: &EmbeddedScript,
+    line: usize,
+    column: usize,
+) -> DisplayPosition {
+    let line = embedded.host_start_line + line.saturating_sub(1);
+    let column = if line == embedded.host_start_line {
+        embedded.host_start_column + column.saturating_sub(1)
+    } else {
+        column
+    };
+    DisplayPosition::new(line, column)
+}
+
+fn prefixed_embedded_message(embedded: &EmbeddedScript, message: &str) -> String {
+    format!("{}: {message}", embedded.label)
+}
+
 fn read_shared_source(path: &Path) -> Result<Arc<str>> {
     Ok(Arc::<str>::from(fs::read_to_string(path)?))
 }
@@ -1581,6 +1818,7 @@ mod tests {
                     storage_root: project_root.to_path_buf(),
                     canonical_root: fs::canonicalize(project_root).unwrap(),
                 },
+                kind: FileKind::Shell,
             },
             file_key: shuck_cache::FileCacheKey::from_path(path).unwrap(),
         }
@@ -1706,6 +1944,121 @@ mod tests {
         assert_eq!(report.diagnostics.len(), 1);
         assert_eq!(report.cache_hits, 0);
         assert_eq!(report.cache_misses, 1);
+    }
+
+    #[test]
+    fn checks_embedded_github_actions_workflows() {
+        let tempdir = tempdir().unwrap();
+        let workflows = tempdir.path().join(".github/workflows");
+        fs::create_dir_all(&workflows).unwrap();
+        fs::write(
+            workflows.join("ci.yml"),
+            r#"on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          unused=1
+          echo ok
+"#,
+        )
+        .unwrap();
+
+        let report = run_check_with_cwd(
+            &check_args(true),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            diagnostic_codes(&report),
+            vec![Rule::UnusedAssignment.code().to_owned()]
+        );
+        assert_eq!(
+            report.diagnostics[0].path,
+            PathBuf::from(".github/workflows/ci.yml")
+        );
+        assert_eq!(report.diagnostics[0].span.start.line, 7);
+        assert_eq!(report.diagnostics[0].span.start.column, 11);
+        assert!(
+            report.diagnostics[0]
+                .message
+                .starts_with("jobs.test.steps[0].run:")
+        );
+        assert!(
+            report.diagnostics[0]
+                .source
+                .as_deref()
+                .is_some_and(|source| source.contains("on: push"))
+        );
+    }
+
+    #[test]
+    fn skips_default_windows_shell_steps() {
+        let tempdir = tempdir().unwrap();
+        let workflows = tempdir.path().join(".github/workflows");
+        fs::create_dir_all(&workflows).unwrap();
+        fs::write(
+            workflows.join("ci.yml"),
+            r#"on: push
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - run: |
+          unused=1
+          echo ok
+"#,
+        )
+        .unwrap();
+
+        let report = run_check_with_cwd(
+            &check_args(true),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn can_disable_embedded_workflow_checks_in_config() {
+        let tempdir = tempdir().unwrap();
+        let workflows = tempdir.path().join(".github/workflows");
+        fs::create_dir_all(&workflows).unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[check]\nembedded = false\n",
+        )
+        .unwrap();
+        fs::write(
+            workflows.join("ci.yml"),
+            r#"on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          unused=1
+          echo ok
+"#,
+        )
+        .unwrap();
+
+        let report = run_check_with_cwd(
+            &check_args(true),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert!(report.diagnostics.is_empty());
     }
 
     #[test]
@@ -2085,7 +2438,11 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.diagnostics.len(), 1);
-        assert!(matches!(result.cache_data, CheckCacheData::ParseError(_)));
+        assert_eq!(result.cache_data.diagnostics.len(), 1);
+        assert!(matches!(
+            result.cache_data.diagnostics[0].kind,
+            CachedDisplayedDiagnosticKind::ParseError
+        ));
         match &result.diagnostics[0].kind {
             DisplayedDiagnosticKind::ParseError => {}
             other => panic!("expected parse error, got {other:?}"),
@@ -2452,8 +2809,9 @@ mod tests {
             &parse_result,
             &LinterSettings::default(),
             &ShellCheckCodeMap::default(),
+            &path,
         );
-        let (_, diagnostics) = display_lint_diagnostics(&pending, &source, &diagnostics, true);
+        let diagnostics = display_lint_diagnostics(&pending, &source, &diagnostics, true);
 
         let diagnostic_source = diagnostics[0]
             .source

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1799,9 +1799,9 @@ fn remap_embedded_column(
         }
 
         let substituted_start = placeholder_column.saturating_sub(1);
-        let substituted_len = placeholder.substituted_span.len();
+        let substituted_len = span_char_len(&embedded.source, &placeholder.substituted_span);
         let substituted_end = substituted_start + substituted_len;
-        let host_len = placeholder.host_span.len();
+        let host_len = placeholder.original.chars().count();
 
         if local_column >= substituted_end {
             cumulative_delta += host_len as isize - substituted_len as isize;
@@ -1836,6 +1836,12 @@ fn source_line_column_for_offset(source: &str, offset: usize) -> (usize, usize) 
     }
 
     (line, column)
+}
+
+fn span_char_len(source: &str, span: &std::ops::Range<usize>) -> usize {
+    source
+        .get(span.clone())
+        .map_or(0, |value| value.chars().count())
 }
 
 fn prefixed_embedded_message(embedded: &EmbeddedScript, message: &str) -> String {
@@ -2148,7 +2154,33 @@ jobs:
                 expression: "github.ref".to_owned(),
                 taint: shuck_extract::ExpressionTaint::Trusted,
                 substituted_span: 5..20,
-                host_span: 5..23,
+                host_span: 5..22,
+            }],
+            implicit_flags: ImplicitShellFlags::default(),
+        };
+
+        let position = remap_embedded_position(&embedded, 1, 21);
+        assert_eq!(position.line, 7);
+        assert_eq!(position.column, 31);
+    }
+
+    #[test]
+    fn remaps_columns_after_non_ascii_placeholder_expansion() {
+        let embedded = EmbeddedScript {
+            source: "echo ${_SHUCK_GHA_1}$FOO\n".to_owned(),
+            host_offset: 0,
+            host_start_line: 7,
+            host_start_column: 9,
+            dialect: ExtractedDialect::Bash,
+            label: "jobs.test.steps[0].run".to_owned(),
+            format: EmbeddedFormat::GitHubActions,
+            placeholders: vec![shuck_extract::PlaceholderMapping {
+                name: "_SHUCK_GHA_1".to_owned(),
+                original: "${{ github.refé }}".to_owned(),
+                expression: "github.refé".to_owned(),
+                taint: shuck_extract::ExpressionTaint::Trusted,
+                substituted_span: 5..20,
+                host_span: 5..24,
             }],
             implicit_flags: ImplicitShellFlags::default(),
         };

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1776,8 +1776,66 @@ fn remap_embedded_position(
     column: usize,
 ) -> DisplayPosition {
     let line = embedded.host_start_line + line.saturating_sub(1);
-    let column = embedded.host_start_column + column.saturating_sub(1);
+    let column = remap_embedded_column(embedded, line, column);
     DisplayPosition::new(line, column)
+}
+
+fn remap_embedded_column(
+    embedded: &EmbeddedScript,
+    host_line: usize,
+    snippet_column: usize,
+) -> usize {
+    let snippet_line = host_line
+        .saturating_sub(embedded.host_start_line)
+        .saturating_add(1);
+    let local_column = snippet_column.saturating_sub(1);
+    let mut cumulative_delta = 0isize;
+
+    for placeholder in &embedded.placeholders {
+        let (placeholder_line, placeholder_column) =
+            source_line_column_for_offset(&embedded.source, placeholder.substituted_span.start);
+        if placeholder_line != snippet_line {
+            continue;
+        }
+
+        let substituted_start = placeholder_column.saturating_sub(1);
+        let substituted_len = placeholder.substituted_span.len();
+        let substituted_end = substituted_start + substituted_len;
+        let host_len = placeholder.host_span.len();
+
+        if local_column >= substituted_end {
+            cumulative_delta += host_len as isize - substituted_len as isize;
+            continue;
+        }
+
+        if local_column >= substituted_start {
+            let host_start = substituted_start as isize + cumulative_delta;
+            let relative = local_column - substituted_start;
+            let mapped = host_start + relative.min(host_len.saturating_sub(1)) as isize;
+            return embedded.host_start_column + mapped.max(0) as usize;
+        }
+    }
+
+    embedded.host_start_column + (local_column as isize + cumulative_delta).max(0) as usize
+}
+
+fn source_line_column_for_offset(source: &str, offset: usize) -> (usize, usize) {
+    let mut line = 1usize;
+    let mut column = 1usize;
+
+    for (index, ch) in source.char_indices() {
+        if index >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+
+    (line, column)
 }
 
 fn prefixed_embedded_message(embedded: &EmbeddedScript, message: &str) -> String {
@@ -2072,6 +2130,32 @@ jobs:
         let position = remap_embedded_position(&embedded, 2, 5);
         assert_eq!(position.line, 8);
         assert_eq!(position.column, 13);
+    }
+
+    #[test]
+    fn remaps_columns_after_placeholder_expansion_on_the_same_line() {
+        let embedded = EmbeddedScript {
+            source: "echo ${_SHUCK_GHA_1}$FOO\n".to_owned(),
+            host_offset: 0,
+            host_start_line: 7,
+            host_start_column: 9,
+            dialect: ExtractedDialect::Bash,
+            label: "jobs.test.steps[0].run".to_owned(),
+            format: EmbeddedFormat::GitHubActions,
+            placeholders: vec![shuck_extract::PlaceholderMapping {
+                name: "_SHUCK_GHA_1".to_owned(),
+                original: "${{ github.ref }}".to_owned(),
+                expression: "github.ref".to_owned(),
+                taint: shuck_extract::ExpressionTaint::Trusted,
+                substituted_span: 5..20,
+                host_span: 5..23,
+            }],
+            implicit_flags: ImplicitShellFlags::default(),
+        };
+
+        let position = remap_embedded_position(&embedded, 1, 21);
+        assert_eq!(position.line, 7);
+        assert_eq!(position.column, 32);
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -12,7 +12,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use shuck_ast::TextSize;
 use shuck_cache::{CacheKey, CacheKeyHasher};
-use shuck_extract::{EmbeddedScript, ExtractedDialect, extract_all};
+use shuck_extract::{EmbeddedScript, ExtractedDialect, HostLineStart, extract_all};
 use shuck_indexer::Indexer;
 use shuck_linter::{
     Applicability, CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore, Rule, RuleSelector,
@@ -1775,19 +1775,25 @@ fn remap_embedded_position(
     line: usize,
     column: usize,
 ) -> DisplayPosition {
-    let line = embedded.host_start_line + line.saturating_sub(1);
-    let column = remap_embedded_column(embedded, line, column);
-    DisplayPosition::new(line, column)
+    let snippet_line = line.max(1);
+    let host_line_start = embedded
+        .host_line_starts
+        .get(snippet_line.saturating_sub(1))
+        .copied()
+        .unwrap_or(HostLineStart {
+            line: embedded.host_start_line + snippet_line.saturating_sub(1),
+            column: embedded.host_start_column,
+        });
+    let column = remap_embedded_column(embedded, snippet_line, host_line_start.column, column);
+    DisplayPosition::new(host_line_start.line, column)
 }
 
 fn remap_embedded_column(
     embedded: &EmbeddedScript,
-    host_line: usize,
+    snippet_line: usize,
+    host_start_column: usize,
     snippet_column: usize,
 ) -> usize {
-    let snippet_line = host_line
-        .saturating_sub(embedded.host_start_line)
-        .saturating_add(1);
     let local_column = snippet_column.saturating_sub(1);
     let mut cumulative_delta = 0isize;
 
@@ -1812,11 +1818,11 @@ fn remap_embedded_column(
             let host_start = substituted_start as isize + cumulative_delta;
             let relative = local_column - substituted_start;
             let mapped = host_start + relative.min(host_len.saturating_sub(1)) as isize;
-            return embedded.host_start_column + mapped.max(0) as usize;
+            return host_start_column + mapped.max(0) as usize;
         }
     }
 
-    embedded.host_start_column + (local_column as isize + cumulative_delta).max(0) as usize
+    host_start_column + (local_column as isize + cumulative_delta).max(0) as usize
 }
 
 fn source_line_column_for_offset(source: &str, offset: usize) -> (usize, usize) {
@@ -2126,6 +2132,11 @@ jobs:
             host_offset: 0,
             host_start_line: 7,
             host_start_column: 9,
+            host_line_starts: vec![
+                HostLineStart { line: 7, column: 9 },
+                HostLineStart { line: 8, column: 9 },
+                HostLineStart { line: 9, column: 9 },
+            ],
             dialect: ExtractedDialect::Bash,
             label: "jobs.test.steps[0].run".to_owned(),
             format: EmbeddedFormat::GitHubActions,
@@ -2145,6 +2156,7 @@ jobs:
             host_offset: 0,
             host_start_line: 7,
             host_start_column: 9,
+            host_line_starts: vec![HostLineStart { line: 7, column: 9 }],
             dialect: ExtractedDialect::Bash,
             label: "jobs.test.steps[0].run".to_owned(),
             format: EmbeddedFormat::GitHubActions,
@@ -2171,6 +2183,7 @@ jobs:
             host_offset: 0,
             host_start_line: 7,
             host_start_column: 9,
+            host_line_starts: vec![HostLineStart { line: 7, column: 9 }],
             dialect: ExtractedDialect::Bash,
             label: "jobs.test.steps[0].run".to_owned(),
             format: EmbeddedFormat::GitHubActions,
@@ -2188,6 +2201,39 @@ jobs:
         let position = remap_embedded_position(&embedded, 1, 21);
         assert_eq!(position.line, 7);
         assert_eq!(position.column, 32);
+    }
+
+    #[test]
+    fn remaps_positions_for_escaped_yaml_newlines() {
+        let embedded = EmbeddedScript {
+            source: "echo hi\nif true\n".to_owned(),
+            host_offset: 0,
+            host_start_line: 7,
+            host_start_column: 15,
+            host_line_starts: vec![
+                HostLineStart {
+                    line: 7,
+                    column: 15,
+                },
+                HostLineStart {
+                    line: 7,
+                    column: 24,
+                },
+                HostLineStart {
+                    line: 7,
+                    column: 33,
+                },
+            ],
+            dialect: ExtractedDialect::Bash,
+            label: "jobs.test.steps[0].run".to_owned(),
+            format: EmbeddedFormat::GitHubActions,
+            placeholders: Vec::new(),
+            implicit_flags: ImplicitShellFlags::default(),
+        };
+
+        let position = remap_embedded_position(&embedded, 2, 1);
+        assert_eq!(position.line, 7);
+        assert_eq!(position.column, 24);
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1403,10 +1403,7 @@ fn analyze_embedded_file(
 
     let mut displayed = Vec::new();
 
-    for embedded in extracted
-        .into_iter()
-        .filter(|embedded| embedded_supported_dialect(embedded))
-    {
+    for embedded in extracted.into_iter().filter(embedded_supported_dialect) {
         let Some((shell_dialect, parse_dialect)) = embedded_dialects(embedded.dialect) else {
             continue;
         };
@@ -1779,11 +1776,7 @@ fn remap_embedded_position(
     column: usize,
 ) -> DisplayPosition {
     let line = embedded.host_start_line + line.saturating_sub(1);
-    let column = if line == embedded.host_start_line {
-        embedded.host_start_column + column.saturating_sub(1)
-    } else {
-        column
-    };
+    let column = embedded.host_start_column + column.saturating_sub(1);
     DisplayPosition::new(line, column)
 }
 
@@ -1801,6 +1794,7 @@ mod tests {
     use std::sync::Arc;
 
     use notify::event::{CreateKind, EventAttributes, ModifyKind, RemoveKind, RenameMode};
+    use shuck_extract::{EmbeddedFormat, ImplicitShellFlags};
     use shuck_linter::{Category, Rule, RuleSelector};
     use tempfile::tempdir;
 
@@ -2059,6 +2053,25 @@ jobs:
         .unwrap();
 
         assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn remaps_embedded_columns_on_later_lines() {
+        let embedded = EmbeddedScript {
+            source: "echo hi\necho bye\n".to_owned(),
+            host_offset: 0,
+            host_start_line: 7,
+            host_start_column: 9,
+            dialect: ExtractedDialect::Bash,
+            label: "jobs.test.steps[0].run".to_owned(),
+            format: EmbeddedFormat::GitHubActions,
+            placeholders: Vec::new(),
+            implicit_flags: ImplicitShellFlags::default(),
+        };
+
+        let position = remap_embedded_position(&embedded, 2, 5);
+        assert_eq!(position.line, 8);
+        assert_eq!(position.column, 13);
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1082,6 +1082,7 @@ fn run_check_with_cwd(
         let analyzed_paths = run
             .files
             .iter()
+            .filter(|file| file.kind == FileKind::Shell)
             .map(|file| file.absolute_path.clone())
             .collect::<Vec<_>>();
         let project_settings = run.settings.clone();
@@ -1790,18 +1791,17 @@ fn remap_embedded_position(
             line: embedded.host_start_line + snippet_line.saturating_sub(1),
             column: embedded.host_start_column,
         });
-    let column = remap_embedded_column(embedded, snippet_line, host_line_start.column, column);
-    DisplayPosition::new(host_line_start.line, column)
+    remap_embedded_column(embedded, snippet_line, host_line_start, column)
 }
 
 fn remap_embedded_column(
     embedded: &EmbeddedScript,
     snippet_line: usize,
-    host_start_column: usize,
+    host_line_start: HostLineStart,
     snippet_column: usize,
-) -> usize {
+) -> DisplayPosition {
     let decoded_column = remap_placeholder_column(embedded, snippet_line, snippet_column);
-    remap_decoded_yaml_column(embedded, snippet_line, host_start_column, decoded_column)
+    remap_decoded_yaml_column(embedded, snippet_line, host_line_start, decoded_column)
 }
 
 fn remap_placeholder_column(
@@ -1843,29 +1843,28 @@ fn remap_placeholder_column(
 fn remap_decoded_yaml_column(
     embedded: &EmbeddedScript,
     snippet_line: usize,
-    host_start_column: usize,
+    host_line_start: HostLineStart,
     decoded_column: usize,
-) -> usize {
-    let local_column = decoded_column.saturating_sub(1);
-    let mut cumulative_delta = 0usize;
+) -> DisplayPosition {
+    let mut segment = host_line_start;
+    let mut segment_column = 1usize;
 
     for mapping in embedded
         .host_column_mappings
         .iter()
-        .filter(|mapping| mapping.line == snippet_line)
+        .filter(|mapping| mapping.line == snippet_line && mapping.column <= decoded_column)
     {
-        let mapped_start = mapping.column.saturating_sub(1);
-        if local_column > mapped_start {
-            cumulative_delta += mapping.host_columns.saturating_sub(1);
-            continue;
-        }
-
-        if local_column == mapped_start {
-            return host_start_column + mapped_start + cumulative_delta;
-        }
+        segment = HostLineStart {
+            line: mapping.host_line,
+            column: mapping.host_column,
+        };
+        segment_column = mapping.column;
     }
 
-    host_start_column + local_column + cumulative_delta
+    DisplayPosition::new(
+        segment.line,
+        segment.column + decoded_column.saturating_sub(segment_column),
+    )
 }
 
 fn source_line_column_for_offset(source: &str, offset: usize) -> (usize, usize) {
@@ -2296,8 +2295,9 @@ jobs:
             }],
             host_column_mappings: vec![shuck_extract::HostColumnMapping {
                 line: 1,
-                column: 5,
-                host_columns: 2,
+                column: 6,
+                host_line: 7,
+                host_column: 21,
             }],
             dialect: ExtractedDialect::Bash,
             label: "jobs.test.steps[0].run".to_owned(),
@@ -2309,6 +2309,35 @@ jobs:
         let position = remap_embedded_position(&embedded, 1, 6);
         assert_eq!(position.line, 7);
         assert_eq!(position.column, 21);
+    }
+
+    #[test]
+    fn remaps_columns_after_folded_double_quoted_yaml_newlines() {
+        let embedded = EmbeddedScript {
+            source: "echo ok ; unused=1\n".to_owned(),
+            host_offset: 0,
+            host_start_line: 6,
+            host_start_column: 15,
+            host_line_starts: vec![HostLineStart {
+                line: 6,
+                column: 15,
+            }],
+            host_column_mappings: vec![shuck_extract::HostColumnMapping {
+                line: 1,
+                column: 9,
+                host_line: 7,
+                host_column: 13,
+            }],
+            dialect: ExtractedDialect::Bash,
+            label: "jobs.test.steps[0].run".to_owned(),
+            format: EmbeddedFormat::GitHubActions,
+            placeholders: Vec::new(),
+            implicit_flags: ImplicitShellFlags::default(),
+        };
+
+        let position = remap_embedded_position(&embedded, 1, 9);
+        assert_eq!(position.line, 7);
+        assert_eq!(position.column, 13);
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/format.rs
+++ b/crates/shuck-cli/src/commands/format.rs
@@ -15,7 +15,7 @@ use crate::args::FormatCommand;
 use crate::cache::resolve_cache_root;
 use crate::commands::project_runner::{PendingProjectFile, prepare_project_runs};
 use crate::config::ConfigArguments;
-use crate::discover::DiscoveryOptions;
+use crate::discover::{DiscoveryOptions, FileKind};
 use crate::format_settings::{ResolvedFormatSettings, resolve_project_format_settings};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -172,6 +172,7 @@ fn run_format_with_cwd(
     let mut report = FormatReport::default();
 
     for mut run in runs {
+        run.files.retain(|file| file.kind == FileKind::Shell);
         let settings = run.settings.to_shell_format_options();
         let pending = run.take_pending_files(|file, cached| {
             report.cache_hits += 1;
@@ -498,5 +499,40 @@ mod tests {
         assert_eq!(first.cache_misses, 1);
         assert_eq!(second.cache_hits, 1);
         assert_eq!(second.cache_misses, 0);
+    }
+
+    #[test]
+    fn skips_embedded_workflow_yaml_during_format() {
+        let tempdir = tempdir().unwrap();
+        fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+        fs::write(tempdir.path().join("script.sh"), "#!/bin/bash\necho ok\n").unwrap();
+        fs::write(
+            tempdir.path().join(".github/workflows/ci.yml"),
+            r#"on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"#,
+        )
+        .unwrap();
+
+        let mut args = format_args(true);
+        args.check = true;
+
+        let report = run_format_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &tempdir.path().join("cache"),
+            FormatMode::Check,
+        )
+        .unwrap();
+
+        assert_eq!(report.exit_status(FormatMode::Check), ExitStatus::Success);
+        assert!(report.errors.is_empty());
+        assert!(report.changed_files.is_empty());
+        assert_eq!(report.cache_misses, 1);
     }
 }

--- a/crates/shuck-cli/src/config.rs
+++ b/crates/shuck-cli/src/config.rs
@@ -15,7 +15,8 @@ use crate::format_settings::{FormatSettingsPatch, parse_config_indent_style};
 
 const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
 pub(crate) const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
-const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["format", "lint"];
+const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["check", "format", "lint"];
+const CONFIG_OVERRIDE_CHECK_KEYS: &[&str] = &["embedded"];
 const CONFIG_OVERRIDE_FORMAT_KEYS: &[&str] = &[
     "dialect",
     "indent-style",
@@ -45,8 +46,15 @@ const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
 pub(crate) struct ShuckConfig {
+    pub check: CheckConfig,
     pub format: FormatConfig,
     pub lint: LintConfig,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub(crate) struct CheckConfig {
+    pub embedded: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
@@ -297,8 +305,17 @@ impl FormatConfig {
 
 impl ShuckConfig {
     fn apply_overrides(&mut self, overrides: ShuckConfig) {
+        self.check.apply_overrides(overrides.check);
         self.format.apply_overrides(overrides.format);
         self.lint.apply_overrides(overrides.lint);
+    }
+}
+
+impl CheckConfig {
+    fn apply_overrides(&mut self, overrides: CheckConfig) {
+        if overrides.embedded.is_some() {
+            self.embedded = overrides.embedded;
+        }
     }
 }
 
@@ -399,6 +416,20 @@ fn validate_override_table(table: &toml::Table) -> std::result::Result<(), Strin
                 return Err(format!(
                     "unsupported `[format]` option `{key}`; expected one of: {}",
                     CONFIG_OVERRIDE_FORMAT_KEYS.join(", ")
+                ));
+            }
+        }
+    }
+
+    if let Some(check_value) = table.get("check") {
+        let check = check_value
+            .as_table()
+            .ok_or_else(|| "`check` must be a TOML table".to_owned())?;
+        for key in check.keys() {
+            if !CONFIG_OVERRIDE_CHECK_KEYS.contains(&key.as_str()) {
+                return Err(format!(
+                    "unsupported `[check]` option `{key}`; expected one of: {}",
+                    CONFIG_OVERRIDE_CHECK_KEYS.join(", ")
                 ));
             }
         }
@@ -580,9 +611,21 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_check_keys() {
+        let config = parse_config_override("check.embedded = false").unwrap();
+        assert_eq!(config.check.embedded, Some(false));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_check_keys() {
+        let err = parse_config_override("check.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[check]` option `preview`"));
+    }
+
+    #[test]
     fn inline_config_overrides_reject_unknown_root_keys() {
-        let err = parse_config_override("check.embedded = false").unwrap_err();
-        assert!(err.contains("unsupported config option `check`"));
+        let err = parse_config_override("unknown.value = false").unwrap_err();
+        assert!(err.contains("unsupported config option `unknown`"));
     }
 
     #[test]

--- a/crates/shuck-cli/src/discover.rs
+++ b/crates/shuck-cli/src/discover.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result, anyhow};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::{DirEntry, ParallelVisitor, WalkBuilder, WalkState};
+use shuck_extract::is_extractable;
 
 use crate::config::{resolve_project_root_for_file, resolve_project_root_for_input};
 
@@ -38,6 +39,13 @@ pub(crate) struct DiscoveredFile {
     pub absolute_path: PathBuf,
     pub relative_path: PathBuf,
     pub project_root: ProjectRoot,
+    pub kind: FileKind,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) enum FileKind {
+    Shell,
+    Embedded,
 }
 
 #[derive(Debug)]
@@ -135,7 +143,9 @@ fn collect_input(
             return Ok(());
         }
         collect_directory(input, cwd, project_root, exclude_matcher, options, files)?;
-    } else if metadata.is_file() && is_shell_script(input)? {
+    } else if metadata.is_file()
+        && let Some(kind) = discovered_file_kind(input)?
+    {
         if options.force_exclude {
             if exclude_matcher.matches(input, cwd) {
                 return Ok(());
@@ -155,6 +165,7 @@ fn collect_input(
             &fallback_start,
             project_root,
             options.use_config_roots,
+            kind,
             files,
         )?;
     }
@@ -201,10 +212,12 @@ fn collect_directory(
         let path = entry.path();
         if should_ignore_path(path, options.cache_root.as_deref())
             || exclude_matcher.matches(path, cwd)
-            || !is_shell_script(path)?
         {
             continue;
         }
+        let Some(kind) = discovered_file_kind(path)? else {
+            continue;
+        };
 
         add_file(
             path,
@@ -212,6 +225,7 @@ fn collect_directory(
             input,
             project_root,
             options.use_config_roots,
+            kind,
             files,
         )?;
     }
@@ -251,14 +265,16 @@ fn collect_directory_parallel(
         .matched_paths
         .into_inner()
         .map_err(|_| anyhow!("parallel discovery matched-path state mutex poisoned"))?;
-    matched_paths.sort();
+    matched_paths
+        .sort_by(|left, right| left.path.cmp(&right.path).then(left.kind.cmp(&right.kind)));
     for matched_path in matched_paths {
         add_file(
-            &matched_path,
+            &matched_path.path,
             cwd,
             input,
             project_root,
             use_config_roots,
+            matched_path.kind,
             files,
         )?;
     }
@@ -403,8 +419,14 @@ fn path_matches_cache_root(path: &Path, cache_root: Option<&Path>) -> bool {
 
 #[derive(Default)]
 struct ParallelDiscoveryState {
-    matched_paths: Mutex<Vec<PathBuf>>,
+    matched_paths: Mutex<Vec<MatchedPath>>,
     error: Mutex<Option<anyhow::Error>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct MatchedPath {
+    path: PathBuf,
+    kind: FileKind,
 }
 
 struct ShellFilesVisitorBuilder<'a> {
@@ -435,7 +457,7 @@ struct ShellFilesVisitor<'a> {
     cwd: &'a Path,
     exclude_matcher: &'a ExcludeMatcher,
     state: &'a ParallelDiscoveryState,
-    local_paths: Vec<PathBuf>,
+    local_paths: Vec<MatchedPath>,
     local_error: Option<anyhow::Error>,
 }
 
@@ -475,9 +497,12 @@ impl ParallelVisitor for ShellFilesVisitor<'_> {
             return WalkState::Continue;
         }
 
-        match is_shell_script(path) {
-            Ok(true) => self.local_paths.push(entry.into_path()),
-            Ok(false) => {}
+        match discovered_file_kind(path) {
+            Ok(Some(kind)) => self.local_paths.push(MatchedPath {
+                path: entry.into_path(),
+                kind,
+            }),
+            Ok(None) => {}
             Err(err) => {
                 self.local_error = Some(err);
                 return WalkState::Quit;
@@ -510,6 +535,7 @@ pub(crate) fn add_file(
     fallback_start: &Path,
     default_project_root: &ProjectRoot,
     use_config_roots: bool,
+    kind: FileKind,
     files: &mut BTreeMap<PathBuf, DiscoveredFile>,
 ) -> Result<()> {
     let absolute_path =
@@ -547,6 +573,7 @@ pub(crate) fn add_file(
             absolute_path,
             relative_path,
             project_root,
+            kind,
         });
 
     Ok(())
@@ -581,6 +608,16 @@ pub(crate) fn is_shell_script(path: &Path) -> Result<bool> {
 
     let bytes = read_shebang_prefix(path)?;
     Ok(infer_shebang_dialect(&bytes).is_some())
+}
+
+fn discovered_file_kind(path: &Path) -> Result<Option<FileKind>> {
+    if is_shell_script(path)? {
+        return Ok(Some(FileKind::Shell));
+    }
+    if is_extractable(path) {
+        return Ok(Some(FileKind::Embedded));
+    }
+    Ok(None)
 }
 
 fn read_shebang_prefix(path: &Path) -> Result<Vec<u8>> {
@@ -663,6 +700,8 @@ impl ExcludeMatcher {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use tempfile::tempdir;
 
     use super::*;
@@ -710,5 +749,31 @@ mod tests {
         assert!(!is_allowed_by_gitignore(&first, &mut cache, true).unwrap());
         assert!(!is_allowed_by_gitignore(&second, &mut cache, true).unwrap());
         assert_eq!(cache.matchers.len(), 1);
+    }
+
+    #[test]
+    fn discovers_github_actions_workflows_as_embedded_files() {
+        let tempdir = tempdir().unwrap();
+        let workflows = tempdir.path().join(".github/workflows");
+        fs::create_dir_all(&workflows).unwrap();
+        fs::write(
+            workflows.join("ci.yml"),
+            "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: []\n",
+        )
+        .unwrap();
+
+        let files = discover_files(
+            &[tempdir.path().to_path_buf()],
+            tempdir.path(),
+            &DiscoveryOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].display_path,
+            PathBuf::from(".github/workflows/ci.yml")
+        );
+        assert_eq!(files[0].kind, FileKind::Embedded);
     }
 }

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -959,6 +959,7 @@ fn lint_with_context(
         rules: options.enabled_rules,
         severity_overrides: Default::default(),
         shell,
+        ambient_shell_options: Default::default(),
         analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
         per_file_ignores: Default::default(),
         report_environment_style_names: options.report_environment_style_names,

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -963,6 +963,34 @@ fn check_concise_output_remaps_single_quoted_workflow_runs() {
 }
 
 #[test]
+fn check_concise_output_remaps_plain_multiline_workflow_runs() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/plain.yml"),
+        r#"on: push
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+          ; unused=1
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:7:13: warning[C001] jobs.triage.steps[0].run: variable `unused` is assigned but never used\n",
+        platform_path(".github/workflows/plain.yml")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
 fn check_output_format_env_var_selects_json() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -716,6 +716,61 @@ jobs:
 }
 
 #[test]
+fn check_concise_output_uses_implicit_github_actions_errexit() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/deploy.yml"),
+        r#"on: push
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          cd /tmp
+          echo ready
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    cmd.assert().code(0).stdout("");
+}
+
+#[test]
+fn check_concise_output_reports_mapping_form_runs_on_workflow_lint() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/mapping.yml"),
+        r#"on: push
+jobs:
+  triage:
+    runs-on:
+      group: hosted
+      labels: ubuntu-latest
+    steps:
+      - run: |
+          unused=1
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:9:11: warning[C001] jobs.triage.steps[0].run: variable `unused` is assigned but never used\n",
+        platform_path(".github/workflows/mapping.yml")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
 fn check_output_format_env_var_selects_json() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -913,6 +913,27 @@ fn check_concise_output_remaps_double_quoted_workflow_line_continuations() {
 }
 
 #[test]
+fn check_concise_output_remaps_single_quoted_workflow_runs() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/single-quoted.yml"),
+        "on: push\njobs:\n  triage:\n    runs-on: ubuntu-latest\n    steps:\n      - run: 'echo ''ok''; unused=1'\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:6:28: warning[C001] jobs.triage.steps[0].run: variable `unused` is assigned but never used\n",
+        platform_path(".github/workflows/single-quoted.yml")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
 fn check_output_format_env_var_selects_json() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -771,6 +771,37 @@ jobs:
 }
 
 #[test]
+fn check_concise_output_ignores_windows_substrings_in_self_hosted_runner_labels() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/self-hosted.yml"),
+        r#"on: push
+jobs:
+  triage:
+    runs-on:
+      - self-hosted
+      - linux
+      - windows-tools
+    steps:
+      - run: |
+          unused=1
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:10:11: warning[C001] jobs.triage.steps[0].run: variable `unused` is assigned but never used\n",
+        platform_path(".github/workflows/self-hosted.yml")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
 fn check_output_format_env_var_selects_json() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -832,6 +832,66 @@ jobs:
 }
 
 #[test]
+fn check_concise_output_keeps_embedded_workflows_out_of_source_tracking() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join("main.sh"),
+        "#!/bin/sh\n. ./.github/workflows/ci.yml\n",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/ci.yml"),
+        r#"on: push
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:2:3: warning[C003] sourced file is not available to this analysis\n",
+        platform_path("main.sh")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
+fn check_concise_output_remaps_folded_double_quoted_workflow_lines() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/quoted.yml"),
+        r#"on: push
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo ok
+          ; unused=1"
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:7:13: warning[C001] jobs.triage.steps[0].run: variable `unused` is assigned but never used\n",
+        platform_path(".github/workflows/quoted.yml")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
 fn check_output_format_env_var_selects_json() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -684,6 +684,35 @@ jobs:
 }
 
 #[test]
+fn check_concise_output_avoids_placeholder_collisions_with_user_variables() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/collision.yml"),
+        r#"on: push
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          _SHUCK_GHA_1=1
+          echo "${{ github.ref }}"
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:7:11: warning[C001] jobs.triage.steps[0].run: variable `_SHUCK_GHA_1` is assigned but never used\n",
+        platform_path(".github/workflows/collision.yml")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
 fn check_concise_output_reports_realistic_issue_comment_workflow_parse_rule() {
     let tempdir = tempdir().unwrap();
     fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -892,6 +892,27 @@ jobs:
 }
 
 #[test]
+fn check_concise_output_remaps_double_quoted_workflow_line_continuations() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/continued.yml"),
+        "on: push\njobs:\n  triage:\n    runs-on: ubuntu-latest\n    steps:\n      - run: \"echo a\\\n          ; unused=1\"\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:7:13: warning[C001] jobs.triage.steps[0].run: variable `unused` is assigned but never used\n",
+        platform_path(".github/workflows/continued.yml")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
 fn check_output_format_env_var_selects_json() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -48,6 +48,14 @@ fn stdout_string(output: &std::process::Output) -> String {
     String::from_utf8(output.stdout.clone()).unwrap()
 }
 
+fn platform_path(path: &str) -> String {
+    if std::path::MAIN_SEPARATOR == '/' {
+        path.to_owned()
+    } else {
+        path.replace('/', std::path::MAIN_SEPARATOR_STR)
+    }
+}
+
 #[derive(Clone, Copy)]
 enum StreamKind {
     Stdout,
@@ -668,9 +676,11 @@ jobs:
     configure_env_cache(&mut cmd, tempdir.path());
     cmd.current_dir(tempdir.path())
         .args(["check", "--output-format", "concise"]);
-    cmd.assert().code(1).stdout(
-        ".github/workflows/issues.yml:10:11: warning[C001] jobs.triage.steps[0].run: variable `summary` is assigned but never used\n",
+    let expected = format!(
+        "{}:10:11: warning[C001] jobs.triage.steps[0].run: variable `summary` is assigned but never used\n",
+        platform_path(".github/workflows/issues.yml")
     );
+    cmd.assert().code(1).stdout(expected);
 }
 
 #[test]
@@ -698,9 +708,11 @@ jobs:
     configure_env_cache(&mut cmd, tempdir.path());
     cmd.current_dir(tempdir.path())
         .args(["check", "--output-format", "concise"]);
-    cmd.assert().code(1).stdout(
-        ".github/workflows/comment.yml:12:1: error[C035] jobs.reply.steps[0].run: this `if` block is missing a closing `fi`\n",
+    let expected = format!(
+        "{}:12:11: error[C035] jobs.reply.steps[0].run: this `if` block is missing a closing `fi`\n",
+        platform_path(".github/workflows/comment.yml")
     );
+    cmd.assert().code(1).stdout(expected);
 }
 
 #[test]

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -802,6 +802,36 @@ jobs:
 }
 
 #[test]
+fn check_concise_output_preserves_folded_workflow_line_gaps() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/folded.yml"),
+        r#"on: push
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >
+          echo ok
+
+          unused=1
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    let expected = format!(
+        "{}:9:11: warning[C001] jobs.triage.steps[0].run: variable `unused` is assigned but never used\n",
+        platform_path(".github/workflows/folded.yml")
+    );
+    cmd.assert().code(1).stdout(expected);
+}
+
+#[test]
 fn check_output_format_env_var_selects_json() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -645,6 +645,65 @@ fn check_concise_output_preserves_legacy_one_line_format() {
 }
 
 #[test]
+fn check_concise_output_reports_realistic_issue_workflow_lint() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/issues.yml"),
+        r#"on:
+  issues:
+    types: [opened, edited]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build summary
+        run: |
+          summary="${{ github.event.issue.title }}"
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    cmd.assert().code(1).stdout(
+        ".github/workflows/issues.yml:10:11: warning[C001] jobs.triage.steps[0].run: variable `summary` is assigned but never used\n",
+    );
+}
+
+#[test]
+fn check_concise_output_reports_realistic_issue_comment_workflow_parse_rule() {
+    let tempdir = tempdir().unwrap();
+    fs::create_dir_all(tempdir.path().join(".github/workflows")).unwrap();
+    fs::write(
+        tempdir.path().join(".github/workflows/comment.yml"),
+        r#"on:
+  issue_comment:
+    types: [created]
+jobs:
+  reply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Render comment
+        run: |
+          if [ -n "${{ github.event.comment.body }}" ]; then
+            echo ready
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise"]);
+    cmd.assert().code(1).stdout(
+        ".github/workflows/comment.yml:12:1: error[C035] jobs.reply.steps[0].run: this `if` block is missing a closing `fi`\n",
+    );
+}
+
+#[test]
 fn check_output_format_env_var_selects_json() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/zsh_option_state.rs
+++ b/crates/shuck-cli/tests/zsh_option_state.rs
@@ -8,7 +8,8 @@ use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    Checker, ExpansionContext, RuleSet, ShellDialect, WordFactContext, classify_file_context,
+    AmbientShellOptions, Checker, ExpansionContext, RuleSet, ShellDialect, WordFactContext,
+    classify_file_context,
 };
 use shuck_parser::parser::Parser;
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
@@ -150,6 +151,7 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
         &indexer,
         &rules,
         ShellDialect::Zsh,
+        AmbientShellOptions::default(),
         false,
         shuck_linter::LinterRuleOptions::default(),
         &file_context,

--- a/crates/shuck-extract/Cargo.toml
+++ b/crates/shuck-extract/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "shuck-extract"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Embedded shell script extraction for shuck"
+readme = "README.md"
+
+[dependencies]
+anyhow = { workspace = true }
+marked-yaml = { workspace = true }

--- a/crates/shuck-extract/README.md
+++ b/crates/shuck-extract/README.md
@@ -1,0 +1,12 @@
+# shuck-extract
+
+`shuck-extract` extracts shell scripts embedded in non-shell host files.
+
+Today it provides the extraction layer behind embedded GitHub Actions support in `shuck check`.
+It matches workflow files under `.github/workflows/` plus composite actions in `action.yml`,
+extracts `run:` blocks, resolves the effective shell, substitutes `${{ ... }}` expressions with
+synthetic shell placeholders, and returns enough source-location metadata to remap diagnostics back
+to the host YAML file.
+
+The crate is part of the published Shuck toolchain, but its Rust API is still pre-1.0 and may
+grow as more embedded-shell formats are added.

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -724,6 +724,10 @@ fn source_mapping_for_scalar(source: &str, start_offset: usize, scalar: &str) ->
         return mapping;
     }
 
+    if let Some(mapping) = plain_scalar_source_mapping(source, start_offset, scalar) {
+        return mapping;
+    }
+
     let host_offset = adjust_offset_to_scalar_content(source, start_offset, scalar);
     let (host_start_line, host_start_column) = line_column_for_offset(source, host_offset);
     SourceMapping {
@@ -927,6 +931,76 @@ fn single_quoted_source_mapping(
     }
 
     None
+}
+
+fn plain_scalar_source_mapping(
+    source: &str,
+    start_offset: usize,
+    scalar: &str,
+) -> Option<SourceMapping> {
+    let host_offset = adjust_offset_to_scalar_content(source, start_offset, scalar);
+    let content_line_start = line_start_offset(source, host_offset);
+    if previous_line_text(source, content_line_start).is_some_and(header_line_is_block_scalar) {
+        return None;
+    }
+
+    let (host_start_line, host_start_column) = line_column_for_offset(source, host_offset);
+    let mut host_line_starts = vec![HostLineStart {
+        line: host_start_line,
+        column: host_start_column,
+    }];
+    let mut host_column_mappings = Vec::new();
+    let mut decoded_line = 1usize;
+    let mut decoded_column = 1usize;
+    let mut decoded_offset = 0usize;
+    let mut relative_offset = 0usize;
+    let content = &source[host_offset..];
+    let mut saw_physical_newline = false;
+
+    while relative_offset < content.len() && decoded_offset < scalar.len() {
+        let absolute_offset = host_offset + relative_offset;
+        let ch = source[absolute_offset..].chars().next()?;
+        match ch {
+            '\n' => {
+                saw_physical_newline = true;
+                let folded =
+                    scan_quoted_physical_newline(source, host_offset, relative_offset, '\0')?;
+                let next_relative_offset = folded.next_relative_offset;
+                consume_quoted_fold(
+                    scalar,
+                    &mut decoded_offset,
+                    &mut decoded_line,
+                    &mut decoded_column,
+                    &mut host_line_starts,
+                    &mut host_column_mappings,
+                    folded,
+                )?;
+                relative_offset = next_relative_offset;
+            }
+            _ => {
+                let decoded_char = consume_decoded_char(
+                    scalar,
+                    &mut decoded_offset,
+                    &mut decoded_line,
+                    &mut decoded_column,
+                )?;
+                if decoded_char != ch {
+                    return None;
+                }
+                relative_offset += ch.len_utf8();
+            }
+        }
+    }
+
+    if !saw_physical_newline || decoded_offset != scalar.len() {
+        return None;
+    }
+
+    Some(SourceMapping {
+        host_offset,
+        host_line_starts,
+        host_column_mappings,
+    })
 }
 
 fn push_host_column_mapping(
@@ -1238,6 +1312,12 @@ fn header_line_is_folded_block(line: &str) -> bool {
     line.rsplit_once(':')
         .map(|(_, value)| value.trim_start().starts_with('>'))
         .unwrap_or(false)
+}
+
+fn header_line_is_block_scalar(line: &str) -> bool {
+    line.rsplit_once(':')
+        .and_then(|(_, value)| value.trim_start().chars().next())
+        .is_some_and(|indicator| matches!(indicator, '>' | '|'))
 }
 
 struct ParsedYamlEscape {
@@ -1949,6 +2029,31 @@ jobs:
                     host_column: 26,
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn remaps_plain_multiline_runs_onto_later_host_lines() {
+        let source = r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+          ; unused=1
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "echo ok ; unused=1");
+        assert_eq!(
+            scripts[0].host_column_mappings,
+            vec![HostColumnMapping {
+                line: 1,
+                column: 9,
+                host_line: 7,
+                host_column: 11,
+            }]
         );
     }
 

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -23,6 +23,8 @@ pub struct EmbeddedScript {
     pub host_start_column: usize,
     /// Per-line host positions for decoded snippet lines.
     pub host_line_starts: Vec<HostLineStart>,
+    /// Host column expansions for decoded characters that came from YAML escapes.
+    pub host_column_mappings: Vec<HostColumnMapping>,
     /// The shell dialect for this snippet.
     pub dialect: ExtractedDialect,
     /// Human-readable location label inside the host file.
@@ -60,6 +62,17 @@ pub struct HostLineStart {
     pub line: usize,
     /// 1-based column number in the host file.
     pub column: usize,
+}
+
+/// Host-file span of a decoded snippet character.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostColumnMapping {
+    /// 1-based decoded snippet line number.
+    pub line: usize,
+    /// 1-based decoded snippet column number.
+    pub column: usize,
+    /// Number of host-file columns consumed by the source character.
+    pub host_columns: usize,
 }
 
 /// Mapping between a synthetic placeholder and the original template expression.
@@ -580,10 +593,9 @@ fn runner_kind(runs_on: Option<&Node>) -> RunnerKind {
 }
 
 fn node_contains_runner_label(node: &Node, label: &str) -> bool {
-    let label = label.to_ascii_lowercase();
     if node
         .as_scalar()
-        .is_some_and(|scalar| scalar.as_str().to_ascii_lowercase().contains(&label))
+        .is_some_and(|scalar| scalar_matches_runner_label(scalar.as_str(), label))
     {
         return true;
     }
@@ -591,11 +603,41 @@ fn node_contains_runner_label(node: &Node, label: &str) -> bool {
     node.as_sequence().is_some_and(|sequence| {
         sequence
             .iter()
-            .any(|item| node_contains_runner_label(item, &label))
+            .any(|item| node_contains_runner_label(item, label))
     }) || node
         .as_mapping()
         .and_then(|mapping| mapping.get_node("labels"))
-        .is_some_and(|labels| node_contains_runner_label(labels, &label))
+        .is_some_and(|labels| node_contains_runner_label(labels, label))
+}
+
+fn scalar_matches_runner_label(scalar: &str, label: &str) -> bool {
+    let scalar = scalar.trim().to_ascii_lowercase();
+    match label {
+        "windows" => {
+            scalar == "windows"
+                || scalar.strip_prefix("windows-").is_some_and(|suffix| {
+                    suffix == "latest"
+                        || suffix.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+                })
+        }
+        "ubuntu" => {
+            scalar == "ubuntu"
+                || scalar.strip_prefix("ubuntu-").is_some_and(|suffix| {
+                    suffix == "latest"
+                        || suffix == "slim"
+                        || suffix.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+                })
+        }
+        "macos" => {
+            scalar == "macos"
+                || scalar.strip_prefix("macos-").is_some_and(|suffix| {
+                    suffix == "latest"
+                        || suffix.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+                })
+        }
+        "linux" => scalar == "linux",
+        _ => scalar == label,
+    }
 }
 
 fn node_contains_github_expression(node: &Node) -> bool {
@@ -650,6 +692,7 @@ fn build_embedded_script(
         host_start_line,
         host_start_column,
         host_line_starts: source_mapping.host_line_starts,
+        host_column_mappings: source_mapping.host_column_mappings,
         dialect: shell.dialect,
         label: label.to_owned(),
         format,
@@ -661,6 +704,7 @@ fn build_embedded_script(
 struct SourceMapping {
     host_offset: usize,
     host_line_starts: Vec<HostLineStart>,
+    host_column_mappings: Vec<HostColumnMapping>,
 }
 
 fn source_mapping_for_scalar(source: &str, start_offset: usize, scalar: &str) -> SourceMapping {
@@ -673,6 +717,7 @@ fn source_mapping_for_scalar(source: &str, start_offset: usize, scalar: &str) ->
     SourceMapping {
         host_offset,
         host_line_starts: default_host_line_starts(host_start_line, host_start_column, scalar),
+        host_column_mappings: Vec::new(),
     }
 }
 
@@ -690,37 +735,91 @@ fn double_quoted_source_mapping(
         let (line, column) = line_column_for_offset(source, content_offset);
         HostLineStart { line, column }
     }];
+    let mut host_column_mappings = Vec::new();
     let expected_line_count = decoded_line_count(scalar);
-    let mut escaped = false;
+    let mut decoded_line = 1usize;
+    let mut decoded_column = 1usize;
+    let mut relative_offset = 0usize;
+    let content = &source[content_offset..];
 
-    for (relative_offset, ch) in source[content_offset..].char_indices() {
+    while relative_offset < content.len() {
         let absolute_offset = content_offset + relative_offset;
-        if escaped {
-            if matches!(ch, 'n' | 'r' | 'N' | 'L' | 'P') {
-                let (line, column) =
-                    line_column_for_offset(source, absolute_offset + ch.len_utf8());
-                host_line_starts.push(HostLineStart { line, column });
-            }
-            escaped = false;
-            continue;
-        }
-
+        let ch = source[absolute_offset..].chars().next()?;
         match ch {
-            '\\' => escaped = true,
+            '\\' => {
+                let escape = parse_double_quoted_yaml_escape(source, absolute_offset)?;
+                if escape.produces_newline {
+                    let (line, column) =
+                        line_column_for_offset(source, absolute_offset + escape.host_columns);
+                    host_line_starts.push(HostLineStart { line, column });
+                    decoded_line += 1;
+                    decoded_column = 1;
+                } else {
+                    if escape.host_columns > 1 {
+                        host_column_mappings.push(HostColumnMapping {
+                            line: decoded_line,
+                            column: decoded_column,
+                            host_columns: escape.host_columns,
+                        });
+                    }
+                    decoded_column += 1;
+                }
+                relative_offset += escape.host_columns;
+            }
             '"' => {
                 if host_line_starts.len() == expected_line_count {
                     return Some(SourceMapping {
                         host_offset: content_offset,
                         host_line_starts,
+                        host_column_mappings,
                     });
                 }
                 return None;
             }
-            _ => {}
+            '\n' => {
+                decoded_line += 1;
+                decoded_column = 1;
+                relative_offset += ch.len_utf8();
+            }
+            _ => {
+                decoded_column += 1;
+                relative_offset += ch.len_utf8();
+            }
         }
     }
 
     None
+}
+
+struct ParsedYamlEscape {
+    host_columns: usize,
+    produces_newline: bool,
+}
+
+fn parse_double_quoted_yaml_escape(source: &str, offset: usize) -> Option<ParsedYamlEscape> {
+    debug_assert_eq!(source[offset..].chars().next(), Some('\\'));
+    let escape = source[offset + '\\'.len_utf8()..].chars().next()?;
+    let host_columns = match escape {
+        'x' => '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 2)?,
+        'u' => '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 4)?,
+        'U' => '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 8)?,
+        _ => '\\'.len_utf8() + escape.len_utf8(),
+    };
+
+    Some(ParsedYamlEscape {
+        host_columns,
+        produces_newline: matches!(escape, 'n' | 'r' | 'N' | 'L' | 'P'),
+    })
+}
+
+fn fixed_hex_escape_len(source: &str, offset: usize, digits: usize) -> Option<usize> {
+    let start = offset + '\\'.len_utf8() + 1;
+    let end = start + digits;
+    source
+        .get(start..end)?
+        .chars()
+        .all(|ch| ch.is_ascii_hexdigit())
+        .then_some(digits)
 }
 
 fn default_host_line_starts(
@@ -1067,6 +1166,27 @@ jobs:
     }
 
     #[test]
+    fn prefers_unix_runner_when_custom_self_hosted_label_mentions_windows() {
+        let source = r#"
+on: push
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - linux
+      - windows-tools
+    steps:
+      - run: echo hi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
+        assert!(scripts[0].implicit_flags.errexit);
+        assert!(scripts[0].implicit_flags.pipefail);
+    }
+
+    #[test]
     fn recognizes_path_and_env_shell_templates() {
         let source = r#"
 on: push
@@ -1192,6 +1312,42 @@ jobs:
                 HostLineStart {
                     line: 7,
                     column: 33,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_host_columns_for_non_newline_escaped_double_quoted_runs() {
+        let source = r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo\t\"hi\""
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "echo\t\"hi\"");
+        assert_eq!(
+            scripts[0].host_column_mappings,
+            vec![
+                HostColumnMapping {
+                    line: 1,
+                    column: 5,
+                    host_columns: 2,
+                },
+                HostColumnMapping {
+                    line: 1,
+                    column: 6,
+                    host_columns: 2,
+                },
+                HostColumnMapping {
+                    line: 1,
+                    column: 9,
+                    host_columns: 2,
                 },
             ]
         );

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Extract embedded shell scripts from non-shell host files.
 
+use std::collections::HashSet;
 use std::ops::Range;
 use std::path::Path;
 
@@ -9,6 +10,7 @@ use anyhow::{Result, anyhow};
 use marked_yaml::{Node, parse_yaml};
 
 const GITHUB_ACTIONS_SOURCE_ID: usize = 0;
+const GITHUB_ACTIONS_PLACEHOLDER_PREFIX: &str = "_SHUCK_GHA_";
 
 /// A shell snippet extracted from a host file.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1365,6 +1367,7 @@ fn substitute_github_actions_expressions(
 ) -> (String, Vec<PlaceholderMapping>) {
     let mut output = String::with_capacity(source.len());
     let mut placeholders = Vec::new();
+    let mut occupied_names = collect_placeholder_names(source);
     let mut cursor = 0usize;
     let mut counter = 1usize;
 
@@ -1383,7 +1386,7 @@ fn substitute_github_actions_expressions(
             .trim_end_matches("}}")
             .trim()
             .to_owned();
-        let name = format!("_SHUCK_GHA_{counter}");
+        let name = next_placeholder_name(&mut occupied_names, &mut counter);
         let replacement = format!("${{{name}}}");
         let substituted_start = output.len();
         output.push_str(&replacement);
@@ -1396,7 +1399,6 @@ fn substitute_github_actions_expressions(
             substituted_span: substituted_start..substituted_end,
             host_span: host_offset + start..host_offset + end,
         });
-        counter += 1;
         cursor = end;
     }
 
@@ -1405,6 +1407,50 @@ fn substitute_github_actions_expressions(
     }
 
     (output, placeholders)
+}
+
+fn collect_placeholder_names(source: &str) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let bytes = source.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if !is_shell_identifier_start(bytes[index]) {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        index += 1;
+        while index < bytes.len() && is_shell_identifier_continue(bytes[index]) {
+            index += 1;
+        }
+
+        let candidate = &source[start..index];
+        if candidate.starts_with(GITHUB_ACTIONS_PLACEHOLDER_PREFIX) {
+            names.insert(candidate.to_owned());
+        }
+    }
+
+    names
+}
+
+fn next_placeholder_name(occupied_names: &mut HashSet<String>, counter: &mut usize) -> String {
+    loop {
+        let name = format!("{GITHUB_ACTIONS_PLACEHOLDER_PREFIX}{counter}");
+        *counter += 1;
+        if occupied_names.insert(name.clone()) {
+            return name;
+        }
+    }
+}
+
+fn is_shell_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn is_shell_identifier_continue(byte: u8) -> bool {
+    is_shell_identifier_start(byte) || byte.is_ascii_digit()
 }
 
 fn find_github_actions_expression_end(source: &str, expression_start: usize) -> Option<usize> {
@@ -1966,6 +2012,29 @@ jobs:
         assert_eq!(scripts.len(), 1);
         assert_eq!(scripts[0].source, "echo ${_SHUCK_GHA_1}suffix");
         assert_eq!(scripts[0].placeholders[0].substituted_span, 5..20);
+    }
+
+    #[test]
+    fn skips_placeholder_names_already_present_in_source() {
+        let source = r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          _SHUCK_GHA_1=1
+          echo "${{ github.ref }}"
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(
+            scripts[0].source,
+            "_SHUCK_GHA_1=1\necho \"${_SHUCK_GHA_2}\"\n"
+        );
+        assert_eq!(scripts[0].placeholders.len(), 1);
+        assert_eq!(scripts[0].placeholders[0].name, "_SHUCK_GHA_2");
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -369,8 +369,20 @@ fn detect_shell_dialect(template: &str) -> ExtractedDialect {
 
     let first = shell_token_basename(&first);
     if first == "env" {
+        let mut skip_next = false;
         for token in tokens {
-            if token == "{0}" || token.starts_with('-') || looks_like_env_assignment(&token) {
+            if skip_next {
+                skip_next = false;
+                continue;
+            }
+            if token == "{0}" || looks_like_env_assignment(&token) {
+                continue;
+            }
+            if env_option_consumes_value(&token) {
+                skip_next = env_option_uses_separate_value(&token);
+                continue;
+            }
+            if token.starts_with('-') {
                 continue;
             }
             return shell_name_dialect(&shell_token_basename(&token));
@@ -379,6 +391,18 @@ fn detect_shell_dialect(template: &str) -> ExtractedDialect {
     }
 
     shell_name_dialect(&first)
+}
+
+fn env_option_consumes_value(token: &str) -> bool {
+    matches!(token, "-u" | "-C" | "--unset" | "--chdir")
+        || token.starts_with("-u")
+        || token.starts_with("-C")
+        || token.starts_with("--unset=")
+        || token.starts_with("--chdir=")
+}
+
+fn env_option_uses_separate_value(token: &str) -> bool {
+    matches!(token, "-u" | "-C" | "--unset" | "--chdir")
 }
 
 fn template_tokens(template: &str) -> Vec<String> {
@@ -544,15 +568,15 @@ fn runner_kind(runs_on: Option<&Node>) -> RunnerKind {
         return RunnerKind::Windows;
     }
 
+    if node_contains_unix_runner_label(runs_on) {
+        return RunnerKind::Unix;
+    }
+
     if node_contains_github_expression(runs_on) {
         return RunnerKind::Unknown;
     }
 
-    if node_contains_unix_runner_label(runs_on) {
-        RunnerKind::Unix
-    } else {
-        RunnerKind::Unknown
-    }
+    RunnerKind::Unknown
 }
 
 fn node_contains_runner_label(node: &Node, label: &str) -> bool {
@@ -1025,6 +1049,24 @@ jobs:
     }
 
     #[test]
+    fn infers_default_shell_when_fixed_runner_labels_mix_with_expressions() {
+        let source = r#"
+on: push
+jobs:
+  build:
+    runs-on:
+      - ubuntu-latest
+      - ${{ matrix.arch }}
+    steps:
+      - run: echo hi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
+    }
+
+    #[test]
     fn recognizes_path_and_env_shell_templates() {
         let source = r#"
 on: push
@@ -1038,6 +1080,8 @@ jobs:
         run: echo hi
       - shell: /usr/bin/env FOO=1 bash -e {0}
         run: echo hi
+      - shell: /usr/bin/env -u FOO bash -e {0}
+        run: echo hi
       - shell: /bin/sh -e {0}
         run: echo hi
       - shell: '"C:/Program Files/Git/bin/bash.exe" -e {0}'
@@ -1047,13 +1091,14 @@ jobs:
 "#;
 
         let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
-        assert_eq!(scripts.len(), 6);
+        assert_eq!(scripts.len(), 7);
         assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
         assert_eq!(scripts[1].dialect, ExtractedDialect::Bash);
         assert_eq!(scripts[2].dialect, ExtractedDialect::Bash);
-        assert_eq!(scripts[3].dialect, ExtractedDialect::Sh);
-        assert_eq!(scripts[4].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[3].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[4].dialect, ExtractedDialect::Sh);
         assert_eq!(scripts[5].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[6].dialect, ExtractedDialect::Bash);
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -389,7 +389,15 @@ fn template_tokens(template: &str) -> Vec<String> {
                 '\'' => state = QuoteState::SingleQuoted,
                 '"' => state = QuoteState::DoubleQuoted,
                 '\\' => match chars.next() {
-                    Some(escaped) => current.push(escaped),
+                    Some(escaped)
+                        if escaped.is_whitespace() || matches!(escaped, '"' | '\'' | '\\') =>
+                    {
+                        current.push(escaped);
+                    }
+                    Some(escaped) => {
+                        current.push(ch);
+                        current.push(escaped);
+                    }
                     None => current.push(ch),
                 },
                 ch if ch.is_whitespace() => push_template_token(&mut tokens, &mut current),
@@ -405,7 +413,13 @@ fn template_tokens(template: &str) -> Vec<String> {
             QuoteState::DoubleQuoted => match ch {
                 '"' => state = QuoteState::Unquoted,
                 '\\' => match chars.next() {
-                    Some(escaped) => current.push(escaped),
+                    Some(escaped) if matches!(escaped, '"' | '\\' | '$' | '`') => {
+                        current.push(escaped);
+                    }
+                    Some(escaped) => {
+                        current.push(ch);
+                        current.push(escaped);
+                    }
                     None => current.push(ch),
                 },
                 _ => current.push(ch),
@@ -424,9 +438,9 @@ fn push_template_token(tokens: &mut Vec<String>, current: &mut String) {
 }
 
 fn shell_token_basename(token: &str) -> String {
-    let basename = Path::new(token)
-        .file_name()
-        .and_then(|value| value.to_str())
+    let basename = token
+        .rsplit(['/', '\\'])
+        .next()
         .unwrap_or(token)
         .to_ascii_lowercase();
 
@@ -507,7 +521,11 @@ fn runner_kind(runs_on: Option<&Node>) -> RunnerKind {
         return RunnerKind::Unknown;
     }
 
-    RunnerKind::Unix
+    if node_contains_unix_runner_label(runs_on) {
+        RunnerKind::Unix
+    } else {
+        RunnerKind::Unknown
+    }
 }
 
 fn node_contains_runner_label(node: &Node, label: &str) -> bool {
@@ -541,6 +559,12 @@ fn node_contains_github_expression(node: &Node) -> bool {
                 .is_some_and(|scalar| scalar.as_str().contains("${{"))
         })
     })
+}
+
+fn node_contains_unix_runner_label(node: &Node) -> bool {
+    ["ubuntu", "linux", "macos"]
+        .into_iter()
+        .any(|label| node_contains_runner_label(node, label))
 }
 
 fn build_embedded_script(
@@ -884,14 +908,38 @@ jobs:
         run: echo hi
       - shell: '"C:/Program Files/Git/bin/bash.exe" -e {0}'
         run: echo hi
+      - shell: '"C:\Program Files\Git\bin\bash.exe" -e {0}'
+        run: echo hi
 "#;
 
         let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
-        assert_eq!(scripts.len(), 4);
+        assert_eq!(scripts.len(), 5);
         assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
         assert_eq!(scripts[1].dialect, ExtractedDialect::Bash);
         assert_eq!(scripts[2].dialect, ExtractedDialect::Sh);
         assert_eq!(scripts[3].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[4].dialect, ExtractedDialect::Bash);
+    }
+
+    #[test]
+    fn skips_default_shell_for_ambiguous_runner_labels() {
+        let source = r#"
+on: push
+jobs:
+  self_hosted:
+    runs-on: self-hosted
+    steps:
+      - run: echo hi
+  labeled:
+    runs-on: [self-hosted, x64]
+    steps:
+      - run: echo hi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 2);
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Unsupported);
+        assert_eq!(scripts[1].dialect, ExtractedDialect::Unsupported);
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -351,18 +351,18 @@ fn resolve_shell(shell: Option<&str>, runner_kind: RunnerKind) -> ShellResolutio
 }
 
 fn detect_shell_dialect(template: &str) -> ExtractedDialect {
-    let mut tokens = template.split_whitespace();
+    let mut tokens = template_tokens(template).into_iter();
     let Some(first) = tokens.next() else {
         return ExtractedDialect::Unsupported;
     };
 
-    let first = shell_token_basename(first);
+    let first = shell_token_basename(&first);
     if first == "env" {
         for token in tokens {
             if token == "{0}" || token.starts_with('-') {
                 continue;
             }
-            return shell_name_dialect(&shell_token_basename(token));
+            return shell_name_dialect(&shell_token_basename(&token));
         }
         return ExtractedDialect::Unsupported;
     }
@@ -370,12 +370,72 @@ fn detect_shell_dialect(template: &str) -> ExtractedDialect {
     shell_name_dialect(&first)
 }
 
+fn template_tokens(template: &str) -> Vec<String> {
+    #[derive(Clone, Copy)]
+    enum QuoteState {
+        Unquoted,
+        SingleQuoted,
+        DoubleQuoted,
+    }
+
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = template.chars();
+    let mut state = QuoteState::Unquoted;
+
+    while let Some(ch) = chars.next() {
+        match state {
+            QuoteState::Unquoted => match ch {
+                '\'' => state = QuoteState::SingleQuoted,
+                '"' => state = QuoteState::DoubleQuoted,
+                '\\' => match chars.next() {
+                    Some(escaped) => current.push(escaped),
+                    None => current.push(ch),
+                },
+                ch if ch.is_whitespace() => push_template_token(&mut tokens, &mut current),
+                _ => current.push(ch),
+            },
+            QuoteState::SingleQuoted => {
+                if ch == '\'' {
+                    state = QuoteState::Unquoted;
+                } else {
+                    current.push(ch);
+                }
+            }
+            QuoteState::DoubleQuoted => match ch {
+                '"' => state = QuoteState::Unquoted,
+                '\\' => match chars.next() {
+                    Some(escaped) => current.push(escaped),
+                    None => current.push(ch),
+                },
+                _ => current.push(ch),
+            },
+        }
+    }
+
+    push_template_token(&mut tokens, &mut current);
+    tokens
+}
+
+fn push_template_token(tokens: &mut Vec<String>, current: &mut String) {
+    if !current.is_empty() {
+        tokens.push(std::mem::take(current));
+    }
+}
+
 fn shell_token_basename(token: &str) -> String {
-    Path::new(token)
+    let basename = Path::new(token)
         .file_name()
         .and_then(|value| value.to_str())
         .unwrap_or(token)
-        .to_ascii_lowercase()
+        .to_ascii_lowercase();
+
+    basename
+        .strip_suffix(".exe")
+        .or_else(|| basename.strip_suffix(".cmd"))
+        .or_else(|| basename.strip_suffix(".bat"))
+        .unwrap_or(&basename)
+        .to_owned()
 }
 
 fn shell_name_dialect(name: &str) -> ExtractedDialect {
@@ -390,16 +450,16 @@ fn shell_name_dialect(name: &str) -> ExtractedDialect {
 fn parse_template_flags(template: &str) -> ImplicitShellFlags {
     let mut errexit = false;
     let mut pipefail = false;
-    let mut tokens = template.split_whitespace().peekable();
+    let mut tokens = template_tokens(template).into_iter().peekable();
     let _ = tokens.next();
 
     while let Some(token) = tokens.next() {
-        match token {
+        match token.as_str() {
             "{0}" => {}
             "-e" | "--errexit" => errexit = true,
             "-o" => match tokens.next() {
-                Some("errexit") => errexit = true,
-                Some("pipefail") => pipefail = true,
+                Some(value) if value == "errexit" => errexit = true,
+                Some(value) if value == "pipefail" => pipefail = true,
                 _ => {}
             },
             token if token.starts_with('-') && !token.starts_with("--") => {
@@ -408,7 +468,7 @@ fn parse_template_flags(template: &str) -> ImplicitShellFlags {
                     errexit = true;
                 }
                 if flags.contains('o')
-                    && let Some(next) = tokens.peek().copied()
+                    && let Some(next) = tokens.peek().map(String::as_str)
                 {
                     match next {
                         "errexit" => {
@@ -822,13 +882,16 @@ jobs:
         run: echo hi
       - shell: /bin/sh -e {0}
         run: echo hi
+      - shell: '"C:/Program Files/Git/bin/bash.exe" -e {0}'
+        run: echo hi
 "#;
 
         let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
-        assert_eq!(scripts.len(), 3);
+        assert_eq!(scripts.len(), 4);
         assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
         assert_eq!(scripts[1].dialect, ExtractedDialect::Bash);
         assert_eq!(scripts[2].dialect, ExtractedDialect::Sh);
+        assert_eq!(scripts[3].dialect, ExtractedDialect::Bash);
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -304,6 +304,7 @@ struct ShellResolution {
 enum RunnerKind {
     Unix,
     Windows,
+    Unknown,
 }
 
 fn resolve_shell(shell: Option<&str>, runner_kind: RunnerKind) -> ShellResolution {
@@ -318,6 +319,10 @@ fn resolve_shell(shell: Option<&str>, runner_kind: RunnerKind) -> ShellResolutio
                 },
             },
             RunnerKind::Windows => ShellResolution {
+                dialect: ExtractedDialect::Unsupported,
+                implicit_flags: ImplicitShellFlags::default(),
+            },
+            RunnerKind::Unknown => ShellResolution {
                 dialect: ExtractedDialect::Unsupported,
                 implicit_flags: ImplicitShellFlags::default(),
             },
@@ -338,24 +343,47 @@ fn resolve_shell(shell: Option<&str>, runner_kind: RunnerKind) -> ShellResolutio
                 template: Some("sh -e {0}".to_owned()),
             },
         },
-        Some(value) => {
-            let base = value
-                .split_whitespace()
-                .next()
-                .map(|token| token.to_ascii_lowercase())
-                .unwrap_or_default();
-            let dialect = match base.as_str() {
-                "bash" => ExtractedDialect::Bash,
-                "sh" => ExtractedDialect::Sh,
-                "pwsh" | "powershell" | "cmd" | "python" => ExtractedDialect::Unsupported,
-                _ => ExtractedDialect::Unsupported,
-            };
+        Some(value) => ShellResolution {
+            dialect: detect_shell_dialect(value),
+            implicit_flags: parse_template_flags(value),
+        },
+    }
+}
 
-            ShellResolution {
-                dialect,
-                implicit_flags: parse_template_flags(value),
+fn detect_shell_dialect(template: &str) -> ExtractedDialect {
+    let mut tokens = template.split_whitespace();
+    let Some(first) = tokens.next() else {
+        return ExtractedDialect::Unsupported;
+    };
+
+    let first = shell_token_basename(first);
+    if first == "env" {
+        for token in tokens {
+            if token == "{0}" || token.starts_with('-') {
+                continue;
             }
+            return shell_name_dialect(&shell_token_basename(token));
         }
+        return ExtractedDialect::Unsupported;
+    }
+
+    shell_name_dialect(&first)
+}
+
+fn shell_token_basename(token: &str) -> String {
+    Path::new(token)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(token)
+        .to_ascii_lowercase()
+}
+
+fn shell_name_dialect(name: &str) -> ExtractedDialect {
+    match name {
+        "bash" => ExtractedDialect::Bash,
+        "sh" => ExtractedDialect::Sh,
+        "pwsh" | "powershell" | "cmd" | "python" => ExtractedDialect::Unsupported,
+        _ => ExtractedDialect::Unsupported,
     }
 }
 
@@ -411,23 +439,48 @@ fn runner_kind(runs_on: Option<&Node>) -> RunnerKind {
         return RunnerKind::Unix;
     };
 
-    if runs_on
-        .as_scalar()
-        .is_some_and(|scalar| scalar.as_str().to_ascii_lowercase().contains("windows"))
-    {
+    if node_contains_runner_label(runs_on, "windows") {
         return RunnerKind::Windows;
     }
 
-    if let Some(sequence) = runs_on.as_sequence()
-        && sequence.iter().any(|node| {
-            node.as_scalar()
-                .is_some_and(|scalar| scalar.as_str().to_ascii_lowercase().contains("windows"))
-        })
-    {
-        return RunnerKind::Windows;
+    if node_contains_github_expression(runs_on) {
+        return RunnerKind::Unknown;
     }
 
     RunnerKind::Unix
+}
+
+fn node_contains_runner_label(node: &Node, label: &str) -> bool {
+    let label = label.to_ascii_lowercase();
+    if node
+        .as_scalar()
+        .is_some_and(|scalar| scalar.as_str().to_ascii_lowercase().contains(&label))
+    {
+        return true;
+    }
+
+    node.as_sequence().is_some_and(|sequence| {
+        sequence.iter().any(|item| {
+            item.as_scalar()
+                .is_some_and(|scalar| scalar.as_str().to_ascii_lowercase().contains(&label))
+        })
+    })
+}
+
+fn node_contains_github_expression(node: &Node) -> bool {
+    if node
+        .as_scalar()
+        .is_some_and(|scalar| scalar.as_str().contains("${{"))
+    {
+        return true;
+    }
+
+    node.as_sequence().is_some_and(|sequence| {
+        sequence.iter().any(|item| {
+            item.as_scalar()
+                .is_some_and(|scalar| scalar.as_str().contains("${{"))
+        })
+    })
 }
 
 fn build_embedded_script(
@@ -737,6 +790,45 @@ jobs:
         assert!(scripts[0].implicit_flags.errexit);
         assert!(scripts[0].implicit_flags.pipefail);
         assert_eq!(scripts[1].dialect, ExtractedDialect::Unsupported);
+    }
+
+    #[test]
+    fn skips_default_shell_when_runner_is_dynamic() {
+        let source = r#"
+on: push
+jobs:
+  dynamic:
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: echo hi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Unsupported);
+    }
+
+    #[test]
+    fn recognizes_path_and_env_shell_templates() {
+        let source = r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: /bin/bash -e {0}
+        run: echo hi
+      - shell: /usr/bin/env bash -e {0}
+        run: echo hi
+      - shell: /bin/sh -e {0}
+        run: echo hi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 3);
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[1].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[2].dialect, ExtractedDialect::Sh);
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -712,6 +712,10 @@ fn source_mapping_for_scalar(source: &str, start_offset: usize, scalar: &str) ->
         return mapping;
     }
 
+    if let Some(mapping) = folded_block_source_mapping(source, start_offset, scalar) {
+        return mapping;
+    }
+
     let host_offset = adjust_offset_to_scalar_content(source, start_offset, scalar);
     let (host_start_line, host_start_column) = line_column_for_offset(source, host_offset);
     SourceMapping {
@@ -789,6 +793,165 @@ fn double_quoted_source_mapping(
     }
 
     None
+}
+
+fn folded_block_source_mapping(
+    source: &str,
+    start_offset: usize,
+    scalar: &str,
+) -> Option<SourceMapping> {
+    let host_offset = adjust_offset_to_scalar_content(source, start_offset, scalar);
+    let (host_start_line, host_start_column) = line_column_for_offset(source, host_offset);
+    let content_line_start = line_start_offset(source, host_offset);
+    let header_line = previous_line_text(source, content_line_start)?;
+    if !header_line_is_folded_block(header_line) {
+        return None;
+    }
+
+    let content_indent = host_start_column.saturating_sub(1);
+    let expected_line_count = decoded_line_count(scalar);
+    let mut host_line_starts = vec![HostLineStart {
+        line: host_start_line,
+        column: host_start_column,
+    }];
+    let mut current_line_start = content_line_start;
+    let mut current_line_number = host_start_line;
+    let mut previous_nonblank = classify_block_scalar_line(
+        source,
+        current_line_start,
+        current_line_number,
+        content_indent,
+    )?;
+    let mut pending_blank_lines = Vec::new();
+
+    while let Some(next_line_start) = next_line_start_offset(source, current_line_start) {
+        current_line_number += 1;
+        let next_line = classify_block_scalar_line(
+            source,
+            next_line_start,
+            current_line_number,
+            content_indent,
+        )?;
+        if next_line.ends_block {
+            break;
+        }
+        current_line_start = next_line_start;
+
+        if next_line.is_blank {
+            pending_blank_lines.push(next_line.line);
+            continue;
+        }
+
+        if !pending_blank_lines.is_empty() {
+            for blank_line in pending_blank_lines
+                .iter()
+                .copied()
+                .take(pending_blank_lines.len().saturating_sub(1))
+            {
+                host_line_starts.push(HostLineStart {
+                    line: blank_line,
+                    column: host_start_column,
+                });
+            }
+            host_line_starts.push(HostLineStart {
+                line: next_line.line,
+                column: host_start_column,
+            });
+            pending_blank_lines.clear();
+        } else if previous_nonblank.is_more_indented || next_line.is_more_indented {
+            host_line_starts.push(HostLineStart {
+                line: next_line.line,
+                column: host_start_column,
+            });
+        }
+
+        previous_nonblank = next_line;
+
+        if host_line_starts.len() >= expected_line_count {
+            break;
+        }
+    }
+
+    while host_line_starts.len() < expected_line_count {
+        let previous = host_line_starts.last().copied().unwrap_or(HostLineStart {
+            line: host_start_line,
+            column: host_start_column,
+        });
+        host_line_starts.push(HostLineStart {
+            line: previous.line + 1,
+            column: host_start_column,
+        });
+    }
+
+    Some(SourceMapping {
+        host_offset,
+        host_line_starts,
+        host_column_mappings: Vec::new(),
+    })
+}
+
+#[derive(Clone, Copy)]
+struct BlockScalarLine {
+    line: usize,
+    is_blank: bool,
+    is_more_indented: bool,
+    ends_block: bool,
+}
+
+fn classify_block_scalar_line(
+    source: &str,
+    line_start: usize,
+    line_number: usize,
+    content_indent: usize,
+) -> Option<BlockScalarLine> {
+    let line_end = source[line_start..]
+        .find('\n')
+        .map(|relative| line_start + relative)
+        .unwrap_or(source.len());
+    let line = source.get(line_start..line_end)?.trim_end_matches('\r');
+    let indent = line.chars().take_while(|&ch| ch == ' ').count();
+    let is_blank = line.trim().is_empty();
+    Some(BlockScalarLine {
+        line: line_number,
+        is_blank,
+        is_more_indented: !is_blank && indent > content_indent,
+        ends_block: !is_blank && indent < content_indent,
+    })
+}
+
+fn line_start_offset(source: &str, offset: usize) -> usize {
+    source[..offset]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0)
+}
+
+fn previous_line_text(source: &str, line_start: usize) -> Option<&str> {
+    if line_start == 0 {
+        return None;
+    }
+
+    let previous_line_end = line_start - 1;
+    let previous_line_start = source[..previous_line_end]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    source
+        .get(previous_line_start..previous_line_end)
+        .map(|line| line.trim_end_matches('\r'))
+}
+
+fn next_line_start_offset(source: &str, line_start: usize) -> Option<usize> {
+    source[line_start..]
+        .find('\n')
+        .map(|relative| line_start + relative + 1)
+        .filter(|offset| *offset <= source.len())
+}
+
+fn header_line_is_folded_block(line: &str) -> bool {
+    line.rsplit_once(':')
+        .map(|(_, value)| value.trim_start().starts_with('>'))
+        .unwrap_or(false)
 }
 
 struct ParsedYamlEscape {
@@ -1348,6 +1511,51 @@ jobs:
                     line: 1,
                     column: 9,
                     host_columns: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_host_line_gaps_for_folded_block_runs() {
+        let source = r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >
+          if true
+
+          then
+            echo hi
+          fi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "if true\nthen\n  echo hi\nfi\n");
+        assert_eq!(
+            scripts[0].host_line_starts,
+            vec![
+                HostLineStart {
+                    line: 7,
+                    column: 11
+                },
+                HostLineStart {
+                    line: 9,
+                    column: 11
+                },
+                HostLineStart {
+                    line: 10,
+                    column: 11,
+                },
+                HostLineStart {
+                    line: 11,
+                    column: 11,
+                },
+                HostLineStart {
+                    line: 12,
+                    column: 11,
                 },
             ]
         );

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -493,12 +493,11 @@ fn substitute_github_actions_expressions(
         let start = cursor + start_relative;
         output.push_str(&source[cursor..start]);
         let expression_start = start + 3;
-        let Some(end_relative) = source[expression_start..].find("}}") else {
+        let Some(end) = find_github_actions_expression_end(source, expression_start) else {
             output.push_str(&source[start..]);
             cursor = source.len();
             break;
         };
-        let end = expression_start + end_relative + 2;
         let original = &source[start..end];
         let expression = original
             .trim_start_matches("${{")
@@ -527,6 +526,41 @@ fn substitute_github_actions_expressions(
     }
 
     (output, placeholders)
+}
+
+fn find_github_actions_expression_end(source: &str, expression_start: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut index = expression_start;
+    let mut in_single_quoted_string = false;
+
+    while index + 1 < bytes.len() {
+        if in_single_quoted_string {
+            if bytes[index] == b'\'' {
+                // GitHub Actions expressions escape `'` inside string literals as `''`.
+                if index + 1 < bytes.len() && bytes[index + 1] == b'\'' {
+                    index += 2;
+                    continue;
+                }
+                in_single_quoted_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if bytes[index] == b'\'' {
+            in_single_quoted_string = true;
+            index += 1;
+            continue;
+        }
+
+        if bytes[index] == b'}' && bytes[index + 1] == b'}' {
+            return Some(index + 2);
+        }
+
+        index += 1;
+    }
+
+    None
 }
 
 fn classify_expression_taint(expression: &str) -> ExpressionTaint {
@@ -742,6 +776,27 @@ jobs:
         assert_eq!(scripts.len(), 1);
         assert_eq!(scripts[0].source, "echo ${_SHUCK_GHA_1}suffix");
         assert_eq!(scripts[0].placeholders[0].substituted_span, 5..20);
+    }
+
+    #[test]
+    fn keeps_double_closing_braces_inside_expression_string_literals() {
+        let source = r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ format('}}', github.ref) }}
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "echo ${_SHUCK_GHA_1}");
+        assert_eq!(scripts[0].placeholders.len(), 1);
+        assert_eq!(
+            scripts[0].placeholders[0].expression,
+            "format('}}', github.ref)"
+        );
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -565,11 +565,13 @@ fn node_contains_runner_label(node: &Node, label: &str) -> bool {
     }
 
     node.as_sequence().is_some_and(|sequence| {
-        sequence.iter().any(|item| {
-            item.as_scalar()
-                .is_some_and(|scalar| scalar.as_str().to_ascii_lowercase().contains(&label))
-        })
-    })
+        sequence
+            .iter()
+            .any(|item| node_contains_runner_label(item, &label))
+    }) || node
+        .as_mapping()
+        .and_then(|mapping| mapping.get_node("labels"))
+        .is_some_and(|labels| node_contains_runner_label(labels, &label))
 }
 
 fn node_contains_github_expression(node: &Node) -> bool {
@@ -580,11 +582,17 @@ fn node_contains_github_expression(node: &Node) -> bool {
         return true;
     }
 
-    node.as_sequence().is_some_and(|sequence| {
-        sequence.iter().any(|item| {
-            item.as_scalar()
-                .is_some_and(|scalar| scalar.as_str().contains("${{"))
-        })
+    if node
+        .as_sequence()
+        .is_some_and(|sequence| sequence.iter().any(node_contains_github_expression))
+    {
+        return true;
+    }
+
+    node.as_mapping().is_some_and(|mapping| {
+        mapping
+            .iter()
+            .any(|(_, value)| node_contains_github_expression(value))
     })
 }
 
@@ -1067,6 +1075,26 @@ jobs:
         assert_eq!(scripts.len(), 2);
         assert_eq!(scripts[0].dialect, ExtractedDialect::Unsupported);
         assert_eq!(scripts[1].dialect, ExtractedDialect::Unsupported);
+    }
+
+    #[test]
+    fn infers_default_shell_from_mapping_form_runner_labels() {
+        let source = r#"
+on: push
+jobs:
+  labeled:
+    runs-on:
+      group: hosted
+      labels: ubuntu-latest
+    steps:
+      - run: echo hi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
+        assert!(scripts[0].implicit_flags.errexit);
+        assert!(scripts[0].implicit_flags.pipefail);
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -21,6 +21,8 @@ pub struct EmbeddedScript {
     pub host_start_line: usize,
     /// 1-based column of the snippet's first character within the host file.
     pub host_start_column: usize,
+    /// Per-line host positions for decoded snippet lines.
+    pub host_line_starts: Vec<HostLineStart>,
     /// The shell dialect for this snippet.
     pub dialect: ExtractedDialect,
     /// Human-readable location label inside the host file.
@@ -49,6 +51,15 @@ pub enum ExtractedDialect {
 pub enum EmbeddedFormat {
     /// GitHub Actions workflows and composite actions.
     GitHubActions,
+}
+
+/// Host-file position of an extracted snippet line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostLineStart {
+    /// 1-based line number in the host file.
+    pub line: usize,
+    /// 1-based column number in the host file.
+    pub column: usize,
 }
 
 /// Mapping between a synthetic placeholder and the original template expression.
@@ -359,7 +370,7 @@ fn detect_shell_dialect(template: &str) -> ExtractedDialect {
     let first = shell_token_basename(&first);
     if first == "env" {
         for token in tokens {
-            if token == "{0}" || token.starts_with('-') {
+            if token == "{0}" || token.starts_with('-') || looks_like_env_assignment(&token) {
                 continue;
             }
             return shell_name_dialect(&shell_token_basename(&token));
@@ -459,6 +470,22 @@ fn shell_name_dialect(name: &str) -> ExtractedDialect {
         "pwsh" | "powershell" | "cmd" | "python" => ExtractedDialect::Unsupported,
         _ => ExtractedDialect::Unsupported,
     }
+}
+
+fn looks_like_env_assignment(token: &str) -> bool {
+    let Some((name, _value)) = token.split_once('=') else {
+        return false;
+    };
+
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !matches!(first, 'A'..='Z' | 'a'..='z' | '_') {
+        return false;
+    }
+
+    chars.all(|ch| matches!(ch, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_'))
 }
 
 fn parse_template_flags(template: &str) -> ImplicitShellFlags {
@@ -579,8 +606,10 @@ fn build_embedded_script(
     let start_offset = marker
         .map(|marker| byte_offset_for_line_column(host_source, marker.line(), marker.column()))
         .unwrap_or_default();
-    let host_offset = adjust_offset_to_scalar_content(host_source, start_offset, raw_source);
-    let (host_start_line, host_start_column) = line_column_for_offset(host_source, host_offset);
+    let source_mapping = source_mapping_for_scalar(host_source, start_offset, raw_source);
+    let host_offset = source_mapping.host_offset;
+    let host_start_line = source_mapping.host_line_starts[0].line;
+    let host_start_column = source_mapping.host_line_starts[0].column;
     let (source, placeholders) = substitute_github_actions_expressions(raw_source, host_offset);
 
     EmbeddedScript {
@@ -588,12 +617,107 @@ fn build_embedded_script(
         host_offset,
         host_start_line,
         host_start_column,
+        host_line_starts: source_mapping.host_line_starts,
         dialect: shell.dialect,
         label: label.to_owned(),
         format,
         placeholders,
         implicit_flags: shell.implicit_flags,
     }
+}
+
+struct SourceMapping {
+    host_offset: usize,
+    host_line_starts: Vec<HostLineStart>,
+}
+
+fn source_mapping_for_scalar(source: &str, start_offset: usize, scalar: &str) -> SourceMapping {
+    if let Some(mapping) = double_quoted_source_mapping(source, start_offset, scalar) {
+        return mapping;
+    }
+
+    let host_offset = adjust_offset_to_scalar_content(source, start_offset, scalar);
+    let (host_start_line, host_start_column) = line_column_for_offset(source, host_offset);
+    SourceMapping {
+        host_offset,
+        host_line_starts: default_host_line_starts(host_start_line, host_start_column, scalar),
+    }
+}
+
+fn double_quoted_source_mapping(
+    source: &str,
+    start_offset: usize,
+    scalar: &str,
+) -> Option<SourceMapping> {
+    if source.get(start_offset..)?.chars().next()? != '"' {
+        return None;
+    }
+
+    let content_offset = start_offset + '"'.len_utf8();
+    let mut host_line_starts = vec![{
+        let (line, column) = line_column_for_offset(source, content_offset);
+        HostLineStart { line, column }
+    }];
+    let expected_line_count = decoded_line_count(scalar);
+    let mut escaped = false;
+
+    for (relative_offset, ch) in source[content_offset..].char_indices() {
+        let absolute_offset = content_offset + relative_offset;
+        if escaped {
+            if matches!(ch, 'n' | 'r' | 'N' | 'L' | 'P') {
+                let (line, column) =
+                    line_column_for_offset(source, absolute_offset + ch.len_utf8());
+                host_line_starts.push(HostLineStart { line, column });
+            }
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '"' => {
+                if host_line_starts.len() == expected_line_count {
+                    return Some(SourceMapping {
+                        host_offset: content_offset,
+                        host_line_starts,
+                    });
+                }
+                return None;
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn default_host_line_starts(
+    host_start_line: usize,
+    host_start_column: usize,
+    source: &str,
+) -> Vec<HostLineStart> {
+    let mut line_starts = vec![HostLineStart {
+        line: host_start_line,
+        column: host_start_column,
+    }];
+
+    let line_count = decoded_line_count(source);
+    while line_starts.len() < line_count {
+        let previous = line_starts.last().copied().unwrap_or(HostLineStart {
+            line: host_start_line,
+            column: host_start_column,
+        });
+        line_starts.push(HostLineStart {
+            line: previous.line + 1,
+            column: host_start_column,
+        });
+    }
+
+    line_starts
+}
+
+fn decoded_line_count(source: &str) -> usize {
+    source.chars().filter(|&ch| ch == '\n').count() + 1
 }
 
 fn adjust_offset_to_scalar_content(source: &str, offset: usize, scalar: &str) -> usize {
@@ -904,6 +1028,8 @@ jobs:
         run: echo hi
       - shell: /usr/bin/env bash -e {0}
         run: echo hi
+      - shell: /usr/bin/env FOO=1 bash -e {0}
+        run: echo hi
       - shell: /bin/sh -e {0}
         run: echo hi
       - shell: '"C:/Program Files/Git/bin/bash.exe" -e {0}'
@@ -913,12 +1039,13 @@ jobs:
 "#;
 
         let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
-        assert_eq!(scripts.len(), 5);
+        assert_eq!(scripts.len(), 6);
         assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
         assert_eq!(scripts[1].dialect, ExtractedDialect::Bash);
-        assert_eq!(scripts[2].dialect, ExtractedDialect::Sh);
-        assert_eq!(scripts[3].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[2].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[3].dialect, ExtractedDialect::Sh);
         assert_eq!(scripts[4].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[5].dialect, ExtractedDialect::Bash);
     }
 
     #[test]
@@ -962,6 +1089,39 @@ runs:
         assert_eq!(scripts[0].host_start_column, 9);
         assert_eq!(scripts[0].source, "echo hi\necho \"${_SHUCK_GHA_1}\"\n");
         assert_eq!(scripts[0].placeholders[0].taint, ExpressionTaint::Trusted);
+    }
+
+    #[test]
+    fn preserves_host_line_starts_for_escaped_double_quoted_runs() {
+        let source = r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo hi\nif true\nfi"
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "echo hi\nif true\nfi");
+        assert_eq!(
+            scripts[0].host_line_starts,
+            vec![
+                HostLineStart {
+                    line: 7,
+                    column: 15,
+                },
+                HostLineStart {
+                    line: 7,
+                    column: 24,
+                },
+                HostLineStart {
+                    line: 7,
+                    column: 33,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -714,6 +714,10 @@ fn source_mapping_for_scalar(source: &str, start_offset: usize, scalar: &str) ->
         return mapping;
     }
 
+    if let Some(mapping) = single_quoted_source_mapping(source, start_offset, scalar) {
+        return mapping;
+    }
+
     if let Some(mapping) = folded_block_source_mapping(source, start_offset, scalar) {
         return mapping;
     }
@@ -804,9 +808,100 @@ fn double_quoted_source_mapping(
             }
             '\n' => {
                 let folded =
-                    scan_double_quoted_physical_newline(source, content_offset, relative_offset)?;
+                    scan_quoted_physical_newline(source, content_offset, relative_offset, '"')?;
                 let next_relative_offset = folded.next_relative_offset;
-                consume_double_quoted_fold(
+                consume_quoted_fold(
+                    scalar,
+                    &mut decoded_offset,
+                    &mut decoded_line,
+                    &mut decoded_column,
+                    &mut host_line_starts,
+                    &mut host_column_mappings,
+                    folded,
+                )?;
+                relative_offset = next_relative_offset;
+            }
+            _ => {
+                consume_decoded_char(
+                    scalar,
+                    &mut decoded_offset,
+                    &mut decoded_line,
+                    &mut decoded_column,
+                )?;
+                relative_offset += ch.len_utf8();
+            }
+        }
+    }
+
+    None
+}
+
+fn single_quoted_source_mapping(
+    source: &str,
+    start_offset: usize,
+    scalar: &str,
+) -> Option<SourceMapping> {
+    if source.get(start_offset..)?.chars().next()? != '\'' {
+        return None;
+    }
+
+    let content_offset = start_offset + '\''.len_utf8();
+    let mut host_line_starts = vec![{
+        let (line, column) = line_column_for_offset(source, content_offset);
+        HostLineStart { line, column }
+    }];
+    let mut host_column_mappings = Vec::new();
+    let expected_line_count = decoded_line_count(scalar);
+    let mut decoded_line = 1usize;
+    let mut decoded_column = 1usize;
+    let mut decoded_offset = 0usize;
+    let mut relative_offset = 0usize;
+    let content = &source[content_offset..];
+
+    while relative_offset < content.len() {
+        let absolute_offset = content_offset + relative_offset;
+        let ch = source[absolute_offset..].chars().next()?;
+        match ch {
+            '\'' => {
+                let escaped_quote_offset = absolute_offset + '\''.len_utf8();
+                if source.get(escaped_quote_offset..)?.starts_with('\'') {
+                    consume_decoded_char(
+                        scalar,
+                        &mut decoded_offset,
+                        &mut decoded_line,
+                        &mut decoded_column,
+                    )?;
+                    let (line, column) =
+                        line_column_for_offset(source, escaped_quote_offset + '\''.len_utf8());
+                    if decoded_offset < scalar.len() {
+                        push_host_column_mapping(
+                            &mut host_column_mappings,
+                            HostColumnMapping {
+                                line: decoded_line,
+                                column: decoded_column,
+                                host_line: line,
+                                host_column: column,
+                            },
+                        );
+                    }
+                    relative_offset += '\''.len_utf8() * 2;
+                    continue;
+                }
+
+                if host_line_starts.len() == expected_line_count {
+                    return Some(SourceMapping {
+                        host_offset: content_offset,
+                        host_line_starts,
+                        host_column_mappings,
+                    });
+                }
+                return None;
+            }
+            '\n' => {
+                let folded =
+                    scan_quoted_physical_newline(source, content_offset, relative_offset, '\'')?;
+                let next_relative_offset = folded.next_relative_offset;
+                consume_quoted_fold(
                     scalar,
                     &mut decoded_offset,
                     &mut decoded_line,
@@ -859,18 +954,20 @@ fn consume_decoded_char(
     Some(ch)
 }
 
-struct DoubleQuotedPhysicalNewline {
+struct QuotedPhysicalNewline {
     next_relative_offset: usize,
     continuation: HostLineStart,
     continuation_char: char,
+    quote_char: char,
     blank_lines: Vec<usize>,
 }
 
-fn scan_double_quoted_physical_newline(
+fn scan_quoted_physical_newline(
     source: &str,
     content_offset: usize,
     relative_offset: usize,
-) -> Option<DoubleQuotedPhysicalNewline> {
+    quote_char: char,
+) -> Option<QuotedPhysicalNewline> {
     let mut scan_offset = relative_offset;
     let mut blank_lines = Vec::new();
 
@@ -899,31 +996,32 @@ fn scan_double_quoted_physical_newline(
         }
 
         let (line, column) = line_column_for_offset(source, content_start);
-        return Some(DoubleQuotedPhysicalNewline {
+        return Some(QuotedPhysicalNewline {
             next_relative_offset: content_start - content_offset,
             continuation: HostLineStart { line, column },
             continuation_char,
+            quote_char,
             blank_lines,
         });
     }
 }
 
-fn consume_double_quoted_fold(
+fn consume_quoted_fold(
     scalar: &str,
     decoded_offset: &mut usize,
     decoded_line: &mut usize,
     decoded_column: &mut usize,
     host_line_starts: &mut Vec<HostLineStart>,
     host_column_mappings: &mut Vec<HostColumnMapping>,
-    folded: DoubleQuotedPhysicalNewline,
+    folded: QuotedPhysicalNewline,
 ) -> Option<()> {
     let mut folded_output = Vec::new();
 
     while let Some(ch) = scalar.get(*decoded_offset..)?.chars().next() {
-        if ch == folded.continuation_char && folded.continuation_char != '"' {
+        if ch == folded.continuation_char && folded.continuation_char != folded.quote_char {
             break;
         }
-        if folded.continuation_char == '"' && *decoded_offset == scalar.len() {
+        if folded.continuation_char == folded.quote_char && *decoded_offset == scalar.len() {
             break;
         }
         if !matches!(ch, ' ' | '\n') {
@@ -963,7 +1061,10 @@ fn consume_double_quoted_fold(
         }
     }
 
-    if newline_count == 0 && folded.continuation_char != '"' && *decoded_offset < scalar.len() {
+    if newline_count == 0
+        && folded.continuation_char != folded.quote_char
+        && *decoded_offset < scalar.len()
+    {
         push_host_column_mapping(
             host_column_mappings,
             HostColumnMapping {
@@ -1776,6 +1877,32 @@ jobs:
                 host_line: 7,
                 host_column: 11,
             }]
+        );
+    }
+
+    #[test]
+    fn remaps_single_quoted_runs_after_doubled_quotes() {
+        let source = "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: 'echo ''ok''; unused=1'\n";
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "echo 'ok'; unused=1");
+        assert_eq!(
+            scripts[0].host_column_mappings,
+            vec![
+                HostColumnMapping {
+                    line: 1,
+                    column: 7,
+                    host_line: 6,
+                    host_column: 22,
+                },
+                HostColumnMapping {
+                    line: 1,
+                    column: 10,
+                    host_line: 6,
+                    host_column: 26,
+                },
+            ]
         );
     }
 

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -1,0 +1,749 @@
+#![warn(missing_docs)]
+
+//! Extract embedded shell scripts from non-shell host files.
+
+use std::ops::Range;
+use std::path::Path;
+
+use anyhow::{Result, anyhow};
+use marked_yaml::{Node, parse_yaml};
+
+const GITHUB_ACTIONS_SOURCE_ID: usize = 0;
+
+/// A shell snippet extracted from a host file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedScript {
+    /// The shell source code after placeholder substitution.
+    pub source: String,
+    /// Byte offset of the snippet's first character within the host file.
+    pub host_offset: usize,
+    /// 1-based line number of the snippet's first character within the host file.
+    pub host_start_line: usize,
+    /// 1-based column of the snippet's first character within the host file.
+    pub host_start_column: usize,
+    /// The shell dialect for this snippet.
+    pub dialect: ExtractedDialect,
+    /// Human-readable location label inside the host file.
+    pub label: String,
+    /// Which embedded format produced this snippet.
+    pub format: EmbeddedFormat,
+    /// Placeholder mappings produced during expression substitution.
+    pub placeholders: Vec<PlaceholderMapping>,
+    /// Shell flags implied by the host environment.
+    pub implicit_flags: ImplicitShellFlags,
+}
+
+/// Shell dialect inferred for an extracted snippet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtractedDialect {
+    /// Bash syntax.
+    Bash,
+    /// POSIX `sh` syntax.
+    Sh,
+    /// A shell that shuck does not currently lint.
+    Unsupported,
+}
+
+/// Host format that produced an embedded shell snippet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddedFormat {
+    /// GitHub Actions workflows and composite actions.
+    GitHubActions,
+}
+
+/// Mapping between a synthetic placeholder and the original template expression.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlaceholderMapping {
+    /// Placeholder variable name without the leading `$`.
+    pub name: String,
+    /// Original expression including `${{` / `}}`.
+    pub original: String,
+    /// Inner expression text.
+    pub expression: String,
+    /// Taint classification for the expression.
+    pub taint: ExpressionTaint,
+    /// Span of the substituted `$NAME` text within the extracted source.
+    pub substituted_span: Range<usize>,
+    /// Approximate span of the original `${{ ... }}` text within the host file.
+    pub host_span: Range<usize>,
+}
+
+/// Trust level for a GitHub Actions expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpressionTaint {
+    /// Value is influenced by untrusted user input at runtime.
+    UserControlled,
+    /// Value contains a secret.
+    Secret,
+    /// Value is repository or workflow controlled.
+    Trusted,
+    /// Value could not be classified confidently.
+    Unknown,
+}
+
+/// Shell flags injected by the host environment.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImplicitShellFlags {
+    /// Whether `errexit` is active.
+    pub errexit: bool,
+    /// Whether `pipefail` is active.
+    pub pipefail: bool,
+    /// Effective shell template when known.
+    pub template: Option<String>,
+}
+
+/// Extracts embedded shell snippets from a host file.
+pub trait Extractor {
+    /// Returns true when this extractor should inspect the given path.
+    fn matches(&self, path: &Path) -> bool;
+
+    /// Returns true when the given source looks like the extractor's format.
+    fn probe(&self, source: &str) -> bool;
+
+    /// Extracts embedded shell snippets from the given source.
+    fn extract(&self, source: &str) -> Result<Vec<EmbeddedScript>>;
+}
+
+/// Returns true when any registered extractor can handle the path.
+pub fn is_extractable(path: &Path) -> bool {
+    extractors().iter().any(|extractor| extractor.matches(path))
+}
+
+/// Runs all matching extractors for a host path and source.
+pub fn extract_all(path: &Path, source: &str) -> Result<Vec<EmbeddedScript>> {
+    let mut scripts = Vec::new();
+    for extractor in extractors() {
+        if extractor.matches(path) {
+            scripts.extend(extractor.extract(source)?);
+        }
+    }
+    Ok(scripts)
+}
+
+fn extractors() -> [GitHubActionsExtractor; 1] {
+    [GitHubActionsExtractor]
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GitHubActionsExtractor;
+
+impl Extractor for GitHubActionsExtractor {
+    fn matches(&self, path: &Path) -> bool {
+        gha_path_matches(path)
+    }
+
+    fn probe(&self, source: &str) -> bool {
+        parse_yaml(GITHUB_ACTIONS_SOURCE_ID, source)
+            .ok()
+            .and_then(|node| node.as_mapping().cloned())
+            .is_some_and(|mapping| is_github_actions_mapping(&mapping))
+    }
+
+    fn extract(&self, source: &str) -> Result<Vec<EmbeddedScript>> {
+        let root = parse_yaml(GITHUB_ACTIONS_SOURCE_ID, source)
+            .map_err(|err| anyhow!("parse GitHub Actions YAML: {err}"))?;
+        let Some(root) = root.as_mapping() else {
+            return Ok(Vec::new());
+        };
+        if !is_github_actions_mapping(root) {
+            return Ok(Vec::new());
+        }
+
+        if is_composite_action(root) {
+            extract_composite_action(root, source)
+        } else {
+            extract_workflow(root, source)
+        }
+    }
+}
+
+fn gha_path_matches(path: &Path) -> bool {
+    let Some(extension) = path.extension().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    if !matches!(extension.to_ascii_lowercase().as_str(), "yml" | "yaml") {
+        return false;
+    }
+
+    if path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|name| {
+            matches!(
+                name.to_ascii_lowercase().as_str(),
+                "action.yml" | "action.yaml"
+            )
+        })
+    {
+        return true;
+    }
+
+    let parts = path
+        .iter()
+        .filter_map(|part| part.to_str())
+        .collect::<Vec<_>>();
+    parts
+        .windows(2)
+        .any(|window| matches!(window, [".github", "workflows"]))
+}
+
+fn is_github_actions_mapping(root: &marked_yaml::types::MarkedMappingNode) -> bool {
+    is_workflow(root) || is_composite_action(root)
+}
+
+fn is_workflow(root: &marked_yaml::types::MarkedMappingNode) -> bool {
+    root.get_node("on").is_some() && root.get_mapping("jobs").is_some()
+}
+
+fn is_composite_action(root: &marked_yaml::types::MarkedMappingNode) -> bool {
+    root.get_mapping("runs")
+        .and_then(|runs| runs.get_scalar("using"))
+        .is_some_and(|using| using.as_str().eq_ignore_ascii_case("composite"))
+}
+
+fn extract_workflow(
+    root: &marked_yaml::types::MarkedMappingNode,
+    host_source: &str,
+) -> Result<Vec<EmbeddedScript>> {
+    let mut scripts = Vec::new();
+    let workflow_default_shell = nested_scalar(root, &["defaults", "run", "shell"]);
+    let Some(jobs) = root.get_mapping("jobs") else {
+        return Ok(scripts);
+    };
+
+    for (job_name, job_node) in jobs.iter() {
+        let Some(job) = job_node.as_mapping() else {
+            continue;
+        };
+        let job_default_shell = nested_scalar(job, &["defaults", "run", "shell"])
+            .or_else(|| workflow_default_shell.clone());
+        let runner_kind = runner_kind(job.get_node("runs-on"));
+        let Some(steps) = job.get_sequence("steps") else {
+            continue;
+        };
+
+        for (index, step_node) in steps.iter().enumerate() {
+            let Some(step) = step_node.as_mapping() else {
+                continue;
+            };
+            let Some(run) = step.get_scalar("run") else {
+                continue;
+            };
+
+            let shell = step
+                .get_scalar("shell")
+                .map(|scalar| scalar.as_str().to_owned())
+                .or_else(|| job_default_shell.clone());
+            let label = format!("jobs.{}.steps[{index}].run", job_name.as_str());
+            scripts.push(build_embedded_script(
+                run,
+                host_source,
+                &label,
+                EmbeddedFormat::GitHubActions,
+                resolve_shell(shell.as_deref(), runner_kind),
+            ));
+        }
+    }
+
+    Ok(scripts)
+}
+
+fn extract_composite_action(
+    root: &marked_yaml::types::MarkedMappingNode,
+    host_source: &str,
+) -> Result<Vec<EmbeddedScript>> {
+    let mut scripts = Vec::new();
+    let Some(steps) = root
+        .get_mapping("runs")
+        .and_then(|runs| runs.get_sequence("steps"))
+    else {
+        return Ok(scripts);
+    };
+
+    for (index, step_node) in steps.iter().enumerate() {
+        let Some(step) = step_node.as_mapping() else {
+            continue;
+        };
+        let Some(run) = step.get_scalar("run") else {
+            continue;
+        };
+        let shell = step
+            .get_scalar("shell")
+            .map(|scalar| scalar.as_str().to_owned());
+        let label = format!("runs.steps[{index}].run");
+        scripts.push(build_embedded_script(
+            run,
+            host_source,
+            &label,
+            EmbeddedFormat::GitHubActions,
+            resolve_shell(shell.as_deref(), RunnerKind::Unix),
+        ));
+    }
+
+    Ok(scripts)
+}
+
+fn nested_scalar(mapping: &marked_yaml::types::MarkedMappingNode, path: &[&str]) -> Option<String> {
+    let (last, parents) = path.split_last()?;
+    let mut current = mapping;
+    for segment in parents {
+        current = current.get_mapping(segment)?;
+    }
+    current
+        .get_scalar(last)
+        .map(|scalar| scalar.as_str().to_owned())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ShellResolution {
+    dialect: ExtractedDialect,
+    implicit_flags: ImplicitShellFlags,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RunnerKind {
+    Unix,
+    Windows,
+}
+
+fn resolve_shell(shell: Option<&str>, runner_kind: RunnerKind) -> ShellResolution {
+    match shell.map(str::trim).filter(|value| !value.is_empty()) {
+        None => match runner_kind {
+            RunnerKind::Unix => ShellResolution {
+                dialect: ExtractedDialect::Bash,
+                implicit_flags: ImplicitShellFlags {
+                    errexit: true,
+                    pipefail: true,
+                    template: Some("bash --noprofile --norc -eo pipefail {0}".to_owned()),
+                },
+            },
+            RunnerKind::Windows => ShellResolution {
+                dialect: ExtractedDialect::Unsupported,
+                implicit_flags: ImplicitShellFlags::default(),
+            },
+        },
+        Some("bash") => ShellResolution {
+            dialect: ExtractedDialect::Bash,
+            implicit_flags: ImplicitShellFlags {
+                errexit: true,
+                pipefail: true,
+                template: Some("bash --noprofile --norc -eo pipefail {0}".to_owned()),
+            },
+        },
+        Some("sh") => ShellResolution {
+            dialect: ExtractedDialect::Sh,
+            implicit_flags: ImplicitShellFlags {
+                errexit: true,
+                pipefail: false,
+                template: Some("sh -e {0}".to_owned()),
+            },
+        },
+        Some(value) => {
+            let base = value
+                .split_whitespace()
+                .next()
+                .map(|token| token.to_ascii_lowercase())
+                .unwrap_or_default();
+            let dialect = match base.as_str() {
+                "bash" => ExtractedDialect::Bash,
+                "sh" => ExtractedDialect::Sh,
+                "pwsh" | "powershell" | "cmd" | "python" => ExtractedDialect::Unsupported,
+                _ => ExtractedDialect::Unsupported,
+            };
+
+            ShellResolution {
+                dialect,
+                implicit_flags: parse_template_flags(value),
+            }
+        }
+    }
+}
+
+fn parse_template_flags(template: &str) -> ImplicitShellFlags {
+    let mut errexit = false;
+    let mut pipefail = false;
+    let mut tokens = template.split_whitespace().peekable();
+    let _ = tokens.next();
+
+    while let Some(token) = tokens.next() {
+        match token {
+            "{0}" => {}
+            "-e" | "--errexit" => errexit = true,
+            "-o" => match tokens.next() {
+                Some("errexit") => errexit = true,
+                Some("pipefail") => pipefail = true,
+                _ => {}
+            },
+            token if token.starts_with('-') && !token.starts_with("--") => {
+                let flags = token.trim_start_matches('-');
+                if flags.contains('e') {
+                    errexit = true;
+                }
+                if flags.contains('o')
+                    && let Some(next) = tokens.peek().copied()
+                {
+                    match next {
+                        "errexit" => {
+                            errexit = true;
+                            let _ = tokens.next();
+                        }
+                        "pipefail" => {
+                            pipefail = true;
+                            let _ = tokens.next();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    ImplicitShellFlags {
+        errexit,
+        pipefail,
+        template: Some(template.to_owned()),
+    }
+}
+
+fn runner_kind(runs_on: Option<&Node>) -> RunnerKind {
+    let Some(runs_on) = runs_on else {
+        return RunnerKind::Unix;
+    };
+
+    if runs_on
+        .as_scalar()
+        .is_some_and(|scalar| scalar.as_str().to_ascii_lowercase().contains("windows"))
+    {
+        return RunnerKind::Windows;
+    }
+
+    if let Some(sequence) = runs_on.as_sequence()
+        && sequence.iter().any(|node| {
+            node.as_scalar()
+                .is_some_and(|scalar| scalar.as_str().to_ascii_lowercase().contains("windows"))
+        })
+    {
+        return RunnerKind::Windows;
+    }
+
+    RunnerKind::Unix
+}
+
+fn build_embedded_script(
+    run: &marked_yaml::types::MarkedScalarNode,
+    host_source: &str,
+    label: &str,
+    format: EmbeddedFormat,
+    shell: ShellResolution,
+) -> EmbeddedScript {
+    let raw_source = run.as_str();
+    let marker = run.span().start().copied();
+    let start_offset = marker
+        .map(|marker| byte_offset_for_line_column(host_source, marker.line(), marker.column()))
+        .unwrap_or_default();
+    let host_offset = adjust_offset_to_scalar_content(host_source, start_offset, raw_source);
+    let (host_start_line, host_start_column) = line_column_for_offset(host_source, host_offset);
+    let (source, placeholders) = substitute_github_actions_expressions(raw_source, host_offset);
+
+    EmbeddedScript {
+        source,
+        host_offset,
+        host_start_line,
+        host_start_column,
+        dialect: shell.dialect,
+        label: label.to_owned(),
+        format,
+        placeholders,
+        implicit_flags: shell.implicit_flags,
+    }
+}
+
+fn adjust_offset_to_scalar_content(source: &str, offset: usize, scalar: &str) -> usize {
+    if scalar.is_empty() || offset >= source.len() {
+        return offset.min(source.len());
+    }
+    if source[offset..].starts_with(scalar) {
+        return offset;
+    }
+
+    let probe_len = scalar
+        .char_indices()
+        .nth(16)
+        .map(|(index, _)| index)
+        .unwrap_or(scalar.len());
+    let probe = &scalar[..probe_len];
+    let search_end = source.len().min(offset.saturating_add(512));
+    source[offset..search_end]
+        .find(probe)
+        .map(|relative| offset + relative)
+        .unwrap_or(offset)
+}
+
+fn substitute_github_actions_expressions(
+    source: &str,
+    host_offset: usize,
+) -> (String, Vec<PlaceholderMapping>) {
+    let mut output = String::with_capacity(source.len());
+    let mut placeholders = Vec::new();
+    let mut cursor = 0usize;
+    let mut counter = 1usize;
+
+    while let Some(start_relative) = source[cursor..].find("${{") {
+        let start = cursor + start_relative;
+        output.push_str(&source[cursor..start]);
+        let expression_start = start + 3;
+        let Some(end_relative) = source[expression_start..].find("}}") else {
+            output.push_str(&source[start..]);
+            cursor = source.len();
+            break;
+        };
+        let end = expression_start + end_relative + 2;
+        let original = &source[start..end];
+        let expression = original
+            .trim_start_matches("${{")
+            .trim_end_matches("}}")
+            .trim()
+            .to_owned();
+        let name = format!("_SHUCK_GHA_{counter}");
+        let replacement = format!("${name}");
+        let substituted_start = output.len();
+        output.push_str(&replacement);
+        let substituted_end = output.len();
+        placeholders.push(PlaceholderMapping {
+            name,
+            original: original.to_owned(),
+            expression: expression.clone(),
+            taint: classify_expression_taint(&expression),
+            substituted_span: substituted_start..substituted_end,
+            host_span: host_offset + start..host_offset + end,
+        });
+        counter += 1;
+        cursor = end;
+    }
+
+    if cursor < source.len() {
+        output.push_str(&source[cursor..]);
+    }
+
+    (output, placeholders)
+}
+
+fn classify_expression_taint(expression: &str) -> ExpressionTaint {
+    let expression = expression.trim().to_ascii_lowercase();
+    if expression.starts_with("secrets.") || expression == "github.token" {
+        return ExpressionTaint::Secret;
+    }
+    if expression == "github.head_ref"
+        || matches!(
+            expression.as_str(),
+            "github.event.issue.title"
+                | "github.event.issue.body"
+                | "github.event.pull_request.title"
+                | "github.event.pull_request.body"
+                | "github.event.pull_request.head.ref"
+                | "github.event.comment.body"
+                | "github.event.review.body"
+                | "github.event.discussion.title"
+                | "github.event.discussion.body"
+        )
+        || (expression.starts_with("github.event.pages.") && expression.ends_with(".page_name"))
+        || (expression.starts_with("github.event.commits.")
+            && (expression.ends_with(".message")
+                || expression.ends_with(".author.name")
+                || expression.ends_with(".author.email")))
+    {
+        return ExpressionTaint::UserControlled;
+    }
+    if matches!(
+        expression.as_str(),
+        "github.repository"
+            | "github.sha"
+            | "github.ref"
+            | "github.run_id"
+            | "runner.os"
+            | "runner.arch"
+    ) || ["env.", "vars.", "matrix.", "needs.", "steps."]
+        .iter()
+        .any(|prefix| expression.starts_with(prefix))
+    {
+        return ExpressionTaint::Trusted;
+    }
+    if expression.starts_with("inputs.") || expression.contains('(') {
+        return ExpressionTaint::Unknown;
+    }
+
+    ExpressionTaint::Unknown
+}
+
+fn byte_offset_for_line_column(source: &str, target_line: usize, target_column: usize) -> usize {
+    if target_line <= 1 && target_column <= 1 {
+        return 0;
+    }
+
+    let mut line = 1usize;
+    let mut column = 1usize;
+    for (offset, ch) in source.char_indices() {
+        if line == target_line && column == target_column {
+            return offset;
+        }
+
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+
+    source.len()
+}
+
+fn line_column_for_offset(source: &str, target_offset: usize) -> (usize, usize) {
+    let mut line = 1usize;
+    let mut column = 1usize;
+    for (offset, ch) in source.char_indices() {
+        if offset >= target_offset {
+            break;
+        }
+
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    (line, column)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_github_actions_paths() {
+        assert!(is_extractable(Path::new(".github/workflows/ci.yml")));
+        assert!(is_extractable(Path::new("action.yaml")));
+        assert!(!is_extractable(Path::new("ci.yml")));
+        assert!(!is_extractable(Path::new("script.sh")));
+    }
+
+    #[test]
+    fn probes_workflows_and_composite_actions() {
+        let extractor = GitHubActionsExtractor;
+        assert!(
+            extractor
+                .probe("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: []\n")
+        );
+        assert!(extractor.probe("name: test\nruns:\n  using: composite\n  steps: []\n"));
+        assert!(!extractor.probe("name: config\nservices:\n  db: {}\n"));
+    }
+
+    #[test]
+    fn extracts_workflow_steps_with_shell_hierarchy_and_placeholders() {
+        let source = r#"
+on: push
+defaults:
+  run:
+    shell: sh
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash {0}
+    steps:
+      - run: echo ${{ github.event.pull_request.title }}
+      - shell: sh
+        run: echo hi
+      - shell: pwsh
+        run: Write-Host hi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 3);
+
+        assert_eq!(scripts[0].label, "jobs.build.steps[0].run");
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[0].source, "echo $_SHUCK_GHA_1");
+        assert_eq!(scripts[0].placeholders.len(), 1);
+        assert_eq!(
+            scripts[0].placeholders[0].taint,
+            ExpressionTaint::UserControlled
+        );
+        assert!(!scripts[0].implicit_flags.errexit);
+        assert!(!scripts[0].implicit_flags.pipefail);
+
+        assert_eq!(scripts[1].dialect, ExtractedDialect::Sh);
+        assert!(scripts[1].implicit_flags.errexit);
+        assert!(!scripts[1].implicit_flags.pipefail);
+
+        assert_eq!(scripts[2].dialect, ExtractedDialect::Unsupported);
+    }
+
+    #[test]
+    fn uses_default_shell_for_windows_and_unix_runners() {
+        let source = r#"
+on: push
+jobs:
+  unix:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+  windows:
+    runs-on: windows-latest
+    steps:
+      - run: echo hi
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 2);
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
+        assert!(scripts[0].implicit_flags.errexit);
+        assert!(scripts[0].implicit_flags.pipefail);
+        assert_eq!(scripts[1].dialect, ExtractedDialect::Unsupported);
+    }
+
+    #[test]
+    fn extracts_composite_action_steps() {
+        let source = r#"
+name: demo
+runs:
+  using: composite
+  steps:
+    - run: |
+        echo hi
+        echo "${{ github.sha }}"
+"#;
+
+        let scripts = extract_all(Path::new("action.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].label, "runs.steps[0].run");
+        assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
+        assert_eq!(scripts[0].host_start_line, 7);
+        assert_eq!(scripts[0].host_start_column, 9);
+        assert_eq!(scripts[0].source, "echo hi\necho \"$_SHUCK_GHA_1\"\n");
+        assert_eq!(scripts[0].placeholders[0].taint, ExpressionTaint::Trusted);
+    }
+
+    #[test]
+    fn classifies_taint_patterns() {
+        assert_eq!(
+            classify_expression_taint("github.event.comment.body"),
+            ExpressionTaint::UserControlled
+        );
+        assert_eq!(
+            classify_expression_taint("secrets.API_KEY"),
+            ExpressionTaint::Secret
+        );
+        assert_eq!(
+            classify_expression_taint("matrix.os"),
+            ExpressionTaint::Trusted
+        );
+        assert_eq!(
+            classify_expression_taint("format('{0}', github.ref)"),
+            ExpressionTaint::Unknown
+        );
+    }
+}

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -62,7 +62,7 @@ pub struct PlaceholderMapping {
     pub expression: String,
     /// Taint classification for the expression.
     pub taint: ExpressionTaint,
-    /// Span of the substituted `$NAME` text within the extracted source.
+    /// Span of the substituted `${NAME}` text within the extracted source.
     pub substituted_span: Range<usize>,
     /// Approximate span of the original `${{ ... }}` text within the host file.
     pub host_span: Range<usize>,
@@ -506,7 +506,7 @@ fn substitute_github_actions_expressions(
             .trim()
             .to_owned();
         let name = format!("_SHUCK_GHA_{counter}");
-        let replacement = format!("${name}");
+        let replacement = format!("${{{name}}}");
         let substituted_start = output.len();
         output.push_str(&replacement);
         let substituted_end = output.len();
@@ -666,7 +666,7 @@ jobs:
 
         assert_eq!(scripts[0].label, "jobs.build.steps[0].run");
         assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
-        assert_eq!(scripts[0].source, "echo $_SHUCK_GHA_1");
+        assert_eq!(scripts[0].source, "echo ${_SHUCK_GHA_1}");
         assert_eq!(scripts[0].placeholders.len(), 1);
         assert_eq!(
             scripts[0].placeholders[0].taint,
@@ -723,8 +723,25 @@ runs:
         assert_eq!(scripts[0].dialect, ExtractedDialect::Bash);
         assert_eq!(scripts[0].host_start_line, 7);
         assert_eq!(scripts[0].host_start_column, 9);
-        assert_eq!(scripts[0].source, "echo hi\necho \"$_SHUCK_GHA_1\"\n");
+        assert_eq!(scripts[0].source, "echo hi\necho \"${_SHUCK_GHA_1}\"\n");
         assert_eq!(scripts[0].placeholders[0].taint, ExpressionTaint::Trusted);
+    }
+
+    #[test]
+    fn wraps_placeholder_expansions_to_preserve_identifier_boundaries() {
+        let source = r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ github.ref }}suffix
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "echo ${_SHUCK_GHA_1}suffix");
+        assert_eq!(scripts[0].placeholders[0].substituted_span, 5..20);
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -64,15 +64,17 @@ pub struct HostLineStart {
     pub column: usize,
 }
 
-/// Host-file span of a decoded snippet character.
+/// Host-file position where a decoded snippet segment begins.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HostColumnMapping {
     /// 1-based decoded snippet line number.
     pub line: usize,
-    /// 1-based decoded snippet column number.
+    /// 1-based decoded snippet column number where this host segment begins.
     pub column: usize,
-    /// Number of host-file columns consumed by the source character.
-    pub host_columns: usize,
+    /// 1-based host-file line number for the segment start.
+    pub host_line: usize,
+    /// 1-based host-file column number for the segment start.
+    pub host_column: usize,
 }
 
 /// Mapping between a synthetic placeholder and the original template expression.
@@ -743,6 +745,7 @@ fn double_quoted_source_mapping(
     let expected_line_count = decoded_line_count(scalar);
     let mut decoded_line = 1usize;
     let mut decoded_column = 1usize;
+    let mut decoded_offset = 0usize;
     let mut relative_offset = 0usize;
     let content = &source[content_offset..];
 
@@ -752,21 +755,28 @@ fn double_quoted_source_mapping(
         match ch {
             '\\' => {
                 let escape = parse_double_quoted_yaml_escape(source, absolute_offset)?;
-                if escape.produces_newline {
-                    let (line, column) =
-                        line_column_for_offset(source, absolute_offset + escape.host_columns);
+                let decoded_char = consume_decoded_char(
+                    scalar,
+                    &mut decoded_offset,
+                    &mut decoded_line,
+                    &mut decoded_column,
+                )?;
+                let (line, column) =
+                    line_column_for_offset(source, absolute_offset + escape.host_columns);
+                if decoded_char == '\n' {
                     host_line_starts.push(HostLineStart { line, column });
-                    decoded_line += 1;
-                    decoded_column = 1;
                 } else {
-                    if escape.host_columns > 1 {
-                        host_column_mappings.push(HostColumnMapping {
-                            line: decoded_line,
-                            column: decoded_column,
-                            host_columns: escape.host_columns,
-                        });
+                    if escape.host_columns > 1 && decoded_offset < scalar.len() {
+                        push_host_column_mapping(
+                            &mut host_column_mappings,
+                            HostColumnMapping {
+                                line: decoded_line,
+                                column: decoded_column,
+                                host_line: line,
+                                host_column: column,
+                            },
+                        );
                     }
-                    decoded_column += 1;
                 }
                 relative_offset += escape.host_columns;
             }
@@ -781,18 +791,179 @@ fn double_quoted_source_mapping(
                 return None;
             }
             '\n' => {
-                decoded_line += 1;
-                decoded_column = 1;
-                relative_offset += ch.len_utf8();
+                let folded =
+                    scan_double_quoted_physical_newline(source, content_offset, relative_offset)?;
+                let next_relative_offset = folded.next_relative_offset;
+                consume_double_quoted_fold(
+                    scalar,
+                    &mut decoded_offset,
+                    &mut decoded_line,
+                    &mut decoded_column,
+                    &mut host_line_starts,
+                    &mut host_column_mappings,
+                    folded,
+                )?;
+                relative_offset = next_relative_offset;
             }
             _ => {
-                decoded_column += 1;
+                consume_decoded_char(
+                    scalar,
+                    &mut decoded_offset,
+                    &mut decoded_line,
+                    &mut decoded_column,
+                )?;
                 relative_offset += ch.len_utf8();
             }
         }
     }
 
     None
+}
+
+fn push_host_column_mapping(
+    host_column_mappings: &mut Vec<HostColumnMapping>,
+    mapping: HostColumnMapping,
+) {
+    if host_column_mappings.last().copied() == Some(mapping) {
+        return;
+    }
+    host_column_mappings.push(mapping);
+}
+
+fn consume_decoded_char(
+    scalar: &str,
+    decoded_offset: &mut usize,
+    decoded_line: &mut usize,
+    decoded_column: &mut usize,
+) -> Option<char> {
+    let ch = scalar.get(*decoded_offset..)?.chars().next()?;
+    *decoded_offset += ch.len_utf8();
+    if ch == '\n' {
+        *decoded_line += 1;
+        *decoded_column = 1;
+    } else {
+        *decoded_column += 1;
+    }
+    Some(ch)
+}
+
+struct DoubleQuotedPhysicalNewline {
+    next_relative_offset: usize,
+    continuation: HostLineStart,
+    continuation_char: char,
+    blank_lines: Vec<usize>,
+}
+
+fn scan_double_quoted_physical_newline(
+    source: &str,
+    content_offset: usize,
+    relative_offset: usize,
+) -> Option<DoubleQuotedPhysicalNewline> {
+    let mut scan_offset = relative_offset;
+    let mut blank_lines = Vec::new();
+
+    loop {
+        let absolute_offset = content_offset + scan_offset;
+        if source.get(absolute_offset..)?.chars().next()? != '\n' {
+            return None;
+        }
+        scan_offset += '\n'.len_utf8();
+
+        let line_start = content_offset + scan_offset;
+        let mut content_start = line_start;
+        while matches!(
+            source.get(content_start..)?.chars().next(),
+            Some(' ' | '\t')
+        ) {
+            content_start += 1;
+        }
+
+        let continuation_char = source.get(content_start..)?.chars().next()?;
+        if continuation_char == '\n' {
+            let (line, _) = line_column_for_offset(source, line_start);
+            blank_lines.push(line);
+            scan_offset = content_start - content_offset;
+            continue;
+        }
+
+        let (line, column) = line_column_for_offset(source, content_start);
+        return Some(DoubleQuotedPhysicalNewline {
+            next_relative_offset: content_start - content_offset,
+            continuation: HostLineStart { line, column },
+            continuation_char,
+            blank_lines,
+        });
+    }
+}
+
+fn consume_double_quoted_fold(
+    scalar: &str,
+    decoded_offset: &mut usize,
+    decoded_line: &mut usize,
+    decoded_column: &mut usize,
+    host_line_starts: &mut Vec<HostLineStart>,
+    host_column_mappings: &mut Vec<HostColumnMapping>,
+    folded: DoubleQuotedPhysicalNewline,
+) -> Option<()> {
+    let mut folded_output = Vec::new();
+
+    while let Some(ch) = scalar.get(*decoded_offset..)?.chars().next() {
+        if ch == folded.continuation_char && folded.continuation_char != '"' {
+            break;
+        }
+        if folded.continuation_char == '"' && *decoded_offset == scalar.len() {
+            break;
+        }
+        if !matches!(ch, ' ' | '\n') {
+            return None;
+        }
+        folded_output.push(ch);
+        *decoded_offset += ch.len_utf8();
+    }
+
+    let newline_count = folded_output.iter().filter(|&&ch| ch == '\n').count();
+    let mut newline_index = 0usize;
+
+    for ch in folded_output {
+        match ch {
+            ' ' => {
+                *decoded_column += 1;
+            }
+            '\n' => {
+                newline_index += 1;
+                let host_line_start = if newline_index == newline_count {
+                    folded.continuation
+                } else {
+                    HostLineStart {
+                        line: folded
+                            .blank_lines
+                            .get(newline_index.saturating_sub(1))
+                            .copied()
+                            .unwrap_or(folded.continuation.line),
+                        column: folded.continuation.column,
+                    }
+                };
+                host_line_starts.push(host_line_start);
+                *decoded_line += 1;
+                *decoded_column = 1;
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    if newline_count == 0 && folded.continuation_char != '"' && *decoded_offset < scalar.len() {
+        push_host_column_mapping(
+            host_column_mappings,
+            HostColumnMapping {
+                line: *decoded_line,
+                column: *decoded_column,
+                host_line: folded.continuation.line,
+                host_column: folded.continuation.column,
+            },
+        );
+    }
+
+    Some(())
 }
 
 fn folded_block_source_mapping(
@@ -956,7 +1127,6 @@ fn header_line_is_folded_block(line: &str) -> bool {
 
 struct ParsedYamlEscape {
     host_columns: usize,
-    produces_newline: bool,
 }
 
 fn parse_double_quoted_yaml_escape(source: &str, offset: usize) -> Option<ParsedYamlEscape> {
@@ -969,10 +1139,7 @@ fn parse_double_quoted_yaml_escape(source: &str, offset: usize) -> Option<Parsed
         _ => '\\'.len_utf8() + escape.len_utf8(),
     };
 
-    Some(ParsedYamlEscape {
-        host_columns,
-        produces_newline: matches!(escape, 'n' | 'r' | 'N' | 'L' | 'P'),
-    })
+    Some(ParsedYamlEscape { host_columns })
 }
 
 fn fixed_hex_escape_len(source: &str, offset: usize, digits: usize) -> Option<usize> {
@@ -1499,20 +1666,42 @@ jobs:
             vec![
                 HostColumnMapping {
                     line: 1,
-                    column: 5,
-                    host_columns: 2,
-                },
-                HostColumnMapping {
-                    line: 1,
                     column: 6,
-                    host_columns: 2,
+                    host_line: 7,
+                    host_column: 21,
                 },
                 HostColumnMapping {
                     line: 1,
-                    column: 9,
-                    host_columns: 2,
+                    column: 7,
+                    host_line: 7,
+                    host_column: 23,
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn remaps_folded_double_quoted_runs_onto_later_host_lines() {
+        let source = r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo ok
+          ; unused=1"
+"#;
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "echo ok ; unused=1");
+        assert_eq!(
+            scripts[0].host_column_mappings,
+            vec![HostColumnMapping {
+                line: 1,
+                column: 9,
+                host_line: 7,
+                host_column: 11,
+            }]
         );
     }
 

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -755,18 +755,30 @@ fn double_quoted_source_mapping(
         match ch {
             '\\' => {
                 let escape = parse_double_quoted_yaml_escape(source, absolute_offset)?;
-                let decoded_char = consume_decoded_char(
-                    scalar,
-                    &mut decoded_offset,
-                    &mut decoded_line,
-                    &mut decoded_column,
-                )?;
                 let (line, column) =
                     line_column_for_offset(source, absolute_offset + escape.host_columns);
-                if decoded_char == '\n' {
-                    host_line_starts.push(HostLineStart { line, column });
+                if !escape.emits_char {
+                    if decoded_offset < scalar.len() {
+                        push_host_column_mapping(
+                            &mut host_column_mappings,
+                            HostColumnMapping {
+                                line: decoded_line,
+                                column: decoded_column,
+                                host_line: line,
+                                host_column: column,
+                            },
+                        );
+                    }
                 } else {
-                    if escape.host_columns > 1 && decoded_offset < scalar.len() {
+                    let decoded_char = consume_decoded_char(
+                        scalar,
+                        &mut decoded_offset,
+                        &mut decoded_line,
+                        &mut decoded_column,
+                    )?;
+                    if decoded_char == '\n' {
+                        host_line_starts.push(HostLineStart { line, column });
+                    } else if escape.host_columns > 1 && decoded_offset < scalar.len() {
                         push_host_column_mapping(
                             &mut host_column_mappings,
                             HostColumnMapping {
@@ -1127,19 +1139,33 @@ fn header_line_is_folded_block(line: &str) -> bool {
 
 struct ParsedYamlEscape {
     host_columns: usize,
+    emits_char: bool,
 }
 
 fn parse_double_quoted_yaml_escape(source: &str, offset: usize) -> Option<ParsedYamlEscape> {
     debug_assert_eq!(source[offset..].chars().next(), Some('\\'));
     let escape = source[offset + '\\'.len_utf8()..].chars().next()?;
-    let host_columns = match escape {
-        'x' => '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 2)?,
-        'u' => '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 4)?,
-        'U' => '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 8)?,
-        _ => '\\'.len_utf8() + escape.len_utf8(),
+    let (host_columns, emits_char) = match escape {
+        '\n' | '\r' => (line_continuation_escape_len(source, offset)?, false),
+        'x' => (
+            '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 2)?,
+            true,
+        ),
+        'u' => (
+            '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 4)?,
+            true,
+        ),
+        'U' => (
+            '\\'.len_utf8() + escape.len_utf8() + fixed_hex_escape_len(source, offset, 8)?,
+            true,
+        ),
+        _ => ('\\'.len_utf8() + escape.len_utf8(), true),
     };
 
-    Some(ParsedYamlEscape { host_columns })
+    Some(ParsedYamlEscape {
+        host_columns,
+        emits_char,
+    })
 }
 
 fn fixed_hex_escape_len(source: &str, offset: usize, digits: usize) -> Option<usize> {
@@ -1150,6 +1176,36 @@ fn fixed_hex_escape_len(source: &str, offset: usize, digits: usize) -> Option<us
         .chars()
         .all(|ch| ch.is_ascii_hexdigit())
         .then_some(digits)
+}
+
+fn line_continuation_escape_len(source: &str, offset: usize) -> Option<usize> {
+    let mut absolute_offset = offset + '\\'.len_utf8();
+    let mut host_columns = '\\'.len_utf8();
+    match source.get(absolute_offset..)?.chars().next()? {
+        '\n' => {
+            absolute_offset += '\n'.len_utf8();
+            host_columns += '\n'.len_utf8();
+        }
+        '\r' => {
+            absolute_offset += '\r'.len_utf8();
+            host_columns += '\r'.len_utf8();
+            if source.get(absolute_offset..)?.starts_with('\n') {
+                absolute_offset += '\n'.len_utf8();
+                host_columns += '\n'.len_utf8();
+            }
+        }
+        _ => return None,
+    }
+
+    while matches!(
+        source.get(absolute_offset..)?.chars().next(),
+        Some(' ' | '\t')
+    ) {
+        absolute_offset += 1;
+        host_columns += 1;
+    }
+
+    Some(host_columns)
 }
 
 fn default_host_line_starts(
@@ -1699,6 +1755,24 @@ jobs:
             vec![HostColumnMapping {
                 line: 1,
                 column: 9,
+                host_line: 7,
+                host_column: 11,
+            }]
+        );
+    }
+
+    #[test]
+    fn remaps_double_quoted_line_continuations_onto_later_host_lines() {
+        let source = "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: \"echo a\\\n          ; unused=1\"\n";
+
+        let scripts = extract_all(Path::new(".github/workflows/ci.yml"), source).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].source, "echo a; unused=1");
+        assert_eq!(
+            scripts[0].host_column_mappings,
+            vec![HostColumnMapping {
+                line: 1,
+                column: 7,
                 host_line: 7,
                 host_column: 11,
             }]

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -4,8 +4,8 @@ use shuck_indexer::Indexer;
 use shuck_semantic::{SemanticAnalysis, SemanticModel};
 
 use crate::{
-    AmbientShellOptions, Diagnostic, FileContext, LinterFacts, Rule, RuleSet, ShellDialect,
-    Violation, rules, LinterRuleOptions,
+    AmbientShellOptions, Diagnostic, FileContext, LinterFacts, LinterRuleOptions, Rule, RuleSet,
+    ShellDialect, Violation, rules,
 };
 
 pub struct Checker<'a> {

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -4,8 +4,8 @@ use shuck_indexer::Indexer;
 use shuck_semantic::{SemanticAnalysis, SemanticModel};
 
 use crate::{
-    Diagnostic, FileContext, LinterFacts, LinterRuleOptions, Rule, RuleSet, ShellDialect,
-    Violation, rules,
+    AmbientShellOptions, Diagnostic, FileContext, LinterFacts, Rule, RuleSet, ShellDialect,
+    Violation, rules, LinterRuleOptions,
 };
 
 pub struct Checker<'a> {
@@ -51,6 +51,7 @@ impl<'a> Checker<'a> {
         indexer: &'a Indexer,
         rules: &'a RuleSet,
         shell: ShellDialect,
+        ambient_shell_options: AmbientShellOptions,
         report_environment_style_names: bool,
         rule_options: LinterRuleOptions,
         file_context: &'a FileContext,
@@ -62,7 +63,14 @@ impl<'a> Checker<'a> {
             indexer,
             file,
             source,
-            facts: LinterFacts::build(file, source, semantic, indexer, file_context),
+            facts: LinterFacts::build_with_ambient_shell_options(
+                file,
+                source,
+                semantic,
+                indexer,
+                file_context,
+                ambient_shell_options,
+            ),
             rules,
             shell,
             report_environment_style_names,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -4,6 +4,7 @@ struct LinterFactsBuilder<'a> {
     semantic: &'a SemanticModel,
     _indexer: &'a Indexer,
     _file_context: &'a FileContext,
+    ambient_shell_options: AmbientShellOptions,
 }
 
 #[derive(Debug, Default)]
@@ -32,6 +33,7 @@ impl<'a> LinterFactsBuilder<'a> {
         semantic: &'a SemanticModel,
         indexer: &'a Indexer,
         file_context: &'a FileContext,
+        ambient_shell_options: AmbientShellOptions,
     ) -> Self {
         Self {
             file,
@@ -39,6 +41,7 @@ impl<'a> LinterFactsBuilder<'a> {
             semantic,
             _indexer: indexer,
             _file_context: file_context,
+            ambient_shell_options,
         }
     }
 
@@ -364,7 +367,8 @@ impl<'a> LinterFactsBuilder<'a> {
         let subshell_test_group_spans =
             build_subshell_test_group_spans(&commands, &command_ids_by_span, self.source);
         let shebang_header_facts = build_shebang_header_facts(self.source);
-        let errexit_enabled_anywhere = shebang_header_facts.enables_errexit
+        let errexit_enabled_anywhere = self.ambient_shell_options.errexit
+            || shebang_header_facts.enables_errexit
             || commands
                 .iter()
                 .filter_map(|fact| fact.options().set())

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -30,7 +30,6 @@ use self::{
         rewrite_word_as_single_double_quoted_string,
     },
 };
-use crate::FileContext;
 use crate::context::ContextRegionKind;
 use crate::rules::common::expansion::{
     ExpansionAnalysis, ExpansionContext, RedirectTargetAnalysis, RuntimeLiteralAnalysis,
@@ -50,6 +49,7 @@ use crate::rules::common::{
     },
 };
 use crate::suppression::shellcheck_directive_can_apply_to_following_command;
+use crate::{AmbientShellOptions, FileContext};
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -120,7 +120,33 @@ impl<'a> LinterFacts<'a> {
         indexer: &'a Indexer,
         file_context: &'a FileContext,
     ) -> Self {
-        LinterFactsBuilder::new(file, source, semantic, indexer, file_context).build()
+        Self::build_with_ambient_shell_options(
+            file,
+            source,
+            semantic,
+            indexer,
+            file_context,
+            AmbientShellOptions::default(),
+        )
+    }
+
+    pub fn build_with_ambient_shell_options(
+        file: &'a File,
+        source: &'a str,
+        semantic: &'a SemanticModel,
+        indexer: &'a Indexer,
+        file_context: &'a FileContext,
+        ambient_shell_options: AmbientShellOptions,
+    ) -> Self {
+        LinterFactsBuilder::new(
+            file,
+            source,
+            semantic,
+            indexer,
+            file_context,
+            ambient_shell_options,
+        )
+        .build()
     }
 
     pub fn commands(&self) -> &[CommandFact<'a>] {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -132,7 +132,8 @@ pub(crate) use rules::common::word::{
 };
 /// Linter configuration and per-file ignore types.
 pub use settings::{
-    C001RuleOptions, CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings, PerFileIgnore,
+    AmbientShellOptions, C001RuleOptions, CompiledPerFileIgnoreList, LinterRuleOptions,
+    LinterSettings, PerFileIgnore,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;
@@ -311,6 +312,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
         indexer,
         &settings.rules,
         shell,
+        settings.ambient_shell_options,
         settings.report_environment_style_names,
         settings.rule_options.clone(),
         &file_context,

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -48,10 +48,17 @@ pub struct LinterSettings {
     pub rules: RuleSet,
     pub severity_overrides: FxHashMap<Rule, Severity>,
     pub shell: ShellDialect,
+    pub ambient_shell_options: AmbientShellOptions,
     pub analyzed_paths: Option<Arc<FxHashSet<PathBuf>>>,
     pub per_file_ignores: Arc<CompiledPerFileIgnoreList>,
     pub report_environment_style_names: bool,
     pub rule_options: LinterRuleOptions,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AmbientShellOptions {
+    pub errexit: bool,
+    pub pipefail: bool,
 }
 
 impl Default for LinterSettings {
@@ -60,6 +67,7 @@ impl Default for LinterSettings {
             rules: Self::default_rules(),
             severity_overrides: FxHashMap::default(),
             shell: ShellDialect::Unknown,
+            ambient_shell_options: AmbientShellOptions::default(),
             analyzed_paths: None,
             per_file_ignores: Arc::new(CompiledPerFileIgnoreList::default()),
             report_environment_style_names: false,
@@ -162,6 +170,14 @@ impl LinterSettings {
 
     pub fn with_shell(mut self, shell: ShellDialect) -> Self {
         self.shell = shell;
+        self
+    }
+
+    pub fn with_ambient_shell_options(
+        mut self,
+        ambient_shell_options: AmbientShellOptions,
+    ) -> Self {
+        self.ambient_shell_options = ambient_shell_options;
         self
     }
 

--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { flattenNav, docsNavigation } from "@/app/lib/docs-navigation";
 // Map of slug paths to their MDX imports
 const pages: Record<string, () => Promise<{ default: React.ComponentType; metadata?: { title?: string; description?: string } }>> = {
   "getting-started": () => import("@/content/getting-started/index.mdx"),
+  "embedded-scripts": () => import("@/content/embedded-scripts/index.mdx"),
   "configuration": () => import("@/content/configuration/index.mdx"),
   "shellcheck-compat": () => import("@/content/shellcheck-compat/index.mdx"),
   "performance/benchmarks": () => import("@/content/performance/benchmarks"),

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -9,6 +9,7 @@ export const docsNavigation: NavItem[] = [
     title: "Getting Started",
     items: [
       { title: "Overview", href: "/docs/getting-started" },
+      { title: "Embedded Scripts", href: "/docs/embedded-scripts" },
       { title: "Configuration", href: "/docs/configuration" },
       { title: "ShellCheck Compatibility", href: "/docs/shellcheck-compat" },
     ],

--- a/website/content/configuration/index.mdx
+++ b/website/content/configuration/index.mdx
@@ -65,9 +65,28 @@ shuck --config ci/shuck.toml check .
 shuck --isolated --config "lint.select = ['C001']" check .
 ```
 
+## Check settings
+
+The `[check]` section controls file-level analysis behavior.
+
+### `embedded`
+
+Enables linting for supported embedded shell scripts in non-shell files such as GitHub Actions workflows and composite actions.
+
+This setting defaults to `true`.
+
+```toml
+[check]
+embedded = true
+```
+
+Set it to `false` if you want `shuck check` to ignore embedded `run:` blocks and only lint standalone shell files.
+
+See the [Embedded Scripts guide](/docs/embedded-scripts) for the supported file types and how diagnostics are remapped back to workflow YAML.
+
 ## Lint settings
 
-Shuck's stable config surface lives under `[lint]`.
+Shuck's stable rule-selection config surface lives under `[lint]`.
 
 ### `select`
 

--- a/website/content/embedded-scripts/index.mdx
+++ b/website/content/embedded-scripts/index.mdx
@@ -1,0 +1,71 @@
+# Embedded Scripts
+
+`shuck check` can lint shell embedded in supported non-shell files, starting with GitHub Actions workflows and composite actions.
+
+## Supported files
+
+- `.github/workflows/*.yml`
+- `.github/workflows/*.yaml`
+- `action.yml`
+- `action.yaml`
+
+Each GitHub Actions `run:` block is extracted and linted as its own shell script.
+
+## How it works
+
+When Shuck analyzes one of those files, it:
+
+1. Resolves the effective shell from `shell:`, `defaults.run.shell`, and job defaults.
+2. Lints supported shells such as `bash` and `sh`.
+3. Skips unsupported shells such as PowerShell, `cmd`, and `python`.
+4. Replaces `${{ ... }}` expressions with synthetic placeholders so the shell parser sees valid shell syntax.
+5. Remaps diagnostics back to the original YAML file and includes the workflow step path in the message.
+
+That means you can lint GitHub Actions directly without copying `run:` blocks into temporary `.sh` files.
+
+## Example
+
+```yaml
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build summary
+        run: |
+          summary="${{ github.event.issue.title }}"
+```
+
+```bash
+shuck check --output-format concise .github/workflows/issues.yml
+```
+
+```text
+.github/workflows/issues.yml:10:11: warning[C001] jobs.triage.steps[0].run: variable `summary` is assigned but never used
+```
+
+## Suppressions
+
+For embedded scripts, suppression comments must live inside the `run:` block as shell comments:
+
+```yaml
+- run: |
+    # shellcheck disable=SC2086
+    echo $FOO
+```
+
+YAML comments outside the scalar are not part of the extracted shell script, so they do not suppress shell diagnostics.
+
+## Configuration
+
+Embedded-script extraction is enabled by default. You can control it with the `[check]` section in `shuck.toml` or `.shuck.toml`:
+
+```toml
+[check]
+embedded = true
+```
+
+Set `embedded = false` to lint only standalone shell files.

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -6,6 +6,7 @@ An extremely fast shell script linter, written in Rust.
 - 🐚 Multi-dialect support for bash, sh/POSIX, dash, ksh, mksh, and zsh
 - 🤝 ShellCheck suppression compatibility (`# shellcheck disable=SC2086` just works)
 - 🔄 ShellCheck CLI compatibility mode for existing editor, CI, and local workflows
+- 🧩 Embedded shell extraction for GitHub Actions workflows and composite actions
 - 🔧 Fix support, for automatic error correction (`--fix` and `--unsafe-fixes`)
 - 📏 Rules across correctness, style, performance, and portability categories
 - 💾 Per-file caching to avoid re-analyzing unchanged files
@@ -34,6 +35,9 @@ shuck check script.sh src/
 # Check the current directory
 shuck check .
 
+# Check embedded GitHub Actions `run:` blocks
+shuck check .github/workflows/ci.yml
+
 # Read from stdin
 echo 'echo $foo' | shuck check -
 
@@ -46,3 +50,7 @@ shuck check --fix .
 If you already have tools that invoke `shellcheck`, Shuck can expose a ShellCheck-shaped CLI without changing your primary workflow all at once.
 
 See the dedicated [ShellCheck compatibility guide](/docs/shellcheck-compat) for activation, supported flags, `.shellcheckrc` handling, and current caveats.
+
+## Embedded scripts
+
+Shuck also lints shell embedded in supported GitHub Actions workflows and composite actions. See the dedicated [Embedded Scripts guide](/docs/embedded-scripts) for supported files, shell resolution, diagnostic remapping, and suppression behavior inside `run:` blocks.


### PR DESCRIPTION
## Summary

This adds embedded shell linting for GitHub Actions workflows and composite actions.

- add the new `shuck-extract` crate and GitHub Actions `run:` extraction pipeline
- discover workflow and composite-action YAML files, resolve effective shells, remap diagnostics, and support opting out with `[check].embedded = false`
- add integration coverage for realistic issue and issue_comment workflows
- document embedded scripts in the README and website docs, including a dedicated `/docs/embedded-scripts` page

## Why

Shuck previously ignored one of the most common places teams write shell: GitHub Actions `run:` blocks. This closes that gap so workflows can be linted directly alongside standalone shell files.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-extract`
- `cargo test -p shuck-cli --lib`
- `cargo test -p shuck-cli --test integration_test realistic_issue`
- `npx -y pnpm@10.33.0 --dir website build`
