### PR TITLE
test(large-corpus): drop ohmyzsh metadata entries

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -54,9 +54,6 @@ reviewed_divergences:
     path_contains: "sstephenson__bats__"
     reason: "These legacy Bats harness helpers exchange state through sourced callbacks and outer harness control flow. The remaining C001 hits in this repo family are reviewed harness-state handoffs rather than dead assignments."
   - side: shuck-only
-    path_contains: "ohmyzsh__ohmyzsh__"
-    reason: "These oh-my-zsh completion and prompt helpers are compared through helper-library and shell-collapse paths while exchanging state with the surrounding zsh completion runtime. The surviving C001 hits are reviewed helper-runtime divergences rather than dead assignments."
-  - side: shuck-only
     path_contains: "pyenv__pyenv__"
     reason: "These pyenv rehash and python-build helpers exchange state through sourced helper libraries, plugin hooks, and later tool entrypoints. The remaining C001 hits in this repo family are reviewed library-state handoffs rather than dead assignments."
   - side: shuck-only

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -8,21 +8,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__fast__Unit tests__nvm_install_no_progress_bar"
     reason: "This nvm test harness reads helper-produced line bookkeeping that ShellCheck does not compare as live state in the corpus run."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    reason: "This oh-my-zsh helper relies on completion/runtime state provided by surrounding functions, so the remaining Shuck-side read is reviewed narrowly."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "This oh-my-zsh entrypoint uses zsh-only loop bindings and `${name:h:t}`-style modifiers inside a shell-collapse/project-closure context, so we review these Shuck-only reads narrowly instead of widening C006 around non-native zsh syntax."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    reason: "This zunit test harness populates `lines` as framework-managed result state, and ShellCheck does not compare that helper-owned array as a live undefined-variable read here."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
-    reason: "This completion helper reaches into zsh's special `parameters` table inside a shell-collapse helper context, and ShellCheck stays quiet on that zsh-specific runtime surface in the corpus run."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
-    reason: "This zsh completion helper uses a zsh-specific mapfile expansion shape inside a shell-collapse context, and ShellCheck stays quiet on the corpus fixture."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__bin__rvmsudo"
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c063.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c063.yaml
@@ -20,10 +20,6 @@ reviewed_divergences:
     line: 12
     reason: "This fixture sources nvm.sh and then replaces the version-check helper with a mock implementation to generate test data."
   - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    line: 3
-    reason: "This formatter helper is replaced with a no-op only on the non-terminal branch, while terminal output still uses the original definition later in the file."
-  - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__requirements__openindiana"
     line: 68
     reason: "This platform-specific helper is part of RVM's override chain, so the overwrite is intentional rather than a real dead-definition bug."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c099.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c099.yaml
@@ -51,9 +51,6 @@ reviewed_divergences:
     path_contains: "nvm-sh__nvm__"
     reason: "The remaining SC2124 reports in this repo family are broader array-to-scalar assignments, not the quoted all-elements `@`-slice form C099 intentionally targets. Shuck keeps C099 scoped to quoted `${@:N}`-style slice assignments instead of every scalar assignment from positional or array data."
   - side: shellcheck-only
-    path_contains: "ohmyzsh__ohmyzsh__"
-    reason: "The remaining SC2124 reports in this repo family are broader array-to-scalar assignments, not the quoted all-elements `@`-slice form C099 intentionally targets. Shuck keeps C099 scoped to quoted `${@:N}`-style slice assignments instead of every scalar assignment from positional or array data."
-  - side: shellcheck-only
     path_contains: "openrc__openrc__"
     reason: "The remaining SC2124 reports in this repo family are broader array-to-scalar assignments, not the quoted all-elements `@`-slice form C099 intentionally targets. Shuck keeps C099 scoped to quoted `${@:N}`-style slice assignments instead of every scalar assignment from positional or array data."
   - side: shellcheck-only

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c100.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c100.yaml
@@ -48,9 +48,6 @@ reviewed_divergences:
     path_contains: "nextcloud__docker__"
     reason: "The remaining SC2128 reports in this repo family are broader unindexed-array or array-to-scalar expansions, not the quoted scalar `BASH_SOURCE` form C100 intentionally targets. Shuck keeps C100 scoped to quoted scalar `BASH_SOURCE` expansions instead of every SC2128 pattern."
   - side: shellcheck-only
