### PR TITLE
ci: bump shuck-extract via release-please extra-files

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -34,7 +34,8 @@
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-indexer'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-linter'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-parser'].version" },
-        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-semantic'].version" }
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-semantic'].version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-extract'].version" }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- `shuck-extract` (added in #417) was never added to `.release-please-config.json`'s `extra-files` list, so release-please left its `[workspace.dependencies]` entry pinned at `0.0.17` while bumping every other internal crate to `0.0.18`.
- `crates/shuck-extract/Cargo.toml` inherits `version.workspace = true` (now `0.0.18`), producing an internal version skew that broke workspace resolution on PR #425 with `failed to select a version for the requirement shuck-extract = "^0.0.17"` across cargo test/clippy/deny/fuzz/large-corpus.
- Adds the missing entry so release-please keeps `shuck-extract` in lockstep on future releases. Once this lands, release-please will regenerate PR #425 with the correct `0.0.18` pin.

## Test plan
- [ ] Confirm release-please regenerates PR #425 with `shuck-extract = { path = "crates/shuck-extract", version = "0.0.18" }` after merge.
- [ ] Confirm the regenerated release PR's CI (cargo test, clippy, deny, fuzz smoke, large corpus) goes green.