### PR TITLE
fix(cli): align default rule baseline with shellcheck compat

### DIFF
--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -2000,6 +2000,7 @@ mod tests {
         let mut args = check_args(true);
         args.fix = true;
         args.rule_selection = RuleSelectionArgs {
+            extend_select: vec![RuleSelector::Rule(Rule::AmpersandSemicolon)],
             unfixable: vec![RuleSelector::Rule(Rule::AmpersandSemicolon)],
             ..RuleSelectionArgs::default()
         };

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1518,7 +1518,7 @@ mod tests {
     use std::sync::Arc;
 
     use notify::event::{CreateKind, EventAttributes, ModifyKind, RemoveKind, RenameMode};
-    use shuck_linter::{Rule, RuleSelector};
+    use shuck_linter::{Category, Rule, RuleSelector};
     use tempfile::tempdir;
 
     use super::*;
@@ -1762,6 +1762,113 @@ mod tests {
         assert_eq!(
             diagnostic_codes(&report),
             vec![Rule::BareRead.code().to_owned()]
+        );
+    }
+
+    #[test]
+    fn style_rules_are_disabled_by_default() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("script.sh"),
+            "#!/bin/bash\nprintf '%s\\n' x &;\n",
+        )
+        .unwrap();
+
+        let report = run_check_with_cwd(
+            &check_args(true),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn extend_select_can_reenable_s074() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("script.sh"),
+            "#!/bin/bash\nprintf '%s\\n' x &;\n",
+        )
+        .unwrap();
+
+        let mut args = check_args(true);
+        args.rule_selection = RuleSelectionArgs {
+            extend_select: vec![RuleSelector::Rule(Rule::AmpersandSemicolon)],
+            ..RuleSelectionArgs::default()
+        };
+
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            diagnostic_codes(&report),
+            vec![Rule::AmpersandSemicolon.code().to_owned()]
+        );
+    }
+
+    #[test]
+    fn extend_select_category_reenables_style_rules() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("script.sh"),
+            "#!/bin/bash\nprintf '%s\\n' x &;\n",
+        )
+        .unwrap();
+
+        let mut args = check_args(true);
+        args.rule_selection = RuleSelectionArgs {
+            extend_select: vec![RuleSelector::Category(Category::Style)],
+            ..RuleSelectionArgs::default()
+        };
+
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            diagnostic_codes(&report),
+            vec![Rule::AmpersandSemicolon.code().to_owned()]
+        );
+    }
+
+    #[test]
+    fn select_all_includes_style_rules() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("script.sh"),
+            "#!/bin/bash\nprintf '%s\\n' x &;\n",
+        )
+        .unwrap();
+
+        let mut args = check_args(true);
+        args.rule_selection = RuleSelectionArgs {
+            select: Some(vec![RuleSelector::All]),
+            ..RuleSelectionArgs::default()
+        };
+
+        let report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            diagnostic_codes(&report),
+            vec![Rule::AmpersandSemicolon.code().to_owned()]
         );
     }
 

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -22,7 +22,10 @@ use shuck_semantic::SourcePathResolver;
 use shuck_semantic::SourceRefKind;
 
 use self::config::{CompatConfig, load_config, resolve_config_override};
-use self::optional::{OPTIONAL_CHECKS, find_optional_check};
+use self::optional::{
+    OPTIONAL_CHECKS, OptionalCheck, OptionalCheckBehavior, compat_default_disabled_rules,
+    find_optional_check, supported_optional_checks,
+};
 use self::render::{
     print_error_help, print_list_optional, print_report, print_version, usage_text,
 };
@@ -320,13 +323,16 @@ struct CompatOptions {
 
 #[derive(Debug, Clone, Copy, Default)]
 struct CompatOptionalState {
-    check_unassigned_uppercase: bool,
+    report_environment_style_names: bool,
 }
 
 impl CompatOptionalState {
-    fn enable(&mut self, check_name: &str) {
-        if check_name == "check-unassigned-uppercase" {
-            self.check_unassigned_uppercase = true;
+    fn enable(&mut self, check: &OptionalCheck) {
+        if matches!(
+            check.behavior,
+            OptionalCheckBehavior::ReportEnvironmentStyleNames
+        ) {
+            self.report_environment_style_names = true;
         }
     }
 }
@@ -677,7 +683,7 @@ fn resolve_options(
                 .or(config.extended_analysis)
                 .unwrap_or(true),
         ),
-        report_environment_style_names: selection.optional_state.check_unassigned_uppercase,
+        report_environment_style_names: selection.optional_state.report_environment_style_names,
         shellcheck_map,
     })
 }