-    path_contains: "ohmyzsh__ohmyzsh__"
-    reason: "The remaining SC2128 reports in this repo family are broader unindexed-array or array-to-scalar expansions, not the quoted scalar `BASH_SOURCE` form C100 intentionally targets. Shuck keeps C100 scoped to quoted scalar `BASH_SOURCE` expansions instead of every SC2128 pattern."
-  - side: shellcheck-only
     path_contains: "pyenv__pyenv__"
     reason: "The remaining SC2128 reports in this repo family are broader unindexed-array or array-to-scalar expansions, not the quoted scalar `BASH_SOURCE` form C100 intentionally targets. Shuck keeps C100 scoped to quoted scalar `BASH_SOURCE` expansions instead of every SC2128 pattern."
   - side: shellcheck-only

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c133.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c133.yaml
@@ -27,9 +27,6 @@ reviewed_divergences:
     path_contains: "nextcloud__docker__"
     reason: "C133 intentionally requires an actual array-expansion conversion pattern in the assignment value. Plain same-name scalar reassignments after historical array bindings stay out of scope for this rule."
   - side: shellcheck-only
-    path_contains: "ohmyzsh__ohmyzsh__"
-    reason: "C133 intentionally requires an actual array-expansion conversion pattern in the assignment value. Plain same-name scalar reassignments after historical array bindings stay out of scope for this rule."
-  - side: shellcheck-only
     path_contains: "pyenv__pyenv__"
     reason: "C133 intentionally requires an actual array-expansion conversion pattern in the assignment value. Plain same-name scalar reassignments after historical array bindings stay out of scope for this rule."
   - side: shellcheck-only

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c156.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c156.yaml
@@ -6,20 +6,6 @@ reviewed_divergences:
     column: 33
     end_column: 38
     reason: "PPID is a shell-provided parent-process variable here, so the uppercase read can be intentional even though a lowercase helper binding exists elsewhere in the script."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__drush__drush.complete.sh"
-    line: 24
-    end_line: 24
-    column: 20
-    end_column: 32
-    reason: "This helper intentionally mirrors a project-specific double-underscore variable name, and shuck keeps C156 narrower than ShellCheck's helper-name guessing in collapsed plugin code."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    line: 197
-    end_line: 197
-    column: 67
-    end_column: 85
-    reason: "This is a one-off string typo inside helper code, but shuck does not broaden C156 into a general edit-distance spell checker for arbitrary uppercase names."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 116

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -25,12 +25,6 @@ reviewed_divergences:
     path_suffix: "nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__tools__install.sh"
-    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
-  - side: shellcheck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shellcheck-only
@@ -347,9 +341,6 @@ reviewed_divergences:
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__fast__Unit tests__nvm_get_arch_unofficial"
-    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__catimg__catimg.sh"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shuck-only
     path_suffix: "pi-hole__pi-hole__advanced__Scripts__piholeDebug.sh"
@@ -1132,12 +1123,6 @@ reviewed_divergences:
     path_suffix: "nvm-sh__nvm__test__xenial__install version specified in .nvmrc from source"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__tools__install.sh"
-    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
-  - side: shuck-only
     path_suffix: "pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shuck-only
@@ -1713,15 +1698,6 @@ reviewed_divergences:
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__common.sh"
-    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
-    reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-prompt.sh"
     reason: "This file is part of the current S001 baseline tail and is treated as a reviewed divergence for this file."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-version"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s005.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s005.yaml
@@ -29,11 +29,6 @@ reviewed_divergences:
     line: 2250
     end_line: 2250
     reason: "This shell-collapse wrapper is kept as a reviewed S005 divergence in the corpus comparison."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    line: 63
-    end_line: 63
-    reason: "This helper-library help text is compared through the project-closure copy, and the corpus treats the backtick style warning as reviewed there."
   - side: shuck-only
     path_suffix: "pyenv__pyenv__libexec__pyenv-init"
     line: 327

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s014.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s014.yaml
@@ -1,9 +1,5 @@
 reviewed_divergences:
   - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    line: 5
