### PR TITLE
fix(c001): compat-gate indirect expansion targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ That said, shuck is not a port of ShellCheck. It is a clean-room reimplementatio
 
 - Shuck's parser and analysis logic were written from scratch. Edge cases may be handled differently, and some diagnostics may fire in slightly different locations or contexts.
 - In cases where ShellCheck's behavior appears incorrect or inconsistent with shell semantics, shuck intentionally chooses correctness over compatibility.
+- `C001`/`SC2034` differs by default for resolved indirect expansions such as `${!name}`. Shuck treats the resolved target as live, while ShellCheck warns when that target is only referenced indirectly. Set `[lint.rule-options.c001].treat-indirect-expansion-targets-as-used = false` to opt into ShellCheck-compatible `C001` behavior.
 
 Compatibility is continuously validated against a large corpus of shell scripts from popular open-source projects including [acme.sh](https://github.com/acmesh-official/acme.sh), [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh), [nvm](https://github.com/nvm-sh/nvm), [pyenv](https://github.com/pyenv/pyenv), [pi-hole](https://github.com/pi-hole/pi-hole), [bats-core](https://github.com/bats-core/bats-core), [powerlevel10k](https://github.com/romkatv/powerlevel10k), [dokku](https://github.com/dokku/dokku), [gentoo](https://github.com/gentoo/gentoo), and [many others](scripts/corpus-download.sh). The latest conformance report is published at [ewhauser.github.io/shuck/reports/corpus](https://ewhauser.github.io/shuck/reports/corpus/).
 

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -732,6 +732,7 @@ fn resolve_project_check_settings(
         parse_lint_config_layer(&config.lint)?,
         parse_cli_rule_selection_layer(cli_rule_selection),
     ];
+    let rule_options = linter_rule_options_for_lint_config(&config.lint);
 
     let mut enabled_rules = LinterSettings::default_rules();
     let mut fixable_rules = RuleSet::all();
@@ -767,11 +768,26 @@ fn resolve_project_check_settings(
         linter_settings: LinterSettings {
             rules: enabled_rules,
             per_file_ignores: Arc::new(compiled_per_file_ignores),
+            rule_options,
             ..LinterSettings::default()
         },
         fixable_rules,
         effective,
     })
