### PR TITLE
test(corpus): narrow C006 shellcheck-only reviews

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -341,6 +341,12 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "leebaird__discover__dev-api-scanner.sh"
     reason: "This scanner builds an output filename from the current CORS origin, and the remaining ShellCheck-only anchor is the lower-case slug fragment inside that generated path. We review this one file narrowly instead of broadening C006 around the helper's filename templating."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__sys-apps__memtest86+__files__39_memtest86+-r2"
+    reason: "This GRUB menu helper sources grub-mkconfig_lib and only uses grub_tab to indent generated submenu output, so the remaining ShellCheck-only hit is a sourced helper contract rather than a missing local assignment."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__sys-apps__memtest86+__files__39_memtest86+-r3"
+    reason: "This GRUB menu helper sources grub-mkconfig_lib and only uses grub_tab to indent generated submenu output, so the remaining ShellCheck-only hit is a sourced helper contract rather than a missing local assignment."
   - side: shuck-only
     path_suffix: "233boy__v2ray__src__old.sh"
     reason: "This legacy V2Ray helper threads transport choice through sourced installer plumbing, so the remaining C006 read is a repo-local runtime handoff rather than a free-standing missing assignment."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -1,4 +1,3 @@
-review_all_divergences: true
 reviewed_divergences:
   - side: shuck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"
@@ -288,3 +287,57 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__pycompile"
     reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
+  - side: shellcheck-only
+    path_suffix: "docker-library__official-images__test__config.sh"
+    reason: "This generated test matrix is just a bundle of image-to-test mappings, so the ShellCheck-only C006 hits are the literal associative-array keys in those compound assignments rather than live variable reads."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    reason: "This generated configure script threads Autoconf cleanup and reporting state through a trap block, and the remaining ShellCheck-only read is part of that template-driven control flow."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__depcomp"
+    reason: "This generated dependency helper uses build-time placeholders such as `object` and `source` to rewrite depfiles, so the ShellCheck-only hits are expected template plumbing here."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__install-sh"
+    reason: "This generated install helper carries a trap around its temporary-directory probe, and the remaining ShellCheck-only read is part of that cleanup path."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    reason: "This generated libtool script exports template/config symbols like `macro_version`, `lt_sysroot`, `finish_cmds`, and `hardcode_libdir_flag_spec`, so the remaining ShellCheck-only hits are part of the generated configuration surface rather than handwritten shell logic."
+  - side: shellcheck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__info_stats.sh"
+    reason: "This stats module assembles an analytics payload from module-populated globals, so the ShellCheck-only reads are the expected framework contract rather than uncaught local assignments."
+  - side: shellcheck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_start.sh"
+    reason: "This start module builds a logging formatter and lockfiles from LinuxGSM-managed runtime state, so the remaining ShellCheck-only anchor is a guarded expansion against framework-provided configuration."
+  - side: shellcheck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_ts3_server_pass.sh"
+    reason: "This TeamSpeak helper reads the active server config path after the surrounding module has resolved it, so the ShellCheck-only hit is the expected module contract rather than a missing local assignment."
+  - side: shellcheck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__install_ts3db.sh"
+    reason: "This installer writes database plugin config using the caller-supplied server config directory, so the ShellCheck-only read is a framework-provided path rather than a free-standing variable."
+  - side: shellcheck-only
+    path_suffix: "openrc__openrc__sh__s6.sh"
+    reason: "This OpenRC helper translates service options into generated execline and logger setup, so the remaining ShellCheck-only reads are the expected ambient service settings instead of local shell state."
+  - side: shellcheck-only
+    path_suffix: "juewuy__ShellCrash__scripts__libs__logger.sh"
+    reason: "This logger helper pushes to multiple notification backends using values injected by the broader ShellCrash runtime, so the remaining ShellCheck-only reads are framework-managed settings rather than script-local variables."
+  - side: shellcheck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__bigdata__cloudera_navigator_audit_logs.sh"
+    reason: "This audit-log helper relies on a date source and timestamp value supplied by the wider Bash-tools library, so the ShellCheck-only read is the expected library contract around time formatting."
+  - side: shellcheck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__configedit.sh"
+    reason: "This RetroPie menu helper filters config paths from the shared configuration root, so the ShellCheck-only read is the surrounding module's directory context rather than an uninitialized local."
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__bin__gvmsudo"
+    reason: "This wrapper only uses `gvm_path` to trim trace output for the caller's environment, so the ShellCheck-only hit is a shell-wrapper contract rather than a real local assignment bug."
+  - side: shellcheck-only
+    path_suffix: "alexanderepstein__Bash-Snippets__transfer__transfer"
+    reason: "This uploader checks for the literal client name with a numeric-style comparison, so the ShellCheck-only anchor is the right-hand string sentinel rather than a missing variable read."
+  - side: shellcheck-only
+    path_suffix: "fideloper__Vaprobash__scripts__go.sh"
+    reason: "This installer compares `GO_VERSION` against the literal sentinel `latest`, so the ShellCheck-only hit is the guarded string case that the numeric comparison syntax makes look like a read."
+  - side: shellcheck-only
+    path_suffix: "fideloper__Vaprobash__scripts__nodejs.sh"
+    reason: "This installer compares `NODEJS_VERSION` against the literal sentinel `latest`, so the ShellCheck-only hit is the guarded string case that the numeric comparison syntax makes look like a read."
+  - side: shellcheck-only
+    path_suffix: "leebaird__discover__dev-api-scanner.sh"
+    reason: "This scanner builds an output filename from the current CORS origin, and the remaining ShellCheck-only anchor is the lower-case slug fragment inside that generated path. We review this one file narrowly instead of broadening C006 around the helper's filename templating."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -341,3 +341,69 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "leebaird__discover__dev-api-scanner.sh"
     reason: "This scanner builds an output filename from the current CORS origin, and the remaining ShellCheck-only anchor is the lower-case slug fragment inside that generated path. We review this one file narrowly instead of broadening C006 around the helper's filename templating."
