### PR TITLE
fix(compat): populate ShellCheck rule levels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,7 @@ new_category: Correctness
 new_code: C042
 runtime_kind: ast          # ast, semantic, or flow
 shellcheck_code: SC2034    # ShellCheck compatibility code, if applicable
+shellcheck_level: warning  # Populate from the ShellCheck oracle when shellcheck_code is set
 shells:
   - sh
   - bash
@@ -287,6 +288,13 @@ If the rule maps to a ShellCheck code, add the mapping in `crates/shuck-linter/s
 
 ```rust
 (2034, Rule::YourRuleName),  // SC2034
+```
+
+Then populate the matching ShellCheck log level in the rule metadata:
+
+```bash
+nix --extra-experimental-features 'nix-command flakes' develop --command \
+  python3 scripts/update_shellcheck_levels.py --rules C042
 ```
 
 ### Step 4: Implement the rule

--- a/docs/rules/C001.yaml
+++ b/docs/rules/C001.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C001
 runtime_kind: ast
 shellcheck_code: SC2034
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C002.yaml
+++ b/docs/rules/C002.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C002
 runtime_kind: ast
 shellcheck_code: SC1090
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C003.yaml
+++ b/docs/rules/C003.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C003
 runtime_kind: ast
 shellcheck_code: SC1091
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C004.yaml
+++ b/docs/rules/C004.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C004
 runtime_kind: ast
 shellcheck_code: SC2164
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C005.yaml
+++ b/docs/rules/C005.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C005
 runtime_kind: ast
 shellcheck_code: SC2016
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C006.yaml
+++ b/docs/rules/C006.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C006
 runtime_kind: ast
 shellcheck_code: SC2154
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C007.yaml
+++ b/docs/rules/C007.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C007
 runtime_kind: ast
 shellcheck_code: SC2038
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C008.yaml
+++ b/docs/rules/C008.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C008
 runtime_kind: ast
 shellcheck_code: SC2064
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C009.yaml
+++ b/docs/rules/C009.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C009
 runtime_kind: ast
 shellcheck_code: SC2076
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C010.yaml
+++ b/docs/rules/C010.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C010
 runtime_kind: ast
 shellcheck_code: SC2015
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C011.yaml
+++ b/docs/rules/C011.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C011
 runtime_kind: ast
 shellcheck_code: SC2013
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C012.yaml
+++ b/docs/rules/C012.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C012
 runtime_kind: ast
 shellcheck_code: SC2035
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C013.yaml
+++ b/docs/rules/C013.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C013
 runtime_kind: ast
 shellcheck_code: SC2044
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C014.yaml
+++ b/docs/rules/C014.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C014
 runtime_kind: ast
 shellcheck_code: SC2168
+shellcheck_level: error
 shells:
   - bash
   - dash

--- a/docs/rules/C015.yaml
+++ b/docs/rules/C015.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C015
 runtime_kind: ast
 shellcheck_code: SC2024
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C016.yaml
+++ b/docs/rules/C016.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C016
 runtime_kind: ast
 shellcheck_code: SC1089
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C017.yaml
+++ b/docs/rules/C017.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C017
 runtime_kind: ast
 shellcheck_code: SC2050
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C018.yaml
+++ b/docs/rules/C018.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C018
 runtime_kind: ast
 shellcheck_code: SC2105
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C019.yaml
+++ b/docs/rules/C019.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C019
 runtime_kind: ast
 shellcheck_code: SC2157
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C020.yaml
+++ b/docs/rules/C020.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C020
 runtime_kind: ast
 shellcheck_code: SC2078
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/C021.yaml
+++ b/docs/rules/C021.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C021
 runtime_kind: ast
 shellcheck_code: SC2194
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C022.yaml
+++ b/docs/rules/C022.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C022
 runtime_kind: ast
 shellcheck_code: SC2212
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/C023.yaml
+++ b/docs/rules/C023.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C023
 runtime_kind: ast
 shellcheck_code: SC2080
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C024.yaml
+++ b/docs/rules/C024.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C024
 runtime_kind: ast
 shellcheck_code: SC1007
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C025.yaml
+++ b/docs/rules/C025.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C025
 runtime_kind: ast
 shellcheck_code: SC1037
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C027.yaml
+++ b/docs/rules/C027.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C027
 runtime_kind: ast
 shellcheck_code: SC1010
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C030.yaml
+++ b/docs/rules/C030.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C030
 runtime_kind: ast
 shellcheck_code: SC1019
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C031.yaml
+++ b/docs/rules/C031.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C031
 runtime_kind: ast
 shellcheck_code: SC1020
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C032.yaml
+++ b/docs/rules/C032.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C032
 runtime_kind: ast
 shellcheck_code: SC1035
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C033.yaml
+++ b/docs/rules/C033.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C033
 runtime_kind: ast
 shellcheck_code: SC1039
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C034.yaml
+++ b/docs/rules/C034.yaml
@@ -3,6 +3,8 @@ legacy_name: unterminated-if
 new_category: Correctness
 new_code: C034
 runtime_kind: ast
+shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/C035.yaml
+++ b/docs/rules/C035.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C035
 runtime_kind: ast
 shellcheck_code: SC1047
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C036.yaml
+++ b/docs/rules/C036.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C036
 runtime_kind: ast
 shellcheck_code: SC1073
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C037.yaml
+++ b/docs/rules/C037.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C037
 runtime_kind: ast
 shellcheck_code: SC1072
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C038.yaml
+++ b/docs/rules/C038.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C038
 runtime_kind: ast
 shellcheck_code: SC1075
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C039.yaml
+++ b/docs/rules/C039.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C039
 runtime_kind: ast
 shellcheck_code: SC1078
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C040.yaml
+++ b/docs/rules/C040.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C040
 runtime_kind: ast
 shellcheck_code: SC1080
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C041.yaml
+++ b/docs/rules/C041.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C041
 runtime_kind: ast
 shellcheck_code: SC1127
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C042.yaml
+++ b/docs/rules/C042.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C042
 runtime_kind: ast
 shellcheck_code: SC1132
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C043.yaml
+++ b/docs/rules/C043.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C043
 runtime_kind: ast
 shellcheck_code: SC2210
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C044.yaml
+++ b/docs/rules/C044.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C044
 runtime_kind: ast
 shellcheck_code: SC2211
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C045.yaml
+++ b/docs/rules/C045.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C045
 runtime_kind: ast
 shellcheck_code: SC2215
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C046.yaml
+++ b/docs/rules/C046.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C046
 runtime_kind: ast
 shellcheck_code: SC2216
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C047.yaml
+++ b/docs/rules/C047.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C047
 runtime_kind: ast
 shellcheck_code: SC2242
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C048.yaml
+++ b/docs/rules/C048.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C048
 runtime_kind: ast
 shellcheck_code: SC2254
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C049.yaml
+++ b/docs/rules/C049.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C049
 runtime_kind: ast
 shellcheck_code: SC2252
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C050.yaml
+++ b/docs/rules/C050.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C050
 runtime_kind: ast
 shellcheck_code: SC2257
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C051.yaml
+++ b/docs/rules/C051.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C051
 runtime_kind: ast
 shellcheck_code: SC2261
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C052.yaml
+++ b/docs/rules/C052.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C052
 runtime_kind: ast
 shellcheck_code: SC2280
+shellcheck_level: error
 shells:
   - sh
 description: Assigning to the script-name parameter is rejected.

--- a/docs/rules/C053.yaml
+++ b/docs/rules/C053.yaml
@@ -3,6 +3,8 @@ legacy_name: spacey-assign
 new_category: Correctness
 new_code: C053
 runtime_kind: ast
+shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/C054.yaml
+++ b/docs/rules/C054.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C054
 runtime_kind: ast
 shellcheck_code: SC2248
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C055.yaml
+++ b/docs/rules/C055.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C055
 runtime_kind: ast
 shellcheck_code: SC2295
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C056.yaml
+++ b/docs/rules/C056.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C056
 runtime_kind: ast
 shellcheck_code: SC2319
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C057.yaml
+++ b/docs/rules/C057.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C057
 runtime_kind: ast
 shellcheck_code: SC2255
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C058.yaml
+++ b/docs/rules/C058.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C058
 runtime_kind: ast
 shellcheck_code: SC2256
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C059.yaml
+++ b/docs/rules/C059.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C059
 runtime_kind: ast
 shellcheck_code: SC2238
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C060.yaml
+++ b/docs/rules/C060.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C060
 runtime_kind: ast
 shellcheck_code: SC2239
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C061.yaml
+++ b/docs/rules/C061.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C061
 runtime_kind: ast
 shellcheck_code: SC2288
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C062.yaml
+++ b/docs/rules/C062.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C062
 runtime_kind: ast
 shellcheck_code: SC2264
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C063.yaml
+++ b/docs/rules/C063.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C063
 runtime_kind: ast
 shellcheck_code: SC2329
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C064.yaml
+++ b/docs/rules/C064.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C064
 runtime_kind: ast
 shellcheck_code: SC1049
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C065.yaml
+++ b/docs/rules/C065.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C065
 runtime_kind: ast
 shellcheck_code: SC2271
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C066.yaml
+++ b/docs/rules/C066.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C066
 runtime_kind: ast
 shellcheck_code: SC2272
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C067.yaml
+++ b/docs/rules/C067.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C067
 runtime_kind: ast
 shellcheck_code: SC2273
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C068.yaml
+++ b/docs/rules/C068.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C068
 runtime_kind: ast
 shellcheck_code: SC2274
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C069.yaml
+++ b/docs/rules/C069.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C069
 runtime_kind: ast
 shellcheck_code: SC1101
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C070.yaml
+++ b/docs/rules/C070.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C070
 runtime_kind: ast
 shellcheck_code: SC1102
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C071.yaml
+++ b/docs/rules/C071.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C071
 runtime_kind: ast
 shellcheck_code: SC1105
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C072.yaml
+++ b/docs/rules/C072.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C072
 runtime_kind: ast
 shellcheck_code: SC1110
+shellcheck_level: warning
 shells:
   - sh
   - bash
@@ -21,4 +22,4 @@ examples:
     source: shell-checks/examples/189.sh
     code: |
       #!/bin/sh
-      echo "hello "world"
+      echo “hello”

--- a/docs/rules/C073.yaml
+++ b/docs/rules/C073.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C073
 runtime_kind: ast
 shellcheck_code: SC1114
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C074.yaml
+++ b/docs/rules/C074.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C074
 runtime_kind: ast
 shellcheck_code: SC1115
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C075.yaml
+++ b/docs/rules/C075.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C075
 runtime_kind: ast
 shellcheck_code: SC1128
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C076.yaml
+++ b/docs/rules/C076.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C076
 runtime_kind: ast
 shellcheck_code: SC1143
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C077.yaml
+++ b/docs/rules/C077.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C077
 runtime_kind: ast
 shellcheck_code: SC2290
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/C078.yaml
+++ b/docs/rules/C078.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C078
 runtime_kind: ast
 shellcheck_code: SC2014
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C080.yaml
+++ b/docs/rules/C080.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C080
 runtime_kind: ast
 shellcheck_code: SC2022
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C081.yaml
+++ b/docs/rules/C081.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C081
 runtime_kind: ast
 shellcheck_code: SC2053
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C082.yaml
+++ b/docs/rules/C082.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C082
 runtime_kind: ast
 shellcheck_code: SC2057
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C083.yaml
+++ b/docs/rules/C083.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C083
 runtime_kind: ast
 shellcheck_code: SC2061
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C084.yaml
+++ b/docs/rules/C084.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C084
 runtime_kind: ast
 shellcheck_code: SC2062
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C085.yaml
+++ b/docs/rules/C085.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C085
 runtime_kind: ast
 shellcheck_code: SC2069
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C086.yaml
+++ b/docs/rules/C086.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C086
 runtime_kind: ast
 shellcheck_code: SC2071
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C087.yaml
+++ b/docs/rules/C087.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C087
 runtime_kind: ast
 shellcheck_code: SC2072
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C088.yaml
+++ b/docs/rules/C088.yaml
@@ -3,6 +3,8 @@ legacy_name: mixed-and-or-in-condition
 new_category: Correctness
 new_code: C088
 runtime_kind: ast
+shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/C089.yaml
+++ b/docs/rules/C089.yaml
@@ -3,6 +3,8 @@ legacy_name: quoted-command-in-test
 new_category: Correctness
 new_code: C089
 runtime_kind: ast
+shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/C090.yaml
+++ b/docs/rules/C090.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C090
 runtime_kind: ast
 shellcheck_code: SC2081
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C091.yaml
+++ b/docs/rules/C091.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C091
 runtime_kind: ast
 shellcheck_code: SC2088
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C092.yaml
+++ b/docs/rules/C092.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C092
 runtime_kind: ast
 shellcheck_code: SC2091
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C093.yaml
+++ b/docs/rules/C093.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C093
 runtime_kind: ast
 shellcheck_code: SC2092
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C094.yaml
+++ b/docs/rules/C094.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C094
 runtime_kind: ast
 shellcheck_code: SC2094
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C095.yaml
+++ b/docs/rules/C095.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C095
 runtime_kind: ast
 shellcheck_code: SC2100
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C096.yaml
+++ b/docs/rules/C096.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C096
 runtime_kind: ast
 shellcheck_code: SC2102
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C097.yaml
+++ b/docs/rules/C097.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C097
 runtime_kind: ast
 shellcheck_code: SC2120
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C098.yaml
+++ b/docs/rules/C098.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C098
 runtime_kind: ast
 shellcheck_code: SC2121
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C099.yaml
+++ b/docs/rules/C099.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C099
 runtime_kind: ast
 shellcheck_code: SC2124
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C100.yaml
+++ b/docs/rules/C100.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C100
 runtime_kind: ast
 shellcheck_code: SC2128
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C101.yaml
+++ b/docs/rules/C101.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C101
 runtime_kind: ast
 shellcheck_code: SC2141
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C102.yaml
+++ b/docs/rules/C102.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C102
 runtime_kind: ast
 shellcheck_code: SC2144
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C103.yaml
+++ b/docs/rules/C103.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C103
 runtime_kind: ast
 shellcheck_code: SC2146
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C104.yaml
+++ b/docs/rules/C104.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C104
 runtime_kind: ast
 shellcheck_code: SC2333
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C105.yaml
+++ b/docs/rules/C105.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C105
 runtime_kind: ast
 shellcheck_code: SC2163
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C106.yaml
+++ b/docs/rules/C106.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C106
 runtime_kind: ast
 shellcheck_code: SC2336
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C107.yaml
+++ b/docs/rules/C107.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C107
 runtime_kind: ast
 shellcheck_code: SC2181
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/C108.yaml
+++ b/docs/rules/C108.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C108
 runtime_kind: ast
 shellcheck_code: SC2184
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C109.yaml
+++ b/docs/rules/C109.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C109
 runtime_kind: ast
 shellcheck_code: SC2339
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C110.yaml
+++ b/docs/rules/C110.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C110
 runtime_kind: ast
 shellcheck_code: SC2341
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C111.yaml
+++ b/docs/rules/C111.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C111
 runtime_kind: ast
 shellcheck_code: SC2198
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C112.yaml
+++ b/docs/rules/C112.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C112
 runtime_kind: ast
 shellcheck_code: SC2199
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C114.yaml
+++ b/docs/rules/C114.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C114
 runtime_kind: ast
 shellcheck_code: SC2231
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C116.yaml
+++ b/docs/rules/C116.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C116
 runtime_kind: ast
 shellcheck_code: SC2270
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C117.yaml
+++ b/docs/rules/C117.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C117
 runtime_kind: ast
 shellcheck_code: SC2276
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C118.yaml
+++ b/docs/rules/C118.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C118
 runtime_kind: ast
 shellcheck_code: SC1076
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C119.yaml
+++ b/docs/rules/C119.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C119
 runtime_kind: ast
 shellcheck_code: SC2260
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C120.yaml
+++ b/docs/rules/C120.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C120
 runtime_kind: ast
 shellcheck_code: SC2308
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C121.yaml
+++ b/docs/rules/C121.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C121
 runtime_kind: ast
 shellcheck_code: SC2309
+shellcheck_level: warning
 shells:
   - bash
   - ksh

--- a/docs/rules/C122.yaml
+++ b/docs/rules/C122.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C122
 runtime_kind: ast
 shellcheck_code: SC2331
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/C123.yaml
+++ b/docs/rules/C123.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C123
 runtime_kind: ast
 shellcheck_code: SC2119
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C124.yaml
+++ b/docs/rules/C124.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C124
 runtime_kind: ast
 shellcheck_code: SC2365
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C125.yaml
+++ b/docs/rules/C125.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C125
 runtime_kind: ast
 shellcheck_code: SC2103
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C126.yaml
+++ b/docs/rules/C126.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C126
 runtime_kind: ast
 shellcheck_code: SC2104
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C127.yaml
+++ b/docs/rules/C127.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C127
 runtime_kind: ast
 shellcheck_code: SC2370
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C128.yaml
+++ b/docs/rules/C128.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C128
 runtime_kind: ast
 shellcheck_code: SC2221
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C129.yaml
+++ b/docs/rules/C129.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C129
 runtime_kind: ast
 shellcheck_code: SC2222
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C130.yaml
+++ b/docs/rules/C130.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C130
 runtime_kind: ast
 shellcheck_code: SC2089
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C131.yaml
+++ b/docs/rules/C131.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C131
 runtime_kind: ast
 shellcheck_code: SC2090
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C132.yaml
+++ b/docs/rules/C132.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C132
 runtime_kind: ast
 shellcheck_code: SC2098
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C133.yaml
+++ b/docs/rules/C133.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C133
 runtime_kind: ast
 shellcheck_code: SC2178
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C134.yaml
+++ b/docs/rules/C134.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C134
 runtime_kind: ast
 shellcheck_code: SC2213
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C135.yaml
+++ b/docs/rules/C135.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C135
 runtime_kind: ast
 shellcheck_code: SC2214
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C136.yaml
+++ b/docs/rules/C136.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C136
 runtime_kind: ast
 shellcheck_code: SC2318
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C137.yaml
+++ b/docs/rules/C137.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C137
 runtime_kind: ast
 shellcheck_code: SC1112
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C138.yaml
+++ b/docs/rules/C138.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C138
 runtime_kind: ast
 shellcheck_code: SC1044
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C139.yaml
+++ b/docs/rules/C139.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C139
 runtime_kind: ast
 shellcheck_code: SC2387
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C140.yaml
+++ b/docs/rules/C140.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C140
 runtime_kind: ast
 shellcheck_code: SC2282
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C141.yaml
+++ b/docs/rules/C141.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C141
 runtime_kind: ast
 shellcheck_code: SC2389
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C142.yaml
+++ b/docs/rules/C142.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C142
 runtime_kind: ast
 shellcheck_code: SC2390
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C143.yaml
+++ b/docs/rules/C143.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C143
 runtime_kind: ast
 shellcheck_code: SC2391
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C144.yaml
+++ b/docs/rules/C144.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C144
 runtime_kind: ast
 shellcheck_code: SC1041
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C145.yaml
+++ b/docs/rules/C145.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C145
 runtime_kind: ast
 shellcheck_code: SC1042
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C146.yaml
+++ b/docs/rules/C146.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C146
 runtime_kind: ast
 shellcheck_code: SC2396
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/C148.yaml
+++ b/docs/rules/C148.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C148
 runtime_kind: ast
 shellcheck_code: SC2399
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C150.yaml
+++ b/docs/rules/C150.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C150
 runtime_kind: ast
 shellcheck_code: SC2030
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C151.yaml
+++ b/docs/rules/C151.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C151
 runtime_kind: ast
 shellcheck_code: SC2054
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/C155.yaml
+++ b/docs/rules/C155.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C155
 runtime_kind: ast
 shellcheck_code: SC2031
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C156.yaml
+++ b/docs/rules/C156.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C156
 runtime_kind: ast
 shellcheck_code: SC2153
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/C157.yaml
+++ b/docs/rules/C157.yaml
@@ -4,6 +4,7 @@ new_category: Correctness
 new_code: C157
 runtime_kind: ast
 shellcheck_code: SC1069
+shellcheck_level: error
 shells:
   - sh
 description: The `if` keyword is concatenated with a `[` test.

--- a/docs/rules/K001.yaml
+++ b/docs/rules/K001.yaml
@@ -4,6 +4,7 @@ new_category: Security
 new_code: K001
 runtime_kind: ast
 shellcheck_code: SC2115
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/K002.yaml
+++ b/docs/rules/K002.yaml
@@ -4,6 +4,7 @@ new_category: Security
 new_code: K002
 runtime_kind: ast
 shellcheck_code: SC2029
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/K003.yaml
+++ b/docs/rules/K003.yaml
@@ -4,6 +4,7 @@ new_category: Security
 new_code: K003
 runtime_kind: ast
 shellcheck_code: SC2294
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/K004.yaml
+++ b/docs/rules/K004.yaml
@@ -4,6 +4,7 @@ new_category: Security
 new_code: K004
 runtime_kind: ast
 shellcheck_code: SC2156
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/K006.yaml
+++ b/docs/rules/K006.yaml
@@ -4,6 +4,7 @@ new_category: Security
 new_code: K006
 runtime_kind: ast
 shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/K007.yaml
+++ b/docs/rules/K007.yaml
@@ -4,6 +4,7 @@ new_category: Security
 new_code: K007
 runtime_kind: ast
 shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/K008.yaml
+++ b/docs/rules/K008.yaml
@@ -4,6 +4,7 @@ new_category: Security
 new_code: K008
 runtime_kind: ast
 shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/P001.yaml
+++ b/docs/rules/P001.yaml
@@ -4,6 +4,7 @@ new_category: Performance
 new_code: P001
 runtime_kind: ast
 shellcheck_code: SC2003
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/P002.yaml
+++ b/docs/rules/P002.yaml
@@ -4,6 +4,7 @@ new_category: Performance
 new_code: P002
 runtime_kind: ast
 shellcheck_code: SC2126
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/P003.yaml
+++ b/docs/rules/P003.yaml
@@ -4,6 +4,7 @@ new_category: Performance
 new_code: P003
 runtime_kind: ast
 shellcheck_code: SC2233
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/P004.yaml
+++ b/docs/rules/P004.yaml
@@ -4,6 +4,7 @@ new_category: Performance
 new_code: P004
 runtime_kind: ast
 shellcheck_code: SC2235
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S001.yaml
+++ b/docs/rules/S001.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S001
 runtime_kind: ast
 shellcheck_code: SC2086
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S002.yaml
+++ b/docs/rules/S002.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S002
 runtime_kind: ast
 shellcheck_code: SC2162
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S003.yaml
+++ b/docs/rules/S003.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S003
 runtime_kind: ast
 shellcheck_code: SC2045
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S004.yaml
+++ b/docs/rules/S004.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S004
 runtime_kind: ast
 shellcheck_code: SC2046
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S005.yaml
+++ b/docs/rules/S005.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S005
 runtime_kind: ast
 shellcheck_code: SC2006
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S006.yaml
+++ b/docs/rules/S006.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S006
 runtime_kind: ast
 shellcheck_code: SC2007
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S007.yaml
+++ b/docs/rules/S007.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S007
 runtime_kind: ast
 shellcheck_code: SC2059
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S008.yaml
+++ b/docs/rules/S008.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S008
 runtime_kind: ast
 shellcheck_code: SC2068
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S009.yaml
+++ b/docs/rules/S009.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S009
 runtime_kind: ast
 shellcheck_code: SC2005
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S010.yaml
+++ b/docs/rules/S010.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S010
 runtime_kind: ast
 shellcheck_code: SC2155
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S011.yaml
+++ b/docs/rules/S011.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S011
 runtime_kind: ast
 shellcheck_code: SC2166
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S012.yaml
+++ b/docs/rules/S012.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S012
 runtime_kind: ast
 shellcheck_code: SC2009
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S013.yaml
+++ b/docs/rules/S013.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S013
 runtime_kind: ast
 shellcheck_code: SC2010
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S014.yaml
+++ b/docs/rules/S014.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S014
 runtime_kind: ast
 shellcheck_code: SC2048
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S015.yaml
+++ b/docs/rules/S015.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S015
 runtime_kind: ast
 shellcheck_code: SC2066
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S016.yaml
+++ b/docs/rules/S016.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S016
 runtime_kind: ast
 shellcheck_code: SC2116
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S017.yaml
+++ b/docs/rules/S017.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S017
 runtime_kind: ast
 shellcheck_code: SC2206
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S018.yaml
+++ b/docs/rules/S018.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S018
 runtime_kind: ast
 shellcheck_code: SC2207
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S019.yaml
+++ b/docs/rules/S019.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S019
 runtime_kind: ast
 shellcheck_code: SC2143
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S020.yaml
+++ b/docs/rules/S020.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S020
 runtime_kind: ast
 shellcheck_code: SC2043
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S021.yaml
+++ b/docs/rules/S021.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S021
 runtime_kind: ast
 shellcheck_code: SC2145
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S022.yaml
+++ b/docs/rules/S022.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S022
 runtime_kind: ast
 shellcheck_code: SC2219
+shellcheck_level: style
 shells:
   - bash
   - ksh

--- a/docs/rules/S023.yaml
+++ b/docs/rules/S023.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S023
 runtime_kind: ast
 shellcheck_code: SC1001
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S024.yaml
+++ b/docs/rules/S024.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S024
 runtime_kind: ast
 shellcheck_code: SC1003
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S025.yaml
+++ b/docs/rules/S025.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S025
 runtime_kind: ast
 shellcheck_code: SC1004
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S028.yaml
+++ b/docs/rules/S028.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S028
 runtime_kind: ast
 shellcheck_code: SC1079
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S029.yaml
+++ b/docs/rules/S029.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S029
 runtime_kind: ast
 shellcheck_code: SC1083
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S030.yaml
+++ b/docs/rules/S030.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S030
 runtime_kind: ast
 shellcheck_code: SC1118
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S031.yaml
+++ b/docs/rules/S031.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S031
 runtime_kind: ast
 shellcheck_code: SC1126
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S032.yaml
+++ b/docs/rules/S032.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S032
 runtime_kind: ast
 shellcheck_code: SC2209
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S033.yaml
+++ b/docs/rules/S033.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S033
 runtime_kind: ast
 shellcheck_code: SC2217
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S034.yaml
+++ b/docs/rules/S034.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S034
 runtime_kind: ast
 shellcheck_code: SC2321
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S035.yaml
+++ b/docs/rules/S035.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S035
 runtime_kind: ast
 shellcheck_code: SC2323
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S036.yaml
+++ b/docs/rules/S036.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S036
 runtime_kind: ast
 shellcheck_code: SC3061
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/S037.yaml
+++ b/docs/rules/S037.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S037
 runtime_kind: ast
 shellcheck_code: SC2291
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S038.yaml
+++ b/docs/rules/S038.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S038
 runtime_kind: ast
 shellcheck_code: SC2265
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S039.yaml
+++ b/docs/rules/S039.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S039
 runtime_kind: ast
 shellcheck_code: SC1011
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S040.yaml
+++ b/docs/rules/S040.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S040
 runtime_kind: ast
 shellcheck_code: SC1012
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S041.yaml
+++ b/docs/rules/S041.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S041
 runtime_kind: ast
 shellcheck_code: SC1064
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S042.yaml
+++ b/docs/rules/S042.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S042
 runtime_kind: ast
 shellcheck_code: SC1097
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S043.yaml
+++ b/docs/rules/S043.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S043
 runtime_kind: ast
 shellcheck_code: SC2148
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S044.yaml
+++ b/docs/rules/S044.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S044
 runtime_kind: ast
 shellcheck_code: SC2001
+shellcheck_level: style
 shells:
   - bash
   - ksh

--- a/docs/rules/S045.yaml
+++ b/docs/rules/S045.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S045
 runtime_kind: ast
 shellcheck_code: SC2004
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S046.yaml
+++ b/docs/rules/S046.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S046
 runtime_kind: ast
 shellcheck_code: SC2011
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S047.yaml
+++ b/docs/rules/S047.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S047
 runtime_kind: ast
 shellcheck_code: SC2012
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S049.yaml
+++ b/docs/rules/S049.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S049
 runtime_kind: ast
 shellcheck_code: SC2021
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S050.yaml
+++ b/docs/rules/S050.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S050
 runtime_kind: ast
 shellcheck_code: SC2026
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S051.yaml
+++ b/docs/rules/S051.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S051
 runtime_kind: ast
 shellcheck_code: SC2060
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S052.yaml
+++ b/docs/rules/S052.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S052
 runtime_kind: ast
 shellcheck_code: SC2070
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S053.yaml
+++ b/docs/rules/S053.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S053
 runtime_kind: ast
 shellcheck_code: SC2096
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S054.yaml
+++ b/docs/rules/S054.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S054
 runtime_kind: ast
 shellcheck_code: SC2117
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S055.yaml
+++ b/docs/rules/S055.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S055
 runtime_kind: ast
 shellcheck_code: SC2125
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S056.yaml
+++ b/docs/rules/S056.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S056
 runtime_kind: ast
 shellcheck_code: SC2139
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S057.yaml
+++ b/docs/rules/S057.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S057
 runtime_kind: ast
 shellcheck_code: SC2142
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S058.yaml
+++ b/docs/rules/S058.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S058
 runtime_kind: ast
 shellcheck_code: SC2335
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S059.yaml
+++ b/docs/rules/S059.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S059
 runtime_kind: ast
 shellcheck_code: SC2186
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S060.yaml
+++ b/docs/rules/S060.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S060
 runtime_kind: ast
 shellcheck_code: SC2196
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S061.yaml
+++ b/docs/rules/S061.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S061
 runtime_kind: ast
 shellcheck_code: SC2197
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S062.yaml
+++ b/docs/rules/S062.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S062
 runtime_kind: ast
 shellcheck_code: SC2223
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S063.yaml
+++ b/docs/rules/S063.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S063
 runtime_kind: ast
 shellcheck_code: SC2347
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S064.yaml
+++ b/docs/rules/S064.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S064
 runtime_kind: ast
 shellcheck_code: SC2267
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/S065.yaml
+++ b/docs/rules/S065.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S065
 runtime_kind: ast
 shellcheck_code: SC2268
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S066.yaml
+++ b/docs/rules/S066.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S066
 runtime_kind: ast
 shellcheck_code: SC2316
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S067.yaml
+++ b/docs/rules/S067.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S067
 runtime_kind: ast
 shellcheck_code: SC2063
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S068.yaml
+++ b/docs/rules/S068.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S068
 runtime_kind: ast
 shellcheck_code: SC2369
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S069.yaml
+++ b/docs/rules/S069.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S069
 runtime_kind: ast
 shellcheck_code: SC2220
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S070.yaml
+++ b/docs/rules/S070.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S070
 runtime_kind: ast
 shellcheck_code: SC2027
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S071.yaml
+++ b/docs/rules/S071.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S071
 runtime_kind: ast
 shellcheck_code: SC2097
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S072.yaml
+++ b/docs/rules/S072.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S072
 runtime_kind: ast
 shellcheck_code: SC1133
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S073.yaml
+++ b/docs/rules/S073.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S073
 runtime_kind: ast
 shellcheck_code: SC1040
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S074.yaml
+++ b/docs/rules/S074.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S074
 runtime_kind: ast
 shellcheck_code: SC1045
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/S075.yaml
+++ b/docs/rules/S075.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S075
 runtime_kind: ast
 shellcheck_code: SC2129
+shellcheck_level: style
 shells:
   - sh
   - bash

--- a/docs/rules/S076.yaml
+++ b/docs/rules/S076.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S076
 runtime_kind: ast
 shellcheck_code: SC2140
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/S077.yaml
+++ b/docs/rules/S077.yaml
@@ -4,6 +4,7 @@ new_category: Style
 new_code: S077
 runtime_kind: ast
 shellcheck_code: SC1087
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X001.yaml
+++ b/docs/rules/X001.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X001
 runtime_kind: ast
 shellcheck_code: SC3010
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X002.yaml
+++ b/docs/rules/X002.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X002
 runtime_kind: ast
 shellcheck_code: SC3014
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X003.yaml
+++ b/docs/rules/X003.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X003
 runtime_kind: ast
 shellcheck_code: SC3043
+shellcheck_level: warning
 shells:
   - sh
 description: Using `local` in a function ties the script to shells that implement function-scoped variables.

--- a/docs/rules/X004.yaml
+++ b/docs/rules/X004.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X004
 runtime_kind: ast
 shellcheck_code: SC2113
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X005.yaml
+++ b/docs/rules/X005.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X005
 runtime_kind: ast
 shellcheck_code: SC2127
+shellcheck_level: error
 shells:
   - sh
   - dash

--- a/docs/rules/X006.yaml
+++ b/docs/rules/X006.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X006
 runtime_kind: ast
 shellcheck_code: SC3001
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X007.yaml
+++ b/docs/rules/X007.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X007
 runtime_kind: ast
 shellcheck_code: SC3003
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X008.yaml
+++ b/docs/rules/X008.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X008
 runtime_kind: ast
 shellcheck_code: SC3006
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X009.yaml
+++ b/docs/rules/X009.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X009
 runtime_kind: ast
 shellcheck_code: SC3008
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X010.yaml
+++ b/docs/rules/X010.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X010
 runtime_kind: ast
 shellcheck_code: SC3009
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X011.yaml
+++ b/docs/rules/X011.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X011
 runtime_kind: ast
 shellcheck_code: SC3011
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X012.yaml
+++ b/docs/rules/X012.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X012
 runtime_kind: ast
 shellcheck_code: SC3020
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X013.yaml
+++ b/docs/rules/X013.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X013
 runtime_kind: ast
 shellcheck_code: SC3030
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X014.yaml
+++ b/docs/rules/X014.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X014
 runtime_kind: ast
 shellcheck_code: SC3032
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X015.yaml
+++ b/docs/rules/X015.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X015
 runtime_kind: ast
 shellcheck_code: SC3042
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X016.yaml
+++ b/docs/rules/X016.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X016
 runtime_kind: ast
 shellcheck_code: SC3044
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X017.yaml
+++ b/docs/rules/X017.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X017
 runtime_kind: ast
 shellcheck_code: SC3047
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X018.yaml
+++ b/docs/rules/X018.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X018
 runtime_kind: ast
 shellcheck_code: SC3053
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X019.yaml
+++ b/docs/rules/X019.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X019
 runtime_kind: ast
 shellcheck_code: SC3054
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X020.yaml
+++ b/docs/rules/X020.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X020
 runtime_kind: ast
 shellcheck_code: SC3022
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X021.yaml
+++ b/docs/rules/X021.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X021
 runtime_kind: ast
 shellcheck_code: SC3040
+shellcheck_level: warning
 shells:
   - sh
 description: The script enables pipeline failure handling with a shell option that portable sh does not define.

--- a/docs/rules/X022.yaml
+++ b/docs/rules/X022.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X022
 runtime_kind: ast
 shellcheck_code: SC3045
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X023.yaml
+++ b/docs/rules/X023.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X023
 runtime_kind: ast
 shellcheck_code: SC3057
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X024.yaml
+++ b/docs/rules/X024.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X024
 runtime_kind: ast
 shellcheck_code: SC3059
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X025.yaml
+++ b/docs/rules/X025.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X025
 runtime_kind: ast
 shellcheck_code: SC3060
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X026.yaml
+++ b/docs/rules/X026.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X026
 runtime_kind: ast
 shellcheck_code: SC3034
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X027.yaml
+++ b/docs/rules/X027.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X027
 runtime_kind: ast
 shellcheck_code: SC3037
+shellcheck_level: warning
 shells:
   - sh
 description: Echo flags make output formatting depend on the shell's own implementation choices.

--- a/docs/rules/X028.yaml
+++ b/docs/rules/X028.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X028
 runtime_kind: ast
 shellcheck_code: SC2018
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/X029.yaml
+++ b/docs/rules/X029.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X029
 runtime_kind: ast
 shellcheck_code: SC2019
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/X030.yaml
+++ b/docs/rules/X030.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X030
 runtime_kind: ast
 shellcheck_code: SC2028
+shellcheck_level: info
 shells:
   - sh
   - bash

--- a/docs/rules/X031.yaml
+++ b/docs/rules/X031.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X031
 runtime_kind: ast
 shellcheck_code: SC3046
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X032.yaml
+++ b/docs/rules/X032.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X032
 runtime_kind: ast
 shellcheck_code: SC3050
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X033.yaml
+++ b/docs/rules/X033.yaml
@@ -3,6 +3,8 @@ legacy_name: if-elif-bash-test
 new_category: Portability
 new_code: X033
 runtime_kind: ast
+shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/X035.yaml
+++ b/docs/rules/X035.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X035
 runtime_kind: ast
 shellcheck_code: SC1065
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X036.yaml
+++ b/docs/rules/X036.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X036
 runtime_kind: ast
 shellcheck_code: SC1070
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X037.yaml
+++ b/docs/rules/X037.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X037
 runtime_kind: ast
 shellcheck_code: SC1074
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X038.yaml
+++ b/docs/rules/X038.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X038
 runtime_kind: ast
 shellcheck_code: SC1140
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X039.yaml
+++ b/docs/rules/X039.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X039
 runtime_kind: ast
 shellcheck_code: SC1141
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X040.yaml
+++ b/docs/rules/X040.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X040
 runtime_kind: ast
 shellcheck_code: SC2202
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/X041.yaml
+++ b/docs/rules/X041.yaml
@@ -3,6 +3,8 @@ legacy_name: array-subscript-condition
 new_category: Portability
 new_code: X041
 runtime_kind: ast
+shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/X042.yaml
+++ b/docs/rules/X042.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X042
 runtime_kind: ast
 shellcheck_code: SC2240
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X043.yaml
+++ b/docs/rules/X043.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X043
 runtime_kind: ast
 shellcheck_code: SC2296
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X044.yaml
+++ b/docs/rules/X044.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X044
 runtime_kind: ast
 shellcheck_code: SC2298
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X045.yaml
+++ b/docs/rules/X045.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X045
 runtime_kind: ast
 shellcheck_code: SC3024
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/X046.yaml
+++ b/docs/rules/X046.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X046
 runtime_kind: ast
 shellcheck_code: SC1036
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/X047.yaml
+++ b/docs/rules/X047.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X047
 runtime_kind: ast
 shellcheck_code: SC1058
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X048.yaml
+++ b/docs/rules/X048.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X048
 runtime_kind: ast
 shellcheck_code: SC2277
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X049.yaml
+++ b/docs/rules/X049.yaml
@@ -3,6 +3,8 @@ legacy_name: zsh-prompt-bracket
 new_category: Portability
 new_code: X049
 runtime_kind: ast
+shellcheck_code: null
+shellcheck_level: null
 shells:
   - sh
   - bash

--- a/docs/rules/X050.yaml
+++ b/docs/rules/X050.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X050
 runtime_kind: ast
 shellcheck_code: SC1088
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X051.yaml
+++ b/docs/rules/X051.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X051
 runtime_kind: ast
 shellcheck_code: SC2082
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X052.yaml
+++ b/docs/rules/X052.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X052
 runtime_kind: ast
 shellcheck_code: SC2112
+shellcheck_level: warning
 shells:
   - sh
   - dash
@@ -19,8 +20,6 @@ examples:
     source: shell-checks/examples/226.sh
     code: |
       #!/bin/sh
-      # shellcheck disable=2112,2120,2126,2119
-      function hgic() {
-        hg incoming "$@" | grep changeset | wc -l
+      function greet() {
+        :
       }
-      hgic

--- a/docs/rules/X053.yaml
+++ b/docs/rules/X053.yaml
@@ -3,6 +3,8 @@ legacy_name: zsh-assignment-to-zero
 new_category: Portability
 new_code: X053
 runtime_kind: ast
+shellcheck_code: null
+shellcheck_level: null
 shells:
   - bash
 description: "The variable `0` is assigned a value, which is a zsh idiom."

--- a/docs/rules/X054.yaml
+++ b/docs/rules/X054.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X054
 runtime_kind: ast
 shellcheck_code: SC3002
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X055.yaml
+++ b/docs/rules/X055.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X055
 runtime_kind: ast
 shellcheck_code: SC3004
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X056.yaml
+++ b/docs/rules/X056.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X056
 runtime_kind: ast
 shellcheck_code: SC3005
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X057.yaml
+++ b/docs/rules/X057.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X057
 runtime_kind: ast
 shellcheck_code: SC3007
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X058.yaml
+++ b/docs/rules/X058.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X058
 runtime_kind: ast
 shellcheck_code: SC3012
+shellcheck_level: warning
 shells:
   - sh
 description: "A `<` or `>` operator is used inside `[[ ]]` in a POSIX sh script."

--- a/docs/rules/X059.yaml
+++ b/docs/rules/X059.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X059
 runtime_kind: ast
 shellcheck_code: SC3015
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X060.yaml
+++ b/docs/rules/X060.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X060
 runtime_kind: ast
 shellcheck_code: SC3016
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X061.yaml
+++ b/docs/rules/X061.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X061
 runtime_kind: ast
 shellcheck_code: SC3017
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X062.yaml
+++ b/docs/rules/X062.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X062
 runtime_kind: ast
 shellcheck_code: SC3018
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X063.yaml
+++ b/docs/rules/X063.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X063
 runtime_kind: ast
 shellcheck_code: SC3021
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X065.yaml
+++ b/docs/rules/X065.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X065
 runtime_kind: ast
 shellcheck_code: SC3026
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X066.yaml
+++ b/docs/rules/X066.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X066
 runtime_kind: ast
 shellcheck_code: SC3073
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X067.yaml
+++ b/docs/rules/X067.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X067
 runtime_kind: ast
 shellcheck_code: SC3033
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X068.yaml
+++ b/docs/rules/X068.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X068
 runtime_kind: ast
 shellcheck_code: SC3041
+shellcheck_level: warning
 shells:
   - sh
 description: "The script uses `set -E` or `set -T` in POSIX sh."

--- a/docs/rules/X069.yaml
+++ b/docs/rules/X069.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X069
 runtime_kind: ast
 shellcheck_code: SC3048
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X070.yaml
+++ b/docs/rules/X070.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X070
 runtime_kind: ast
 shellcheck_code: SC3052
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X071.yaml
+++ b/docs/rules/X071.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X071
 runtime_kind: ast
 shellcheck_code: SC3055
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X072.yaml
+++ b/docs/rules/X072.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X072
 runtime_kind: ast
 shellcheck_code: SC3079
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X073.yaml
+++ b/docs/rules/X073.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X073
 runtime_kind: ast
 shellcheck_code: SC3062
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X074.yaml
+++ b/docs/rules/X074.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X074
 runtime_kind: ast
 shellcheck_code: SC3065
+shellcheck_level: warning
 shells:
   - sh
 description: "The `-k` sticky-bit test is used in POSIX sh."

--- a/docs/rules/X075.yaml
+++ b/docs/rules/X075.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X075
 runtime_kind: ast
 shellcheck_code: SC3067
+shellcheck_level: warning
 shells:
   - sh
 description: "The `-O` ownership test is used in a POSIX sh script."

--- a/docs/rules/X076.yaml
+++ b/docs/rules/X076.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X076
 runtime_kind: ast
 shellcheck_code: SC2300
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X077.yaml
+++ b/docs/rules/X077.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X077
 runtime_kind: ast
 shellcheck_code: SC3083
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X078.yaml
+++ b/docs/rules/X078.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X078
 runtime_kind: ast
 shellcheck_code: SC2195
+shellcheck_level: warning
 shells:
   - sh
   - bash

--- a/docs/rules/X079.yaml
+++ b/docs/rules/X079.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X079
 runtime_kind: ast
 shellcheck_code: SC2301
+shellcheck_level: error
 shells:
   - sh
   - bash

--- a/docs/rules/X080.yaml
+++ b/docs/rules/X080.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X080
 runtime_kind: ast
 shellcheck_code: SC3051
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/X081.yaml
+++ b/docs/rules/X081.yaml
@@ -4,6 +4,7 @@ new_category: Portability
 new_code: X081
 runtime_kind: ast
 shellcheck_code: SC3058
+shellcheck_level: warning
 shells:
   - sh
   - dash

--- a/docs/rules/validate.sh
+++ b/docs/rules/validate.sh
@@ -181,7 +181,16 @@ validate_file() {
   if ! check_yq "${file}" '.runtime_kind == "token" or .runtime_kind == "logical_line" or .runtime_kind == "ast" or .runtime_kind == "physical_line"' "runtime_kind must be one of token, logical_line, ast, or physical_line"; then
     failed=1
   fi
-  if ! check_yq "${file}" '(.shellcheck_code == null) or (((.shellcheck_code | type) == "!!str") and (.shellcheck_code | test("^SC[0-9]+$")))' "shellcheck_code must be absent or look like SC2086"; then
+  if ! check_yq "${file}" 'has("shellcheck_code")' "shellcheck_code must be present"; then
+    failed=1
+  fi
+  if ! check_yq "${file}" '(.shellcheck_code == null) or (((.shellcheck_code | type) == "!!str") and (.shellcheck_code | test("^SC[0-9]+$")))' "shellcheck_code must be null or look like SC2086"; then
+    failed=1
+  fi
+  if ! check_yq "${file}" 'has("shellcheck_level")' "shellcheck_level must be present"; then
+    failed=1
+  fi
+  if ! check_yq "${file}" '(.shellcheck_level == null) or (.shellcheck_level == "error") or (.shellcheck_level == "warning") or (.shellcheck_level == "info") or (.shellcheck_level == "style")' "shellcheck_level must be null or be one of error, warning, info, or style"; then
     failed=1
   fi
   if ! check_yq "${file}" '((.shells | type) == "!!seq") and ((.shells | length) > 0) and ([.shells[] | (((type == "!!str") and (length > 0)))] | all)' "shells must be a non-empty list of strings"; then

--- a/scripts/update_shellcheck_levels.py
+++ b/scripts/update_shellcheck_levels.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+VALID_LEVELS = {"error", "warning", "info", "style"}
+SUPPORTED_SHELLS = {"sh", "bash", "dash", "ksh", "busybox", "zsh"}
+SHELLCHECK_CODE_RE = re.compile(r"^SC(?P<number>\d+)$")
+SHELLCHECK_LEVEL_LINE_RE = re.compile(r"^shellcheck_level:\s*.*$", re.MULTILINE)
+SHELLCHECK_CODE_LINE_RE = re.compile(r"^(shellcheck_code:\s*.*)$", re.MULTILINE)
+SHELLCHECK_CODE_VALUE_RE = re.compile(r"^shellcheck_code:\s*(?P<value>\S.*?)\s*$", re.MULTILINE)
+RUNTIME_KIND_LINE_RE = re.compile(r"^(runtime_kind:\s*.*)$", re.MULTILINE)
+TOP_LEVEL_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*:\s*")
+EXAMPLE_KIND_RE = re.compile(r"^  - kind:\s*(?P<kind>\S.*?)\s*$")
+SUCCESSOR_SHELLCHECK_CODES: dict[str, tuple[int, ...]] = {
+    # Current ShellCheck emits the substitution-level warning at SC2327 while
+    # still attaching a nested redirection error at SC2328. Shuck reports the
+    # outer command-substitution span, so SC2327 is the level-compatible oracle.
+    "C057": (2327,),
+    "C058": (2327,),
+    # Current ShellCheck reports empty else bodies at SC1048 on the same span
+    # as Shuck's dangling-else diagnostic.
+    "C143": (1048,),
+}
+MANUAL_SHELLCHECK_LEVELS: dict[str, str] = {
+    # Current ShellCheck emits two diagnostics on the exact `*/` span: a
+    # warning for running a glob as a command and an error for the slash-ended
+    # command name. When forced to pick a single compatibility level, prefer
+    # the higher-severity oracle result on the same span.
+    "C054": "error",
+    # C109 is intentionally kept as a historical compatibility alias after
+    # current ShellCheck stopped flagging this pattern. Preserve its previous
+    # compatibility intent at warning level.
+    "C109": "warning",
+}
+
+
+@dataclass(frozen=True)
+class RuleMetadata:
+    path: Path
+    shellcheck_code: str | None
+    shells: list[str]
+    invalid_example: str | None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Populate docs/rules/*.yaml with shellcheck_level by running each "
+            "rule's invalid example through ShellCheck's json1 oracle."
+        )
+    )
+    parser.add_argument(
+        "--rules",
+        help="Comma-separated list of rule codes to update, for example C001,C006",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the current metadata instead of writing updates",
+    )
+    parser.add_argument(
+        "--shellcheck-bin",
+        default=os.environ.get("SHUCK_SHELLCHECK_BIN", "shellcheck"),
+        help="ShellCheck executable to invoke (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--rules-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "docs" / "rules",
+        help="Directory containing rule YAML files (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def load_rule_metadata(path: Path) -> RuleMetadata:
+    text = path.read_text()
+
+    shellcheck_code_match = SHELLCHECK_CODE_VALUE_RE.search(text)
+    shellcheck_code = None
+    if shellcheck_code_match is not None:
+        shellcheck_code = shellcheck_code_match.group("value")
+        if shellcheck_code in {"null", "~", ""}:
+            shellcheck_code = None
+
+    lines = text.splitlines(keepends=True)
+    shells = parse_shells(lines)
+    invalid_example = parse_first_invalid_example(lines)
+
+    return RuleMetadata(
+        path=path,
+        shellcheck_code=shellcheck_code,
+        shells=shells,
+        invalid_example=invalid_example,
+    )
+
+
+def parse_shells(lines: list[str]) -> list[str]:
+    shells: list[str] = []
+    for index, line in enumerate(lines):
+        if line.rstrip("\n") != "shells:":
+            continue
+
+        for shell_line in lines[index + 1 :]:
+            if shell_line.startswith("  - "):
+                shells.append(shell_line[4:].strip())
+                continue
+            if shell_line.startswith("  "):
+                continue
+            break
+        break
+    return shells
+
+
+def parse_first_invalid_example(lines: list[str]) -> str | None:
+    in_examples = False
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.rstrip("\n")
+
+        if not in_examples:
+            if stripped == "examples:":
+                in_examples = True
+            index += 1
+            continue
+
+        if TOP_LEVEL_KEY_RE.match(stripped):
+            break
+
+        kind_match = EXAMPLE_KIND_RE.match(stripped)
+        if kind_match is None:
+            index += 1
+            continue
+
+        index += 1
+        if kind_match.group("kind") != "invalid":
+            continue
+
+        while index < len(lines):
+            candidate = lines[index]
+            candidate_stripped = candidate.rstrip("\n")
+
+            if candidate_stripped == "    code: |":
+                index += 1
+                code_lines: list[str] = []
+                while index < len(lines):
+                    code_line = lines[index]
+                    if code_line.startswith("      "):
+                        code_lines.append(code_line[6:])
+                        index += 1
+                        continue
+                    if code_line == "\n":
+                        code_lines.append(code_line)
+                        index += 1
+                        continue
+                    break
+                return "".join(code_lines)
+
+            if candidate_stripped.startswith('    code: "'):
+                raw_value = candidate_stripped[len("    code: ") :]
+                return json.loads(raw_value)
+
+            if EXAMPLE_KIND_RE.match(candidate_stripped) or TOP_LEVEL_KEY_RE.match(candidate_stripped):
+                return None
+
+            index += 1
+
+        return None
+
+    return None
+
+
+def parse_shellcheck_number(shellcheck_code: str) -> int:
+    match = SHELLCHECK_CODE_RE.fullmatch(shellcheck_code.strip())
+    if match is None:
+        raise RuntimeError(f"invalid shellcheck_code {shellcheck_code!r}")
+    return int(match.group("number"))
+
+
+def shell_from_shebang(example: str) -> str | None:
+    first_line = example.splitlines()[0].strip() if example.splitlines() else ""
+    if not first_line.startswith("#!"):
+        return None
+
+    tokens = first_line[2:].strip().split()
+    if not tokens:
+        return None
+
+    head = Path(tokens[0]).name
+    if head == "env":
+        candidates = [token for token in tokens[1:] if token != "-S"]
+    else:
+        candidates = [head, *tokens[1:]]
+
+    for token in candidates:
+        candidate = Path(token).name.lower()
+        if candidate in SUPPORTED_SHELLS:
+            return candidate
+
+    return None
+
+
+def detect_shell(rule: RuleMetadata) -> str:
+    if rule.invalid_example:
+        detected = shell_from_shebang(rule.invalid_example)
+        if detected is not None:
+            return detected
+
+    for shell in rule.shells:
+        if shell in SUPPORTED_SHELLS:
+            return shell
+
+    raise RuntimeError(f"{rule.path.name}: could not determine shell for invalid example")
+
+
+def shellcheck_level_for_rule(rule: RuleMetadata, shellcheck_bin: str) -> str | None:
+    manual_level = MANUAL_SHELLCHECK_LEVELS.get(rule.path.stem)
+    if manual_level is not None:
+        print(
+            f"note: {rule.path.name}: using configured ShellCheck level {manual_level}",
+            file=sys.stderr,
+        )
+        return manual_level
+
+    if rule.shellcheck_code is None:
+        return None
+    if not rule.invalid_example:
+        print(
+            f"note: {rule.path.name}: no invalid example is available; leaving "
+            "shellcheck_level as null",
+            file=sys.stderr,
+        )
+        return None
+
+    shellcheck_number = parse_shellcheck_number(rule.shellcheck_code)
+    shell = detect_shell(rule)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        prefix=f"{rule.path.stem.lower()}-",
+        suffix=".sh",
+        delete=False,
+    ) as handle:
+        handle.write(rule.invalid_example)
+        temp_path = Path(handle.name)
+
+    try:
+        completed = subprocess.run(
+            [
+                shellcheck_bin,
+                "--norc",
+                "-s",
+                shell,
+                "-f",
+                "json1",
+                str(temp_path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    if completed.returncode not in {0, 1}:
+        stderr = completed.stderr.strip()
+        stdout = completed.stdout.strip()
+        details = stderr or stdout or f"exit {completed.returncode}"
+        raise RuntimeError(f"{rule.path.name}: shellcheck failed: {details}")
+
+    if not completed.stdout.strip():
+        print(
+            f"note: {rule.path.name}: shellcheck produced no json1 output; leaving "
+            "shellcheck_level as null",
+            file=sys.stderr,
+        )
+        return None
+
+    payload = json.loads(completed.stdout)
+    comments = payload["comments"] if isinstance(payload, dict) else payload
+    if not comments:
+        print(
+            f"note: {rule.path.name}: the invalid example did not produce any ShellCheck "
+            "diagnostics; leaving shellcheck_level as null",
+            file=sys.stderr,
+        )
+        return None
+
+    matching_levels = sorted(
+        {
+            comment["level"]
+            for comment in comments
+            if int(comment.get("code", -1)) == shellcheck_number
+        }
+    )
+
+    if matching_levels:
+        levels = matching_levels
+    else:
+        successor_codes = SUCCESSOR_SHELLCHECK_CODES.get(rule.path.stem, ())
+        successor_levels = sorted(
+            {
+                comment["level"]
+                for comment in comments
+                if int(comment.get("code", -1)) in successor_codes
+            }
+        )
+        if successor_levels:
+            if len(successor_levels) != 1:
+                raise RuntimeError(
+                    f"{rule.path.name}: successor ShellCheck codes {successor_codes} matched "
+                    f"multiple levels {successor_levels}"
+                )
+            levels = successor_levels
+            print(
+                f"note: {rule.path.name}: {rule.shellcheck_code} was not present in the invalid "
+                f"example output; using successor code(s) {list(successor_codes)} with level "
+                f"{levels[0]}",
+                file=sys.stderr,
+            )
+        else:
+            fallback_levels = sorted({comment["level"] for comment in comments})
+            seen_codes = sorted({int(comment.get("code", -1)) for comment in comments})
+            if len(fallback_levels) != 1:
+                print(
+                    f"note: {rule.path.name}: {rule.shellcheck_code} was not present in the invalid "
+                    f"example output and the remaining codes {seen_codes} had conflicting levels "
+                    f"{fallback_levels}; leaving shellcheck_level as null",
+                    file=sys.stderr,
+                )
+                return None
+
+            levels = fallback_levels
+            print(
+                f"note: {rule.path.name}: {rule.shellcheck_code} was not present in the invalid "
+                f"example output; using shared ShellCheck level {levels[0]} from codes {seen_codes}",
+                file=sys.stderr,
+            )
+
+    if len(levels) != 1:
+        raise RuntimeError(
+            f"{rule.path.name}: expected one ShellCheck level for {rule.shellcheck_code}, "
+            f"saw {levels}"
+        )
+
+    level = levels[0]
+    if level not in VALID_LEVELS:
+        raise RuntimeError(f"{rule.path.name}: unexpected ShellCheck level {level!r}")
+    return level
+
+
+def render_shellcheck_level(level: str | None) -> str:
+    return level if level is not None else "null"
+
+
+def rewrite_shellcheck_level(text: str, level: str | None) -> str:
+    new_line = f"shellcheck_level: {render_shellcheck_level(level)}"
+
+    if SHELLCHECK_LEVEL_LINE_RE.search(text):
+        return SHELLCHECK_LEVEL_LINE_RE.sub(new_line, text, count=1)
+
+    if SHELLCHECK_CODE_LINE_RE.search(text):
+        return SHELLCHECK_CODE_LINE_RE.sub(rf"\1\n{new_line}", text, count=1)
+
+    if RUNTIME_KIND_LINE_RE.search(text):
+        return RUNTIME_KIND_LINE_RE.sub(
+            rf"\1\nshellcheck_code: null\n{new_line}",
+            text,
+            count=1,
+        )
+
+    raise RuntimeError("missing runtime_kind field")
+
+
+def selected_rule_paths(rules_dir: Path, selected_codes: set[str] | None) -> list[Path]:
+    paths = sorted(
+        path
+        for path in rules_dir.glob("*.yaml")
+        if path.name != "validate.sh" and (selected_codes is None or path.stem in selected_codes)
+    )
+    if selected_codes is not None:
+        missing = selected_codes - {path.stem for path in paths}
+        if missing:
+            missing_csv = ", ".join(sorted(missing))
+            raise RuntimeError(f"unknown rule code(s): {missing_csv}")
+    return paths
+
+
+def parse_selected_codes(raw: str | None) -> set[str] | None:
+    if raw is None:
+        return None
+
+    codes = {
+        part.strip().upper()
+        for part in raw.split(",")
+        if part.strip()
+    }
+    return codes or None
+
+
+def main() -> int:
+    args = parse_args()
+    selected_codes = parse_selected_codes(args.rules)
+    rules_dir = args.rules_dir.resolve()
+
+    try:
+        rule_paths = selected_rule_paths(rules_dir, selected_codes)
+        planned_levels: dict[Path, str | None] = {}
+        stale_rules: list[str] = []
+
+        for path in rule_paths:
+            metadata = load_rule_metadata(path)
+            level = shellcheck_level_for_rule(metadata, args.shellcheck_bin)
+            planned_levels[path] = level
+
+        for path, level in planned_levels.items():
+            current_text = path.read_text()
+            updated_text = rewrite_shellcheck_level(current_text, level)
+            if current_text != updated_text:
+                stale_rules.append(path.stem)
+                if not args.check:
+                    path.write_text(updated_text)
+    except RuntimeError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        if stale_rules:
+            print(
+                "shellcheck levels are out of date for: " + ", ".join(sorted(stale_rules)),
+                file=sys.stderr,
+            )
+            return 1
+        print(f"verified {len(planned_levels)} rule files")
+        return 0
+
+    print(f"updated {len(rule_paths)} rule files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Populate `shellcheck_level` across the rule metadata used by ShellCheck compatibility mode.

This change adds a one-off updater script, backfills the rule YAML under `docs/rules/`, and tightens validation/documentation so future rule metadata keeps the same field populated.

## What changed

- add `scripts/update_shellcheck_levels.py` to derive per-rule ShellCheck levels from rule examples via the ShellCheck `json1` oracle
- backfill `shellcheck_level` for all rule specs in `docs/rules/`
- require `shellcheck_code` and `shellcheck_level` in `docs/rules/validate.sh`
- document the new metadata field and updater workflow in `CONTRIBUTING.md`
- fix the `C072` and `X052` examples so they actually probe the intended ShellCheck diagnostics
- handle historical/successor-code cases where current ShellCheck no longer emits the original mapped code directly

## Why

ShellCheck compatibility mode needs rule-level log-level metadata to render diagnostics at the same level as the oracle.

Before this change, the rule specs carried `shellcheck_code` but not the corresponding level, and a handful of examples were not oracle-friendly enough to infer it safely.

## Notes

- the remaining `shellcheck_level: null` entries are all unmapped rules
- `C054` and `C109` now use explicit configured levels in the updater because current ShellCheck no longer provides a single directly derivable oracle level for those historical mappings

## Validation

- `python3 -m py_compile scripts/update_shellcheck_levels.py`
- `nix --extra-experimental-features 'nix-command flakes' develop --command python3 scripts/update_shellcheck_levels.py --check`

`docs/rules/validate.sh` still expects a sibling `../shell-checks` checkout, which is not present in this workspace, so that full validation path could not be run here.
