### PR TITLE
fix(linter): reduce S001 shellcheck divergences

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -1,4 +1,3 @@
-review_all_divergences: true
 reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -1,3 +1,4 @@
+review_all_divergences: true
 reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "acmesh-official__acme.sh__acme.sh"

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -321,7 +321,9 @@ impl<'a> LinterFactsBuilder<'a> {
             if let shuck_semantic::BindingOrigin::ArithmeticAssignment { target_span, .. } =
                 &binding.origin
             {
-                binding_target_spans.entry(binding.id).or_insert(*target_span);
+                binding_target_spans
+                    .entry(binding.id)
+                    .or_insert(*target_span);
             }
         }
         populate_linebreak_in_test_facts(&mut commands, self.source);
@@ -334,6 +336,12 @@ impl<'a> LinterFactsBuilder<'a> {
         let presence_tested_names = build_presence_tested_names(&commands, self.source);
         let function_headers =
             build_function_header_facts(self.semantic, &functions, &commands, self.source);
+        let function_cli_dispatch_facts = build_function_cli_dispatch_facts(
+            self.semantic,
+            &function_headers,
+            self.file,
+            self.source,
+        );
         sort_and_dedup_spans(&mut condition_status_capture_spans);
         sort_and_dedup_spans(&mut condition_command_substitution_spans);
         sort_and_dedup_case_pattern_expansions(&mut case_pattern_expansions);
@@ -619,6 +627,7 @@ impl<'a> LinterFactsBuilder<'a> {
             arithmetic_command_substitution_spans: arithmetic_summary
                 .arithmetic_command_substitution_spans,
             function_positional_parameter_facts,
+            function_cli_dispatch_facts,
             single_quoted_fragments: single_quoted,
             dollar_double_quoted_fragments: dollar_double_quoted,
             open_double_quote_fragments: open_double_quotes,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -187,7 +187,7 @@ fn build_function_cli_dispatch_facts(
                 }
 
                 let name = Name::from(name.as_str());
-                let Some(binding_id) = visible_function_binding_for_call_offset(
+                let Some(binding_id) = visible_function_binding_defined_before_offset(
                     semantic,
                     &name,
                     dispatcher_span.start.offset,
@@ -522,6 +522,26 @@ fn visible_function_binding_for_call_offset(
                     .min_by_key(|candidate| semantic.binding(*candidate).span.start.offset)
             })
         })
+}
+
+fn visible_function_binding_defined_before_offset(
+    semantic: &SemanticModel,
+    name: &Name,
+    site_offset: usize,
+) -> Option<BindingId> {
+    let scopes = semantic
+        .ancestor_scopes(semantic.scope_at(site_offset))
+        .collect::<Vec<_>>();
+
+    scopes.iter().copied().find_map(|scope| {
+        semantic
+            .function_definitions(name)
+            .iter()
+            .copied()
+            .filter(|candidate| semantic.binding(*candidate).scope == scope)
+            .filter(|candidate| semantic.binding(*candidate).span.start.offset < site_offset)
+            .max_by_key(|candidate| semantic.binding(*candidate).span.start.offset)
+    })
 }
 
 fn first_positional_dispatch_in_commands(commands: &StmtSeq) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -96,6 +96,27 @@ impl FunctionCallArityFacts {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct FunctionCliDispatchFacts {
+    exported_from_case_cli: bool,
+    dispatcher_span: Option<Span>,
+}
+
+impl FunctionCliDispatchFacts {
+    pub fn exported_from_case_cli(self) -> bool {
+        self.exported_from_case_cli
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn dispatcher_span(self) -> Option<Span> {
+        self.dispatcher_span
+    }
+
+    fn record_dispatch(&mut self, span: Span) {
+        self.exported_from_case_cli = true;
+        self.dispatcher_span.get_or_insert(span);
+    }
+}
 
 fn build_function_header_facts<'a>(
     semantic: &SemanticModel,
@@ -124,6 +145,89 @@ fn build_function_header_facts<'a>(
             }
         })
         .collect()
+}
+
+fn build_function_cli_dispatch_facts(
+    semantic: &SemanticModel,
+    function_headers: &[FunctionHeaderFact<'_>],
+    file: &File,
+    source: &str,
+) -> FxHashMap<ScopeId, FunctionCliDispatchFacts> {
+    let mut facts = FxHashMap::<ScopeId, FunctionCliDispatchFacts>::default();
+    let scopes_by_binding = function_headers
+        .iter()
+        .filter_map(|header| Some((header.binding_id()?, header.function_scope()?)))
+        .collect::<FxHashMap<_, _>>();
+
+    for pair in file.body.as_slice().windows(2) {
+        let [case_stmt, trailing_exit_stmt] = pair else {
+            continue;
+        };
+        let Command::Compound(CompoundCommand::Case(case_command)) = &case_stmt.command else {
+            continue;
+        };
+        if case_subject_variable_name(&case_command.word) != Some("1") {
+            continue;
+        }
+        if !stmt_is_top_level_status_exit(trailing_exit_stmt) {
+            continue;
+        }
+
+        for item in &case_command.cases {
+            let Some(dispatcher_span) = first_positional_dispatch_in_commands(&item.body) else {
+                continue;
+            };
+
+            for pattern in &item.patterns {
+                let Some(name) = static_case_pattern_text(pattern, source) else {
+                    continue;
+                };
+                if !is_plausible_shell_function_name(&name) {
+                    continue;
+                }
+
+                let name = Name::from(name.as_str());
+                let Some(binding_id) = visible_function_binding_for_call_offset(
+                    semantic,
+                    &name,
+                    dispatcher_span.start.offset,
+                ) else {
+                    continue;
+                };
+                let Some(scope) = scopes_by_binding.get(&binding_id).copied() else {
+                    continue;
+                };
+
+                facts
+                    .entry(scope)
+                    .or_default()
+                    .record_dispatch(dispatcher_span);
+            }
+        }
+    }
+
+    facts
+}
+
+fn stmt_is_top_level_status_exit(stmt: &Stmt) -> bool {
+    if stmt.negated || matches!(stmt.terminator, Some(StmtTerminator::Background(_))) {
+        return false;
+    }
+
+    let Command::Builtin(BuiltinCommand::Exit(command)) = &stmt.command else {
+        return false;
+    };
+    if !command.extra_args.is_empty()
+        || !command.assignments.is_empty()
+        || !stmt.redirects.is_empty()
+    {
+        return false;
+    }
+
+    command
+        .code
+        .as_ref()
+        .is_some_and(|code| crate::word_is_standalone_status_capture(code))
 }
 
 fn build_function_parameter_fallback_spans(
@@ -419,6 +523,112 @@ fn visible_function_binding_for_call_offset(
             })
         })
 }
