### PR TITLE
fix(c001): preserve array-like indirect targets in shellcheck compat mode

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1745,6 +1745,26 @@ printf '%s\\n' \"${!name}\"
     }
 
     #[test]
+    fn unused_assignment_shellcheck_compat_keeps_dynamic_target_arrays_live() {
+        let diagnostics = lint(
+            "\
+#!/bin/bash
+apache_args=(--apache)
+nginx_args=(--nginx)
+apache_args+=(--common)
+nginx_args+=(--common)
+web_server=apache
+args_var=\"${web_server}_args[@]\"
+printf '%s\\n' \"${!args_var}\"
+",
+            &LinterSettings::for_rule(Rule::UnusedAssignment)
+                .with_c001_treat_indirect_expansion_targets_as_used(false),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn unused_assignment_ignores_plain_underscore_bindings() {
         let diagnostics = lint_for_rule("#!/bin/bash\n_=1\n", Rule::UnusedAssignment);
 

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -24,7 +24,8 @@ pub struct LinterRuleOptions {
 /// Behavior overrides for `C001` unused-assignment analysis.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C001RuleOptions {
-    /// Whether resolved indirect-expansion targets like `${!name}` count as a use of the target.
+    /// Whether scalar indirect-expansion targets like `${!name}` count as a use of the target.
+    /// Array-like targets such as `name=arr[@]; ${!name}` stay live in both modes.
     pub treat_indirect_expansion_targets_as_used: bool,
 }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -75,6 +75,7 @@ pub(crate) struct DataflowContext<'a> {
     pub(crate) resolved: &'a FxHashMap<ReferenceId, BindingId>,
     pub(crate) call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     pub(crate) indirect_targets_by_reference: &'a FxHashMap<ReferenceId, Vec<BindingId>>,
+    pub(crate) array_like_indirect_expansion_refs: &'a FxHashSet<ReferenceId>,
     pub(crate) synthetic_reads: &'a [SyntheticRead],
     pub(crate) entry_bindings: &'a [BindingId],
 }
@@ -472,7 +473,10 @@ fn analyze_unused_assignments_exact(
             );
         }
 
-        if options.treat_indirect_expansion_targets_as_used
+        if (options.treat_indirect_expansion_targets_as_used
+            || context
+                .array_like_indirect_expansion_refs
+                .contains(&reference.id))
             && let Some(candidates) = context.indirect_targets_by_reference.get(&reference.id)
             && !candidates.is_empty()
         {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -121,7 +121,9 @@ pub struct SyntheticRead {
 /// Behavior flags for unused-assignment analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnusedAssignmentAnalysisOptions {
-    /// Whether a resolved indirect-expansion target like `${!name}` counts as a use of the target.
+    /// Whether a resolved scalar indirect-expansion target like `${!name}` counts as a use
+    /// of the target. Array-like targets such as `name=arr[@]; ${!name}` stay live in
+    /// both modes.
     pub treat_indirect_expansion_targets_as_used: bool,
 }
 
@@ -444,6 +446,7 @@ pub struct SemanticModel {
     declarations: Vec<Declaration>,
     indirect_targets_by_binding: FxHashMap<BindingId, Vec<BindingId>>,
     indirect_targets_by_reference: FxHashMap<ReferenceId, Vec<BindingId>>,
+    array_like_indirect_expansion_refs: FxHashSet<ReferenceId>,
     synthetic_reads: Vec<SyntheticRead>,
     entry_bindings: Vec<BindingId>,
     flow_contexts: Vec<(Span, FlowContext)>,
@@ -510,6 +513,12 @@ impl SemanticModel {
             &built.indirect_expansion_refs,
             &indirect_targets_by_binding,
         );
+        let array_like_indirect_expansion_refs = build_array_like_indirect_expansion_refs(
+            &built.references,
+            &built.resolved,
+            &built.indirect_expansion_refs,
+            &built.indirect_target_hints,
+        );
         let zsh_option_analysis = zsh_options::analyze(
             &built.shell_profile,
             &built.scopes,
@@ -537,6 +546,7 @@ impl SemanticModel {
             declarations: built.declarations,
             indirect_targets_by_binding,
             indirect_targets_by_reference,
+            array_like_indirect_expansion_refs,
             synthetic_reads: Vec::new(),
             entry_bindings: Vec::new(),
             flow_contexts: built.flow_contexts,
@@ -1132,6 +1142,7 @@ impl SemanticModel {
             resolved: &self.resolved,
             call_sites: &self.call_sites,
             indirect_targets_by_reference: &self.indirect_targets_by_reference,
+            array_like_indirect_expansion_refs: &self.array_like_indirect_expansion_refs,
             synthetic_reads: &self.synthetic_reads,
             entry_bindings: &self.entry_bindings,
         }
@@ -1884,6 +1895,34 @@ fn build_indirect_targets_by_reference(
         }
     }
     targets_by_reference
+}
+
+fn build_array_like_indirect_expansion_refs(
+    references: &[Reference],
+    resolved: &FxHashMap<ReferenceId, BindingId>,
+    indirect_expansion_refs: &FxHashSet<ReferenceId>,
+    indirect_target_hints: &FxHashMap<BindingId, IndirectTargetHint>,
+) -> FxHashSet<ReferenceId> {
+    let mut array_like_refs = FxHashSet::default();
+    for reference in references {
+        if !indirect_expansion_refs.contains(&reference.id) {
+            continue;
+        }
+        let Some(binding_id) = resolved.get(&reference.id).copied() else {
+            continue;
+        };
+        let Some(hint) = indirect_target_hints.get(&binding_id) else {
+            continue;
+        };
+        let array_like = match hint {
+            IndirectTargetHint::Exact { array_like, .. }
+            | IndirectTargetHint::Pattern { array_like, .. } => *array_like,
+        };
+        if array_like {
+            array_like_refs.insert(reference.id);
+        }
+    }
+    array_like_refs
 }
 
 fn build_binding_block_index(blocks: &[BasicBlock], binding_count: usize) -> Vec<Vec<BlockId>> {
@@ -5212,6 +5251,30 @@ printf '%s\\n' \"${!name}\"
 
         assert_eq!(default_unused, vec!["other"]);
         assert_eq!(compat_unused, vec!["target", "other"]);
+    }
+
+    #[test]
+    fn unused_assignment_options_keep_array_like_indirect_targets_live() {
+        let source = "\
+#!/bin/bash
+apache_args=(--apache)
+unused_args=(--unused)
+args_var=apache_args[@]
+printf '%s\\n' \"${!args_var}\"
+";
+        let model = model(source);
+        let default_unused = binding_names(&model, model.analysis().unused_assignments());
+        let compat_unused = binding_names(
+            &model,
+            model
+                .analysis()
+                .unused_assignments_with_options(UnusedAssignmentAnalysisOptions {
+                    treat_indirect_expansion_targets_as_used: false,
+                }),
+        );
+
+        assert_eq!(default_unused, vec!["unused_args"]);
+        assert_eq!(compat_unused, vec!["unused_args"]);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- preserve array-like indirect targets in C001 ShellCheck-compat mode
- track array-like indirect-expansion references in the semantic model and dataflow path
- add semantic and linter regression coverage for scalar versus array-like indirect expansions

## Why

The large-corpus C001 compatibility mode was disabling indirect-target liveness too broadly. That helped match ShellCheck for scalar indirect-only reads like `${!name}`, but it also started flagging array-like carrier patterns such as `args_var=apache_args[@]; "${!args_var}"` that ShellCheck does not report.

## Impact

- large-corpus C001 runs keep the intended ShellCheck-compatible behavior for scalar indirect-only targets
- default Shuck behavior is unchanged and still treats indirect targets as live
- array-like indirect carrier patterns stay non-issues in both modes

## Validation

- `cargo test -p shuck-semantic unused_assignment_options`
- `cargo test -p shuck-linter unused_assignment_shellcheck_compat`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
  - summary after the fix: `implementation_diffs=0`, `reviewed_divergences=417`