-    reason: "This project-closure bootstrap fixture is shell-collapsed by the oracle, so SC2048 is not surfaced at this unquoted star-splat callsite."
-  - side: shuck-only
     path_suffix: "pyenv__pyenv__plugins__python-build__bin__python-build"
     line: 314
     reason: "This helper-library fixture falls into a project-closure path where the oracle does not emit SC2048 for this forwarding form, while shuck still reports the star-splat expansion."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s029.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s029.yaml
@@ -1,19 +1,5 @@
 reviewed_divergences:
   - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 3
-    end_line: 3
-    column: 8
-    end_column: 8
-    reason: "This zunit test harness uses `@setup {` as a framework block opener, so the remaining SC1083 hit is fallout from non-shell harness syntax rather than a brace-expansion ambiguity Shuck should model as S029."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
-    line: 1029
-    end_line: 1029
-    column: 4
-    end_column: 4
-    reason: "This completion helper uses `{)` as a literal case-pattern arm while the corpus has already collapsed the file away from its authored shell context, so the surviving SC1083 report is treated as an oracle-specific helper-library mismatch instead of an S029 bug."
-  - side: shellcheck-only
     path_suffix: "termux__termux-packages__scripts__build__setup__termux_setup_gir.sh"
     line: 105
     end_line: 105
@@ -139,69 +125,6 @@ reviewed_divergences:
     column: 60
     end_column: 60
     reason: "This harness fixture serializes a variable reference through an escaped nested template inside a project-closure test case, so the remaining closing-brace hit is reviewed as harness-specific divergence."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 15
-    end_line: 15
-    column: 41
-    end_column: 41
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 24
-    end_line: 24
-    column: 66
-    end_column: 66
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 33
-    end_line: 33
-    column: 50
-    end_column: 50
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 44
-    end_line: 44
-    column: 75
-    end_column: 75
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 53
-    end_line: 53
-    column: 90
-    end_column: 90
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 62
-    end_line: 62
-    column: 91
-    end_column: 91
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 74
-    end_line: 74
-    column: 106
-    end_column: 106
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 84
-    end_line: 84
-    column: 62
-    end_column: 62
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    line: 97
-    end_line: 97
-    column: 89
-    end_column: 89
-    reason: "After the non-shell `@test ... {` opener, this zunit harness keeps later `${#lines[@]}` assertions in a framework-specific context that Shuck currently reinterprets as plain shell text."
   - side: shuck-only
     path_suffix: "scop__bash-completion__completions-core__tmux.bash"
     line: 59

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s045.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s045.yaml
@@ -16,22 +16,6 @@ reviewed_divergences:
     line: 765
     reason: "The current ShellCheck oracle reuses SC2004 for substring and slice bounds, while Shuck keeps S045 scoped to explicit dollar-prefixed arithmetic operands rather than slice offsets and lengths."
   - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    line: 231
-    reason: "The current ShellCheck oracle reuses SC2004 for substring and slice bounds, while Shuck keeps S045 scoped to explicit dollar-prefixed arithmetic operands rather than slice offsets and lengths."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    line: 256
-    reason: "The current ShellCheck oracle reuses SC2004 for substring and slice bounds, while Shuck keeps S045 scoped to explicit dollar-prefixed arithmetic operands rather than slice offsets and lengths."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    line: 260
-    reason: "The current ShellCheck oracle reuses SC2004 for substring and slice bounds, while Shuck keeps S045 scoped to explicit dollar-prefixed arithmetic operands rather than slice offsets and lengths."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__macos__spotify"
-    line: 263
-    reason: "The current ShellCheck oracle reuses SC2004 for substring and slice bounds, while Shuck keeps S045 scoped to explicit dollar-prefixed arithmetic operands rather than slice offsets and lengths."
-  - side: shuck-only
     path_suffix: "sstephenson__bats__libexec__bats"
     line: 68
     reason: "The current ShellCheck oracle reuses SC2004 for substring and slice bounds, while Shuck keeps S045 scoped to explicit dollar-prefixed arithmetic operands rather than slice offsets and lengths."
@@ -93,10 +77,6 @@ reviewed_divergences:
     path_suffix: "moovweb__gvm__scripts__function___bash_pseudo_hash"
     line: 283
     reason: "The current ShellCheck oracle reuses SC2004 for substring and slice bounds, while Shuck keeps S045 scoped to explicit dollar-prefixed arithmetic operands rather than slice offsets and lengths."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    line: 136