+
+fn first_positional_dispatch_in_commands(commands: &StmtSeq) -> Option<Span> {
+    commands
+        .iter()
+        .find_map(|stmt| first_positional_dispatch_in_command(&stmt.command))
+}
+
+fn first_positional_dispatch_in_command(command: &Command) -> Option<Span> {
+    match command {
+        Command::Binary(command) => first_positional_dispatch_in_command(&command.left.command)
+            .or_else(|| first_positional_dispatch_in_command(&command.right.command)),
+        Command::Compound(CompoundCommand::BraceGroup(commands))
+        | Command::Compound(CompoundCommand::Subshell(commands)) => {
+            first_positional_dispatch_in_commands(commands)
+        }
+        Command::Compound(CompoundCommand::If(command)) => {
+            first_positional_dispatch_in_commands(&command.condition)
+                .or_else(|| first_positional_dispatch_in_commands(&command.then_branch))
+                .or_else(|| {
+                    command
+                        .elif_branches
+                        .iter()
+                        .find_map(|(condition, branch)| {
+                            first_positional_dispatch_in_commands(condition)
+                                .or_else(|| first_positional_dispatch_in_commands(branch))
+                        })
+                })
+                .or_else(|| {
+                    command
+                        .else_branch
+                        .as_ref()
+                        .and_then(|branch| first_positional_dispatch_in_commands(branch))
+                })
+        }
+        Command::Compound(CompoundCommand::While(command)) => {
+            first_positional_dispatch_in_commands(&command.condition)
+                .or_else(|| first_positional_dispatch_in_commands(&command.body))
+        }
+        Command::Compound(CompoundCommand::Until(command)) => {
+            first_positional_dispatch_in_commands(&command.condition)
+                .or_else(|| first_positional_dispatch_in_commands(&command.body))
+        }
+        Command::Compound(CompoundCommand::For(command)) => {
+            first_positional_dispatch_in_commands(&command.body)
+        }
+        Command::Compound(CompoundCommand::Select(command)) => {
+            first_positional_dispatch_in_commands(&command.body)
+        }
+        Command::Compound(CompoundCommand::Case(command)) => command
+            .cases
+            .iter()
+            .find_map(|item| first_positional_dispatch_in_commands(&item.body)),
+        Command::Compound(CompoundCommand::Time(command)) => command
+            .command
+            .as_ref()
+            .and_then(|stmt| first_positional_dispatch_in_command(&stmt.command)),
+        Command::Compound(CompoundCommand::Conditional(_))
+        | Command::Compound(_)
+        | Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => None,
+        Command::Simple(command) => {
+            word_is_plain_positional_parameter(&command.name, "1").then_some(command.name.span)
+        }
+    }
+}
+
+fn word_is_plain_positional_parameter(word: &Word, target: &str) -> bool {
+    let [part] = word.parts.as_slice() else {
+        return false;
+    };
+
+    word_part_is_plain_positional_parameter(&part.kind, target)
+}
+
+fn word_part_is_plain_positional_parameter(part: &WordPart, target: &str) -> bool {
+    match part {
+        WordPart::Variable(name) => name.as_str() == target,
+        WordPart::DoubleQuoted { parts, .. } => {
+            let [part] = parts.as_slice() else {
+                return false;
+            };
+            word_part_is_plain_positional_parameter(&part.kind, target)
+        }
+        WordPart::Parameter(parameter) => match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
+                reference.subscript.is_none() && reference.name.as_str() == target
+            }
+            ParameterExpansionSyntax::Zsh(syntax) => {
+                syntax.length_prefix.is_none()
+                    && syntax.operation.is_none()
+                    && syntax.modifiers.is_empty()
+                    && matches!(
+                        &syntax.target,
+                        ZshExpansionTarget::Reference(reference)
+                            if reference.subscript.is_none()
+                                && reference.name.as_str() == target
+                    )
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
 fn function_body_without_braces_span(function: &FunctionDef) -> Option<Span> {
     match &function.body.command {
         Command::Compound(CompoundCommand::BraceGroup(_)) => None,
@@ -796,4 +1006,3 @@ fn special_positional_parameter_name(name: &str) -> Option<bool> {
         _ => None,
     }
 }
-

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -227,7 +227,7 @@ fn stmt_is_top_level_status_exit(stmt: &Stmt) -> bool {
     command
         .code
         .as_ref()
-        .is_some_and(|code| crate::word_is_standalone_status_capture(code))
+        .is_some_and(crate::word_is_standalone_status_capture)
 }
 
 fn build_function_parameter_fallback_spans(
@@ -554,7 +554,7 @@ fn first_positional_dispatch_in_command(command: &Command) -> Option<Span> {
                     command
                         .else_branch
                         .as_ref()
-                        .and_then(|branch| first_positional_dispatch_in_commands(branch))
+                        .and_then(first_positional_dispatch_in_commands)
                 })
         }
         Command::Compound(CompoundCommand::While(command)) => {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -81,6 +81,7 @@ pub struct LinterFacts<'a> {
     dollar_in_arithmetic_spans: Vec<Span>,
     arithmetic_command_substitution_spans: Vec<Span>,
     function_positional_parameter_facts: FxHashMap<ScopeId, FunctionPositionalParameterFacts>,
+    function_cli_dispatch_facts: FxHashMap<ScopeId, FunctionCliDispatchFacts>,
     single_quoted_fragments: Vec<SingleQuotedFragmentFact>,
     dollar_double_quoted_fragments: Vec<DollarDoubleQuotedFragmentFact>,
     open_double_quote_fragments: Vec<OpenDoubleQuoteFragmentFact>,
@@ -191,6 +192,16 @@ impl<'a> LinterFacts<'a> {
         scope: ScopeId,
     ) -> FunctionPositionalParameterFacts {
         self.function_positional_parameter_facts
+            .get(&scope)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn function_cli_dispatch_facts(
+        &self,
+        scope: ScopeId,
+    ) -> FunctionCliDispatchFacts {
+        self.function_cli_dispatch_facts
             .get(&scope)
             .copied()
             .unwrap_or_default()

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -167,6 +167,109 @@ value=\"`greet`\"
 }
 
 #[test]
+fn function_cli_dispatch_facts_track_case_positional_entrypoints_with_top_level_exit_status() {
+    let source = "\
+#!/bin/sh
+start() { echo hi; }
+stop() { echo bye; }
+case \"$1\" in
+  start) $1 ;;
+  stop) \"$1\" ;;
+esac
+exit $?
+";
+
+    with_facts(source, None, |_, facts| {
+        for name in ["start", "stop"] {
+            let header = facts
+                .function_headers()
+                .iter()
+                .find(|header| {
+                    header
+                        .static_name_entry()
+                        .is_some_and(|(candidate, _)| candidate == name)
+                })
+                .expect("expected dispatched function header");
+            let scope = header.function_scope().expect("expected function scope");
+            let dispatch = facts.function_cli_dispatch_facts(scope);
+
+            assert!(
+                dispatch.exported_from_case_cli(),
+                "expected {name} to be marked"
+            );
+            assert_eq!(
+                dispatch
+                    .dispatcher_span()
+                    .expect("expected dispatcher span")
+                    .slice(source),
+                if name == "start" { "$1" } else { "\"$1\"" }
+            );
+        }
+    });
+}
+
+#[test]
+fn function_cli_dispatch_facts_ignore_case_positional_entrypoints_without_top_level_exit_status() {
+    let source = "\
+#!/bin/sh
+start() { echo hi; }
+case \"$1\" in
+  start) $1 ;;
+esac
+";
+
+    with_facts(source, None, |_, facts| {
+        let header = facts
+            .function_headers()
+            .iter()
+            .find(|header| {
+                header
+                    .static_name_entry()
+                    .is_some_and(|(candidate, _)| candidate == "start")
+            })
+            .expect("expected start header");
+        let scope = header.function_scope().expect("expected function scope");
+
+        assert!(
+            !facts
+                .function_cli_dispatch_facts(scope)
+                .exported_from_case_cli()
+        );
+    });
+}
+
+#[test]
+fn function_cli_dispatch_facts_ignore_static_case_calls() {
+    let source = "\
+#!/bin/sh
+start() { echo hi; }
+case \"$1\" in
+  start) start ;;
+esac
+exit $?
+";
+
+    with_facts(source, None, |_, facts| {
+        let header = facts
+            .function_headers()
+            .iter()
+            .find(|header| {
+                header
+                    .static_name_entry()
+                    .is_some_and(|(candidate, _)| candidate == "start")
+            })
+            .expect("expected start header");
+        let scope = header.function_scope().expect("expected function scope");
+
+        assert!(
+            !facts
+                .function_cli_dispatch_facts(scope)
+                .exported_from_case_cli()
+        );
+    });
+}
+
+#[test]
 fn builds_function_style_spans() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -270,6 +270,38 @@ exit $?
 }
 
 #[test]
+fn function_cli_dispatch_facts_ignore_later_defined_functions() {
+    let source = "\
+#!/bin/sh
+case \"$1\" in
+  start) $1 ;;
+esac
+exit $?
+
+start() { echo hi; }
+";
+
+    with_facts(source, None, |_, facts| {
+        let header = facts
+            .function_headers()
+            .iter()
+            .find(|header| {
+                header
+                    .static_name_entry()
+                    .is_some_and(|(candidate, _)| candidate == "start")
+            })
+            .expect("expected start header");
+        let scope = header.function_scope().expect("expected function scope");
+
+        assert!(
+            !facts
+                .function_cli_dispatch_facts(scope)
+                .exported_from_case_cli()
+        );
+    });
+}
+
+#[test]
 fn builds_function_style_spans() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -255,6 +255,31 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.word().parts_with_spans()
     }
 
+    pub fn diagnostic_part_span(self, part: &WordPart, part_span: Span, source: &str) -> Span {
+        let WordPart::Variable(name) = part else {
+            return part_span;
+        };
+
+        let expected = format!("${}", name.as_str());
+        if part_span.slice(source) == expected {
+            return part_span;
+        }
+
+        let search_start = part_span.start.offset.saturating_sub(1);
+        let search_end = (part_span.end.offset + 1).min(source.len());
+        let Some(window) = source.get(search_start..search_end) else {
+            return part_span;
+        };
+        let Some(relative_start) = window.find(&expected) else {
+            return part_span;
+        };
+        let start_offset = search_start + relative_start;
+        let end_offset = start_offset + expected.len();
+        let start = Position::new().advanced_by(&source[..start_offset]);
+        let end = Position::new().advanced_by(&source[..end_offset]);
+        Span::from_positions(start, end)
+    }
+
     pub fn has_direct_all_elements_array_expansion_in_source(self, source: &str) -> bool {
         crate::word_has_direct_all_elements_array_expansion_in_source(self.word(), source)
     }

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1356,6 +1356,37 @@ value=\"$(free ${humanreadable} | awk '{print $2}')\"
     }
 
     #[test]