+}
+
+fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::LinterRuleOptions {
+    let mut rule_options = shuck_linter::LinterRuleOptions::default();
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.c001.as_ref())
+        .and_then(|c001| c001.treat_indirect_expansion_targets_as_used)
+    {
+        rule_options.c001.treat_indirect_expansion_targets_as_used = value;
+    }
+
+    rule_options
 }
 
 fn parse_lint_config_layer(lint: &LintConfig) -> Result<RuleSelectionLayer> {

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -85,6 +85,7 @@ fn diagnostics_exit_status(diagnostics: &[DisplayedDiagnostic], exit_zero: bool)
 struct EffectiveCheckSettings {
     enabled_rules: Vec<String>,
     per_file_ignores: Vec<EffectivePerFileIgnore>,
+    rule_options: EffectiveRuleOptions,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,8 +94,17 @@ struct EffectivePerFileIgnore {
     rules: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EffectiveRuleOptions {
+    c001_treat_indirect_expansion_targets_as_used: bool,
+}
+
 impl EffectiveCheckSettings {
-    fn new(enabled_rules: RuleSet, per_file_ignores: &[PerFileIgnore]) -> Self {
+    fn new(
+        enabled_rules: RuleSet,
+        per_file_ignores: &[PerFileIgnore],
+        rule_options: &shuck_linter::LinterRuleOptions,
+    ) -> Self {
         let mut enabled_rules = enabled_rules
             .iter()
             .map(|rule| rule.code().to_owned())
@@ -121,6 +131,7 @@ impl EffectiveCheckSettings {
         Self {
             enabled_rules,
             per_file_ignores,
+            rule_options: EffectiveRuleOptions::new(rule_options),
         }
     }
 }
@@ -130,6 +141,7 @@ impl CacheKey for EffectiveCheckSettings {
         state.write_tag(b"effective-check-settings");
         self.enabled_rules.cache_key(state);
         self.per_file_ignores.cache_key(state);
+        self.rule_options.cache_key(state);
     }
 }
 
@@ -137,6 +149,24 @@ impl CacheKey for EffectivePerFileIgnore {
     fn cache_key(&self, state: &mut CacheKeyHasher) {
         self.pattern.cache_key(state);
         self.rules.cache_key(state);
+    }
+}
+
+impl EffectiveRuleOptions {
+    fn new(rule_options: &shuck_linter::LinterRuleOptions) -> Self {
+        Self {
+            c001_treat_indirect_expansion_targets_as_used: rule_options
+                .c001
+                .treat_indirect_expansion_targets_as_used,
+        }
+    }
+}
+
+impl CacheKey for EffectiveRuleOptions {
+    fn cache_key(&self, state: &mut CacheKeyHasher) {
+        state.write_tag(b"effective-rule-options");
+        self.c001_treat_indirect_expansion_targets_as_used
+            .cache_key(state);
     }
 }
 
@@ -762,7 +792,7 @@ fn resolve_project_check_settings(
         project_root.canonical_root.clone(),
         per_file_ignores.clone(),
     )?;
-    let effective = EffectiveCheckSettings::new(enabled_rules, &per_file_ignores);
+    let effective = EffectiveCheckSettings::new(enabled_rules, &per_file_ignores, &rule_options);
 
     Ok(ResolvedCheckSettings {
         linter_settings: LinterSettings {
@@ -2118,6 +2148,51 @@ mod tests {
         assert_eq!(second.cache_hits, 0);
         assert_eq!(second.cache_misses, 1);
         assert_eq!(second.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn invalidates_cache_when_rule_options_change() {
+        let tempdir = tempdir().unwrap();
+        let script = tempdir.path().join("script.sh");
+        fs::write(
+            &script,
+            "#!/bin/bash\ntarget=ok\nname=target\nprintf '%s\\n' \"${!name}\"\n",
+        )
+        .unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nselect = ['C001']\n",
+        )
+        .unwrap();
+
+        let first = run_check_with_cwd(
+            &check_args(false),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+        assert_eq!(first.cache_hits, 0);
+        assert_eq!(first.cache_misses, 1);
+        assert!(first.diagnostics.is_empty());
+
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nselect = ['C001']\n\n[lint.rule-options.c001]\ntreat-indirect-expansion-targets-as-used = false\n",
+        )
+        .unwrap();
+
+        let second = run_check_with_cwd(
+            &check_args(false),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+        assert_eq!(second.cache_hits, 0);
+        assert_eq!(second.cache_misses, 1);
+        assert_eq!(second.diagnostics.len(), 1);
+        assert!(second.diagnostics[0].message.contains("target"));
     }
 
     #[test]

--- a/crates/shuck-cli/src/config.rs
+++ b/crates/shuck-cli/src/config.rs
@@ -36,7 +36,11 @@ const CONFIG_OVERRIDE_LINT_KEYS: &[&str] = &[
     "fixable",
     "unfixable",
     "extend-fixable",
+    "rule-options",
 ];
+const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &["c001"];
+const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
+    &["treat-indirect-expansion-targets-as-used"];
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
@@ -70,6 +74,36 @@ pub(crate) struct LintConfig {
     pub fixable: Option<Vec<String>>,
     pub unfixable: Option<Vec<String>>,
     pub extend_fixable: Option<Vec<String>>,
+    pub rule_options: Option<LintRuleOptionsConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) struct LintRuleOptionsConfig {
+    pub c001: Option<C001RuleOptionsConfig>,
+}
+
+impl LintRuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if let Some(c001) = overrides.c001 {
+            self.c001.get_or_insert_default().apply_overrides(c001);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) struct C001RuleOptionsConfig {
+    pub treat_indirect_expansion_targets_as_used: Option<bool>,
+}
+
+impl C001RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.treat_indirect_expansion_targets_as_used.is_some() {
+            self.treat_indirect_expansion_targets_as_used =
+                overrides.treat_indirect_expansion_targets_as_used;
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -326,6 +360,11 @@ impl LintConfig {
         if overrides.extend_fixable.is_some() {
             self.extend_fixable = overrides.extend_fixable;
         }
+        if let Some(rule_options) = overrides.rule_options {
+            self.rule_options
+                .get_or_insert_default()
+                .apply_overrides(rule_options);
+        }
     }
 }
 
@@ -376,6 +415,45 @@ fn validate_override_table(table: &toml::Table) -> std::result::Result<(), Strin
                     CONFIG_OVERRIDE_LINT_KEYS.join(", ")
                 ));
             }
+        }
+        if let Some(rule_options_value) = lint.get("rule-options") {
+            validate_lint_rule_options_override(rule_options_value)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let rule_options = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options]` must be a TOML table".to_owned())?;
+    for key in rule_options.keys() {
+        if !CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    if let Some(c001_value) = rule_options.get("c001") {
+        validate_c001_rule_options_override(c001_value)?;
+    }
+
+    Ok(())
+}
+
+fn validate_c001_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let c001 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.c001]` must be a TOML table".to_owned())?;
+    for key in c001.keys() {
+        if !CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.c001]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS.join(", ")
+            ));
         }
     }
 
@@ -520,9 +598,38 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_rule_option_keys() {
+        let config = parse_config_override(
+            "lint.rule-options.c001.treat-indirect-expansion-targets-as-used = false",
+        )
+        .unwrap();
+        assert_eq!(
+            config
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c001.as_ref())
+                .and_then(|c001| c001.treat_indirect_expansion_targets_as_used),
+            Some(false)
+        );
+    }
+
+    #[test]
     fn inline_config_overrides_reject_unknown_lint_keys() {
         let err = parse_config_override("lint.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint]` option `preview`"));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.preview.enabled = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options]` option `preview`"));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_c001_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.c001.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.c001]` option `preview`"));
     }
 
     #[test]
