### PR TITLE
fix(linter): skip X007 in regex operands

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x007.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x007.yaml
@@ -1,6 +1,0 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__show.sh"
-    line: 54
-    end_line: 54
-    reason: "this helper already uses bash-only `[[ ... =~ ... ]]` syntax at the same site, so treating the nested `$'\\n'` as a standalone sh portability warning is a shell-collapse artifact"

--- a/crates/shuck-linter/src/rules/portability/ansi_c_quoting.rs
+++ b/crates/shuck-linter/src/rules/portability/ansi_c_quoting.rs
@@ -17,16 +17,34 @@ pub fn ansi_c_quoting(checker: &mut Checker) {
         return;
     }
 
+    let regex_rhs_spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter_map(|fact| fact.conditional())
+        .flat_map(|fact| fact.regex_nodes())
+        .filter_map(|regex| regex.right().word().map(|word| word.span))
+        .collect::<Vec<_>>();
+
     let spans = checker
         .facts()
         .single_quoted_fragments()
         .iter()
         .filter(|fragment| fragment.dollar_quoted())
         .filter(|fragment| is_well_formed_ansi_c_quote(fragment.span(), checker.source()))
+        .filter(|fragment| {
+            !regex_rhs_spans
+                .iter()
+                .any(|span| span_contains(*span, fragment.span()))
+        })
         .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || AnsiCQuoting);
+}
+
+fn span_contains(outer: shuck_ast::Span, inner: shuck_ast::Span) -> bool {
+    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
 }
 
 fn is_well_formed_ansi_c_quote(span: shuck_ast::Span, source: &str) -> bool {
@@ -127,6 +145,28 @@ show_pkg_var \"$var\" \"${!var//$'\\n'/' '}\"\n\
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$'\\n'"]
+        );
+    }
+
+    #[test]
+    fn ignores_ansi_c_quoting_inside_regex_operands_but_not_other_double_bracket_operands() {
+        let source = "\
+#!/bin/sh
+[[ \"$value\" =~ $'\\n' ]]
+[[ \"$value\" =~ ^$'\\n'$ ]]
+[[ \"$value\" == $'a' ]]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AnsiCQuoting).with_shell(ShellDialect::Sh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$'a'"]
         );
     }
 }


### PR DESCRIPTION
## Summary
- stop `X007` from reporting ANSI-C quotes that appear inside the right-hand regex operand of `[[ ... =~ ... ]]`
- add a regression test covering both bare and mixed regex RHS cases
- remove the now-stale `X007` reviewed-divergence corpus metadata entry

## Why
`X007` was still flagging `$'...'` fragments inside `[[ ... =~ ... ]]` regex operands in `sh` mode even though the ShellCheck oracle does not emit `SC3003` for that context. That left a reviewed divergence in the large-corpus conformance run.

## Impact
This keeps ordinary ANSI-C quote portability warnings intact while avoiding the false positive in regex-match operands. The large-corpus selector for `X007` now reaches zero reviewed divergences.

## Validation
- `cargo test -p shuck-linter ansi_c_quoting`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X007` (still reports 5 unrelated existing harness parse failures, but `implementation_diffs=0` and `reviewed_divergences=0` for `X007`)