-    reason: "The current ShellCheck oracle does not emit SC2004 for this explicit dollar-prefixed arithmetic operand, but Shuck still warns on the same arithmetic form elsewhere in the corpus."
   - side: shuck-only
     path_suffix: "paulirish__dotfiles__.git-completion.bash"
     line: 191

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x001.yaml
@@ -1,4 +1,1 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "the script exits before its zsh-only body when it is sourced outside zsh, so later `[[ ... ]]` forms are intentionally guarded"
+reviewed_divergences: []

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x003.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x003.yaml
@@ -3,8 +3,5 @@ reviewed_divergences:
     path_suffix: "nvm-sh__nvm__test__install_script__install_nvm_from_git"
     reason: "ShellCheck aborts on a malformed test expression in this harness before it produces portability findings for the later `local` declarations. Shuck still recovers far enough to report the `#!/bin/sh` portability issue."
   - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "This entrypoint mixes POSIX-compatible guards with later zsh-only syntax that makes ShellCheck stop before it reaches the `local` declarations. Shuck still reports the `local` portability findings after recovering past that unsupported syntax."
-  - side: shuck-only
     path_suffix: "romkatv__powerlevel10k__gitstatus__install"
     reason: "ShellCheck emits syntax diagnostics on this installer and never surfaces the `local` portability findings from the surrounding `#!/bin/sh` functions. Shuck continues past those parse problems and keeps the `local` diagnostics visible."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x004.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x004.yaml
@@ -1,17 +1,5 @@
 reviewed_divergences:
   - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__catimg__catimg.sh"
-    reason: "ShellCheck still anchors this helper's `function` portability hit to the whole multi-line definition body. Shuck now reports the same X004 finding on the header span only, so this remaining delta is range-only."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__catimg__catimg.sh"
-    reason: "ShellCheck still anchors this helper's `function` portability hit to the whole multi-line definition body. Shuck now reports the same X004 finding on the header span only, so this remaining delta is range-only."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
-    reason: "ShellCheck still anchors this helper's `function` portability hit to the whole multi-line definition body. Shuck now reports the same X004 finding on the header span only, so this remaining delta is range-only."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
-    reason: "ShellCheck still anchors this helper's `function` portability hit to the whole multi-line definition body. Shuck now reports the same X004 finding on the header span only, so this remaining delta is range-only."
-  - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__system__munin-node__rc.munin-node"
     reason: "ShellCheck anchors this bare `function name {}` helper to the full multi-line body, while shuck reports the same X004 finding on the header span only. The remaining difference is range-only."
   - side: shuck-only

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x008.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x008.yaml
@@ -1,4 +1,1 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "This bootstrap script returns before the `(( ))` commands when `ZSH_VERSION` is unset, so the arithmetic form is intentionally confined to the zsh-only execution path for this fixture."
+reviewed_divergences: []

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x010.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x010.yaml
@@ -3,9 +3,6 @@ reviewed_divergences:
     path_contains: "termux__termux-packages__"
     reason: "The remaining ShellCheck-only SC3009 corpus hits come from sourced Termux package recipes and build helpers that the comparison path collapses to POSIX sh more aggressively than Shuck's project-aware dialect resolution. X010 intentionally stays tied to files Shuck actually treats as sh or dash."
   - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "This startup file is loading zsh-specific function paths, so the brace lists belong to intentional zsh setup rather than the POSIX sh portability target for X010."
-  - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__build__termux_create_debian_subpackages.sh"
     line: 10
     end_line: 10

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x013.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x013.yaml
@@ -1,4 +1,1 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "This startup file is building zsh-specific arrays such as `fpath`, `aliases_pre`, and `galiases_pre`, so the remaining X013 hits are intentional zsh setup that only shows up after the corpus path collapses the project to POSIX sh."
+reviewed_divergences: []

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x016.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x016.yaml
@@ -24,9 +24,6 @@ reviewed_divergences:
     path_contains: "nvm-sh__nvm__"
     reason: "The remaining SC3044 reports in this repo family are other bash-only builtins such as `typeset`, `shopt`, `complete`, `pushd`, `popd`, `mapfile`, `disown`, or `suspend`. X016 intentionally covers only `declare`, so these broader portability warnings stay reviewed for this corpus slice."
   - side: shellcheck-only