@@ -566,6 +673,40 @@ mod tests {
     }
 
     #[test]
+    fn rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.c001.treat-indirect-expansion-targets-as-used = true",
+                    )
+                    .unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.c001.treat-indirect-expansion-targets-as-used = false",
+                    )
+                    .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c001.as_ref())
+                .and_then(|c001| c001.treat_indirect_expansion_targets_as_used),
+            Some(false)
+        );
+    }
+
+    #[test]
     fn isolated_rejects_explicit_config_files() {
         let tempdir = tempdir().unwrap();
         let config_path = tempdir.path().join("shuck.toml");
@@ -596,6 +737,22 @@ mod tests {
         let loaded = load_project_config(tempdir.path(), &config).unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(true));
+    }
+
+    #[test]
+    fn config_file_rejects_unknown_nested_rule_option_fields() {
+        let tempdir = tempdir().unwrap();
+        let config_path = tempdir.path().join("shuck.toml");
+        fs::write(&config_path, "[lint.rule-options.c001]\npreview = true\n").unwrap();
+
+        let err = load_project_config(
+            tempdir.path(),
+            &ConfigArguments::from_cli(vec![SingleConfigArgument::FilePath(config_path)], false)
+                .unwrap(),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("preview"));
     }
 
     #[test]

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -962,7 +962,9 @@ fn lint_with_context(
         analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
         per_file_ignores: Default::default(),
         report_environment_style_names: options.report_environment_style_names,
-    };
+        rule_options: Default::default(),
+    }
+    .with_c001_treat_indirect_expansion_targets_as_used(false);
 
     let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
         &parse_result,

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -486,6 +486,36 @@ fn check_cli_select_replaces_config_selection() {
 }
 
 #[test]
+fn check_config_rule_option_can_enable_shellcheck_compatible_c001_behavior() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "\
+[lint]
+select = ['C001']
+
+[lint.rule-options.c001]
+treat-indirect-expansion-targets-as-used = false
+",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("script.sh"),
+        "#!/bin/bash\ntarget=ok\nname=target\nprintf '%s\\n' \"${!name}\"\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise", "script.sh"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("warning[C001]"))
+        .stdout(predicate::str::contains("target"));
+}
+
+#[test]
 fn check_per_file_ignores_skip_matching_files() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -50,6 +50,7 @@ const LARGE_CORPUS_PROGRESS_BUCKET_COUNT: usize = 100 / LARGE_CORPUS_PROGRESS_PE
 const LARGE_CORPUS_TIMING_LIMIT: usize = 25;
 const RULE_CORPUS_METADATA_DIR: &str = "tests/testdata/corpus-metadata";
 const LARGE_CORPUS_ALLOWED_FAILING_RULE_REASON: &str = "known large-corpus rule allowlist";