+    fn nested_command_substitution_arguments_with_dynamic_values_stay_unsafe() {
+        let source = "\
+#!/bin/sh
+PRGNAM=cproc
+GIT_SHA=$( git rev-parse --short HEAD )
+DATE=$( git log --date=format:%Y%m%d --format=%cd | head -1 )
+VERSION=${DATE}_${GIT_SHA}
+echo \"MD5SUM=\\\"$( md5sum $PRGNAM-$VERSION.tar.xz | cut -d' ' -f1 )\\\"\"
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let version_use = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.is_nested_word_command()
+                    && fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source).contains("VERSION")
+            })
+            .expect("expected nested command argument fact for VERSION");
+
+        assert!(!safe_values.word_occurrence_is_safe(version_use, SafeValueQuery::Argv));
+    }
+
+    #[test]
     fn helper_initialized_option_flags_stay_safe_across_top_level_call_sequences() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -218,6 +218,19 @@ impl<'a> SafeValueIndex<'a> {
         if bindings.is_empty() {
             return safe_numeric_shell_variable(name);
         }
+        let case_cli_scope = matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+            .then(|| self.case_cli_dispatch_scope_at(at.start.offset))
+            .flatten();
+        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+            if case_cli_scope.is_some()
+                && !self.case_cli_dispatch_outer_bindings_can_stay_safe(&bindings, at, query)
+                && !bindings.iter().copied().any(|binding_id| {
+                    Some(self.semantic.binding(binding_id).scope) == case_cli_scope
+                })
+            {
+                return safe_numeric_shell_variable(name);
+            }
+        }
         if self.maybe_uninitialized_refs.contains(&FactSpan::new(at))
             && !bindings
                 .iter()
@@ -229,10 +242,63 @@ impl<'a> SafeValueIndex<'a> {
 
         bindings
             .into_iter()
-            .all(|binding_id| self.binding_is_safe(binding_id, query))
+            .all(|binding_id| self.binding_is_safe(binding_id, query, case_cli_scope))
     }
 
