### PR TITLE
fix(linter): add autofixes for completed backlog rules

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c020.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c020.yaml
@@ -11,3 +11,9 @@ reviewed_divergences:
     column: 6
     end_column: 11
     reason: "This shellspec source-helper uses `test dummy` as a fixed-status probe during harness setup. Shuck still treats that plain literal `test` call as a constant condition, but the current oracle does not emit the mapped comparison warning there."
+  - side: shellcheck-only
+    path_suffix: "acmesh-official__acme.sh__acme.sh"
+    line: 987
+    column: 5
+    end_column: 7
+    reason: "This acme.sh helper uses `[ \"\" ]` as an already-explicit false sentinel. Shuck intentionally keeps explicit boolean literals out of C020 so the rule can focus on accidental constant probes and its autofix does not rewrite one warned literal into another."

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C007.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C007.sh
@@ -6,6 +6,9 @@ find . -name '*.txt' | xargs rm
 # Invalid: only enabling -0 on xargs is not enough
 find . -type f | xargs -0 wc -l
 
+# Invalid: only enabling -print0 on find is not enough
+find "$pkg" -print0 | xargs rm
+
 # Invalid: nested command substitutions should still be checked
 summary=$(find . -type f | xargs wc -l)
 

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C019.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C019.sh
@@ -4,6 +4,7 @@
 [ -z foo ]
 test -n bar
 [[ -z baz ]]
+[ -z "${rootfs_path}_path" ]
 
 # Valid: checking runtime values is meaningful
 [ -z "$value" ]

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C050.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C050.sh
@@ -8,5 +8,8 @@ echo hi > "$((i++))"
 # Invalid: append redirections have the same problem.
 printf '%s\n' ok >> "$((i + 1))"
 
+# Invalid: decrement updates are also not allowed here.
+echo hi > "$((i--))"
+
 # Valid: redirect to a normal filename.
 echo hi > output.txt

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C080_fix_C080.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C080_fix_C080.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+grep start* out.txt
+grep 'foo\*bar*' out.txt
+grep item\* out.txt
+grep --regexp='start*' out.txt
+grep --fixed-strings foo*bar out.txt

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -676,9 +676,10 @@ fn build_linebreak_in_test_site(
         .as_deref()
         == Some("]");
     let current_span = current.span();
-    if last_arg_is_closing_bracket || !current_span.slice(source).ends_with('\n') {
+    if last_arg_is_closing_bracket {
         return None;
     }
+    let insert_offset = linebreak_in_test_insert_offset(current_span, source)?;
 
     let between = source.get(current_span.end.offset..next.span().start.offset)?;
     if !between.chars().all(|char| matches!(char, ' ' | '\t')) {
@@ -692,11 +693,49 @@ fn build_linebreak_in_test_site(
         .or_else(|| current.body_name_word().map(|word| word.span))
         .map(|span| Span::from_positions(span.end, span.end))
         .unwrap_or_else(|| Span::from_positions(current_span.end, current_span.end));
-    Some((anchor_span, current_span.end.offset - 1))
+    Some((anchor_span, insert_offset))
+}
+
+fn linebreak_in_test_insert_offset(span: Span, source: &str) -> Option<usize> {
+    let text = span.slice(source);
+    if text.ends_with("\r\n") {
+        Some(span.end.offset - 2)
+    } else if text.ends_with('\n') {
+        Some(span.end.offset - 1)
+    } else {
+        None
+    }
 }
 
 fn sort_and_dedup_case_pattern_expansions(expansions: &mut Vec<CasePatternExpansionFact>) {
     let mut seen = FxHashSet::default();
     expansions.retain(|fact| seen.insert(FactSpan::new(fact.span())));
     expansions.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));
+}
+
+#[cfg(test)]
+mod builder_tests {
+    use shuck_ast::{Position, Span};
+
+    use super::linebreak_in_test_insert_offset;
+
+    #[test]
+    fn linebreak_in_test_insert_offset_targets_lf_newlines() {
+        let source = "if [ \"$x\" = y\n";
+        let span = Span::from_positions(Position::new(), Position::new().advanced_by(source));
+        let insert_offset =
+            linebreak_in_test_insert_offset(span, source).expect("expected LF insert offset");
+
+        assert_eq!(&source[insert_offset..], "\n");
+    }
+
+    #[test]
+    fn linebreak_in_test_insert_offset_targets_crlf_newlines() {
+        let source = "if [ \"$x\" = y\r\n";
+        let span = Span::from_positions(Position::new(), Position::new().advanced_by(source));
+        let insert_offset =
+            linebreak_in_test_insert_offset(span, source).expect("expected CRLF insert offset");
+
+        assert_eq!(&source[insert_offset..], "\r\n");
+    }
 }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -161,6 +161,8 @@ impl<'a> LinterFactsBuilder<'a> {
             );
             let glued_closing_bracket_operand_span =
                 build_glued_closing_bracket_operand_span(visit.command, self.source);
+            let glued_closing_bracket_insert_offset =
+                build_glued_closing_bracket_insert_offset(visit.command, self.source);
             let simple_test =
                 build_simple_test_fact(visit.command, self.source, self._file_context);
             let conditional = build_conditional_fact(visit.command, self.source);
@@ -177,6 +179,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 scope_read_source_words: Vec::new().into_boxed_slice(),
                 declaration_assignment_probes,
                 glued_closing_bracket_operand_span,
+                glued_closing_bracket_insert_offset,
                 simple_test,
                 conditional,
             });

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -61,7 +61,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut array_assignment_split_word_ids = Vec::new();
         let mut assoc_binding_visibility_memo = FxHashMap::default();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
-        let mut case_pattern_expansion_spans = Vec::new();
+        let mut case_pattern_expansions = Vec::new();
         let mut pattern_literal_spans = Vec::new();
         let mut pattern_charclass_spans = Vec::new();
         let mut arithmetic_summary = ArithmeticFactSummary::default();
@@ -144,7 +144,7 @@ impl<'a> LinterFactsBuilder<'a> {
                     compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
                     array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
                     assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
-                    case_pattern_expansion_spans: &mut case_pattern_expansion_spans,
+                    case_pattern_expansions: &mut case_pattern_expansions,
                     pattern_literal_spans: &mut pattern_literal_spans,
                     arithmetic: &mut arithmetic_summary,
                     surface: &mut surface_fragments,
@@ -333,7 +333,7 @@ impl<'a> LinterFactsBuilder<'a> {
             build_function_header_facts(self.semantic, &functions, &commands, self.source);
         sort_and_dedup_spans(&mut condition_status_capture_spans);
         sort_and_dedup_spans(&mut condition_command_substitution_spans);
-        sort_and_dedup_spans(&mut case_pattern_expansion_spans);
+        sort_and_dedup_case_pattern_expansions(&mut case_pattern_expansions);
         let function_in_alias_spans = build_function_in_alias_spans(&commands, self.source);
         let function_parameter_fallback_spans = build_function_parameter_fallback_spans(
             &commands,
@@ -565,7 +565,7 @@ impl<'a> LinterFactsBuilder<'a> {
             case_items,
             case_pattern_shadows,
             case_pattern_impossible_spans,
-            case_pattern_expansion_spans,
+            case_pattern_expansions,
             getopts_cases,
             pipelines,
             lists,
@@ -690,4 +690,10 @@ fn build_linebreak_in_test_site(
         .map(|span| Span::from_positions(span.end, span.end))
         .unwrap_or_else(|| Span::from_positions(current_span.end, current_span.end));
     Some((anchor_span, current_span.end.offset - 1))
+}
+
+fn sort_and_dedup_case_pattern_expansions(expansions: &mut Vec<CasePatternExpansionFact>) {
+    let mut seen = FxHashSet::default();
+    expansions.retain(|fact| seen.insert(FactSpan::new(fact.span())));
+    expansions.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));
 }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -180,6 +180,8 @@ impl<'a> LinterFactsBuilder<'a> {
                 declaration_assignment_probes,
                 glued_closing_bracket_operand_span,
                 glued_closing_bracket_insert_offset,
+                linebreak_in_test_anchor_span: None,
+                linebreak_in_test_insert_offset: None,
                 simple_test,
                 conditional,
             });
@@ -319,7 +321,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 binding_target_spans.entry(binding.id).or_insert(*target_span);
             }
         }
-
+        populate_linebreak_in_test_facts(&mut commands, self.source);
         let substitution_facts =
             build_substitution_facts(&commands, &command_ids_by_span, self.source);
         for (fact, substitutions) in commands.iter_mut().zip(substitution_facts) {
@@ -634,4 +636,58 @@ impl<'a> LinterFactsBuilder<'a> {
             conditional_portability,
         }
     }
