### PR TITLE
fix(cli): use shellcheck metadata levels in compat mode

### DIFF
--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    Category, LinterSettings, Rule, RuleSet, Severity, ShellCheckCodeMap, ShellDialect,
-    SuppressionIndex, first_statement_line, parse_directives,
+    LinterSettings, Rule, RuleSet, Severity, ShellCheckCodeMap, ShellCheckLevel, ShellDialect,
+    SuppressionIndex, first_statement_line, parse_directives, rule_metadata,
 };
 use shuck_parser::ShellProfile;
 use shuck_parser::parser::Parser;
@@ -1123,12 +1123,38 @@ fn compat_fix_for_diagnostic(
 }
 
 fn level_for_diagnostic(rule: Rule, severity: Severity, shellcheck_code: u32) -> CompatLevel {
+    if let Some(level) = rule_metadata(rule).and_then(|metadata| metadata.shellcheck_level) {
+        return compat_level(level);
+    }
+
+    debug_assert!(
+        false,
+        "missing shellcheck_level metadata for mapped ShellCheck-compatible rule {}",
+        rule.code()
+    );
+    legacy_level_for_diagnostic(rule, severity, shellcheck_code)
+}
+
+fn compat_level(level: ShellCheckLevel) -> CompatLevel {
+    match level {
+        ShellCheckLevel::Style => CompatLevel::Style,
+        ShellCheckLevel::Info => CompatLevel::Info,
+        ShellCheckLevel::Warning => CompatLevel::Warning,
+        ShellCheckLevel::Error => CompatLevel::Error,
+    }
+}
+
+fn legacy_level_for_diagnostic(
+    rule: Rule,
+    severity: Severity,
+    shellcheck_code: u32,
+) -> CompatLevel {
     match severity {
         Severity::Hint => CompatLevel::Style,
         Severity::Error | Severity::Warning => {
             if shellcheck_code < 2000 {
                 CompatLevel::Error
-            } else if matches!(rule.category(), Category::Style) {
+            } else if matches!(rule.category(), shuck_linter::Category::Style) {
                 CompatLevel::Info
             } else {
                 CompatLevel::Warning

--- a/crates/shuck-cli/tests/shellcheck_compat.rs
+++ b/crates/shuck-cli/tests/shellcheck_compat.rs
@@ -140,6 +140,66 @@ fn compat_include_and_severity_filter_work_on_sc_codes() {
 }
 
 #[test]
+fn compat_json1_uses_metadata_info_level_for_sc1091() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\n. ./lib.sh\n").unwrap();
+
+    let output = run_compat(["--norc", "-f", "json1", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    let sc1091 = comment_by_code(&comments, 1091);
+    assert_eq!(sc1091["level"].as_str(), Some("info"));
+}
+
+#[test]
+fn compat_severity_filter_respects_metadata_info_level_for_sc1091() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\n. ./lib.sh\n").unwrap();
+
+    let output = run_compat(
+        ["--norc", "-f", "json1", "--severity=warning", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(json1_comments(&output), Vec::<Value>::new());
+}
+
+#[test]
+fn compat_json1_uses_metadata_style_level_for_sc2003() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/sh\nprintf '%s\\n' \"$(expr 1 + 2)\"\n",
+    )
+    .unwrap();
+
+    let output = run_compat(["--norc", "-f", "json1", "x.sh"].as_slice(), tempdir.path());
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    let sc2003 = comment_by_code(&comments, 2003);
+    assert_eq!(sc2003["level"].as_str(), Some("style"));
+}
+
+#[test]
+fn compat_severity_filter_respects_metadata_style_level_for_sc2003() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/sh\nprintf '%s\\n' \"$(expr 1 + 2)\"\n",
+    )
+    .unwrap();
+
+    let output = run_compat(
+        ["--norc", "-f", "json1", "--severity=info", "x.sh"].as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(json1_comments(&output), Vec::<Value>::new());
+}
+
+#[test]
 fn compat_include_unknown_sc_code_is_accepted_as_empty_selection() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\necho $foo\n").unwrap();

--- a/crates/shuck-linter/build.rs
+++ b/crates/shuck-linter/build.rs
@@ -8,9 +8,18 @@ use serde::Deserialize;
 struct RuleMetadata {
     new_code: String,
     shellcheck_code: Option<String>,
+    shellcheck_level: Option<String>,
     description: String,
     rationale: String,
     fix_description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellCheckLevel {
+    Style,
+    Info,
+    Warning,
+    Error,
 }
 
 fn parse_shellcheck_code_value(raw: &str) -> Result<Option<u32>, String> {
@@ -29,7 +38,24 @@ fn parse_shellcheck_code_value(raw: &str) -> Result<Option<u32>, String> {
     Ok(Some(number))
 }
 
-fn parse_rule_metadata(data: &str) -> Result<(RuleMetadata, Option<u32>), String> {
+fn parse_shellcheck_level_value(raw: &str) -> Result<Option<ShellCheckLevel>, String> {
+    let raw = raw.trim().trim_matches(|ch| matches!(ch, '"' | '\''));
+    if raw.is_empty() || raw.eq_ignore_ascii_case("null") || raw == "~" {
+        return Ok(None);
+    }
+
+    match raw.to_ascii_lowercase().as_str() {
+        "style" => Ok(Some(ShellCheckLevel::Style)),
+        "info" => Ok(Some(ShellCheckLevel::Info)),
+        "warning" => Ok(Some(ShellCheckLevel::Warning)),
+        "error" => Ok(Some(ShellCheckLevel::Error)),
+        _ => Err("invalid shellcheck_level".to_owned()),
+    }
+}
+
+fn parse_rule_metadata(
+    data: &str,
+) -> Result<(RuleMetadata, Option<u32>, Option<ShellCheckLevel>), String> {
     let metadata: RuleMetadata =
         serde_yaml::from_str(data).map_err(|err| format!("invalid rule metadata: {err}"))?;
 
@@ -45,7 +71,18 @@ fn parse_rule_metadata(data: &str) -> Result<(RuleMetadata, Option<u32>), String
         .transpose()?
         .flatten();
 
-    Ok((metadata, shellcheck_code))
+    let shellcheck_level = metadata
+        .shellcheck_level
+        .as_deref()
+        .map(parse_shellcheck_level_value)
+        .transpose()?
+        .flatten();
+
+    if shellcheck_code.is_some() && shellcheck_level.is_none() {
+        return Err("shellcheck_level must be set when shellcheck_code is set".to_owned());
+    }
+
+    Ok((metadata, shellcheck_code, shellcheck_level))
 }
 
 fn main() {
@@ -74,7 +111,7 @@ fn main() {
         let data = fs::read_to_string(&path)
             .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
 
-        let (metadata, shellcheck_code) =
+        let (metadata, shellcheck_code, shellcheck_level) =
             parse_rule_metadata(&data).unwrap_or_else(|err| panic!("{err} in {}", path.display()));
         let rule_code = metadata.new_code.trim().to_owned();
         metadata_rows.push((
@@ -82,6 +119,7 @@ fn main() {
             metadata.description,
             metadata.rationale,
             metadata.fix_description,
+            shellcheck_level,
         ));
 
         let Some(shellcheck_code) = shellcheck_code else {
@@ -105,9 +143,19 @@ fn main() {
         .unwrap_or_else(|err| panic!("write {}: {err}", out_path.display()));
 
     let mut metadata_generated = String::from("pub const RULE_METADATA: &[RuleMetadata] = &[\n");
-    for (rule_code, description, rationale, fix_description) in metadata_rows {
+    for (rule_code, description, rationale, fix_description, shellcheck_level) in metadata_rows {
         metadata_generated.push_str("    RuleMetadata {\n");
         metadata_generated.push_str(&format!("        code: {:?},\n", rule_code));
+        metadata_generated.push_str(&format!(
+            "        shellcheck_level: {},\n",
+            match shellcheck_level {
+                Some(ShellCheckLevel::Style) => "Some(ShellCheckLevel::Style)".to_owned(),
+                Some(ShellCheckLevel::Info) => "Some(ShellCheckLevel::Info)".to_owned(),
+                Some(ShellCheckLevel::Warning) => "Some(ShellCheckLevel::Warning)".to_owned(),
+                Some(ShellCheckLevel::Error) => "Some(ShellCheckLevel::Error)".to_owned(),
+                None => "None".to_owned(),
+            }
+        ));
         metadata_generated.push_str(&format!("        description: {:?},\n", description));
         metadata_generated.push_str(&format!("        rationale: {:?},\n", rationale));
         metadata_generated.push_str(&format!(

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -75,7 +75,7 @@ pub use fix::{Applicability, AppliedFixes, Edit, Fix, FixAvailability, apply_fix
 /// Rule identifiers, categories, and registry lookup helpers.
 pub use registry::{Category, Rule, code_to_rule};
 /// Rule metadata lookup utilities.
-pub use rule_metadata::{RuleMetadata, rule_metadata, rule_metadata_by_code};
+pub use rule_metadata::{RuleMetadata, ShellCheckLevel, rule_metadata, rule_metadata_by_code};
 /// Rule selector parsing types.
 pub use rule_selector::{RuleSelector, SelectorParseError};
 /// Sets of enabled or disabled rules.

--- a/crates/shuck-linter/src/rule_metadata.rs
+++ b/crates/shuck-linter/src/rule_metadata.rs
@@ -1,8 +1,17 @@
 use crate::{Rule, code_to_rule};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellCheckLevel {
+    Style,
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RuleMetadata {
     pub code: &'static str,
+    pub shellcheck_level: Option<ShellCheckLevel>,
     pub description: &'static str,
     pub rationale: &'static str,
     pub fix_description: Option<&'static str>,
@@ -29,6 +38,7 @@ mod tests {
     fn loads_rule_metadata_for_known_rules() {
         let metadata = rule_metadata(Rule::UnusedAssignment).expect("metadata for C001");
         assert_eq!(metadata.code, "C001");
+        assert_eq!(metadata.shellcheck_level, Some(ShellCheckLevel::Warning));
         assert!(metadata.description.contains("assigned"));
         assert!(metadata.rationale.contains("dead assignments"));
     }

--- a/crates/shuck-linter/tests/build_script.rs
+++ b/crates/shuck-linter/tests/build_script.rs
@@ -20,20 +20,38 @@ mod build_script {
     }
 
     #[test]
+    fn parse_shellcheck_level_value_accepts_quoted_levels() {
+        assert_eq!(
+            parse_shellcheck_level_value("warning"),
+            Ok(Some(ShellCheckLevel::Warning))
+        );
+        assert_eq!(
+            parse_shellcheck_level_value("\"info\""),
+            Ok(Some(ShellCheckLevel::Info))
+        );
+        assert_eq!(
+            parse_shellcheck_level_value("'STYLE'"),
+            Ok(Some(ShellCheckLevel::Style))
+        );
+    }
+
+    #[test]
     fn parse_rule_metadata_accepts_quoted_new_code() {
         let yaml = r#"
 new_code: "C001"
 shellcheck_code: SC2034
+shellcheck_level: warning
 description: Example description
 rationale: Example rationale
 "#;
 
-        let (metadata, shellcheck_code) = parse_rule_metadata(yaml).unwrap();
+        let (metadata, shellcheck_code, shellcheck_level) = parse_rule_metadata(yaml).unwrap();
         assert_eq!(metadata.new_code, "C001");
         assert_eq!(metadata.description, "Example description");
         assert_eq!(metadata.rationale, "Example rationale");
         assert_eq!(metadata.fix_description, None);
         assert_eq!(shellcheck_code, Some(2034));
+        assert_eq!(shellcheck_level, Some(ShellCheckLevel::Warning));
     }
 
     #[test]
@@ -41,15 +59,17 @@ rationale: Example rationale
         let yaml = r#"
 new_code: C001
 shellcheck_code: SC2034 # compatibility code
+shellcheck_level: warning
 description: Example description
 rationale: Example rationale
 "#;
 
-        let (metadata, shellcheck_code) = parse_rule_metadata(yaml).unwrap();
+        let (metadata, shellcheck_code, shellcheck_level) = parse_rule_metadata(yaml).unwrap();
         assert_eq!(metadata.new_code, "C001");
         assert_eq!(metadata.description, "Example description");
         assert_eq!(metadata.rationale, "Example rationale");
         assert_eq!(shellcheck_code, Some(2034));
+        assert_eq!(shellcheck_level, Some(ShellCheckLevel::Warning));
     }
 
     #[test]
@@ -57,14 +77,47 @@ rationale: Example rationale
         let yaml = r#"
 new_code: C001
 shellcheck_code: null
+shellcheck_level: null
 description: Example description
 rationale: Example rationale
 "#;
 
-        let (metadata, shellcheck_code) = parse_rule_metadata(yaml).unwrap();
+        let (metadata, shellcheck_code, shellcheck_level) = parse_rule_metadata(yaml).unwrap();
         assert_eq!(metadata.new_code, "C001");
         assert_eq!(metadata.description, "Example description");
         assert_eq!(metadata.rationale, "Example rationale");
         assert_eq!(shellcheck_code, None);
+        assert_eq!(shellcheck_level, None);
+    }
+
+    #[test]
+    fn parse_rule_metadata_requires_shellcheck_level_for_mapped_rules() {
+        let yaml = r#"
+new_code: C001
+shellcheck_code: SC2034
+description: Example description
+rationale: Example rationale
+"#;
+
+        let error = parse_rule_metadata(yaml).unwrap_err();
+        assert_eq!(
+            error,
+            "shellcheck_level must be set when shellcheck_code is set"
+        );
+    }
+
+    #[test]
+    fn parse_rule_metadata_keeps_shellcheck_level_without_code() {
+        let yaml = r#"
+new_code: C001
+shellcheck_code: null
+shellcheck_level: info
+description: Example description
+rationale: Example rationale
+"#;
+
+        let (_, shellcheck_code, shellcheck_level) = parse_rule_metadata(yaml).unwrap();
+        assert_eq!(shellcheck_code, None);
+        assert_eq!(shellcheck_level, Some(ShellCheckLevel::Info));
     }
 }


### PR DESCRIPTION
## Summary
- route shellcheck compatibility output levels through rule metadata instead of CLI heuristics
- extend generated rule metadata to carry parsed shellcheck log levels
- add regression coverage for metadata parsing and compatibility-mode severity filtering

## Testing
- cargo test -p shuck-linter --test build_script
- cargo test -p shuck-linter rule_metadata::tests::loads_rule_metadata_for_known_rules
- cargo test -p shuck-cli --test shellcheck_compat