### PR TITLE
fix(linter): align C121 variable-name suppression with shellcheck

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c121.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c121.yaml
@@ -1,5 +1,0 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
-    line: 1269
-    reason: "This runcommand helper compares a quoted variable-name token after configuration globals have been populated through another helper path. The remaining C121 hit depends on cross-function project-closure state that shuck does not yet promote into this literal-name suppression, so we record the narrow divergence instead of restoring the old blanket allowlist."

--- a/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
@@ -135,8 +135,15 @@ fn looks_like_defined_variable_name(checker: &Checker<'_>, text: &str, span: Spa
                 return false;
             }
 
-            checker.semantic().binding_visible_at(binding_id, span)
-                && binding.span.start.offset != span.start.offset
+            if binding.span.start.offset == span.start.offset {
+                return false;
+            }
+
+            let imported_binding = binding.attributes.intersects(
+                BindingAttributes::IMPORTED_POSSIBLE | BindingAttributes::IMPORTED_FILE_ENTRY,
+            ) || matches!(binding.kind, BindingKind::Imported);
+
+            !imported_binding || checker.semantic().binding_visible_at(binding_id, span)
         })
 }
 
@@ -241,7 +248,7 @@ done
     }
 
     #[test]
-    fn later_or_out_of_scope_bindings_do_not_suppress_diagnostics() {
+    fn same_file_bindings_suppress_literal_variable_name_heuristics() {
         let source = "\
 #!/bin/bash
 [[ foo -eq 1 ]]
@@ -250,6 +257,29 @@ helper() {
   local bar=1
 }
 [[ bar -eq 1 ]]
+show_launch() {
+  [[ \"$LEGACY_JOY2KEY\" -eq 0 && \"DISABLE_MENU\" -ne 1 ]]
+}
+get_config() {
+  DISABLE_MENU=1
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::StringComparedWithEq),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn function_definitions_do_not_suppress_diagnostics() {
+        let source = "\
+#!/bin/bash
+DISABLE_MENU() {
+  :
+}
+[[ \"DISABLE_MENU\" -ne 1 ]]
 ";
         let diagnostics = test_snippet(
             source,
@@ -261,7 +291,7 @@ helper() {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["foo", "bar"]
+            vec!["\"DISABLE_MENU\""]
         );
     }
 


### PR DESCRIPTION
## Summary
- align `C121` with ShellCheck's broader same-file variable-name suppression heuristic
- keep imported bindings gated by visibility while continuing to warn on function names
- remove the obsolete `C121` large-corpus reviewed divergence metadata

## Root Cause
`C121` only suppressed diagnostics when a matching binding was visible at the comparison site. ShellCheck also suppresses these numeric-string warnings when the quoted token matches a variable assignment elsewhere in the same file, which left the RetroPie corpus case stuck behind reviewed metadata.

## Validation
- `cargo test -p shuck-linter string_compared_with_eq`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C121` (remaining failures are unrelated large-corpus harness parse gaps; `C121` now reports `implementation_diffs=0` and `reviewed_divergences=0`)