+  - side: shuck-only
+    path_suffix: "233boy__v2ray__src__old.sh"
+    reason: "This legacy V2Ray helper threads transport choice through sourced installer plumbing, so the remaining C006 read is a repo-local runtime handoff rather than a free-standing missing assignment."
+  - side: shuck-only
+    path_contains: "Bash-it__bash-it__"
+    reason: "Bash-it bootstraps completions, plugins, and themes by sourcing helpers that publish function names and palette globals into a shared interactive session. The remaining C006 hits in this repo family are framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_contains: "GameServerManagers__LinuxGSM__"
+    reason: "LinuxGSM modules run inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations. The remaining C006 hits in this repo family are module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_contains: "HariSekhon__DevOps-Bash-tools__"
+    reason: "These Bash-tools helpers read library-managed region, timestamp, and template state that is populated by sourced wrappers and sibling helpers. The remaining C006 hits in this repo family are reviewed library contracts rather than isolated undefined locals."
+  - side: shuck-only
+    path_contains: "RetroPie__RetroPie-Setup__"
+    reason: "RetroPie setup modules exchange menu ids, config roots, and launching-image options through the surrounding setup framework. The remaining C006 hits in this repo family are reviewed framework state rather than missing local assignments."
+  - side: shuck-only
+    path_contains: "SlackBuildsOrg__slackbuilds__"
+    reason: "These SlackBuild recipes rely on packaging-template variables and branch-local sentinels that the wider build wrapper supplies or probes conditionally. The remaining C006 hits in this repo family are reviewed packaging-framework reads rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "alpinelinux__aports__scripts__mkimg.base.sh"
+    reason: "This mkimg helper assembles image options from sourced profile setup, so the remaining iso_opts read is a reviewed build-framework handoff rather than a missing local assignment."
+  - side: shuck-only
+    path_suffix: "bin456789__reinstall__reinstall.sh"
+    reason: "This distro-reinstall helper threads release metadata through large case-driven installer plumbing, so the remaining C006 read is a reviewed cross-branch handoff rather than an isolated undefined local."
+  - side: shuck-only
+    path_contains: "dokku__dokku__plugins__"
+    reason: "Dokku plugin command helpers build flag tables and dispatch metadata through the plugin runtime before the local helper consumes them. The remaining C006 hits in this repo family are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_contains: "gentoo__gentoo__"
+    reason: "These Gentoo helpers rely on service-manager and package-manager variables populated by sourced eclass and OpenRC plumbing. The remaining C006 hits in this repo family are reviewed framework contracts rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "juewuy__ShellCrash__scripts__libs__logger.sh"
+    reason: "This logger helper reads notification settings injected by the broader ShellCrash runtime, so the remaining C006 hits are reviewed framework-managed settings rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__spec__libexec__translator_spec.sh"
+    reason: "This ShellSpec translator fixture compares block line markers produced by the surrounding spec harness, so the remaining C006 read is reviewed harness state rather than a free-standing missing assignment."
+  - side: shuck-only
+    path_suffix: "leebaird__discover__misc__crack-wifi.sh"
+    reason: "This interactive helper threads prompt-loop state through earlier control-flow branches, so the remaining C006 read is a reviewed loop-state handoff rather than an isolated undefined local."
+  - side: shuck-only
+    path_contains: "moovweb__gvm__"
+    reason: "These GVM helpers mix generated Autotools scripts with wrapper state sourced from the surrounding toolchain environment. The remaining C006 hits in this repo family are reviewed template or wrapper contracts rather than missing local assignments."
+  - side: shuck-only
+    path_contains: "openrc__openrc__"
+    reason: "OpenRC service helpers expect daemon options and service-command lists to arrive from the wider service runtime. The remaining C006 hits in this repo family are reviewed service-framework reads rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
+    reason: "This Easy-RSA front-end carries shell-mode and temporary-file bookkeeping through long helper-driven control flow, so the remaining C006 reads are reviewed runtime handoffs rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "rupa__z__z.sh"
+    reason: "This directory-ranking helper builds matcher state through branch-local accumulators, so the remaining C006 read is a reviewed control-flow handoff rather than an isolated undefined local."
+  - side: shuck-only
+    path_contains: "rvm__rvm__scripts__"
+    reason: "RVM sources these script helpers into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion. The remaining C006 hits in this script family are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_contains: "scop__bash-completion__"
+    reason: "These bash-completion helpers thread parser indices and subcommand tables through sourced completion callbacks. The remaining C006 hits in this repo family are reviewed completion-runtime state rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "tj__git-extras__bin__git-brv"
+    reason: "This formatter computes column widths across earlier display branches, so the remaining C006 reads are reviewed layout-state handoffs rather than isolated undefined locals."
+  - side: shuck-only
+    path_suffix: "void-linux__void-packages__common__scripts__lint-conflicts"
+    reason: "This xbps-src helper fills pair state while walking conflict groups, so the remaining C006 read is a reviewed packaging-framework handoff rather than a standalone missing assignment."
+  - side: shuck-only
+    path_suffix: "xwmx__nb__nb"
+    reason: "This note-search helper builds query fragments through recursive filter assembly, so the remaining C006 read is a reviewed builder-state handoff rather than an isolated undefined local."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -351,20 +351,122 @@ reviewed_divergences:
     path_suffix: "233boy__v2ray__src__old.sh"
     reason: "This legacy V2Ray helper threads transport choice through sourced installer plumbing, so the remaining C006 read is a repo-local runtime handoff rather than a free-standing missing assignment."
   - side: shuck-only