+const LARGE_CORPUS_C001_COMPAT_NOTE: &str = "large corpus compatibility note: C001 is evaluated with ShellCheck-compatible indirect-expansion handling.";
 const LARGE_CORPUS_STATIC_IGNORE_SUFFIXES: &[&str] = &[
     "super-linter__super-linter__test__linters__bash__shell_bad_1.sh",
     "super-linter__super-linter__test__linters__bash_exec__shell_bad_1.sh",
@@ -1011,6 +1012,7 @@ fn large_corpus_conforms_with_shellcheck() {
         failure_collection.harness_warnings.len(),
         failure_collection.harness_failures.len(),
     );
+    emit_large_corpus_c001_compat_note(&linter_settings);
     emit_timeout_cap_note(
         "large corpus compatibility",
         failure_collection.timeout_cap_reached,
@@ -2687,17 +2689,44 @@ fn build_large_corpus_linter_settings(
     selected_rules: Option<shuck_linter::RuleSet>,
     mapped_only: bool,
 ) -> shuck_linter::LinterSettings {
-    if let Some(rules) = selected_rules {
-        return shuck_linter::LinterSettings::for_rules(rules.iter());
-    }
-    if mapped_only {
+    let settings = if let Some(rules) = selected_rules {
+        shuck_linter::LinterSettings::for_rules(rules.iter())
+    } else if mapped_only {
         let mapped_rules: HashSet<_> = shuck_linter::ShellCheckCodeMap::default()
             .mappings()
             .map(|(_, rule)| rule)
             .collect();
-        return shuck_linter::LinterSettings::for_rules(mapped_rules);
+        shuck_linter::LinterSettings::for_rules(mapped_rules)
+    } else {
+        shuck_linter::LinterSettings::default()
+    };
+
+    settings.with_c001_treat_indirect_expansion_targets_as_used(false)
+}
+
+fn large_corpus_uses_c001_shellcheck_compat(
+    linter_settings: &shuck_linter::LinterSettings,
+) -> bool {
+    linter_settings
+        .rules
+        .contains(shuck_linter::Rule::UnusedAssignment)
+        && !linter_settings
+            .rule_options
+            .c001
+            .treat_indirect_expansion_targets_as_used
+}
+
+fn large_corpus_c001_compat_note_line(
+    linter_settings: &shuck_linter::LinterSettings,
+) -> Option<&'static str> {
+    large_corpus_uses_c001_shellcheck_compat(linter_settings)
+        .then_some(LARGE_CORPUS_C001_COMPAT_NOTE)
+}
+
+fn emit_large_corpus_c001_compat_note(linter_settings: &shuck_linter::LinterSettings) {
+    if let Some(note) = large_corpus_c001_compat_note_line(linter_settings) {
+        eprintln!("{note}");
     }
-    shuck_linter::LinterSettings::default()
 }
 
 fn build_shellcheck_filter_codes(
@@ -3695,11 +3724,9 @@ mod tests {
     fn load_all_rule_corpus_metadata_keeps_scoped_review_entries() {
         let metadata = load_all_rule_corpus_metadata();
 
-        assert!(
-            metadata
-                .get("C001")
-                .is_some_and(|rule_metadata| rule_metadata.review_all_divergences)
-        );
+        assert!(metadata.get("C001").is_some_and(|rule_metadata| {
+            !rule_metadata.review_all_divergences && !rule_metadata.reviewed_divergences.is_empty()
+        }));
         assert!(
             metadata
                 .get("C057")
@@ -4749,6 +4776,31 @@ mod tests {
                 .as_deref()
                 .is_some_and(|error| error.contains("expected 'fi'"))
         );
+    }
+
+    #[test]
+    fn build_large_corpus_linter_settings_enables_c001_shellcheck_compat() {
+        let settings = build_large_corpus_linter_settings(None, false);
+
+        assert!(
+            large_corpus_uses_c001_shellcheck_compat(&settings),
+            "{settings:?}"
+        );
+        assert_eq!(
+            large_corpus_c001_compat_note_line(&settings),
+            Some(LARGE_CORPUS_C001_COMPAT_NOTE)
+        );
+    }
+
+    #[test]
+    fn large_corpus_c001_compat_note_only_applies_when_c001_is_enabled() {
+        let settings = build_large_corpus_linter_settings(None, false);
+        assert!(large_corpus_uses_c001_shellcheck_compat(&settings));
+
+        let without_c001 = shuck_linter::LinterSettings::for_rule(shuck_linter::Rule::EmptyTest)
+            .with_c001_treat_indirect_expansion_targets_as_used(false);
+        assert!(!large_corpus_uses_c001_shellcheck_compat(&without_c001));
+        assert_eq!(large_corpus_c001_compat_note_line(&without_c001), None);
     }
 
     fn probe(version_text: &str) -> ShellCheckProbe {

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -3721,11 +3721,11 @@ mod tests {
     }
 
     #[test]
-    fn load_all_rule_corpus_metadata_keeps_scoped_review_entries() {
+    fn load_all_rule_corpus_metadata_keeps_c001_review_allowlist_and_scoped_entries() {
         let metadata = load_all_rule_corpus_metadata();
 
         assert!(metadata.get("C001").is_some_and(|rule_metadata| {
-            !rule_metadata.review_all_divergences && !rule_metadata.reviewed_divergences.is_empty()
+            rule_metadata.review_all_divergences && !rule_metadata.reviewed_divergences.is_empty()
         }));
         assert!(
             metadata

--- a/crates/shuck-cli/tests/shellcheck_compat.rs
+++ b/crates/shuck-cli/tests/shellcheck_compat.rs
@@ -236,6 +236,27 @@ fn compat_include_sc2335_does_not_select_unquoted_path_in_mkdir() {
 }
 
 #[test]
+fn compat_flags_indirect_only_sc2034_targets() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/bash\ntarget=ok\nname=target\nprintf '%s\\n' \"${!name}\"\n",
+    )
+    .unwrap();
+
+    let output = run_compat(
+        ["--norc", "-s", "bash", "-f", "json1", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    let comment = comment_by_code(&comments, 2034);
+    assert_eq!(comment["line"].as_u64(), Some(2));
+    assert_eq!(comment["endLine"].as_u64(), Some(2));
+}
+
+#[test]
 fn compat_accepts_busybox_shell_alias() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("x.sh"), "echo hi\n").unwrap();

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -1,3 +1,4 @@
+review_all_divergences: true
 reviewed_divergences:
   - side: shuck-only
     path_contains: "termux__termux-packages__"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -1,4 +1,3 @@
-review_all_divergences: true
 reviewed_divergences:
   - side: shuck-only
     path_contains: "termux__termux-packages__"

--- a/crates/shuck-cli/tests/zsh_option_state.rs
+++ b/crates/shuck-cli/tests/zsh_option_state.rs
@@ -151,6 +151,7 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
         &rules,
         ShellDialect::Zsh,
         false,
+        shuck_linter::LinterRuleOptions::default(),
         &file_context,
         None,
     );

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -3,7 +3,10 @@ use shuck_ast::{File, Span};
 use shuck_indexer::Indexer;
 use shuck_semantic::{SemanticAnalysis, SemanticModel};
 
-use crate::{Diagnostic, FileContext, LinterFacts, Rule, RuleSet, ShellDialect, Violation, rules};
+use crate::{
+    Diagnostic, FileContext, LinterFacts, LinterRuleOptions, Rule, RuleSet, ShellDialect,
+    Violation, rules,
+};
 
 pub struct Checker<'a> {
     semantic: &'a SemanticModel,
@@ -15,6 +18,7 @@ pub struct Checker<'a> {
     rules: &'a RuleSet,
     shell: ShellDialect,
     report_environment_style_names: bool,
+    rule_options: LinterRuleOptions,
     file_context: &'a FileContext,
     first_parse_error: Option<(usize, usize)>,
     diagnostics: Vec<Diagnostic>,
@@ -48,6 +52,7 @@ impl<'a> Checker<'a> {
         rules: &'a RuleSet,
         shell: ShellDialect,
         report_environment_style_names: bool,
+        rule_options: LinterRuleOptions,
         file_context: &'a FileContext,
         first_parse_error: Option<(usize, usize)>,
     ) -> Self {
@@ -61,6 +66,7 @@ impl<'a> Checker<'a> {
             rules,
             shell,
             report_environment_style_names,
+            rule_options,
             file_context,
             first_parse_error,
             diagnostics: Vec::new(),
@@ -102,6 +108,10 @@ impl<'a> Checker<'a> {
 
     pub fn report_environment_style_names(&self) -> bool {
         self.report_environment_style_names
+    }
+
+    pub fn rule_options(&self) -> &LinterRuleOptions {
+        &self.rule_options
     }
 
     pub fn file_context(&self) -> &'a FileContext {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -131,7 +131,9 @@ pub(crate) use rules::common::word::{
     word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 /// Linter configuration and per-file ignore types.
-pub use settings::{CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore};
+pub use settings::{
+    C001RuleOptions, CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings, PerFileIgnore,
+};
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;
 /// Suppression directives, shellcheck mappings, and rewrite helpers.
@@ -310,6 +312,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
         &settings.rules,
         shell,
         settings.report_environment_style_names,
+        settings.rule_options.clone(),
         &file_context,
         first_parse_error,
     );
@@ -1705,6 +1708,40 @@ echo $bar
         assert_eq!(diagnostics[0].rule, Rule::UnusedAssignment);
         assert!(diagnostics[0].message.contains("foo"));
         assert_eq!(diagnostics[0].span.slice(source), "foo");
+    }
+
+    #[test]
+    fn unused_assignment_keeps_indirect_only_target_live_by_default() {
+        let diagnostics = lint_for_rule(
+            "\
+#!/bin/bash
+target=ok
+name=target
+printf '%s\\n' \"${!name}\"
+",
+            Rule::UnusedAssignment,
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unused_assignment_shellcheck_compat_flags_indirect_only_target() {
+        let source = "\
+#!/bin/bash
+target=ok
+name=target
+printf '%s\\n' \"${!name}\"
+";
+        let diagnostics = lint(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment)
+                .with_c001_treat_indirect_expansion_targets_as_used(false),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UnusedAssignment);
+        assert_eq!(diagnostics[0].span.slice(source), "target");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -30,7 +30,9 @@ impl Violation for UnusedAssignment {
 
 pub fn unused_assignment(checker: &mut Checker) {
     let semantic = checker.semantic();
-    let unused_bindings = checker.semantic_analysis().unused_assignments();
+    let unused_bindings = checker
+        .semantic_analysis()
+        .unused_assignments_with_options(checker.rule_options().c001.semantic_options());
     let unused_binding_ids = unused_bindings.iter().copied().collect::<HashSet<_>>();
     let mut families_with_used_bindings = HashSet::new();
     let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use globset::{Glob, GlobMatcher};
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
+use shuck_semantic::UnusedAssignmentAnalysisOptions;
 
 use crate::{Category, Rule, RuleSelector, RuleSet, Severity, ShellDialect};
 
@@ -13,6 +14,35 @@ use crate::{Category, Rule, RuleSelector, RuleSet, Severity, ShellDialect};
 // toggles in this repository, not to standalone implemented non-style rules.
 const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] = &[];
 
+/// Per-rule behavior overrides applied during lint analysis.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LinterRuleOptions {
+    /// Behavior overrides for `C001`.
+    pub c001: C001RuleOptions,
+}
+
+/// Behavior overrides for `C001` unused-assignment analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct C001RuleOptions {
+    /// Whether resolved indirect-expansion targets like `${!name}` count as a use of the target.
+    pub treat_indirect_expansion_targets_as_used: bool,
+}
+
+impl Default for C001RuleOptions {
+    fn default() -> Self {
+        Self {
+            treat_indirect_expansion_targets_as_used: true,
+        }
+    }
+}
+
+impl C001RuleOptions {
+    pub(crate) fn semantic_options(&self) -> UnusedAssignmentAnalysisOptions {
+        UnusedAssignmentAnalysisOptions {
+            treat_indirect_expansion_targets_as_used: self.treat_indirect_expansion_targets_as_used,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinterSettings {
     pub rules: RuleSet,
@@ -21,6 +51,7 @@ pub struct LinterSettings {
     pub analyzed_paths: Option<Arc<FxHashSet<PathBuf>>>,
     pub per_file_ignores: Arc<CompiledPerFileIgnoreList>,
     pub report_environment_style_names: bool,
+    pub rule_options: LinterRuleOptions,
 }
 
 impl Default for LinterSettings {
@@ -32,6 +63,7 @@ impl Default for LinterSettings {
             analyzed_paths: None,
             per_file_ignores: Arc::new(CompiledPerFileIgnoreList::default()),
             report_environment_style_names: false,
+            rule_options: LinterRuleOptions::default(),
         }
     }
 }
@@ -145,6 +177,13 @@ impl LinterSettings {
 
     pub fn with_per_file_ignores(mut self, per_file_ignores: CompiledPerFileIgnoreList) -> Self {
         self.per_file_ignores = Arc::new(per_file_ignores);
+        self
+    }
+
+    pub fn with_c001_treat_indirect_expansion_targets_as_used(mut self, value: bool) -> Self {
+        self.rule_options
+            .c001
+            .treat_indirect_expansion_targets_as_used = value;
         self
     }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -8,6 +8,7 @@ use crate::{
     Binding, BindingAttributes, BindingId, BindingKind, BlockId, CallSite, ContractCertainty,
     ControlFlowGraph, EdgeKind, FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, Reference,
     ReferenceId, ReferenceKind, Scope, ScopeId, ScopeKind, SpanKey, SyntheticRead,
+    UnusedAssignmentAnalysisOptions,
 };
 use std::sync::OnceLock;
 
@@ -184,7 +185,19 @@ pub(crate) fn analyze_unused_assignments(
     context: &DataflowContext<'_>,
     exact: &ExactVariableDataflow,
 ) -> Vec<BindingId> {
-    analyze_unused_assignments_exact(context, exact).unused_assignment_ids
+    analyze_unused_assignments_with_options(
+        context,
+        exact,
+        UnusedAssignmentAnalysisOptions::default(),
+    )
+}
+
+pub(crate) fn analyze_unused_assignments_with_options(
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
+    options: UnusedAssignmentAnalysisOptions,
+) -> Vec<BindingId> {
+    analyze_unused_assignments_exact(context, exact, options).unused_assignment_ids
 }
 
 pub(crate) fn build_exact_variable_dataflow(
@@ -216,7 +229,11 @@ pub(crate) fn analyze(
     context: &DataflowContext<'_>,
     exact: &ExactVariableDataflow,
 ) -> DataflowResult {
-    let unused_assignments = analyze_unused_assignments_exact(context, exact);
+    let unused_assignments = analyze_unused_assignments_exact(
+        context,
+        exact,
+        UnusedAssignmentAnalysisOptions::default(),
+    );
     let uninitialized_references = analyze_uninitialized_references_exact(context, exact);
     let dead_code = build_dead_code(context.cfg);
     let reaching_definitions = exact.reaching_definitions(context);
@@ -352,6 +369,7 @@ fn build_bindings_by_name(bindings: &[Binding]) -> FxHashMap<Name, SmallVec<[Bin
 fn analyze_unused_assignments_exact(
     context: &DataflowContext<'_>,
     exact: &ExactVariableDataflow,
+    options: UnusedAssignmentAnalysisOptions,
 ) -> UnusedAssignmentsResult {
     let reaching_definitions = exact.reaching_definitions(context);
     let reference_name_ids = context
@@ -454,7 +472,8 @@ fn analyze_unused_assignments_exact(
             );
         }
 
-        if let Some(candidates) = context.indirect_targets_by_reference.get(&reference.id)
+        if options.treat_indirect_expansion_targets_as_used
+            && let Some(candidates) = context.indirect_targets_by_reference.get(&reference.id)
             && !candidates.is_empty()
         {
             mark_reaching_candidate_bindings_used(&mut used_bindings, incoming, candidates);

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -118,6 +118,21 @@ pub struct SyntheticRead {
     pub(crate) name: Name,
 }
 
+/// Behavior flags for unused-assignment analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnusedAssignmentAnalysisOptions {
+    /// Whether a resolved indirect-expansion target like `${!name}` counts as a use of the target.
+    pub treat_indirect_expansion_targets_as_used: bool,
+}
+
+impl Default for UnusedAssignmentAnalysisOptions {
+    fn default() -> Self {
+        Self {
+            treat_indirect_expansion_targets_as_used: true,
+        }
+    }
+}
+
 #[allow(missing_docs)]
 impl SyntheticRead {
     pub fn scope(&self) -> ScopeId {
@@ -449,6 +464,7 @@ pub struct SemanticAnalysis<'model> {
     exact_variable_dataflow: OnceLock<ExactVariableDataflow>,
     dataflow: OnceLock<DataflowResult>,
     unused_assignments: OnceLock<Vec<BindingId>>,
+    unused_assignments_shellcheck_compat: OnceLock<Vec<BindingId>>,
     uninitialized_references: OnceLock<Vec<UninitializedReference>>,
     dead_code: OnceLock<Vec<DeadCode>>,
     overwritten_functions: OnceLock<Vec<OverwrittenFunction>>,
@@ -1131,6 +1147,7 @@ impl<'model> SemanticAnalysis<'model> {
             exact_variable_dataflow: OnceLock::new(),
             dataflow: OnceLock::new(),
             unused_assignments: OnceLock::new(),
+            unused_assignments_shellcheck_compat: OnceLock::new(),
             uninitialized_references: OnceLock::new(),
             dead_code: OnceLock::new(),
             overwritten_functions: OnceLock::new(),
@@ -1188,6 +1205,25 @@ impl<'model> SemanticAnalysis<'model> {
                 let context = self.model.dataflow_context(cfg);
                 let exact = self.exact_variable_dataflow();
                 dataflow::analyze_unused_assignments(&context, exact)
+            })
+            .as_slice()
+    }
+
+    /// Returns unused assignments using the requested behavior flags.
+    pub fn unused_assignments_with_options(
+        &self,
+        options: UnusedAssignmentAnalysisOptions,
+    ) -> &[BindingId] {
+        if options == UnusedAssignmentAnalysisOptions::default() {
+            return self.unused_assignments();
+        }
+
+        self.unused_assignments_shellcheck_compat
+            .get_or_init(|| {
+                let cfg = self.cfg();
+                let context = self.model.dataflow_context(cfg);
+                let exact = self.exact_variable_dataflow();
+                dataflow::analyze_unused_assignments_with_options(&context, exact, options)
             })
             .as_slice()
     }
@@ -5142,6 +5178,30 @@ printf '%s\\n' \"${!name}\"
             binding_names(&model, model.indirect_targets_for_reference(reference.id)),
             vec!["target"]
         );
+    }
+
+    #[test]
+    fn unused_assignment_options_only_change_indirect_target_liveness() {
+        let source = "\
+#!/bin/bash
+target=ok
+name=target
+other=1
+printf '%s\\n' \"${!name}\"
+";
+        let model = model(source);
+        let default_unused = binding_names(&model, model.analysis().unused_assignments());
+        let compat_unused = binding_names(
+            &model,
+            model
+                .analysis()
+                .unused_assignments_with_options(UnusedAssignmentAnalysisOptions {
+                    treat_indirect_expansion_targets_as_used: false,
+                }),
+        );
+
+        assert_eq!(default_unused, vec!["other"]);
+        assert_eq!(compat_unused, vec!["target", "other"]);
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1218,9 +1218,19 @@ impl<'model> SemanticAnalysis<'model> {
             return self.unused_assignments();
         }
 
+        if !self.model.needs_precise_unused_assignments() {
+            return &self.model.heuristic_unused_assignments;
+        }
+
         self.unused_assignments_shellcheck_compat
             .get_or_init(|| {
                 let cfg = self.cfg();
+                if self
+                    .model
+                    .can_use_heuristic_unused_assignments_with_linear_cfg(cfg)
+                {
+                    return self.model.heuristic_unused_assignments.clone();
+                }
                 let context = self.model.dataflow_context(cfg);
                 let exact = self.exact_variable_dataflow();
                 dataflow::analyze_unused_assignments_with_options(&context, exact, options)
@@ -5202,6 +5212,22 @@ printf '%s\\n' \"${!name}\"
 
         assert_eq!(default_unused, vec!["other"]);
         assert_eq!(compat_unused, vec!["target", "other"]);
+    }
+
+    #[test]
+    fn unused_assignment_options_preserve_heuristic_fast_path_without_indirect_targets() {
+        let model = model("unused=1\n");
+        let analysis = model.analysis();
+
+        let compat_unused = analysis
+            .unused_assignments_with_options(UnusedAssignmentAnalysisOptions {
+                treat_indirect_expansion_targets_as_used: false,
+            })
+            .to_vec();
+
+        assert!(analysis.exact_variable_dataflow.get().is_none());
+        assert!(analysis.dataflow.get().is_none());
+        assert_eq!(binding_names(&model, &compat_unused), vec!["unused"]);
     }
 
     #[test]

--- a/docs/rules/C001.yaml
+++ b/docs/rules/C001.yaml
@@ -10,8 +10,8 @@ shells:
   - bash
   - dash
   - ksh
-description: A variable is assigned but never read later, so the statement has no effect on the script's behavior.
-rationale: Remove dead assignments, or export the value if a child process needs it.
+description: A variable is assigned but never read later, so the statement has no effect on the script's behavior. By default, Shuck treats resolved indirect-expansion targets such as `${!name}` as live reads of the target variable.
+rationale: Remove dead assignments, or export the value if a child process needs it. ShellCheck warns on indirect-only target reads; set `[lint.rule-options.c001].treat-indirect-expansion-targets-as-used = false` to opt into that compatibility mode.
 safe_fix: false
 fix_description: "Rename the reported unused assignment target to `_`."
 source:


### PR DESCRIPTION
## Summary
- add a `C001` rule option for whether indirect expansion targets count as used, with the default preserving current `shuck check` behavior
- route `C001` through an option-aware unused-assignment analysis and enable ShellCheck-compatible behavior in shellcheck-compat mode and the large-corpus harness
- document the `C001` indirect-expansion divergence and remove the blanket `C001` large-corpus reviewed-divergence escape hatch

## Why
`C001` currently diverges from `SC2034` when a variable is only referenced through resolved indirect expansion like `${!name}`. This change makes that behavior explicit and configurable for normal lint runs while letting compatibility-oriented entrypoints opt into ShellCheck-style handling automatically.

## Validation
- `cargo test -p shuck-cli -p shuck-linter -p shuck-semantic`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
  - this still reports the existing `C001` compatibility backlog, but it now runs with the compat toggle enabled and emits the corpus summary note for that mode
- Criterion comparison against `main`
  - full-suite results were noisy across unrelated groups, but focused reruns of the suspicious slow cases flipped direction
  - the directly relevant `unused_assignment` benchmark showed no statistically significant regression on rerun
