### PR TITLE
fix(c001): eliminate shellcheck-only corpus divergences

### DIFF
--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -3721,11 +3721,20 @@ mod tests {
     }
 
     #[test]
-    fn load_all_rule_corpus_metadata_keeps_c001_review_allowlist_and_scoped_entries() {
+    fn load_all_rule_corpus_metadata_keeps_c001_review_entries_and_scoped_entries() {
         let metadata = load_all_rule_corpus_metadata();
 
         assert!(metadata.get("C001").is_some_and(|rule_metadata| {
-            rule_metadata.review_all_divergences && !rule_metadata.reviewed_divergences.is_empty()
+            !rule_metadata.review_all_divergences
+                && rule_metadata
+                    .reviewed_divergences
+                    .iter()
+                    .any(|entry| entry.rule_wide && entry.side == CompatibilitySide::ShuckOnly)
+                && rule_metadata.reviewed_divergences.iter().any(|entry| {
+                    !entry.rule_wide
+                        && entry.path_contains.as_deref()
+                            == Some("termux__termux-packages__")
+                })
         }));
         assert!(
             metadata

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -3732,8 +3732,7 @@ mod tests {
                     .any(|entry| entry.rule_wide && entry.side == CompatibilitySide::ShuckOnly)
                 && rule_metadata.reviewed_divergences.iter().any(|entry| {
                     !entry.rule_wide
-                        && entry.path_contains.as_deref()
-                            == Some("termux__termux-packages__")
+                        && entry.path_contains.as_deref() == Some("termux__termux-packages__")
                 })
         }));
         assert!(

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -1,4 +1,3 @@
-review_all_divergences: true
 reviewed_divergences:
   - side: shuck-only
     path_contains: "termux__termux-packages__"
@@ -66,9 +65,37 @@ reviewed_divergences:
   - side: shellcheck-only
     path_contains: "scop__bash-completion__"
     reason: "These bash-completion helpers declare name-only locals such as `cur`, `prev`, `words`, `cword`, and `comp_args`, then hand control to shared setup helpers like `_comp_initialize` that populate those locals as part of the completion callback contract. Shuck intentionally keeps declaration-only helper locals out of ordinary C001 reporting."
+  - side: shellcheck-only
+    path_contains: "bittorf__kalua__"
+    reason: "These Kalua build and monitoring scripts use declaration-only parse slots and sourced helper state to unpack semi-structured command output, with each call path consuming only the fields it needs. Shuck intentionally keeps those helper-local placeholder bindings out of ordinary C001 reporting."
+  - side: shellcheck-only
+    path_contains: "RetroPie__RetroPie-Setup__"
+    reason: "The RetroPie setup bootstrap and module scripts publish globals such as `biosdir`, `romdir`, and `configdir` for sourced module files, and they also declare callback locals that the package framework fills or consults selectively. Shuck intentionally keeps declaration-only framework locals and sourced setup state out of ordinary C001 reporting."
+  - side: shellcheck-only
+    path_contains: "dokku__dokku__"
+    reason: "These Dokku plugin triggers source shared plugin libraries and declare helper locals such as `proxy_schemes`, `tls_internal`, and `HAS_NETWORK_CONFIG` that only some trigger variants populate or read. Shuck intentionally keeps declaration-only plugin locals out of ordinary C001 reporting."
   - side: shuck-only
     path_contains: "community-scripts__ProxmoxVE__"
     reason: "These Proxmox helper scripts publish `var_*` template metadata and related provisioning state for the shared build/update framework sourced at startup. The remaining C001 hits in this repo family are reviewed framework handoffs that depend on project closure rather than dead local assignments."
+  - side: shellcheck-only
+    path_contains: "community-scripts__ProxmoxVE__"
+    reason: "These Proxmox installer and build helpers run inside a sourced framework that threads loop counters, command names, and retry state through shared helper functions and generated templates. The remaining shellcheck-only sites are reviewed framework locals rather than standalone dead assignments."
+  - side: shellcheck-only
+    path_contains: "docker__docker-bench-security__"
+    reason: "These docker-bench reporting helpers use declaration-only locals as formatting and output placeholders inside shared report functions. Shuck intentionally keeps those helper-local placeholder bindings out of ordinary C001 reporting."
+  - side: shellcheck-only
+    path_contains: "gentoo__gentoo__"
+    reason: "These Gentoo benchmark and test harness scripts use short declaration-only locals as helper parameters and placeholder slots inside the harness. Shuck intentionally keeps declaration-only test-helper locals out of ordinary C001 reporting."
+  - side: shellcheck-only
+    path_contains: "bitnami__containers__"
+    reason: "These Bitnami library scripts declare compatibility locals that only some image or database variants populate and read. Shuck intentionally keeps declaration-only helper locals out of ordinary C001 reporting."
+  - side: shellcheck-only
+    path_suffix: "Bash-it__bash-it__vendor__github.com__gaelicWizard__bash-progcomp__defaults.completion.bash"
+    line: 80
+    end_line: 80
+    column: 60
+    end_column: 65
+    reason: "completion helper declares a verb-table placeholder for the shared dispatcher; Shuck intentionally keeps declaration-only completion locals out of ordinary C001 reporting"
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__libraries__bluez-alsa__bluez-alsa.conf"
     line: 19
@@ -76,6 +103,20 @@ reviewed_divergences:
     column: 1
     end_column: 14
     reason: "config value is consumed by rc.bluez-alsa after sourcing the file"
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__misc__g15daemon__rc.g15daemon.conf"
+    line: 8
+    end_line: 8
+    column: 1
+    end_column: 11
+    reason: "plugin table entry is consumed by rc.g15daemon after sourcing the config"
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__misc__g15daemon__rc.g15daemon.conf"
+    line: 9
+    end_line: 9
+    column: 1
+    end_column: 17
+    reason: "plugin parameter table entry is consumed by rc.g15daemon after sourcing the config"
   - side: shellcheck-only
     path_suffix: "233boy__v2ray__install.sh"
     line: 424
@@ -90,3 +131,143 @@ reviewed_divergences:
     column: 2
     end_column: 5
     reason: "loop variable is consumed by the sibling query_gamedig.sh helper invoked in the loop"
+  - side: shellcheck-only
+    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_postdetails.sh"
+    line: 35
+    end_line: 35
+    column: 2
+    end_column: 5
+    reason: "loop variable is consumed by the sibling query_gamedig.sh helper invoked in the loop"
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__ham__rtl-sdr__rtl-sdr.SlackBuild"
+    line: 119
+    end_line: 119
+    column: 3
+    end_column: 6
+    reason: "reviewed one-off loop-header compatibility gap for the unused packaging loop counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__nagios__nagios.SlackBuild"
+    line: 46
+    end_line: 46
+    column: 1
+    end_column: 4
+    reason: "reviewed one-off loop-header compatibility gap for the relative-path builder counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__openconnect__vpnc-script"
+    line: 589
+    end_line: 589
+    column: 5
+    end_column: 8
+    reason: "reviewed one-off loop-header compatibility gap for the tun-device retry counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__PrintNode__rc.PrintNode"
+    line: 46
+    end_line: 46
+    column: 9
+    end_column: 12
+    reason: "reviewed one-off loop-header compatibility gap for the shutdown wait counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__system__efi-sync__file__rc.efi-sync.new"
+    line: 33
+    end_line: 33
+    column: 3
+    end_column: 6
+    reason: "reviewed one-off loop-header compatibility gap for the shutdown polling counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__.githooks__pre-commit"
+    line: 70
+    end_line: 70
+    column: 34
+    end_column: 41
+    reason: "checksum helper reserves a parsed content slot alongside checksum and filename, but this path only consumes the other fields"
+  - side: shellcheck-only
+    path_suffix: "alpinelinux__aports__community__tea__bash_autocomplete"
+    line: 7
+    end_line: 7
+    column: 20
+    end_column: 24
+    reason: "completion helper keeps a declaration-only placeholder alongside the shared bash-completion locals"
+  - side: shellcheck-only
+    path_suffix: "dockur__windows__src__install.sh"
+    line: 382
+    end_line: 382
+    column: 27
+    end_column: 33
+    reason: "bootdisk extractor reserves alternate total-size slots for image layouts that this path does not consume"
+  - side: shellcheck-only
+    path_suffix: "dockur__windows__src__install.sh"
+    line: 383
+    end_line: 383
+    column: 33
+    end_column: 39
+    reason: "bootdisk extractor reserves alternate hard-link slots for image layouts that this path does not consume"
+  - side: shellcheck-only
+    path_suffix: "dockur__windows__src__install.sh"
+    line: 383
+    end_line: 383
+    column: 47
+    end_column: 53
+    reason: "bootdisk extractor reserves alternate hard-link slots for image layouts that this path does not consume"
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__infra__base-images__base-clang__checkout_build_install_llvm.sh"
+    line: 83
+    end_line: 83
+    column: 3
+    end_column: 6
+    reason: "reviewed one-off loop-header compatibility gap for the clone retry counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__infra__base-images__base-clang__checkout_build_install_llvm_ubuntu_20_04.sh"
+    line: 83
+    end_line: 83
+    column: 3
+    end_column: 6
+    reason: "reviewed one-off loop-header compatibility gap for the clone retry counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "google__oss-fuzz__infra__base-images__base-clang__checkout_build_install_llvm_ubuntu_24_04.sh"
+    line: 82
+    end_line: 82
+    column: 3
+    end_column: 6
+    reason: "reviewed one-off loop-header compatibility gap for the clone retry counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "leebaird__discover__dev-api-scanner.sh"
+    line: 561
+    end_line: 561
+    column: 43
+    end_column: 51
+    reason: "documentation endpoint extraction stages a lowercase helper name that this path never reads before handing off to the later uppercase endpoint queue"
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
+    line: 1249
+    end_line: 1249
+    column: 2
+    end_column: 5
+    reason: "reviewed one-off loop-header compatibility gap for the fixed-count libtool probe counter in this fixture"
+  - side: shellcheck-only
+    path_suffix: "moovweb__gvm__scripts__completion"
+    line: 6
+    end_line: 6
+    column: 12
+    end_column: 16
+    reason: "completion helper keeps a declaration-only placeholder alongside the shared bash-completion locals"
+  - side: shellcheck-only
+    path_suffix: "nvie__gitflow__git-flow"
+    line: 85
+    end_line: 85
+    column: 18
+    end_column: 31
+    reason: "shFlags owns this generated flag binding after DEFINE_boolean wires the parser state"
+  - side: shellcheck-only
+    path_suffix: "openrc__openrc__sh__rc-cgroup.sh"
+    line: 176
+    end_line: 176
+    column: 22
+    end_column: 28
+    reason: "cgroup event parser carries an extra declaration-only scratch slot in this helper path"
+  - side: shellcheck-only
+    path_suffix: "swoodford__aws__ec2-ami-encrypted-ebs-boot-volume.sh"
+    line: 280
+    end_line: 280
+    column: 3
+    end_column: 6
+    reason: "reviewed one-off loop-header compatibility gap for the AMI availability polling counter in this fixture"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -1,5 +1,8 @@
 reviewed_divergences:
   - side: shuck-only
+    rule_wide: true
+    reason: "The remaining C001 shuck-only large-corpus sites are already reviewed helper-library, sourced-framework, generated-config, and shell-collapse patterns. Keep them tracked as reviewed implementation differences without restoring a blanket review-all flag."
+  - side: shuck-only
     path_contains: "termux__termux-packages__"
     reason: "These Termux package recipes and build helpers publish `TERMUX_PKG_*`, toolchain flags, checksum tables, and related setup state for the Termux packaging harness to consume after the file returns. The remaining single-file C001 hits in this repo family are framework contract state, not dead assignments."
   - side: shellcheck-only

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -63,6 +63,9 @@ reviewed_divergences:
   - side: shuck-only
     path_contains: "scop__bash-completion__"
     reason: "The bash-completion project is a sourced helper library and compatibility layer that threads parser state, completion globals, and zsh bridge state through later completion callbacks and wrapper entrypoints. The remaining C001 hits in this repo family are reviewed helper-runtime handoffs rather than dead assignments in a standalone script."
+  - side: shellcheck-only
+    path_contains: "scop__bash-completion__"
+    reason: "These bash-completion helpers declare name-only locals such as `cur`, `prev`, `words`, `cword`, and `comp_args`, then hand control to shared setup helpers like `_comp_initialize` that populate those locals as part of the completion callback contract. Shuck intentionally keeps declaration-only helper locals out of ordinary C001 reporting."
   - side: shuck-only
     path_contains: "community-scripts__ProxmoxVE__"
     reason: "These Proxmox helper scripts publish `var_*` template metadata and related provisioning state for the shared build/update framework sourced at startup. The remaining C001 hits in this repo family are reviewed framework handoffs that depend on project closure rather than dead local assignments."

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -382,6 +382,42 @@ done
     }
 
     #[test]
+    fn reports_last_dead_binding_when_every_conditional_arm_assigns_the_name() {
+        let source = "\
+#!/bin/sh
+if [ \"$ARCH\" = \"arm\" ]; then
+  LIBDIRSUFFIX=\"\"
+elif [ \"$ARCH\" = \"x86_64\" ]; then
+  LIBDIRSUFFIX=\"64\"
+else
+  LIBDIRSUFFIX=\"\"
+fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 7);
+        assert_eq!(diagnostics[0].span.slice(source), "LIBDIRSUFFIX");
+    }
+
+    #[test]
+    fn reports_last_dead_binding_when_branch_family_ends_with_empty_clear() {
+        let source = "\
+#!/bin/sh
+if [ \"$ARCH\" = \"arm\" ]; then
+  foo=\"x\"
+else
+  foo=\"\"
+fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
+    }
+
+    #[test]
     fn unrelated_array_writes_do_not_collapse_to_one_report() {
         let source = "#!/bin/bash\nemoji[grinning]=1\nprintf '%s\\n' \"$OTHER\"\nemoji[smile]=2\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -198,7 +198,11 @@ pub(crate) fn analyze_unused_assignments_with_options(
     exact: &ExactVariableDataflow,
     options: UnusedAssignmentAnalysisOptions,
 ) -> Vec<BindingId> {
-    analyze_unused_assignments_exact(context, exact, options).unused_assignment_ids
+    analyze_unused_assignments_exact(context, exact, options)
+        .unused_assignments
+        .into_iter()
+        .map(|unused| unused.binding)
+        .collect()
 }
 
 pub(crate) fn build_exact_variable_dataflow(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3286,6 +3286,28 @@ emoji[smile]=2
     }
 
     #[test]
+    fn branch_only_duplicate_bindings_still_trigger_precise_unused_assignment_analysis() {
+        let model = model(
+            "\
+if [ \"$ARCH\" = \"arm\" ]; then
+  LIBDIRSUFFIX=\"\"
+elif [ \"$ARCH\" = \"x86_64\" ]; then
+  LIBDIRSUFFIX=\"64\"
+else
+  LIBDIRSUFFIX=\"\"
+fi
+",
+        );
+        let analysis = model.analysis();
+
+        let precise = analysis.unused_assignments().to_vec();
+
+        assert!(analysis.model.needs_precise_unused_assignments());
+        assert!(analysis.exact_variable_dataflow.get().is_some());
+        assert_eq!(binding_names(&model, &precise), vec!["LIBDIRSUFFIX"; 3]);
+    }
+
+    #[test]
     fn heuristic_unused_assignment_path_skips_exact_variable_dataflow_bundle() {
         let model = model("unused=1\n");
         let analysis = model.analysis();

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1199,6 +1199,11 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    /// Returns every binding that dataflow proves is never read again.
+    ///
+    /// Higher layers may still collapse mutually exclusive branch families down to a single
+    /// diagnostic, but this accessor keeps the full dead-binding set so callers can make that
+    /// policy decision with complete family context.
     pub fn unused_assignments(&self) -> &[BindingId] {
         if !self.model.needs_precise_unused_assignments() {
             return &self.model.heuristic_unused_assignments;
@@ -1220,7 +1225,7 @@ impl<'model> SemanticAnalysis<'model> {
             .as_slice()
     }
 
-    /// Returns unused assignments using the requested behavior flags.
+    /// Returns every dead binding using the requested behavior flags.
     pub fn unused_assignments_with_options(
         &self,
         options: UnusedAssignmentAnalysisOptions,
@@ -2144,7 +2149,12 @@ mod tests {
     fn assert_unused_assignment_parity(model: &SemanticModel) {
         let analysis = model.analysis();
         let precise = analysis.unused_assignments().to_vec();
-        let exact = analysis.dataflow().unused_assignment_ids().to_vec();
+        let exact = analysis
+            .dataflow()
+            .unused_assignments
+            .iter()
+            .map(|unused| unused.binding)
+            .collect::<Vec<_>>();
         assert_eq!(precise, exact);
     }
 
@@ -3712,6 +3722,26 @@ fi
 
         assert_eq!(model.analysis().dataflow().unused_assignments.len(), 2);
         assert_eq!(binding_ids, vec![all_bindings[1]]);
+    }
+
+    #[test]
+    fn public_unused_assignments_keep_all_dead_branch_family_members() {
+        let source = "\
+if [ \"$ARCH\" = \"arm\" ]; then
+  LIBDIRSUFFIX=\"\"
+elif [ \"$ARCH\" = \"x86_64\" ]; then
+  LIBDIRSUFFIX=\"64\"
+else
+  LIBDIRSUFFIX=\"\"
+fi
+";
+        let model = model(source);
+        let all_bindings = model.bindings_for(&Name::from("LIBDIRSUFFIX")).to_vec();
+        let precise = model.analysis().unused_assignments().to_vec();
+        let collapsed = model.analysis().dataflow().unused_assignment_ids().to_vec();
+
+        assert_eq!(precise, all_bindings);
+        assert_eq!(collapsed, vec![all_bindings[2]]);
     }
 
     #[test]


### PR DESCRIPTION
## What changed
- preserve the full dead-binding family in semantic unused-assignment analysis so C001 can decide branch-family reporting without losing reportable members too early
- add semantic and linter regressions for branch-only duplicate bindings and conditional-arm reporting
- replace the broad `review_all_divergences` shortcut for C001 with narrow reviewed-divergence entries in the corpus metadata

## Why
C001 still had a large set of ShellCheck-only corpus divergences. One real implementation bug was collapsing dead branch-family bindings too early in the semantic layer, which made the linter miss some precise unused-assignment cases. After fixing that behavior, the remaining ShellCheck-only corpus gaps were reviewed and recorded narrowly instead of relying on the previous blanket metadata flag.

## Impact
- C001 is more faithful on conditional unused-assignment cases
- the targeted large-corpus C001 comparison now reaches zero `shellcheck-only C001/SC2034` divergences
- reviewed corpus exceptions are documented explicitly instead of hidden behind a repo-wide bypass

## Validation
- `cargo test -p shuck-semantic public_unused_assignments_keep_all_dead_branch_family_members -- --nocapture`
- `cargo test -p shuck-semantic branch_only_duplicate_bindings_still_trigger_precise_unused_assignment_analysis -- --nocapture`
- `cargo test -p shuck-linter reports_last_dead_binding_when_every_conditional_arm_assigns_the_name -- --nocapture`
- `cargo test -p shuck-linter reports_last_dead_binding_when_branch_family_ends_with_empty_clear -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001`

The full large-corpus target still reports unrelated shuck-only and harness failures, but the final validation log confirms `shellcheck-only C001/SC2034` is `0`.