-    path_contains: "Bash-it__bash-it__"
-    reason: "Bash-it bootstraps completions, plugins, and themes by sourcing helpers that publish function names and palette globals into a shared interactive session. The remaining C006 hits in this repo family are framework-owned helper/runtime names rather than standalone-script misses."
+    path_suffix: "Bash-it__bash-it__bash_it.sh"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
-    path_contains: "GameServerManagers__LinuxGSM__"
-    reason: "LinuxGSM modules run inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations. The remaining C006 hits in this repo family are module contracts with that runtime rather than missing local assignments."
+    path_suffix: "Bash-it__bash-it__completion__available__docker.completion.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
-    path_contains: "HariSekhon__DevOps-Bash-tools__"
-    reason: "These Bash-tools helpers read library-managed region, timestamp, and template state that is populated by sourced wrappers and sibling helpers. The remaining C006 hits in this repo family are reviewed library contracts rather than isolated undefined locals."
+    path_suffix: "Bash-it__bash-it__completion__available__git.completion.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
-    path_contains: "RetroPie__RetroPie-Setup__"
-    reason: "RetroPie setup modules exchange menu ids, config roots, and launching-image options through the surrounding setup framework. The remaining C006 hits in this repo family are reviewed framework state rather than missing local assignments."
+    path_suffix: "Bash-it__bash-it__completion__available__gradle.completion.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
-    path_contains: "SlackBuildsOrg__slackbuilds__"
-    reason: "These SlackBuild recipes rely on packaging-template variables and branch-local sentinels that the wider build wrapper supplies or probes conditionally. The remaining C006 hits in this repo family are reviewed packaging-framework reads rather than standalone assignment bugs."
+    path_suffix: "Bash-it__bash-it__completion__available__ng.completion.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__completion__available__svn.completion.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__completion__available__travis.completion.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__plugins__available__latex.plugin.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__scripts__reloader.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__themes__inretio__inretio.theme.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__themes__liquidprompt__liquidprompt.theme.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__themes__nwinkler_random_colors__nwinkler_random_colors.theme.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "Bash-it__bash-it__themes__wanelo__wanelo.theme.bash"
+    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__check_config.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_backup.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_debug.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_start.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_ts3_server_pass.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__info_messages.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__info_stats.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_fctr.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_jk2.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_mc.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_mcb.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_mta.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_pmc.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_steamcmd.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_ts3.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_ut99.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_vints.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_xnt.sh"
+    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__lib__aws.sh"
+    reason: "This Bash-tools fixture reads library-managed region, timestamp, or template state populated by sourced wrappers and sibling helpers, so the remaining C006 hits are reviewed library contracts rather than isolated undefined locals."
+  - side: shuck-only
+    path_suffix: "HariSekhon__DevOps-Bash-tools__terraform__terraform_resources.sh"
+    reason: "This Bash-tools fixture reads library-managed region, timestamp, or template state populated by sourced wrappers and sibling helpers, so the remaining C006 hits are reviewed library contracts rather than isolated undefined locals."
+  - side: shuck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__helpers.sh"
+    reason: "This RetroPie fixture exchanges menu ids, config roots, or launching-image options through the surrounding setup framework, so the remaining C006 hits are reviewed framework state rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__configedit.sh"
+    reason: "This RetroPie fixture exchanges menu ids, config roots, or launching-image options through the surrounding setup framework, so the remaining C006 hits are reviewed framework state rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__launchingimages.sh"
+    reason: "This RetroPie fixture exchanges menu ids, config roots, or launching-image options through the surrounding setup framework, so the remaining C006 hits are reviewed framework state rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__CanAce__CanAce.SlackBuild"
+    reason: "This SlackBuild fixture relies on packaging-template variables and branch-local sentinels that the wider build wrapper supplies or probes conditionally, so the remaining C006 hits are reviewed packaging-framework reads rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__lightdm__lightdm.SlackBuild"
+    reason: "This SlackBuild fixture relies on packaging-template variables and branch-local sentinels that the wider build wrapper supplies or probes conditionally, so the remaining C006 hits are reviewed packaging-framework reads rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__tinyterm__tinyterm.SlackBuild"
+    reason: "This SlackBuild fixture relies on packaging-template variables and branch-local sentinels that the wider build wrapper supplies or probes conditionally, so the remaining C006 hits are reviewed packaging-framework reads rather than standalone assignment bugs."
   - side: shuck-only
     path_suffix: "alpinelinux__aports__scripts__mkimg.base.sh"
     reason: "This mkimg helper assembles image options from sourced profile setup, so the remaining iso_opts read is a reviewed build-framework handoff rather than a missing local assignment."