-    path_contains: "ohmyzsh__ohmyzsh__"
-    reason: "The remaining SC3044 reports in this repo family are other bash-only builtins such as `typeset`, `shopt`, `complete`, `pushd`, `popd`, `mapfile`, `disown`, or `suspend`. X016 intentionally covers only `declare`, so these broader portability warnings stay reviewed for this corpus slice."
-  - side: shellcheck-only
     path_contains: "romkatv__powerlevel10k__"
     reason: "The remaining SC3044 reports in this repo family are other bash-only builtins such as `typeset`, `shopt`, `complete`, `pushd`, `popd`, `mapfile`, `disown`, or `suspend`. X016 intentionally covers only `declare`, so these broader portability warnings stay reviewed for this corpus slice."
   - side: shellcheck-only

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x019.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x019.yaml
@@ -1,8 +1,5 @@
 reviewed_divergences:
   - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh"
-    reason: "This zunit test harness is exercising zsh plugin behavior through the `${lines[@]}` capture array, so the remaining X019 hits are test-only array references that appear after the corpus path collapses the helper into portable sh."
-  - side: shuck-only
     path_suffix: "pyenv__pyenv__pyenv.d__rehash__source.bash"
     line: 11
     end_line: 11

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x022.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x022.yaml
@@ -6,6 +6,3 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "oh-my-fish__oh-my-fish__bin__install"
     reason: "This installer is a fish script with fish-specific `read -g` and `read -l` flag usage. Shuck can still see those helper paths through project-closure analysis, but they are outside the POSIX sh portability target for X022."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh"
-    reason: "This upgrade helper belongs to a zsh codebase and uses zsh-specific syntax such as `[[ ... ]]` patterns alongside `read -k`. X022 intentionally stays scoped to files Shuck actually treats as sh or dash instead of collapsing that helper to POSIX sh."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x023.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x023.yaml
@@ -1,7 +1,4 @@
 reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "This startup script is intentionally zsh-specific and already depends on zsh path modifiers, associative arrays, and glob qualifiers, so the remaining X023 hits are zsh substring forms exposed only after the corpus path collapses the file to POSIX sh."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__packages__luajit__build.sh"
     line: 45

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x025.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x025.yaml
@@ -1,15 +1,1 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    line: 103
-    end_line: 103
-    column: 71
-    end_column: 82
-    reason: "This fixture is a zsh startup script. The replacement form is part of zsh-only control flow, so a shell-collapsed sh comparison is not a reliable portability oracle here."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    line: 105
-    end_line: 105
-    column: 15
-    end_column: 26
-    reason: "This fixture is a zsh startup script. The replacement form is part of zsh-only control flow, so a shell-collapsed sh comparison is not a reliable portability oracle here."
+reviewed_divergences: []

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x031.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x031.yaml
@@ -29,9 +29,6 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "void-linux__void-packages__common__xbps-src__shutils__show.sh"
     reason: "This helper sources another script from inside a function while project-closure analysis treats the file as POSIX `sh`. Shuck now routes that function-local `source` case to X080, while the current ShellCheck oracle still emits the generic X031 portability code on this path."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    reason: "This fixture is an Oh My Zsh startup script. In the shell-collapse comparison path it gets treated like portable `sh`, but these `source` commands belong to Zsh-specific startup loading rather than the POSIX portability target for X031."
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__misc__cwiid__rc.cwiid.new"
     line: 39

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x043.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x043.yaml
@@ -1,9 +1,4 @@
 reviewed_divergences:
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
-    line: 326
-    end_line: 326
-    reason: "This completion helper reaches the nested `${(M)${(k)...}}` form only inside a guarded `ZSH_VERSION` branch. Shuck keeps that compound expansion on X044 and does not duplicate separate X043 modifier hits for the inner and outer flag groups in this shell-collapsed helper."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__build"
     reason: "This Bash helper only uses the `${=...}` split form inside an explicit `ZSH_VERSION` branch before falling back to the Bash form. The pinned ShellCheck run stays quiet on that guarded zsh path in this project-closure comparison, so the remaining X043 hit is reviewed for this helper."