+}
+
+fn populate_linebreak_in_test_facts(commands: &mut [CommandFact<'_>], source: &str) {
+    for index in 0..commands.len().saturating_sub(1) {
+        let (current_slice, next_slice) = commands.split_at_mut(index + 1);
+        let current = &mut current_slice[index];
+        let next = &next_slice[0];
+        let Some((anchor_span, insert_offset)) =
+            build_linebreak_in_test_site(current, next, source)
+        else {
+            continue;
+        };
+
+        current.linebreak_in_test_anchor_span = Some(anchor_span);
+        current.linebreak_in_test_insert_offset = Some(insert_offset);
+    }
+}
+
+fn build_linebreak_in_test_site(
+    current: &CommandFact<'_>,
+    next: &CommandFact<'_>,
+    source: &str,
+) -> Option<(Span, usize)> {
+    if !current.static_utility_name_is("[")
+        || !next.static_utility_name_is("]")
+        || !next.body_args().is_empty()
+    {
+        return None;
+    }
+
+    let last_arg_is_closing_bracket = current
+        .body_args()
+        .last()
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("]");
+    let current_span = current.span();
+    if last_arg_is_closing_bracket || !current_span.slice(source).ends_with('\n') {
+        return None;
+    }
+
+    let between = source.get(current_span.end.offset..next.span().start.offset)?;
+    if !between.chars().all(|char| matches!(char, ' ' | '\t')) {
+        return None;
+    }
+
+    let anchor_span = current
+        .body_args()
+        .last()
+        .map(|word| word.span)
+        .or_else(|| current.body_name_word().map(|word| word.span))
+        .map(|span| Span::from_positions(span.end, span.end))
+        .unwrap_or_else(|| Span::from_positions(current_span.end, current_span.end));
+    Some((anchor_span, current_span.end.offset - 1))
 }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -576,6 +576,8 @@ impl<'a> LinterFactsBuilder<'a> {
             indented_shebang_span: shebang_header_facts.indented_shebang_span,
             indented_shebang_indent_span: shebang_header_facts.indented_shebang_indent_span,
             space_after_hash_bang_span: shebang_header_facts.space_after_hash_bang_span,
+            space_after_hash_bang_whitespace_span: shebang_header_facts
+                .space_after_hash_bang_whitespace_span,
             shebang_not_on_first_line_span: shebang_header_facts.shebang_not_on_first_line_span,
             missing_shebang_line_span: shebang_header_facts.missing_shebang_line_span,
             duplicate_shebang_flag_span: shebang_header_facts.duplicate_shebang_flag_span,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -574,6 +574,7 @@ impl<'a> LinterFactsBuilder<'a> {
             single_test_subshell_spans,
             subshell_test_group_spans,
             indented_shebang_span: shebang_header_facts.indented_shebang_span,
+            indented_shebang_indent_span: shebang_header_facts.indented_shebang_indent_span,
             space_after_hash_bang_span: shebang_header_facts.space_after_hash_bang_span,
             shebang_not_on_first_line_span: shebang_header_facts.shebang_not_on_first_line_span,
             missing_shebang_line_span: shebang_header_facts.missing_shebang_line_span,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -491,30 +491,27 @@ impl<'a> LinterFactsBuilder<'a> {
         );
         let assignment_like_command_name_spans =
             build_assignment_like_command_name_spans(&commands, self.source);
-        let bare_command_name_assignment_spans =
-            build_bare_command_name_assignment_spans(
-                &commands,
-                &word_nodes,
-                &word_occurrences,
-                &word_index,
-                source,
-            );
-        let unquoted_command_argument_use_offsets =
-            build_unquoted_command_argument_use_offsets(
-                self.semantic,
-                &word_nodes,
-                &word_occurrences,
-            );
+        let bare_command_name_assignment_spans = build_bare_command_name_assignment_spans(
+            &commands,
+            &word_nodes,
+            &word_occurrences,
+            &word_index,
+            source,
+        );
+        let unquoted_command_argument_use_offsets = build_unquoted_command_argument_use_offsets(
+            self.semantic,
+            &word_nodes,
+            &word_occurrences,
+        );
         let brace_variable_before_bracket_spans =
             build_brace_variable_before_bracket_spans(&word_nodes, &word_occurrences, source);
-        let alias_definition_expansion_spans =
-            build_alias_definition_expansion_spans(
-                &commands,
-                &word_nodes,
-                &word_occurrences,
-                &word_index,
-                source,
-            );
+        let alias_definition_expansion_spans = build_alias_definition_expansion_spans(
+            &commands,
+            &word_nodes,
+            &word_occurrences,
+            &word_index,
+            source,
+        );
         let innermost_command_ids_by_offset = build_innermost_command_ids_by_offset(
             &commands,
             commands
@@ -523,8 +520,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 .collect(),
         );
         let command_parent_ids = build_command_parent_ids(&commands);
-        let command_dominance_barrier_flags =
-            build_command_dominance_barrier_flags(&commands);
+        let command_dominance_barrier_flags = build_command_dominance_barrier_flags(&commands);
 
         LinterFacts {
             source,
@@ -579,6 +575,10 @@ impl<'a> LinterFactsBuilder<'a> {
             space_after_hash_bang_whitespace_span: shebang_header_facts
                 .space_after_hash_bang_whitespace_span,
             shebang_not_on_first_line_span: shebang_header_facts.shebang_not_on_first_line_span,
+            shebang_not_on_first_line_fix_span: shebang_header_facts
+                .shebang_not_on_first_line_fix_span,
+            shebang_not_on_first_line_preferred_newline: shebang_header_facts
+                .shebang_not_on_first_line_preferred_newline,
             missing_shebang_line_span: shebang_header_facts.missing_shebang_line_span,
             duplicate_shebang_flag_span: shebang_header_facts.duplicate_shebang_flag_span,
             non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -284,6 +284,7 @@ pub struct GrepPatternFact<'a> {
     source_kind: GrepPatternSourceKind,
     starts_with_glob_style_star: bool,
     has_glob_style_star_confusion: bool,
+    glob_style_star_replacement_spans: Box<[Span]>,
 }
 
 impl<'a> GrepPatternFact<'a> {
@@ -309,6 +310,10 @@ impl<'a> GrepPatternFact<'a> {
 
     pub fn has_glob_style_star_confusion(&self) -> bool {
         self.has_glob_style_star_confusion
+    }
+
+    pub fn glob_style_star_replacement_spans(&self) -> &[Span] {
+        &self.glob_style_star_replacement_spans
     }
 }
 
@@ -2349,15 +2354,22 @@ fn grep_prefixed_pattern_fact<'a>(
     prefix_len: usize,
     source_kind: GrepPatternSourceKind,
 ) -> GrepPatternFact<'a> {
-    let static_text = cooked_static_word_text(word, source)
-        .and_then(|text| text.get(prefix_len..).map(str::to_owned))
-        .map(String::into_boxed_str);
+    let (static_text, glob_style_star_replacement_spans) =
+        cooked_static_word_text_with_source_spans(word, source)
+            .and_then(|(text, source_spans)| {
+                let text = text.get(prefix_len..)?.to_owned();
+                let source_spans = source_spans.get(prefix_len..)?.to_vec();
+                Some((text, source_spans))
+            })
+            .map(|(text, source_spans)| {
+                let spans = grep_pattern_glob_style_star_replacement_spans(&text, &source_spans);
+                (Some(text.into_boxed_str()), spans.into_boxed_slice())
+            })
+            .unwrap_or_else(|| (None, Box::new([])));
     let starts_with_glob_style_star = static_text
         .as_deref()
         .is_some_and(|text| text.starts_with('*') || text == "^*");
-    let has_glob_style_star_confusion = static_text
-        .as_deref()
-        .is_some_and(grep_pattern_has_glob_style_star_confusion);
+    let has_glob_style_star_confusion = !glob_style_star_replacement_spans.is_empty();
 
     GrepPatternFact {
         word,
@@ -2365,33 +2377,72 @@ fn grep_prefixed_pattern_fact<'a>(
         source_kind,
         starts_with_glob_style_star,
         has_glob_style_star_confusion,
+        glob_style_star_replacement_spans,
     }
 }
 
-fn cooked_static_word_text(word: &Word, source: &str) -> Option<String> {
-    let mut cooked = String::new();
-    collect_cooked_static_word_text_parts(&word.parts, source, false, &mut cooked).then_some(cooked)
+fn cooked_static_word_text_with_source_spans(
+    word: &Word,
+    source: &str,
+) -> Option<(String, Vec<Span>)> {
+    let mut cooked = Vec::new();
+    let mut source_spans = Vec::new();
+    collect_cooked_static_word_text_parts_with_source_spans(
+        &word.parts,
+        source,
+        false,
+        &mut cooked,
+        &mut source_spans,
+    )
+    .then_some(())?;
+
+    Some((String::from_utf8(cooked).ok()?, source_spans))
 }
 
-fn collect_cooked_static_word_text_parts(
+fn collect_cooked_static_word_text_parts_with_source_spans(
     parts: &[WordPartNode],
     source: &str,
     in_double_quotes: bool,
-    out: &mut String,
+    out: &mut Vec<u8>,
+    source_spans: &mut Vec<Span>,
 ) -> bool {
     for part in parts {
         match &part.kind {
             WordPart::Literal(text) => {
                 let slice = text.as_str(source, part.span);
                 if in_double_quotes {
-                    push_cooked_double_quoted_literal_text(slice, out);
+                    push_cooked_double_quoted_literal_text_with_source_spans(
+                        slice,
+                        part.span.start,
+                        out,
+                        source_spans,
+                    );
                 } else {
-                    push_cooked_unquoted_literal_text(slice, out);
+                    push_cooked_unquoted_literal_text_with_source_spans(
+                        slice,
+                        part.span.start,
+                        out,
+                        source_spans,
+                    );
                 }
             }
-            WordPart::SingleQuoted { value, .. } => out.push_str(value.slice(source)),
+            WordPart::SingleQuoted { value, .. } => {
+                let text = value.slice(source);
+                push_cooked_literal_text_with_source_spans(
+                    text,
+                    value.span().start,
+                    out,
+                    source_spans,
+                );
+            }
             WordPart::DoubleQuoted { parts, .. } => {
-                if !collect_cooked_static_word_text_parts(parts, source, true, out) {
+                if !collect_cooked_static_word_text_parts_with_source_spans(
+                    parts,
+                    source,
+                    true,
+                    out,
+                    source_spans,
+                ) {
                     return false;
                 }
             }
@@ -2417,54 +2468,129 @@ fn collect_cooked_static_word_text_parts(
     true
 }
 
-fn push_cooked_unquoted_literal_text(text: &str, out: &mut String) {
-    let mut chars = text.chars();
-    while let Some(ch) = chars.next() {
+fn push_cooked_literal_text_with_source_spans(
+    text: &str,
+    start_position: Position,
+    out: &mut Vec<u8>,
+    source_spans: &mut Vec<Span>,
+) {
+    for (index, ch) in text.char_indices() {
+        let span = Span::from_positions(
+            start_position.advanced_by(&text[..index]),
+            start_position.advanced_by(&text[..index + ch.len_utf8()]),
+        );
+        push_cooked_char_with_source_span(ch, span, out, source_spans);
+    }
+}
+
+fn push_cooked_unquoted_literal_text_with_source_spans(
+    text: &str,
+    start_position: Position,
+    out: &mut Vec<u8>,
+    source_spans: &mut Vec<Span>,
+) {
+    let mut chars = text.char_indices().peekable();
+    while let Some((index, ch)) = chars.next() {
         if ch == '\\' {
-            if let Some(escaped) = chars.next()
+            if let Some((next_index, escaped)) = chars.next()
                 && escaped != '\n'
             {
-                out.push(escaped);
+                let span = Span::from_positions(
+                    start_position.advanced_by(&text[..index]),
+                    start_position.advanced_by(&text[..next_index + escaped.len_utf8()]),
+                );
+                push_cooked_char_with_source_span(escaped, span, out, source_spans);
             }
             continue;
         }
 
-        out.push(ch);
+        let span = Span::from_positions(
+            start_position.advanced_by(&text[..index]),
+            start_position.advanced_by(&text[..index + ch.len_utf8()]),
+        );
+        push_cooked_char_with_source_span(ch, span, out, source_spans);
     }
 }
 
-fn push_cooked_double_quoted_literal_text(text: &str, out: &mut String) {
-    let mut chars = text.chars();
-    while let Some(ch) = chars.next() {
+fn push_cooked_double_quoted_literal_text_with_source_spans(
+    text: &str,
+    start_position: Position,
+    out: &mut Vec<u8>,
+    source_spans: &mut Vec<Span>,
+) {
+    let mut chars = text.char_indices().peekable();
+    while let Some((index, ch)) = chars.next() {
         if ch != '\\' {
-            out.push(ch);
+            let span = Span::from_positions(
+                start_position.advanced_by(&text[..index]),
+                start_position.advanced_by(&text[..index + ch.len_utf8()]),
+            );
+            push_cooked_char_with_source_span(ch, span, out, source_spans);
             continue;
         }
 
         match chars.next() {
-            Some(escaped @ ('$' | '"' | '\\' | '`')) => out.push(escaped),
-            Some('\n') => {}
-            Some(other) => {
-                out.push('\\');
-                out.push(other);
+            Some((next_index, escaped @ ('$' | '"' | '\\' | '`'))) => {
+                let span = Span::from_positions(
+                    start_position.advanced_by(&text[..index]),
+                    start_position.advanced_by(&text[..next_index + escaped.len_utf8()]),
+                );
+                push_cooked_char_with_source_span(escaped, span, out, source_spans);
             }
-            None => out.push('\\'),
+            Some((_next_index, '\n')) => {}
+            Some((next_index, other)) => {
+                let backslash_span = Span::from_positions(
+                    start_position.advanced_by(&text[..index]),
+                    start_position.advanced_by(&text[..index + ch.len_utf8()]),
+                );
+                push_cooked_char_with_source_span('\\', backslash_span, out, source_spans);
+
+                let span = Span::from_positions(
+                    start_position.advanced_by(&text[..next_index]),
+                    start_position.advanced_by(&text[..next_index + other.len_utf8()]),
+                );
+                push_cooked_char_with_source_span(other, span, out, source_spans);
+            }
+            None => {
+                let span = Span::from_positions(
+                    start_position.advanced_by(&text[..index]),
+                    start_position.advanced_by(&text[..index + ch.len_utf8()]),
+                );
+                push_cooked_char_with_source_span('\\', span, out, source_spans);
+            }
         }
     }
 }
-fn grep_pattern_has_glob_style_star_confusion(pattern: &str) -> bool {
-    let bytes = pattern.as_bytes();
 
-    if pattern.starts_with('^')
+fn push_cooked_char_with_source_span(
+    ch: char,
+    source_span: Span,
+    out: &mut Vec<u8>,
+    source_spans: &mut Vec<Span>,
+) {
+    let mut buf = [0u8; 4];
+    let encoded = ch.encode_utf8(&mut buf).as_bytes();
+    out.extend_from_slice(encoded);
+    source_spans.extend(std::iter::repeat_n(source_span, encoded.len()));
+}
+
+fn grep_pattern_glob_style_star_replacement_spans(text: &str, source_spans: &[Span]) -> Vec<Span> {
+    let bytes = text.as_bytes();
+    let mut spans = Vec::new();
+
+    if bytes.is_empty() {
+        return spans;
+    }
+
+    if text.starts_with('^')
         || ends_with_unescaped_dollar(bytes)
         || bytes.contains(&b'[')
         || bytes.contains(&b'+')
     {
-        return false;
+        return spans;
     }
-
     if first_unescaped_star_index(bytes).is_some_and(|index| index == 0) {
-        return false;
+        return spans;
     }
 
     let mut index = 0usize;
@@ -2488,10 +2614,13 @@ fn grep_pattern_has_glob_style_star_confusion(pattern: &str) -> bool {
             continue;
         }
 
-        return true;
+        if let Some(span) = source_spans.get(star_index).copied() {
+            spans.push(span);
+        }
+        index = star_index + 1;
     }
 
-    false
+    spans
 }
 
 fn first_unescaped_star_index(bytes: &[u8]) -> Option<usize> {

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -13,6 +13,8 @@ pub struct CommandFact<'a> {
     declaration_assignment_probes: Box<[DeclarationAssignmentProbe]>,
     glued_closing_bracket_operand_span: Option<Span>,
     glued_closing_bracket_insert_offset: Option<usize>,
+    linebreak_in_test_anchor_span: Option<Span>,
+    linebreak_in_test_insert_offset: Option<usize>,
     simple_test: Option<SimpleTestFact<'a>>,
     conditional: Option<ConditionalFact<'a>>,
 }
@@ -84,6 +86,14 @@ impl<'a> CommandFact<'a> {
 
     pub fn glued_closing_bracket_insert_offset(&self) -> Option<usize> {
         self.glued_closing_bracket_insert_offset
+    }
+
+    pub fn linebreak_in_test_anchor_span(&self) -> Option<Span> {
+        self.linebreak_in_test_anchor_span
+    }
+
+    pub fn linebreak_in_test_insert_offset(&self) -> Option<usize> {
+        self.linebreak_in_test_insert_offset
     }
 
     pub fn simple_test(&self) -> Option<&SimpleTestFact<'a>> {

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -12,6 +12,7 @@ pub struct CommandFact<'a> {
     scope_read_source_words: Box<[PathWordFact<'a>]>,
     declaration_assignment_probes: Box<[DeclarationAssignmentProbe]>,
     glued_closing_bracket_operand_span: Option<Span>,
+    glued_closing_bracket_insert_offset: Option<usize>,
     simple_test: Option<SimpleTestFact<'a>>,
     conditional: Option<ConditionalFact<'a>>,
 }
@@ -79,6 +80,10 @@ impl<'a> CommandFact<'a> {
 
     pub fn glued_closing_bracket_operand_span(&self) -> Option<Span> {
         self.glued_closing_bracket_operand_span
+    }
+
+    pub fn glued_closing_bracket_insert_offset(&self) -> Option<usize> {
+        self.glued_closing_bracket_insert_offset
     }
 
     pub fn simple_test(&self) -> Option<&SimpleTestFact<'a>> {

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -3,6 +3,7 @@ struct ShebangHeaderFacts {
     indented_shebang_span: Option<Span>,
     indented_shebang_indent_span: Option<Span>,
     space_after_hash_bang_span: Option<Span>,
+    space_after_hash_bang_whitespace_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
     missing_shebang_line_span: Option<Span>,
     duplicate_shebang_flag_span: Option<Span>,
@@ -19,6 +20,7 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
     let mut indented_shebang_span = None;
     let mut indented_shebang_indent_span = None;
     let mut space_after_hash_bang_span = None;
+    let mut space_after_hash_bang_whitespace_span = None;
     let mut shebang_not_on_first_line_span = None;
 
     for (line_index, (offset, raw_line)) in
@@ -29,7 +31,7 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         let shebang_candidate = source_line_has_shebang_candidate(line);
         let indented_candidate = source_line_has_leading_whitespace_before_shebang_candidate(line);
         let leading_whitespace_len = source_line_leading_whitespace_len(line);
-        let space_after_hash_offset = shebang_space_after_hash_offset_in_line(line);
+        let space_after_hash = shebang_space_after_hash_in_line(line);
         let line_number = line_index + 1;
 
         if indented_shebang_span.is_none() && indented_candidate {
@@ -39,12 +41,19 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
                 .map(|len| line_prefix_span(line_number, offset, &line[..len]));
         }
         if space_after_hash_bang_span.is_none()
-            && let Some(space_offset) = space_after_hash_offset
+            && let Some((space_offset, whitespace_len)) = space_after_hash
         {
             space_after_hash_bang_span = Some(point_span(
                 line_number,
                 space_offset + 1,
                 offset + space_offset,
+            ));
+            space_after_hash_bang_whitespace_span = Some(line_slice_span(
+                line_number,
+                offset,
+                line,
+                space_offset,
+                whitespace_len,
             ));
         }
         if line_index > 0 && shebang_candidate {
@@ -97,6 +106,7 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         indented_shebang_span,
         indented_shebang_indent_span,
         space_after_hash_bang_span,
+        space_after_hash_bang_whitespace_span,
         shebang_not_on_first_line_span,
         missing_shebang_line_span,
         duplicate_shebang_flag_span,
@@ -112,7 +122,7 @@ fn source_line_is_header_like(line: &str) -> bool {
 
 fn source_line_has_shebang_candidate(line: &str) -> bool {
     let trimmed = line.trim_start_matches(char::is_whitespace);
-    trimmed.starts_with("#!") || shebang_space_after_hash_offset_in_line(trimmed).is_some()
+    trimmed.starts_with("#!") || shebang_space_after_hash_in_line(trimmed).is_some()
 }
 
 fn source_line_has_leading_whitespace_before_shebang_candidate(line: &str) -> bool {
@@ -125,7 +135,7 @@ fn source_line_leading_whitespace_len(line: &str) -> Option<usize> {
     (trimmed.len() != line.len()).then_some(line.len() - trimmed.len())
 }
 
-fn shebang_space_after_hash_offset_in_line(line: &str) -> Option<usize> {
+fn shebang_space_after_hash_in_line(line: &str) -> Option<(usize, usize)> {
     let trimmed = line.trim_start_matches(char::is_whitespace);
     let leading_whitespace_len = line.len().saturating_sub(trimmed.len());
     let rest = trimmed.strip_prefix('#')?;
@@ -133,7 +143,7 @@ fn shebang_space_after_hash_offset_in_line(line: &str) -> Option<usize> {
         .len()
         .saturating_sub(rest.trim_start_matches(char::is_whitespace).len());
     (whitespace_len > 0 && rest[whitespace_len..].starts_with('!'))
-        .then_some(leading_whitespace_len + 1)
+        .then_some((leading_whitespace_len + 1, whitespace_len))
 }
 
 fn point_span(line_number: usize, column: usize, offset: usize) -> Span {
@@ -151,6 +161,23 @@ fn line_prefix_span(line_number: usize, offset: usize, prefix: &str) -> Span {
         offset,
     };
     let end = start.advanced_by(prefix);
+    Span::from_positions(start, end)
+}
+
+fn line_slice_span(
+    line_number: usize,
+    line_offset: usize,
+    line: &str,
+    slice_start: usize,
+    slice_len: usize,
+) -> Span {
+    let line_start = Position {
+        line: line_number,
+        column: 1,
+        offset: line_offset,
+    };
+    let start = line_start.advanced_by(&line[..slice_start]);
+    let end = start.advanced_by(&line[slice_start..slice_start + slice_len]);
     Span::from_positions(start, end)
 }
 

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -5,6 +5,8 @@ struct ShebangHeaderFacts {
     space_after_hash_bang_span: Option<Span>,
     space_after_hash_bang_whitespace_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
+    shebang_not_on_first_line_fix_span: Option<Span>,
+    shebang_not_on_first_line_preferred_newline: Option<&'static str>,
     missing_shebang_line_span: Option<Span>,
     duplicate_shebang_flag_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
@@ -13,19 +15,24 @@ struct ShebangHeaderFacts {
 
 fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
     let mut source_lines = source_lines_with_offsets(source).enumerate();
-    let Some((_, (first_line_offset, first_line_text))) = source_lines.next() else {
+    let Some((_, first_line)) = source_lines.next() else {
         return ShebangHeaderFacts::default();
     };
-    let first_line = first_line_text.trim_end_matches('\r');
+    let first_line_offset = first_line.offset;
+    let first_line_text = first_line.text.trim_end_matches('\r');
     let mut indented_shebang_span = None;
     let mut indented_shebang_indent_span = None;
     let mut space_after_hash_bang_span = None;
     let mut space_after_hash_bang_whitespace_span = None;
     let mut shebang_not_on_first_line_span = None;
+    let mut shebang_not_on_first_line_fix_span = None;
+    let mut shebang_not_on_first_line_preferred_newline = None;
+    let mut last_line_ending =
+        (!first_line.line_ending.is_empty()).then_some(first_line.line_ending);
 
-    for (line_index, (offset, raw_line)) in
-        std::iter::once((0, (first_line_offset, first_line_text))).chain(source_lines)
-    {
+    for (line_index, source_line) in std::iter::once((0, first_line)).chain(source_lines) {
+        let offset = source_line.offset;
+        let raw_line = source_line.text;
         let line = raw_line.trim_end_matches('\r');
         let header_like = source_line_is_header_like(line);
         let shebang_candidate = source_line_has_shebang_candidate(line);
@@ -58,14 +65,29 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         }
         if line_index > 0 && shebang_candidate {
             shebang_not_on_first_line_span = Some(point_span(line_number, 1, offset));
+            shebang_not_on_first_line_fix_span = Some(line_with_ending_span(
+                line_number,
+                offset,
+                raw_line,
+                source_line.line_ending,
+            ));
+            shebang_not_on_first_line_preferred_newline = if source_line.line_ending.is_empty() {
+                last_line_ending
+            } else {
+                Some(source_line.line_ending)
+            };
         }
 
         if shebang_candidate || !header_like {
             break;
         }
+
+        if !source_line.line_ending.is_empty() {
+            last_line_ending = Some(source_line.line_ending);
+        }
     }
 
-    let first_line_shellcheck_shell_directive = first_line
+    let first_line_shellcheck_shell_directive = first_line_text
         .strip_prefix('#')
         .map(str::trim_start)
         .is_some_and(|comment| {
@@ -73,20 +95,20 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
                 .to_ascii_lowercase()
                 .starts_with("shellcheck shell=")
         });
-    let missing_shebang_line_span = (!first_line.trim_start().starts_with("#!")
+    let missing_shebang_line_span = (!first_line_text.trim_start().starts_with("#!")
         && space_after_hash_bang_span.is_none()
         && shebang_not_on_first_line_span.is_none()
         && !first_line_shellcheck_shell_directive
-        && first_line.trim_start().starts_with('#'))
-    .then(|| line_span(1, first_line_offset, first_line));
+        && first_line_text.trim_start().starts_with('#'))
+    .then(|| line_span(1, first_line_offset, first_line_text));
 
-    let shebang_words = first_line
+    let shebang_words = first_line_text
         .strip_prefix("#!")
         .map(parse_shebang_words)
         .unwrap_or_default();
 
-    let duplicate_shebang_flag_span =
-        shebang_duplicate_flag(&shebang_words).map(|_| line_span(1, first_line_offset, first_line));
+    let duplicate_shebang_flag_span = shebang_duplicate_flag(&shebang_words)
+        .map(|_| line_span(1, first_line_offset, first_line_text));
 
     let non_absolute_shebang_span = shebang_words.first().and_then(|interpreter| {
         if interpreter.starts_with('/') || *interpreter == "/usr/bin/env" {
@@ -95,7 +117,7 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         if has_header_shellcheck_shell_directive(source) {
             return None;
         }
-        Some(line_span(1, first_line_offset, first_line))
+        Some(line_span(1, first_line_offset, first_line_text))
     });
     let enables_errexit = first_nonempty_source_line(source)
         .and_then(|(_, line)| line.trim_end_matches('\r').strip_prefix("#!"))
@@ -108,6 +130,8 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         space_after_hash_bang_span,
         space_after_hash_bang_whitespace_span,
         shebang_not_on_first_line_span,
+        shebang_not_on_first_line_fix_span,
+        shebang_not_on_first_line_preferred_newline,
         missing_shebang_line_span,
         duplicate_shebang_flag_span,
         non_absolute_shebang_span,
@@ -181,23 +205,52 @@ fn line_slice_span(
     Span::from_positions(start, end)
 }
 
+fn line_with_ending_span(line_number: usize, offset: usize, line: &str, line_ending: &str) -> Span {
+    let start = Position {
+        line: line_number,
+        column: 1,
+        offset,
+    };
+    let end = start.advanced_by(line).advanced_by(line_ending);
+    Span::from_positions(start, end)
+}
+
 fn parse_shebang_words(shebang: &str) -> Vec<&str> {
     shebang.split_whitespace().collect()
 }
 
-fn source_lines_with_offsets(source: &str) -> impl Iterator<Item = (usize, &str)> + '_ {
+#[derive(Debug, Clone, Copy)]
+struct SourceLine<'a> {
+    offset: usize,
+    text: &'a str,
+    line_ending: &'static str,
+}
+
+fn source_lines_with_offsets(source: &str) -> impl Iterator<Item = SourceLine<'_>> + '_ {
     source
         .split_inclusive('\n')
         .scan(0usize, |offset, raw_line| {
-            let line = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+            let (line, line_ending) = if let Some(line) = raw_line.strip_suffix("\r\n") {
+                (line, "\r\n")
+            } else if let Some(line) = raw_line.strip_suffix('\n') {
+                (line, "\n")
+            } else {
+                (raw_line, "")
+            };
             let line_offset = *offset;
             *offset += raw_line.len();
-            Some((line_offset, line))
+            Some(SourceLine {
+                offset: line_offset,
+                text: line,
+                line_ending,
+            })
         })
 }
 
 fn first_nonempty_source_line(source: &str) -> Option<(usize, &str)> {
-    source_lines_with_offsets(source).find(|(_, line)| !line.trim().is_empty())
+    source_lines_with_offsets(source)
+        .find(|line| !line.text.trim().is_empty())
+        .map(|line| (line.offset, line.text))
 }
 
 fn shebang_duplicate_flag<'a>(shebang_words: &[&'a str]) -> Option<&'a str> {

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, Copy, Default)]
 struct ShebangHeaderFacts {
     indented_shebang_span: Option<Span>,
+    indented_shebang_indent_span: Option<Span>,
     space_after_hash_bang_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
     missing_shebang_line_span: Option<Span>,
@@ -16,6 +17,7 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
     };
     let first_line = first_line_text.trim_end_matches('\r');
     let mut indented_shebang_span = None;
+    let mut indented_shebang_indent_span = None;
     let mut space_after_hash_bang_span = None;
     let mut shebang_not_on_first_line_span = None;
 
@@ -26,11 +28,15 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         let header_like = source_line_is_header_like(line);
         let shebang_candidate = source_line_has_shebang_candidate(line);
         let indented_candidate = source_line_has_leading_whitespace_before_shebang_candidate(line);
+        let leading_whitespace_len = source_line_leading_whitespace_len(line);
         let space_after_hash_offset = shebang_space_after_hash_offset_in_line(line);
         let line_number = line_index + 1;
 
         if indented_shebang_span.is_none() && indented_candidate {
             indented_shebang_span = Some(point_span(line_number, 1, offset));
+            indented_shebang_indent_span = leading_whitespace_len
+                .filter(|&len| len > 0)
+                .map(|len| line_prefix_span(line_number, offset, &line[..len]));
         }
         if space_after_hash_bang_span.is_none()
             && let Some(space_offset) = space_after_hash_offset
@@ -89,6 +95,7 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
 
     ShebangHeaderFacts {
         indented_shebang_span,
+        indented_shebang_indent_span,
         space_after_hash_bang_span,
         shebang_not_on_first_line_span,
         missing_shebang_line_span,
@@ -113,6 +120,11 @@ fn source_line_has_leading_whitespace_before_shebang_candidate(line: &str) -> bo
     trimmed.len() != line.len() && source_line_has_shebang_candidate(line)
 }
 
+fn source_line_leading_whitespace_len(line: &str) -> Option<usize> {
+    let trimmed = line.trim_start_matches(char::is_whitespace);
+    (trimmed.len() != line.len()).then_some(line.len() - trimmed.len())
+}
+
 fn shebang_space_after_hash_offset_in_line(line: &str) -> Option<usize> {
     let trimmed = line.trim_start_matches(char::is_whitespace);
     let leading_whitespace_len = line.len().saturating_sub(trimmed.len());
@@ -130,6 +142,16 @@ fn point_span(line_number: usize, column: usize, offset: usize) -> Span {
         column,
         offset,
     })
+}
+
+fn line_prefix_span(line_number: usize, offset: usize, prefix: &str) -> Span {
+    let start = Position {
+        line: line_number,
+        column: 1,
+        offset,
+    };
+    let end = start.advanced_by(prefix);
+    Span::from_positions(start, end)
 }
 
 fn parse_shebang_words(shebang: &str) -> Vec<&str> {
@@ -309,7 +331,6 @@ fn case_item_label_comment(
     })
 }
 
-
 fn has_header_shellcheck_shell_directive(source: &str) -> bool {
     for line in source.lines().skip(1) {
         let trimmed = line.trim_start();
@@ -328,5 +349,3 @@ fn has_header_shellcheck_shell_directive(source: &str) -> bool {
 
     false
 }
-
-

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -19,13 +19,15 @@ use self::{
     escape_scan::{EscapeScanContext, EscapeScanInputs, build_escape_scan_matches},
     presence::build_presence_tested_names,
     surface::{
-        CaseModificationFragmentFact, DollarDoubleQuotedFragmentFact,
+        CaseModificationFragmentFact, CasePatternExpansionFact, DollarDoubleQuotedFragmentFact,
         IndexedArrayReferenceFragmentFact, IndirectExpansionFragmentFact,
         NestedParameterExpansionFragmentFact, OpenDoubleQuoteFragmentFact,
         ParameterPatternSpecialTargetFragmentFact, ReplacementExpansionFragmentFact,
         StarGlobRemovalFragmentFact, SubstringExpansionFragmentFact, SurfaceFragmentFacts,
         SurfaceFragmentSink, SurfaceScanContext, SuspectClosingQuoteFragmentFact,
         ZshParameterIndexFlagFragmentFact, build_subscript_index_reference_spans,
+        rewrite_pattern_as_single_double_quoted_string,
+        rewrite_word_as_single_double_quoted_string,
     },
 };
 use crate::FileContext;

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -47,6 +47,7 @@ pub struct LinterFacts<'a> {
     single_test_subshell_spans: Vec<Span>,
     subshell_test_group_spans: Vec<Span>,
     indented_shebang_span: Option<Span>,
+    indented_shebang_indent_span: Option<Span>,
     space_after_hash_bang_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
     missing_shebang_line_span: Option<Span>,
@@ -492,6 +493,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn indented_shebang_span(&self) -> Option<Span> {
         self.indented_shebang_span
+    }
+
+    pub fn indented_shebang_indent_span(&self) -> Option<Span> {
+        self.indented_shebang_indent_span
     }
 
     pub fn space_after_hash_bang_span(&self) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -51,6 +51,8 @@ pub struct LinterFacts<'a> {
     space_after_hash_bang_span: Option<Span>,
     space_after_hash_bang_whitespace_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
+    shebang_not_on_first_line_fix_span: Option<Span>,
+    shebang_not_on_first_line_preferred_newline: Option<&'static str>,
     missing_shebang_line_span: Option<Span>,
     duplicate_shebang_flag_span: Option<Span>,
     non_absolute_shebang_span: Option<Span>,
@@ -179,7 +181,8 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn innermost_command_at(&self, offset: usize) -> Option<&CommandFact<'a>> {
-        self.innermost_command_id_at(offset).map(|id| self.command(id))
+        self.innermost_command_id_at(offset)
+            .map(|id| self.command(id))
     }
 
     pub fn innermost_command_id_at(&self, offset: usize) -> Option<CommandId> {
@@ -191,7 +194,8 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn command_parent(&self, id: CommandId) -> Option<&CommandFact<'a>> {
-        self.command_parent_id(id).map(|parent_id| self.command(parent_id))
+        self.command_parent_id(id)
+            .map(|parent_id| self.command(parent_id))
     }
 
     pub fn command_is_dominance_barrier(&self, id: CommandId) -> bool {
@@ -289,10 +293,7 @@ impl<'a> LinterFacts<'a> {
             .contains(&fact.key())
     }
 
-    pub fn expansion_word_facts(
-        &self,
-        context: ExpansionContext,
-    ) -> WordOccurrenceIter<'_, 'a> {
+    pub fn expansion_word_facts(&self, context: ExpansionContext) -> WordOccurrenceIter<'_, 'a> {
         WordOccurrenceIter {
             inner: Box::new(
                 self.word_facts()
@@ -340,9 +341,7 @@ impl<'a> LinterFacts<'a> {
             })
     }
 
-    pub fn array_assignment_split_word_facts(
-        &self,
-    ) -> WordOccurrenceIter<'_, 'a> {
+    pub fn array_assignment_split_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
         WordOccurrenceIter {
             inner: Box::new(
                 self.array_assignment_split_word_ids
@@ -361,10 +360,7 @@ impl<'a> LinterFacts<'a> {
         &self.word_occurrences[id.index()]
     }
 
-    fn word_occurrence_ids_for_command(
-        &self,
-        id: CommandId,
-    ) -> &[WordOccurrenceId] {
+    fn word_occurrence_ids_for_command(&self, id: CommandId) -> &[WordOccurrenceId] {
         self.word_occurrence_ids_by_command
             .get(id.index())
             .map_or(&[], SmallVec::as_slice)
@@ -510,6 +506,14 @@ impl<'a> LinterFacts<'a> {
 
     pub fn shebang_not_on_first_line_span(&self) -> Option<Span> {
         self.shebang_not_on_first_line_span
+    }
+
+    pub fn shebang_not_on_first_line_fix_span(&self) -> Option<Span> {
+        self.shebang_not_on_first_line_fix_span
+    }
+
+    pub fn shebang_not_on_first_line_preferred_newline(&self) -> Option<&'static str> {
+        self.shebang_not_on_first_line_preferred_newline
     }
 
     pub fn missing_shebang_line_span(&self) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -38,7 +38,7 @@ pub struct LinterFacts<'a> {
     case_items: Vec<CaseItemFact<'a>>,
     case_pattern_shadows: Vec<CasePatternShadowFact>,
     case_pattern_impossible_spans: Vec<Span>,
-    case_pattern_expansion_spans: Vec<Span>,
+    case_pattern_expansions: Vec<CasePatternExpansionFact>,
     getopts_cases: Vec<GetoptsCaseFact>,
     pipelines: Vec<PipelineFact<'a>>,
     lists: Vec<ListFact<'a>>,
@@ -458,8 +458,8 @@ impl<'a> LinterFacts<'a> {
         &self.case_pattern_impossible_spans
     }
 
-    pub fn case_pattern_expansion_spans(&self) -> &[Span] {
-        &self.case_pattern_expansion_spans
+    pub fn case_pattern_expansions(&self) -> &[CasePatternExpansionFact] {
+        &self.case_pattern_expansions
     }
 
     pub fn getopts_cases(&self) -> &[GetoptsCaseFact] {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -49,6 +49,7 @@ pub struct LinterFacts<'a> {
     indented_shebang_span: Option<Span>,
     indented_shebang_indent_span: Option<Span>,
     space_after_hash_bang_span: Option<Span>,
+    space_after_hash_bang_whitespace_span: Option<Span>,
     shebang_not_on_first_line_span: Option<Span>,
     missing_shebang_line_span: Option<Span>,
     duplicate_shebang_flag_span: Option<Span>,
@@ -501,6 +502,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn space_after_hash_bang_span(&self) -> Option<Span> {
         self.space_after_hash_bang_span
+    }
+
+    pub fn space_after_hash_bang_whitespace_span(&self) -> Option<Span> {
+        self.space_after_hash_bang_whitespace_span
     }
 
     pub fn shebang_not_on_first_line_span(&self) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -265,6 +265,18 @@ fn build_simple_test_fact<'a>(
 }
 
 fn build_glued_closing_bracket_operand_span(command: &Command, source: &str) -> Option<Span> {
+    build_glued_closing_bracket_operand_word(command, source)
+        .map(|operand| Span::from_positions(operand.span.start, operand.span.start))
+}
+
+fn build_glued_closing_bracket_insert_offset(command: &Command, source: &str) -> Option<usize> {
+    build_glued_closing_bracket_operand_word(command, source).map(|operand| operand.span.end.offset - 1)
+}
+
+fn build_glued_closing_bracket_operand_word<'a>(
+    command: &'a Command,
+    source: &str,
+) -> Option<&'a Word> {
     let Command::Simple(command) = command else {
         return None;
     };
@@ -279,10 +291,10 @@ fn build_glued_closing_bracket_operand_span(command: &Command, source: &str) -> 
         return None;
     }
 
-    glued_closing_bracket_unary_operand_span(&args, source)
+    glued_closing_bracket_unary_operand(&args, source)
 }
 
-fn glued_closing_bracket_unary_operand_span(args: &[&Word], source: &str) -> Option<Span> {
+fn glued_closing_bracket_unary_operand<'a>(args: &[&'a Word], source: &str) -> Option<&'a Word> {
     let [first, second] = args else {
         let [bang, operator, operand] = args else {
             return None;
@@ -294,7 +306,7 @@ fn glued_closing_bracket_unary_operand_span(args: &[&Word], source: &str) -> Opt
                 .slice(source)
                 .strip_suffix(']')
                 .is_some_and(|prefix| !prefix.is_empty()))
-        .then_some(Span::from_positions(operand.span.start, operand.span.start));
+        .then_some(*operand);
     };
 
     (simple_test_is_unary_operator(first.span.slice(source))
@@ -303,7 +315,7 @@ fn glued_closing_bracket_unary_operand_span(args: &[&Word], source: &str) -> Opt
             .slice(source)
             .strip_suffix(']')
             .is_some_and(|prefix| !prefix.is_empty()))
-    .then_some(Span::from_positions(second.span.start, second.span.start))
+    .then_some(*second)
 }
 
 fn simple_test_shape(operand_count: usize) -> SimpleTestShape {

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -104,6 +104,29 @@ impl<'a> SimpleTestFact<'a> {
         }
     }
 
+    pub fn escaped_negation_spans(&self, source: &str) -> Option<(Span, Span)> {
+        let leading = self.operands.first().copied()?;
+        if leading.span.slice(source) != "\\!" {
+            return None;
+        }
+
+        escaped_negation_is_operator(self, source).then(|| {
+            let diagnostic_span =
+                if self.syntax == SimpleTestSyntax::Bracket && self.shape == SimpleTestShape::Binary
+                {
+                    self.operands
+                        .get(1)
+                        .copied()
+                        .map_or(leading.span, |word| word.span)
+                } else {
+                    leading.span
+                };
+            let fix_start = leading.span.start;
+            let fix_end = fix_start.advanced_by("\\");
+            (diagnostic_span, Span::from_positions(fix_start, fix_end))
+        })
+    }
+
     pub fn compound_operator_spans(&self, source: &str) -> Vec<Span> {
         let Some((end, spans)) = simple_test_parse_logical_expression(self, 0, source) else {
             return Vec::new();
@@ -184,6 +207,25 @@ impl<'a> SimpleTestFact<'a> {
         (self.shape == SimpleTestShape::Binary)
             .then(|| Some((self.operand_class(0)?, self.operand_class(2)?)))
             .flatten()
+    }
+}
+
+fn escaped_negation_is_operator(simple_test: &SimpleTestFact<'_>, source: &str) -> bool {
+    match simple_test.shape() {
+        SimpleTestShape::Unary => true,
+        SimpleTestShape::Binary => simple_test
+            .operands()
+            .get(1)
+            .and_then(|word| static_word_text(word, source))
+            .as_deref()
+            .is_some_and(|operator| !simple_test_is_binary_operator(operator)),
+        SimpleTestShape::Other => simple_test
+            .operands()
+            .get(2)
+            .and_then(|word| static_word_text(word, source))
+            .as_deref()
+            .is_some_and(simple_test_is_binary_operator),
+        SimpleTestShape::Empty | SimpleTestShape::Truthy => false,
     }
 }
 

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -9,13 +9,16 @@ pub enum SubstitutionHostKind {
     Other,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct SubstitutionFact {
     span: Span,
     kind: CommandSubstitutionKind,
     command_syntax: Option<CommandSubstitutionSyntax>,
     stdout_intent: SubstitutionOutputIntent,
+    terminal_stdout_intent: SubstitutionOutputIntent,
     has_stdout_redirect: bool,
+    stdout_redirect_spans: Box<[Span]>,
+    stdout_dev_null_redirect_spans: Box<[Span]>,
     body_contains_ls: bool,
     body_contains_echo: bool,
     body_contains_grep: bool,
@@ -50,8 +53,20 @@ impl SubstitutionFact {
         self.stdout_intent
     }
 
+    pub fn terminal_stdout_intent(&self) -> SubstitutionOutputIntent {
+        self.terminal_stdout_intent
+    }
+
     pub fn has_stdout_redirect(&self) -> bool {
         self.has_stdout_redirect
+    }
+
+    pub fn stdout_redirect_spans(&self) -> &[Span] {
+        &self.stdout_redirect_spans
+    }
+
+    pub fn stdout_dev_null_redirect_spans(&self) -> &[Span] {
+        &self.stdout_dev_null_redirect_spans
     }
 
     pub fn body_contains_ls(&self) -> bool {
@@ -270,7 +285,10 @@ fn collect_or_update_substitution_facts_from_occurrences<'a>(
             kind: occurrence.kind,
             command_syntax: occurrence.command_syntax,
             stdout_intent: body_facts.stdout_intent,
+            terminal_stdout_intent: body_facts.terminal_stdout_intent,
             has_stdout_redirect: body_facts.has_stdout_redirect,
+            stdout_redirect_spans: body_facts.stdout_redirect_spans,
+            stdout_dev_null_redirect_spans: body_facts.stdout_dev_null_redirect_spans,
             body_contains_ls: body_facts.body_contains_ls,
             body_contains_echo: body_facts.body_contains_echo,
             body_contains_grep: body_facts.body_contains_grep,
@@ -438,10 +456,13 @@ fn collect_arithmetic_lvalue_substitution_occurrences<'a>(
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct SubstitutionBodyFacts {
     stdout_intent: SubstitutionOutputIntent,
+    terminal_stdout_intent: SubstitutionOutputIntent,
     has_stdout_redirect: bool,
+    stdout_redirect_spans: Box<[Span]>,
+    stdout_dev_null_redirect_spans: Box<[Span]>,
     body_contains_ls: bool,
     body_contains_echo: bool,
     body_contains_grep: bool,
@@ -458,6 +479,24 @@ fn classify_substitution_body<'a>(
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> SubstitutionBodyFacts {
+    let redirect_state_for_command = |command, redirects| {
+        if let Some(id) = command_id_for_command(command, command_ids_by_span) {
+            let redirects = command_fact(commands, id).redirect_facts();
+            (
+                classify_redirect_facts(redirects),
+                stdout_redirect_spans_for_fix(redirects),
+                stdout_dev_null_redirect_spans_for_fix(redirects),
+            )
+        } else {
+            let redirect_facts = build_redirect_facts(redirects, source, None);
+            (
+                classify_redirect_facts(&redirect_facts),
+                stdout_redirect_spans_for_fix(&redirect_facts),
+                stdout_dev_null_redirect_spans_for_fix(&redirect_facts),
+            )
+        }
+    };
+
     let visits = query::iter_commands(
         body,
         CommandWalkOptions {
@@ -465,16 +504,12 @@ fn classify_substitution_body<'a>(
         },
     )
     .collect::<Vec<_>>();
+
     let mut stdout_intent: Option<SubstitutionOutputIntent> = None;
     let mut has_stdout_redirect = false;
 
     for visit in &visits {
-        let state = if let Some(id) = command_id_for_command(visit.command, command_ids_by_span) {
-            classify_redirect_facts(command_fact(commands, id).redirect_facts())
-        } else {
-            let redirect_facts = build_redirect_facts(visit.redirects, source, None);
-            classify_redirect_facts(&redirect_facts)
-        };
+        let (state, _, _) = redirect_state_for_command(visit.command, visit.redirects);
 
         has_stdout_redirect |= state.has_stdout_redirect;
         stdout_intent = Some(match stdout_intent {
@@ -484,9 +519,27 @@ fn classify_substitution_body<'a>(
         });
     }
 
+    let mut terminal_stdout_intent = SubstitutionOutputIntent::Captured;
+    let mut stdout_redirect_spans = Vec::new();
+    let mut stdout_dev_null_redirect_spans = Vec::new();
+
+    for stmt in &body.stmts {
+        let (state, redirect_spans, dev_null_redirect_spans) =
+            redirect_state_for_command(&stmt.command, &stmt.redirects);
+
+        if !matches!(state.stdout_intent, SubstitutionOutputIntent::Captured) {
+            stdout_redirect_spans.extend(redirect_spans);
+            stdout_dev_null_redirect_spans.extend(dev_null_redirect_spans);
+        }
+        terminal_stdout_intent = state.stdout_intent;
+    }
+
     SubstitutionBodyFacts {
         stdout_intent: stdout_intent.unwrap_or(SubstitutionOutputIntent::Captured),
+        terminal_stdout_intent,
         has_stdout_redirect,
+        stdout_redirect_spans: stdout_redirect_spans.into_boxed_slice(),
+        stdout_dev_null_redirect_spans: stdout_dev_null_redirect_spans.into_boxed_slice(),
         body_contains_ls: substitution_body_contains_ls(body, commands, command_ids_by_span),
         body_contains_echo: substitution_body_contains_echo(body, source),
         body_contains_grep: substitution_body_contains_grep(body, source),
@@ -564,6 +617,42 @@ fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
         stdout_intent,
         has_stdout_redirect,
     }
+}
+
+fn stdout_redirect_spans_for_fix(redirects: &[RedirectFact<'_>]) -> Vec<Span> {
+    redirects
+        .iter()
+        .filter(|redirect| redirect_affects_stdout(redirect))
+        .map(|redirect| redirect.redirect().span)
+        .collect()
+}
+
+fn stdout_dev_null_redirect_spans_for_fix(redirects: &[RedirectFact<'_>]) -> Vec<Span> {
+    redirects
+        .iter()
+        .filter(|redirect| redirect_targets_stdout_dev_null(redirect))
+        .map(|redirect| redirect.redirect().span)
+        .collect()
+}
+
+fn redirect_affects_stdout(redirect: &RedirectFact<'_>) -> bool {
+    match redirect.redirect().kind {
+        RedirectKind::Output
+        | RedirectKind::Clobber
+        | RedirectKind::Append
+        | RedirectKind::DupOutput => redirect.redirect().fd.unwrap_or(1) == 1,
+        RedirectKind::OutputBoth => true,
+        RedirectKind::Input
+        | RedirectKind::ReadWrite
+        | RedirectKind::HereDoc
+        | RedirectKind::HereDocStrip
+        | RedirectKind::HereString
+        | RedirectKind::DupInput => false,
+    }
+}
+
+fn redirect_targets_stdout_dev_null(redirect: &RedirectFact<'_>) -> bool {
+    redirect_affects_stdout(redirect) && redirect_file_sink(redirect) == OutputSink::DevNull
 }
 
 fn substitution_body_contains_echo(body: &StmtSeq, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -48,14 +48,24 @@ impl DollarDoubleQuotedFragmentFact {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct OpenDoubleQuoteFragmentFact {
     span: Span,
+    replacement_span: Span,
+    replacement: Box<str>,
 }
 
 impl OpenDoubleQuoteFragmentFact {
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    pub fn replacement_span(&self) -> Span {
+        self.replacement_span
+    }
+
+    pub fn replacement(&self) -> &str {
+        &self.replacement
     }
 }
 
@@ -525,12 +535,20 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     fn collect_open_double_quote_fragments(&mut self, word: &Word, command_name: Option<&str>) {
-        for (opening_span, closing_span) in
-            suspect_double_quote_spans(word, self.source, command_name)
-        {
+        let fragments = suspect_double_quote_spans(word, self.source, command_name);
+        if fragments.is_empty() {
+            return;
+        }
+
+        let replacement = rewrite_reopened_double_quote_word(word, self.source);
+        for (opening_span, closing_span) in fragments {
             self.facts
                 .open_double_quotes
-                .push(OpenDoubleQuoteFragmentFact { span: opening_span });
+                .push(OpenDoubleQuoteFragmentFact {
+                    span: opening_span,
+                    replacement_span: word.span,
+                    replacement: replacement.clone(),
+                });
             self.facts
                 .suspect_closing_quotes
                 .push(SuspectClosingQuoteFragmentFact { span: closing_span });
@@ -2098,6 +2116,58 @@ fn suspect_double_quote_spans(
             ))
         })
         .collect()
+}
+
+fn rewrite_reopened_double_quote_word(word: &Word, source: &str) -> Box<str> {
+    let mut rendered = String::from("\"");
+    for part in &word.parts {
+        render_word_part_inside_double_quotes(&mut rendered, part, source);
+    }
+    rendered.push('"');
+    rendered.into_boxed_str()
+}
+
+fn render_word_part_inside_double_quotes(rendered: &mut String, part: &WordPartNode, source: &str) {
+    match &part.kind {
+        WordPart::Literal(text) => {
+            push_double_quoted_literal(rendered, text.as_str(source, part.span));
+        }
+        WordPart::SingleQuoted { value, .. } => {
+            push_double_quoted_literal(rendered, value.slice(source));
+        }
+        WordPart::DoubleQuoted { parts, .. } => {
+            for nested_part in parts {
+                render_word_part_inside_double_quotes(rendered, nested_part, source);
+            }
+        }
+        WordPart::Variable(name) => {
+            rendered.push_str("${");
+            rendered.push_str(name.as_ref());
+            rendered.push('}');
+        }
+        _ => rendered.push_str(&word_part_syntax(part, source)),
+    }
+}
+
+fn push_double_quoted_literal(rendered: &mut String, text: &str) {
+    for ch in text.chars() {
+        match ch {
+            '"' | '\\' | '$' | '`' => {
+                rendered.push('\\');
+                rendered.push(ch);
+            }
+            _ => rendered.push(ch),
+        }
+    }
+}
+
+fn word_part_syntax(part: &WordPartNode, source: &str) -> String {
+    Word {
+        parts: vec![part.clone()],
+        span: part.span,
+        brace_syntax: Vec::new(),
+    }
+    .render_syntax(source)
 }
 
 pub(super) fn word_has_reopened_double_quote_window(

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -2143,7 +2143,7 @@ fn suspect_double_quote_spans(
 pub(super) fn rewrite_word_as_single_double_quoted_string(word: &Word, source: &str) -> Box<str> {
     let mut rendered = String::from("\"");
     for part in &word.parts {
-        render_word_part_inside_double_quotes(&mut rendered, part, source);
+        render_word_part_inside_double_quotes(&mut rendered, part, source, false);
     }
     rendered.push('"');
     rendered.into_boxed_str()
@@ -2172,7 +2172,7 @@ fn render_pattern_part_inside_double_quotes(
         }
         PatternPart::Word(word) => {
             for word_part in &word.parts {
-                render_word_part_inside_double_quotes(rendered, word_part, source);
+                render_word_part_inside_double_quotes(rendered, word_part, source, false);
             }
         }
         PatternPart::AnyString
@@ -2189,17 +2189,29 @@ fn render_pattern_part_inside_double_quotes(
     }
 }
 
-fn render_word_part_inside_double_quotes(rendered: &mut String, part: &WordPartNode, source: &str) {
+fn render_word_part_inside_double_quotes(
+    rendered: &mut String,
+    part: &WordPartNode,
+    source: &str,
+    source_is_double_quoted: bool,
+) {
     match &part.kind {
         WordPart::Literal(text) => {
-            push_double_quoted_literal(rendered, text.as_str(source, part.span));
+            if source_is_double_quoted {
+                push_double_quoted_literal(rendered, text.as_str(source, part.span));
+            } else {
+                push_cooked_unquoted_literal_inside_double_quotes(
+                    rendered,
+                    text.as_str(source, part.span),
+                );
+            }
         }
         WordPart::SingleQuoted { value, .. } => {
             push_double_quoted_literal(rendered, value.slice(source));
         }
         WordPart::DoubleQuoted { parts, .. } => {
             for nested_part in parts {
-                render_word_part_inside_double_quotes(rendered, nested_part, source);
+                render_word_part_inside_double_quotes(rendered, nested_part, source, true);
             }
         }
         WordPart::Variable(name) => {
@@ -2221,6 +2233,26 @@ fn push_double_quoted_literal(rendered: &mut String, text: &str) {
             _ => rendered.push(ch),
         }
     }
+}
+
+fn push_cooked_unquoted_literal_inside_double_quotes(rendered: &mut String, text: &str) {
+    let mut cooked = String::with_capacity(text.len());
+    let mut chars = text.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.next() {
+                Some('\n') => {}
+                Some(escaped) => cooked.push(escaped),
+                None => cooked.push('\\'),
+            }
+            continue;
+        }
+
+        cooked.push(ch);
+    }
+
+    push_double_quoted_literal(rendered, &cooked);
 }
 
 fn word_part_syntax(part: &WordPartNode, source: &str) -> String {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1,5 +1,7 @@
 use super::*;
-use shuck_ast::{HeredocBody, HeredocBodyPart, HeredocBodyPartNode, PatternGroupKind};
+use shuck_ast::{
+    HeredocBody, HeredocBodyPart, HeredocBodyPartNode, PatternGroupKind, PatternPartNode,
+};
 
 #[derive(Debug)]
 pub struct SingleQuotedFragmentFact {
@@ -62,6 +64,26 @@ impl OpenDoubleQuoteFragmentFact {
 
     pub fn replacement_span(&self) -> Span {
         self.replacement_span
+    }
+
+    pub fn replacement(&self) -> &str {
+        &self.replacement
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CasePatternExpansionFact {
+    span: Span,
+    replacement: Box<str>,
+}
+
+impl CasePatternExpansionFact {
+    pub(super) fn new(span: Span, replacement: Box<str>) -> Self {
+        Self { span, replacement }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
     }
 
     pub fn replacement(&self) -> &str {
@@ -540,7 +562,7 @@ impl<'a> SurfaceFragmentSink<'a> {
             return;
         }
 
-        let replacement = rewrite_reopened_double_quote_word(word, self.source);
+        let replacement = rewrite_word_as_single_double_quoted_string(word, self.source);
         for (opening_span, closing_span) in fragments {
             self.facts
                 .open_double_quotes
@@ -2118,13 +2140,53 @@ fn suspect_double_quote_spans(
         .collect()
 }
 
-fn rewrite_reopened_double_quote_word(word: &Word, source: &str) -> Box<str> {
+pub(super) fn rewrite_word_as_single_double_quoted_string(word: &Word, source: &str) -> Box<str> {
     let mut rendered = String::from("\"");
     for part in &word.parts {
         render_word_part_inside_double_quotes(&mut rendered, part, source);
     }
     rendered.push('"');
     rendered.into_boxed_str()
+}
+
+pub(super) fn rewrite_pattern_as_single_double_quoted_string(
+    pattern: &Pattern,
+    source: &str,
+) -> Box<str> {
+    let mut rendered = String::from("\"");
+    for part in &pattern.parts {
+        render_pattern_part_inside_double_quotes(&mut rendered, part, source);
+    }
+    rendered.push('"');
+    rendered.into_boxed_str()
+}
+
+fn render_pattern_part_inside_double_quotes(
+    rendered: &mut String,
+    part: &PatternPartNode,
+    source: &str,
+) {
+    match &part.kind {
+        PatternPart::Literal(text) => {
+            push_double_quoted_literal(rendered, text.as_str(source, part.span));
+        }
+        PatternPart::Word(word) => {
+            for word_part in &word.parts {
+                render_word_part_inside_double_quotes(rendered, word_part, source);
+            }
+        }
+        PatternPart::AnyString
+        | PatternPart::AnyChar
+        | PatternPart::CharClass(_)
+        | PatternPart::Group { .. } => {
+            let syntax = Pattern {
+                parts: vec![part.clone()],
+                span: part.span,
+            }
+            .render_syntax(source);
+            push_double_quoted_literal(rendered, &syntax);
+        }
+    }
 }
 
 fn render_word_part_inside_double_quotes(rendered: &mut String, part: &WordPartNode, source: &str) {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1371,6 +1371,50 @@ grep 'foo*bar+' data.txt
 }
 
 #[test]
+fn grep_pattern_facts_track_glob_style_star_replacement_spans() {
+    let source = "\
+#!/bin/bash
+grep 'foo\\*bar*' data.txt
+grep item\\* data.txt
+grep start* data.txt
+grep --regexp='start*' data.txt
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let file_context = classify_file_context(source, None, ShellDialect::Bash);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+    let grep_patterns = facts
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("grep"))
+        .filter_map(|fact| fact.options().grep())
+        .flat_map(|grep| grep.patterns().iter())
+        .map(|pattern| {
+            (
+                pattern.span().slice(source),
+                pattern
+                    .glob_style_star_replacement_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        grep_patterns,
+        vec![
+            ("'foo\\*bar*'", vec!["*"]),
+            ("item\\*", vec!["\\*"]),
+            ("start*", vec!["*"]),
+            ("--regexp='start*'", vec!["*"]),
+        ]
+    );
+}
+
+#[test]
 fn attached_short_e_patterns_do_not_accidentally_toggle_only_matching() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -2684,7 +2684,7 @@ z=$(ls layout.*.h | cut -d. -f2 | xargs echo)
         let substitutions = facts
             .commands()
             .iter()
-            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .flat_map(|fact| fact.substitution_facts().iter().cloned())
             .map(|fact| {
                 (
                     fact.span().slice(source).to_owned(),
@@ -2813,6 +2813,33 @@ z=$(ls layout.*.h | cut -d. -f2 | xargs echo)
 }
 
 #[test]
+fn treats_stderr_capture_before_stdout_redirect_as_captured_substitution_output() {
+    let source = "#!/bin/sh\nchoice=$(printf hi 2>&1 >/dev/tty)\n";
+
+    with_facts(source, None, |_, facts| {
+        let substitution = facts
+            .commands()
+            .iter()
+            .flat_map(|fact| fact.substitution_facts().iter())
+            .find(|fact| fact.span().slice(source) == "$(printf hi 2>&1 >/dev/tty)")
+            .expect("expected substitution fact");
+
+        assert_eq!(
+            substitution.stdout_intent(),
+            SubstitutionOutputIntent::Captured
+        );
+        assert_eq!(
+            substitution
+                .stdout_redirect_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            Vec::<&str>::new()
+        );
+    });
+}
+
+#[test]
 fn builds_docker_ps_substitution_facts_without_pgrep_exemptions() {
     let source = "\
 #!/bin/bash
@@ -2849,7 +2876,7 @@ printf '%s\\n' `date` $(uname) <(cat /etc/hosts)
         let substitutions = facts
             .commands()
             .iter()
-            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .flat_map(|fact| fact.substitution_facts().iter().cloned())
             .map(|fact| {
                 (
                     fact.span().slice(source).to_owned(),

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -2894,7 +2894,7 @@ docker inspect -f '{{ if ne \"true\" (index .Config.Labels \"com.dokku.devcontai
         let substitution = facts
             .commands()
             .iter()
-            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .flat_map(|fact| fact.substitution_facts().iter())
             .find(|fact| fact.span().slice(source) == "$(docker ps -q)")
             .expect("expected docker ps substitution fact");
 

--- a/crates/shuck-linter/src/facts/tests/comments.rs
+++ b/crates/shuck-linter/src/facts/tests/comments.rs
@@ -27,3 +27,42 @@ fn ignores_non_header_like_c074_lines_in_facts() {
         assert!(facts.space_after_hash_bang_whitespace_span().is_none());
     });
 }
+
+#[test]
+fn captures_c075_move_span_with_existing_newline() {
+    let source = "\n#!/bin/sh\n";
+
+    with_facts(source, None, |_, facts| {
+        let anchor = facts
+            .shebang_not_on_first_line_span()
+            .expect("expected C075 anchor span");
+        let fix_span = facts
+            .shebang_not_on_first_line_fix_span()
+            .expect("expected C075 move span");
+
+        assert_eq!(anchor.start.line, 2);
+        assert_eq!(anchor.start.column, 1);
+        assert_eq!(fix_span.slice(source), "#!/bin/sh\n");
+        assert_eq!(
+            facts.shebang_not_on_first_line_preferred_newline(),
+            Some("\n")
+        );
+    });
+}
+
+#[test]
+fn captures_c075_preferred_newline_for_eof_shebangs() {
+    let source = "# comment\r\n#!/bin/sh";
+
+    with_facts(source, None, |_, facts| {
+        let fix_span = facts
+            .shebang_not_on_first_line_fix_span()
+            .expect("expected C075 move span");
+
+        assert_eq!(fix_span.slice(source), "#!/bin/sh");
+        assert_eq!(
+            facts.shebang_not_on_first_line_preferred_newline(),
+            Some("\r\n")
+        );
+    });
+}

--- a/crates/shuck-linter/src/facts/tests/comments.rs
+++ b/crates/shuck-linter/src/facts/tests/comments.rs
@@ -1,0 +1,29 @@
+use super::with_facts;
+
+#[test]
+fn captures_c074_anchor_and_whitespace_span() {
+    let source = "# \t!/bin/sh\n";
+
+    with_facts(source, None, |_, facts| {
+        let anchor = facts
+            .space_after_hash_bang_span()
+            .expect("expected C074 anchor span");
+        let whitespace = facts
+            .space_after_hash_bang_whitespace_span()
+            .expect("expected C074 whitespace span");
+
+        assert_eq!(anchor.start.line, 1);
+        assert_eq!(anchor.start.column, 2);
+        assert_eq!(whitespace.start.column, 2);
+        assert_eq!(whitespace.end.column, 4);
+        assert_eq!(whitespace.slice(source), " \t");
+    });
+}
+
+#[test]
+fn ignores_non_header_like_c074_lines_in_facts() {
+    with_facts("echo ok\n# !/bin/sh\n", None, |_, facts| {
+        assert!(facts.space_after_hash_bang_span().is_none());
+        assert!(facts.space_after_hash_bang_whitespace_span().is_none());
+    });
+}

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -13,7 +13,7 @@ conditional=$( [[ -n $value ]] && printf '%s\\n' ok )
         let substitutions = facts
             .commands()
             .iter()
-            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .flat_map(|fact| fact.substitution_facts().iter().cloned())
             .map(|fact| {
                 (
                     fact.span().slice(source).to_owned(),
@@ -59,7 +59,7 @@ brace_like=$(echo {a,b})
         let substitutions = facts
             .commands()
             .iter()
-            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .flat_map(|fact| fact.substitution_facts().iter().cloned())
             .map(|fact| {
                 (
                     fact.span().slice(source).to_owned(),
@@ -107,7 +107,7 @@ CANDIDATES+=(\"$(echo \"$line\" | cut -d' ' -f2-)\")
         let substitutions = facts
             .commands()
             .iter()
-            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .flat_map(|fact| fact.substitution_facts().iter().cloned())
             .filter(|fact| fact.span().slice(source).contains("$(echo"))
             .map(|fact| {
                 (
@@ -149,7 +149,7 @@ legacy=`nvm ls | grep '^ *\\.'`
         let substitutions = facts
             .commands()
             .iter()
-            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .flat_map(|fact| fact.substitution_facts().iter().cloned())
             .map(|fact| {
                 (
                     fact.span().slice(source).to_owned(),
@@ -201,7 +201,7 @@ printf '%s\\n' $(<input.txt) \"$( < spaced.txt )\" $(0< fd.txt) $(< quiet.txt 2>
         let substitutions = facts
             .commands()
             .iter()
-            .flat_map(|fact| fact.substitution_facts().iter().copied())
+            .flat_map(|fact| fact.substitution_facts().iter().cloned())
             .map(|fact| {
                 (
                     fact.span().slice(source).to_owned(),

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -931,6 +931,51 @@ fn records_glued_closing_bracket_operand_spans_for_unary_tests() {
 }
 
 #[test]
+fn records_linebreak_in_test_fix_sites() {
+    let source = "\
+#!/bin/sh
+if [ \"$x\" = y
+]; then :; fi
+if [ \"$x\" = y \\
+]; then :; fi
+if [ \"$x\" = y ]; then :; fi
+";
+
+    with_facts(source, None, |_, facts| {
+        let commands = facts.structural_commands().collect::<Vec<_>>();
+        let broken = commands
+            .iter()
+            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line == 2)
+            .expect("expected broken bracket test");
+        let continued = commands
+            .iter()
+            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line == 4)
+            .expect("expected continued bracket test");
+        let single_line = commands
+            .iter()
+            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line == 6)
+            .expect("expected single-line bracket test");
+
+        assert_eq!(
+            broken
+                .linebreak_in_test_anchor_span()
+                .map(|span| (span.start.line, span.start.column)),
+            Some((2, 14))
+        );
+        assert_eq!(
+            broken
+                .linebreak_in_test_insert_offset()
+                .map(|offset| &source[offset..offset + 1]),
+            Some("\n")
+        );
+        assert_eq!(continued.linebreak_in_test_anchor_span(), None);
+        assert_eq!(continued.linebreak_in_test_insert_offset(), None);
+        assert_eq!(single_line.linebreak_in_test_anchor_span(), None);
+        assert_eq!(single_line.linebreak_in_test_insert_offset(), None);
+    });
+}
+
+#[test]
 fn collects_bare_command_name_assignment_spans() {
     let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -906,13 +906,27 @@ fn records_glued_closing_bracket_operand_spans_for_unary_tests() {
             Some((2, 6))
         );
         assert_eq!(
+            commands[0]
+                .glued_closing_bracket_insert_offset()
+                .map(|offset| &source[offset..offset + 1]),
+            Some("]")
+        );
+        assert_eq!(
             commands[1]
                 .glued_closing_bracket_operand_span()
                 .map(|span| (span.start.line, span.start.column)),
             Some((3, 8))
         );
+        assert_eq!(
+            commands[1]
+                .glued_closing_bracket_insert_offset()
+                .map(|offset| &source[offset..offset + 1]),
+            Some("]")
+        );
         assert_eq!(commands[2].glued_closing_bracket_operand_span(), None);
+        assert_eq!(commands[2].glued_closing_bracket_insert_offset(), None);
         assert_eq!(commands[3].glued_closing_bracket_operand_span(), None);
+        assert_eq!(commands[3].glued_closing_bracket_insert_offset(), None);
     });
 }
 

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -381,6 +381,74 @@ test
 }
 
 #[test]
+fn simple_test_fact_tracks_escaped_negation_spans_for_fixes() {
+    let source = "\
+#!/bin/sh
+[ \\! -f foo ]
+test \\! -n foo
+[ \\! foo = bar ]
+[ \\! = right ]
+[ ! -f foo ]
+";
+
+    with_facts(source, None, |_, facts| {
+        let commands = facts
+            .structural_commands()
+            .map(|fact| (fact.span().slice(source).trim_end().to_owned(), fact))
+            .collect::<Vec<_>>();
+
+        let bracket_unary = commands
+            .iter()
+            .find(|(text, _)| text == "[ \\! -f foo ]")
+            .and_then(|(_, fact)| fact.simple_test())
+            .and_then(|simple_test| simple_test.escaped_negation_spans(source))
+            .expect("expected escaped negation spans for bracket unary test");
+        assert_eq!(
+            (
+                bracket_unary.0.slice(source).to_owned(),
+                bracket_unary.1.slice(source).to_owned()
+            ),
+            ("-f".to_owned(), "\\".to_owned())
+        );
+
+        let builtin_unary = commands
+            .iter()
+            .find(|(text, _)| text == "test \\! -n foo")
+            .and_then(|(_, fact)| fact.simple_test())
+            .and_then(|simple_test| simple_test.escaped_negation_spans(source))
+            .expect("expected escaped negation spans for test builtin");
+        assert_eq!(
+            (
+                builtin_unary.0.slice(source).to_owned(),
+                builtin_unary.1.slice(source).to_owned()
+            ),
+            ("\\!".to_owned(), "\\".to_owned())
+        );
+
+        let bracket_binary = commands
+            .iter()
+            .find(|(text, _)| text == "[ \\! foo = bar ]")
+            .and_then(|(_, fact)| fact.simple_test())
+            .and_then(|simple_test| simple_test.escaped_negation_spans(source))
+            .expect("expected escaped negation spans for bracket binary test");
+        assert_eq!(
+            (
+                bracket_binary.0.slice(source).to_owned(),
+                bracket_binary.1.slice(source).to_owned()
+            ),
+            ("\\!".to_owned(), "\\".to_owned())
+        );
+
+        let non_operator = commands
+            .iter()
+            .find(|(text, _)| text == "[ \\! = right ]")
+            .and_then(|(_, fact)| fact.simple_test())
+            .and_then(|simple_test| simple_test.escaped_negation_spans(source));
+        assert!(non_operator.is_none());
+    });
+}
+
+#[test]
 fn simple_test_fact_tracks_truthy_string_unary_and_string_binary_subexpressions() {
     let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts/tests/mod.rs
+++ b/crates/shuck-linter/src/facts/tests/mod.rs
@@ -21,6 +21,7 @@ use crate::{LinterFacts, ShellDialect, classify_file_context};
 
 mod assignments;
 mod commands;
+mod comments;
 mod conditions;
 mod flow;
 mod functions;

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1033,11 +1033,16 @@ esac
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
-                .case_pattern_expansion_spans()
+                .case_pattern_expansions()
                 .iter()
-                .map(|span| span.slice(source))
+                .map(|fact| (fact.span().slice(source), fact.replacement().to_owned()))
                 .collect::<Vec<_>>(),
-            vec!["$pat", "x$pat", "$(printf '%s' foo)", "\"$left\"$right"]
+            vec![
+                ("$pat", "\"${pat}\"".to_owned()),
+                ("x$pat", "\"x${pat}\"".to_owned()),
+                ("$(printf '%s' foo)", "\"$(printf '%s' foo)\"".to_owned()),
+                ("\"$left\"$right", "\"${left}${right}\"".to_owned()),
+            ]
         );
     });
 }
@@ -1059,7 +1064,7 @@ esac
 ";
 
     with_facts(source, None, |_, facts| {
-        assert!(facts.case_pattern_expansion_spans().is_empty());
+        assert!(facts.case_pattern_expansions().is_empty());
     });
 }
 

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -118,6 +118,22 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .open_double_quote_fragments()
+                .iter()
+                .map(|fragment| fragment.replacement_span().slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"#!/bin/bash\nif [[ \"$@\" =~ x ]]; then :; fi\n\""]
+        );
+        assert_eq!(
+            facts
+                .open_double_quote_fragments()
+                .iter()
+                .map(|fragment| fragment.replacement().to_owned())
+                .collect::<Vec<_>>(),
+            vec!["\"#!/bin/bash\nif [[ ${@} =~ x ]]; then :; fi\n\"".to_owned()]
+        );
+        assert_eq!(
+            facts
                 .suspect_closing_quote_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -527,6 +543,10 @@ say \"configure\" now
 
         assert_eq!(open, vec![(2, 6)]);
         assert_eq!(close, vec![(3, 5)]);
+        assert_eq!(
+            facts.open_double_quote_fragments()[0].replacement(),
+            "\"help text\nsay configure now\n\""
+        );
     });
 }
 

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1503,7 +1503,7 @@ pub(crate) fn benchmark_collect_word_facts(
     let mut compound_assignment_value_word_spans = FxHashSet::default();
     let mut array_assignment_split_word_ids = Vec::new();
     let mut assoc_binding_visibility_memo = FxHashMap::default();
-    let mut case_pattern_expansion_spans = Vec::new();
+    let mut case_pattern_expansions = Vec::new();
     let mut pattern_literal_spans = Vec::new();
     let mut arithmetic_summary = ArithmeticFactSummary::default();
     let mut surface_fragments = SurfaceFragmentSink::new(source);
@@ -1540,7 +1540,7 @@ pub(crate) fn benchmark_collect_word_facts(
                 compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
                 array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
                 assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
-                case_pattern_expansion_spans: &mut case_pattern_expansion_spans,
+                case_pattern_expansions: &mut case_pattern_expansions,
                 pattern_literal_spans: &mut pattern_literal_spans,
                 arithmetic: &mut arithmetic_summary,
                 surface: &mut surface_fragments,
@@ -1554,7 +1554,7 @@ pub(crate) fn benchmark_collect_word_facts(
         + word_nodes.len()
         + compound_assignment_value_word_spans.len()
         + array_assignment_split_word_ids.len()
-        + case_pattern_expansion_spans.len()
+        + case_pattern_expansions.len()
         + pattern_literal_spans.len()
         + arithmetic_summary.array_index_arithmetic_spans.len()
         + arithmetic_summary.arithmetic_score_line_spans.len()
@@ -1582,7 +1582,7 @@ struct WordFactOutputs<'out, 'a> {
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     assoc_binding_visibility_memo:
         &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
-    case_pattern_expansion_spans: &'out mut Vec<Span>,
+    case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pattern_literal_spans: &'out mut Vec<Span>,
     arithmetic: &'out mut ArithmeticFactSummary,
     surface: &'out mut SurfaceFragmentSink<'a>,
@@ -1639,7 +1639,7 @@ struct WordFactCollector<'out, 'a, 'norm> {
         &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     seen: FxHashSet<(FactSpan, WordFactContext, WordFactHostKind)>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
-    case_pattern_expansion_spans: &'out mut Vec<Span>,
+    case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pattern_literal_spans: &'out mut Vec<Span>,
     arithmetic: &'out mut ArithmeticFactSummary,
     surface: &'out mut SurfaceFragmentSink<'a>,
@@ -1669,7 +1669,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
             seen: FxHashSet::default(),
             compound_assignment_value_word_spans: outputs.compound_assignment_value_word_spans,
-            case_pattern_expansion_spans: outputs.case_pattern_expansion_spans,
+            case_pattern_expansions: outputs.case_pattern_expansions,
             pattern_literal_spans: outputs.pattern_literal_spans,
             arithmetic: outputs.arithmetic,
             surface: outputs.surface,
@@ -1747,7 +1747,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         for pattern in &case.patterns {
                             let pattern_context = surface_context.with_pattern_charclass_scan();
                             self.surface.collect_pattern_structure(pattern, pattern_context);
-                            self.collect_case_pattern_expansion_spans(pattern);
+                            self.collect_case_pattern_expansions(pattern);
                             self.collect_pattern_context_words(
                                 pattern,
                                 WordFactContext::Expansion(ExpansionContext::CasePattern),
@@ -2232,7 +2232,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
     }
 
-    fn collect_case_pattern_expansion_spans(&mut self, pattern: &Pattern) {
+    fn collect_case_pattern_expansions(&mut self, pattern: &Pattern) {
         if pattern_has_glob_structure(pattern, self.source) {
             return;
         }
@@ -2241,7 +2241,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             return;
         }
 
-        let expanded_word_spans = pattern
+        let expanded_words = pattern
             .parts
             .iter()
             .filter_map(|part| match &part.kind {
@@ -2250,7 +2250,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         analyze_word(word, self.source, self.command_zsh_options.as_ref());
                     (analysis.literalness == WordLiteralness::Expanded
                         && analysis.quote != WordQuote::FullyQuoted)
-                        .then_some(word.span)
+                        .then_some(word)
                 }
                 PatternPart::Literal(_)
                 | PatternPart::AnyString
@@ -2260,15 +2260,23 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             })
             .collect::<Vec<_>>();
 
-        if expanded_word_spans.is_empty() {
+        if expanded_words.is_empty() {
             return;
         }
 
         if pattern.parts.len() > 1 {
-            self.case_pattern_expansion_spans.push(pattern.span);
+            self.case_pattern_expansions.push(CasePatternExpansionFact::new(
+                pattern.span,
+                rewrite_pattern_as_single_double_quoted_string(pattern, self.source),
+            ));
         } else {
-            self.case_pattern_expansion_spans
-                .extend(expanded_word_spans);
+            self.case_pattern_expansions
+                .extend(expanded_words.into_iter().map(|word| {
+                    CasePatternExpansionFact::new(
+                        word.span,
+                        rewrite_word_as_single_double_quoted_string(word, self.source),
+                    )
+                }));
         }
     }
 

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -103,6 +103,10 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.word().span
     }
 
+    pub fn single_double_quoted_replacement(self, source: &str) -> Box<str> {
+        rewrite_word_as_single_double_quoted_string(self.word(), source)
+    }
+
     pub fn command_id(self) -> CommandId {
         self.occurrence().command_id
     }

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -226,6 +226,13 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         &self.derived().double_quoted_expansion_spans
     }
 
+    pub fn single_quoted_equivalent_if_plain_double_quoted(
+        self,
+        source: &str,
+    ) -> Option<String> {
+        single_quoted_equivalent_if_plain_double_quoted_word(self.word(), source)
+    }
+
     pub fn unquoted_literal_between_double_quoted_segments_spans(self) -> &'facts [Span] {
         &self
             .derived()
@@ -4260,6 +4267,59 @@ fn double_quoted_expansion_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_double_quoted_expansion_spans(&word.parts, false, &mut spans);
     spans
+}
+
+fn single_quoted_equivalent_if_plain_double_quoted_word(
+    word: &Word,
+    source: &str,
+) -> Option<String> {
+    let [part] = word.parts.as_slice() else {
+        return None;
+    };
+    let WordPart::DoubleQuoted { dollar: false, .. } = &part.kind else {
+        return None;
+    };
+
+    let text = word.span.slice(source);
+    let body = text.strip_prefix('"')?.strip_suffix('"')?;
+    let mut cooked = String::with_capacity(body.len());
+    push_cooked_double_quoted_word_text(body, &mut cooked);
+
+    Some(shell_single_quoted_literal(&cooked))
+}
+
+fn push_cooked_double_quoted_word_text(text: &str, out: &mut String) {
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some(escaped @ ('$' | '"' | '\\' | '`')) => out.push(escaped),
+            Some('\n') => {}
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+}
+
+fn shell_single_quoted_literal(text: &str) -> String {
+    let mut quoted = String::with_capacity(text.len() + 2);
+    quoted.push('\'');
+    for ch in text.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
 }
 
 fn collect_double_quoted_expansion_spans(

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -117,7 +117,10 @@ pub(crate) fn collect_parse_rule_diagnostics(
             let Some(span) = c_prototype_fragment_span(diagnostic, source) else {
                 continue;
             };
-            diagnostics.push(Diagnostic::new(CPrototypeFragment, span));
+            diagnostics.push(
+                Diagnostic::new(CPrototypeFragment, span)
+                    .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset + 1, " "))),
+            );
         }
     }
 
@@ -1642,6 +1645,14 @@ fi
         assert_eq!(diagnostics[0].rule, Rule::CPrototypeFragment);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.start.column, 3);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Safe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("insert a space after `&`")
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -15,7 +15,7 @@ use crate::rules::portability::targets_non_zsh_shell;
 use crate::rules::portability::zsh_always_block::ZshAlwaysBlock;
 use crate::rules::portability::zsh_brace_if::ZshBraceIf;
 use crate::rules::style::linebreak_before_and::LinebreakBeforeAnd;
-use crate::{Diagnostic, Rule, RuleSet, ShellDialect, Violation};
+use crate::{Diagnostic, Edit, Fix, Rule, RuleSet, ShellDialect, Violation};
 
 pub struct ExtglobCase;
 pub struct ExtglobInCasePattern;
@@ -61,7 +61,8 @@ pub(crate) fn collect_parse_rule_diagnostics(
             .iter()
             .any(|diagnostic| is_missing_fi_error(&diagnostic.message))
     {
-        diagnostics.push(Diagnostic::new(MissingFi, eof_point(file)));
+        diagnostics
+            .push(Diagnostic::new(MissingFi, eof_point(file)).with_fix(missing_fi_fix(source)));
     }
     if enabled_rules.contains(crate::Rule::IfMissingThen)
         && let Some(span) = if_missing_then_span(source, parse_diagnostics)
@@ -162,6 +163,16 @@ pub(crate) fn collect_parse_rule_diagnostics(
 
 fn is_missing_fi_error(message: &str) -> bool {
     message.starts_with("expected 'fi'")
+}
+
+fn missing_fi_fix(source: &str) -> Fix {
+    let content = if source.is_empty() || source.ends_with('\n') {
+        "fi\n"
+    } else {
+        "\nfi\n"
+    };
+
+    Fix::unsafe_edit(Edit::insertion(source.len(), content))
 }
 
 fn is_missing_then_error(message: &str) -> bool {
@@ -880,7 +891,7 @@ mod tests {
         collect_parse_rule_diagnostics, if_bracket_glued_span_on_line, is_expected_command_error,
         line_contains_shell_word,
     };
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn maps_missing_fi_parse_error_to_c035_at_end_of_file() {
@@ -899,6 +910,14 @@ mod tests {
         assert_eq!(diagnostics[0].rule, Rule::MissingFi);
         assert_eq!(diagnostics[0].span.start.line, 4);
         assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("append a closing `fi`")
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/arithmetic_redirection_target.rs
+++ b/crates/shuck-linter/src/rules/correctness/arithmetic_redirection_target.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct ArithmeticRedirectionTarget;
 
 impl Violation for ArithmeticRedirectionTarget {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ArithmeticRedirectionTarget
     }
 
     fn message(&self) -> String {
         "redirection targets should not use arithmetic expansion".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the update operator from the redirect target".to_owned())
     }
 }
 
@@ -24,13 +30,20 @@ pub fn arithmetic_redirection_target(checker: &mut Checker) {
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || ArithmeticRedirectionTarget);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(ArithmeticRedirectionTarget, span)
+                .with_fix(Fix::unsafe_edit(Edit::deletion(span))),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_redirect_targets_with_arithmetic_expansion() {
@@ -38,6 +51,7 @@ mod tests {
 #!/bin/bash
 echo hi > \"$((i++))\"
 echo hi > \"$((i + 1))\"
+echo hi > \"$((i--))\"
 echo hi > \"$target\"
 echo hi > out.txt
 ";
@@ -51,8 +65,50 @@ echo hi > out.txt
                 .iter()
                 .map(|diagnostic| diagnostic.span.start.line)
                 .collect::<Vec<_>>(),
-            vec![2]
+            vec![2, 4]
         );
         assert_eq!(diagnostics[0].span.slice(source), "++");
+        assert_eq!(diagnostics[1].span.slice(source), "--");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_redirect_update_operators() {
+        let source = "\
+#!/bin/bash
+i=1
+echo hi > \"$((i++))\"
+echo hi > \"$((i--))\"
+echo hi > \"$((i + 1))\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ArithmeticRedirectionTarget),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+i=1
+echo hi > \"$((i))\"
+echo hi > \"$((i))\"
+echo hi > \"$((i + 1))\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C050.sh").as_path(),
+            &LinterSettings::for_rule(Rule::ArithmeticRedirectionTarget),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C050_fix_C050.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
+++ b/crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
@@ -26,19 +26,19 @@ pub fn backslash_before_closing_backtick(checker: &mut Checker) {
         .backtick_fragments()
         .iter()
         .filter_map(|fragment| {
-            backslash_before_closing_backtick_span(fragment.span(), checker.source())
+            backslash_before_closing_backtick_spans(fragment.span(), checker.source())
         })
         .collect::<Vec<_>>();
 
-    for span in spans {
+    for (report_span, fix_span) in spans {
         checker.report_diagnostic_dedup(
-            crate::Diagnostic::new(BackslashBeforeClosingBacktick, span)
-                .with_fix(crate::Fix::unsafe_edit(crate::Edit::deletion(span))),
+            crate::Diagnostic::new(BackslashBeforeClosingBacktick, report_span)
+                .with_fix(crate::Fix::unsafe_edit(crate::Edit::deletion(fix_span))),
         );
     }
 }
 
-fn backslash_before_closing_backtick_span(span: Span, source: &str) -> Option<Span> {
+fn backslash_before_closing_backtick_spans(span: Span, source: &str) -> Option<(Span, Span)> {
     let text = span.slice(source);
     if !text.starts_with('`') || !text.ends_with('`') || text.len() < 3 {
         return None;
@@ -57,7 +57,9 @@ fn backslash_before_closing_backtick_span(span: Span, source: &str) -> Option<Sp
 
     let prefix = &text[..1 + backslash_index];
     let start = span.start.advanced_by(prefix);
-    Some(Span::from_positions(start, start.advanced_by("\\")))
+    let report_span = Span::from_positions(start, start);
+    let fix_span = Span::from_positions(start, start.advanced_by("\\"));
+    Some((report_span, fix_span))
 }
 
 #[cfg(test)]
@@ -83,14 +85,21 @@ echo \"$ARCH\"
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| {
+                    (
+                        diagnostic.span.start.line,
+                        diagnostic.span.start.column,
+                        diagnostic.span.end.line,
+                        diagnostic.span.end.column,
+                    )
+                })
                 .collect::<Vec<_>>(),
-            vec![(3, 29)]
+            vec![(3, 29, 3, 29)]
         );
         assert!(
             diagnostics
                 .iter()
-                .all(|diagnostic| diagnostic.span.slice(source) == "\\")
+                .all(|diagnostic| diagnostic.span.slice(source).is_empty())
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
+++ b/crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
@@ -1,16 +1,22 @@
 use shuck_ast::Span;
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, FixAvailability, Rule, Violation};
 
 pub struct BackslashBeforeClosingBacktick;
 
 impl Violation for BackslashBeforeClosingBacktick {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::BackslashBeforeClosingBacktick
     }
 
     fn message(&self) -> String {
         "remove the escaped trailing space before closing backtick".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the backslash before the closing backtick".to_owned())
     }
 }
 
@@ -24,7 +30,12 @@ pub fn backslash_before_closing_backtick(checker: &mut Checker) {
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || BackslashBeforeClosingBacktick);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(BackslashBeforeClosingBacktick, span)
+                .with_fix(crate::Fix::unsafe_edit(crate::Edit::deletion(span))),
+        );
+    }
 }
 
 fn backslash_before_closing_backtick_span(span: Span, source: &str) -> Option<Span> {
@@ -46,13 +57,15 @@ fn backslash_before_closing_backtick_span(span: Span, source: &str) -> Option<Sp
 
     let prefix = &text[..1 + backslash_index];
     let start = span.start.advanced_by(prefix);
-    Some(Span::at(start))
+    Some(Span::from_positions(start, start.advanced_by("\\")))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_path_with_fix, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
+    use std::path::Path;
 
     #[test]
     fn reports_backslash_space_before_closing_backtick() {
@@ -77,7 +90,7 @@ echo \"$ARCH\"
         assert!(
             diagnostics
                 .iter()
-                .all(|diagnostic| diagnostic.span.start == diagnostic.span.end)
+                .all(|diagnostic| diagnostic.span.slice(source) == "\\")
         );
     }
 
@@ -95,5 +108,63 @@ echo \"$ARCH\"
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_backslash_before_closing_backtick() {
+        let source = "\
+#!/bin/bash
+# shellcheck disable=2006
+ARCH=`uname -a | cut -f12 -d\\ `
+echo \"$ARCH\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BackslashBeforeClosingBacktick),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+# shellcheck disable=2006
+ARCH=`uname -a | cut -f12 -d `
+echo \"$ARCH\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_similar_backticks_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+# shellcheck disable=2006
+ARCH=`uname -a | cut -f12 -d ','`
+echo \"$ARCH\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BackslashBeforeClosingBacktick),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C069.sh").as_path(),
+            &LinterSettings::for_rule(Rule::BackslashBeforeClosingBacktick),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C069_fix_C069.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/c_prototype_fragment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_prototype_fragment.rs
@@ -1,10 +1,12 @@
 use shuck_ast::{BackgroundOperator, Span, StmtTerminator};
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CPrototypeFragment;
 
 impl Violation for CPrototypeFragment {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::CPrototypeFragment
     }
@@ -12,17 +14,27 @@ impl Violation for CPrototypeFragment {
     fn message(&self) -> String {
         "add a space after `&` when using background execution".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("insert a space after `&`".to_owned())
+    }
 }
 
 pub fn c_prototype_fragment(checker: &mut Checker) {
+    let source = checker.source();
     let spans = checker
         .facts()
         .commands()
         .iter()
-        .filter_map(|command| attached_background_ampersand_span(command, checker.source()))
+        .filter_map(|command| attached_background_ampersand_span(command, source))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || CPrototypeFragment);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(CPrototypeFragment, span)
+                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset + 1, " "))),
+        );
+    }
 }
 
 fn attached_background_ampersand_span(
@@ -51,6 +63,7 @@ fn attached_background_ampersand_span(
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
+    use crate::test::test_snippet_with_fix;
     use crate::{LinterSettings, Rule};
 
     #[test]
@@ -79,5 +92,52 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CPrototypeFragment));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn attaches_safe_fix_metadata() {
+        let source = "#!/bin/sh\nX &NextItem ();\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CPrototypeFragment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(crate::Applicability::Safe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("insert a space after `&`")
+        );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_attached_background_ampersands() {
+        let source = "#!/bin/sh\nX &NextItem ();\necho foo &bar\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CPrototypeFragment),
+            crate::Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nX & NextItem ();\necho foo & bar\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_near_misses_unchanged_when_fixing() {
+        let source = "#!/bin/sh\necho foo \\&bar\necho '&bar'\necho foo & bar\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CPrototypeFragment),
+            crate::Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
@@ -1,15 +1,21 @@
 use crate::context::FileContextTag;
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CStyleComment;
 
 impl Violation for CStyleComment {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::CStyleComment
     }
 
     fn message(&self) -> String {
         "C-style comment syntax is not valid shell syntax".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("insert `# ` before the C-style comment".to_owned())
     }
 }
 
@@ -18,7 +24,7 @@ pub fn c_style_comment(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -27,20 +33,25 @@ pub fn c_style_comment(checker: &mut Checker) {
             name.span
                 .slice(checker.source())
                 .starts_with("/*")
-                .then_some(name.span)
+                .then_some(crate::Diagnostic::new(CStyleComment, name.span).with_fix(
+                    Fix::unsafe_edit(Edit::insertion(name.span.start.offset, "# ")),
+                ))
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || CStyleComment);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::Path;
 
-    use crate::test::test_snippet;
-    use crate::test::test_snippet_at_path;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{
+        test_path_with_fix, test_snippet, test_snippet_at_path, test_snippet_with_fix,
+    };
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_c_style_comment_tokens() {
@@ -61,6 +72,39 @@ mod tests {
     }
 
     #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\n/* note */\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CStyleComment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("insert `# ` before the C-style comment")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_c_style_comment_commands() {
+        let source = "#!/bin/sh\n/* note */\n/*compact*/\necho '/* note */'\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleComment),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\n# /* note */\n# /*compact*/\necho '/* note */'\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_patch_file_context() {
         let source = "/* Find the appropriate server to reach an ip */\n";
         let diagnostics = test_snippet_at_path(
@@ -70,5 +114,17 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C041.sh").as_path(),
+            &LinterSettings::for_rule(Rule::CStyleComment),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C041_fix_C041.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CasePatternVar;
 
 impl Violation for CasePatternVar {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::CasePatternVar
     }
@@ -10,19 +12,36 @@ impl Violation for CasePatternVar {
     fn message(&self) -> String {
         "case patterns should be literal instead of built from expansions".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the pattern as one double-quoted word".to_owned())
+    }
 }
 
 pub fn case_pattern_var(checker: &mut Checker) {
-    checker.report_all(
-        checker.facts().case_pattern_expansion_spans().to_vec(),
-        || CasePatternVar,
-    );
+    let diagnostics = checker
+        .facts()
+        .case_pattern_expansions()
+        .iter()
+        .map(|fact| {
+            crate::Diagnostic::new(CasePatternVar, fact.span()).with_fix(Fix::unsafe_edit(
+                Edit::replacement(fact.replacement(), fact.span()),
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use super::*;
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, assert_diagnostics_diff};
 
     #[test]
     fn reports_simple_case_pattern_expansions() {
@@ -44,6 +63,67 @@ esac
                 .collect::<Vec<_>>(),
             vec!["$pat", "$(printf '%s' bar)", "\"$left\"$right"]
         );
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\ncase $value in\n  $pat) : ;;\nesac\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CasePatternVar));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("rewrite the pattern as one double-quoted word")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_dynamic_case_patterns() {
+        let source = "\
+#!/bin/sh
+case $value in
+  $pat) : ;;
+  x$pat) : ;;
+  $(printf '%s' bar)) : ;;
+  \"$left\"$right) : ;;
+esac
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CasePatternVar),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+case $value in
+  \"${pat}\") : ;;
+  \"x${pat}\") : ;;
+  \"$(printf '%s' bar)\") : ;;
+  \"${left}${right}\") : ;;
+esac
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C048.sh").as_path(),
+            &LinterSettings::for_rule(Rule::CasePatternVar),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C048_fix_C048.sh", result);
+        Ok(())
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CommentedContinuationLine;
 
 impl Violation for CommentedContinuationLine {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::CommentedContinuationLine
     }
@@ -10,22 +12,37 @@ impl Violation for CommentedContinuationLine {
     fn message(&self) -> String {
         "line continuation is followed by a comment-only line".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the trailing `\\` from the comment-only line".to_owned())
+    }
 }
 
 pub fn commented_continuation_line(checker: &mut Checker) {
-    checker.report_all(
-        checker
-            .facts()
-            .commented_continuation_comment_spans()
-            .to_vec(),
-        || CommentedContinuationLine,
-    );
+    let spans = checker
+        .facts()
+        .commented_continuation_comment_spans()
+        .to_vec();
+    for span in spans {
+        let backslash_offset = span
+            .start
+            .offset
+            .checked_sub(1)
+            .expect("commented continuation anchors should follow a trailing backslash");
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(CommentedContinuationLine, span).with_fix(Fix::unsafe_edit(
+                Edit::deletion_at(backslash_offset, span.start.offset),
+            )),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_comment_line_after_continuation() {
@@ -42,6 +59,25 @@ mod tests {
         assert_eq!(
             &source[diagnostics[0].span.start.offset - 1..diagnostics[0].span.start.offset],
             "\\"
+        );
+    }
+
+    #[test]
+    fn exposes_unsafe_fix_metadata_for_commented_continuation_lines() {
+        let source = "#!/bin/bash\necho hello \\\n  #world \\\n  foo\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CommentedContinuationLine),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("remove the trailing `\\` from the comment-only line")
         );
     }
 
@@ -79,6 +115,23 @@ mod tests {
     }
 
     #[test]
+    fn applies_unsafe_fix_to_commented_continuation_lines() {
+        let source = "#!/bin/bash\necho hello \\\n  #world \\\n  foo\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CommentedContinuationLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\necho hello \\\n  #world \n  foo\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_comment_breaks_in_conditional_chains() {
         let source = "#!/bin/bash\ncommand -v brew && \\\n  # allow stubbed brew in tests\n  brew --prefix\n";
         let diagnostics = test_snippet(
@@ -87,5 +140,31 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_comment_breaks_in_conditional_chains_unchanged_when_fixing() {
+        let source = "#!/bin/bash\ncommand -v brew && \\\n  # allow stubbed brew in tests\n  brew --prefix\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CommentedContinuationLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C076.sh").as_path(),
+            &LinterSettings::for_rule(Rule::CommentedContinuationLine),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C076_fix_C076.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
@@ -1,11 +1,14 @@
 use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, SimpleTestOperatorFamily,
-    SimpleTestShape, Violation,
+    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Edit, Fix, FixAvailability, Rule,
+    SimpleTestOperatorFamily, SimpleTestShape, Violation, static_word_text,
 };
+use shuck_ast::ConditionalBinaryOp;
 
 pub struct ConstantComparisonTest;
 
 impl Violation for ConstantComparisonTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::ConstantComparisonTest
     }
@@ -13,29 +16,35 @@ impl Violation for ConstantComparisonTest {
     fn message(&self) -> String {
         "this comparison only checks fixed literals".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace the constant comparison with its known result".to_owned())
+    }
 }
 
 pub fn constant_comparison_test(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .flat_map(|fact| {
-            let simple_test_spans = fact
+            let simple_test_diagnostics = fact
                 .simple_test()
                 .into_iter()
-                .filter(|simple_test| simple_test_is_constant(simple_test))
-                .filter_map(simple_test_report_span);
-            let conditional_spans = fact
+                .filter_map(|simple_test| simple_test_diagnostic(simple_test, source));
+            let conditional_diagnostics = fact
                 .conditional()
                 .into_iter()
-                .flat_map(conditional_report_spans);
+                .flat_map(|conditional| conditional_diagnostics(conditional, source));
 
-            simple_test_spans.chain(conditional_spans)
+            simple_test_diagnostics.chain(conditional_diagnostics)
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || ConstantComparisonTest);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn simple_test_is_constant(fact: &crate::SimpleTestFact<'_>) -> bool {
@@ -53,6 +62,39 @@ fn simple_test_report_span(fact: &crate::SimpleTestFact<'_>) -> Option<shuck_ast
         .flatten()
 }
 
+fn simple_test_diagnostic(
+    fact: &crate::SimpleTestFact<'_>,
+    source: &str,
+) -> Option<crate::Diagnostic> {
+    if !simple_test_is_constant(fact) {
+        return None;
+    }
+
+    let span = simple_test_report_span(fact)?;
+    let diagnostic = crate::Diagnostic::new(ConstantComparisonTest, span);
+    match simple_test_fix(fact, source) {
+        Some(fix) => Some(diagnostic.with_fix(fix)),
+        None => Some(diagnostic),
+    }
+}
+
+fn simple_test_fix(fact: &crate::SimpleTestFact<'_>, source: &str) -> Option<Fix> {
+    let (left, operator, right) = fact
+        .string_binary_expression_words(source)
+        .into_iter()
+        .next()?;
+    let left_text = static_word_text(left, source)?;
+    let operator_text = static_word_text(operator, source)?;
+    let right_text = static_word_text(right, source)?;
+    let result = evaluate_simple_test_comparison(&left_text, &operator_text, &right_text)?;
+    let replacement_span = shuck_ast::Span::from_positions(left.span.start, right.span.end);
+
+    Some(Fix::safe_edit(Edit::replacement(
+        constant_boolean_replacement(result),
+        replacement_span,
+    )))
+}
+
 fn conditional_node_is_constant(fact: &crate::ConditionalNodeFact<'_>) -> bool {
     match fact {
         ConditionalNodeFact::Binary(binary) => {
@@ -66,12 +108,17 @@ fn conditional_node_is_constant(fact: &crate::ConditionalNodeFact<'_>) -> bool {
     }
 }
 
-fn conditional_report_spans<'a>(
+fn conditional_diagnostics<'a>(
     fact: &'a crate::ConditionalFact<'a>,
-) -> impl Iterator<Item = shuck_ast::Span> + 'a {
+    source: &'a str,
+) -> impl Iterator<Item = crate::Diagnostic> + 'a {
     fact.nodes().iter().filter_map(|node| match node {
         ConditionalNodeFact::Binary(binary) if conditional_node_is_constant(node) => {
-            Some(binary.operator_span())
+            let diagnostic = crate::Diagnostic::new(ConstantComparisonTest, binary.operator_span());
+            match conditional_fix(binary, source) {
+                Some(fix) => Some(diagnostic.with_fix(fix)),
+                None => Some(diagnostic),
+            }
         }
         ConditionalNodeFact::BareWord(_)
         | ConditionalNodeFact::Unary(_)
@@ -80,10 +127,80 @@ fn conditional_report_spans<'a>(
     })
 }
 
+fn conditional_fix(binary: &crate::ConditionalBinaryFact<'_>, source: &str) -> Option<Fix> {
+    let left_text = conditional_operand_static_text(binary.left(), source)?;
+    let right_text = conditional_operand_static_text(binary.right(), source)?;
+    let result = evaluate_conditional_comparison(binary.op(), &left_text, &right_text)?;
+
+    Some(Fix::safe_edit(Edit::replacement(
+        constant_boolean_replacement(result),
+        binary.expression().span(),
+    )))
+}
+
+fn conditional_operand_static_text(
+    operand: crate::ConditionalOperandFact<'_>,
+    source: &str,
+) -> Option<String> {
+    if let Some(word) = operand.word() {
+        return static_word_text(word, source).map(|text| text.into_owned());
+    }
+
+    operand
+        .class()
+        .is_fixed_literal()
+        .then(|| operand.expression().span().slice(source).to_owned())
+}
+
+fn evaluate_simple_test_comparison(left: &str, operator: &str, right: &str) -> Option<bool> {
+    match operator {
+        "=" | "==" => Some(left == right),
+        "!=" => Some(left != right),
+        _ => None,
+    }
+}
+
+fn evaluate_conditional_comparison(
+    op: ConditionalBinaryOp,
+    left: &str,
+    right: &str,
+) -> Option<bool> {
+    match op {
+        ConditionalBinaryOp::PatternEqShort | ConditionalBinaryOp::PatternEq => {
+            (!looks_like_conditional_pattern(right)).then_some(left == right)
+        }
+        ConditionalBinaryOp::PatternNe => {
+            (!looks_like_conditional_pattern(right)).then_some(left != right)
+        }
+        _ => None,
+    }
+}
+
+fn looks_like_conditional_pattern(text: &str) -> bool {
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if matches!(ch, '*' | '?' | '[' | ']') {
+            return true;
+        }
+
+        if matches!(ch, '@' | '!' | '+' | '?') && matches!(chars.peek(), Some('(')) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn constant_boolean_replacement(result: bool) -> &'static str {
+    if result { "x" } else { "\"\"" }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn ignores_runtime_sensitive_and_non_string_comparisons() {
@@ -121,6 +238,25 @@ mod tests {
     }
 
     #[test]
+    fn attaches_safe_fix_metadata_to_simple_constant_comparisons() {
+        let source = "#!/bin/bash\n[ 1 = 1 ]\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ConstantComparisonTest),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Safe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("replace the constant comparison with its known result")
+        );
+    }
+
+    #[test]
     fn anchors_binary_simple_tests_on_the_operator() {
         let source = "\
 #!/bin/bash
@@ -151,5 +287,69 @@ fi
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.slice(source), "=");
+    }
+
+    #[test]
+    fn applies_safe_fix_to_simple_and_nested_constant_comparisons() {
+        let source = "\
+#!/bin/bash
+[ 1 = 1 ]
+test foo != bar
+[[ left == right ]]
+[[ \"$value\" = ok || left == right ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ConstantComparisonTest),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ x ]
+test x
+[[ \"\" ]]
+[[ \"$value\" = ok || \"\" ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_ordering_conditionals_unfixed() {
+        let source = "\
+#!/bin/bash
+[[ a < b ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ConstantComparisonTest),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.diagnostics.len(), 1);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C017.sh").as_path(),
+            &LinterSettings::for_rule(Rule::ConstantComparisonTest),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C017_fix_C017.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct DoubleParenGrouping;
 
 impl Violation for DoubleParenGrouping {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::DoubleParenGrouping
     }
@@ -10,17 +12,27 @@ impl Violation for DoubleParenGrouping {
     fn message(&self) -> String {
         "double parentheses are used to group commands instead of arithmetic".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("insert a space after the first `(`".to_owned())
+    }
 }
 
 pub fn double_paren_grouping(checker: &mut Checker) {
     let spans = checker.facts().double_paren_grouping_spans().to_vec();
-    checker.report_all_dedup(spans, || DoubleParenGrouping);
+    for span in spans {
+        checker.report_diagnostic_dedup(Diagnostic::new(DoubleParenGrouping, span).with_fix(
+            Fix::unsafe_edit(Edit::insertion(span.start.offset + 1, " ")),
+        ));
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_command_style_double_paren_grouping() {
@@ -58,5 +70,57 @@ if ((threads>(cpu_height-3)*3 && tty_width>=200)); then :; fi
             test_snippet(source, &LinterSettings::for_rule(Rule::DoubleParenGrouping));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_double_paren_grouping() {
+        let source = "\
+#!/bin/sh
+((ps aux | grep foo) || kill \"$pid\") 2>/dev/null
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DoubleParenGrouping),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+( (ps aux | grep foo) || kill \"$pid\") 2>/dev/null
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_normal_arithmetic_commands_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+(( i += 1 ))
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DoubleParenGrouping),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C071.sh").as_path(),
+            &LinterSettings::for_rule(Rule::DoubleParenGrouping),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C071_fix_C071.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/escaped_negation_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/escaped_negation_in_test.rs
@@ -1,12 +1,10 @@
-use shuck_ast::Span;
-
-use crate::{
-    Checker, Rule, SimpleTestFact, SimpleTestShape, SimpleTestSyntax, Violation, static_word_text,
-};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct EscapedNegationInTest;
 
 impl Violation for EscapedNegationInTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::EscapedNegationInTest
     }
@@ -14,84 +12,39 @@ impl Violation for EscapedNegationInTest {
     fn message(&self) -> String {
         "write ! directly when negating a test".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the backslash before the leading `!`".to_owned())
+    }
 }
 
 pub fn escaped_negation_in_test(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| {
-            fact.simple_test()
-                .and_then(|simple_test| report_span(simple_test, checker.source()))
+            let simple_test = fact.simple_test()?;
+            let (diagnostic_span, fix_span) = simple_test.escaped_negation_spans(source)?;
+            Some(
+                Diagnostic::new(EscapedNegationInTest, diagnostic_span)
+                    .with_fix(Fix::safe_edit(Edit::deletion(fix_span))),
+            )
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || EscapedNegationInTest);
-}
-
-fn report_span(fact: &SimpleTestFact<'_>, source: &str) -> Option<Span> {
-    let leading = fact.operands().first().copied()?;
-    if leading.span.slice(source) != "\\!" {
-        return None;
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
     }
-
-    escaped_negation_is_operator(fact, source).then(|| {
-        if fact.syntax() == SimpleTestSyntax::Bracket && fact.shape() == SimpleTestShape::Binary {
-            fact.operands()
-                .get(1)
-                .copied()
-                .map_or(leading.span, |word| word.span)
-        } else {
-            leading.span
-        }
-    })
-}
-
-fn escaped_negation_is_operator(fact: &SimpleTestFact<'_>, source: &str) -> bool {
-    match fact.shape() {
-        SimpleTestShape::Unary => true,
-        SimpleTestShape::Binary => fact
-            .operands()
-            .get(1)
-            .and_then(|word| static_word_text(word, source))
-            .as_deref()
-            .is_some_and(|operator| !is_simple_test_binary_operator(operator)),
-        SimpleTestShape::Other => fact
-            .operands()
-            .get(2)
-            .and_then(|word| static_word_text(word, source))
-            .as_deref()
-            .is_some_and(is_simple_test_binary_operator),
-        SimpleTestShape::Empty | SimpleTestShape::Truthy => false,
-    }
-}
-
-fn is_simple_test_binary_operator(operator: &str) -> bool {
-    matches!(
-        operator,
-        "=" | "=="
-            | "!="
-            | "-a"
-            | "-o"
-            | "<"
-            | ">"
-            | "-eq"
-            | "-ne"
-            | "-lt"
-            | "-le"
-            | "-gt"
-            | "-ge"
-            | "-ef"
-            | "-nt"
-            | "-ot"
-    )
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_escaped_negation_in_simple_tests() {
@@ -116,23 +69,80 @@ test \\! -n \"$value\"
     }
 
     #[test]
-    fn ignores_plain_negation_truthy_literals_and_non_leading_bangs() {
-        let source = "\
-#!/bin/bash
-[ ! -f \"$file\" ]
-test !
-[ \\! = \"$value\" ]
-[ \\! -a foo ]
-[ \\! -o foo ]
-[ \\! -eq 1 ]
-[ \"$value\" = \\! ]
-[[ \\! -f \"$file\" ]]
-";
+    fn attaches_safe_fix_metadata_for_escaped_negation() {
+        let source = "#!/bin/bash\n[ \\! -f \"$file\" ]\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::EscapedNegationInTest),
         );
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Safe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("remove the backslash before the leading `!`")
+        );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_escaped_negation_in_test() {
+        let source = "\
+#!/bin/bash
+[ \\! -f \"$file\" ]
+test \\! -n \"$value\"
+[ \\! \"$value\" = ok ]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EscapedNegationInTest),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ ! -f \"$file\" ]
+test ! -n \"$value\"
+[ ! \"$value\" = ok ]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_literal_bang_cases_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[ ! -f \"$file\" ]
+test !
+[ \"$value\" = \\! ]
+[[ \\! -f \"$file\" ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EscapedNegationInTest),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C082.sh").as_path(),
+            &LinterSettings::for_rule(Rule::EscapedNegationInTest),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C082_fix_C082.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -1,10 +1,15 @@
 use shuck_ast::{Command, Span};
 
-use crate::{Checker, CommandFact, PipelineFact, PipelineSegmentFact, Rule, Violation};
+use crate::{
+    Checker, CommandFact, Edit, Fix, FixAvailability, PipelineFact, PipelineSegmentFact, Rule,
+    Violation,
+};
 
 pub struct FindOutputToXargs;
 
 impl Violation for FindOutputToXargs {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::FindOutputToXargs
     }
@@ -12,20 +17,29 @@ impl Violation for FindOutputToXargs {
     fn message(&self) -> String {
         "raw `find` output piped to `xargs` can break on whitespace".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("make the `find | xargs` handoff NUL-delimited".to_owned())
+    }
 }
 
 pub fn find_output_to_xargs(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .pipelines()
         .iter()
-        .flat_map(|pipeline| unsafe_find_to_xargs_spans(checker, pipeline))
+        .flat_map(|pipeline| unsafe_find_to_xargs_diagnostics(checker, pipeline))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || FindOutputToXargs);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
-fn unsafe_find_to_xargs_spans(checker: &Checker<'_>, pipeline: &PipelineFact<'_>) -> Vec<Span> {
+fn unsafe_find_to_xargs_diagnostics(
+    checker: &Checker<'_>,
+    pipeline: &PipelineFact<'_>,
+) -> Vec<crate::Diagnostic> {
     pipeline
         .segments()
         .windows(2)
@@ -57,9 +71,57 @@ fn unsafe_find_to_xargs_spans(checker: &Checker<'_>, pipeline: &PipelineFact<'_>
                 return None;
             }
 
-            Some(find_command_span(left_segment, left))
+            let span = find_command_span(left_segment, left);
+            let fix = find_output_to_xargs_fix(left, right);
+
+            Some(crate::Diagnostic::new(FindOutputToXargs, span).with_fix(fix))
         })
         .collect()
+}
+
+fn find_output_to_xargs_fix(left: &CommandFact<'_>, right: &CommandFact<'_>) -> Fix {
+    let mut edits = Vec::new();
+
+    if !left.options().find().is_some_and(|find| find.has_print0) {
+        edits.push(Edit::insertion(
+            find_print0_insertion_offset(left),
+            " -print0",
+        ));
+    }
+
+    if !right
+        .options()
+        .xargs()
+        .is_some_and(|xargs| xargs.uses_null_input)
+    {
+        edits.push(Edit::insertion(
+            xargs_null_input_insertion_offset(right),
+            " -0",
+        ));
+    }
+
+    debug_assert!(
+        !edits.is_empty(),
+        "fixable find | xargs diagnostics should add at least one edit"
+    );
+    Fix::unsafe_edits(edits)
+}
+
+fn find_print0_insertion_offset(command: &CommandFact<'_>) -> usize {
+    command
+        .redirect_facts()
+        .first()
+        .map(|redirect| redirect.redirect().span.start.offset)
+        .or_else(|| command.body_args().last().map(|word| word.span.end.offset))
+        .or_else(|| command.body_name_word().map(|word| word.span.end.offset))
+        .expect("find command diagnostics should have a body insertion point")
+}
+
+fn xargs_null_input_insertion_offset(command: &CommandFact<'_>) -> usize {
+    command
+        .body_name_word()
+        .map(|word| word.span.end.offset)
+        .expect("xargs command diagnostics should have a body name word")
 }
 
 fn find_command_span(segment: &PipelineSegmentFact<'_>, fact: &CommandFact<'_>) -> Span {
@@ -80,8 +142,10 @@ fn find_command_span(segment: &PipelineSegmentFact<'_>, fact: &CommandFact<'_>) 
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn anchors_on_effective_find_command_name() {
@@ -90,6 +154,14 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "find . -type f");
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("make the `find | xargs` handoff NUL-delimited")
+        );
     }
 
     #[test]
@@ -142,5 +214,65 @@ find \"$pkg\" -print0 | xargs rm
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.slice(source), "find \"$pkg\" -print0");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_find_xargs_pairs_missing_null_handoff_flags() {
+        let source = "\
+#!/bin/sh
+find . -name '*.txt' | xargs rm
+find . -type f | xargs -0 wc -l
+find \"$pkg\" -print0 | xargs rm
+command find . -type f | command xargs wc -l
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FindOutputToXargs),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+find . -name '*.txt' -print0 | xargs -0 rm
+find . -type f -print0 | xargs -0 wc -l
+find \"$pkg\" -print0 | xargs -0 rm
+command find . -type f -print0 | command xargs -0 wc -l
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_formatted_find_output_and_safe_pairs_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+find plugins/ -maxdepth 2 -name '__init__.py' -printf '%h\\n' | xargs mv -t \"$dest\"
+find . -name '*.txt' -print0 | xargs -0 rm
+printf '%s\\n' ./a ./b | xargs rm
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FindOutputToXargs),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C007.sh").as_path(),
+            &LinterSettings::for_rule(Rule::FindOutputToXargs),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C007_fix_C007.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation, WrapperKind};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation, WrapperKind};
 
 pub struct GlobInFindSubstitution;
 
 impl Violation for GlobInFindSubstitution {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GlobInFindSubstitution
     }
@@ -10,9 +12,15 @@ impl Violation for GlobInFindSubstitution {
     fn message(&self) -> String {
         "quote glob patterns passed to `find` so the shell does not expand them early".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("wrap the reported `find` pattern operand in double quotes".to_owned())
+    }
 }
 
 pub fn glob_in_find_substitution(checker: &mut Checker) {
+    let source = checker.source();
+    let facts = checker.facts();
     let spans = checker
         .facts()
         .commands()
@@ -24,15 +32,27 @@ pub fn glob_in_find_substitution(checker: &mut Checker) {
         })
         .filter_map(|fact| fact.options().find())
         .flat_map(|find| find.glob_pattern_operand_spans().iter().copied())
+        .map(|span| {
+            let replacement = facts
+                .any_word_fact(span)
+                .expect("find pattern operand span should map to a word fact")
+                .single_double_quoted_replacement(source);
+            crate::Diagnostic::new(GlobInFindSubstitution, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, span)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GlobInFindSubstitution);
+    for diagnostic in spans {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_path_with_fix, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
+    use std::path::Path;
 
     #[test]
     fn reports_find_pattern_operands_that_can_glob_expand() {
@@ -86,5 +106,109 @@ find ./ -name \"$pattern\"
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata_for_find_pattern_operands() {
+        let source = "#!/bin/bash\nfind ./ -name *.jar\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInFindSubstitution),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("wrap the reported `find` pattern operand in double quotes")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_find_pattern_operands_preserving_expansions() {
+        let source = "\
+#!/bin/bash
+find ./ -name \"$prefix\"*.jar
+printf '%s\\n' \"$(find . -path \"$prefix\"*/tmp/*)\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInFindSubstitution),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+find ./ -name \"${prefix}*.jar\"
+printf '%s\\n' \"$(find . -path \"${prefix}*/tmp/*\")\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_find_pattern_operands() {
+        let source = "\
+#!/bin/bash
+find ./ -name *.jar
+find ./ -wholename */tmp/*
+find ./ -name \\*.[15] -exec gzip -9 {} \\;
+for f in $(find ./ -name *.cfg); do :; done
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInFindSubstitution),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+find ./ -name \"*.jar\"
+find ./ -wholename \"*/tmp/*\"
+find ./ -name \"*.[15]\" -exec gzip -9 {} \\;
+for f in $(find ./ -name \"*.cfg\"); do :; done
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_quoted_find_patterns_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+find ./ -name '*.jar'
+find ./ -name \"$pattern\"
+command find ./ -name *.jar
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInFindSubstitution),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C083.sh").as_path(),
+            &LinterSettings::for_rule(Rule::GlobInFindSubstitution),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C083_fix_C083.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct GlobInGrepPattern;
 
 impl Violation for GlobInGrepPattern {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GlobInGrepPattern
     }
@@ -10,10 +12,14 @@ impl Violation for GlobInGrepPattern {
     fn message(&self) -> String {
         "use regex-style wildcards in grep patterns, not glob-style `*`".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace glob-style `*` with `.*` in the pattern".to_owned())
+    }
 }
 
 pub fn glob_in_grep_pattern(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -23,16 +29,30 @@ pub fn glob_in_grep_pattern(checker: &mut Checker) {
         .flat_map(|grep| grep.patterns().iter())
         .filter(|pattern| !pattern.starts_with_glob_style_star())
         .filter(|pattern| pattern.has_glob_style_star_confusion())
-        .map(|pattern| pattern.span())
+        .map(|pattern| {
+            let span = pattern.span();
+            let fix = Fix::unsafe_edits(
+                pattern
+                    .glob_style_star_replacement_spans()
+                    .iter()
+                    .copied()
+                    .map(|span| Edit::replacement(".*", span)),
+            );
+            crate::Diagnostic::new(GlobInGrepPattern, span).with_fix(fix)
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GlobInGrepPattern);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_glob_style_stars_in_grep_patterns() {
@@ -112,5 +132,82 @@ grep -efoo out.txt
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata_for_grep_patterns() {
+        let source = "#!/bin/sh\ngrep start* out.txt\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GlobInGrepPattern));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("replace glob-style `*` with `.*` in the pattern")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_glob_style_grep_patterns() {
+        let source = "\
+#!/bin/sh
+grep start* out.txt
+grep 'foo\\*bar*' out.txt
+grep item\\* out.txt
+grep --regexp='start*' out.txt
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInGrepPattern),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+grep start.* out.txt
+grep 'foo\\*bar.*' out.txt
+grep item.* out.txt
+grep --regexp='start.*' out.txt
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_violating_grep_patterns_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+grep '*start' out.txt
+grep 'a.*' out.txt
+grep -F foo*bar out.txt
+grep --fixed-strings \"foo*bar\" out.txt
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInGrepPattern),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C080_fix_C080.sh").as_path(),
+            &LinterSettings::for_rule(Rule::GlobInGrepPattern),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C080_fix_C080.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
@@ -1,11 +1,13 @@
 use crate::{
-    Checker, ConditionalNodeFact, Rule, Violation, WordQuote,
-    conditional_binary_op_is_string_match, word_is_standalone_variable_like,
+    Checker, ConditionalNodeFact, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation,
+    WordQuote, conditional_binary_op_is_string_match, word_is_standalone_variable_like,
 };
 
 pub struct GlobInStringComparison;
 
 impl Violation for GlobInStringComparison {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GlobInStringComparison
     }
@@ -13,10 +15,15 @@ impl Violation for GlobInStringComparison {
     fn message(&self) -> String {
         "quote the right-hand side so string comparisons do not turn into glob matches".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("wrap the right-hand operand in double quotes".to_owned())
+    }
 }
 
 pub fn glob_in_string_comparison(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -42,15 +49,25 @@ pub fn glob_in_string_comparison(checker: &mut Checker) {
             let word = right.word()?;
             word_is_standalone_variable_like(word).then_some(word.span)
         })
+        .map(|span| {
+            Diagnostic::new(GlobInStringComparison, span).with_fix(Fix::unsafe_edit(
+                Edit::replacement(format!("\"{}\"", span.slice(source)), span),
+            ))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GlobInStringComparison);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_path_with_fix, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_unquoted_standalone_variable_patterns() {
@@ -94,5 +111,86 @@ printf '%s\\n' \"$( [[ $mirror == $pkgs ]] && echo same )\"
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "$pkgs");
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata_for_variable_like_rhs() {
+        let source = "#!/bin/bash\nif [[ $mirror == $pkgs ]]; then echo same; fi\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInStringComparison),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("wrap the right-hand operand in double quotes")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_variable_like_rhs_operands() {
+        let source = "\
+#!/bin/bash
+if [[ $mirror == $pkgs ]]; then echo same; fi
+if [[ \"$a\" = $1 ]]; then :; fi
+if [[ \"$a\" != ${b%%x} ]]; then :; fi
+if [[ \"$a\" == ${arr[0]} ]]; then :; fi
+printf '%s\\n' \"$( [[ $mirror == $pkgs ]] && echo same )\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInStringComparison),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 5);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+if [[ $mirror == \"$pkgs\" ]]; then echo same; fi
+if [[ \"$a\" = \"$1\" ]]; then :; fi
+if [[ \"$a\" != \"${b%%x}\" ]]; then :; fi
+if [[ \"$a\" == \"${arr[0]}\" ]]; then :; fi
+printf '%s\\n' \"$( [[ $mirror == \"$pkgs\" ]] && echo same )\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_variable_like_rhs_operands_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+if [[ \"$a\" == \"$b\" ]]; then :; fi
+if [[ \"$a\" == $b* ]]; then :; fi
+if [ \"$a\" = $b ]; then :; fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInStringComparison),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C081.sh").as_path(),
+            &LinterSettings::for_rule(Rule::GlobInStringComparison),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C081_fix_C081.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct IndentedShebang;
 
 impl Violation for IndentedShebang {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::IndentedShebang
     }
@@ -10,18 +12,32 @@ impl Violation for IndentedShebang {
     fn message(&self) -> String {
         "shebang must start in column 1".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the leading whitespace before the shebang".to_owned())
+    }
 }
 
 pub fn indented_shebang(checker: &mut Checker) {
-    if let Some(span) = checker.facts().indented_shebang_span() {
-        checker.report(IndentedShebang, span);
+    if let Some((span, indent_span)) = checker
+        .facts()
+        .indented_shebang_span()
+        .zip(checker.facts().indented_shebang_indent_span())
+    {
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(IndentedShebang, span)
+                .with_fix(Fix::unsafe_edit(Edit::deletion(indent_span))),
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use super::*;
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, assert_diagnostics_diff};
 
     #[test]
     fn reports_indented_shebang_on_first_line() {
@@ -57,5 +73,62 @@ mod tests {
                 test_snippet(source, &LinterSettings::for_rule(Rule::IndentedShebang));
             assert!(diagnostics.is_empty());
         }
+    }
+
+    #[test]
+    fn exposes_unsafe_fix_metadata_for_indented_shebangs() {
+        let source = "\t#!/bin/sh\n:\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::IndentedShebang));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("remove the leading whitespace before the shebang")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_indented_shebangs() {
+        let source = " \t#!/bin/sh\n:\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::IndentedShebang),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n:\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_indented_header_cases_unchanged_when_fixing() {
+        for source in ["#!/bin/sh\n:\n", "#! /bin/sh\n:\n", "\n#!/bin/sh\n:\n"] {
+            let result = test_snippet_with_fix(
+                source,
+                &LinterSettings::for_rule(Rule::IndentedShebang),
+                Applicability::Unsafe,
+            );
+
+            assert_eq!(result.fixes_applied, 0);
+            assert_eq!(result.fixed_source, source);
+            assert!(result.fixed_diagnostics.is_empty());
+        }
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C073.sh").as_path(),
+            &LinterSettings::for_rule(Rule::IndentedShebang),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C073_fix_C073.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -1,10 +1,12 @@
 use crate::facts::WordFactHostKind;
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{Checker, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation};
 use shuck_ast::Span;
 
 pub struct LeadingGlobArgument;
 
 impl Violation for LeadingGlobArgument {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LeadingGlobArgument
     }
@@ -12,23 +14,29 @@ impl Violation for LeadingGlobArgument {
     fn message(&self) -> String {
         "wildcard arguments should be guarded with `./` or `--`".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("prefix the wildcard argument with `./`".to_owned())
+    }
 }
 
 pub fn leading_glob_argument(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
-        .filter_map(|fact| reportable_glob_span(checker, fact))
+        .filter_map(|fact| reportable_glob_diagnostic(checker, fact))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || LeadingGlobArgument);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
-fn reportable_glob_span(
+fn reportable_glob_diagnostic(
     checker: &Checker<'_>,
     fact: crate::facts::WordOccurrenceRef<'_, '_>,
-) -> Option<Span> {
+) -> Option<crate::Diagnostic> {
     let command = checker.facts().command(fact.command_id());
     if command_exempts_glob_warning(command.effective_name()) {
         return None;
@@ -59,7 +67,12 @@ fn reportable_glob_span(
         return None;
     }
 
-    Some(anchor_span(fact.span()))
+    let word_span = fact.span();
+    Some(
+        crate::Diagnostic::new(LeadingGlobArgument, anchor_span(word_span)).with_fix(
+            Fix::unsafe_edit(Edit::insertion(word_span.start.offset, "./")),
+        ),
+    )
 }
 
 fn command_exempts_glob_warning(command: Option<&str>) -> bool {
@@ -85,8 +98,28 @@ fn anchor_span(span: Span) -> Span {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
+
+    #[test]
+    fn anchors_on_wildcard_and_attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\nrm *\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::LeadingGlobArgument));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "*");
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("prefix the wildcard argument with `./`")
+        );
+    }
 
     #[test]
     fn reports_unguarded_leading_globs() {
@@ -120,6 +153,48 @@ set -- *
             test_snippet(source, &LinterSettings::for_rule(Rule::LeadingGlobArgument));
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_reported_wildcard_arguments() {
+        let source = "\
+rm *
+cat ?a
+command mv *a dest/
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "rm ./*\ncat ./?a\ncommand mv ./*a dest/\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_guarded_and_exempt_patterns_unchanged_when_fixing() {
+        let source = "\
+rm -- *
+rm ./*
+rm foo/*
+rm a*
+echo *
+printf '%s\\n' *
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]
@@ -180,5 +255,17 @@ printf '%s\\n' *
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C012.sh").as_path(),
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C012_fix_C012.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/linebreak_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/linebreak_in_test.rs
@@ -1,10 +1,10 @@
-use shuck_ast::Span;
-
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct LinebreakInTest;
 
 impl Violation for LinebreakInTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LinebreakInTest
     }
@@ -12,67 +12,38 @@ impl Violation for LinebreakInTest {
     fn message(&self) -> String {
         "`[` test spans lines without a trailing `\\` before the newline".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("insert a trailing `\\` before the newline".to_owned())
+    }
 }
 
 pub fn linebreak_in_test(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
-        .windows(2)
-        .filter_map(|pair| {
-            let [current, next] = pair else {
-                return None;
-            };
-            linebreak_in_test_span(current, next, checker.source())
+        .iter()
+        .filter_map(|fact| {
+            let anchor_span = fact.linebreak_in_test_anchor_span()?;
+            let insert_offset = fact.linebreak_in_test_insert_offset()?;
+            Some(
+                crate::Diagnostic::new(LinebreakInTest, anchor_span)
+                    .with_fix(Fix::unsafe_edit(Edit::insertion(insert_offset, "\\"))),
+            )
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || LinebreakInTest);
-}
-
-fn linebreak_in_test_span(
-    current: &crate::CommandFact<'_>,
-    next: &crate::CommandFact<'_>,
-    source: &str,
-) -> Option<Span> {
-    if !current.static_utility_name_is("[")
-        || !next.static_utility_name_is("]")
-        || !next.body_args().is_empty()
-    {
-        return None;
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
     }
-
-    let last_arg_is_closing_bracket = current
-        .body_args()
-        .last()
-        .and_then(|word| static_word_text(word, source))
-        .as_deref()
-        == Some("]");
-    if last_arg_is_closing_bracket || !current.span().slice(source).ends_with('\n') {
-        return None;
-    }
-    let between = source.get(current.span().end.offset..next.span().start.offset)?;
-    if !between.chars().all(|char| matches!(char, ' ' | '\t')) {
-        return None;
-    }
-
-    let anchor = current
-        .body_args()
-        .last()
-        .map(|word| word.span)
-        .or_else(|| current.body_name_word().map(|word| word.span))
-        .unwrap_or(current.span());
-    span_end_point(anchor)
-}
-
-fn span_end_point(span: Span) -> Option<Span> {
-    Some(Span::from_positions(span.end, span.end))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_linebreak_between_open_and_close_brackets() {
@@ -107,6 +78,65 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LinebreakInTest));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\nif [ \"$x\" = y\n]; then :; fi\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LinebreakInTest));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("insert a trailing `\\` before the newline")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_split_bracket_tests() {
+        let source = "\
+#!/bin/sh
+if [ \"$x\" = y
+]; then :; fi
+
+if [ \"$x\" = z
+]; then :; fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LinebreakInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+if [ \"$x\" = y\\
+]; then :; fi
+
+if [ \"$x\" = z\\
+]; then :; fi
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C040.sh").as_path(),
+            &LinterSettings::for_rule(Rule::LinebreakInTest),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C040_fix_C040.sh", result);
+        Ok(())
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/literal_unary_string_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/literal_unary_string_test.rs
@@ -1,13 +1,16 @@
-use shuck_ast::{Span, Word};
+use shuck_ast::{ConditionalUnaryOp, Word};
 
 use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, Violation,
-    double_quoted_scalar_affix_span, quoted_word_content_span_in_source,
+    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Edit, Fix, FixAvailability, Rule,
+    Violation, double_quoted_scalar_affix_span, quoted_word_content_span_in_source,
+    static_word_text,
 };
 
 pub struct LiteralUnaryStringTest;
 
 impl Violation for LiteralUnaryStringTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LiteralUnaryStringTest
     }
@@ -15,41 +18,55 @@ impl Violation for LiteralUnaryStringTest {
     fn message(&self) -> String {
         "this string test checks a fixed literal".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace the constant string-test operand with an explicit literal".to_owned())
+    }
 }
 
 pub fn literal_unary_string_test(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .flat_map(|fact| {
-            let mut spans = Vec::new();
+            let mut diagnostics = Vec::new();
             if let Some(simple_test) = fact.simple_test() {
-                spans.extend(simple_test_report_spans(simple_test, source));
+                diagnostics.extend(simple_test_diagnostics(simple_test, source));
             }
             if let Some(conditional) = fact.conditional() {
-                spans.extend(conditional_report_spans(conditional, source));
+                diagnostics.extend(conditional_diagnostics(conditional, source));
             }
-            spans
+            diagnostics
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || LiteralUnaryStringTest);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
-fn simple_test_report_spans(fact: &crate::SimpleTestFact<'_>, source: &str) -> Vec<Span> {
+fn simple_test_diagnostics(
+    fact: &crate::SimpleTestFact<'_>,
+    source: &str,
+) -> Vec<crate::Diagnostic> {
     fact.string_unary_expression_words(source)
         .into_iter()
-        .filter_map(|(_, operand)| simple_test_operand_span(fact, operand, source))
+        .filter_map(|(operator, operand)| simple_test_diagnostic(fact, operator, operand, source))
         .collect()
 }
 
-fn simple_test_operand_span(
+fn simple_test_diagnostic(
     fact: &crate::SimpleTestFact<'_>,
+    operator: &Word,
     operand: &Word,
     source: &str,
-) -> Option<Span> {
+) -> Option<crate::Diagnostic> {
+    if unary_operand_is_explicit_boolean_literal(operator, operand, source) {
+        return None;
+    }
+
     let index = fact
         .effective_operands()
         .iter()
@@ -59,44 +76,150 @@ fn simple_test_operand_span(
         .effective_operand_class(index)
         .is_some_and(|class| class.is_fixed_literal())
     {
-        return quoted_word_content_span_in_source(operand, source).or(Some(operand.span));
+        let span = quoted_word_content_span_in_source(operand, source).unwrap_or(operand.span);
+        let replacement = explicit_literal_replacement_for_word(operand, source);
+        return Some(
+            crate::Diagnostic::new(LiteralUnaryStringTest, span).with_fix(Fix::unsafe_edit(
+                Edit::replacement(replacement, operand.span),
+            )),
+        );
     }
 
-    double_quoted_scalar_affix_span(operand)
+    let span = double_quoted_scalar_affix_span(operand)?;
+    Some(
+        crate::Diagnostic::new(LiteralUnaryStringTest, span)
+            .with_fix(Fix::unsafe_edit(Edit::replacement("x", operand.span))),
+    )
 }
 
-fn conditional_report_spans(fact: &crate::ConditionalFact<'_>, source: &str) -> Vec<Span> {
+fn conditional_diagnostics(
+    fact: &crate::ConditionalFact<'_>,
+    source: &str,
+) -> Vec<crate::Diagnostic> {
     fact.nodes()
         .iter()
         .filter_map(|node| match node {
             ConditionalNodeFact::Unary(unary)
                 if unary.operator_family() == ConditionalOperatorFamily::StringUnary =>
             {
-                conditional_operand_span(unary.operand(), source)
+                conditional_diagnostic(unary.op(), unary.operand(), source)
             }
             _ => None,
         })
         .collect()
 }
 
-fn conditional_operand_span(
+fn conditional_diagnostic(
+    op: ConditionalUnaryOp,
     operand: crate::ConditionalOperandFact<'_>,
     source: &str,
-) -> Option<Span> {
-    if operand.class().is_fixed_literal() {
-        return operand
-            .word()
-            .map(|word| quoted_word_content_span_in_source(word, source).unwrap_or(word.span))
-            .or_else(|| Some(operand.expression().span()));
+) -> Option<crate::Diagnostic> {
+    if conditional_unary_operand_is_explicit_boolean_literal(op, operand, source) {
+        return None;
     }
 
-    operand.word().and_then(double_quoted_scalar_affix_span)
+    if operand.class().is_fixed_literal() {
+        let replacement = operand
+            .word()
+            .map(|word| explicit_literal_replacement_for_word(word, source))
+            .unwrap_or_else(|| {
+                explicit_literal_replacement_for_text(operand.expression().span().slice(source))
+            });
+
+        let span = operand
+            .word()
+            .map(|word| quoted_word_content_span_in_source(word, source).unwrap_or(word.span))
+            .unwrap_or_else(|| operand.expression().span());
+        let fix_span = operand
+            .word()
+            .map(|word| word.span)
+            .unwrap_or_else(|| operand.expression().span());
+        return Some(
+            crate::Diagnostic::new(LiteralUnaryStringTest, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, fix_span))),
+        );
+    }
+
+    let word = operand.word()?;
+    let span = double_quoted_scalar_affix_span(word)?;
+    Some(
+        crate::Diagnostic::new(LiteralUnaryStringTest, span)
+            .with_fix(Fix::unsafe_edit(Edit::replacement("x", word.span))),
+    )
+}
+
+const EMPTY_LITERAL_REPLACEMENT: &str = "\"\"";
+const NON_EMPTY_LITERAL_REPLACEMENT: &str = "x";
+
+fn explicit_literal_replacement_for_word(word: &Word, source: &str) -> &'static str {
+    explicit_literal_replacement_for_text(
+        static_word_text(word, source)
+            .as_deref()
+            .unwrap_or_else(|| word.span.slice(source)),
+    )
+}
+
+fn explicit_literal_replacement_for_text(text: &str) -> &'static str {
+    if text.is_empty() || quoted_literal_body(text).is_some_and(str::is_empty) {
+        EMPTY_LITERAL_REPLACEMENT
+    } else {
+        NON_EMPTY_LITERAL_REPLACEMENT
+    }
+}
+
+fn quoted_literal_body(text: &str) -> Option<&str> {
+    let quote = text.chars().next()?;
+    if !matches!(quote, '"' | '\'') {
+        return None;
+    }
+
+    text.strip_prefix(quote)?.strip_suffix(quote)
+}
+
+fn unary_operand_is_explicit_boolean_literal(
+    operator: &Word,
+    operand: &Word,
+    source: &str,
+) -> bool {
+    matches!(
+        static_word_text(operator, source).as_deref(),
+        Some("-z" | "-n")
+    ) && matches!(static_word_text(operand, source).as_deref(), Some("" | "x"))
+}
+
+fn conditional_unary_operand_is_explicit_boolean_literal(
+    op: ConditionalUnaryOp,
+    operand: crate::ConditionalOperandFact<'_>,
+    source: &str,
+) -> bool {
+    matches!(
+        op,
+        ConditionalUnaryOp::EmptyString | ConditionalUnaryOp::NonEmptyString
+    ) && conditional_operand_text(operand, source)
+        .as_deref()
+        .is_some_and(|text| matches!(text, "" | "x"))
+}
+
+fn conditional_operand_text(
+    operand: crate::ConditionalOperandFact<'_>,
+    source: &str,
+) -> Option<String> {
+    if let Some(word) = operand.word() {
+        return static_word_text(word, source).map(|text| text.into_owned());
+    }
+
+    operand
+        .class()
+        .is_fixed_literal()
+        .then(|| operand.expression().span().slice(source).to_owned())
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_nested_unary_string_tests_in_simple_and_conditional_logical_chains() {
@@ -140,5 +263,109 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["_path", "prefix"]
         );
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/bash\n[ -z foo ]\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralUnaryStringTest),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("replace the constant string-test operand with an explicit literal")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_fixed_and_affix_operands() {
+        let source = "\
+#!/bin/bash
+[ -z foo -o -z \"$path\" ]
+[[ -z \"name\" || -z \"$path\" ]]
+[[ ! -n bar ]]
+[ -z \"${rootfs_path}_path\" ]
+[[ -n \"prefix${rootfs_path}\" ]]
+test -n ''
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralUnaryStringTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 5);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ -z x -o -z \"$path\" ]
+[[ -z x || -z \"$path\" ]]
+[[ ! -n x ]]
+[ -z x ]
+[[ -n x ]]
+test -n ''
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_explicit_boolean_literals() {
+        let source = "\
+#!/bin/bash
+[ -z x ]
+[ -z \"\" ]
+[ -n '' ]
+[ -n \"\" ]
+[[ -z x ]]
+[[ -z \"\" ]]
+[[ -n '' ]]
+[[ -n \"\" ]]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralUnaryStringTest),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_runtime_sensitive_unary_string_tests_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[ -z \"$value\" ]
+test -n \"$value\"
+[[ -z $value ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralUnaryStringTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C019.sh").as_path(),
+            &LinterSettings::for_rule(Rule::LiteralUnaryStringTest),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C019_fix_C019.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
@@ -1,10 +1,14 @@
 use std::collections::HashSet;
 
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct MissingBracketSpace;
 
 impl Violation for MissingBracketSpace {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::MissingBracketSpace
     }
@@ -12,25 +16,44 @@ impl Violation for MissingBracketSpace {
     fn message(&self) -> String {
         "this unary `[` test operator is missing its operand before the closing `]`".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("insert a space before the closing `]`".to_owned())
+    }
 }
 
 pub fn missing_bracket_space(checker: &mut Checker) {
     let mut seen_lines = HashSet::new();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| fact.glued_closing_bracket_operand_span())
-        .filter(|span| seen_lines.insert(span.start.line))
+        .filter_map(|fact| {
+            let span = fact.glued_closing_bracket_operand_span()?;
+            let insert_offset = fact.glued_closing_bracket_insert_offset()?;
+            seen_lines
+                .insert(span.start.line)
+                .then_some((span, insert_offset))
+        })
+        .map(|(span, insert_offset)| diagnostic_for_glued_closing_bracket(span, insert_offset))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || MissingBracketSpace);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn diagnostic_for_glued_closing_bracket(span: Span, insert_offset: usize) -> crate::Diagnostic {
+    crate::Diagnostic::new(MissingBracketSpace, span)
+        .with_fix(Fix::unsafe_edit(Edit::insertion(insert_offset, " ")))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_bracket_tests_with_a_glued_closing_bracket() {
@@ -98,5 +121,73 @@ echo /tmp]
             test_snippet(source, &LinterSettings::for_rule(Rule::MissingBracketSpace));
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\nif [ -d /tmp]; then\n  :\nfi\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::MissingBracketSpace));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("insert a space before the closing `]`")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_glued_closing_brackets() {
+        let source = "\
+#!/bin/sh
+if [ -d /tmp]; then
+  :
+fi
+if [ ! -n \"$dir\"]; then
+  :
+fi
+if [ -a /tmp]; then
+  :
+fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MissingBracketSpace),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+if [ -d /tmp ]; then
+  :
+fi
+if [ ! -n \"$dir\" ]; then
+  :
+fi
+if [ -a /tmp ]; then
+  :
+fi
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C030.sh").as_path(),
+            &LinterSettings::for_rule(Rule::MissingBracketSpace),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C030_fix_C030.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/missing_fi.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_fi.rs
@@ -1,13 +1,94 @@
-use crate::{Rule, Violation};
+use crate::{FixAvailability, Rule, Violation};
 
 pub struct MissingFi;
 
 impl Violation for MissingFi {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::MissingFi
     }
 
     fn message(&self) -> String {
         "this `if` block is missing a closing `fi`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("append a closing `fi`".to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
+
+    #[test]
+    fn reports_missing_fi_from_parse_diagnostics() {
+        let source = "#!/bin/sh\nif true; then\n  :\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MissingFi));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code(), "C035");
+        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.column, 1);
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\nif true; then\n  :\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MissingFi));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("append a closing `fi`")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_unclosed_if_blocks() {
+        let source = "#!/bin/sh\nif true; then\n  :\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFi),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\nif true; then\n  :\nfi\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn inserts_a_newline_before_fi_when_source_lacks_one() {
+        let source = "#!/bin/sh\nif true; then\n  :";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFi),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\nif true; then\n  :\nfi\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C035.sh").as_path(),
+            &LinterSettings::for_rule(Rule::MissingFi),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C035_fix_C035.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use std::path::Path;
+
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct NonAbsoluteShebang;
 
 impl Violation for NonAbsoluteShebang {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::NonAbsoluteShebang
     }
@@ -10,18 +14,53 @@ impl Violation for NonAbsoluteShebang {
     fn message(&self) -> String {
         "shebang should use an absolute path or `/usr/bin/env`".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the shebang to use `/usr/bin/env`".to_owned())
+    }
 }
 
 pub fn non_absolute_shebang(checker: &mut Checker) {
+    let source = checker.source();
     if let Some(span) = checker.facts().non_absolute_shebang_span() {
-        checker.report(NonAbsoluteShebang, span);
+        let replacement = rewrite_shebang(span.slice(source));
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(NonAbsoluteShebang, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, span))),
+        );
     }
+}
+
+fn rewrite_shebang(shebang_line: &str) -> String {
+    let mut words = shebang_line
+        .strip_prefix("#!")
+        .map(str::split_whitespace)
+        .into_iter()
+        .flatten();
+
+    let interpreter = words.next().unwrap_or_default();
+    let interpreter = Path::new(interpreter)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(interpreter);
+
+    let mut rewritten = String::from("#!/usr/bin/env ");
+    rewritten.push_str(interpreter);
+
+    for arg in words {
+        rewritten.push(' ');
+        rewritten.push_str(arg);
+    }
+
+    rewritten
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_non_absolute_shebangs() {
@@ -52,5 +91,47 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::NonAbsoluteShebang));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn exposes_unsafe_fix_metadata_for_reported_shebangs() {
+        let source = "#!@PREFIX@/bin/sh -x\n:\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::NonAbsoluteShebang));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("rewrite the shebang to use `/usr/bin/env`")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_non_absolute_shebangs() {
+        let source = "#!@PREFIX@/bin/sh -x\n:\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::NonAbsoluteShebang),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/usr/bin/env sh -x\n:\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C060.sh").as_path(),
+            &LinterSettings::for_rule(Rule::NonAbsoluteShebang),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C060_fix_C060.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
@@ -44,8 +44,11 @@ fn rewrite_shebang(shebang_line: &str) -> String {
         .and_then(|name| name.to_str())
         .unwrap_or(interpreter);
 
-    let mut rewritten = String::from("#!/usr/bin/env ");
-    rewritten.push_str(interpreter);
+    let mut rewritten = String::from("#!/usr/bin/env");
+    if interpreter != "env" {
+        rewritten.push(' ');
+        rewritten.push_str(interpreter);
+    }
 
     for arg in words {
         rewritten.push(' ');
@@ -121,6 +124,24 @@ mod tests {
         assert_eq!(result.fixes_applied, 1);
         assert_eq!(result.fixed_source, "#!/usr/bin/env sh -x\n:\n");
         assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn preserves_existing_env_interpreters_when_rewriting() {
+        for (source, expected) in [
+            ("#!env bash\n:\n", "#!/usr/bin/env bash\n:\n"),
+            ("#!env -S bash -e\n:\n", "#!/usr/bin/env -S bash -e\n:\n"),
+        ] {
+            let result = test_snippet_with_fix(
+                source,
+                &LinterSettings::for_rule(Rule::NonAbsoluteShebang),
+                Applicability::Unsafe,
+            );
+
+            assert_eq!(result.fixes_applied, 1);
+            assert_eq!(result.fixed_source, expected);
+            assert!(result.fixed_diagnostics.is_empty());
+        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
+++ b/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct OpenDoubleQuote;
 
 impl Violation for OpenDoubleQuote {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::OpenDoubleQuote
     }
@@ -10,23 +12,38 @@ impl Violation for OpenDoubleQuote {
     fn message(&self) -> String {
         "double-quoted string looks unterminated".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the word as one double-quoted string".to_owned())
+    }
 }
 
 pub fn open_double_quote(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .open_double_quote_fragments()
         .iter()
-        .map(|fragment| fragment.span())
+        .map(|fragment| {
+            crate::Diagnostic::new(OpenDoubleQuote, fragment.span()).with_fix(Fix::unsafe_edit(
+                Edit::replacement(
+                    fragment.replacement().to_owned(),
+                    fragment.replacement_span(),
+                ),
+            ))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || OpenDoubleQuote);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_suspicious_opening_double_quote() {
@@ -110,6 +127,88 @@ echo \"a
         assert_eq!(diagnostics[0].span.start.column, 6);
         assert_eq!(diagnostics[1].span.start.line, 3);
         assert_eq!(diagnostics[1].span.start.column, 11);
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/bash\necho \"#!/bin/bash\nif [[ \"$@\" =~ x ]]; then :; fi\n\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("rewrite the word as one double-quoted string")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_scalar_gap_words() {
+        let source = "\
+#!/bin/bash
+echo \"alpha
+\"$foo\"beta
+\"$bar\"gamma\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::OpenDoubleQuote),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+echo \"alpha
+${foo}beta
+${bar}gamma\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_literal_gap_words() {
+        let source = "\
+#!/bin/sh
+echo \"help text
+say \"configure\" now
+\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::OpenDoubleQuote),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo \"help text
+say configure now
+\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C039.sh").as_path(),
+            &LinterSettings::for_rule(Rule::OpenDoubleQuote),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C039_fix_C039.sh", result);
+        Ok(())
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,12 +1,16 @@
 use crate::context::FileContextTag;
-use crate::{Checker, Rule, Violation};
-use shuck_semantic::{BindingKind, OverwrittenFunction as SemanticOverwrittenFunction};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
+use shuck_semantic::{
+    BindingKind, BindingOrigin, OverwrittenFunction as SemanticOverwrittenFunction,
+};
 
 pub struct OverwrittenFunction {
     pub name: String,
 }
 
 impl Violation for OverwrittenFunction {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::OverwrittenFunction
     }
@@ -17,23 +21,38 @@ impl Violation for OverwrittenFunction {
             self.name
         )
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the earlier overwritten function definition".to_owned())
+    }
 }
 
 pub fn overwritten_function(checker: &mut Checker) {
-    let overwritten = checker
-        .semantic_analysis()
-        .overwritten_functions()
-        .iter()
-        .filter(|overwritten| !overwritten.first_called)
-        .filter(|overwritten| !should_suppress_overwrite(checker, overwritten))
-        .map(|overwritten| {
-            let span = checker.semantic().binding(overwritten.first).span;
-            (overwritten.name.to_string(), span)
-        })
-        .collect::<Vec<_>>();
+    let overwritten = checker.semantic_analysis().overwritten_functions().to_vec();
 
-    for (name, span) in overwritten {
-        checker.report(OverwrittenFunction { name }, span);
+    for overwritten in overwritten {
+        if overwritten.first_called {
+            continue;
+        }
+        if should_suppress_overwrite(checker, &overwritten) {
+            continue;
+        }
+
+        let binding = checker.semantic().binding(overwritten.first);
+        let definition_span = match &binding.origin {
+            BindingOrigin::FunctionDefinition { definition_span } => *definition_span,
+            _ => binding.span,
+        };
+
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(
+                OverwrittenFunction {
+                    name: overwritten.name.to_string(),
+                },
+                definition_span,
+            )
+            .with_fix(Fix::unsafe_edit(Edit::deletion(definition_span))),
+        );
     }
 }
 
@@ -147,8 +166,8 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use crate::test::test_snippet_at_path;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_path_with_fix, test_snippet_at_path, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn shellspec_nested_helper_factories_are_suppressed() {
@@ -224,6 +243,48 @@ myfunc
     }
 
     #[test]
+    fn attaches_unsafe_fix_metadata_for_reported_overwrites() {
+        let source = "\
+myfunc() { return 1; }
+myfunc() { return 0; }
+myfunc
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("delete the earlier overwritten function definition")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_overwritten_functions() {
+        let source = "\
+myfunc() { return 1; }
+myfunc() { return 0; }
+myfunc
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "myfunc() { return 0; }\nmyfunc\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
     fn plain_unset_does_not_suppress_function_overwrites() {
         let source = "\
 curl() { printf '%s\\n' first; }
@@ -256,6 +317,18 @@ myfunc
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C063.sh").as_path(),
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C063_fix_C063.sh", result);
+        Ok(())
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
@@ -1,10 +1,12 @@
 use shuck_ast::Span;
 
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{Checker, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation};
 
 pub struct PatternWithVariable;
 
 impl Violation for PatternWithVariable {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::PatternWithVariable
     }
@@ -12,9 +14,14 @@ impl Violation for PatternWithVariable {
     fn message(&self) -> String {
         "pattern expressions should not expand variables".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the expansion in the pattern".to_owned())
+    }
 }
 
 pub fn pattern_with_variable(checker: &mut Checker) {
+    let source = checker.source();
     let replacement_expansion_spans = checker
         .facts()
         .replacement_expansion_fragments()
@@ -28,7 +35,7 @@ pub fn pattern_with_variable(checker: &mut Checker) {
         .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .expansion_word_facts(ExpansionContext::ParameterPattern)
         .flat_map(|fact| {
@@ -43,11 +50,18 @@ pub fn pattern_with_variable(checker: &mut Checker) {
                 .iter()
                 .copied()
                 .filter(|span| !span_is_within_any(*span, quoted_expansion_spans))
+                .map(|span| {
+                    crate::Diagnostic::new(PatternWithVariable, span).with_fix(Fix::unsafe_edit(
+                        Edit::replacement(format!("\"{}\"", span.slice(source)), span),
+                    ))
+                })
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || PatternWithVariable);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn span_is_within_any(span: Span, hosts: &[Span]) -> bool {
@@ -59,7 +73,8 @@ fn span_is_within_any(span: Span, hosts: &[Span]) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_path_with_fix, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_nested_parameter_pattern_groups_and_substitutions() {
@@ -139,5 +154,65 @@ nested=${items[i]%${name%$suffix}}
                 .collect::<Vec<_>>(),
             vec!["$suffix"]
         );
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata_to_reported_expansions() {
+        let source = "\
+#!/bin/bash
+suffix=b
+trimmed=${name%$suffix}
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::PatternWithVariable));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("quote the expansion in the pattern")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_parameter_pattern_expansions() {
+        let source = "\
+#!/bin/bash
+suffix=b
+trimmed=${name%$suffix}
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::PatternWithVariable),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+suffix=b
+trimmed=${name%\"$suffix\"}
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            std::path::Path::new("correctness")
+                .join("C055.sh")
+                .as_path(),
+            &LinterSettings::for_rule(Rule::PatternWithVariable),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C055_fix_C055.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct PositionalTenBraces;
 
 impl Violation for PositionalTenBraces {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::PositionalTenBraces
     }
@@ -10,24 +14,46 @@ impl Violation for PositionalTenBraces {
     fn message(&self) -> String {
         "use braces for positional parameters above 9".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("wrap the positional parameter in braces".to_owned())
+    }
 }
 
 pub fn positional_ten_braces(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .positional_parameter_fragments()
         .iter()
         .filter(|fragment| fragment.is_above_nine())
-        .map(|fragment| fragment.span())
+        .map(|fragment| diagnostic_for_positional_parameter(fragment.span(), source))
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || PositionalTenBraces);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
+}
+
+fn diagnostic_for_positional_parameter(span: Span, source: &str) -> crate::Diagnostic {
+    crate::Diagnostic::new(PositionalTenBraces, span).with_fix(Fix::unsafe_edit(Edit::replacement(
+        braced_positional_parameter(span, source),
+        span,
+    )))
+}
+
+fn braced_positional_parameter(span: Span, source: &str) -> String {
+    let text = span.slice(source);
+    let digits = text.strip_prefix('$').unwrap_or(text);
+    format!("${{{digits}}}")
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_positional_ten_in_assignment_subscripts() {
@@ -77,5 +103,61 @@ eval "$(printf '%s\n' x | "$10_rework")"
             diagnostics[0].span.slice(source).contains("$10"),
             "diagnostics: {diagnostics:?}"
         );
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\nprintf '%s\\n' \"$10\"\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::PositionalTenBraces));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("wrap the positional parameter in braces")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_unbraced_positional_parameters() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' \"$10\" $123
+arr[$10]=1
+printf '%s\\n' \"$2x\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::PositionalTenBraces),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+printf '%s\\n' \"${10}\" ${123}
+arr[${10}]=1
+printf '%s\\n' \"$2x\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C025.sh").as_path(),
+            &LinterSettings::for_rule(Rule::PositionalTenBraces),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C025_fix_C025.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
@@ -1,8 +1,13 @@
-use crate::{Checker, Rule, TestOperandClass, Violation, WordQuote, static_word_text};
+use crate::{
+    Checker, Edit, Fix, FixAvailability, Rule, TestOperandClass, Violation, WordQuote,
+    quoted_word_content_span_in_source, static_word_text,
+};
 
 pub struct QuotedBashRegex;
 
 impl Violation for QuotedBashRegex {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::QuotedBashRegex
     }
@@ -10,11 +15,15 @@ impl Violation for QuotedBashRegex {
     fn message(&self) -> String {
         "quoting the right-hand side of `=~` forces a literal string match".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the surrounding quotes from the regex operand".to_owned())
+    }
 }
 
 pub fn quoted_bash_regex(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -37,13 +46,27 @@ pub fn quoted_bash_regex(checker: &mut Checker) {
                     .is_some_and(literal_uses_regex_significance),
             };
 
-            should_report.then_some(word.span)
+            should_report.then(|| {
+                let diagnostic = crate::Diagnostic::new(QuotedBashRegex, word.span);
+                match quoted_bash_regex_fix(word, source) {
+                    Some(fix) => diagnostic.with_fix(fix),
+                    None => diagnostic,
+                }
+            })
         })
         .collect::<Vec<_>>();
 
-    for span in spans {
-        checker.report_dedup(QuotedBashRegex, span);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
     }
+}
+
+fn quoted_bash_regex_fix(word: &shuck_ast::Word, source: &str) -> Option<Fix> {
+    let content_span = quoted_word_content_span_in_source(word, source)?;
+    Some(Fix::unsafe_edits([
+        Edit::deletion_at(word.span.start.offset, content_span.start.offset),
+        Edit::deletion_at(content_span.end.offset, word.span.end.offset),
+    ]))
 }
 
 fn literal_uses_regex_significance(text: &str) -> bool {
@@ -69,8 +92,10 @@ fn literal_uses_regex_significance(text: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn ignores_quoted_fixed_literals_without_regex_semantics() {
@@ -84,6 +109,22 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashRegex));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata_for_plain_quoted_regex_operands() {
+        let source = "#!/bin/bash\n[[ foo =~ \"a+\" ]]\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashRegex));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("remove the surrounding quotes from the regex operand")
+        );
     }
 
     #[test]
@@ -117,6 +158,67 @@ mod tests {
     }
 
     #[test]
+    fn applies_unsafe_fix_to_plain_quoted_regex_operands() {
+        let source = "\
+#!/bin/bash
+re='a+'
+[[ $value =~ \"$re\" ]]
+[[ foo =~ \"a+\" ]]
+[[ $value =~ 'a+' ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedBashRegex),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+re='a+'
+[[ $value =~ $re ]]
+[[ foo =~ a+ ]]
+[[ $value =~ a+ ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_dollar_quoted_regex_operands_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[[ foo =~ $\"a+\" ]]
+[[ foo =~ $'a+' ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedBashRegex),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.diagnostics.len(), 2);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(
+            result
+                .fixed_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$\"a+\"", "$'a+'"]
+        );
+    }
+
+    #[test]
     fn reports_nested_regex_matches_inside_logical_expressions() {
         let source = "#!/bin/bash\n[[ \"$left\" = right && $value =~ \"$re\" ]]\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashRegex));
@@ -132,5 +234,17 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "\"$re\"");
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C009.sh").as_path(),
+            &LinterSettings::for_rule(Rule::QuotedBashRegex),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C009_fix_C009.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/redirect_to_command_name.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_to_command_name.rs
@@ -1,16 +1,22 @@
 use shuck_ast::RedirectKind;
 
-use crate::{Checker, Rule, Violation, WordQuote};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation, WordQuote};
 
 pub struct RedirectToCommandName;
 
 impl Violation for RedirectToCommandName {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::RedirectToCommandName
     }
 
     fn message(&self) -> String {
         "redirection target matches a command name; use a distinct file path".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("prefix the redirection target with `./`".to_owned())
     }
 }
 
@@ -56,7 +62,12 @@ pub fn redirect_to_command_name(checker: &mut Checker) {
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || RedirectToCommandName);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(RedirectToCommandName, span)
+                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset, "./"))),
+        );
+    }
 }
 
 fn is_shadowed_command_name(name: &str) -> bool {
@@ -158,8 +169,10 @@ fn is_shadowed_command_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_command_named_redirect_targets() {
@@ -169,6 +182,7 @@ cat input > c99
 cat input >> grep
 cat input 2> sed
 cat input < awk
+cat input <> basename
 cat input >| command
 cat input &> printf
 ";
@@ -182,12 +196,58 @@ cat input &> printf
                 .iter()
                 .map(|diagnostic| diagnostic.span.start.line)
                 .collect::<Vec<_>>(),
-            vec![2, 3, 4, 5, 6, 7]
+            vec![2, 3, 4, 5, 6, 7, 8]
         );
     }
 
     #[test]
-    fn ignores_quoted_paths_dynamic_targets_and_non_command_names() {
+    fn exposes_safe_fix_metadata_for_reported_targets() {
+        let source = "#!/bin/bash\ncat input > c99\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectToCommandName),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "c99");
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Safe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("prefix the redirection target with `./`")
+        );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_command_named_redirect_targets() {
+        let source = "\
+#!/bin/bash
+cat input > c99
+cat input >> grep
+cat input 2> sed
+cat input < awk
+cat input <> basename
+cat input >| command
+cat input &> printf
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectToCommandName),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 7);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\ncat input > ./c99\ncat input >> ./grep\ncat input 2> ./sed\ncat input < ./awk\ncat input <> ./basename\ncat input >| ./command\ncat input &> ./printf\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_qualified_and_dynamic_redirect_targets_unchanged_when_fixing() {
         let source = "\
 #!/bin/bash
 cat input > \"cat\"
@@ -205,5 +265,41 @@ cat input > true
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_qualified_and_dynamic_redirect_targets_unchanged_when_applying_fixes() {
+        let source = "\
+#!/bin/bash
+cat input > \"cat\"
+cat input > ./cat
+cat input > /tmp/cat
+cat input > cat.txt
+cat input > \"$name\"
+cat input > ${name}
+cat input <<< cat
+cat input > true
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectToCommandName),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C059.sh").as_path(),
+            &LinterSettings::for_rule(Rule::RedirectToCommandName),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C059_fix_C059.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct ShebangNotOnFirstLine;
 
 impl Violation for ShebangNotOnFirstLine {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ShebangNotOnFirstLine
     }
@@ -10,18 +12,47 @@ impl Violation for ShebangNotOnFirstLine {
     fn message(&self) -> String {
         "move the shebang to the first line of the file".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("move the shebang line to the top of the file".to_owned())
+    }
 }
 
 pub fn shebang_not_on_first_line(checker: &mut Checker) {
-    if let Some(span) = checker.facts().shebang_not_on_first_line_span() {
-        checker.report(ShebangNotOnFirstLine, span);
+    let source = checker.source();
+    if let Some((span, fix_span)) = checker
+        .facts()
+        .shebang_not_on_first_line_span()
+        .zip(checker.facts().shebang_not_on_first_line_fix_span())
+    {
+        let preferred_newline = checker
+            .facts()
+            .shebang_not_on_first_line_preferred_newline()
+            .unwrap_or("\n");
+        let moved_line = moved_shebang_line(fix_span.slice(source), preferred_newline);
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(ShebangNotOnFirstLine, span).with_fix(Fix::unsafe_edits([
+                Edit::insertion(0, moved_line),
+                Edit::deletion(fix_span),
+            ])),
+        );
+    }
+}
+
+fn moved_shebang_line(shebang_line: &str, preferred_newline: &str) -> String {
+    if shebang_line.ends_with('\n') {
+        shebang_line.to_owned()
+    } else {
+        format!("{shebang_line}{preferred_newline}")
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_shebang_on_second_line() {
@@ -75,6 +106,53 @@ mod tests {
     }
 
     #[test]
+    fn exposes_unsafe_fix_metadata_for_non_first_line_shebangs() {
+        let source = "# comment\n#!/bin/sh\n:\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("move the shebang line to the top of the file")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_shebang_after_header_comment() {
+        let source = "# comment\n#!/bin/sh\n:\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n# comment\n:\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn adds_a_newline_when_moving_an_eof_shebang_to_the_top() {
+        let source = "# comment\r\n#!/bin/sh";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\r\n# comment\r\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_first_line_or_non_header_later_shebangs() {
         for source in [
             "#!/bin/sh\n:\n",
@@ -87,5 +165,32 @@ mod tests {
             );
             assert!(diagnostics.is_empty());
         }
+    }
+
+    #[test]
+    fn leaves_non_header_later_shebangs_unchanged_when_fixing() {
+        for source in ["echo hi\n#!/bin/sh\n:\n", "cat <<EOF\n#!/bin/sh\nEOF\n"] {
+            let result = test_snippet_with_fix(
+                source,
+                &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+                Applicability::Unsafe,
+            );
+
+            assert_eq!(result.fixes_applied, 0);
+            assert_eq!(result.fixed_source, source);
+            assert!(result.fixed_diagnostics.is_empty());
+        }
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C075.sh").as_path(),
+            &LinterSettings::for_rule(Rule::ShebangNotOnFirstLine),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C075_fix_C075.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SingleQuotedLiteral;
 
 impl Violation for SingleQuotedLiteral {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::SingleQuotedLiteral
     }
 
     fn message(&self) -> String {
         "shell expansion inside single quotes stays literal".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the fragment with double quotes".to_owned())
     }
 }
 
@@ -21,7 +27,7 @@ struct ScanContext<'a> {
 
 pub fn single_quoted_literal(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .single_quoted_fragments()
         .iter()
@@ -32,14 +38,57 @@ pub fn single_quoted_literal(checker: &mut Checker) {
                 variable_set_operand: fragment.variable_set_operand(),
             };
 
-            should_report_single_quoted_literal(fragment.span().slice(source), context)
-                .then(|| fragment.span())
+            should_report_single_quoted_literal(fragment.span().slice(source), context).then(|| {
+                let diagnostic = crate::Diagnostic::new(SingleQuotedLiteral, fragment.span());
+                match single_quoted_literal_fix(
+                    fragment.span(),
+                    fragment.span().slice(source),
+                    fragment.dollar_quoted(),
+                ) {
+                    Some(fix) => diagnostic.with_fix(fix),
+                    None => diagnostic,
+                }
+            })
         })
         .collect::<Vec<_>>();
 
-    for span in spans {
-        checker.report_dedup(SingleQuotedLiteral, span);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
     }
+}
+
+fn single_quoted_literal_fix(
+    span: shuck_ast::Span,
+    text: &str,
+    dollar_quoted: bool,
+) -> Option<Fix> {
+    if dollar_quoted {
+        return None;
+    }
+
+    quoted_fragment_to_double_quotes(text)
+        .map(|replacement| Fix::unsafe_edit(Edit::replacement(replacement, span)))
+}
+
+fn quoted_fragment_to_double_quotes(text: &str) -> Option<String> {
+    if !(text.starts_with('\'') && text.ends_with('\'')) {
+        return None;
+    }
+
+    let body = &text[1..text.len() - 1];
+    let mut replacement = String::with_capacity(body.len() + 2);
+    replacement.push('"');
+    for ch in body.chars() {
+        match ch {
+            '"' | '\\' => {
+                replacement.push('\\');
+                replacement.push(ch);
+            }
+            _ => replacement.push(ch),
+        }
+    }
+    replacement.push('"');
+    Some(replacement)
 }
 
 fn should_report_single_quoted_literal(text: &str, context: ScanContext<'_>) -> bool {
@@ -150,12 +199,14 @@ fn command_name_is_exempt(command_name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::{
         assignment_target_is_exempt, command_name_is_exempt, contains_sc2016_trigger,
-        sed_text_is_exempt,
+        quoted_fragment_to_double_quotes, sed_text_is_exempt,
     };
-    use crate::test::test_snippet;
-    use crate::{Diagnostic, LinterSettings, Rule};
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, Diagnostic, LinterSettings, Rule, assert_diagnostics_diff};
 
     fn c005(source: &str) -> usize {
         c005_diagnostics(source).len()
@@ -163,6 +214,19 @@ mod tests {
 
     fn c005_diagnostics(source: &str) -> Vec<Diagnostic> {
         test_snippet(source, &LinterSettings::for_rule(Rule::SingleQuotedLiteral))
+    }
+
+    #[test]
+    fn rewrites_plain_single_quoted_fragments_as_double_quoted_fragments() {
+        assert_eq!(
+            quoted_fragment_to_double_quotes("'$HOME'"),
+            Some("\"$HOME\"".to_owned())
+        );
+        assert_eq!(
+            quoted_fragment_to_double_quotes("'\"$HOME\" and \\\\path'"),
+            Some("\"\\\"$HOME\\\" and \\\\\\\\path\"".to_owned())
+        );
+        assert_eq!(quoted_fragment_to_double_quotes("$'$HOME'"), None);
     }
 
     #[test]
@@ -258,7 +322,7 @@ mod tests {
     }
 
     #[test]
-    fn diagnostic_span_covers_the_full_single_quoted_region() {
+    fn diagnostic_span_covers_the_full_single_quoted_region_and_attaches_fix_metadata() {
         let diagnostics = c005_diagnostics("echo '$HOME'\n");
 
         assert_eq!(diagnostics.len(), 1);
@@ -266,6 +330,14 @@ mod tests {
         assert_eq!(diagnostics[0].span.start.column, 6);
         assert_eq!(diagnostics[0].span.end.line, 1);
         assert_eq!(diagnostics[0].span.end.column, 13);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("rewrite the fragment with double quotes")
+        );
     }
 
     #[test]
@@ -298,6 +370,53 @@ mod tests {
     #[test]
     fn reports_single_quoted_literals_inside_keyed_array_subscripts() {
         assert_eq!(c005("declare -A map=(['$HOME']=1)\n"), 1);
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_reported_single_quoted_fragments() {
+        let source = "\
+#!/bin/sh
+echo '$HOME'
+printf '%s\\n' '${value:-fallback}'
+msg='$(pwd)'
+echo '`pwd`'
+echo '\"$HOME\" and \\\\path'
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SingleQuotedLiteral),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 5);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo \"$HOME\"
+printf '%s\\n' \"${value:-fallback}\"
+msg=\"$(pwd)\"
+echo \"`pwd`\"
+echo \"\\\"$HOME\\\" and \\\\\\\\path\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_ansi_c_single_quoted_fragments_unchanged_when_fixing() {
+        let source = "echo $'$HOME'\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SingleQuotedLiteral),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+        assert_eq!(result.fixed_diagnostics[0].span.slice(source), "$'$HOME'");
     }
 
     #[test]
@@ -344,5 +463,17 @@ mod tests {
     #[test]
     fn ignores_single_quoted_sequences_inside_quoted_heredoc_bodies() {
         assert_eq!(c005("cat <<'EOF'\n'$HOME'\nEOF\n"), 0);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C005.sh").as_path(),
+            &LinterSettings::for_rule(Rule::SingleQuotedLiteral),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C005_fix_C005.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__arithmetic_redirection_target__tests__C050_fix_C050.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__arithmetic_redirection_target__tests__C050_fix_C050.sh.snap
@@ -1,0 +1,59 @@
+---
+source: crates/shuck-linter/src/rules/correctness/arithmetic_redirection_target.rs
+assertion_line: 111
+---
+Diagnostics:
+C050 redirection targets should not use arithmetic expansion
+ --> <source>:6:16
+  |
+6 | echo hi > "$((i++))"
+  |
+
+C050 redirection targets should not use arithmetic expansion
+  --> <source>:12:16
+   |
+12 | echo hi > "$((i--))"
+   |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -3,13 +3,13 @@
+ i=1
+ 
+ # Invalid: arithmetic expansion should not name the redirect target.
+-echo hi > "$((i++))"
++echo hi > "$((i))"
+ 
+ # Invalid: append redirections have the same problem.
+ printf '%s\n' ok >> "$((i + 1))"
+ 
+ # Invalid: decrement updates are also not allowed here.
+-echo hi > "$((i--))"
++echo hi > "$((i))"
+ 
+ # Valid: redirect to a normal filename.
+ echo hi > output.txt
+
+Fixed source:
+#!/bin/bash
+
+i=1
+
+# Invalid: arithmetic expansion should not name the redirect target.
+echo hi > "$((i))"
+
+# Invalid: append redirections have the same problem.
+printf '%s\n' ok >> "$((i + 1))"
+
+# Invalid: decrement updates are also not allowed here.
+echo hi > "$((i))"
+
+# Valid: redirect to a normal filename.
+echo hi > output.txt
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__backslash_before_closing_backtick__tests__C069_fix_C069.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__backslash_before_closing_backtick__tests__C069_fix_C069.sh.snap
@@ -1,0 +1,32 @@
+---
+source: crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
+assertion_line: 163
+---
+Diagnostics:
+C069 remove the escaped trailing space before closing backtick
+ --> <source>:3:29
+  |
+3 | ARCH=`uname -a | cut -f12 -d\ `
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,4 +1,4 @@
+ #!/bin/bash
+ # shellcheck disable=2006
+-ARCH=`uname -a | cut -f12 -d\ `
++ARCH=`uname -a | cut -f12 -d `
+ echo "$ARCH"
+
+Fixed source:
+#!/bin/bash
+# shellcheck disable=2006
+ARCH=`uname -a | cut -f12 -d `
+echo "$ARCH"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__c_style_comment__tests__C041_fix_C041.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__c_style_comment__tests__C041_fix_C041.sh.snap
@@ -1,0 +1,38 @@
+---
+source: crates/shuck-linter/src/rules/correctness/c_style_comment.rs
+---
+Diagnostics:
+C041 C-style comment syntax is not valid shell syntax
+ --> <source>:2:1
+  |
+2 | /* note */
+  |
+
+C041 C-style comment syntax is not valid shell syntax
+ --> <source>:3:1
+  |
+3 | /*compact*/
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,4 +1,4 @@
+ #!/bin/sh
+-/* note */
+-/*compact*/
++# /* note */
++# /*compact*/
+ echo '/* note */'
+
+Fixed source:
+#!/bin/sh
+# /* note */
+# /*compact*/
+echo '/* note */'
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__case_pattern_var__tests__C048_fix_C048.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__case_pattern_var__tests__C048_fix_C048.sh.snap
@@ -1,0 +1,80 @@
+---
+source: crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
+---
+Diagnostics:
+C048 case patterns should be literal instead of built from expansions
+ --> <source>:8:3
+  |
+8 |   $pat) printf '%s\n' match ;;
+  |
+
+C048 case patterns should be literal instead of built from expansions
+  --> <source>:13:3
+   |
+13 |   $(printf '%s' foo)) printf '%s\n' match ;;
+   |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -5,12 +5,12 @@
+ 
+ # Invalid: variable expansion builds the case pattern at runtime.
+ case $x in
+-  $pat) printf '%s\n' match ;;
++  "${pat}") printf '%s\n' match ;;
+ esac
+ 
+ # Invalid: command substitution also makes the pattern dynamic.
+ case $x in
+-  $(printf '%s' foo)) printf '%s\n' match ;;
++  "$(printf '%s' foo)") printf '%s\n' match ;;
+ esac
+ 
+ # Valid: literal patterns stay stable.
+
+Fixed source:
+#!/bin/sh
+
+x=foo
+pat=foo
+
+# Invalid: variable expansion builds the case pattern at runtime.
+case $x in
+  "${pat}") printf '%s\n' match ;;
+esac
+
+# Invalid: command substitution also makes the pattern dynamic.
+case $x in
+  "$(printf '%s' foo)") printf '%s\n' match ;;
+esac
+
+# Valid: literal patterns stay stable.
+case $x in
+  foo|bar) printf '%s\n' literal ;;
+esac
+
+# Valid: real glob structure suppresses the warning even when the pattern is dynamic.
+case $x in
+  gm$MAMEVER*) printf '%s\n' glob ;;
+  *${IDN_ITEM}*) printf '%s\n' glob ;;
+  ${pat}*) printf '%s\n' glob ;;
+  *${pat}) printf '%s\n' glob ;;
+  x${pat}*) printf '%s\n' glob ;;
+  [$hex]) printf '%s\n' glob ;;
+  @($pat|bar)) printf '%s\n' glob ;;
+  x$left@(foo|bar)) printf '%s\n' glob ;;
+esac
+
+# Valid: arithmetic-only case patterns are treated as stable enough for this rule.
+case $x in
+  $((error_code <= 125))) printf '%s\n' arithmetic ;;
+  $((__git_cmd_idx+1))) printf '%s\n' arithmetic ;;
+  x$((1))) printf '%s\n' arithmetic ;;
+esac
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__commented_continuation_line__tests__C076_fix_C076.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__commented_continuation_line__tests__C076_fix_C076.sh.snap
@@ -1,0 +1,39 @@
+---
+source: crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
+---
+Diagnostics:
+C076 line continuation is followed by a comment-only line
+ --> <source>:3:11
+  |
+3 |   #world \
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,6 +1,6 @@
+ #!/bin/bash
+ echo hello \
+-  #world \
++  #world 
+   foo
+ 
+ echo hello \
+
+Fixed source:
+#!/bin/bash
+echo hello \
+  #world 
+  foo
+
+echo hello \
+  world
+
+echo hello
+  #world
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__constant_comparison_test__tests__C017_fix_C017.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__constant_comparison_test__tests__C017_fix_C017.sh.snap
@@ -1,0 +1,78 @@
+---
+source: crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
+assertion_line: 346
+---
+Diagnostics:
+C017 this comparison only checks fixed literals
+ --> <source>:4:5
+  |
+4 | [ 1 = 1 ]
+  |
+
+C017 this comparison only checks fixed literals
+ --> <source>:7:10
+  |
+7 | test foo != bar
+  |
+
+C017 this comparison only checks fixed literals
+  --> <source>:10:9
+   |
+10 | [[ left == right ]]
+   |
+
+C017 this comparison only checks fixed literals
+  --> <source>:13:26
+   |
+13 | [[ "$value" = ok || left == right ]]
+   |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,16 +1,16 @@
+ #!/bin/bash
+ 
+ # Invalid: simple test compares only fixed literals
+-[ 1 = 1 ]
++[ x ]
+ 
+ # Invalid: `test` with literal operands is also constant
+-test foo != bar
++test x
+ 
+ # Invalid: bash conditionals can be constant too
+-[[ left == right ]]
++[[ "" ]]
+ 
+ # Invalid: nested constant comparisons inside larger conditions are still fixed
+-[[ "$value" = ok || left == right ]]
++[[ "$value" = ok || "" ]]
+ 
+ # Valid: runtime data makes the comparison meaningful
+ [ "$value" = ok ]
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: simple test compares only fixed literals
+[ x ]
+
+# Invalid: `test` with literal operands is also constant
+test x
+
+# Invalid: bash conditionals can be constant too
+[[ "" ]]
+
+# Invalid: nested constant comparisons inside larger conditions are still fixed
+[[ "$value" = ok || "" ]]
+
+# Valid: runtime data makes the comparison meaningful
+[ "$value" = ok ]
+[[ $value == right ]]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__double_paren_grouping__tests__C071_fix_C071.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__double_paren_grouping__tests__C071_fix_C071.sh.snap
@@ -1,0 +1,30 @@
+---
+source: crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
+assertion_line: 124
+---
+Diagnostics:
+C071 double parentheses are used to group commands instead of arithmetic
+ --> <source>:3:1
+  |
+3 | ((ps aux | grep foo) || kill "$pid") 2>/dev/null
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,3 +1,3 @@
+ #!/bin/sh
+ # shellcheck disable=2154,2009
+-((ps aux | grep foo) || kill "$pid") 2>/dev/null
++( (ps aux | grep foo) || kill "$pid") 2>/dev/null
+
+Fixed source:
+#!/bin/sh
+# shellcheck disable=2154,2009
+( (ps aux | grep foo) || kill "$pid") 2>/dev/null
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__escaped_negation_in_test__tests__C082_fix_C082.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__escaped_negation_in_test__tests__C082_fix_C082.sh.snap
@@ -1,0 +1,70 @@
+---
+source: crates/shuck-linter/src/rules/correctness/escaped_negation_in_test.rs
+assertion_line: 145
+---
+Diagnostics:
+C082 write ! directly when negating a test
+ --> <source>:4:6
+  |
+4 | [ \! -f "$file" ]
+  |
+
+C082 write ! directly when negating a test
+ --> <source>:7:6
+  |
+7 | test \! -n "$value"
+  |
+
+C082 write ! directly when negating a test
+  --> <source>:10:3
+   |
+10 | [ \! "$value" = ok ]
+   |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -1,13 +1,13 @@
+ #!/bin/bash
+ 
+ # Invalid: bracket tests should not escape the negation token.
+-[ \! -f "$file" ]
++[ ! -f "$file" ]
+ 
+ # Invalid: the `test` builtin takes plain `!` too.
+-test \! -n "$value"
++test ! -n "$value"
+ 
+ # Invalid: escaped negation still looks wrong in longer test expressions.
+-[ \! "$value" = ok ]
++[ ! "$value" = ok ]
+ 
+ # Valid: plain negation is the intended spelling.
+ [ ! -f "$file" ]
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: bracket tests should not escape the negation token.
+[ ! -f "$file" ]
+
+# Invalid: the `test` builtin takes plain `!` too.
+test ! -n "$value"
+
+# Invalid: escaped negation still looks wrong in longer test expressions.
+[ ! "$value" = ok ]
+
+# Valid: plain negation is the intended spelling.
+[ ! -f "$file" ]
+test ! -n "$value"
+
+# Valid: a literal bang used as data should not trigger.
+test !
+[ "$value" = \! ]
+[[ \! -f "$file" ]]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__find_output_to_xargs__tests__C007_fix_C007.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__find_output_to_xargs__tests__C007_fix_C007.sh.snap
@@ -1,0 +1,79 @@
+---
+source: crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+---
+Diagnostics:
+C007 raw `find` output piped to `xargs` can break on whitespace
+ --> <source>:4:1
+  |
+4 | find . -name '*.txt' | xargs rm
+  |
+
+C007 raw `find` output piped to `xargs` can break on whitespace
+ --> <source>:7:1
+  |
+7 | find . -type f | xargs -0 wc -l
+  |
+
+C007 raw `find` output piped to `xargs` can break on whitespace
+  --> <source>:10:1
+   |
+10 | find "$pkg" -print0 | xargs rm
+   |
+
+C007 raw `find` output piped to `xargs` can break on whitespace
+  --> <source>:13:11
+   |
+13 | summary=$(find . -type f | xargs wc -l)
+   |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,16 +1,16 @@
+ #!/bin/sh
+ 
+ # Invalid: raw find output is split on whitespace by xargs
+-find . -name '*.txt' | xargs rm
++find . -name '*.txt' -print0 | xargs -0 rm
+ 
+ # Invalid: only enabling -0 on xargs is not enough
+-find . -type f | xargs -0 wc -l
++find . -type f -print0 | xargs -0 wc -l
+ 
+ # Invalid: only enabling -print0 on find is not enough
+-find "$pkg" -print0 | xargs rm
++find "$pkg" -print0 | xargs -0 rm
+ 
+ # Invalid: nested command substitutions should still be checked
+-summary=$(find . -type f | xargs wc -l)
++summary=$(find . -type f -print0 | xargs -0 wc -l)
+ 
+ # Valid: null-delimited handoff is safe
+ find . -name '*.txt' -print0 | xargs -0 rm
+
+Fixed source:
+#!/bin/sh
+
+# Invalid: raw find output is split on whitespace by xargs
+find . -name '*.txt' -print0 | xargs -0 rm
+
+# Invalid: only enabling -0 on xargs is not enough
+find . -type f -print0 | xargs -0 wc -l
+
+# Invalid: only enabling -print0 on find is not enough
+find "$pkg" -print0 | xargs -0 rm
+
+# Invalid: nested command substitutions should still be checked
+summary=$(find . -type f -print0 | xargs -0 wc -l)
+
+# Valid: null-delimited handoff is safe
+find . -name '*.txt' -print0 | xargs -0 rm
+
+# Valid: non-find pipelines are outside this rule
+printf '%s\n' ./a ./b | xargs rm
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_find_substitution__tests__C083_fix_C083.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_find_substitution__tests__C083_fix_C083.sh.snap
@@ -1,0 +1,75 @@
+---
+source: crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+assertion_line: 211
+---
+Diagnostics:
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:2:15
+  |
+2 | find ./ -name *.jar
+  |
+
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:3:15
+  |
+3 | find ./ -name "$prefix"*.jar
+  |
+
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:4:20
+  |
+4 | find ./ -wholename */tmp/*
+  |
+
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:5:26
+  |
+5 | for f in $(find ./ -name *.cfg); do :; done
+  |
+
+C083 quote glob patterns passed to `find` so the shell does not expand them early
+ --> <source>:6:31
+  |
+6 | printf '%s\n' "$(find . -path */tmp/*)"
+  |
+
+
+Applied fixes: 5
+
+Diff:
+--- before
++++ after
+@@ -1,9 +1,9 @@
+ #!/bin/bash
+-find ./ -name *.jar
+-find ./ -name "$prefix"*.jar
+-find ./ -wholename */tmp/*
+-for f in $(find ./ -name *.cfg); do :; done
+-printf '%s\n' "$(find . -path */tmp/*)"
++find ./ -name "*.jar"
++find ./ -name "${prefix}*.jar"
++find ./ -wholename "*/tmp/*"
++for f in $(find ./ -name "*.cfg"); do :; done
++printf '%s\n' "$(find . -path "*/tmp/*")"
+ 
+ find ./ -name '*.jar'
+ find ./ -name \*.tmp
+
+Fixed source:
+#!/bin/bash
+find ./ -name "*.jar"
+find ./ -name "${prefix}*.jar"
+find ./ -wholename "*/tmp/*"
+for f in $(find ./ -name "*.cfg"); do :; done
+printf '%s\n' "$(find . -path "*/tmp/*")"
+
+find ./ -name '*.jar'
+find ./ -name \*.tmp
+find ./ -path \*/tmp/\*
+find ./ -wholename \*/tmp/\*
+find ./ -type f*
+command find ./ -name *.jar
+find ./ -name "$pattern"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_grep_pattern__tests__C080_fix_C080.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_grep_pattern__tests__C080_fix_C080.sh.snap
@@ -1,0 +1,57 @@
+---
+source: crates/shuck-linter/src/rules/correctness/glob_in_grep_pattern.rs
+assertion_line: 210
+---
+Diagnostics:
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:2:6
+  |
+2 | grep start* out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:3:6
+  |
+3 | grep 'foo\*bar*' out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:4:6
+  |
+4 | grep item\* out.txt
+  |
+
+C080 use regex-style wildcards in grep patterns, not glob-style `*`
+ --> <source>:5:6
+  |
+5 | grep --regexp='start*' out.txt
+  |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+-grep start* out.txt
+-grep 'foo\*bar*' out.txt
+-grep item\* out.txt
+-grep --regexp='start*' out.txt
++grep start.* out.txt
++grep 'foo\*bar.*' out.txt
++grep item.* out.txt
++grep --regexp='start.*' out.txt
+ grep --fixed-strings foo*bar out.txt
+
+Fixed source:
+#!/bin/sh
+grep start.* out.txt
+grep 'foo\*bar.*' out.txt
+grep item.* out.txt
+grep --regexp='start.*' out.txt
+grep --fixed-strings foo*bar out.txt
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_string_comparison__tests__C081_fix_C081.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_string_comparison__tests__C081_fix_C081.sh.snap
@@ -1,0 +1,74 @@
+---
+source: crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
+assertion_line: 193
+---
+Diagnostics:
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:2:18
+  |
+2 | if [[ $mirror == $pkgs ]]; then echo same; fi
+  |
+
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:3:14
+  |
+3 | if [[ "$a" = $1 ]]; then :; fi
+  |
+
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:4:15
+  |
+4 | if [[ "$a" != ${b%%x} ]]; then :; fi
+  |
+
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:5:15
+  |
+5 | if [[ "$a" == ${arr[0]} ]]; then :; fi
+  |
+
+C081 quote the right-hand side so string comparisons do not turn into glob matches
+ --> <source>:6:33
+  |
+6 | printf '%s\n' "$( [[ $mirror == $pkgs ]] && echo same )"
+  |
+
+
+Applied fixes: 5
+
+Diff:
+--- before
++++ after
+@@ -1,9 +1,9 @@
+ #!/bin/bash
+-if [[ $mirror == $pkgs ]]; then echo same; fi
+-if [[ "$a" = $1 ]]; then :; fi
+-if [[ "$a" != ${b%%x} ]]; then :; fi
+-if [[ "$a" == ${arr[0]} ]]; then :; fi
+-printf '%s\n' "$( [[ $mirror == $pkgs ]] && echo same )"
++if [[ $mirror == "$pkgs" ]]; then echo same; fi
++if [[ "$a" = "$1" ]]; then :; fi
++if [[ "$a" != "${b%%x}" ]]; then :; fi
++if [[ "$a" == "${arr[0]}" ]]; then :; fi
++printf '%s\n' "$( [[ $mirror == "$pkgs" ]] && echo same )"
+ 
+ if [[ "$a" == "$b" ]]; then :; fi
+ if [[ "$a" == $b* ]]; then :; fi
+
+Fixed source:
+#!/bin/bash
+if [[ $mirror == "$pkgs" ]]; then echo same; fi
+if [[ "$a" = "$1" ]]; then :; fi
+if [[ "$a" != "${b%%x}" ]]; then :; fi
+if [[ "$a" == "${arr[0]}" ]]; then :; fi
+printf '%s\n' "$( [[ $mirror == "$pkgs" ]] && echo same )"
+
+if [[ "$a" == "$b" ]]; then :; fi
+if [[ "$a" == $b* ]]; then :; fi
+if [[ "$a" == $b$c ]]; then :; fi
+if [[ "$a" == ${b}_x ]]; then :; fi
+if [[ "$a" < $b ]]; then :; fi
+if [ "$a" = $b ]; then :; fi
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__indented_shebang__tests__C073_fix_C073.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__indented_shebang__tests__C073_fix_C073.sh.snap
@@ -1,0 +1,36 @@
+---
+source: crates/shuck-linter/src/rules/correctness/indented_shebang.rs
+assertion_line: 131
+---
+Diagnostics:
+C073 shebang must start in column 1
+ --> <source>:1:1
+  |
+1 |  #!/bin/sh
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,4 +1,4 @@
+- #!/bin/sh
++#!/bin/sh
+ :
+ 
+ # should not trigger: only the file header counts as the shebang
+
+Fixed source:
+#!/bin/sh
+:
+
+# should not trigger: only the file header counts as the shebang
+#!/bin/sh
+
+# should not trigger: spacing after `#!` is a different rule
+#! /bin/sh
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__leading_glob_argument__tests__C012_fix_C012.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__leading_glob_argument__tests__C012_fix_C012.sh.snap
@@ -1,0 +1,56 @@
+---
+source: crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+assertion_line: 268
+---
+Diagnostics:
+C012 wildcard arguments should be guarded with `./` or `--`
+ --> <source>:2:4
+  |
+2 | rm *
+  |
+
+C012 wildcard arguments should be guarded with `./` or `--`
+ --> <source>:3:5
+  |
+3 | cat ?a
+  |
+
+C012 wildcard arguments should be guarded with `./` or `--`
+ --> <source>:4:12
+  |
+4 | command mv *a dest/
+  |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+-rm *
+-cat ?a
+-command mv *a dest/
++rm ./*
++cat ./?a
++command mv ./*a dest/
+ 
+ rm -- *
+ rm ./*
+
+Fixed source:
+#!/bin/sh
+rm ./*
+cat ./?a
+command mv ./*a dest/
+
+rm -- *
+rm ./*
+rm foo/*
+rm a*
+echo *
+printf '%s\n' *
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__linebreak_in_test__tests__C040_fix_C040.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__linebreak_in_test__tests__C040_fix_C040.sh.snap
@@ -1,0 +1,36 @@
+---
+source: crates/shuck-linter/src/rules/correctness/linebreak_in_test.rs
+---
+Diagnostics:
+C040 `[` test spans lines without a trailing `\` before the newline
+ --> <source>:2:14
+  |
+2 | if [ "$x" = y
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,5 +1,5 @@
+ #!/bin/sh
+-if [ "$x" = y
++if [ "$x" = y\
+ ]; then :; fi
+ 
+ if [ "$x" = y \
+
+Fixed source:
+#!/bin/sh
+if [ "$x" = y\
+]; then :; fi
+
+if [ "$x" = y \
+]; then :; fi
+
+if [ "$x" = y ]; then :; fi
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__literal_unary_string_test__tests__C019_fix_C019.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__literal_unary_string_test__tests__C019_fix_C019.sh.snap
@@ -1,0 +1,66 @@
+---
+source: crates/shuck-linter/src/rules/correctness/literal_unary_string_test.rs
+assertion_line: 368
+---
+Diagnostics:
+C019 this string test checks a fixed literal
+ --> <source>:4:6
+  |
+4 | [ -z foo ]
+  |
+
+C019 this string test checks a fixed literal
+ --> <source>:5:9
+  |
+5 | test -n bar
+  |
+
+C019 this string test checks a fixed literal
+ --> <source>:6:7
+  |
+6 | [[ -z baz ]]
+  |
+
+C019 this string test checks a fixed literal
+ --> <source>:7:21
+  |
+7 | [ -z "${rootfs_path}_path" ]
+  |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/bash
+ 
+ # Invalid: unary string tests on literals are always fixed
+-[ -z foo ]
+-test -n bar
+-[[ -z baz ]]
+-[ -z "${rootfs_path}_path" ]
++[ -z x ]
++test -n x
++[[ -z x ]]
++[ -z x ]
+ 
+ # Valid: checking runtime values is meaningful
+ [ -z "$value" ]
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: unary string tests on literals are always fixed
+[ -z x ]
+test -n x
+[[ -z x ]]
+[ -z x ]
+
+# Valid: checking runtime values is meaningful
+[ -z "$value" ]
+[[ -n $value ]]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__missing_bracket_space__tests__C030_fix_C030.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__missing_bracket_space__tests__C030_fix_C030.sh.snap
@@ -1,0 +1,32 @@
+---
+source: crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
+assertion_line: 193
+---
+Diagnostics:
+C030 this unary `[` test operator is missing its operand before the closing `]`
+ --> <source>:2:9
+  |
+2 | if [ -d /tmp]; then
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,4 +1,4 @@
+ #!/bin/sh
+-if [ -d /tmp]; then
++if [ -d /tmp ]; then
+   :
+ fi
+
+Fixed source:
+#!/bin/sh
+if [ -d /tmp ]; then
+  :
+fi
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__missing_fi__tests__C035_fix_C035.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__missing_fi__tests__C035_fix_C035.sh.snap
@@ -1,0 +1,29 @@
+---
+source: crates/shuck-linter/src/rules/correctness/missing_fi.rs
+---
+Diagnostics:
+C035 this `if` block is missing a closing `fi`
+ --> <source>:4:1
+  |
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,3 +1,4 @@
+ #!/bin/sh
+ if true; then
+   :
++fi
+
+Fixed source:
+#!/bin/sh
+if true; then
+  :
+fi
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__non_absolute_shebang__tests__C060_fix_C060.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__non_absolute_shebang__tests__C060_fix_C060.sh.snap
@@ -1,0 +1,32 @@
+---
+source: crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
+---
+Diagnostics:
+C060 shebang should use an absolute path or `/usr/bin/env`
+ --> <source>:1:1
+  |
+1 | #!@PREFIX@/bin/sh
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,4 +1,4 @@
+-#!@PREFIX@/bin/sh
++#!/usr/bin/env sh
+ :
+ 
+ # the rule should only inspect the first line
+
+Fixed source:
+#!/usr/bin/env sh
+:
+
+# the rule should only inspect the first line
+#!/bin/sh
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__open_double_quote__tests__C039_fix_C039.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__open_double_quote__tests__C039_fix_C039.sh.snap
@@ -1,0 +1,36 @@
+---
+source: crates/shuck-linter/src/rules/correctness/open_double_quote.rs
+---
+Diagnostics:
+C039 double-quoted string looks unterminated
+ --> <source>:2:6
+  |
+2 | echo "#!/bin/bash
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,6 +1,6 @@
+ #!/bin/bash
+ echo "#!/bin/bash
+-if [[ "$@" =~ x ]]; then :; fi
++if [[ ${@} =~ x ]]; then :; fi
+ "
+ 
+ echo "line one
+
+Fixed source:
+#!/bin/bash
+echo "#!/bin/bash
+if [[ ${@} =~ x ]]; then :; fi
+"
+
+echo "line one
+line two"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__overwritten_function__tests__C063_fix_C063.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__overwritten_function__tests__C063_fix_C063.sh.snap
@@ -1,0 +1,46 @@
+---
+source: crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+---
+Diagnostics:
+C063 function `myfunc` is overwritten before any direct call can reach it
+ --> <source>:4:1
+  |
+4 | myfunc() { return 1; }
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,7 +1,6 @@
+ #!/bin/sh
+ 
+ # Invalid: the first definition is replaced before any direct call can reach it.
+-myfunc() { return 1; }
+ myfunc() { return 0; }
+ myfunc
+ 
+
+Fixed source:
+#!/bin/sh
+
+# Invalid: the first definition is replaced before any direct call can reach it.
+myfunc() { return 0; }
+myfunc
+
+# Valid: the first definition is exercised before the overwrite happens.
+ok() { printf '%s\n' first; }
+ok
+ok() { printf '%s\n' second; }
+ok
+
+# Valid: unrelated functions are unaffected.
+left() { :; }
+right() { :; }
+left
+right
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__pattern_with_variable__tests__C055_fix_C055.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__pattern_with_variable__tests__C055_fix_C055.sh.snap
@@ -1,0 +1,44 @@
+---
+source: crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
+---
+Diagnostics:
+C055 pattern expressions should not expand variables
+ --> <source>:7:16
+  |
+7 | trimmed=${name%$suffix}
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -4,7 +4,7 @@
+ suffix=b
+ 
+ # Invalid: a variable expansion is used inside the pattern.
+-trimmed=${name%$suffix}
++trimmed=${name%"$suffix"}
+ 
+ # Invalid: replacement patterns have the same problem.
+ rewritten=${name/$suffix/x}
+
+Fixed source:
+#!/bin/bash
+
+name=abc
+suffix=b
+
+# Invalid: a variable expansion is used inside the pattern.
+trimmed=${name%"$suffix"}
+
+# Invalid: replacement patterns have the same problem.
+rewritten=${name/$suffix/x}
+
+# Valid: literal patterns are fine.
+trimmed=${name%b}
+rewritten=${name/ab/x}
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__positional_ten_braces__tests__C025_fix_C025.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__positional_ten_braces__tests__C025_fix_C025.sh.snap
@@ -1,0 +1,55 @@
+---
+source: crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
+assertion_line: 159
+---
+Diagnostics:
+C025 use braces for positional parameters above 9
+ --> <source>:4:16
+  |
+4 | printf '%s\n' "$10"
+  |
+
+C025 use braces for positional parameters above 9
+ --> <source>:7:15
+  |
+7 | printf '%s\n' $123
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/sh
+ 
+ # Invalid: $10 is parsed as $1 followed by a literal 0.
+-printf '%s\n' "$10"
++printf '%s\n' "${10}"
+ 
+ # Invalid: larger numbers have the same problem.
+-printf '%s\n' $123
++printf '%s\n' ${123}
+ 
+ # Valid: braces address the positional parameter directly.
+ printf '%s\n' "${10}"
+
+Fixed source:
+#!/bin/sh
+
+# Invalid: $10 is parsed as $1 followed by a literal 0.
+printf '%s\n' "${10}"
+
+# Invalid: larger numbers have the same problem.
+printf '%s\n' ${123}
+
+# Valid: braces address the positional parameter directly.
+printf '%s\n' "${10}"
+printf '%s\n' "${123}"
+
+# Valid: concatenating $1 with non-digits is fine.
+printf '%s\n' "$1x"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__quoted_bash_regex__tests__C009_fix_C009.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__quoted_bash_regex__tests__C009_fix_C009.sh.snap
@@ -1,0 +1,53 @@
+---
+source: crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
+assertion_line: 242
+---
+Diagnostics:
+C009 quoting the right-hand side of `=~` forces a literal string match
+ --> <source>:6:14
+  |
+6 | [[ $value =~ "$re" ]]
+  |
+
+C009 quoting the right-hand side of `=~` forces a literal string match
+ --> <source>:9:11
+  |
+9 | [[ foo =~ "a+" ]]
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -3,10 +3,10 @@
+ re='a+'
+ 
+ # Invalid: quoting the regex makes bash treat it as a literal string
+-[[ $value =~ "$re" ]]
++[[ $value =~ $re ]]
+ 
+ # Invalid: quoted literal regexes are also treated literally
+-[[ foo =~ "a+" ]]
++[[ foo =~ a+ ]]
+ 
+ # Valid: unquoted regexes keep regex semantics
+ [[ $value =~ $re ]]
+
+Fixed source:
+#!/bin/bash
+
+re='a+'
+
+# Invalid: quoting the regex makes bash treat it as a literal string
+[[ $value =~ $re ]]
+
+# Invalid: quoted literal regexes are also treated literally
+[[ foo =~ a+ ]]
+
+# Valid: unquoted regexes keep regex semantics
+[[ $value =~ $re ]]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__redirect_to_command_name__tests__C059_fix_C059.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__redirect_to_command_name__tests__C059_fix_C059.sh.snap
@@ -1,0 +1,77 @@
+---
+source: crates/shuck-linter/src/rules/correctness/redirect_to_command_name.rs
+---
+Diagnostics:
+C059 redirection target matches a command name; use a distinct file path
+ --> <source>:3:17
+  |
+3 | cat input.txt > c99
+  |
+
+C059 redirection target matches a command name; use a distinct file path
+ --> <source>:4:18
+  |
+4 | cat input.txt >> grep
+  |
+
+C059 redirection target matches a command name; use a distinct file path
+ --> <source>:5:18
+  |
+5 | cat input.txt 2> sed
+  |
+
+C059 redirection target matches a command name; use a distinct file path
+ --> <source>:6:17
+  |
+6 | cat input.txt < awk
+  |
+
+C059 redirection target matches a command name; use a distinct file path
+ --> <source>:7:18
+  |
+7 | cat input.txt >| command
+  |
+
+
+Applied fixes: 5
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/bash
+ 
+-cat input.txt > c99
+-cat input.txt >> grep
+-cat input.txt 2> sed
+-cat input.txt < awk
+-cat input.txt >| command
++cat input.txt > ./c99
++cat input.txt >> ./grep
++cat input.txt 2> ./sed
++cat input.txt < ./awk
++cat input.txt >| ./command
+ 
+ cat input.txt > "cat"
+ cat input.txt > ./cat
+
+Fixed source:
+#!/bin/bash
+
+cat input.txt > ./c99
+cat input.txt >> ./grep
+cat input.txt 2> ./sed
+cat input.txt < ./awk
+cat input.txt >| ./command
+
+cat input.txt > "cat"
+cat input.txt > ./cat
+cat input.txt > /tmp/cat
+cat input.txt > cat.txt
+cat input.txt > "$name"
+cat input.txt > ${name}
+cat input.txt <<< cat
+cat input.txt > true
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__shebang_not_on_first_line__tests__C075_fix_C075.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__shebang_not_on_first_line__tests__C075_fix_C075.sh.snap
@@ -1,0 +1,36 @@
+---
+source: crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
+assertion_line: 193
+---
+Diagnostics:
+C075 move the shebang to the first line of the file
+ --> <source>:2:1
+  |
+2 | #!/bin/sh
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,5 +1,5 @@
++#!/bin/sh
+ 
+-#!/bin/sh
+ :
+ 
+ # should not trigger: shebang belongs on the first line, not later lines
+
+Fixed source:
+#!/bin/sh
+
+:
+
+# should not trigger: shebang belongs on the first line, not later lines
+echo ok
+#!/bin/sh
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__single_quoted_literal__tests__C005_fix_C005.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__single_quoted_literal__tests__C005_fix_C005.sh.snap
@@ -1,0 +1,159 @@
+---
+source: crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+assertion_line: 470
+---
+Diagnostics:
+C005 shell expansion inside single quotes stays literal
+ --> <source>:4:6
+  |
+4 | echo '$HOME'
+  |
+
+C005 shell expansion inside single quotes stays literal
+ --> <source>:7:15
+  |
+7 | printf '%s\n' '${value:-fallback}'
+  |
+
+C005 shell expansion inside single quotes stays literal
+  --> <source>:10:5
+   |
+10 | msg='$(pwd)'
+   |
+
+C005 shell expansion inside single quotes stays literal
+  --> <source>:13:6
+   |
+13 | echo '`pwd`'
+   |
+
+C005 shell expansion inside single quotes stays literal
+  --> <source>:16:8
+   |
+16 | sed -n '$pattern'
+   |
+
+C005 shell expansion inside single quotes stays literal
+  --> <source>:19:19
+   |
+19 | find . -exec echo '$1' {} +
+   |
+
+C005 shell expansion inside single quotes stays literal
+  --> <source>:22:5
+   |
+22 | git '$a'
+   |
+
+
+Applied fixes: 7
+
+Diff:
+--- before
++++ after
+@@ -1,25 +1,25 @@
+ #!/bin/bash
+ 
+ # Invalid: single-quoted variable reference stays literal
+-echo '$HOME'
++echo "$HOME"
+ 
+ # Invalid: parameter expansion is also literal inside single quotes
+-printf '%s\n' '${value:-fallback}'
++printf '%s\n' "${value:-fallback}"
+ 
+ # Invalid: command substitution text inside single quotes is not executed
+-msg='$(pwd)'
++msg="$(pwd)"
+ 
+ # Invalid: backticks inside single quotes are also literal
+-echo '`pwd`'
++echo "`pwd`"
+ 
+ # Invalid: sed should still warn for variable-like single-quoted text
+-sed -n '$pattern'
++sed -n "$pattern"
+ 
+ # Invalid: find -exec should use the effective subcommand
+-find . -exec echo '$1' {} +
++find . -exec echo "$1" {} +
+ 
+ # Invalid: git subcommands should still warn when not exempt
+-git '$a'
++git "$a"
+ 
+ # Valid: double-quoted variable references still expand
+ echo "$HOME"
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: single-quoted variable reference stays literal
+echo "$HOME"
+
+# Invalid: parameter expansion is also literal inside single quotes
+printf '%s\n' "${value:-fallback}"
+
+# Invalid: command substitution text inside single quotes is not executed
+msg="$(pwd)"
+
+# Invalid: backticks inside single quotes are also literal
+echo "`pwd`"
+
+# Invalid: sed should still warn for variable-like single-quoted text
+sed -n "$pattern"
+
+# Invalid: find -exec should use the effective subcommand
+find . -exec echo "$1" {} +
+
+# Invalid: git subcommands should still warn when not exempt
+git "$a"
+
+# Valid: double-quoted variable references still expand
+echo "$HOME"
+
+# Valid: ordinary single-quoted text is fine
+echo 'hello world'
+
+# Valid: escaped dollar in double quotes is explicit literal text
+echo "\$HOME"
+
+# Valid: ShellCheck does not flag special parameters for SC2016
+echo '$$'
+echo '$?'
+echo '$#'
+echo '$@'
+echo '$*'
+echo '$!'
+echo '$-'
+
+# Valid: sed-specific patterns are exempt
+sed 's/foo$/bar/'
+sed -n '$p'
+sed '${/lol/d}'
+
+# Valid: awk programs are exempt
+awk '{print $1}'
+busybox awk '{print $1}'
+find . -exec awk '{print $1}' {} \;
+
+# Valid: command-specific exemptions
+trap 'echo $SECONDS' EXIT
+eval 'echo $1'
+alias hosts='sudo $EDITOR /etc/hosts'
+git filter-branch 'test $GIT_COMMIT'
+rename 's/(.)a/$1/g' *
+jq '$__loc__'
+command jq '$__loc__'
+exec jq '$__loc__'
+exec -c -a foo jq '$__loc__'
+
+# Valid: prompt assignments are exempt
+PS1='$PWD \\$ '
+export PS4='$PWD'
+
+# Valid: -v test operands are exempt
+[ -v 'bar[$foo]' ]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__space_after_hash_bang__tests__C074_fix_C074.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__space_after_hash_bang__tests__C074_fix_C074.sh.snap
@@ -1,0 +1,36 @@
+---
+source: crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
+assertion_line: 146
+---
+Diagnostics:
+C074 remove the space so the shebang starts with `#!`
+ --> <source>:1:2
+  |
+1 | # !/bin/sh
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,4 +1,4 @@
+-# !/bin/sh
++#!/bin/sh
+ :
+ 
+ # should not trigger: a real shebang
+
+Fixed source:
+#!/bin/sh
+:
+
+# should not trigger: a real shebang
+#!/bin/sh
+
+# should not trigger: only the first line is header metadata
+# !/bin/sh
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__subst_with_redirect__tests__C057_fix_C057.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__subst_with_redirect__tests__C057_fix_C057.sh.snap
@@ -1,0 +1,51 @@
+---
+source: crates/shuck-linter/src/rules/correctness/subst_with_redirect.rs
+assertion_line: 188
+---
+Diagnostics:
+C057 command substitution redirects its output away
+ --> <source>:4:5
+  |
+4 | out=$(printf hi > out.txt)
+  |
+
+C057 command substitution redirects its output away
+ --> <source>:7:5
+  |
+7 | out=$(printf hi >&2)
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/sh
+ 
+ # Invalid: the command substitution writes its stdout to a file instead.
+-out=$(printf hi > out.txt)
++out=$(printf hi )
+ 
+ # Invalid: sending stdout to stderr also leaves nothing to capture.
+-out=$(printf hi >&2)
++out=$(printf hi )
+ 
+ # Valid: capture the command output directly.
+ out=$(printf hi)
+
+Fixed source:
+#!/bin/sh
+
+# Invalid: the command substitution writes its stdout to a file instead.
+out=$(printf hi )
+
+# Invalid: sending stdout to stderr also leaves nothing to capture.
+out=$(printf hi )
+
+# Valid: capture the command output directly.
+out=$(printf hi)
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__subst_with_redirect_err__tests__C058_fix_C058.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__subst_with_redirect_err__tests__C058_fix_C058.sh.snap
@@ -1,0 +1,50 @@
+---
+source: crates/shuck-linter/src/rules/correctness/subst_with_redirect_err.rs
+---
+Diagnostics:
+C058 command substitution redirects its output inside the subshell
+ --> <source>:4:5
+  |
+4 | out=$(printf hi >/dev/null 2>&1)
+  |
+
+C058 command substitution redirects its output inside the subshell
+ --> <source>:7:5
+  |
+7 | out=$(printf hi 1>/dev/null)
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/sh
+ 
+ # Invalid: redirecting inside the substitution makes the capture empty.
+-out=$(printf hi >/dev/null 2>&1)
++out=$(printf hi  2>&1)
+ 
+ # Invalid: an explicit stdout redirect has the same issue.
+-out=$(printf hi 1>/dev/null)
++out=$(printf hi )
+ 
+ # Valid: keep the redirect outside the substitution.
+ out=$(printf hi) >/dev/null 2>&1
+
+Fixed source:
+#!/bin/sh
+
+# Invalid: redirecting inside the substitution makes the capture empty.
+out=$(printf hi  2>&1)
+
+# Invalid: an explicit stdout redirect has the same issue.
+out=$(printf hi )
+
+# Valid: keep the redirect outside the substitution.
+out=$(printf hi) >/dev/null 2>&1
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C007_C007.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C007_C007.sh.snap
@@ -14,7 +14,13 @@ C007 raw `find` output piped to `xargs` can break on whitespace
   |
 
 C007 raw `find` output piped to `xargs` can break on whitespace
-  --> <source>:10:11
+  --> <source>:10:1
    |
-10 | summary=$(find . -type f | xargs wc -l)
+10 | find "$pkg" -print0 | xargs rm
+   |
+
+C007 raw `find` output piped to `xargs` can break on whitespace
+  --> <source>:13:11
+   |
+13 | summary=$(find . -type f | xargs wc -l)
    |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C019_C019.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C019_C019.sh.snap
@@ -19,3 +19,9 @@ C019 this string test checks a fixed literal
   |
 6 | [[ -z baz ]]
   |
+
+C019 this string test checks a fixed literal
+ --> <source>:7:21
+  |
+7 | [ -z "${rootfs_path}_path" ]
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C050_C050.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C050_C050.sh.snap
@@ -6,3 +6,9 @@ C050 redirection targets should not use arithmetic expansion
   |
 6 | echo hi > "$((i++))"
   |
+
+C050 redirection targets should not use arithmetic expansion
+  --> <source>:12:16
+   |
+12 | echo hi > "$((i--))"
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__trap_string_expansion__tests__C008_fix_C008.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__trap_string_expansion__tests__C008_fix_C008.sh.snap
@@ -1,0 +1,57 @@
+---
+source: crates/shuck-linter/src/rules/correctness/trap_string_expansion.rs
+assertion_line: 171
+---
+Diagnostics:
+C008 double-quoted trap handlers expand variables when the trap is set
+ --> <source>:7:12
+  |
+7 | trap "echo $x" EXIT
+  |
+
+C008 double-quoted trap handlers expand variables when the trap is set
+  --> <source>:10:24
+   |
+10 | trap -- "printf '%s\n' $handler" INT
+   |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -4,10 +4,10 @@
+ handler='echo ready'
+ 
+ # Invalid: variables inside a double-quoted trap body expand immediately
+-trap "echo $x" EXIT
++trap 'echo $x' EXIT
+ 
+ # Invalid: the same issue applies with `trap --`
+-trap -- "printf '%s\n' $handler" INT
++trap -- 'printf '\''%s\n'\'' $handler' INT
+ 
+ # Valid: single quotes defer expansion until the trap runs
+ trap 'echo $x' TERM
+
+Fixed source:
+#!/bin/sh
+
+x=1
+handler='echo ready'
+
+# Invalid: variables inside a double-quoted trap body expand immediately
+trap 'echo $x' EXIT
+
+# Invalid: the same issue applies with `trap --`
+trap -- 'printf '\''%s\n'\'' $handler' INT
+
+# Valid: single quotes defer expansion until the trap runs
+trap 'echo $x' TERM
+
+# Valid: plain literal trap bodies are fine
+trap "echo ready" HUP
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__truthy_literal_test__tests__C020_fix_C020.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__truthy_literal_test__tests__C020_fix_C020.sh.snap
@@ -1,0 +1,57 @@
+---
+source: crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
+assertion_line: 428
+---
+Diagnostics:
+C020 this test checks a fixed literal instead of runtime data
+ --> <source>:4:3
+  |
+4 | [ 1 ]
+  |
+
+C020 this test checks a fixed literal instead of runtime data
+ --> <source>:5:6
+  |
+5 | test foo
+  |
+
+C020 this test checks a fixed literal instead of runtime data
+ --> <source>:6:4
+  |
+6 | [[ bar ]]
+  |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -1,9 +1,9 @@
+ #!/bin/bash
+ 
+ # Invalid: a bare literal in a test is predetermined
+-[ 1 ]
+-test foo
+-[[ bar ]]
++[ x ]
++test x
++[[ x ]]
+ 
+ # Valid: runtime values belong in these tests
+ [ "$value" ]
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: a bare literal in a test is predetermined
+[ x ]
+test x
+[[ x ]]
+
+# Valid: runtime values belong in these tests
+[ "$value" ]
+[[ $value ]]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unicode_quote_in_string__tests__C072_fix_C072.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unicode_quote_in_string__tests__C072_fix_C072.sh.snap
@@ -1,0 +1,35 @@
+---
+source: crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
+---
+Diagnostics:
+C072 a unicode smart quote appears inside a shell string
+ --> <source>:3:6
+  |
+3 | echo “hello”
+  |
+
+C072 a unicode smart quote appears inside a shell string
+ --> <source>:3:12
+  |
+3 | echo “hello”
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,3 +1,3 @@
+ #!/bin/sh
+ # shellcheck disable=1110
+-echo “hello”
++echo "hello"
+
+Fixed source:
+#!/bin/sh
+# shellcheck disable=1110
+echo "hello"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unquoted_globs_in_find__tests__C078_fix_C078.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unquoted_globs_in_find__tests__C078_fix_C078.sh.snap
@@ -1,0 +1,79 @@
+---
+source: crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
+assertion_line: 363
+---
+Diagnostics:
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:2:19
+  |
+2 | find . -exec echo *.txt {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:3:22
+  |
+3 | find . -exec echo foo[ab]bar {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:4:19
+  |
+4 | find . -exec echo $(basename "$dir") {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:5:19
+  |
+5 | find . -exec echo $(basename "$dir")* {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:5:37
+  |
+5 | find . -exec echo $(basename "$dir")* {} +
+  |
+
+C078 patterns in `find -exec` arguments expand before `find` runs
+ --> <source>:6:31
+  |
+6 | find . -execdir echo "$prefix"*.tmp {} \;
+  |
+
+
+Applied fixes: 5
+
+Diff:
+--- before
++++ after
+@@ -1,9 +1,9 @@
+ #!/bin/bash
+-find . -exec echo *.txt {} +
+-find . -exec echo foo[ab]bar {} +
+-find . -exec echo $(basename "$dir") {} +
+-find . -exec echo $(basename "$dir")* {} +
+-find . -execdir echo "$prefix"*.tmp {} \;
++find . -exec echo "*.txt" {} +
++find . -exec echo "foo[ab]bar" {} +
++find . -exec echo "$(basename "$dir")" {} +
++find . -exec echo "$(basename "$dir")*" {} +
++find . -execdir echo "${prefix}*.tmp" {} \;
+ 
+ find . -exec echo "$file" {} +
+ find . -exec echo "*.txt" {} +
+
+Fixed source:
+#!/bin/bash
+find . -exec echo "*.txt" {} +
+find . -exec echo "foo[ab]bar" {} +
+find . -exec echo "$(basename "$dir")" {} +
+find . -exec echo "$(basename "$dir")*" {} +
+find . -execdir echo "${prefix}*.tmp" {} \;
+
+find . -exec echo "$file" {} +
+find . -exec echo "*.txt" {} +
+find . -exec echo "$(basename "$dir")" {} +
+find . -name *.txt -print
+printf '*.txt'
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unused_assignment__tests__C001_fix_C001.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unused_assignment__tests__C001_fix_C001.sh.snap
@@ -1,0 +1,42 @@
+---
+source: crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+assertion_line: 180
+---
+Diagnostics:
+C001 variable `unused` is assigned but never used
+ --> <source>:4:1
+  |
+4 | unused=1
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ 
+ # Basic unused assignment
+-unused=1
++_=1
+ 
+ # Used assignment (no diagnostic)
+ used=1
+
+Fixed source:
+#!/bin/sh
+
+# Basic unused assignment
+_=1
+
+# Used assignment (no diagnostic)
+used=1
+echo "$used"
+
+# Exported variable (no diagnostic)
+export EXPORTED=1
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
+++ b/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SpaceAfterHashBang;
 
 impl Violation for SpaceAfterHashBang {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SpaceAfterHashBang
     }
@@ -10,18 +12,32 @@ impl Violation for SpaceAfterHashBang {
     fn message(&self) -> String {
         "remove the space so the shebang starts with `#!`".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the whitespace between `#` and `!`".to_owned())
+    }
 }
 
 pub fn space_after_hash_bang(checker: &mut Checker) {
-    if let Some(span) = checker.facts().space_after_hash_bang_span() {
-        checker.report(SpaceAfterHashBang, span);
+    if let Some((span, whitespace_span)) = checker
+        .facts()
+        .space_after_hash_bang_span()
+        .zip(checker.facts().space_after_hash_bang_whitespace_span())
+    {
+        checker.report_diagnostic_dedup(
+            crate::Diagnostic::new(SpaceAfterHashBang, span)
+                .with_fix(Fix::unsafe_edit(Edit::deletion(whitespace_span))),
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use super::*;
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, assert_diagnostics_diff};
 
     #[test]
     fn reports_space_after_hash_bang_on_first_line() {
@@ -67,5 +83,67 @@ mod tests {
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.start.column, 2);
         assert_eq!(diagnostics[0].span.end.column, 2);
+    }
+
+    #[test]
+    fn exposes_unsafe_fix_metadata_for_space_after_hash_bang() {
+        let source = "# \t!/bin/sh\n:\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("remove the whitespace between `#` and `!`")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_space_after_hash_bang() {
+        let source = "# \t!/bin/sh\n:\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SpaceAfterHashBang),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n:\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_header_cases_unchanged_when_fixing() {
+        for source in [
+            "#!/bin/sh\n:\n",
+            " #!/bin/sh\n:\n",
+            "# comment\n echo ok\n# !/bin/sh\n",
+            "echo ok\n# !/bin/sh\n",
+        ] {
+            let result = test_snippet_with_fix(
+                source,
+                &LinterSettings::for_rule(Rule::SpaceAfterHashBang),
+                Applicability::Unsafe,
+            );
+
+            assert_eq!(result.fixes_applied, 0);
+            assert_eq!(result.fixed_source, source);
+            assert!(result.fixed_diagnostics.is_empty());
+        }
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_c074_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C074.sh").as_path(),
+            &LinterSettings::for_rule(Rule::SpaceAfterHashBang),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C074_fix_C074.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/subst_with_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subst_with_redirect.rs
@@ -1,8 +1,13 @@
-use crate::{Checker, CommandSubstitutionKind, Rule, Violation};
+use crate::{
+    Checker, CommandSubstitutionKind, Edit, Fix, FixAvailability, Rule, SubstitutionOutputIntent,
+    Violation,
+};
 
 pub struct SubstWithRedirect;
 
 impl Violation for SubstWithRedirect {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SubstWithRedirect
     }
@@ -10,10 +15,14 @@ impl Violation for SubstWithRedirect {
     fn message(&self) -> String {
         "command substitution redirects its output away".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the stdout redirects from the substitution".to_owned())
+    }
 }
 
 pub fn subst_with_redirect(checker: &mut Checker) {
-    let spans = checker
+    let substitutions = checker
         .facts()
         .commands()
         .iter()
@@ -21,18 +30,39 @@ pub fn subst_with_redirect(checker: &mut Checker) {
             fact.substitution_facts()
                 .iter()
                 .filter(|substitution| substitution.kind() == CommandSubstitutionKind::Command)
-                .filter(|substitution| substitution.stdout_is_rerouted())
-                .map(|substitution| substitution.span())
+                .filter(|substitution| {
+                    substitution.stdout_intent() == SubstitutionOutputIntent::Rerouted
+                        && !substitution.stdout_redirect_spans().is_empty()
+                })
+                .cloned()
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || SubstWithRedirect);
+    let diagnostics = substitutions
+        .into_iter()
+        .map(|substitution| {
+            let edits = substitution
+                .stdout_redirect_spans()
+                .iter()
+                .copied()
+                .map(Edit::deletion)
+                .collect::<Vec<_>>();
+            crate::Diagnostic::new(SubstWithRedirect, substitution.span())
+                .with_fix(Fix::unsafe_edits(edits))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_only_rerouted_substitutions() {
@@ -61,5 +91,83 @@ declare -A map=([$(printf bye > \"$target\")]=1)
                 .collect::<Vec<_>>(),
             vec![8, 9, 10, 11, 13, 14]
         );
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\nout=$(printf hi > out.txt)\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubstWithRedirect));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("remove the stdout redirects from the substitution")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_rerouted_substitutions() {
+        let source = "\
+#!/bin/sh
+out=$(printf loud > out.txt)
+err=$(printf hi >&2)
+keep=$(printf hi 2>&1)
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SubstWithRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+out=$(printf loud )
+err=$(printf hi )
+keep=$(printf hi 2>&1)
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn keeps_nested_substitution_redirects_scoped_to_their_own_diagnostics() {
+        let source = "\
+#!/bin/sh
+out=$(printf '%s' \"$(printf hi > nested.txt)\" > outer.txt)
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SubstWithRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+out=$(printf '%s' \"$(printf hi )\" )
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C057.sh").as_path(),
+            &LinterSettings::for_rule(Rule::SubstWithRedirect),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C057_fix_C057.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/subst_with_redirect_err.rs
+++ b/crates/shuck-linter/src/rules/correctness/subst_with_redirect_err.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, CommandSubstitutionKind, Rule, Violation};
+use crate::{Checker, CommandSubstitutionKind, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SubstWithRedirectErr;
 
 impl Violation for SubstWithRedirectErr {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::SubstWithRedirectErr
     }
@@ -10,10 +12,14 @@ impl Violation for SubstWithRedirectErr {
     fn message(&self) -> String {
         "command substitution redirects its output inside the subshell".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the stdout-to-`/dev/null` redirects".to_owned())
+    }
 }
 
 pub fn subst_with_redirect_err(checker: &mut Checker) {
-    let spans = checker
+    let substitutions = checker
         .facts()
         .commands()
         .iter()
@@ -22,17 +28,32 @@ pub fn subst_with_redirect_err(checker: &mut Checker) {
                 .iter()
                 .filter(|substitution| substitution.kind() == CommandSubstitutionKind::Command)
                 .filter(|substitution| substitution.stdout_is_discarded())
-                .map(|substitution| substitution.span())
+                .cloned()
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || SubstWithRedirectErr);
+    for substitution in substitutions {
+        let diagnostic = crate::Diagnostic::new(SubstWithRedirectErr, substitution.span());
+        let edits = substitution
+            .stdout_dev_null_redirect_spans()
+            .iter()
+            .copied()
+            .map(Edit::deletion)
+            .collect::<Vec<_>>();
+        if edits.is_empty() {
+            checker.report_diagnostic_dedup(diagnostic);
+        } else {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(Fix::unsafe_edits(edits)));
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn only_reports_substitutions_that_drop_output_to_dev_null() {
@@ -64,5 +85,107 @@ declare -A map=([$(printf bye 1>/dev/null)]=1)
                 .collect::<Vec<_>>(),
             vec![8, 9, 13, 14]
         );
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\nout=$(printf hi >/dev/null 2>&1)\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubstWithRedirectErr),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("remove the stdout-to-`/dev/null` redirects")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_discarded_substitutions() {
+        let source = "\
+#!/bin/sh
+out=$(printf hi >/dev/null 2>&1)
+other=$(printf hi 1>/dev/null)
+keep=$(printf hi > out.txt)
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SubstWithRedirectErr),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+out=$(printf hi  2>&1)
+other=$(printf hi )
+keep=$(printf hi > out.txt)
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_indirect_dev_null_redirects_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+out=$(printf hi 3>/dev/null 1>&3)
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SubstWithRedirectErr),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+        assert_eq!(
+            result.fixed_diagnostics[0].span.slice(source),
+            "$(printf hi 3>/dev/null 1>&3)"
+        );
+    }
+
+    #[test]
+    fn keeps_nested_substitution_redirects_scoped_to_their_own_diagnostics() {
+        let source = "\
+#!/bin/sh
+out=$(printf '%s' \"$(printf hi >/dev/null)\" >/dev/null)
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SubstWithRedirectErr),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+out=$(printf '%s' \"$(printf hi )\" )
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C058.sh").as_path(),
+            &LinterSettings::for_rule(Rule::SubstWithRedirectErr),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C058_fix_C058.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/trap_string_expansion.rs
+++ b/crates/shuck-linter/src/rules/correctness/trap_string_expansion.rs
@@ -1,8 +1,13 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, WordQuote};
+use crate::{
+    Checker, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation, WordOccurrenceRef,
+    WordQuote,
+};
 
 pub struct TrapStringExpansion;
 
 impl Violation for TrapStringExpansion {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::TrapStringExpansion
     }
@@ -10,31 +15,78 @@ impl Violation for TrapStringExpansion {
     fn message(&self) -> String {
         "double-quoted trap handlers expand variables when the trap is set".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the trap action with single quotes".to_owned())
+    }
 }
 
 pub fn trap_string_expansion(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .expansion_word_facts(ExpansionContext::TrapAction)
         .filter(|fact| fact.classification().quote == WordQuote::FullyQuoted)
-        .flat_map(|fact| fact.double_quoted_expansion_spans().iter().copied())
+        .flat_map(|fact| trap_string_expansion_diagnostics(fact, source))
         .collect::<Vec<_>>();
 
-    for span in spans {
-        checker.report_dedup(TrapStringExpansion, span);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
     }
+}
+
+fn trap_string_expansion_diagnostics(
+    fact: WordOccurrenceRef<'_, '_>,
+    source: &str,
+) -> Vec<crate::Diagnostic> {
+    let fix = fact
+        .single_quoted_equivalent_if_plain_double_quoted(source)
+        .map(|replacement| Fix::unsafe_edit(Edit::replacement(replacement, fact.span())));
+
+    fact.double_quoted_expansion_spans()
+        .iter()
+        .copied()
+        .map(|span| {
+            let diagnostic = crate::Diagnostic::new(TrapStringExpansion, span);
+            match fix.as_ref() {
+                Some(fix) => diagnostic.with_fix(fix.clone()),
+                None => diagnostic,
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, Diagnostic, LinterSettings, Rule, assert_diagnostics_diff};
+
+    fn c008_diagnostics(source: &str) -> Vec<Diagnostic> {
+        test_snippet(source, &LinterSettings::for_rule(Rule::TrapStringExpansion))
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata_for_plain_double_quoted_trap_actions() {
+        let source = "trap \"echo $x\" EXIT\n";
+        let diagnostics = c008_diagnostics(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("rewrite the trap action with single quotes")
+        );
+    }
 
     #[test]
     fn reports_each_expansion_inside_the_trap_action() {
         let source = "trap \"echo $x $(date) ${y}\" EXIT\n";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::TrapStringExpansion));
+        let diagnostics = c008_diagnostics(source);
 
         assert_eq!(
             diagnostics
@@ -48,8 +100,7 @@ mod tests {
     #[test]
     fn ignores_trap_listing_modes() {
         let source = "trap -p EXIT\ntrap -l TERM\n";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::TrapStringExpansion));
+        let diagnostics = c008_diagnostics(source);
 
         assert!(diagnostics.is_empty());
     }
@@ -61,9 +112,63 @@ trap foo\"$x\"bar EXIT
 trap \"$x\"\"$y\" EXIT
 trap 'result=$?; '\"delete_container $container msg\"' || : ; exit $result' EXIT
 ";
-        let diagnostics =
-            test_snippet(source, &LinterSettings::for_rule(Rule::TrapStringExpansion));
+        let diagnostics = c008_diagnostics(source);
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_plain_double_quoted_trap_actions() {
+        let source = "\
+#!/bin/sh
+trap \"echo $x $(date) ${y}\" EXIT
+trap -- \"printf '%s\\n' $handler \\$HOME \\\"ok\\\" \\`date\\`\" INT
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::TrapStringExpansion),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.diagnostics.len(), 4);
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+trap 'echo $x $(date) ${y}' EXIT
+trap -- 'printf '\\''%s\\n'\\'' $handler $HOME \"ok\" `date`' INT
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_locale_double_quoted_trap_actions_unchanged_when_fixing() {
+        let source = "#!/bin/bash\ntrap $\"echo $x\" EXIT\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::TrapStringExpansion),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.diagnostics.len(), 1);
+        assert!(result.diagnostics[0].fix.is_none());
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+        assert_eq!(result.fixed_diagnostics[0].span.slice(source), "$x");
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C008.sh").as_path(),
+            &LinterSettings::for_rule(Rule::TrapStringExpansion),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C008_fix_C008.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
@@ -1,10 +1,15 @@
-use shuck_ast::{ConditionalUnaryOp, Span};
+use shuck_ast::{ConditionalUnaryOp, Span, Word};
 
-use crate::{Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, Violation};
+use crate::{
+    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Edit, Fix, FixAvailability, Rule,
+    Violation, static_word_text,
+};
 
 pub struct TruthyLiteralTest;
 
 impl Violation for TruthyLiteralTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::TruthyLiteralTest
     }
@@ -12,44 +17,71 @@ impl Violation for TruthyLiteralTest {
     fn message(&self) -> String {
         "this test checks a fixed literal instead of runtime data".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace the bare test term with an explicit true or false literal".to_owned())
+    }
 }
 
 pub fn truthy_literal_test(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .flat_map(|fact| {
-            let mut spans = Vec::new();
+            let mut diagnostics = Vec::new();
             if let Some(simple_test) = fact.simple_test() {
-                spans.extend(simple_test_report_spans(simple_test, source));
+                diagnostics.extend(simple_test_diagnostics(simple_test, source));
             }
             if let Some(conditional) = fact.conditional() {
-                spans.extend(conditional_report_spans(conditional));
+                diagnostics.extend(conditional_diagnostics(conditional, source));
             }
-            spans
+            diagnostics
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || TruthyLiteralTest);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
-fn simple_test_report_spans(fact: &crate::SimpleTestFact<'_>, source: &str) -> Vec<Span> {
+fn simple_test_diagnostics(
+    fact: &crate::SimpleTestFact<'_>,
+    source: &str,
+) -> Vec<crate::Diagnostic> {
     fact.truthy_expression_words(source)
         .into_iter()
-        .filter_map(|word| {
-            fact.effective_operands()
-                .iter()
-                .position(|operand| operand.span == word.span)
-                .and_then(|index| fact.effective_operand_class(index))
-                .is_some_and(|class| class.is_fixed_literal())
-                .then_some(word.span)
-        })
+        .filter_map(|word| simple_test_diagnostic(fact, word, source))
         .collect()
 }
 
-fn conditional_report_spans(fact: &crate::ConditionalFact<'_>) -> Vec<Span> {
+fn simple_test_diagnostic(
+    fact: &crate::SimpleTestFact<'_>,
+    word: &Word,
+    source: &str,
+) -> Option<crate::Diagnostic> {
+    if truthy_word_is_explicit_boolean_literal(word, source) {
+        return None;
+    }
+
+    let index = fact
+        .effective_operands()
+        .iter()
+        .position(|operand| operand.span == word.span)?;
+    fact.effective_operand_class(index)
+        .filter(|class| class.is_fixed_literal())?;
+
+    diagnostic_for_truthy_literal(
+        word.span,
+        explicit_literal_replacement_for_word(word, source),
+    )
+}
+
+fn conditional_diagnostics(
+    fact: &crate::ConditionalFact<'_>,
+    source: &str,
+) -> Vec<crate::Diagnostic> {
     let excluded_operand_spans = fact
         .nodes()
         .iter()
@@ -85,17 +117,76 @@ fn conditional_report_spans(fact: &crate::ConditionalFact<'_>) -> Vec<Span> {
                         .word()
                         .is_some_and(|operand| !excluded_operand_spans.contains(&operand.span)) =>
             {
-                word.operand().word().map(|operand| operand.span)
+                conditional_diagnostic(word.operand(), source)
             }
             _ => None,
         })
         .collect()
 }
 
+fn conditional_diagnostic(
+    operand: crate::ConditionalOperandFact<'_>,
+    source: &str,
+) -> Option<crate::Diagnostic> {
+    let word = operand.word()?;
+    if truthy_word_is_explicit_boolean_literal(word, source) {
+        return None;
+    }
+
+    diagnostic_for_truthy_literal(
+        word.span,
+        explicit_literal_replacement_for_word(word, source),
+    )
+}
+
+fn diagnostic_for_truthy_literal(
+    span: Span,
+    replacement: &'static str,
+) -> Option<crate::Diagnostic> {
+    Some(
+        crate::Diagnostic::new(TruthyLiteralTest, span)
+            .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, span))),
+    )
+}
+
+const EMPTY_LITERAL_REPLACEMENT: &str = "\"\"";
+const NON_EMPTY_LITERAL_REPLACEMENT: &str = "x";
+
+fn explicit_literal_replacement_for_word(word: &Word, source: &str) -> &'static str {
+    explicit_literal_replacement_for_text(
+        static_word_text(word, source)
+            .as_deref()
+            .unwrap_or_else(|| word.span.slice(source)),
+    )
+}
+
+fn explicit_literal_replacement_for_text(text: &str) -> &'static str {
+    if text.is_empty() || quoted_literal_body(text).is_some_and(str::is_empty) {
+        EMPTY_LITERAL_REPLACEMENT
+    } else {
+        NON_EMPTY_LITERAL_REPLACEMENT
+    }
+}
+
+fn quoted_literal_body(text: &str) -> Option<&str> {
+    let quote = text.chars().next()?;
+    if !matches!(quote, '"' | '\'') {
+        return None;
+    }
+
+    text.strip_prefix(quote)?.strip_suffix(quote)
+}
+
+fn truthy_word_is_explicit_boolean_literal(word: &Word, source: &str) -> bool {
+    matches!(word.span.slice(source), "\"\"" | "x")
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn ignores_runtime_sensitive_literal_words() {
@@ -143,12 +234,12 @@ test foo
     fn anchors_truthy_simple_tests_on_the_operand() {
         let source = "\
 #!/bin/bash
-[ \"\" ]
+[ '' ]
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TruthyLiteralTest));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "\"\"");
+        assert_eq!(diagnostics[0].span.slice(source), "''");
     }
 
     #[test]
@@ -241,5 +332,106 @@ esac
                 ))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn ignores_explicit_boolean_literals() {
+        let source = "\
+#!/bin/bash
+[ x ]
+test \"\"
+[[ x ]]
+[[ \"\" ]]
+[ ! x ]
+[[ ! \"\" ]]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TruthyLiteralTest));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/bash\n[ 1 ]\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TruthyLiteralTest));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("replace the bare test term with an explicit true or false literal")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_truthy_literal_tests() {
+        let source = "\
+#!/bin/bash
+[ 1 ]
+test ''
+[[ ! bar ]]
+[[ foo || \"\" ]]
+[ \"$value\" ]
+[[ $value ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::TruthyLiteralTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ x ]
+test \"\"
+[[ ! x ]]
+[[ x || \"\" ]]
+[ \"$value\" ]
+[[ $value ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_explicit_boolean_literals_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[ x ]
+test \"\"
+[[ x ]]
+[[ \"\" ]]
+[ ! x ]
+[[ ! \"\" ]]
+[ \"$value\" ]
+[[ $value ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::TruthyLiteralTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C020.sh").as_path(),
+            &LinterSettings::for_rule(Rule::TruthyLiteralTest),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C020_fix_C020.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnicodeQuoteInString;
 
 impl Violation for UnicodeQuoteInString {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnicodeQuoteInString
     }
@@ -10,17 +12,39 @@ impl Violation for UnicodeQuoteInString {
     fn message(&self) -> String {
         "a unicode smart quote appears inside a shell string".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace the smart quote with a matching ASCII quote".to_owned())
+    }
 }
 
 pub fn unicode_quote_in_string(checker: &mut Checker) {
+    let source = checker.source();
     let spans = checker.facts().unicode_smart_quote_spans().to_vec();
-    checker.report_all_dedup(spans, || UnicodeQuoteInString);
+    for span in spans {
+        checker.report_diagnostic_dedup(Diagnostic::new(UnicodeQuoteInString, span).with_fix(
+            Fix::unsafe_edit(Edit::replacement(
+                ascii_quote_replacement(span.slice(source)),
+                span,
+            )),
+        ));
+    }
+}
+
+fn ascii_quote_replacement(quote: &str) -> &'static str {
+    match quote {
+        "\u{2018}" | "\u{2019}" => "'",
+        "\u{201C}" | "\u{201D}" => "\"",
+        _ => unreachable!("unicode smart quote spans should contain only smart quote characters"),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_unicode_smart_quotes_in_unquoted_shell_words() {
@@ -71,5 +95,80 @@ EOF
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata_for_unicode_smart_quotes() {
+        let source = "#!/bin/sh\necho “hello”\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnicodeQuoteInString),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert!(diagnostics.iter().all(|diagnostic| {
+            diagnostic.fix.as_ref().map(|fix| fix.applicability()) == Some(Applicability::Unsafe)
+        }));
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix_title.as_deref()
+                    == Some("replace the smart quote with a matching ASCII quote"))
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_unicode_smart_quotes() {
+        let source = "\
+#!/bin/sh
+echo “hello”
+echo ‘world’
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnicodeQuoteInString),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo \"hello\"
+echo 'world'
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_ascii_quoted_strings_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+echo \"hello “world”\"
+echo 'hello ‘world’'
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnicodeQuoteInString),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C072.sh").as_path(),
+            &LinterSettings::for_rule(Rule::UnicodeQuoteInString),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C072_fix_C072.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
@@ -1,10 +1,12 @@
 use rustc_hash::FxHashSet;
 
-use crate::{Checker, ExpansionContext, FactSpan, Rule, Violation};
+use crate::{Checker, Edit, ExpansionContext, FactSpan, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnquotedGlobsInFind;
 
 impl Violation for UnquotedGlobsInFind {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedGlobsInFind
     }
@@ -12,9 +14,14 @@ impl Violation for UnquotedGlobsInFind {
     fn message(&self) -> String {
         "patterns in `find -exec` arguments expand before `find` runs".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the full `find -exec` argument".to_owned())
+    }
 }
 
 pub fn unquoted_globs_in_find(checker: &mut Checker) {
+    let source = checker.source();
     let find_exec_argument_words = checker
         .facts()
         .commands()
@@ -31,25 +38,43 @@ pub fn unquoted_globs_in_find(checker: &mut Checker) {
         .flatten()
         .collect::<FxHashSet<_>>();
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| find_exec_argument_words.contains(&(fact.command_id(), fact.key())))
-        .flat_map(|fact| {
-            fact.unquoted_command_substitution_spans()
-                .iter()
-                .copied()
-                .chain(fact.unquoted_glob_pattern_spans(checker.source()))
-        })
+        .flat_map(|fact| diagnostics_for_find_exec_argument(source, fact))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedGlobsInFind);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn diagnostics_for_find_exec_argument(
+    source: &str,
+    fact: crate::facts::WordOccurrenceRef<'_, '_>,
+) -> Vec<crate::Diagnostic> {
+    let word_span = fact.span();
+    let replacement = fact.single_double_quoted_replacement(source);
+
+    fact.unquoted_command_substitution_spans()
+        .iter()
+        .copied()
+        .chain(fact.unquoted_glob_pattern_spans(source))
+        .map(|span| {
+            crate::Diagnostic::new(UnquotedGlobsInFind, span).with_fix(Fix::unsafe_edit(
+                Edit::replacement(replacement.clone(), word_span),
+            ))
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_globs_and_unquoted_substitutions_in_find_exec_arguments() {
@@ -77,6 +102,24 @@ find . -execdir echo \"$prefix\"*.tmp {} \\;
                 "*",
                 "*"
             ]
+        );
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/bash\nfind . -exec echo *.txt {} +\n";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedGlobsInFind));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "*");
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("quote the full `find -exec` argument")
         );
     }
 
@@ -253,5 +296,71 @@ find . -exec $(pick_cmd) {} \\;
                 .collect::<Vec<_>>(),
             vec!["*", "$(pick_cmd)"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_full_find_exec_argument_words() {
+        let source = "\
+#!/bin/bash
+find . -exec echo *.txt {} +
+find . -exec echo foo[ab]bar {} +
+find . -exec echo $(basename \"$dir\") {} +
+find . -exec echo $(basename \"$dir\")* {} +
+find . -execdir echo \"$prefix\"*.tmp {} \\;
+find . -exec zip -j $OUT/$(basename $dir).zip {} +
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedGlobsInFind),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 6);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+find . -exec echo \"*.txt\" {} +
+find . -exec echo \"foo[ab]bar\" {} +
+find . -exec echo \"$(basename \"$dir\")\" {} +
+find . -exec echo \"$(basename \"$dir\")*\" {} +
+find . -execdir echo \"${prefix}*.tmp\" {} \\;
+find . -exec zip -j \"${OUT}/$(basename $dir).zip\" {} +
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_quoted_or_non_find_exec_arguments_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+find . -exec echo \"$file\" {} +
+find . -exec echo \"*.txt\" {} +
+find . -exec echo \"$(basename \"$dir\")\" {} +
+find . -name *.txt -print
+printf '*.txt'
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedGlobsInFind),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C078.sh").as_path(),
+            &LinterSettings::for_rule(Rule::UnquotedGlobsInFind),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C078_fix_C078.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -4,7 +4,7 @@ use shuck_semantic::{
     Binding, BindingAttributes, BindingId, BindingKind, ScopeId, ScopeKind, SemanticModel,
 };
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 type BindingFamilyKey = (Option<ScopeId>, Option<ScopeId>, String);
 
@@ -13,12 +13,18 @@ pub struct UnusedAssignment {
 }
 
 impl Violation for UnusedAssignment {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnusedAssignment
     }
 
     fn message(&self) -> String {
         format!("variable `{}` is assigned but never used", self.name)
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rename the unused assignment target to `_`".to_owned())
     }
 }
 
@@ -134,11 +140,12 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        checker.report(
-            UnusedAssignment {
-                name: binding.name.to_string(),
-            },
-            binding.span,
+        let name = binding.name.to_string();
+        let span = binding.span;
+
+        checker.report_diagnostic(
+            Diagnostic::new(UnusedAssignment { name }, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement("_", span))),
         );
     }
 }
@@ -258,16 +265,108 @@ fn inherited_local_family_scope(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
-    fn anchors_on_variable_name_span() {
+    fn anchors_on_variable_name_span_and_attaches_fix_metadata() {
         let source = "#!/bin/sh\nunused=1\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "unused");
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("rename the unused assignment target to `_`")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_reported_assignment_targets() {
+        let source = "\
+#!/bin/bash
+unused=1
+arr[0]=x
+read -r read_target <<< \"value\"
+printf -v printf_target '%s' ok
+while getopts \"ab\" opt; do
+  :
+done
+((arith = 1))
+for item in a b; do
+  :
+done
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 7);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+_=1
+_[0]=x
+read -r _ <<< \"value\"
+printf -v _ '%s' ok
+while getopts \"ab\" _; do
+  :
+done
+((_ = 1))
+for _ in a b; do
+  :
+done
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_existing_underscore_targets_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+_=1
+_[0]=x
+read -r _ <<< \"value\"
+printf -v _ '%s' ok
+while getopts \"ab\" _; do
+  :
+done
+((_ = 1))
+for _ in a b; do
+  :
+done
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C001.sh").as_path(),
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C001_fix_C001.sh", result);
+        Ok(())
     }
 
     #[test]

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -954,7 +954,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 parent_scope,
                 span,
                 BindingOrigin::FunctionDefinition {
-                    definition_span: span,
+                    definition_span: function.span,
                 },
                 BindingAttributes::empty(),
             );


### PR DESCRIPTION
## What changed

This PR adds implemented autofixes for the currently completed backlog of documented linter fixes through `C083`.

Highlights include:
- wiring fix metadata and concrete edits into the completed rule set
- extending linter facts where rules needed precise edit spans instead of raw-source rediscovery
- adding focused rewrite coverage and snapshot coverage for the new fixes
- keeping the fixes aligned with the existing YAML metadata for safety and behavior

## Why it changed

A large set of rules already had fix descriptions in `docs/rules/`, but the linter still only emitted diagnostics for them. This PR closes that gap for the completed portion of the backlog so the CLI can actually apply those fixes.

## User impact

Users can now get autofixes for the landed backlog rules when running the fixer flows, including the new unsafe-fix paths where the YAML marks them as unsafe.

## Root cause

The rule specs had fix intent recorded, but the rule implementations were still missing `Fix` attachments, edit construction, and supporting fact-layer spans in a number of places.

## Validation

- Focused rule tests for each landed autofix
- Snapshot coverage for each landed autofix
- Repo-wide `make test`
- Repo-wide `make check`

## Notes

This PR is intentionally scoped to committed work through `C083`. The in-progress local `C084` work is not included.
