### PR TITLE
fix(linter): drop X065 for parameter expansion patterns

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x065.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x065.yaml
@@ -1,6 +1,0 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "alpinelinux__aports__scripts__mkimage.sh"
-    line: 120
-    end_line: 120
-    reason: "This mkimage helper uses `[^a-zA-Z0-9]` inside a POSIX parameter-replacement pattern. Shuck intentionally keeps X065 active in that parameter-pattern context, while the current oracle only reports the broader SC3060 portability warning there and does not emit SC3026."

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -502,6 +502,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 word_occurrences: &word_occurrences,
                 pattern_exactly_one_extglob_spans: &pattern_exactly_one_extglob_spans,
                 pattern_charclass_spans: &pattern_charclass_spans,
+                parameter_pattern_spans: &parameter_pattern_spans,
                 nested_pattern_charclass_spans: &nested_pattern_charclass_spans,
             },
             source,

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -101,6 +101,7 @@ pub(super) struct ConditionalPortabilityInputs<'a> {
     pub word_occurrences: &'a [WordOccurrence],
     pub pattern_exactly_one_extglob_spans: &'a [Span],
     pub pattern_charclass_spans: &'a [Span],
+    pub parameter_pattern_spans: &'a [Span],
     pub nested_pattern_charclass_spans: &'a FxHashSet<FactSpan>,
 }
 
@@ -156,6 +157,7 @@ pub(super) fn build_conditional_portability_facts<'a>(
         inputs
             .pattern_charclass_spans
             .iter()
+            .filter(|span| !span_is_within_any(**span, inputs.parameter_pattern_spans))
             .filter(|span| {
                 !inputs
                     .nested_pattern_charclass_spans
@@ -185,6 +187,12 @@ pub(super) fn build_conditional_portability_facts<'a>(
     }
 
     facts
+}
+
+fn span_is_within_any(span: Span, containers: &[Span]) -> bool {
+    containers.iter().any(|container| {
+        container.start.offset <= span.start.offset && span.end.offset <= container.end.offset
+    })
 }
 
 fn collect_conditional_portability_spans(

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -1800,6 +1800,7 @@ case \"$x\" in @(zip|tar)) : ;; esac
 trimmed=${name%@($suffix|zz)}
 echo [^a]*
 trimmed=${value#[^b]*}
+pkgopts=${value//[^d]/_}
 for item in [^c]*; do :; done
 ";
 
@@ -1821,7 +1822,8 @@ for item in [^c]*; do :; done
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
         assert!(caret_negations.contains(&"[^a]"));
-        assert!(caret_negations.contains(&"[^b]"));
         assert!(caret_negations.contains(&"[^c]"));
+        assert!(!caret_negations.contains(&"[^b]"));
+        assert!(!caret_negations.contains(&"[^d]"));
     });
 }

--- a/crates/shuck-linter/src/rules/portability/conditional_portability.rs
+++ b/crates/shuck-linter/src/rules/portability/conditional_portability.rs
@@ -335,7 +335,7 @@ esac
     }
 
     #[test]
-    fn reports_caret_negation_in_parameter_patterns_in_posix_shells() {
+    fn ignores_caret_negation_in_parameter_patterns_in_posix_shells() {
         let source = "\
 #!/bin/sh
 trimmed=${value#[^a]*}
@@ -346,9 +346,7 @@ pkgopts=\"${XBPS_CURRENT_PKG//[^A-Za-z0-9_]/_}\"
             &LinterSettings::for_rule(Rule::CaretNegationInBracket),
         );
 
-        assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.slice(source), "[^a]");
-        assert_eq!(diagnostics[1].span.slice(source), "[^A-Za-z0-9_]");
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X065_X065.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X065_X065.sh.snap
@@ -2,18 +2,6 @@
 source: crates/shuck-linter/src/rules/portability/mod.rs
 ---
 X065 caret negation in bracket expressions is not portable to POSIX sh
- --> <source>:3:17
-  |
-3 | trimmed=${value#[^a]*}
-  |
-
-X065 caret negation in bracket expressions is not portable to POSIX sh
- --> <source>:4:30
-  |
-4 | pkgopts="${XBPS_CURRENT_PKG//[^A-Za-z0-9_]/_}"
-  |
-
-X065 caret negation in bracket expressions is not portable to POSIX sh
  --> <source>:5:6
   |
 5 | echo [^a]*


### PR DESCRIPTION
## Summary

This changes X065 so it no longer reports caret-negated bracket classes that appear inside parameter-expansion patterns.

## Why

The remaining reviewed X065 corpus divergence came from parameter-expansion patterns such as `${value#[^a]*}` and `${args//[^a-zA-Z0-9]/_}`. In those contexts, the ShellCheck oracle emits the broader replacement/pattern portability warning rather than SC3026, so Shuck was double-reporting portability issues there.

## Root Cause

`ConditionalPortabilityFacts` was treating shared pattern charclass spans from parameter-pattern contexts the same way as real glob/test/case pattern contexts. That caused X065 to surface on parameter-expansion patterns even though those spans should be owned by the parameter-expansion portability diagnostics instead.

## What Changed

- thread `parameter_pattern_spans` into conditional portability fact building
- filter X065's shared charclass scan so spans inside parameter patterns are ignored
- update fact and rule regressions for parameter-pattern cases
- refresh the X065 snapshot and remove the reviewed divergence metadata entry

## Impact

Shuck now matches the oracle for this X065 edge case while preserving the broader portability warning for the underlying parameter expansion.

## Validation

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/shuck-x065 INSTA_UPDATE=always cargo test -p shuck-linter builds_conditional_portability_pattern_buckets_from_surface_and_word_sources -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/shuck-x065 INSTA_UPDATE=always cargo test -p shuck-linter ignores_caret_negation_in_parameter_patterns_in_posix_shells -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/shuck-x065 INSTA_UPDATE=always cargo test -p shuck-linter rule_caretnegationinbracket_path_new_x065_sh_expects -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/shuck-x065 cargo run -q -p shuck-cli -- check <fresh reproducer>`