### PR TITLE
refactor(linter): clarify C087 dotted version policy

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c087.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c087.yaml
@@ -2,4 +2,4 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__ct__immich.sh"
     line: 114
-    reason: "This Proxmox update helper reads a saved version string through `$(cat ~/.immich)` and then compares it lexically against `2.5.1`. Shuck intentionally keeps the version-comparison warning for that file-backed value, while the current oracle stays silent on this project-closure fixture."
+    reason: "This Proxmox update helper compares a saved semver-style string from `$(cat ~/.immich)` against `2.5.1` with lexical `[[ ... > ... ]]`. C087 intentionally keeps this warning because multi-segment dotted versions are still ordered as plain strings here, while the pinned SC2072 oracle only flags decimal-style comparisons and stays silent on `2.5.1`-style operands, so this semver-policy divergence is reviewed."

--- a/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
@@ -58,10 +58,10 @@ fn version_operand_span(binary: &ConditionalBinaryFact<'_>, source: &str) -> Opt
 
     match (
         left.as_ref()
-            .is_some_and(|(_, text)| is_decimal_version_like(text)),
+            .is_some_and(|(_, text)| is_dotted_numeric_version_like(text)),
         right
             .as_ref()
-            .is_some_and(|(_, text)| is_decimal_version_like(text)),
+            .is_some_and(|(_, text)| is_dotted_numeric_version_like(text)),
     ) {
         (false, false) => None,
         (true, false) => left.map(|(span, _)| span),
@@ -69,7 +69,10 @@ fn version_operand_span(binary: &ConditionalBinaryFact<'_>, source: &str) -> Opt
     }
 }
 
-fn is_decimal_version_like(text: &str) -> bool {
+// Treat any all-digit dotted literal (for example `1.27` or `2.5.1`) as
+// version-like here, since lexical `[[ ... < ... ]]` / `[[ ... > ... ]]`
+// comparisons are not version-aware for either shape.
+fn is_dotted_numeric_version_like(text: &str) -> bool {
     let mut saw_dot = false;
     let mut saw_digit = false;
     let mut segment_has_digit = false;
@@ -125,7 +128,7 @@ mod tests {
     }
 
     #[test]
-    fn reports_quoted_version_literals_and_dynamic_version_sources() {
+    fn reports_quoted_version_literals_and_dotted_version_sources() {
         let source = "\
 #!/bin/bash
 [[ \"$actual\" > \"0.8\" ]]

--- a/docs/rules/C087.yaml
+++ b/docs/rules/C087.yaml
@@ -9,8 +9,8 @@ shells:
   - sh
   - bash
   - dash
-description: "A `<` or `>` operator inside `[[ ]]` compares lexicographically, not numerically."
-rationale: "Use `-lt` for numeric comparison or a version-aware tool."
+description: "A `<` or `>` operator inside `[[ ]]` compares dotted numeric values lexicographically, so version-like strings such as `2.5.1` are not ordered by version semantics."
+rationale: "Use `-lt` or `-gt` for integer comparisons, or a version-aware tool for dotted version strings."
 safe_fix: false
 fix_description: null
 source:
@@ -28,4 +28,11 @@ examples:
       #!/bin/bash
       if [[ "$actual" > "0.8" ]]; then
         echo new
+      fi
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      current=$(cat ~/.immich)
+      if [[ $current > 2.5.1 ]]; then
+        echo upgrade
       fi


### PR DESCRIPTION
## What changed

This updates `C087` to clearly document and describe the rule's existing policy for dotted version comparisons.

- clarify the rule docs so `[[ ... < ... ]]` / `[[ ... > ... ]]` are described as lexical for dotted numeric values, including semver-style strings such as `2.5.1`
- rename the internal helper and test to match that broader dotted-version policy
- rewrite the large-corpus reviewed divergence note for the Proxmox fixture so it describes the real semver-policy mismatch with the pinned `SC2072` oracle

## Why

The previous metadata described the remaining large-corpus divergence as a project-closure quirk from a file-backed value. After checking the rule implementation, the in-repo tests, and black-box `shellcheck` behavior, the real difference is narrower and more important: Shuck intentionally keeps warning on semver-style dotted literals like `2.5.1`, while the pinned `SC2072` oracle only reports decimal-style cases.

## Impact

This does not change `C087` behavior. It makes the rule spec, implementation naming, and reviewed divergence metadata line up with the actual policy that Shuck already enforces.

## Validation

- `cargo test -p shuck-linter string_comparison_for_version -- --nocapture`
- `cargo test -p shuck-cli --test large_corpus reviewed_divergence -- --nocapture`