@@ -25,8 +20,3 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__utility_package"
     reason: "This Bash helper only uses the `${=...}` split form inside explicit `ZSH_VERSION` branches before falling back to the Bash form. The pinned ShellCheck run stays quiet on those guarded zsh paths, so the remaining X043 hits are reviewed for this helper."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__wd___wd.sh"
-    line: 22
-    end_line: 22
-    reason: "This helper is a zsh completion plugin (`#compdef`, `zmodload`, zsh arrays), so its modifier form is intentional and the generic `.sh` fallback dialect is not the right portability target for this fixture."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x044.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x044.yaml
@@ -6,8 +6,3 @@ reviewed_divergences:
     column: 49
     end_column: 51
     reason: "This fixture's SC2252 record is the unrelated `||`/`&&` warning surfaced in the corpus, not nested zsh substitution syntax."
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-completion.bash"
-    line: 326
-    end_line: 326
-    reason: "This completion helper only evaluates the nested zsh substitution after an explicit `ZSH_VERSION` guard, so the construct is intentional for that fixture."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x062.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x062.yaml
@@ -1,26 +1,5 @@
 reviewed_divergences:
   - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__catimg__catimg.sh"
-    line: 72
-    end_line: 72
-    column: 8
-    end_column: 10
-    reason: "This SC3018 site is the `I++` operator inside a standalone arithmetic command, not an arithmetic-for header. X062 intentionally stays scoped to update operators in `for ((...))` headers."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__catimg__catimg.sh"
-    line: 77
-    end_line: 77
-    column: 8
-    end_column: 10
-    reason: "This SC3018 site is the `I++` operator inside a standalone arithmetic command, not an arithmetic-for header. X062 intentionally stays scoped to update operators in `for ((...))` headers."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__catimg__catimg.sh"
-    line: 87
-    end_line: 87
-    column: 9
-    end_column: 11
-    reason: "This SC3018 site is the `I++` operator inside a standalone arithmetic command, not an arithmetic-for header. X062 intentionally stays scoped to update operators in `for ((...))` headers."
-  - side: shellcheck-only
     path_suffix: "termux__termux-packages__scripts__build__termux_step_massage.sh"
     line: 329
     end_line: 329
@@ -34,17 +13,3 @@ reviewed_divergences:
     column: 9
     end_column: 11
     reason: "This SC3018 site is the `c++` operator in a standalone arithmetic command guarded with `|| :`, not an arithmetic-for header. That behavior is outside X062's rule definition."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-prompt.sh"
-    line: 195
-    end_line: 195
-    column: 19
-    end_column: 21
-    reason: "This SC3018 site is the `behind++` operator in a standalone arithmetic command inside a loop body, not an update expression in a `for ((...))` header. X062 intentionally stays scoped to arithmetic used by `for` headers."
-  - side: shellcheck-only
-    path_suffix: "ohmyzsh__ohmyzsh__plugins__gitfast__git-prompt.sh"
-    line: 196
-    end_line: 196
-    column: 18
-    end_column: 20
-    reason: "This SC3018 site is the `ahead++` operator in a standalone arithmetic command inside a loop body, not an update expression in a `for ((...))` header. X062 intentionally stays scoped to arithmetic used by `for` headers."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x076.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x076.yaml
@@ -1,8 +1,1 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "ohmyzsh__ohmyzsh__oh-my-zsh.sh"
-    line: 51
-    end_line: 51
-    column: 44
-    end_column: 45
-    reason: "This bootstrap file is sourced by zsh entrypoints despite its `.sh` suffix, so the nested `${${(%):-%x}:a:h}` path setup is intentional project-specific zsh code."
+reviewed_divergences: []


### PR DESCRIPTION
## Summary
- remove reviewed divergence entries in `crates/shuck-cli/tests/testdata/corpus-metadata/*.yaml` that target `ohmyzsh__ohmyzsh__`
- drop metadata for fixtures that are no longer part of the large corpus

## Why
The large corpus no longer includes the oh-my-zsh repo because ShellCheck does not support zsh. The remaining corpus metadata entries for those files were stale and no longer described live fixtures.

## Impact
This keeps the large-corpus metadata aligned with the actual fixture set and trims dead reviewed-divergence records that can no longer affect compatibility runs.

## Validation
- `cargo test -p shuck-cli --test large_corpus load_all_rule_corpus_metadata_keeps_c001_review_entries_and_scoped_entries`