-    fn binding_is_safe(&mut self, binding_id: BindingId, query: SafeValueQuery) -> bool {
+    fn case_cli_dispatch_scope_at(&self, offset: usize) -> Option<ScopeId> {
+        self.semantic
+            .ancestor_scopes(self.semantic.scope_at(offset))
+            .find(|scope| {
+                self.facts
+                    .function_cli_dispatch_facts(*scope)
+                    .exported_from_case_cli()
+            })
+    }
+
+    pub fn in_case_cli_dispatch_entrypoint(&self, offset: usize) -> bool {
+        self.case_cli_dispatch_scope_at(offset).is_some()
+    }
+
+    fn case_cli_dispatch_outer_bindings_can_stay_safe(
+        &self,
+        bindings: &[BindingId],
+        at: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        if query != SafeValueQuery::Argv || !self.is_argument_of_dynamic_command(at) {
+            return false;
+        }
+
+        bindings
+            .iter()
+            .copied()
+            .all(|binding_id| self.binding_is_quoted_static_literal(binding_id))
+    }
+
+    fn is_argument_of_dynamic_command(&self, at: Span) -> bool {
+        self.facts.commands().iter().any(|command| {
+            command.body_args().iter().any(|word| word.span == at)
+                && command
+                    .body_name_word()
+                    .is_some_and(crate::word_is_standalone_variable_like)
+        })
+    }
+
+    fn binding_is_quoted_static_literal(&self, binding_id: BindingId) -> bool {
+        self.facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+            .is_some_and(|word| {
+                word.is_fully_quoted() && static_word_text(word, self.source).is_some()
+            })
+    }
+
+    fn binding_is_safe(
+        &mut self,
+        binding_id: BindingId,
+        query: SafeValueQuery,
+        case_cli_scope: Option<ScopeId>,
+    ) -> bool {
         let binding = self.semantic.binding(binding_id);
         let binding_key = FactSpan::new(binding.span);
         if binding.attributes.contains(BindingAttributes::INTEGER)
@@ -260,7 +326,14 @@ impl<'a> SafeValueIndex<'a> {
                     .binding_value(binding_id)
                     .filter(|value| !value.conditional_assignment_shortcut())
                     .and_then(|value| value.scalar_word());
-                scalar_word.is_some_and(|word| self.word_is_safe(word, query))
+                if case_cli_scope == Some(binding.scope)
+                    && matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+                    && scalar_word.is_some_and(crate::word_is_standalone_status_capture)
+                {
+                    false
+                } else {
+                    scalar_word.is_some_and(|word| self.word_is_safe(word, query))
+                }
             }
             BindingOrigin::LoopVariable {
                 items: LoopValueOrigin::StaticWords,
@@ -326,7 +399,7 @@ impl<'a> SafeValueIndex<'a> {
                 && targets
                     .iter()
                     .copied()
-                    .all(|target| self.binding_is_safe(target, query))
+                    .all(|target| self.binding_is_safe(target, query, None))
         })
     }
 
@@ -1442,6 +1515,99 @@ fn_backup_compression
             .expect("expected helper-provided command argument fact");
 
         assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_cli_dispatch_entry_functions_do_not_inherit_outer_safe_globals() {
+        let source = "\
+#!/bin/sh
+exec=/usr/sbin/collectd
+pidfile=/var/run/collectd.pid
+configfile=/etc/collectd.conf
+
+start() {
+  [ -x $exec ] || exit 5
+  $exec -P $pidfile -C $configfile
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit $?
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_name = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandName)
+                    && fact.span().slice(source) == "$exec"
+            })
+            .expect("expected dynamic command-name fact");
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$pidfile"
+            })
+            .expect("expected dynamic command-argument fact");
+
+        assert!(!safe_values.word_occurrence_is_safe(command_name, SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_cli_dispatch_without_top_level_exit_keeps_outer_safe_globals() {
+        let source = "\
+#!/bin/sh
+exec=/usr/sbin/collectd
+pidfile=/var/run/collectd.pid
+configfile=/etc/collectd.conf
+
+start() {
+  [ -x $exec ] || exit 5
+  $exec -P $pidfile -C $configfile
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_name = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandName)
+                    && fact.span().slice(source) == "$exec"
+            })
+            .expect("expected dynamic command-name fact");
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$pidfile"
+            })
+            .expect("expected dynamic command-argument fact");
+
+        assert!(safe_values.word_occurrence_is_safe(command_name, SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -73,8 +73,8 @@ pub struct SafeValueIndex<'a> {
     source: &'a str,
     definite_uninitialized_refs: FxHashSet<FactSpan>,
     maybe_uninitialized_refs: FxHashSet<FactSpan>,
-    memo: FxHashMap<(FactSpan, SafeValueQuery), bool>,
-    visiting: FxHashSet<(FactSpan, SafeValueQuery)>,
+    memo: FxHashMap<(FactSpan, SafeValueQuery, Option<ScopeId>), bool>,
+    visiting: FxHashSet<(FactSpan, SafeValueQuery, Option<ScopeId>)>,
     helper_binding_memo: FxHashMap<(Name, ScopeId, FactSpan), Box<[BindingId]>>,
     helper_binding_visiting: FxHashSet<(Name, ScopeId, FactSpan)>,
 }
@@ -229,15 +229,15 @@ impl<'a> SafeValueIndex<'a> {
         let case_cli_scope = matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
             .then(|| self.case_cli_dispatch_scope_at(at.start.offset))
             .flatten();
-        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
-            if case_cli_scope.is_some()
-                && !self.case_cli_dispatch_outer_bindings_can_stay_safe(&bindings, at, query)
-                && !bindings.iter().copied().any(|binding_id| {
-                    Some(self.semantic.binding(binding_id).scope) == case_cli_scope
-                })
-            {
-                return safe_numeric_shell_variable(name);
-            }
+        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+            && case_cli_scope.is_some()
+            && !self.case_cli_dispatch_outer_bindings_can_stay_safe(&bindings, at, query)
+            && !bindings
+                .iter()
+                .copied()
+                .any(|binding_id| Some(self.semantic.binding(binding_id).scope) == case_cli_scope)
+        {
+            return safe_numeric_shell_variable(name);
         }
         if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
             && self.bindings_are_all_plain_empty_static_literals(&bindings)
@@ -254,15 +254,14 @@ impl<'a> SafeValueIndex<'a> {
         {
             return false;
         }
-        if self.definite_uninitialized_refs.contains(&FactSpan::new(at)) {
-            if bindings
-                .iter()
-                .copied()
-                .any(|binding_id| {
-                    !helper_bindings.contains(&binding_id)
-                        && self.binding_is_guarded_before_reference(binding_id, at)
-                })
-            {
+        if self
+            .definite_uninitialized_refs
+            .contains(&FactSpan::new(at))
+        {
+            if bindings.iter().copied().any(|binding_id| {
+                !helper_bindings.contains(&binding_id)
+                    && self.binding_is_guarded_before_reference(binding_id, at)
+            }) {
                 return false;
             }
         } else if self.maybe_uninitialized_refs.contains(&FactSpan::new(at)) {
@@ -370,7 +369,7 @@ impl<'a> SafeValueIndex<'a> {
             return true;
         }
 
-        let key = (binding_key, query);
+        let key = (binding_key, query, case_cli_scope);
         if let Some(result) = self.memo.get(&key) {
             return *result;
         }
@@ -676,7 +675,10 @@ impl<'a> SafeValueIndex<'a> {
             .filter_map(|binding_id| {
                 let binding = self.semantic.binding(binding_id);
                 (!binding.attributes.contains(BindingAttributes::LOCAL)
-                    && matches!(self.semantic.scope(binding.scope).kind, ScopeKind::Function(_)))
+                    && matches!(
+                        self.semantic.scope(binding.scope).kind,
+                        ScopeKind::Function(_)
+                    ))
                 .then_some(binding.scope)
             })
             .collect::<FxHashSet<_>>()
@@ -772,10 +774,8 @@ impl<'a> SafeValueIndex<'a> {
             .copied()
             .map(|binding_id| self.semantic.binding(binding_id).scope)
             .collect::<Vec<_>>();
-        let mut stack = vec![self.flow_entry_block_for_binding_scopes(
-            &binding_scopes,
-            at.start.offset,
-        )];
+        let mut stack =
+            vec![self.flow_entry_block_for_binding_scopes(&binding_scopes, at.start.offset)];
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
             if cover_blocks.contains(&block_id)
@@ -804,8 +804,10 @@ impl<'a> SafeValueIndex<'a> {
         self.semantic
             .ancestor_scopes(self.semantic.scope_at(reference_offset))
             .find_map(|scope| {
-                if !matches!(self.semantic.scope(scope).kind, ScopeKind::Function(_) | ScopeKind::File)
-                {
+                if !matches!(
+                    self.semantic.scope(scope).kind,
+                    ScopeKind::Function(_) | ScopeKind::File
+                ) {
                     return None;
                 }
                 binding_scopes
@@ -1656,7 +1658,11 @@ f() {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(validate_uses.len(), 3, "expected all function-local pipeline uses");
+        assert_eq!(
+            validate_uses.len(),
+            3,
+            "expected all function-local pipeline uses"
+        );
         assert!(
             validate_uses
                 .into_iter()
@@ -1894,9 +1900,12 @@ config() {
             .expect("expected pulseopt command-argument fact");
 
         assert!(
-            analysis.uninitialized_references().iter().any(|uninitialized| {
-                semantic.reference(uninitialized.reference).span == word_fact.span()
-            }),
+            analysis
+                .uninitialized_references()
+                .iter()
+                .any(|uninitialized| {
+                    semantic.reference(uninitialized.reference).span == word_fact.span()
+                }),
             "expected pulseopt to be marked uninitialized"
         );
         assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
@@ -1944,7 +1953,10 @@ printf '%s\\n' $opt hi
             .filter(|fact| {
                 fact.expansion_context() == Some(ExpansionContext::CommandArgument)
                     && (fact.span().slice(source) == "$gl2ps"
-                        || fact.span().slice(source).contains("lib${libdirsuffix}/ladspa"))
+                        || fact
+                            .span()
+                            .slice(source)
+                            .contains("lib${libdirsuffix}/ladspa"))
             })
             .collect::<Vec<_>>();
         let safe_words = facts
@@ -1953,7 +1965,10 @@ printf '%s\\n' $opt hi
             .filter(|fact| {
                 fact.expansion_context() == Some(ExpansionContext::CommandArgument)
                     && (fact.span().slice(source) == "$opt"
-                        || fact.span().slice(source).contains("lib${mixedsuffix}/ladspa"))
+                        || fact
+                            .span()
+                            .slice(source)
+                            .contains("lib${mixedsuffix}/ladspa"))
             })
             .collect::<Vec<_>>();
 
@@ -2196,6 +2211,54 @@ esac
 
         assert!(safe_values.word_occurrence_is_safe(command_name, SafeValueQuery::Argv));
         assert!(safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_cli_scope_memoization_does_not_leak_status_capture_unsafety_into_helpers() {
+        let source = "\
+#!/bin/sh
+start() {
+  status=$?
+  printf '%s\\n' ${status}
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit $?
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let dispatched_use = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${status}"
+            })
+            .expect("expected case-cli entrypoint status use");
+        let binding_id = safe_values
+            .safe_bindings_for_name(&Name::new("status"), dispatched_use.span())
+            .into_iter()
+            .next()
+            .expect("expected reaching status binding");
+        let case_cli_scope =
+            safe_values.case_cli_dispatch_scope_at(dispatched_use.span().start.offset);
+
+        assert_eq!(
+            case_cli_scope,
+            Some(semantic.binding(binding_id).scope),
+            "expected the status binding to belong to the case-cli scope"
+        );
+
+        assert!(!safe_values.binding_is_safe(binding_id, SafeValueQuery::Argv, case_cli_scope));
+        assert!(safe_values.binding_is_safe(binding_id, SafeValueQuery::Argv, None));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -71,6 +71,7 @@ pub struct SafeValueIndex<'a> {
     analysis: &'a SemanticAnalysis<'a>,
     facts: &'a LinterFacts<'a>,
     source: &'a str,
+    definite_uninitialized_refs: FxHashSet<FactSpan>,
     maybe_uninitialized_refs: FxHashSet<FactSpan>,
     memo: FxHashMap<(FactSpan, SafeValueQuery), bool>,
     visiting: FxHashSet<(FactSpan, SafeValueQuery)>,
@@ -85,6 +86,12 @@ impl<'a> SafeValueIndex<'a> {
         facts: &'a LinterFacts<'a>,
         source: &'a str,
     ) -> Self {
+        let definite_uninitialized_refs = analysis
+            .uninitialized_references()
+            .iter()
+            .filter(|uninitialized| uninitialized.certainty == UninitializedCertainty::Definite)
+            .map(|uninitialized| FactSpan::new(semantic.reference(uninitialized.reference).span))
+            .collect();
         let maybe_uninitialized_refs = analysis
             .uninitialized_references()
             .iter()
@@ -97,6 +104,7 @@ impl<'a> SafeValueIndex<'a> {
             analysis,
             facts,
             source,
+            definite_uninitialized_refs,
             maybe_uninitialized_refs,
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
@@ -231,13 +239,40 @@ impl<'a> SafeValueIndex<'a> {
                 return safe_numeric_shell_variable(name);
             }
         }
-        if self.maybe_uninitialized_refs.contains(&FactSpan::new(at))
-            && !bindings
-                .iter()
-                .copied()
-                .any(|binding_id| self.binding_dominates_reference(binding_id, name, at))
+        if bindings.len() == 1
+            && matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+            && self.binding_is_plain_empty_static_literal(bindings[0])
         {
             return false;
+        }
+        let helper_bindings = self
+            .called_helper_bindings_for_name(name, at)
+            .into_iter()
+            .collect::<FxHashSet<_>>();
+        if self.definite_uninitialized_refs.contains(&FactSpan::new(at)) {
+            if bindings
+                .iter()
+                .copied()
+                .any(|binding_id| {
+                    !helper_bindings.contains(&binding_id)
+                        && self.binding_is_guarded_before_reference(binding_id, at)
+                })
+            {
+                return false;
+            }
+        } else if self.maybe_uninitialized_refs.contains(&FactSpan::new(at)) {
+            let has_dominating_binding = bindings
+                .iter()
+                .copied()
+                .any(|binding_id| self.binding_dominates_reference(binding_id, name, at));
+            if !has_dominating_binding
+                && !bindings
+                    .iter()
+                    .copied()
+                    .all(|binding_id| helper_bindings.contains(&binding_id))
+            {
+                return false;
+            }
         }
 
         bindings
@@ -291,6 +326,21 @@ impl<'a> SafeValueIndex<'a> {
             .is_some_and(|word| {
                 word.is_fully_quoted() && static_word_text(word, self.source).is_some()
             })
+    }
+
+    fn binding_is_plain_empty_static_literal(&self, binding_id: BindingId) -> bool {
+        matches!(
+            self.semantic.binding(binding_id).origin,
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::StaticLiteral,
+                ..
+            }
+        ) && self
+            .facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+            .and_then(|word| static_word_text(word, self.source))
+            .is_some_and(|text| text.is_empty())
     }
 
     fn binding_is_safe(
@@ -417,8 +467,13 @@ impl<'a> SafeValueIndex<'a> {
                 bindings = expanded;
             }
         }
+        let helper_bindings = self.called_helper_bindings_for_name(name, at);
         if bindings.is_empty() {
-            bindings = self.called_helper_bindings_for_name(name, at);
+            bindings = helper_bindings;
+        } else if !helper_bindings.is_empty() {
+            bindings.extend(helper_bindings);
+            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings.dedup();
         }
 
         bindings
@@ -570,6 +625,31 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         true
+    }
+
+    fn binding_is_guarded_before_reference(&self, binding_id: BindingId, at: Span) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        let Some(mut current) = self
+            .facts
+            .innermost_command_id_at(binding.span.start.offset)
+            .and_then(|id| self.facts.command_parent_id(id))
+        else {
+            return false;
+        };
+
+        loop {
+            let command = self.facts.command(current);
+            if self.facts.command_is_dominance_barrier(current)
+                && command.span().end.offset <= at.start.offset
+            {
+                return true;
+            }
+
+            let Some(parent_id) = self.facts.command_parent_id(current) else {
+                return false;
+            };
+            current = parent_id;
+        }
     }
 
     fn helper_scopes_definitely_providing_name(&self, name: &Name) -> Vec<ScopeId> {
@@ -1457,6 +1537,134 @@ echo \"MD5SUM=\\\"$( md5sum $PRGNAM-$VERSION.tar.xz | cut -d' ' -f1 )\\\"\"
             .expect("expected nested command argument fact for VERSION");
 
         assert!(!safe_values.word_occurrence_is_safe(version_use, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn definite_uninitialized_bindings_stay_unsafe() {
+        let source = "\
+#!/bin/bash
+if [ \"${PULSE:-yes}\" != \"yes\" ]; then
+  pulseopt=\"--without-pulse\"
+fi
+
+config() {
+  ./configure \\
+    $pulseopt \\
+    --prefix=/usr
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$pulseopt"
+            })
+            .expect("expected pulseopt command-argument fact");
+
+        assert!(
+            analysis.uninitialized_references().iter().any(|uninitialized| {
+                semantic.reference(uninitialized.reference).span == word_fact.span()
+            }),
+            "expected pulseopt to be marked uninitialized"
+        );
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn lone_empty_static_literal_bindings_stay_unsafe_but_optional_flags_can_stay_safe() {
+        let source = "\
+#!/bin/bash
+gl2ps=
+libdirsuffix=
+cmake $gl2ps -DOPT=1
+mkdir -p /tmp/usr/lib${libdirsuffix}/ladspa
+
+if true; then
+  opt=-n
+else
+  opt=
+fi
+printf '%s\\n' $opt hi
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let unsafe_words = facts
+            .word_facts()
+            .iter()
+            .filter(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && (fact.span().slice(source) == "$gl2ps"
+                        || fact.span().slice(source).contains("lib${libdirsuffix}/ladspa"))
+            })
+            .collect::<Vec<_>>();
+        let safe_word = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$opt"
+            })
+            .expect("expected optional flag command-argument fact");
+
+        assert_eq!(unsafe_words.len(), 2, "expected both lone empty literal uses");
+        assert!(
+            unsafe_words
+                .into_iter()
+                .all(|fact| !safe_values.word_occurrence_is_safe(fact, SafeValueQuery::Argv))
+        );
+        assert!(safe_values.word_occurrence_is_safe(safe_word, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn helper_call_sequences_can_make_outer_safe_globals_unsafe() {
+        let source = "\
+#!/bin/bash
+Region=default
+
+GetRegion() {
+  Region=\"$(printf '%s' \"$1\")\"
+}
+
+GetAMI() {
+  aws ec2 describe-images --region $Region
+}
+
+GetRegion \"$1\"
+GetAMI
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$Region"
+            })
+            .expect("expected Region command-argument fact");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -711,7 +711,10 @@ impl<'a> SafeValueIndex<'a> {
 
         let cfg = self.analysis.cfg();
         let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
-        let mut stack = vec![cfg.entry()];
+        let mut stack = vec![self.flow_entry_block_for_binding_scopes(
+            &[self.semantic.binding(binding_id).scope],
+            at.start.offset,
+        )];
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
             if block_id == binding_block
@@ -764,7 +767,15 @@ impl<'a> SafeValueIndex<'a> {
 
         let cfg = self.analysis.cfg();
         let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
-        let mut stack = vec![cfg.entry()];
+        let binding_scopes = bindings
+            .iter()
+            .copied()
+            .map(|binding_id| self.semantic.binding(binding_id).scope)
+            .collect::<Vec<_>>();
+        let mut stack = vec![self.flow_entry_block_for_binding_scopes(
+            &binding_scopes,
+            at.start.offset,
+        )];
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
             if cover_blocks.contains(&block_id)
@@ -783,6 +794,34 @@ impl<'a> SafeValueIndex<'a> {
 
         true
     }
+
+    fn flow_entry_block_for_binding_scopes(
+        &self,
+        binding_scopes: &[ScopeId],
+        reference_offset: usize,
+    ) -> BlockId {
+        let cfg = self.analysis.cfg();
+        self.semantic
+            .ancestor_scopes(self.semantic.scope_at(reference_offset))
+            .find_map(|scope| {
+                if !matches!(self.semantic.scope(scope).kind, ScopeKind::Function(_) | ScopeKind::File)
+                {
+                    return None;
+                }
+                binding_scopes
+                    .iter()
+                    .copied()
+                    .all(|binding_scope| {
+                        self.semantic
+                            .ancestor_scopes(binding_scope)
+                            .any(|ancestor| ancestor == scope)
+                    })
+                    .then(|| cfg.scope_entry(scope))
+                    .flatten()
+            })
+            .unwrap_or_else(|| cfg.entry())
+    }
+
     fn reference_id_for_name_at(&self, name: &Name, at: Span) -> Option<ReferenceId> {
         self.semantic
             .references()
@@ -1540,6 +1579,84 @@ fi
             .collect::<Vec<_>>();
 
         assert_eq!(validate_uses.len(), 3, "expected all sibling pipeline uses");
+        assert!(
+            validate_uses
+                .into_iter()
+                .all(|fact| !safe_values.word_occurrence_is_safe(fact, SafeValueQuery::Argv))
+        );
+    }
+
+    #[test]
+    fn function_local_guarded_initializers_do_not_dominate_later_uses() {
+        let source = "\
+#!/bin/bash
+f() {
+  if [ \"$1\" = validate ]; then
+    validate=validate
+  fi
+  echo ${validate}
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${validate}"
+            })
+            .expect("expected function-local validate command argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn function_local_pipeline_uses_stay_unsafe_after_guarded_initializers() {
+        let source = "\
+#!/bin/bash
+f() {
+  if [ \"$1\" = validate ]; then
+    validate=validate
+  fi
+  while :; do
+    if [ \"$appid\" = 90 ]; then
+      if [ -n \"$branch\" ] && [ -n \"$beta\" ]; then
+        echo ${validate} | tee /dev/null
+      elif [ -n \"$branch\" ]; then
+        echo ${validate} | tee /dev/null
+      else
+        echo ${validate} | tee /dev/null
+      fi
+    fi
+    break
+  done
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let validate_uses = facts
+            .word_facts()
+            .iter()
+            .filter(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${validate}"
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(validate_uses.len(), 3, "expected all function-local pipeline uses");
         assert!(
             validate_uses
                 .into_iter()

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -467,6 +467,9 @@ impl<'a> SafeValueIndex<'a> {
         if bindings.is_empty() {
             return false;
         }
+        let case_cli_scope = matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+            .then(|| self.case_cli_dispatch_scope_at(at.start.offset))
+            .flatten();
 
         bindings.into_iter().all(|binding_id| {
             let targets = self.semantic.indirect_targets_for_binding(binding_id);
@@ -474,7 +477,7 @@ impl<'a> SafeValueIndex<'a> {
                 && targets
                     .iter()
                     .copied()
-                    .all(|target| self.binding_is_safe(target, query, None))
+                    .all(|target| self.binding_is_safe(target, query, case_cli_scope))
         })
     }
 
@@ -2320,6 +2323,41 @@ exit $?
         assert!(command_arg.is_nested_word_command());
         assert!(safe_values.word_occurrence_is_safe(command_name, SafeValueQuery::Argv));
         assert!(safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_cli_dispatch_indirect_status_targets_stay_unsafe() {
+        let source = "\
+#!/bin/bash
+start() {
+  status=$?
+  ref=status
+  printf '%s\n' ${!ref}
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit $?
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let indirect_use = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${!ref}"
+            })
+            .expect("expected indirect case-cli status use");
+
+        assert!(!safe_values.word_occurrence_is_safe(indirect_use, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -229,13 +229,16 @@ impl<'a> SafeValueIndex<'a> {
         let case_cli_scope = matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
             .then(|| self.case_cli_dispatch_scope_at(at.start.offset))
             .flatten();
+        let binding_belongs_to_case_cli_scope = case_cli_scope.is_some_and(|scope| {
+            bindings
+                .iter()
+                .copied()
+                .any(|binding_id| self.binding_is_in_scope_or_descendant(binding_id, scope))
+        });
         if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
             && case_cli_scope.is_some()
             && !self.case_cli_dispatch_outer_bindings_can_stay_safe(&bindings, at, query)
-            && !bindings
-                .iter()
-                .copied()
-                .any(|binding_id| Some(self.semantic.binding(binding_id).scope) == case_cli_scope)
+            && !binding_belongs_to_case_cli_scope
         {
             return safe_numeric_shell_variable(name);
         }
@@ -312,6 +315,16 @@ impl<'a> SafeValueIndex<'a> {
             .iter()
             .copied()
             .all(|binding_id| self.binding_is_quoted_static_literal(binding_id))
+    }
+
+    fn binding_is_in_scope_or_descendant(
+        &self,
+        binding_id: BindingId,
+        ancestor_scope: ScopeId,
+    ) -> bool {
+        self.semantic
+            .ancestor_scopes(self.semantic.binding(binding_id).scope)
+            .any(|scope| scope == ancestor_scope)
     }
 
     fn is_argument_of_dynamic_command(&self, at: Span) -> bool {
@@ -2259,6 +2272,54 @@ exit $?
 
         assert!(!safe_values.binding_is_safe(binding_id, SafeValueQuery::Argv, case_cli_scope));
         assert!(safe_values.binding_is_safe(binding_id, SafeValueQuery::Argv, None));
+    }
+
+    #[test]
+    fn case_cli_dispatch_entry_functions_keep_nested_scope_safe_bindings() {
+        let source = "\
+#!/bin/sh
+start() {
+  printf '%s\n' \"$(
+    cmd=/bin/echo
+    arg=hello
+    $cmd $arg
+  )\"
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit $?
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_name = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandName)
+                    && fact.span().slice(source) == "$cmd"
+            })
+            .expect("expected nested command-substitution command name");
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$arg"
+            })
+            .expect("expected nested command-substitution command argument");
+
+        assert!(command_name.is_nested_word_command());
+        assert!(command_arg.is_nested_word_command());
+        assert!(safe_values.word_occurrence_is_safe(command_name, SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -239,9 +239,8 @@ impl<'a> SafeValueIndex<'a> {
                 return safe_numeric_shell_variable(name);
             }
         }
-        if bindings.len() == 1
-            && matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
-            && self.binding_is_plain_empty_static_literal(bindings[0])
+        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+            && self.bindings_are_all_plain_empty_static_literals(&bindings)
         {
             return false;
         }
@@ -341,6 +340,14 @@ impl<'a> SafeValueIndex<'a> {
             .and_then(|value| value.scalar_word())
             .and_then(|word| static_word_text(word, self.source))
             .is_some_and(|text| text.is_empty())
+    }
+
+    fn bindings_are_all_plain_empty_static_literals(&self, bindings: &[BindingId]) -> bool {
+        !bindings.is_empty()
+            && bindings
+                .iter()
+                .copied()
+                .all(|binding_id| self.binding_is_plain_empty_static_literal(binding_id))
     }
 
     fn binding_is_safe(
@@ -1580,13 +1587,25 @@ config() {
     }
 
     #[test]
-    fn lone_empty_static_literal_bindings_stay_unsafe_but_optional_flags_can_stay_safe() {
+    fn all_empty_static_literal_bindings_stay_unsafe_but_mixed_option_bindings_can_stay_safe() {
         let source = "\
 #!/bin/bash
 gl2ps=
-libdirsuffix=
+if true; then
+  libdirsuffix=
+else
+  libdirsuffix=
+fi
+
+if true; then
+  mixedsuffix=64
+else
+  mixedsuffix=
+fi
+
 cmake $gl2ps -DOPT=1
 mkdir -p /tmp/usr/lib${libdirsuffix}/ladspa
+mkdir -p /tmp/usr/lib${mixedsuffix}/ladspa
 
 if true; then
   opt=-n
@@ -1612,22 +1631,28 @@ printf '%s\\n' $opt hi
                         || fact.span().slice(source).contains("lib${libdirsuffix}/ladspa"))
             })
             .collect::<Vec<_>>();
-        let safe_word = facts
+        let safe_words = facts
             .word_facts()
             .iter()
-            .find(|fact| {
+            .filter(|fact| {
                 fact.expansion_context() == Some(ExpansionContext::CommandArgument)
-                    && fact.span().slice(source) == "$opt"
+                    && (fact.span().slice(source) == "$opt"
+                        || fact.span().slice(source).contains("lib${mixedsuffix}/ladspa"))
             })
-            .expect("expected optional flag command-argument fact");
+            .collect::<Vec<_>>();
 
-        assert_eq!(unsafe_words.len(), 2, "expected both lone empty literal uses");
+        assert_eq!(unsafe_words.len(), 2, "expected both empty-only uses");
         assert!(
             unsafe_words
                 .into_iter()
                 .all(|fact| !safe_values.word_occurrence_is_safe(fact, SafeValueQuery::Argv))
         );
-        assert!(safe_values.word_occurrence_is_safe(safe_word, SafeValueQuery::Argv));
+        assert_eq!(safe_words.len(), 2, "expected both mixed-value uses");
+        assert!(
+            safe_words
+                .into_iter()
+                .all(|fact| safe_values.word_occurrence_is_safe(fact, SafeValueQuery::Argv))
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -248,6 +248,12 @@ impl<'a> SafeValueIndex<'a> {
             .called_helper_bindings_for_name(name, at)
             .into_iter()
             .collect::<FxHashSet<_>>();
+        if helper_bindings.is_empty()
+            && matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+            && !self.bindings_cover_all_paths_to_reference(&bindings, name, at)
+        {
+            return false;
+        }
         if self.definite_uninitialized_refs.contains(&FactSpan::new(at)) {
             if bindings
                 .iter()
@@ -690,7 +696,7 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         };
         if binding_block == reference_block {
-            return true;
+            return !self.binding_is_guarded_before_reference(binding_id, at);
         }
 
         let cfg = self.analysis.cfg();
@@ -699,6 +705,59 @@ impl<'a> SafeValueIndex<'a> {
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
             if block_id == binding_block
+                || unreachable.contains(&block_id)
+                || !seen.insert(block_id)
+            {
+                continue;
+            }
+            if block_id == reference_block {
+                return false;
+            }
+            for (successor, _) in cfg.successors(block_id) {
+                stack.push(*successor);
+            }
+        }
+
+        true
+    }
+
+    fn bindings_cover_all_paths_to_reference(
+        &self,
+        bindings: &[BindingId],
+        name: &Name,
+        at: Span,
+    ) -> bool {
+        let Some(reference_id) = self.reference_id_for_name_at(name, at) else {
+            return true;
+        };
+        let Some(reference_block) = self.block_for_reference(reference_id) else {
+            return true;
+        };
+
+        let cover_blocks = bindings
+            .iter()
+            .copied()
+            .filter_map(|binding_id| {
+                let binding_block = self.block_for_binding(binding_id)?;
+                if binding_block == reference_block
+                    && self.binding_is_guarded_before_reference(binding_id, at)
+                {
+                    None
+                } else {
+                    Some(binding_block)
+                }
+            })
+            .collect::<FxHashSet<_>>();
+        if cover_blocks.contains(&reference_block) {
+            return true;
+        }
+
+        let cfg = self.analysis.cfg();
+        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let mut stack = vec![cfg.entry()];
+        let mut seen = FxHashSet::default();
+        while let Some(block_id) = stack.pop() {
+            if cover_blocks.contains(&block_id)
                 || unreachable.contains(&block_id)
                 || !seen.insert(block_id)
             {
@@ -1402,6 +1461,95 @@ f() {
             .expect("expected guarded function command argument");
 
         assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn conditional_same_block_initializers_do_not_dominate_later_uses() {
+        let source = "\
+#!/bin/bash
+counter=0
+while [ \"$counter\" -eq 0 ]; do
+  if [ \"$1\" = validate ] || [ \"$1\" = install ]; then
+    validate=validate
+  fi
+  steamcmd ${validate} +quit
+  break
+done
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${validate}"
+            })
+            .expect("expected conditional initializer command argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_defaults_distinguish_maybe_uninitialized_from_explicit_empty_bindings() {
+        let source = "\
+#!/bin/bash
+case $1 in
+  nfs|dir)
+    disk_ext=.qcow2
+    ;;
+  btrfs)
+    disk_ext=.raw
+    ;;
+esac
+printf '%s\\n' vm-${disk_ext:-}
+
+case $2 in
+  nfs|dir)
+    disk_ext_with_default=.qcow2
+    ;;
+  btrfs)
+    disk_ext_with_default=.raw
+    ;;
+  *)
+    disk_ext_with_default=
+    ;;
+esac
+printf '%s\\n' vm-${disk_ext_with_default:-}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let maybe_uninitialized = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "vm-${disk_ext:-}"
+            })
+            .expect("expected maybe-uninitialized command argument");
+        let explicit_default = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "vm-${disk_ext_with_default:-}"
+            })
+            .expect("expected explicit-default command argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(maybe_uninitialized, SafeValueQuery::Argv));
+        assert!(safe_values.word_occurrence_is_safe(explicit_default, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -493,8 +493,11 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn called_helper_bindings_for_name(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
-        let scope = self.semantic.scope_at(at.start.offset);
-        let mut bindings = self.called_helper_bindings_before(name, scope, at);
+        let mut bindings = self
+            .semantic
+            .ancestor_scopes(self.semantic.scope_at(at.start.offset))
+            .flat_map(|scope| self.called_helper_bindings_before(name, scope, at))
+            .collect::<Vec<_>>();
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         bindings.dedup();
         bindings
@@ -577,7 +580,7 @@ impl<'a> SafeValueIndex<'a> {
     ) -> Vec<BindingId> {
         let mut bindings = Vec::new();
 
-        for callee_scope in self.helper_scopes_definitely_providing_name(name) {
+        for callee_scope in self.helper_scopes_providing_name(name) {
             let Some(function_kind) = self.named_function_kind(callee_scope) else {
                 continue;
             };
@@ -665,12 +668,19 @@ impl<'a> SafeValueIndex<'a> {
         }
     }
 
-    fn helper_scopes_definitely_providing_name(&self, name: &Name) -> Vec<ScopeId> {
-        self.analysis
-            .definite_provider_scopes(name)
+    fn helper_scopes_providing_name(&self, name: &Name) -> Vec<ScopeId> {
+        self.semantic
+            .bindings_for(name)
             .iter()
             .copied()
-            .filter(|scope| matches!(self.semantic.scope(*scope).kind, ScopeKind::Function(_)))
+            .filter_map(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                (!binding.attributes.contains(BindingAttributes::LOCAL)
+                    && matches!(self.semantic.scope(binding.scope).kind, ScopeKind::Function(_)))
+                .then_some(binding.scope)
+            })
+            .collect::<FxHashSet<_>>()
+            .into_iter()
             .collect()
     }
 
@@ -1497,6 +1507,47 @@ done
     }
 
     #[test]
+    fn branch_ladder_pipeline_uses_stay_unsafe_after_guarded_initializers() {
+        let source = "\
+#!/bin/bash
+if [ \"$1\" = validate ] || [ \"$1\" = install ]; then
+  validate=validate
+fi
+
+if [ \"$mode\" = a ]; then
+  steamcmd ${validate} +quit | tee /dev/null
+elif [ \"$mode\" = b ]; then
+  steamcmd ${validate} +runscript foo | tee /dev/null
+else
+  steamcmd ${validate} +app_update 1 | tee /dev/null
+fi
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let validate_uses = facts
+            .word_facts()
+            .iter()
+            .filter(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${validate}"
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(validate_uses.len(), 3, "expected all sibling pipeline uses");
+        assert!(
+            validate_uses
+                .into_iter()
+                .all(|fact| !safe_values.word_occurrence_is_safe(fact, SafeValueQuery::Argv))
+        );
+    }
+
+    #[test]
     fn case_defaults_distinguish_maybe_uninitialized_from_explicit_empty_bindings() {
         let source = "\
 #!/bin/bash
@@ -1836,6 +1887,45 @@ GetAMI
                     && fact.span().slice(source) == "$Region"
             })
             .expect("expected Region command-argument fact");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn conditional_helper_globals_stay_unsafe_inside_nested_command_substitution_consumers() {
+        let source = "\
+#!/bin/bash
+Region=default
+
+GetRegion() {
+  if [ \"$Region\" = default ]; then
+    Region=\"$(printf '%s' \"$1\")\"
+  fi
+}
+
+GetAMI() {
+  AMI=$(aws ssm get-parameters --region $Region)
+}
+
+GetRegion \"$1\"
+GetAMI
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$Region"
+            })
+            .expect("expected nested command-substitution helper-derived argument");
 
         assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -522,9 +522,8 @@ pub fn word_standalone_literal_backslash_span(word: &Word, source: &str) -> Opti
 pub fn word_unquoted_star_parameter_spans(word: &Word, unquoted_array_spans: &[Span]) -> Vec<Span> {
     word.parts_with_spans()
         .filter_map(|(part, span)| {
-            (unquoted_array_spans.contains(&span)
-                && matches!(part, WordPart::Variable(name) if name.as_str() == "*"))
-            .then_some(span)
+            (unquoted_array_spans.contains(&span) && part_uses_star_splat(part))
+                .then_some(span)
         })
         .collect()
 }
@@ -4484,6 +4483,33 @@ printf '%s\\n' $* ${*} ${*:1} ${arr[*]} ${arr[*]:1:2} ${!arr[*]} ${arr[@]} ${arr
         assert_eq!(
             spans,
             vec!["$*", "${*}", "${*:1}", "${arr[*]}", "${arr[*]:1:2}"]
+        );
+    }
+
+    #[test]
+    fn word_unquoted_star_parameter_spans_tracks_star_selector_forms_only() {
+        let source = "\
+printf '%s\\n' $* ${arr[*]} ${arr[*]:1:2} ${!arr[*]} ${arr[@]} ${arr[@]:1} ${arr[0]} \"$*\" \"${arr[*]}\"
+";
+        let output = Parser::new(source).parse().unwrap();
+        let command = &output.file.body[0].command;
+        let shuck_ast::Command::Simple(command) = command else {
+            panic!("expected simple command");
+        };
+
+        let spans = command
+            .args
+            .iter()
+            .flat_map(|word| {
+                let unquoted_array_spans = super::unquoted_array_expansion_part_spans(word, source);
+                super::word_unquoted_star_parameter_spans(word, &unquoted_array_spans)
+            })
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            spans,
+            vec!["$*", "${arr[*]}", "${arr[*]:1:2}"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/common/span.rs
+++ b/crates/shuck-linter/src/rules/common/span.rs
@@ -522,8 +522,7 @@ pub fn word_standalone_literal_backslash_span(word: &Word, source: &str) -> Opti
 pub fn word_unquoted_star_parameter_spans(word: &Word, unquoted_array_spans: &[Span]) -> Vec<Span> {
     word.parts_with_spans()
         .filter_map(|(part, span)| {
-            (unquoted_array_spans.contains(&span) && part_uses_star_splat(part))
-                .then_some(span)
+            (unquoted_array_spans.contains(&span) && part_uses_star_splat(part)).then_some(span)
         })
         .collect()
 }
@@ -4507,10 +4506,7 @@ printf '%s\\n' $* ${arr[*]} ${arr[*]:1:2} ${!arr[*]} ${arr[@]} ${arr[@]:1} ${arr
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
 
-        assert_eq!(
-            spans,
-            vec!["$*", "${arr[*]}", "${arr[*]:1:2}"]
-        );
+        assert_eq!(spans, vec!["$*", "${arr[*]}", "${arr[*]:1:2}"]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -70,35 +70,6 @@ fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool 
     }
 }
 
-fn report_span_for_part(
-    part: &shuck_ast::WordPart,
-    part_span: shuck_ast::Span,
-    source: &str,
-) -> shuck_ast::Span {
-    let shuck_ast::WordPart::Variable(name) = part else {
-        return part_span;
-    };
-
-    let expected = format!("${}", name.as_str());
-    if part_span.slice(source) == expected {
-        return part_span;
-    }
-
-    let search_start = part_span.start.offset.saturating_sub(1);
-    let search_end = (part_span.end.offset + 1).min(source.len());
-    let Some(window) = source.get(search_start..search_end) else {
-        return part_span;
-    };
-    let Some(relative_start) = window.find(&expected) else {
-        return part_span;
-    };
-    let start_offset = search_start + relative_start;
-    let end_offset = start_offset + expected.len();
-    let start = shuck_ast::Position::new().advanced_by(&source[..start_offset]);
-    let end = shuck_ast::Position::new().advanced_by(&source[..end_offset]);
-    shuck_ast::Span::from_positions(start, end)
-}
-
 fn report_word_expansions(
     spans: &mut Vec<shuck_ast::Span>,
     safe_values: &mut SafeValueIndex<'_>,
@@ -147,7 +118,7 @@ fn report_word_expansions(
             continue;
         }
 
-        spans.push(report_span_for_part(part, part_span, source));
+        spans.push(fact.diagnostic_part_span(part, part_span, source));
     }
 }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -45,6 +45,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
         report_word_expansions(
             &mut spans,
             &mut safe_values,
+            source,
             fact,
             context,
             colon_command_ids.contains(&fact.command_id()),
@@ -69,9 +70,35 @@ fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool 
     }
 }
 
+fn report_span_for_part(part: &shuck_ast::WordPart, part_span: shuck_ast::Span, source: &str) -> shuck_ast::Span {
+    let shuck_ast::WordPart::Variable(name) = part else {
+        return part_span;
+    };
+
+    let expected = format!("${}", name.as_str());
+    if part_span.slice(source) == expected {
+        return part_span;
+    }
+
+    let search_start = part_span.start.offset.saturating_sub(1);
+    let search_end = (part_span.end.offset + 1).min(source.len());
+    let Some(window) = source.get(search_start..search_end) else {
+        return part_span;
+    };
+    let Some(relative_start) = window.find(&expected) else {
+        return part_span;
+    };
+    let start_offset = search_start + relative_start;
+    let end_offset = start_offset + expected.len();
+    let start = shuck_ast::Position::new().advanced_by(&source[..start_offset]);
+    let end = shuck_ast::Position::new().advanced_by(&source[..end_offset]);
+    shuck_ast::Span::from_positions(start, end)
+}
+
 fn report_word_expansions(
     spans: &mut Vec<shuck_ast::Span>,
     safe_values: &mut SafeValueIndex<'_>,
+    source: &str,
     fact: WordOccurrenceRef<'_, '_>,
     context: ExpansionContext,
     in_colon_command: bool,
@@ -116,7 +143,7 @@ fn report_word_expansions(
             continue;
         }
 
-        spans.push(part_span);
+        spans.push(report_span_for_part(part, part_span, source));
     }
 }
 
@@ -254,6 +281,24 @@ $HOME/bin/tool $arg
     }
 
     #[test]
+    fn reports_unquoted_star_selector_expansions() {
+        let source = "\
+#!/bin/bash
+RSYNC_OPTIONS=(-a -v)
+rsync ${RSYNC_OPTIONS[*]} src dst
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${RSYNC_OPTIONS[*]}"]
+        );
+    }
+
+    #[test]
     fn reports_bourne_transformations_in_command_arguments() {
         let source = "\
 #!/bin/bash
@@ -374,6 +419,27 @@ printf '%s\\n' ${z:=fallback}
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${x:=fallback}", "${y:=out}"]
+        );
+    }
+
+    #[test]
+    fn reports_dynamic_values_inside_nested_command_substitution_arguments() {
+        let source = "\
+#!/bin/sh
+PRGNAM=cproc
+GIT_SHA=$( git rev-parse --short HEAD )
+DATE=$( git log --date=format:%Y%m%d --format=%cd | head -1 )
+VERSION=${DATE}_${GIT_SHA}
+echo \"MD5SUM=\\\"$( md5sum $PRGNAM-$VERSION.tar.xz | cut -d' ' -f1 )\\\"\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$VERSION"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -70,7 +70,11 @@ fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool 
     }
 }
 
-fn report_span_for_part(part: &shuck_ast::WordPart, part_span: shuck_ast::Span, source: &str) -> shuck_ast::Span {
+fn report_span_for_part(
+    part: &shuck_ast::WordPart,
+    part_span: shuck_ast::Span,
+    source: &str,
+) -> shuck_ast::Span {
     let shuck_ast::WordPart::Variable(name) = part else {
         return part_span;
     };
@@ -214,6 +218,254 @@ printf '%s\\n' prefix\"$HOME\"/$suffix
                 .collect::<Vec<_>>(),
             vec!["$suffix"]
         );
+    }
+
+    #[test]
+    fn reports_unquoted_expansions_in_case_cli_dispatch_entry_functions_with_top_level_exit_status()
+    {
+        let source = "\
+#!/bin/sh
+exec=/usr/sbin/collectd
+pidfile=/var/run/collectd.pid
+configfile=/etc/collectd.conf
+
+start() {
+  [ -x $exec ] || exit 5
+  [ -f $pidfile ] && rm $pidfile
+  $exec -P $pidfile -C $configfile
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit $?
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$exec", "$pidfile", "$pidfile", "$pidfile", "$configfile"]
+        );
+    }
+
+    #[test]
+    fn reports_collectd_style_case_cli_dispatch_entry_functions() {
+        let source = "\
+#!/bin/sh
+exec=/usr/sbin/collectd
+prog=$(basename $exec)
+configfile=/etc/collectd.conf
+pidfile=/var/run/collectd.pid
+
+start() {
+  [ -x $exec ] || exit 5
+  if [ -f $pidfile ]; then
+    echo \"Seems that an active process is up and running with pid $(cat $pidfile)\"
+    echo \"If this is not true try first to remove pidfile $pidfile\"
+    exit 5
+  fi
+  echo $\"Starting $prog\"
+  $exec -P $pidfile -C $configfile
+}
+
+stop() {
+  if [ -e $pidfile ]; then
+    echo \"Stopping $prog\"
+    kill -QUIT $(cat $pidfile) 2>/dev/null
+    rm $pidfile
+  fi
+}
+
+status() {
+  echo -n \"$prog is \"
+  CHECK=$(ps aux | grep $exec | grep -v grep)
+  STATUS=$?
+  if [ \"$STATUS\" == \"1\" ]; then
+    echo \"not running\"
+  else
+    echo \"running\"
+  fi
+}
+
+restart() {
+  stop
+  start
+}
+
+case \"$1\" in
+  start)
+    $1
+    ;;
+  stop)
+    $1
+    ;;
+  restart)
+    $1
+    ;;
+  status)
+    $1
+    ;;
+esac
+exit $?
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "$exec",
+                "$pidfile",
+                "$pidfile",
+                "$pidfile",
+                "$configfile",
+                "$pidfile",
+                "$pidfile",
+                "$pidfile",
+                "$exec",
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_spice_vdagent_style_case_cli_dispatch_entry_functions() {
+        let source = "\
+#!/bin/sh
+exec=\"/usr/sbin/spice-vdagentd\"
+prog=\"spice-vdagentd\"
+port=\"/dev/virtio-ports/com.redhat.spice.0\"
+pid=\"/var/run/spice-vdagentd/spice-vdagentd.pid\"
+lockfile=/var/lock/subsys/$prog
+
+start() {
+  /sbin/modprobe uinput > /dev/null 2>&1
+  /usr/bin/rm -f /var/run/spice-vdagentd/spice-vdagent-sock
+  /usr/bin/mkdir -p /var/run/spice-vdagentd
+  /usr/bin/echo \"Starting $prog: \"
+  $exec -s $port
+  retval=$?
+  /usr/bin/echo
+  [ $retval -eq 0 ] && echo \"$(pidof $prog)\" > $pid && /usr/bin/touch $lockfile
+  return $retval
+}
+
+stop() {
+  if [ \"$(pidof $prog)\" ]; then
+    /usr/bin/echo \"Stopping $prog: \"
+    /bin/kill $(cat $pid)
+  else
+    /usr/bin/echo \"$prog not running\"
+    return 1
+  fi
+  retval=$?
+  /usr/bin/echo
+  [ $retval -eq 0 ] && rm -f $lockfile $pid
+  return $retval
+}
+
+restart() {
+  stop
+  start
+}
+
+case \"$1\" in
+  start)
+    $1
+    ;;
+  stop)
+    $1
+    ;;
+  restart)
+    $1
+    ;;
+  *)
+    /usr/bin/echo $\"Usage: $0 {start|stop|restart}\"
+    exit 2
+esac
+exit $?
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+        let spans = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(spans.iter().filter(|span| **span == "$port").count(), 1);
+        assert_eq!(spans.iter().filter(|span| **span == "$retval").count(), 4);
+        assert_eq!(spans.iter().filter(|span| **span == "$prog").count(), 2);
+        assert_eq!(spans.iter().filter(|span| **span == "$pid").count(), 3);
+        assert_eq!(spans.iter().filter(|span| **span == "$lockfile").count(), 2);
+    }
+
+    #[test]
+    fn does_not_broaden_dynamic_case_dispatch_without_top_level_exit_status() {
+        let source = "\
+#!/bin/sh
+exec=/usr/sbin/collectd
+pidfile=/var/run/collectd.pid
+
+start() {
+  [ -x $exec ] || exit 5
+  $exec -P $pidfile
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn keeps_unknown_option_bundle_warnings_without_broad_command_name_reports() {
+        let source = "\
+#!/bin/sh
+BLUEALSA_BIN=/usr/bin/bluealsa
+
+start() {
+  $BLUEALSA_BIN $BLUEALSA_OPTS
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$BLUEALSA_OPTS"]
+        );
+    }
+
+    #[test]
+    fn ignores_static_case_dispatch_calls() {
+        let source = "\
+#!/bin/sh
+exec=/usr/sbin/collectd
+
+start() {
+  $exec
+}
+
+case \"$1\" in
+  start) start ;;
+esac
+exit $?
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -84,6 +84,10 @@ impl ControlFlowGraph {
         &self.exits
     }
 
+    pub fn scope_entry(&self, scope: ScopeId) -> Option<BlockId> {
+        self.scope_entries.get(&scope).copied()
+    }
+
     pub(crate) fn scope_exits(&self, scope: ScopeId) -> Option<&[BlockId]> {
         self.scope_exits.get(&scope).map(Vec::as_slice)
     }


### PR DESCRIPTION
## Summary
- reduce S001 shellcheck-only divergences across the safe-value analysis series, including empty bindings, guarded initializers, helper bindings, and function-scope CFG handling
- restore `review_all_divergences: true` in the S001 corpus metadata so the remaining divergence tail stays fully reviewed

## Why
The S001 compatibility gaps in this stack came from safe-value reasoning being too optimistic around branch-local and function-local initialization patterns. The fixes tighten that analysis without regressing the focused safe-value test suite.

## Impact
A targeted S001 large-corpus run during this series moved from `shellcheck_only=127 / shuck_only=801 / blocking=368` to `91 / 819 / 363`.

## Validation
- `cargo test -p shuck-linter rules::common::safe_value::tests::`
