### PR TITLE
docs(website): use executable label in rules_lint example

### DIFF
--- a/website/content/shellcheck-compat/index.mdx
+++ b/website/content/shellcheck-compat/index.mdx
@@ -126,13 +126,15 @@ filegroup(
 alias(
     name = "shellcheck",
     actual = select({
-        "@bazel_tools//src/conditions:linux_x86_64": "@shuck//:file",
-        "@bazel_tools//src/conditions:linux_aarch64": "@shuck_linux_arm64//:file",
-        "@bazel_tools//src/conditions:darwin_arm64": "@shuck_osx//:file",
+        "@bazel_tools//src/conditions:linux_x86_64": "@shuck//:shellcheck_bin",
+        "@bazel_tools//src/conditions:linux_aarch64": "@shuck_linux_arm64//:shellcheck_bin",
+        "@bazel_tools//src/conditions:darwin_arm64": "@shuck_osx//:shellcheck_bin",
     }),
     visibility = ["//visibility:public"],
 )
 ```
+
+For `rules_lint`, that alias should resolve to the executable target rather than a forwarding `filegroup`.
 
 ```bzl
 # tools/lint.bzl


### PR DESCRIPTION
## Summary
- update the `rules_lint` Bazel example to point `//tools:shellcheck` at the executable `:shellcheck_bin` target
- add a short note clarifying that `rules_lint` needs an executable label rather than a forwarding `filegroup`

## Why
The previous docs example used `@shuck//:file`, which is a `filegroup`. `rules_lint` declares the shellcheck binary attr as `executable = True`, so the example should point at the executable target instead.

## Validation
- `git diff --check`
- verified the `rules_lint` expectation against `aspect-build/rules_lint` v2.5.0 `lint/shellcheck.bzl`
- confirmed in a Bazel consumer repo that `bazel run //tools:shellcheck -- --version` fails when the alias points at `@shuck_*//:file` because that target is not executable
