### PR TITLE
docs(website): add rules_lint compatibility guide

### DIFF
--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -9,9 +9,9 @@ export const docsNavigation: NavItem[] = [
     title: "Getting Started",
     items: [
       { title: "Overview", href: "/docs/getting-started" },
-      { title: "Embedded Scripts", href: "/docs/embedded-scripts" },
       { title: "Configuration", href: "/docs/configuration" },
       { title: "ShellCheck Compatibility", href: "/docs/shellcheck-compat" },
+      { title: "Embedded Scripts", href: "/docs/embedded-scripts" },
     ],
   },
   {

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -51,6 +51,12 @@ If you already have tools that invoke `shellcheck`, Shuck can expose a ShellChec
 
 See the dedicated [ShellCheck compatibility guide](/docs/shellcheck-compat) for activation, supported flags, `.shellcheckrc` handling, and current caveats.
 
+<h3 id="rules_lint">Use Shuck with rules_lint</h3>
+
+If you use `rules_lint` for shell scripts in Bazel, you can keep the existing ShellCheck-shaped lint hook and swap in Shuck underneath it.
+
+See the dedicated [`rules_lint` replacement example](/docs/shellcheck-compat#rules-lint) for the Bazel targets and compatibility setup.
+
 ## Embedded scripts
 
 Shuck also lints shell embedded in supported GitHub Actions workflows and composite actions. See the dedicated [Embedded Scripts guide](/docs/embedded-scripts) for supported files, shell resolution, diagnostic remapping, and suppression behavior inside `run:` blocks.

--- a/website/content/shellcheck-compat/index.mdx
+++ b/website/content/shellcheck-compat/index.mdx
@@ -63,6 +63,92 @@ shellcheck --norc script.sh
 shellcheck --rcfile ci/shellcheckrc script.sh
 ```
 
+<h2 id="rules-lint">Use Shuck with rules_lint</h2>
+
+If your Bazel repo already uses [`rules_lint`](https://github.com/aspect-build/rules_lint) for shell scripts, you can swap Shuck in without rewriting the lint aspect itself. The trick is to keep exposing a `shellcheck` executable target and let Shuck handle the CLI compatibility layer behind that name.
+
+One workable pattern is:
+
+1. Fetch the platform-specific Shuck release artifacts.
+2. Re-export each downloaded binary as an executable named `shellcheck`.
+3. Keep `lint_shellcheck_aspect` pointed at your `//tools:shellcheck` target.
+
+```bzl
+# repositories.bzl
+def shuck_deps():
+    SHUCK_VERSION = "<shuck-version>"
+
+    http_archive(
+        name = "shuck",
+        build_file = "//tools:shuck.BUILD.bazel",
+        sha256 = "<linux-x86_64-sha256>",
+        strip_prefix = "shuck-cli-x86_64-unknown-linux-gnu",
+        urls = ["https://github.com/ewhauser/shuck/releases/download/v{}/shuck-cli-x86_64-unknown-linux-gnu.tar.xz".format(SHUCK_VERSION)],
+    )
+
+    http_archive(
+        name = "shuck_linux_arm64",
+        build_file = "//tools:shuck.BUILD.bazel",
+        sha256 = "<linux-arm64-sha256>",
+        strip_prefix = "shuck-cli-aarch64-unknown-linux-gnu",
+        urls = ["https://github.com/ewhauser/shuck/releases/download/v{}/shuck-cli-aarch64-unknown-linux-gnu.tar.xz".format(SHUCK_VERSION)],
+    )
+
+    http_archive(
+        name = "shuck_osx",
+        build_file = "//tools:shuck.BUILD.bazel",
+        sha256 = "<darwin-arm64-sha256>",
+        strip_prefix = "shuck-cli-aarch64-apple-darwin",
+        urls = ["https://github.com/ewhauser/shuck/releases/download/v{}/shuck-cli-aarch64-apple-darwin.tar.xz".format(SHUCK_VERSION)],
+    )
+```
+
+```bzl
+# tools/shuck.BUILD.bazel
+package(default_visibility = ["//visibility:public"])
+
+genrule(
+    name = "shellcheck_bin",
+    srcs = ["shuck"],
+    outs = ["shellcheck"],
+    cmd = "cp $(location shuck) $@",
+    executable = True,
+)
+
+filegroup(
+    name = "file",
+    srcs = [":shellcheck_bin"],
+)
+```
+
+```bzl
+# tools/BUILD.bazel
+alias(
+    name = "shellcheck",
+    actual = select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@shuck//:file",
+        "@bazel_tools//src/conditions:linux_aarch64": "@shuck_linux_arm64//:file",
+        "@bazel_tools//src/conditions:darwin_arm64": "@shuck_osx//:file",
+    }),
+    visibility = ["//visibility:public"],
+)
+```
+
+```bzl
+# tools/lint.bzl
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
+load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
+
+shellcheck = lint_shellcheck_aspect(
+    binary = "//tools:shellcheck",
+    config = "//:.shellcheckrc",
+)
+
+shellcheck_test = lint_test(aspect = shellcheck)
+```
+
+That keeps your existing `rules_lint` entry point, target names, and `.shellcheckrc` file in place while swapping in Shuck as the implementation. In practice, the migration boundary stays at the tool label instead of spreading through every lint target in the repo.
+
 ## Migration notes
 
 - Exit status follows the usual ShellCheck shape: `0` for no diagnostics, `1` when diagnostics are reported, and `2` for file or runtime errors.


### PR DESCRIPTION
## Summary
- add a `Use Shuck with rules_lint` subsection to Getting Started with a direct `#rules_lint` anchor
- document the full `rules_lint` replacement pattern on the ShellCheck compatibility page
- move `Embedded Scripts` to the end of the Getting Started docs nav

## Why
Teams migrating from ShellCheck-based workflows need a concrete `rules_lint` example and an easy direct link from the main docs entry point.

## Validation
- `git diff --check`
- verified `http://127.0.0.1:3000/docs/getting-started#rules_lint` on the local Next.js dev server
- verified `http://127.0.0.1:3000/docs/shellcheck-compat#rules-lint` on the local Next.js dev server