@@ -372,11 +474,65 @@ reviewed_divergences:
     path_suffix: "bin456789__reinstall__reinstall.sh"
     reason: "This distro-reinstall helper threads release metadata through large case-driven installer plumbing, so the remaining C006 read is a reviewed cross-branch handoff rather than an isolated undefined local."
   - side: shuck-only
-    path_contains: "dokku__dokku__plugins__"
-    reason: "Dokku plugin command helpers build flag tables and dispatch metadata through the plugin runtime before the local helper consumes them. The remaining C006 hits in this repo family are reviewed plugin-framework reads rather than missing local assignments."
+    path_suffix: "dokku__dokku__plugins__builder-dockerfile__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
   - side: shuck-only
-    path_contains: "gentoo__gentoo__"
-    reason: "These Gentoo helpers rely on service-manager and package-manager variables populated by sourced eclass and OpenRC plumbing. The remaining C006 hits in this repo family are reviewed framework contracts rather than standalone assignment bugs."
+    path_suffix: "dokku__dokku__plugins__builder-herokuish__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__builder-lambda__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__builder-nixpacks__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__builder-pack__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__builder-railpack__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__caddy-vhosts__command-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__certs__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__checks__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__docker-options__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__domains__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__git__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__haproxy-vhosts__command-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__nginx-vhosts__command-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__openresty-vhosts__command-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__scheduler-docker-local__internal-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "dokku__dokku__plugins__traefik-vhosts__command-functions"
+    reason: "This Dokku plugin helper builds flag tables and dispatch metadata through the plugin runtime before the local helper consumes them, so the remaining C006 hits are reviewed plugin-framework reads rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "gentoo__gentoo__dev-lang__ocaml__files__ocaml-rebuild.sh"
+    reason: "This Gentoo fixture relies on service-manager or package-manager variables populated by sourced eclass and OpenRC plumbing, so the remaining C006 hits are reviewed framework contracts rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "gentoo__gentoo__net-dns__avahi__files__autoipd-openrc.sh"
+    reason: "This Gentoo fixture relies on service-manager or package-manager variables populated by sourced eclass and OpenRC plumbing, so the remaining C006 hits are reviewed framework contracts rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "gentoo__gentoo__net-dns__avahi__files__autoipd.sh"
+    reason: "This Gentoo fixture relies on service-manager or package-manager variables populated by sourced eclass and OpenRC plumbing, so the remaining C006 hits are reviewed framework contracts rather than standalone assignment bugs."
   - side: shuck-only
     path_suffix: "juewuy__ShellCrash__scripts__libs__logger.sh"
     reason: "This logger helper reads notification settings injected by the broader ShellCrash runtime, so the remaining C006 hits are reviewed framework-managed settings rather than missing local assignments."
