### PR TITLE
fix(linter): ignore continued echo spacing in S037

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s037.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s037.yaml
@@ -1,8 +1,0 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "pyenv__pyenv__libexec__pyenv-rehash"
-    line: 69
-    column: 7
-    end_line: 70
-    end_column: 86
-    reason: "This helper-library fixture keeps the stderr message split across a backslash-continued line, so the indentation is not a standalone run of repeated spaces on one physical echo line. ShellCheck 0.11.0 stays silent here while shuck currently flags the continued spacing pattern."

--- a/crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
+++ b/crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
@@ -45,7 +45,10 @@ fn repeated_space_gap(left: shuck_ast::Span, right: shuck_ast::Span, source: &st
 
     // Some spans can collapse a backslash-newline continuation onto one logical
     // line. S037 only cares about repeated spaces on the same physical line.
-    let context_start = left.end.offset.saturating_sub(1);
+    let context_start = source[..left.end.offset]
+        .char_indices()
+        .next_back()
+        .map_or(left.end.offset, |(idx, _)| idx);
     let Some(context) = source.get(context_start..right.start.offset) else {
         return false;
     };
@@ -165,5 +168,25 @@ unset tested_for_other_write_errors
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_repeated_spaces_after_utf8_argument() {
+        let source = "\
+#!/bin/bash
+echo café    bar
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedundantSpacesInEcho),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["echo café    bar"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
+++ b/crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
@@ -43,6 +43,16 @@ fn repeated_space_gap(left: shuck_ast::Span, right: shuck_ast::Span, source: &st
         return false;
     }
 
+    // Some spans can collapse a backslash-newline continuation onto one logical
+    // line. S037 only cares about repeated spaces on the same physical line.
+    let context_start = left.end.offset.saturating_sub(1);
+    let Some(context) = source.get(context_start..right.start.offset) else {
+        return false;
+    };
+    if context.chars().any(|ch| matches!(ch, '\n' | '\r')) {
+        return false;
+    }
+
     let Some(gap) = source.get(left.end.offset..right.start.offset) else {
         return false;
     };
@@ -106,6 +116,52 @@ builtin echo foo    bar
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::RedundantSpacesInEcho).with_shell(ShellDialect::Sh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_backslash_continued_echo_arguments() {
+        let source = "\
+#!/bin/bash
+echo \"pyenv: cannot rehash: couldn't acquire lock\"\\
+  \"$PROTOTYPE_SHIM_PATH for $PYENV_REHASH_TIMEOUT seconds. Last error message:\" >&2
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedundantSpacesInEcho),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_backslash_continued_echo_arguments_in_nested_control_flow() {
+        let source = "\
+#!/usr/bin/env bash
+    if [[ -z $tested_for_other_write_errors ]]; then
+      ( t=\"$(TMPDIR=\"$SHIM_PATH\" mktemp)\" && rm \"$t\" ) && tested_for_other_write_errors=1 ||
+        { echo \"pyenv: cannot rehash: $SHIM_PATH isn't writable\" >&2; break; }
+    fi
+    # POSIX sleep(1) doesn't provide subsecond precision, but many others do
+    sleep 0.1 2>/dev/null || sleep 1
+  fi
+done
+
+if [ -z \"${acquired}\" ]; then
+  if [[ -n $tested_for_other_write_errors ]]; then
+      echo \"pyenv: cannot rehash: couldn't acquire lock\"\\
+        \"$PROTOTYPE_SHIM_PATH for $PYENV_REHASH_TIMEOUT seconds. Last error message:\" >&2
+      echo \"$last_acquire_error\" >&2
+  fi
+  exit 1
+fi
+unset tested_for_other_write_errors
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedundantSpacesInEcho),
         );
 
         assert!(diagnostics.is_empty());


### PR DESCRIPTION
## Summary
- ignore backslash-continued `echo` arguments when S037 checks for repeated inter-argument spaces
- add regression coverage for both a simple continued `echo` and the nested `pyenv` reproducer
- drop the now-unneeded S037 large-corpus reviewed divergence metadata entry

## Why
S037 was using command spans that can collapse a backslash-newline continuation onto one logical line. That made the rule treat indentation on the continued line as repeated spaces between `echo` arguments and produced a false positive on `pyenv`'s lock-error message.

## Validation
- `cargo test -p shuck-linter redundant_spaces_in_echo -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S037` (`implementation_diffs=0`; the remaining 5 failures are pre-existing unrelated large-corpus harness parse failures)