@@ -687,10 +693,7 @@ fn resolve_rule_selection(
     cli: &ParsedCompatCli,
     config: &CompatConfig,
 ) -> Result<ResolvedCompatSelection, CompatCliError> {
-    let mut rules = shellcheck_map
-        .mappings()
-        .map(|(_, rule)| rule)
-        .collect::<RuleSet>();
+    let mut rules = compat_default_rules(shellcheck_map);
     let mut optional_state = CompatOptionalState::default();
 
     let mut requested_optional = config.enable_checks.clone();
@@ -698,10 +701,9 @@ fn resolve_rule_selection(
     if !requested_optional.is_empty() {
         for name in requested_optional {
             if name == "all" {
-                for check in OPTIONAL_CHECKS.iter().filter(|check| check.supported) {
-                    let optional_rules = check.rules.iter().copied().collect::<RuleSet>();
-                    rules = rules.union(&optional_rules);
-                    optional_state.enable(check.name);
+                for check in supported_optional_checks() {
+                    rules = rules.union(&check.enabled_rule_set());
+                    optional_state.enable(check);
                 }
                 continue;
             }
@@ -716,9 +718,8 @@ fn resolve_rule_selection(
                 continue;
             }
 
-            let optional_rules = check.rules.iter().copied().collect::<RuleSet>();
-            rules = rules.union(&optional_rules);
-            optional_state.enable(check.name);
+            rules = rules.union(&check.enabled_rule_set());
+            optional_state.enable(check);
         }
     }
 
@@ -736,6 +737,14 @@ fn resolve_rule_selection(
         rules,
         optional_state,
     })
+}
+
+fn compat_default_rules(shellcheck_map: &ShellCheckCodeMap) -> RuleSet {
+    shellcheck_map
+        .mappings()
+        .map(|(_, rule)| rule)
+        .collect::<RuleSet>()
+        .subtract(&compat_default_disabled_rules())
 }
 
 fn combined_codes(config_codes: &[String], cli_codes: &[String]) -> Vec<String> {

--- a/crates/shuck-cli/src/shellcheck_compat/optional.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/optional.rs
@@ -1,4 +1,11 @@
 use shuck_linter::Rule;
+use shuck_linter::RuleSet;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionalCheckBehavior {
+    None,
+    ReportEnvironmentStyleNames,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OptionalCheck {
@@ -6,8 +13,16 @@ pub struct OptionalCheck {
     pub description: &'static str,
     pub example: &'static str,
     pub guidance: &'static str,
-    pub rules: &'static [Rule],
+    pub enable_rules: &'static [Rule],
+    pub default_disabled_rules: &'static [Rule],
+    pub behavior: OptionalCheckBehavior,
     pub supported: bool,
+}
+
+impl OptionalCheck {
+    pub fn enabled_rule_set(self) -> RuleSet {
+        self.enable_rules.iter().copied().collect()
+    }
 }
 
 pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
@@ -16,7 +31,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Reports case statements that omit a fallback branch.",
         example: "case $? in 0) echo ok ;; esac",
         guidance: "Add a catch-all branch when the script should handle unexpected values.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -24,7 +41,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Prefers direct comparison operators over leading negation in tests.",
         example: "[ ! \"$value\" -eq 1 ]",
         guidance: "Rewrite the operator so the intent stays positive without a leading !.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -32,7 +51,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Flags bare [ \"$var\" ] checks that rely on implicit non-empty semantics.",
         example: "[ \"$var\" ]",
         guidance: "Use an explicit string or numeric operator for the condition you mean.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -40,7 +61,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Looks for command substitutions whose failures are easy to miss.",
         example: "rm -r \"$(helper)/home\"",
         guidance: "Split the substitution into a checked step before using the result.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -48,7 +71,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Notes call sites where set -e is neutralized by the surrounding construct.",
         example: "set -e; build && echo ok",
         guidance: "Run the function as its own command when failures should still abort the script.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -56,7 +81,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Adds uppercase-variable coverage to unset-variable style checks.",
         example: "echo $VAR",
         guidance: "Initialize the uppercase name before reading it when it is not inherited from the environment.",
-        rules: &[Rule::UndefinedVariable],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::ReportEnvironmentStyleNames,
         supported: true,
     },
     OptionalCheck {
@@ -64,7 +91,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Discourages the non-portable which utility in favor of shell builtins.",
         example: "which javac",
         guidance: "Prefer command -v when you only need command lookup.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -72,7 +101,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Requests quotes even for scalar variables that look safe today.",
         example: "name=hello; echo $name",
         guidance: "Wrap the expansion in double quotes when consistency matters more than brevity.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -80,7 +111,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Requires [[ ... ]] in shells where that test form is available.",
         example: "[ -e /etc/issue ]",
         guidance: "Use the double-bracket form only when the selected shell actually supports it.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -88,7 +121,9 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Prefers ${name} over bare $name references.",
         example: "name=hello; echo $name",
         guidance: "Add braces when you want every variable reference to follow the same house style.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
     OptionalCheck {
@@ -96,10 +131,24 @@ pub const OPTIONAL_CHECKS: &[OptionalCheck] = &[
         description: "Looks for cat pipelines that can be replaced by a direct file operand.",
         example: "cat foo | grep bar",
         guidance: "Pass the file to the downstream command directly when it reads files itself.",
-        rules: &[],
+        enable_rules: &[],
+        default_disabled_rules: &[],
+        behavior: OptionalCheckBehavior::None,
         supported: false,
     },
 ];
+
+pub fn compat_default_disabled_rules() -> RuleSet {
+    OPTIONAL_CHECKS
+        .iter()
+        .filter(|check| check.supported)
+        .flat_map(|check| check.default_disabled_rules.iter().copied())
+        .collect()
+}
+
+pub fn supported_optional_checks() -> impl Iterator<Item = &'static OptionalCheck> {
+    OPTIONAL_CHECKS.iter().filter(|check| check.supported)
+}
 
 pub fn find_optional_check(name: &str) -> Option<&'static OptionalCheck> {
     OPTIONAL_CHECKS.iter().find(|check| check.name == name)

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -278,7 +278,8 @@ fn check_fix_rewrites_safe_s074_and_bypasses_cache() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    cmd.current_dir(tempdir.path()).args(["check", "--fix"]);
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--fix", "--select", "S074"]);
     cmd.assert().success().stdout("");
 
     assert_eq!(
@@ -297,7 +298,8 @@ fn check_without_fix_leaves_s074_file_unchanged() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    cmd.current_dir(tempdir.path()).arg("check");
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--select", "S074"]);
     cmd.assert()
         .code(1)
         .stdout(predicate::str::contains("warning[S074]:"));
@@ -313,8 +315,13 @@ fn check_exit_non_zero_on_fix_returns_failure_when_fix_is_applied() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    cmd.current_dir(tempdir.path())
-        .args(["check", "--fix", "--exit-non-zero-on-fix"]);
+    cmd.current_dir(tempdir.path()).args([
+        "check",
+        "--fix",
+        "--exit-non-zero-on-fix",
+        "--select",
+        "S074",
+    ]);
     cmd.assert().code(1).stdout("");
 
     assert_eq!(
@@ -332,7 +339,7 @@ fn check_unsafe_fixes_applies_safe_s074_fix() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
     cmd.current_dir(tempdir.path())
-        .args(["check", "--unsafe-fixes"]);
+        .args(["check", "--unsafe-fixes", "--select", "S074"]);
     cmd.assert().success().stdout("");
 
     assert_eq!(
@@ -519,6 +526,8 @@ fn check_unfixable_prevents_fixing_matching_rules() {
     cmd.current_dir(tempdir.path()).args([
         "check",
         "--fix",
+        "--select",
+        "S074",
         "--unfixable",
         "S074",
         "--output-format",
@@ -809,13 +818,19 @@ fn check_json_output_is_identical_on_cache_hit_for_fix_payloads() {
     )
     .unwrap();
 
-    let first = run_check_output(tempdir.path(), &["check", "--output-format", "json"]);
+    let first = run_check_output(
+        tempdir.path(),
+        &["check", "--select", "S074", "--output-format", "json"],
+    );
     assert_eq!(first.status.code(), Some(1));
     let first_stdout = stdout_string(&first);
     let first_value: serde_json::Value = serde_json::from_str(&first_stdout).unwrap();
     assert!(first_value[0]["fix"].is_object());
 
-    let second = run_check_output(tempdir.path(), &["check", "--output-format", "json"]);
+    let second = run_check_output(
+        tempdir.path(),
+        &["check", "--select", "S074", "--output-format", "json"],
+    );
     assert_eq!(second.status.code(), Some(1));
     assert_eq!(stdout_string(&second), first_stdout);
 }

--- a/crates/shuck-cli/tests/oracle_shellcheck_cli.rs
+++ b/crates/shuck-cli/tests/oracle_shellcheck_cli.rs
@@ -234,6 +234,70 @@ fn oracle_check_unassigned_uppercase_matches_shellcheck() {
 
 #[test]
 #[ignore]
+fn oracle_uppercase_optional_is_disabled_by_default() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $VAR\n").unwrap();
+
+    let args = vec!["--norc", "-f", "json1", "x.sh"];
+    let shellcheck = run_shellcheck(&args, tempdir.path());
+    let compat = run_compat(&args, tempdir.path());
+    assert_eq!(shellcheck.status.code(), compat.status.code());
+    assert_eq!(
+        json1_comment_shapes(&shellcheck),
+        json1_comment_shapes(&compat)
+    );
+}
+
+#[test]
+#[ignore]
+fn oracle_include_sc2248_does_not_select_bare_slash_marker() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\n*/\n").unwrap();
+
+    let args = vec!["--norc", "--include=SC2248", "-f", "json1", "x.sh"];
+    let shellcheck = run_shellcheck(&args, tempdir.path());
+    let compat = run_compat(&args, tempdir.path());
+    assert_eq!(shellcheck.status.code(), compat.status.code());
+    assert_eq!(
+        json1_comment_shapes(&shellcheck),
+        json1_comment_shapes(&compat)
+    );
+}
+
+#[test]
+#[ignore]
+fn oracle_include_sc2335_does_not_select_unquoted_path_in_mkdir() {
+    if !shellcheck_available() {
+        return;
+    }
+
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/bash\nmkdir -p -m 750 $PKG/var/lib/app\n",
+    )
+    .unwrap();
+
+    let args = vec!["--norc", "--include=SC2335", "-f", "json1", "x.sh"];
+    let shellcheck = run_shellcheck(&args, tempdir.path());
+    let compat = run_compat(&args, tempdir.path());
+    assert_eq!(shellcheck.status.code(), compat.status.code());
+    assert_eq!(
+        json1_comment_shapes(&shellcheck),
+        json1_comment_shapes(&compat)
+    );
+}
+
+#[test]
+#[ignore]
 fn oracle_config_precedence_matches_for_simple_disable_cases() {
     if !shellcheck_available() {
         return;

--- a/crates/shuck-cli/tests/shellcheck_compat.rs
+++ b/crates/shuck-cli/tests/shellcheck_compat.rs
@@ -171,6 +171,71 @@ fn compat_exclude_unknown_sc_code_is_ignored() {
 }
 
 #[test]
+fn compat_optional_uppercase_check_is_disabled_by_default() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $VAR\n").unwrap();
+
+    let output = run_compat(["--norc", "-f", "json1", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let ordered_codes = json1_comments(&output)
+        .into_iter()
+        .map(|comment| comment["code"].as_u64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ordered_codes, vec![2086]);
+}
+
+#[test]
+fn compat_shellcheckrc_enable_turns_on_check_unassigned_uppercase() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join(".shellcheckrc"),
+        "enable=check-unassigned-uppercase\n",
+    )
+    .unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $VAR\n").unwrap();
+
+    let output = run_compat(["-f", "json1", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let ordered_codes = json1_comments(&output)
+        .into_iter()
+        .map(|comment| comment["code"].as_u64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ordered_codes, vec![2154, 2086]);
+}
+
+#[test]
+fn compat_include_sc2248_does_not_select_bare_slash_marker() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\n*/\n").unwrap();
+
+    let output = run_compat(
+        ["--norc", "-f", "json1", "--include=SC2248", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(json1_comments(&output), Vec::<Value>::new());
+}
+
+#[test]
+fn compat_include_sc2335_does_not_select_unquoted_path_in_mkdir() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/bash\nmkdir -p -m 750 $PKG/var/lib/app\n",
+    )
+    .unwrap();
+
+    let output = run_compat(
+        ["--norc", "-f", "json1", "--include=SC2335", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(json1_comments(&output), Vec::<Value>::new());
+}
+
+#[test]
 fn compat_accepts_busybox_shell_alias() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("x.sh"), "echo hi\n").unwrap();

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -9,6 +9,10 @@ use rustc_hash::FxHashSet;
 
 use crate::{Category, Rule, RuleSelector, RuleSet, Severity, ShellDialect};
 
+// ShellCheck's optional checks currently map only to compat-only behavior
+// toggles in this repository, not to standalone implemented non-style rules.
+const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] = &[];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinterSettings {
     pub rules: RuleSet,
@@ -104,11 +108,9 @@ impl LinterSettings {
 
     pub fn default_rules() -> RuleSet {
         Rule::iter()
-            .filter(|rule| {
-                matches!(rule.category(), Category::Correctness | Category::Security)
-                    || matches!(rule, Rule::AmpersandSemicolon)
-            })
-            .collect()
+            .filter(|rule| !matches!(rule.category(), Category::Style))
+            .collect::<RuleSet>()
+            .subtract(&default_disabled_non_style_rules())
     }
 
     pub fn from_selectors(select: &[RuleSelector], ignore: &[RuleSelector]) -> Self {
@@ -151,6 +153,10 @@ impl LinterSettings {
             self.per_file_ignores.ignored_rules(path)
         })
     }
+}
+
+fn default_disabled_non_style_rules() -> RuleSet {
+    DEFAULT_DISABLED_NON_STYLE_RULES.iter().copied().collect()
 }
 
 impl CompiledPerFileIgnoreList {
@@ -244,8 +250,46 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::{CompiledPerFileIgnoreList, PerFileIgnore, normalized_absolute_match_path};
-    use crate::{Rule, RuleSet};
+    use super::*;
+    use crate::RuleSet;
+
+    #[test]
+    fn default_rules_exclude_all_style_rules() {
+        let defaults = LinterSettings::default_rules();
+
+        for rule in Rule::iter().filter(|rule| matches!(rule.category(), Category::Style)) {
+            assert!(
+                !defaults.contains(rule),
+                "{rule:?} should be disabled by default"
+            );
+        }
+    }
+
+    #[test]
+    fn default_rules_include_non_style_rules() {
+        let defaults = LinterSettings::default_rules();
+
+        assert!(defaults.contains(Rule::UndefinedVariable));
+        assert!(defaults.contains(Rule::ConstantCaseSubject));
+        assert!(defaults.contains(Rule::RmGlobOnVariablePath));
+        assert!(!defaults.contains(Rule::AmpersandSemicolon));
+    }
+
+    #[test]
+    fn default_rules_exclude_verified_default_disabled_non_style_rules() {
+        let defaults = LinterSettings::default_rules();
+
+        for rule in DEFAULT_DISABLED_NON_STYLE_RULES {
+            assert!(
+                !defaults.contains(*rule),
+                "{rule:?} should be excluded from the native default baseline"
+            );
+            assert!(
+                !matches!(rule.category(), Category::Style),
+                "{rule:?} must stay in the non-style default-disabled set"
+            );
+        }
+    }
 
     #[test]
     fn matches_absolute_per_file_ignore_patterns() {

--- a/docs/rules/C054.yaml
+++ b/docs/rules/C054.yaml
@@ -3,7 +3,7 @@ legacy_name: bare-slash-marker
 new_category: Correctness
 new_code: C054
 runtime_kind: ast
-shellcheck_code: SC2248
+shellcheck_code: null
 shellcheck_level: error
 shells:
   - sh

--- a/docs/rules/S058.yaml
+++ b/docs/rules/S058.yaml
@@ -3,7 +3,7 @@ legacy_name: unquoted-path-in-mkdir
 new_category: Style
 new_code: S058
 runtime_kind: ast
-shellcheck_code: SC2335
+shellcheck_code: null
 shellcheck_level: warning
 shells:
   - sh

--- a/website/content/configuration/index.mdx
+++ b/website/content/configuration/index.mdx
@@ -6,21 +6,16 @@ This page covers Shuck's stable native configuration for `shuck check`. ShellChe
 
 ## Default behavior
 
-If you do not add a config file, Shuck behaves as though it were configured like this:
+If you do not add a config file, Shuck enables all implemented non-style rules by default.
 
-```toml
-[lint]
-select = ["C", "K", "S074"]
-ignore = []
-fixable = ["ALL"]
-unfixable = []
-```
+That baseline includes:
 
-That default rule set enables:
+- Correctness rules (`C`)
+- Performance rules (`P`)
+- Portability rules (`X`)
+- Security rules (`K`)
 
-- All correctness rules (`C`)
-- All security rules (`K`)
-- `S074`, which catches `&;` command separators
+All style rules are disabled by default, including `S074`. Shuck also reserves a small internal compatibility exclude list for ShellCheck-style opt-in checks when they map to standalone non-style rules.
 
 You only need a config file when you want to change that baseline.
 
@@ -28,7 +23,6 @@ For example, the following configuration keeps the defaults, adds all style rule
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
 extend-select = ["S"]
 ignore = ["S074"]
 fixable = ["ALL"]
@@ -88,7 +82,7 @@ Selectors can be:
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
+select = ["ALL"]
 ```
 
 ### `ignore`
@@ -97,8 +91,8 @@ Removes rules from the currently selected set.
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
-ignore = ["C011", "S074"]
+select = ["ALL"]
+ignore = ["S", "C011"]
 ```
 
 ### `extend-select`
@@ -107,8 +101,7 @@ Adds more rules on top of the current selection.
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
-extend-select = ["S", "P"]
+extend-select = ["S"]
 ```
 
 ### `per-file-ignores`
@@ -117,7 +110,7 @@ Defines rule ignores for files matching a glob pattern.
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
+extend-select = ["S"]
 
 [lint.per-file-ignores]
 "scripts/*.sh" = ["S074"]
@@ -130,7 +123,7 @@ Adds more per-file ignores on top of any existing `per-file-ignores` entries.
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
+extend-select = ["S"]
 extend-per-file-ignores = { "vendor/**" = ["ALL"], "scripts/*.sh" = ["S074"] }
 ```
 
@@ -142,7 +135,7 @@ By default, all rules are considered fixable candidates when fixes exist.
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
+extend-select = ["S"]
 fixable = ["C", "S074"]
 ```
 
@@ -152,7 +145,7 @@ Marks selected rules as ineligible for automatic fixes, even when `--fix` is ena
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
+select = ["ALL"]
 unfixable = ["C001"]
 ```
 
@@ -162,7 +155,7 @@ Adds more fixable rules on top of an existing `fixable` selection.
 
 ```toml
 [lint]
-select = ["C", "K", "S074"]
+extend-select = ["S"]
 fixable = ["C"]
 extend-fixable = ["S074"]
 ```


### PR DESCRIPTION
## Summary
- change the native default lint baseline to enable all implemented non-style rules and disable style rules by default, including `S074`
- tighten ShellCheck compatibility selection so optional behavior stays opt-in and stale optional-code mappings do not enable unrelated Shuck rules
- update docs and add regression coverage for the new native baseline and compat behavior

## Root cause
The native baseline was still hard-coded to `C`, `K`, and `S074`, and ShellCheck compatibility mode treated every mapped rule as enabled by default. That made native defaults diverge from the intended non-style baseline and let stale SC mappings like `SC2248` and `SC2335` select unrelated diagnostics in compat mode.

## Validation
- `cargo test -p shuck-linter settings::tests -- --nocapture`
- `cargo test -p shuck-cli --test shellcheck_compat -- --nocapture`
- `cargo test -p shuck-cli style_rules_are_disabled_by_default -- --nocapture`
- `cargo test -p shuck-cli extend_select_can_reenable_s074 -- --nocapture`
- `cargo test -p shuck-cli extend_select_category_reenables_style_rules -- --nocapture`
- `cargo test -p shuck-cli select_all_includes_style_rules -- --nocapture`