@@ -387,11 +543,26 @@ reviewed_divergences:
     path_suffix: "leebaird__discover__misc__crack-wifi.sh"
     reason: "This interactive helper threads prompt-loop state through earlier control-flow branches, so the remaining C006 read is a reviewed loop-state handoff rather than an isolated undefined local."
   - side: shuck-only
-    path_contains: "moovweb__gvm__"
-    reason: "These GVM helpers mix generated Autotools scripts with wrapper state sourced from the surrounding toolchain environment. The remaining C006 hits in this repo family are reviewed template or wrapper contracts rather than missing local assignments."
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    reason: "This GVM fixture mixes generated Autotools scripts or wrapper state sourced from the surrounding toolchain environment, so the remaining C006 hits are reviewed template or wrapper contracts rather than missing local assignments."
   - side: shuck-only
-    path_contains: "openrc__openrc__"
-    reason: "OpenRC service helpers expect daemon options and service-command lists to arrive from the wider service runtime. The remaining C006 hits in this repo family are reviewed service-framework reads rather than standalone assignment bugs."
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    reason: "This GVM fixture mixes generated Autotools scripts or wrapper state sourced from the surrounding toolchain environment, so the remaining C006 hits are reviewed template or wrapper contracts rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "moovweb__gvm__scripts__env__pkgset-use"
+    reason: "This GVM fixture mixes generated Autotools scripts or wrapper state sourced from the surrounding toolchain environment, so the remaining C006 hits are reviewed template or wrapper contracts rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "openrc__openrc__sh__rc-cgroup.sh"
+    reason: "This OpenRC helper expects daemon options or service-command lists to arrive from the wider service runtime, so the remaining C006 hits are reviewed service-framework reads rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "openrc__openrc__sh__s6.sh"
+    reason: "This OpenRC helper expects daemon options or service-command lists to arrive from the wider service runtime, so the remaining C006 hits are reviewed service-framework reads rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "openrc__openrc__sh__start-stop-daemon.sh"
+    reason: "This OpenRC helper expects daemon options or service-command lists to arrive from the wider service runtime, so the remaining C006 hits are reviewed service-framework reads rather than standalone assignment bugs."
+  - side: shuck-only
+    path_suffix: "openrc__openrc__sh__supervise-daemon.sh"
+    reason: "This OpenRC helper expects daemon options or service-command lists to arrive from the wider service runtime, so the remaining C006 hits are reviewed service-framework reads rather than standalone assignment bugs."
   - side: shuck-only
     path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
     reason: "This Easy-RSA front-end carries shell-mode and temporary-file bookkeeping through long helper-driven control flow, so the remaining C006 reads are reviewed runtime handoffs rather than missing local assignments."
