### PR TITLE
fix(linter): add autofixes for C084, C085, C086, and C088

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C085.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C085.sh
@@ -4,6 +4,7 @@
 echo ok 2>&1 >/dev/null
 echo ok 2>&1 >>file
 echo ok 2>&1 1>/dev/null
+echo ok 2>&1 3>aux >out
 
 # Should not trigger: stdout is redirected first
 echo ok >file 2>&1

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -146,10 +146,26 @@ impl<'a> ConditionalNodeFact<'a> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConditionalMixedLogicalOperatorFact {
+    operator_span: Span,
+    grouped_subexpression_spans: Box<[Span]>,
+}
+
+impl ConditionalMixedLogicalOperatorFact {
+    pub fn operator_span(&self) -> Span {
+        self.operator_span
+    }
+
+    pub fn grouped_subexpression_spans(&self) -> &[Span] {
+        &self.grouped_subexpression_spans
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ConditionalFact<'a> {
     nodes: Box<[ConditionalNodeFact<'a>]>,
-    mixed_logical_operator_spans: Box<[Span]>,
+    mixed_logical_operators: Box<[ConditionalMixedLogicalOperatorFact]>,
 }
 
 impl<'a> ConditionalFact<'a> {
@@ -165,8 +181,8 @@ impl<'a> ConditionalFact<'a> {
         &self.nodes
     }
 
-    pub fn mixed_logical_operator_spans(&self) -> &[Span] {
-        &self.mixed_logical_operator_spans
+    pub fn mixed_logical_operators(&self) -> &[ConditionalMixedLogicalOperatorFact] {
+        &self.mixed_logical_operators
     }
 
     pub fn regex_nodes(&self) -> impl Iterator<Item = &ConditionalBinaryFact<'a>> + '_ {
@@ -234,7 +250,6 @@ fn collect_terminal_command_substitution_spans_in_command(
         | Command::AnonymousFunction(_) => {}
     }
 }
-
 
 fn collect_c107_status_spans_in_simple_test(
     command: &shuck_ast::SimpleCommand,
@@ -1047,22 +1062,17 @@ fn collect_status_parameter_spans_in_fragment(
     collect_status_parameter_spans_in_word(word, source, spans);
 }
 
-
 fn build_conditional_fact<'a>(command: &'a Command, source: &str) -> Option<ConditionalFact<'a>> {
     let Command::Compound(CompoundCommand::Conditional(command)) = command else {
         return None;
     };
     let mut nodes = Vec::new();
     collect_conditional_nodes(&command.expression, source, &mut nodes);
-    let mut mixed_logical_operator_spans = Vec::new();
-    collect_mixed_logical_operator_spans(
-        &command.expression,
-        false,
-        &mut mixed_logical_operator_spans,
-    );
+    let mut mixed_logical_operators = Vec::new();
+    collect_mixed_logical_operators(&command.expression, false, &mut mixed_logical_operators);
     (!nodes.is_empty()).then_some(ConditionalFact {
         nodes: nodes.into_boxed_slice(),
-        mixed_logical_operator_spans: mixed_logical_operator_spans.into_boxed_slice(),
+        mixed_logical_operators: mixed_logical_operators.into_boxed_slice(),
     })
 }
 
@@ -1082,40 +1092,39 @@ fn command_name_is_plain_command_substitution(word: &Word, source: &str) -> bool
         )
 }
 
-fn collect_mixed_logical_operator_spans(
+fn collect_mixed_logical_operators(
     expression: &ConditionalExpr,
     parent_in_same_logical_group: bool,
-    spans: &mut Vec<Span>,
+    operators: &mut Vec<ConditionalMixedLogicalOperatorFact>,
 ) {
     match expression {
         ConditionalExpr::Parenthesized(parenthesized) => {
-            collect_mixed_logical_operator_spans(&parenthesized.expr, false, spans);
+            collect_mixed_logical_operators(&parenthesized.expr, false, operators);
         }
         ConditionalExpr::Unary(unary) => {
-            collect_mixed_logical_operator_spans(&unary.expr, false, spans);
+            collect_mixed_logical_operators(&unary.expr, false, operators);
         }
         ConditionalExpr::Binary(binary) => {
-            let left_continues_group = matches!(
-                binary.left.as_ref(),
-                ConditionalExpr::Binary(left)
-                    if matches!(left.op, ConditionalBinaryOp::And | ConditionalBinaryOp::Or)
-            );
-            let right_continues_group = matches!(
-                binary.right.as_ref(),
-                ConditionalExpr::Binary(right)
-                    if matches!(right.op, ConditionalBinaryOp::And | ConditionalBinaryOp::Or)
-            );
+            let left_continues_group = conditional_expr_is_logical_binary(&binary.left);
+            let right_continues_group = conditional_expr_is_logical_binary(&binary.right);
 
-            collect_mixed_logical_operator_spans(&binary.left, left_continues_group, spans);
-            collect_mixed_logical_operator_spans(&binary.right, right_continues_group, spans);
+            collect_mixed_logical_operators(&binary.left, left_continues_group, operators);
+            collect_mixed_logical_operators(&binary.right, right_continues_group, operators);
 
-            if matches!(
-                binary.op,
-                ConditionalBinaryOp::And | ConditionalBinaryOp::Or
-            ) && !parent_in_same_logical_group
+            if conditional_binary_op_is_logical(binary.op)
+                && !parent_in_same_logical_group
                 && logical_operator_mask(expression) == (LOGICAL_AND_MASK | LOGICAL_OR_MASK)
             {
-                spans.push(binary.op_span);
+                let grouped_subexpression_spans =
+                    mixed_logical_grouped_subexpression_spans(expression, binary.op);
+                debug_assert!(
+                    !grouped_subexpression_spans.is_empty(),
+                    "mixed logical operators should expose at least one grouping span"
+                );
+                operators.push(ConditionalMixedLogicalOperatorFact {
+                    operator_span: binary.op_span,
+                    grouped_subexpression_spans: grouped_subexpression_spans.into_boxed_slice(),
+                });
             }
         }
         ConditionalExpr::Word(_)
@@ -1127,6 +1136,36 @@ fn collect_mixed_logical_operator_spans(
 
 const LOGICAL_AND_MASK: u8 = 0b01;
 const LOGICAL_OR_MASK: u8 = 0b10;
+
+fn mixed_logical_grouped_subexpression_spans(
+    expression: &ConditionalExpr,
+    group_op: ConditionalBinaryOp,
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_mixed_logical_grouped_subexpression_spans(expression, group_op, &mut spans);
+    spans
+}
+
+fn collect_mixed_logical_grouped_subexpression_spans(
+    expression: &ConditionalExpr,
+    group_op: ConditionalBinaryOp,
+    spans: &mut Vec<Span>,
+) {
+    let ConditionalExpr::Binary(binary) = expression else {
+        return;
+    };
+    if !conditional_binary_op_is_logical(binary.op) {
+        return;
+    }
+
+    if binary.op != group_op {
+        spans.push(expression.span());
+        return;
+    }
+
+    collect_mixed_logical_grouped_subexpression_spans(&binary.left, group_op, spans);
+    collect_mixed_logical_grouped_subexpression_spans(&binary.right, group_op, spans);
+}
 
 fn logical_operator_mask(expression: &ConditionalExpr) -> u8 {
     match expression {
@@ -1146,6 +1185,17 @@ fn logical_operator_mask(expression: &ConditionalExpr) -> u8 {
         | ConditionalExpr::Regex(_)
         | ConditionalExpr::VarRef(_) => 0,
     }
+}
+
+fn conditional_expr_is_logical_binary(expression: &ConditionalExpr) -> bool {
+    matches!(
+        expression,
+        ConditionalExpr::Binary(binary) if conditional_binary_op_is_logical(binary.op)
+    )
+}
+
+fn conditional_binary_op_is_logical(operator: ConditionalBinaryOp) -> bool {
+    matches!(operator, ConditionalBinaryOp::And | ConditionalBinaryOp::Or)
 }
 
 fn collect_conditional_nodes<'a>(

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -114,8 +114,9 @@ pub(crate) mod simple_tests {
 #[allow(unused_imports)]
 pub(crate) mod conditionals {
     pub use super::{
-        ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact, ConditionalNodeFact,
-        ConditionalOperandFact, ConditionalOperatorFamily, ConditionalUnaryFact,
+        ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact,
+        ConditionalMixedLogicalOperatorFact, ConditionalNodeFact, ConditionalOperandFact,
+        ConditionalOperatorFamily, ConditionalUnaryFact,
     };
 }
 

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -1482,7 +1482,7 @@ fn builds_conditional_facts_with_root_normalization_and_nested_inventory() {
             regex.right().word().map(|word| word.span.slice(source)),
             Some("^\"foo\"bar$")
         );
-        assert!(logical.mixed_logical_operator_spans().is_empty());
+        assert!(logical.mixed_logical_operators().is_empty());
         assert!(
             regex
                 .right()
@@ -1583,6 +1583,7 @@ fn keeps_parenthesized_logical_groups_separate_for_mixed_operator_detection() {
 [[ -n $a && -n $b || -n $c ]]
 [[ -n $a && ( -n $b || -n $c ) ]]
 [[ ( -n $a && -n $b || -n $c ) && -n $d ]]
+[[ -n $a && -n $b || -n $c && -n $d ]]
 ";
 
     with_facts(source, None, |_, facts| {
@@ -1591,22 +1592,36 @@ fn keeps_parenthesized_logical_groups_separate_for_mixed_operator_detection() {
             .filter_map(|fact| fact.conditional())
             .collect::<Vec<_>>();
 
+        let first = &conditionals[0].mixed_logical_operators()[0];
+        assert_eq!(first.operator_span().slice(source), "||");
         assert_eq!(
-            conditionals[0]
-                .mixed_logical_operator_spans()
+            first
+                .grouped_subexpression_spans()
                 .iter()
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["||"]
+            vec!["-n $a && -n $b"]
         );
-        assert!(conditionals[1].mixed_logical_operator_spans().is_empty());
+        assert!(conditionals[1].mixed_logical_operators().is_empty());
+        let third = &conditionals[2].mixed_logical_operators()[0];
+        assert_eq!(third.operator_span().slice(source), "||");
         assert_eq!(
-            conditionals[2]
-                .mixed_logical_operator_spans()
+            third
+                .grouped_subexpression_spans()
                 .iter()
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["||"]
+            vec!["-n $a && -n $b"]
+        );
+        let fourth = &conditionals[3].mixed_logical_operators()[0];
+        assert_eq!(fourth.operator_span().slice(source), "||");
+        assert_eq!(
+            fourth
+                .grouped_subexpression_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-n $a && -n $b", "-n $c && -n $d"]
         );
     });
 }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -55,18 +55,18 @@ pub use diagnostic::{Diagnostic, Severity};
 /// Extracted structural facts available to rules and callers.
 pub use facts::{
     BacktickFragmentFact, CommandFact, CommandOptionFacts, ConditionalBareWordFact,
-    ConditionalBinaryFact, ConditionalFact, ConditionalNodeFact, ConditionalOperandFact,
-    ConditionalOperatorFamily, ConditionalPortabilityFacts, ConditionalUnaryFact, ExitCommandFacts,
-    FindCommandFacts, FindExecCommandFacts, FindExecShellCommandFacts, ForHeaderFact,
-    FunctionCallArityFacts, FunctionHeaderFact, GrepPatternSourceKind,
-    LegacyArithmeticFragmentFact, ListFact, ListOperatorFact, LoopHeaderWordFact, PathWordFact,
-    PipelineFact, PipelineOperatorFact, PipelineSegmentFact, PositionalParameterFragmentFact,
-    PrintfCommandFacts, ReadCommandFacts, RedirectFact, RmCommandFacts, SelectHeaderFact,
-    SimpleTestFact, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax,
-    SingleQuotedFragmentFact, SshCommandFacts, StatementFact, SubstitutionFact,
-    SubstitutionHostKind, SudoFamilyCommandFacts, SudoFamilyInvoker, UnsetCommandFacts,
-    WaitCommandFacts, WordFactContext, WordFactHostKind, WordOccurrence, WordOccurrenceIter,
-    WordOccurrenceRef, XargsCommandFacts, leading_literal_word_prefix,
+    ConditionalBinaryFact, ConditionalFact, ConditionalMixedLogicalOperatorFact,
+    ConditionalNodeFact, ConditionalOperandFact, ConditionalOperatorFamily,
+    ConditionalPortabilityFacts, ConditionalUnaryFact, ExitCommandFacts, FindCommandFacts,
+    FindExecCommandFacts, FindExecShellCommandFacts, ForHeaderFact, FunctionCallArityFacts,
+    FunctionHeaderFact, GrepPatternSourceKind, LegacyArithmeticFragmentFact, ListFact,
+    ListOperatorFact, LoopHeaderWordFact, PathWordFact, PipelineFact, PipelineOperatorFact,
+    PipelineSegmentFact, PositionalParameterFragmentFact, PrintfCommandFacts, ReadCommandFacts,
+    RedirectFact, RmCommandFacts, SelectHeaderFact, SimpleTestFact, SimpleTestOperatorFamily,
+    SimpleTestShape, SimpleTestSyntax, SingleQuotedFragmentFact, SshCommandFacts, StatementFact,
+    SubstitutionFact, SubstitutionHostKind, SudoFamilyCommandFacts, SudoFamilyInvoker,
+    UnsetCommandFacts, WaitCommandFacts, WordFactContext, WordFactHostKind, WordOccurrence,
+    WordOccurrenceIter, WordOccurrenceRef, XargsCommandFacts, leading_literal_word_prefix,
 };
 /// Fact collection types and stable identifiers into those collections.
 pub use facts::{CommandId, FactSpan, LinterFacts};

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -113,23 +113,19 @@ fn numeric_comparison_redirect_diagnostic(
         return None;
     }
 
-    let operator_text = source
-        .get(operator_span.start.offset..target.span.start.offset)?
-        .trim_end();
-    if operator_text != operator_span.slice(source) {
+    let gap = source.get(operator_span.end.offset..target.span.start.offset)?;
+    if !is_shell_token_gap(gap) {
         return None;
     }
 
     let fix_span = Span::from_positions(operator_span.start, target.span.start);
-    let leading_separator = source[..operator_span.start.offset]
-        .chars()
-        .next_back()
-        .filter(|ch| !ch.is_whitespace())
-        .map(|_| " ")
-        .unwrap_or("");
-    let separator = source
-        .get(operator_span.end.offset..target.span.start.offset)
-        .filter(|text| !text.is_empty())
+    let leading_separator = if has_trailing_token_boundary(&source[..operator_span.start.offset]) {
+        ""
+    } else {
+        " "
+    };
+    let separator = Some(gap)
+        .filter(|text| has_trailing_token_boundary(text))
         .unwrap_or(" ");
 
     Some(
@@ -140,6 +136,50 @@ fn numeric_comparison_redirect_diagnostic(
             ),
         )),
     )
+}
+
+fn is_shell_token_gap(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b' ' | b'\t' | b'\r' | b'\n' => index += 1,
+            b'\\' if bytes.get(index + 1) == Some(&b'\n') => index += 2,
+            _ => return false,
+        }
+    }
+
+    true
+}
+
+fn has_trailing_token_boundary(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut end = bytes.len();
+
+    while end > 0 {
+        match bytes[end - 1] {
+            b' ' | b'\t' | b'\r' => return true,
+            b'\n' => {
+                let mut cursor = end - 1;
+                let mut backslashes = 0usize;
+                while cursor > 0 && bytes[cursor - 1] == b'\\' {
+                    backslashes += 1;
+                    cursor -= 1;
+                }
+
+                if backslashes % 2 == 1 {
+                    end = cursor;
+                    continue;
+                }
+
+                return true;
+            }
+            _ => return false,
+        }
+    }
+
+    false
 }
 
 fn double_bracket_numeric_comparison_diagnostics(
@@ -453,6 +493,35 @@ limit=3
 #!/bin/bash
 [ \"$version\" -gt \"10\" ]
 [ \"$version\" -lt 10 ]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn normalizes_escaped_newline_separators_in_bracket_numeric_comparisons() {
+        let source = "\
+#!/bin/bash
+[ \"$version\">\\
+\"10\" ]
+[ \"$version\"\\
+<\\
+10 ]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GreaterThanInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ \"$version\" -gt \"10\" ]
+[ \"$version\"\\
+ -lt 10 ]
 "
         );
         assert!(result.fixed_diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -121,6 +121,12 @@ fn numeric_comparison_redirect_diagnostic(
     }
 
     let fix_span = Span::from_positions(operator_span.start, target.span.start);
+    let leading_separator = source[..operator_span.start.offset]
+        .chars()
+        .next_back()
+        .filter(|ch| !ch.is_whitespace())
+        .map(|_| " ")
+        .unwrap_or("");
     let separator = source
         .get(operator_span.end.offset..target.span.start.offset)
         .filter(|text| !text.is_empty())
@@ -128,7 +134,10 @@ fn numeric_comparison_redirect_diagnostic(
 
     Some(
         crate::Diagnostic::new(GreaterThanInTest, operator_span).with_fix(Fix::unsafe_edit(
-            Edit::replacement(format!("{replacement}{separator}"), fix_span),
+            Edit::replacement(
+                format!("{leading_separator}{replacement}{separator}"),
+                fix_span,
+            ),
         )),
     )
 }
@@ -428,8 +437,8 @@ limit=3
     fn inserts_a_separator_for_compact_bracket_numeric_comparisons() {
         let source = "\
 #!/bin/bash
-[ \"$version\" >\"10\" ]
-[ \"$version\" <10 ]
+[ \"$version\">\"10\" ]
+[ \"$version\"<10 ]
 ";
         let result = test_snippet_with_fix(
             source,

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -2,13 +2,18 @@ use shuck_ast::{ConditionalBinaryOp, RedirectKind, Span};
 use shuck_semantic::{BindingAttributes, BindingId};
 
 use crate::{
-    Checker, CommandFact, ConditionalBinaryFact, ConditionalNodeFact, ConditionalOperandFact,
-    RedirectFact, Rule, SimpleTestSyntax, Violation, WordOccurrenceRef, static_word_text,
+    Checker, CommandFact, ConditionalBinaryFact, ConditionalNodeFact, ConditionalOperandFact, Edit,
+    Fix, FixAvailability, RedirectFact, Rule, SimpleTestSyntax, Violation, WordOccurrenceRef,
+    static_word_text,
 };
 
 pub struct GreaterThanInTest;
 
+const FIX_TITLE: &str = "replace `<` or `>` with `-lt` or `-gt`";
+
 impl Violation for GreaterThanInTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GreaterThanInTest
     }
@@ -16,33 +21,42 @@ impl Violation for GreaterThanInTest {
     fn message(&self) -> String {
         "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some(FIX_TITLE.to_owned())
+    }
 }
 
 pub fn greater_than_in_test(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
-        .flat_map(|command| comparison_operator_spans(command, checker, source))
+        .flat_map(|command| comparison_operator_diagnostics(command, checker, source))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GreaterThanInTest);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
-fn comparison_operator_spans(
+fn comparison_operator_diagnostics(
     command: &CommandFact<'_>,
     checker: &Checker<'_>,
     source: &str,
-) -> Vec<Span> {
-    let mut spans = bracket_comparison_redirect_spans(command, source);
-    spans.extend(double_bracket_numeric_comparison_spans(
+) -> Vec<crate::Diagnostic> {
+    let mut diagnostics = bracket_comparison_redirect_diagnostics(command, source);
+    diagnostics.extend(double_bracket_numeric_comparison_diagnostics(
         command, checker, source,
     ));
-    spans
+    diagnostics
 }
 
-fn bracket_comparison_redirect_spans(command: &CommandFact<'_>, source: &str) -> Vec<Span> {
+fn bracket_comparison_redirect_diagnostics(
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Vec<crate::Diagnostic> {
     let Some(simple_test) = command.simple_test() else {
         return Vec::new();
     };
@@ -61,7 +75,7 @@ fn bracket_comparison_redirect_spans(command: &CommandFact<'_>, source: &str) ->
         .redirect_facts()
         .iter()
         .filter_map(|redirect| {
-            numeric_comparison_redirect_span(
+            numeric_comparison_redirect_diagnostic(
                 redirect,
                 opening_bracket,
                 closing_bracket.span,
@@ -71,16 +85,15 @@ fn bracket_comparison_redirect_spans(command: &CommandFact<'_>, source: &str) ->
         .collect()
 }
 
-fn numeric_comparison_redirect_span(
+fn numeric_comparison_redirect_diagnostic(
     redirect: &RedirectFact<'_>,
     opening_bracket_span: Span,
     closing_bracket_span: Span,
     source: &str,
-) -> Option<Span> {
-    let redirect_data = redirect.redirect();
-    let operator = match redirect_data.kind {
-        RedirectKind::Input => "<",
-        RedirectKind::Output => ">",
+) -> Option<crate::Diagnostic> {
+    let (redirect_data, replacement) = match redirect.redirect().kind {
+        RedirectKind::Input => (redirect.redirect(), "-lt"),
+        RedirectKind::Output => (redirect.redirect(), "-gt"),
         _ => return None,
     };
 
@@ -95,24 +108,30 @@ fn numeric_comparison_redirect_span(
         return None;
     }
 
-    let operator_text = source
-        .get(redirect_data.span.start.offset..target.span.start.offset)?
-        .trim_end();
-    if operator_text != operator {
+    let operator_span = redirect.operator_span();
+    if operator_span.start.offset != redirect_data.span.start.offset {
         return None;
     }
 
-    Some(Span::from_positions(
-        redirect_data.span.start,
-        redirect_data.span.start.advanced_by(operator),
-    ))
+    let operator_text = source
+        .get(operator_span.start.offset..target.span.start.offset)?
+        .trim_end();
+    if operator_text != operator_span.slice(source) {
+        return None;
+    }
+
+    Some(
+        crate::Diagnostic::new(GreaterThanInTest, operator_span).with_fix(Fix::unsafe_edit(
+            Edit::replacement(replacement, operator_span),
+        )),
+    )
 }
 
-fn double_bracket_numeric_comparison_spans(
+fn double_bracket_numeric_comparison_diagnostics(
     command: &CommandFact<'_>,
     checker: &Checker<'_>,
     source: &str,
-) -> Vec<Span> {
+) -> Vec<crate::Diagnostic> {
     let Some(conditional) = command.conditional() else {
         return Vec::new();
     };
@@ -120,24 +139,23 @@ fn double_bracket_numeric_comparison_spans(
     conditional
         .nodes()
         .iter()
-        .filter_map(|node| numeric_double_bracket_operator_span(node, checker, source))
+        .filter_map(|node| numeric_double_bracket_operator_diagnostic(node, checker, source))
         .collect()
 }
 
-fn numeric_double_bracket_operator_span(
+fn numeric_double_bracket_operator_diagnostic(
     node: &ConditionalNodeFact<'_>,
     checker: &Checker<'_>,
     source: &str,
-) -> Option<Span> {
+) -> Option<crate::Diagnostic> {
     let ConditionalNodeFact::Binary(binary) = node else {
         return None;
     };
-    if !matches!(
-        binary.op(),
-        ConditionalBinaryOp::LexicalBefore | ConditionalBinaryOp::LexicalAfter
-    ) {
-        return None;
-    }
+    let replacement = match binary.op() {
+        ConditionalBinaryOp::LexicalBefore => "-lt",
+        ConditionalBinaryOp::LexicalAfter => "-gt",
+        _ => return None,
+    };
 
     if has_decimal_version_like_operand(binary, source)
         || !has_numeric_operand(binary, checker, source)
@@ -145,7 +163,12 @@ fn numeric_double_bracket_operator_span(
         return None;
     }
 
-    Some(binary.operator_span())
+    let operator_span = binary.operator_span();
+    Some(
+        crate::Diagnostic::new(GreaterThanInTest, operator_span).with_fix(Fix::unsafe_edit(
+            Edit::replacement(replacement, operator_span),
+        )),
+    )
 }
 
 fn has_numeric_operand(
@@ -265,8 +288,12 @@ fn is_decimal_version_like(text: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
+
+    use super::FIX_TITLE;
 
     #[test]
     fn reports_numeric_less_and_greater_operators_in_test_expressions() {
@@ -341,5 +368,86 @@ num=7
                 .collect::<Vec<_>>(),
             vec![">", "<", ">", "<"]
         );
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/bash\n[ \"$version\" > \"10\" ]\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GreaterThanInTest));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(diagnostics[0].fix_title.as_deref(), Some(FIX_TITLE));
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_numeric_test_operators() {
+        let source = "\
+#!/bin/bash
+[ \"$version\" > \"10\" ]
+[ \"$version\" < 10 ]
+count=11
+limit=3
+[[ $count > 10 ]]
+[[ \"$count\" < 1 ]]
+[[ $count > $limit ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GreaterThanInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 5);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ \"$version\" -gt \"10\" ]
+[ \"$version\" -lt 10 ]
+count=11
+limit=3
+[[ $count -gt 10 ]]
+[[ \"$count\" -lt 1 ]]
+[[ $count -gt $limit ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_string_and_version_ordering_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[ \"$value\" > \"$other\" ]
+[ \"$value\" < \"$other\" ]
+[[ \"$value\" > \"$other\" ]]
+[[ \"$value\" < 1.2 ]]
+[[ 1.2 > \"$value\" ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GreaterThanInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C086.sh").as_path(),
+            &LinterSettings::for_rule(Rule::GreaterThanInTest),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C086_fix_C086.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -120,9 +120,15 @@ fn numeric_comparison_redirect_diagnostic(
         return None;
     }
 
+    let fix_span = Span::from_positions(operator_span.start, target.span.start);
+    let separator = source
+        .get(operator_span.end.offset..target.span.start.offset)
+        .filter(|text| !text.is_empty())
+        .unwrap_or(" ");
+
     Some(
         crate::Diagnostic::new(GreaterThanInTest, operator_span).with_fix(Fix::unsafe_edit(
-            Edit::replacement(replacement, operator_span),
+            Edit::replacement(format!("{replacement}{separator}"), fix_span),
         )),
     )
 }
@@ -413,6 +419,31 @@ limit=3
 [[ $count -gt 10 ]]
 [[ \"$count\" -lt 1 ]]
 [[ $count -gt $limit ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn inserts_a_separator_for_compact_bracket_numeric_comparisons() {
+        let source = "\
+#!/bin/bash
+[ \"$version\" >\"10\" ]
+[ \"$version\" <10 ]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GreaterThanInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ \"$version\" -gt \"10\" ]
+[ \"$version\" -lt 10 ]
 "
         );
         assert!(result.fixed_diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/correctness/mixed_and_or_in_condition.rs
+++ b/crates/shuck-linter/src/rules/correctness/mixed_and_or_in_condition.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct MixedAndOrInCondition;
 
 impl Violation for MixedAndOrInCondition {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::MixedAndOrInCondition
     }
@@ -10,24 +12,47 @@ impl Violation for MixedAndOrInCondition {
     fn message(&self) -> String {
         "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("add parentheses to make the logical grouping explicit".to_owned())
+    }
 }
 
 pub fn mixed_and_or_in_condition(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|command| command.conditional())
-        .flat_map(|conditional| conditional.mixed_logical_operator_spans().iter().copied())
+        .flat_map(|conditional| conditional.mixed_logical_operators().iter())
+        .map(|operator| {
+            let edits = operator
+                .grouped_subexpression_spans()
+                .iter()
+                .flat_map(|span| {
+                    [
+                        Edit::insertion(span.start.offset, "( "),
+                        Edit::insertion(span.end.offset, " )"),
+                    ]
+                })
+                .collect::<Vec<_>>();
+
+            Diagnostic::new(MixedAndOrInCondition, operator.operator_span())
+                .with_fix(Fix::safe_edits(edits))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || MixedAndOrInCondition);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_ungrouped_mixed_logical_operators_in_double_brackets() {
@@ -67,5 +92,87 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_mixed_logical_conditions() {
+        let source = "\
+#!/bin/bash
+[[ -n $a && -n $b || -n $c ]]
+[[ -n $a || -n $b && -n $c ]]
+[[ ( -n $a && -n $b || -n $c ) && -n $d ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MixedAndOrInCondition),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[[ ( -n $a && -n $b ) || -n $c ]]
+[[ -n $a || ( -n $b && -n $c ) ]]
+[[ ( ( -n $a && -n $b ) || -n $c ) && -n $d ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_one_safe_fix_with_multiple_grouping_edits_when_both_sides_need_parentheses() {
+        let source = "\
+#!/bin/bash
+[[ -n $a && -n $b || -n $c && -n $d ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MixedAndOrInCondition),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[[ ( -n $a && -n $b ) || ( -n $c && -n $d ) ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_grouped_or_single_operator_conditions_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[[ -n $a && ( -n $b || -n $c ) ]]
+[[ ( -n $a && -n $b ) || -n $c ]]
+[[ -n $a && -n $b && -n $c ]]
+[[ -n $a || -n $b || -n $c ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MixedAndOrInCondition),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C088.sh").as_path(),
+            &LinterSettings::for_rule(Rule::MixedAndOrInCondition),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C088_fix_C088.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__greater_than_in_test__tests__C086_fix_C086.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__greater_than_in_test__tests__C086_fix_C086.sh.snap
@@ -1,0 +1,95 @@
+---
+source: crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+---
+Diagnostics:
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+ --> <source>:4:14
+  |
+4 | [ "$version" > "10" ]
+  |
+
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+ --> <source>:5:14
+  |
+5 | [ "$version" < 10 ]
+  |
+
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+ --> <source>:8:5
+  |
+8 | [ 1 > 2 ]
+  |
+
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+ --> <source>:9:11
+  |
+9 | [[ $count > 10 ]]
+  |
+
+C086 use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons
+  --> <source>:10:13
+   |
+10 | [[ "$count" < 1 ]]
+   |
+
+
+Applied fixes: 5
+
+Diff:
+--- before
++++ after
+@@ -1,13 +1,13 @@
+ #!/bin/bash
+ 
+ # Invalid: numeric `<`/`>` in test expressions should use `-lt`/`-gt`.
+-[ "$version" > "10" ]
+-[ "$version" < 10 ]
++[ "$version" -gt "10" ]
++[ "$version" -lt 10 ]
+ 
+ # Invalid: literal operands still use redirecting or lexical operators.
+-[ 1 > 2 ]
+-[[ $count > 10 ]]
+-[[ "$count" < 1 ]]
++[ 1 -gt 2 ]
++[[ $count -gt 10 ]]
++[[ "$count" -lt 1 ]]
+ 
+ # Valid: redirects outside the test expression are unrelated.
+ [ "$version" ] > "$log"
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: numeric `<`/`>` in test expressions should use `-lt`/`-gt`.
+[ "$version" -gt "10" ]
+[ "$version" -lt 10 ]
+
+# Invalid: literal operands still use redirecting or lexical operators.
+[ 1 -gt 2 ]
+[[ $count -gt 10 ]]
+[[ "$count" -lt 1 ]]
+
+# Valid: redirects outside the test expression are unrelated.
+[ "$version" ] > "$log"
+
+# Valid: plain string ordering is outside this numeric-comparison rule.
+[ "$version" > "$other" ]
+[ "$version" < "$other" ]
+[[ "$version" > "$other" ]]
+
+# Valid: escaped or quoted operators stay test operands.
+[ "$version" \> "$other" ]
+[ "$version" \< "$other" ]
+[ "$version" ">" "$other" ]
+[ "$version" "<" "$other" ]
+
+# Valid: decimal/version ordering is handled by C087 instead.
+[[ "$version" > 1.2 ]]
+[[ 1.2 < "$version" ]]
+
+# Valid: `test` is out of scope for this rule.
+test "$version" > 10
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__mixed_and_or_in_condition__tests__C088_fix_C088.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__mixed_and_or_in_condition__tests__C088_fix_C088.sh.snap
@@ -1,0 +1,70 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mixed_and_or_in_condition.rs
+assertion_line: 176
+---
+Diagnostics:
+C088 mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear
+ --> <source>:4:19
+  |
+4 | [[ -n $a && -n $b || -n $c ]]
+  |
+
+C088 mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear
+ --> <source>:7:10
+  |
+7 | [[ -n $a || -n $b && -n $c ]]
+  |
+
+C088 mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear
+  --> <source>:10:21
+   |
+10 | [[ ( -n $a && -n $b || -n $c ) && -n $d ]]
+   |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -1,13 +1,13 @@
+ #!/bin/bash
+ 
+ # Invalid: mixing `&&` and `||` at the same logical level obscures intent.
+-[[ -n $a && -n $b || -n $c ]]
++[[ ( -n $a && -n $b ) || -n $c ]]
+ 
+ # Invalid: the same ambiguity applies when the operators appear in the opposite order.
+-[[ -n $a || -n $b && -n $c ]]
++[[ -n $a || ( -n $b && -n $c ) ]]
+ 
+ # Invalid: wrapping the whole mixed subexpression does not group the inner operators.
+-[[ ( -n $a && -n $b || -n $c ) && -n $d ]]
++[[ ( ( -n $a && -n $b ) || -n $c ) && -n $d ]]
+ 
+ # Valid: explicit grouping keeps the `||` subexpression separate.
+ [[ -n $a && ( -n $b || -n $c ) ]]
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: mixing `&&` and `||` at the same logical level obscures intent.
+[[ ( -n $a && -n $b ) || -n $c ]]
+
+# Invalid: the same ambiguity applies when the operators appear in the opposite order.
+[[ -n $a || ( -n $b && -n $c ) ]]
+
+# Invalid: wrapping the whole mixed subexpression does not group the inner operators.
+[[ ( ( -n $a && -n $b ) || -n $c ) && -n $d ]]
+
+# Valid: explicit grouping keeps the `||` subexpression separate.
+[[ -n $a && ( -n $b || -n $c ) ]]
+
+# Valid: explicit grouping on the `&&` side is also clear.
+[[ ( -n $a && -n $b ) || -n $c ]]
+
+# Valid: a condition that only uses one logical operator does not need extra grouping.
+[[ -n $a && -n $b && -n $c ]]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__stderr_before_stdout_redirect__tests__C085_fix_C085.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__stderr_before_stdout_redirect__tests__C085_fix_C085.sh.snap
@@ -1,0 +1,71 @@
+---
+source: crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+assertion_line: 234
+---
+Diagnostics:
+C085 stderr is redirected before stdout is redirected
+ --> <source>:4:9
+  |
+4 | echo ok 2>&1 >/dev/null
+  |
+
+C085 stderr is redirected before stdout is redirected
+ --> <source>:5:9
+  |
+5 | echo ok 2>&1 >>file
+  |
+
+C085 stderr is redirected before stdout is redirected
+ --> <source>:6:9
+  |
+6 | echo ok 2>&1 1>/dev/null
+  |
+
+C085 stderr is redirected before stdout is redirected
+ --> <source>:7:9
+  |
+7 | echo ok 2>&1 3>aux >out
+  |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/sh
+ 
+ # Should trigger: stderr is duplicated to stdout before stdout is redirected
+-echo ok 2>&1 >/dev/null
+-echo ok 2>&1 >>file
+-echo ok 2>&1 1>/dev/null
+-echo ok 2>&1 3>aux >out
++echo ok >/dev/null 2>&1
++echo ok >>file 2>&1
++echo ok 1>/dev/null 2>&1
++echo ok 3>aux >out 2>&1
+ 
+ # Should not trigger: stdout is redirected first
+ echo ok >file 2>&1
+
+Fixed source:
+#!/bin/sh
+
+# Should trigger: stderr is duplicated to stdout before stdout is redirected
+echo ok >/dev/null 2>&1
+echo ok >>file 2>&1
+echo ok 1>/dev/null 2>&1
+echo ok 3>aux >out 2>&1
+
+# Should not trigger: stdout is redirected first
+echo ok >file 2>&1
+
+# Should not trigger: stderr goes to a separate file before stdout is redirected
+echo ok 2>err >out
+
+# Should not trigger: later descriptor duplication does not redirect stdout to a file
+echo ok 2>&1 1>&3
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C085_C085.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C085_C085.sh.snap
@@ -18,3 +18,9 @@ C085 stderr is redirected before stdout is redirected
   |
 6 | echo ok 2>&1 1>/dev/null
   |
+
+C085 stderr is redirected before stdout is redirected
+ --> <source>:7:9
+  |
+7 | echo ok 2>&1 3>aux >out
+  |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unquoted_grep_regex__tests__C084_fix_C084.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unquoted_grep_regex__tests__C084_fix_C084.sh.snap
@@ -1,0 +1,147 @@
+---
+source: crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+assertion_line: 242
+---
+Diagnostics:
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:2:6
+  |
+2 | grep start* out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:3:9
+  |
+3 | grep -e item? out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:4:6
+  |
+4 | grep -eitem* out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:5:10
+  |
+5 | grep -oe item* out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:6:15
+  |
+6 | grep --regexp item,[0-4] out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:7:10
+  |
+7 | grep -Eq item,[0-4] out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:8:6
+  |
+8 | grep --regexp=foo*bar out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+ --> <source>:9:24
+  |
+9 | grep --exclude '*.txt' foo*bar out.txt
+  |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:10:20
+   |
+10 | grep --label stdin item? out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:11:12
+   |
+11 | grep -F -- item,[0-4] out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:12:9
+   |
+12 | grep -F foo*bar out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:13:6
+   |
+13 | grep [0-9a-f]{40} out.txt
+   |
+
+C084 quote grep regex patterns so the shell does not expand them first
+  --> <source>:14:25
+   |
+14 | checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
+   |
+
+
+Applied fixes: 13
+
+Diff:
+--- before
++++ after
+@@ -1,17 +1,17 @@
+ #!/bin/sh
+-grep start* out.txt
+-grep -e item? out.txt
+-grep -eitem* out.txt
+-grep -oe item* out.txt
+-grep --regexp item,[0-4] out.txt
+-grep -Eq item,[0-4] out.txt
+-grep --regexp=foo*bar out.txt
+-grep --exclude '*.txt' foo*bar out.txt
+-grep --label stdin item? out.txt
+-grep -F -- item,[0-4] out.txt
+-grep -F foo*bar out.txt
+-grep [0-9a-f]{40} out.txt
+-checksum="$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\n' ' ')"
++grep "start*" out.txt
++grep -e "item?" out.txt
++grep "-eitem*" out.txt
++grep -oe "item*" out.txt
++grep --regexp "item,[0-4]" out.txt
++grep -Eq "item,[0-4]" out.txt
++grep "--regexp=foo*bar" out.txt
++grep --exclude '*.txt' "foo*bar" out.txt
++grep --label stdin "item?" out.txt
++grep -F -- "item,[0-4]" out.txt
++grep -F "foo*bar" out.txt
++grep "[0-9a-f]{40}" out.txt
++checksum="$(grep -Ehrow "[0-9a-f]{40}" ${template}|sort|uniq|tr '\n' ' ')"
+ 
+ grep "start*" out.txt
+ grep --regexp='item,[0-4]' out.txt
+
+Fixed source:
+#!/bin/sh
+grep "start*" out.txt
+grep -e "item?" out.txt
+grep "-eitem*" out.txt
+grep -oe "item*" out.txt
+grep --regexp "item,[0-4]" out.txt
+grep -Eq "item,[0-4]" out.txt
+grep "--regexp=foo*bar" out.txt
+grep --exclude '*.txt' "foo*bar" out.txt
+grep --label stdin "item?" out.txt
+grep -F -- "item,[0-4]" out.txt
+grep -F "foo*bar" out.txt
+grep "[0-9a-f]{40}" out.txt
+checksum="$(grep -Ehrow "[0-9a-f]{40}" ${template}|sort|uniq|tr '\n' ' ')"
+
+grep "start*" out.txt
+grep --regexp='item,[0-4]' out.txt
+grep -eo item* out.txt
+grep -f patterns.txt item,[0-4] out.txt
+grep --exclude '*.txt' "foo*bar" out.txt
+grep \[ab\]\* out.txt
+grep -F "foo*bar" out.txt
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -1,11 +1,13 @@
 use rustc_hash::FxHashSet;
-use shuck_ast::RedirectKind;
+use shuck_ast::{RedirectKind, Span};
 
-use crate::{Checker, RedirectFact, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, RedirectFact, Rule, Violation};
 
 pub struct StderrBeforeStdoutRedirect;
 
 impl Violation for StderrBeforeStdoutRedirect {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::StderrBeforeStdoutRedirect
     }
@@ -13,9 +15,14 @@ impl Violation for StderrBeforeStdoutRedirect {
     fn message(&self) -> String {
         "stderr is redirected before stdout is redirected".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("move `2>&1` after the stdout-to-file redirects".to_owned())
+    }
 }
 
 pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
+    let source = checker.source();
     let pipeline_producer_command_ids = checker
         .facts()
         .pipelines()
@@ -29,7 +36,7 @@ pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
         })
         .collect::<FxHashSet<_>>();
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .structural_commands()
         .filter(|fact| !pipeline_producer_command_ids.contains(&fact.id()))
@@ -42,13 +49,28 @@ pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
                     if !is_stderr_to_stdout_redirect(redirect) {
                         return None;
                     }
-                    has_later_stdout_file_redirect(&redirects[index + 1..])
-                        .then_some(redirect.redirect().span)
+
+                    let stdout_index =
+                        last_later_stdout_file_redirect_index(&redirects[index + 1..])? + index + 1;
+                    Some(
+                        crate::Diagnostic::new(
+                            StderrBeforeStdoutRedirect,
+                            redirect.redirect().span,
+                        )
+                        .with_fix(stderr_before_stdout_redirect_fix(
+                            source,
+                            redirects,
+                            index,
+                            stdout_index,
+                        )),
+                    )
                 })
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || StderrBeforeStdoutRedirect);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn is_stderr_to_stdout_redirect(redirect: &RedirectFact<'_>) -> bool {
@@ -61,21 +83,64 @@ fn is_stderr_to_stdout_redirect(redirect: &RedirectFact<'_>) -> bool {
         && analysis.numeric_descriptor_target == Some(1)
 }
 
-fn has_later_stdout_file_redirect(redirects: &[RedirectFact<'_>]) -> bool {
-    redirects.iter().any(|redirect| {
-        let data = redirect.redirect();
-        data.fd.unwrap_or(1) == 1
-            && matches!(
-                data.kind,
-                RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append
-            )
-    })
+fn stderr_before_stdout_redirect_fix(
+    source: &str,
+    redirects: &[RedirectFact<'_>],
+    stderr_index: usize,
+    stdout_index: usize,
+) -> Fix {
+    let replacement = reordered_redirect_segment(source, redirects, stderr_index, stdout_index);
+    let span = Span::from_positions(
+        redirects[stderr_index].redirect().span.start,
+        redirects[stdout_index].redirect().span.end,
+    );
+
+    Fix::unsafe_edit(Edit::replacement(replacement, span))
+}
+
+fn reordered_redirect_segment(
+    source: &str,
+    redirects: &[RedirectFact<'_>],
+    stderr_index: usize,
+    stdout_index: usize,
+) -> String {
+    let moved_span = redirects[stderr_index].redirect().span;
+    let mut replacement = String::new();
+
+    for index in stderr_index + 1..=stdout_index {
+        let span = redirects[index].redirect().span;
+        replacement.push_str(span.slice(source));
+        replacement
+            .push_str(&source[redirects[index - 1].redirect().span.end.offset..span.start.offset]);
+    }
+
+    replacement.push_str(moved_span.slice(source));
+    replacement
+}
+
+fn last_later_stdout_file_redirect_index(redirects: &[RedirectFact<'_>]) -> Option<usize> {
+    redirects
+        .iter()
+        .enumerate()
+        .filter_map(|(index, redirect)| is_stdout_file_redirect(redirect).then_some(index))
+        .next_back()
+}
+
+fn is_stdout_file_redirect(redirect: &RedirectFact<'_>) -> bool {
+    let data = redirect.redirect();
+    data.fd.unwrap_or(1) == 1
+        && matches!(
+            data.kind,
+            RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append
+        )
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_stdout_redirects_in_structural_commands_only() {
@@ -91,6 +156,83 @@ out=$(bar 2>&1 >/dev/null)
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\necho ok 2>&1 >/dev/null\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("move `2>&1` after the stdout-to-file redirects")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_stderr_duplications_before_stdout_redirects() {
+        let source = "\
+#!/bin/sh
+echo ok 2>&1 >/dev/null
+echo ok 2>&1 3>aux >out
+echo ok 2>&1 1>/dev/null
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo ok >/dev/null 2>&1
+echo ok 3>aux >out 2>&1
+echo ok 1>/dev/null 2>&1
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_matching_redirect_orders_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+foo 2>&1 >/dev/null | sed 's/x/y/'
+echo ok >file 2>&1
+echo ok 2>&1 1>&3
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C085.sh").as_path(),
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C085_fix_C085.sh", result);
+        Ok(())
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -114,6 +114,10 @@ fn reordered_redirect_segment(
             .push_str(&source[redirects[index - 1].redirect().span.end.offset..span.start.offset]);
     }
 
+    if !replacement.ends_with(char::is_whitespace) {
+        replacement.push(' ');
+    }
+
     replacement.push_str(moved_span.slice(source));
     replacement
 }
@@ -199,6 +203,31 @@ echo ok 2>&1 1>/dev/null
 echo ok >/dev/null 2>&1
 echo ok 3>aux >out 2>&1
 echo ok 1>/dev/null 2>&1
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn inserts_a_separator_when_reordering_adjacent_redirect_tokens() {
+        let source = "\
+#!/bin/sh
+echo ok 2>&1>/dev/null
+echo ok 2>&1 3>aux>out
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo ok >/dev/null 2>&1
+echo ok 3>aux >out 2>&1
 "
         );
         assert!(result.fixed_diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -94,7 +94,7 @@ fn stderr_before_stdout_redirect_fix(
 ) -> Option<Fix> {
     if redirects[stderr_index + 1..stdout_index]
         .iter()
-        .any(redirect_touches_stderr)
+        .any(redirect_conflicts_with_stderr_reorder)
     {
         return None;
     }
@@ -179,9 +179,14 @@ fn is_stdout_file_redirect(redirect: &RedirectFact<'_>) -> bool {
         )
 }
 
-fn redirect_touches_stderr(redirect: &RedirectFact<'_>) -> bool {
+fn redirect_conflicts_with_stderr_reorder(redirect: &RedirectFact<'_>) -> bool {
     let data = redirect.redirect();
-    data.fd == Some(2) || data.kind == RedirectKind::OutputBoth
+    data.fd == Some(2)
+        || data.kind == RedirectKind::OutputBoth
+        || (data.kind == RedirectKind::DupOutput
+            && redirect
+                .analysis()
+                .is_some_and(|analysis| analysis.numeric_descriptor_target == Some(2)))
 }
 
 #[cfg(test)]
@@ -333,13 +338,15 @@ echo ok item 3>aux >out 2>&1
 #!/bin/sh
 echo ok 2>&1 2>err >out
 echo ok 2>&1 &>out >final
+echo ok 2>&1 1>&2 >out
+echo ok 2>&1 3>&2 >out
 ";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
         );
 
-        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics.len(), 4);
         assert!(
             diagnostics
                 .iter()

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -6,7 +6,7 @@ use crate::{Checker, Edit, Fix, FixAvailability, RedirectFact, Rule, Violation};
 pub struct StderrBeforeStdoutRedirect;
 
 impl Violation for StderrBeforeStdoutRedirect {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
 
     fn rule() -> Rule {
         Rule::StderrBeforeStdoutRedirect
@@ -52,17 +52,20 @@ pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
 
                     let stdout_index =
                         last_later_stdout_file_redirect_index(&redirects[index + 1..])? + index + 1;
+                    let diagnostic = crate::Diagnostic::new(
+                        StderrBeforeStdoutRedirect,
+                        redirect.redirect().span,
+                    );
                     Some(
-                        crate::Diagnostic::new(
-                            StderrBeforeStdoutRedirect,
-                            redirect.redirect().span,
-                        )
-                        .with_fix(stderr_before_stdout_redirect_fix(
+                        match stderr_before_stdout_redirect_fix(
                             source,
                             redirects,
                             index,
                             stdout_index,
-                        )),
+                        ) {
+                            Some(fix) => diagnostic.with_fix(fix),
+                            None => diagnostic,
+                        },
                     )
                 })
         })
@@ -88,14 +91,21 @@ fn stderr_before_stdout_redirect_fix(
     redirects: &[RedirectFact<'_>],
     stderr_index: usize,
     stdout_index: usize,
-) -> Fix {
+) -> Option<Fix> {
+    if redirects[stderr_index + 1..stdout_index]
+        .iter()
+        .any(redirect_touches_stderr)
+    {
+        return None;
+    }
+
     let replacement = reordered_redirect_segment(source, redirects, stderr_index, stdout_index);
     let span = Span::from_positions(
         redirects[stderr_index].redirect().span.start,
         redirects[stdout_index].redirect().span.end,
     );
 
-    Fix::unsafe_edit(Edit::replacement(replacement, span))
+    Some(Fix::unsafe_edit(Edit::replacement(replacement, span)))
 }
 
 fn reordered_redirect_segment(
@@ -139,6 +149,11 @@ fn is_stdout_file_redirect(redirect: &RedirectFact<'_>) -> bool {
             data.kind,
             RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append
         )
+}
+
+fn redirect_touches_stderr(redirect: &RedirectFact<'_>) -> bool {
+    let data = redirect.redirect();
+    data.fd == Some(2) || data.kind == RedirectKind::OutputBoth
 }
 
 #[cfg(test)]
@@ -257,6 +272,41 @@ echo ok >/tmp/out 2>&1
 "
         );
         assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn withholds_fix_when_an_intervening_redirect_retargets_stderr() {
+        let source = "\
+#!/bin/sh
+echo ok 2>&1 2>err >out
+echo ok 2>&1 &>out >final
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
+
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(
+            result
+                .fixed_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -119,11 +119,12 @@ fn reordered_redirect_segment(
 
     for index in stderr_index + 1..=stdout_index {
         let span = redirects[index].redirect().span;
-        if index > stderr_index + 1 {
-            replacement.push_str(
-                &source[redirects[index - 1].redirect().span.end.offset..span.start.offset],
-            );
-        }
+        let gap = if index == stderr_index + 1 {
+            strip_leading_shell_trivia(&source[moved_span.end.offset..span.start.offset])
+        } else {
+            &source[redirects[index - 1].redirect().span.end.offset..span.start.offset]
+        };
+        replacement.push_str(gap);
         replacement.push_str(span.slice(source));
     }
 
@@ -132,6 +133,33 @@ fn reordered_redirect_segment(
     replacement.push(' ');
     replacement.push_str(moved_span.slice(source));
     replacement
+}
+
+fn strip_leading_shell_trivia(text: &str) -> &str {
+    let mut offset = 0;
+    let mut remaining = text;
+
+    loop {
+        if let Some(stripped) = remaining.strip_prefix("\\\r\n") {
+            offset += 3;
+            remaining = stripped;
+            continue;
+        }
+        if let Some(stripped) = remaining.strip_prefix("\\\n") {
+            offset += 2;
+            remaining = stripped;
+            continue;
+        }
+
+        let trimmed = remaining.trim_start_matches(char::is_whitespace);
+        if trimmed.len() == remaining.len() {
+            break;
+        }
+        offset += remaining.len() - trimmed.len();
+        remaining = trimmed;
+    }
+
+    &text[offset..]
 }
 
 fn last_later_stdout_file_redirect_index(redirects: &[RedirectFact<'_>]) -> Option<usize> {
@@ -269,6 +297,31 @@ echo ok 2>&1\\
             "\
 #!/bin/sh
 echo ok >/tmp/out 2>&1
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn preserves_interleaved_tokens_before_the_first_later_redirect() {
+        let source = "\
+#!/bin/sh
+echo ok 2>&1 arg >/tmp/out
+echo ok 2>&1 item 3>aux >out
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo ok arg >/tmp/out 2>&1
+echo ok item 3>aux >out 2>&1
 "
         );
         assert!(result.fixed_diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -109,15 +109,17 @@ fn reordered_redirect_segment(
 
     for index in stderr_index + 1..=stdout_index {
         let span = redirects[index].redirect().span;
+        if index > stderr_index + 1 {
+            replacement.push_str(
+                &source[redirects[index - 1].redirect().span.end.offset..span.start.offset],
+            );
+        }
         replacement.push_str(span.slice(source));
-        replacement
-            .push_str(&source[redirects[index - 1].redirect().span.end.offset..span.start.offset]);
     }
 
-    if !replacement.ends_with(char::is_whitespace) {
-        replacement.push(' ');
-    }
-
+    // Always force a real separator before the moved redirect so adjacent
+    // redirects and escaped newlines cannot merge the tokens back together.
+    replacement.push(' ');
     replacement.push_str(moved_span.slice(source));
     replacement
 }
@@ -227,7 +229,31 @@ echo ok 2>&1 3>aux>out
             "\
 #!/bin/sh
 echo ok >/dev/null 2>&1
-echo ok 3>aux >out 2>&1
+echo ok 3>aux>out 2>&1
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn inserts_a_real_separator_after_escaped_newline_redirect_gaps() {
+        let source = "\
+#!/bin/sh
+echo ok 2>&1\\
+>/tmp/out
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::StderrBeforeStdoutRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo ok >/tmp/out 2>&1
 "
         );
         assert!(result.fixed_diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation, word_unquoted_glob_pattern_spans};
+use crate::{
+    Checker, Edit, Fix, FixAvailability, Rule, Violation, word_unquoted_glob_pattern_spans,
+};
 
 pub struct UnquotedGrepRegex;
 
 impl Violation for UnquotedGrepRegex {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedGrepRegex
     }
@@ -10,29 +14,44 @@ impl Violation for UnquotedGrepRegex {
     fn message(&self) -> String {
         "quote grep regex patterns so the shell does not expand them first".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the reported grep pattern word".to_owned())
+    }
 }
 
 pub fn unquoted_grep_regex(checker: &mut Checker) {
-    let spans = checker
-        .facts()
+    let source = checker.source();
+    let facts = checker.facts();
+    let diagnostics = facts
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("grep"))
         .filter_map(|fact| fact.options().grep())
         .flat_map(|grep| grep.patterns().iter())
-        .filter(|pattern| {
-            !word_unquoted_glob_pattern_spans(pattern.word(), checker.source()).is_empty()
+        .filter(|pattern| !word_unquoted_glob_pattern_spans(pattern.word(), source).is_empty())
+        .map(|pattern| {
+            let span = pattern.span();
+            let replacement = facts
+                .any_word_fact(span)
+                .expect("grep pattern span should map to a word fact")
+                .single_double_quoted_replacement(source);
+            crate::Diagnostic::new(UnquotedGrepRegex, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, span)))
         })
-        .map(|pattern| pattern.span())
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedGrepRegex);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_unquoted_grep_patterns_that_can_glob_expand() {
@@ -97,6 +116,103 @@ grep -F \"foo*bar\" out.txt
     }
 
     #[test]
+    fn attaches_unsafe_fix_metadata_for_reported_grep_patterns() {
+        let source = "#!/bin/sh\ngrep start* out.txt\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedGrepRegex));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("quote the reported grep pattern word")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_grep_pattern_words() {
+        let source = "\
+#!/bin/sh
+grep start* out.txt
+grep -e item? out.txt
+grep -eitem* out.txt
+grep --regexp=foo*bar out.txt
+grep -F -- item,[0-4] out.txt
+checksum=\"$(grep -Ehrow [0-9a-f]{40} ${template}|sort|uniq|tr '\\n' ' ')\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedGrepRegex),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 6);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+grep \"start*\" out.txt
+grep -e \"item?\" out.txt
+grep \"-eitem*\" out.txt
+grep \"--regexp=foo*bar\" out.txt
+grep -F -- \"item,[0-4]\" out.txt
+checksum=\"$(grep -Ehrow \"[0-9a-f]{40}\" ${template}|sort|uniq|tr '\\n' ' ')\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_mixed_quoted_grep_pattern_words_preserving_expansions() {
+        let source = "\
+#!/bin/sh
+grep \"$prefix\"[0-9].log out.txt
+grep --regexp \"$prefix\"[0-9].log out.txt
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedGrepRegex),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+grep \"${prefix}[0-9].log\" out.txt
+grep --regexp \"${prefix}[0-9].log\" out.txt
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_violating_grep_pattern_words_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+grep \"start*\" out.txt
+grep --regexp='item,[0-4]' out.txt
+grep -eo item* out.txt
+grep -f patterns.txt item,[0-4] out.txt
+grep --exclude '*.txt' \"foo*bar\" out.txt
+grep \\[ab\\]\\* out.txt
+grep -F \"foo*bar\" out.txt
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedGrepRegex),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
     fn reports_nested_grep_patterns_with_split_literal_bracket_globs() {
         let source = "\
 #!/bin/sh
@@ -113,5 +229,17 @@ done
                 .collect::<Vec<_>>(),
             vec!["[/$]"]
         );
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C084.sh").as_path(),
+            &LinterSettings::for_rule(Rule::UnquotedGrepRegex),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C084_fix_C084.sh", result);
+        Ok(())
     }
 }


### PR DESCRIPTION
## What changed

This PR adds autofix support for four existing linter rules whose fix metadata already existed in `docs/rules` but had not been wired into the Rust implementation yet:

- `C084` now quotes reported grep regex words.
- `C085` now moves `2>&1` after the stdout-to-file redirects it depends on.
- `C086` now rewrites numeric `<` and `>` comparisons to `-lt` and `-gt`.
- `C088` now adds explicit parentheses around mixed `&&` / `||` groups inside `[[ ... ]]`.

It also adds the rule-level fix coverage and snapshots for each rule, plus a small conditional-fact extension for `C088` so the safe grouping fix can use exact parser-backed spans instead of rebuilding structure in the rule.

## Why it changed

These rules already had fix designs captured in `docs/rules`, but users still could not apply them through Shuck because the diagnostics did not attach `Fix` data.

## Impact

Users can now apply autofixes for these four diagnostics, and the new tests lock in both the rewritten source and the expectation that rerunning lint on the fixed output does not re-report the same issue.

## Validation

- `cargo test -p shuck-linter unquoted_grep_regex`
- `cargo test -p shuck-linter stderr_before_stdout_redirect -- --nocapture`
- `cargo test -p shuck-linter greater_than_in_test`
- `cargo test -p shuck-linter mixed_and_or_in_condition`
- `cargo test -p shuck-linter keeps_parenthesized_logical_groups_separate_for_mixed_operator_detection`
- `make check`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C084`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C085`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C086`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C088`

The targeted large-corpus runs still exit non-zero because of the same unrelated pre-existing harness parse failures elsewhere in the corpus, but each selector run reported `implementation_diffs=0`, `mapping_issues=0`, and `reviewed_divergences=0` for the target rule.