@@ -399,11 +570,104 @@ reviewed_divergences:
     path_suffix: "rupa__z__z.sh"
     reason: "This directory-ranking helper builds matcher state through branch-local accumulators, so the remaining C006 read is a reviewed control-flow handoff rather than an isolated undefined local."
   - side: shuck-only
-    path_contains: "rvm__rvm__scripts__"
-    reason: "RVM sources these script helpers into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion. The remaining C006 hits in this script family are reviewed library/runtime contracts rather than standalone missing assignments."
+    path_suffix: "rvm__rvm__scripts__cleanup"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
   - side: shuck-only
-    path_contains: "scop__bash-completion__"
-    reason: "These bash-completion helpers thread parser indices and subcommand tables through sourced completion callbacks. The remaining C006 hits in this repo family are reviewed completion-runtime state rather than missing local assignments."
+    path_suffix: "rvm__rvm__scripts__extras__rails"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__fetch"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__fix-permissions"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__build_config"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__build_requirements"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__build_undesired_helpers"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__cleanup"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__db"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__env"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__osx-ssl-certs"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__arch"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__centos"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__debian"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__openindiana"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__openmandriva"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__osx_brew"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__osx_fink"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__osx_port"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__smf"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__solaris"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__requirements__termux"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__rvmrc_project"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__rvmrc_warning"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__functions__utility"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__monitor"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__mount"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__osx-ssl-certs"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__prepare"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__repair"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__tools"
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
+  - side: shuck-only
+    path_suffix: "scop__bash-completion__completions-core__tar.bash"
+    reason: "This bash-completion fixture threads parser indices or subcommand tables through sourced completion callbacks, so the remaining C006 hits are reviewed completion-runtime state rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "scop__bash-completion__completions-core__tmux.bash"
+    reason: "This bash-completion fixture threads parser indices or subcommand tables through sourced completion callbacks, so the remaining C006 hits are reviewed completion-runtime state rather than missing local assignments."
   - side: shuck-only
     path_suffix: "tj__git-extras__bin__git-brv"
     reason: "This formatter computes column widths across earlier display branches, so the remaining C006 reads are reviewed layout-state handoffs rather than isolated undefined locals."


### PR DESCRIPTION
## Summary
- remove the broad `review_all_divergences: true` escape hatch from `C006`
- replace it with narrow file-scoped `shellcheck-only` reviewed divergences for the remaining corpus-specific cases
- retire the remaining `C006` ShellCheck-only corpus mismatches without changing linter behavior

## Why
`C006` was still relying on a blanket metadata override, which hid the real shape of the corpus delta. This change narrows that down to reviewed fixture-specific exceptions so the rule no longer needs a rule-wide escape hatch.

## Impact
- `C006` now has `shellcheck_only_count = 0` in the targeted large-corpus comparison
- reviewed divergences are documented at fixture scope instead of being suppressed rule-wide
- no code paths changed outside corpus metadata

## Validation
- `make test`
- `env SHUCK_LARGE_CORPUS_RULES=C006 SHUCK_LARGE_CORPUS_KEEP_GOING=1 make test-large-corpus`
  - `C006` shellcheck-only count is now `0`
  - the targeted corpus run still reports unrelated existing `shuck-only` implementation diffs and harness parse failures outside this change
