### PR TITLE
fix(linter): stop misclassifying arithmetic trims as X070

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x070.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x070.yaml
@@ -1,5 +1,1 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "scripts/ko1nksm__shellspec__lib__libexec__list.sh"
-    line: 52
-    reason: "This shared helper is compared through the project-closure harness, and the oracle does not emit the arithmetic-base warning for this file. Shuck keeps the portable arithmetic check visible on the helper itself, so this reviewed divergence narrows the corpus mismatch to this sourced library path."
+reviewed_divergences: []

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -336,6 +336,77 @@ fn collect_base_prefix_spans_in_parameter_expansion(
     }
 }
 
+fn collect_base_prefix_spans_in_arithmetic_parameter_expansion(
+    parameter: &shuck_ast::ParameterExpansion,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+            BourneParameterExpansion::Access { reference }
+            | BourneParameterExpansion::Length { reference }
+            | BourneParameterExpansion::Indices { reference }
+            | BourneParameterExpansion::Transformation { reference, .. } => {
+                collect_base_prefix_spans_in_var_ref(reference, source, spans);
+            }
+            BourneParameterExpansion::Indirect {
+                reference,
+                operand,
+                operand_word_ast,
+                ..
+            }
+            | BourneParameterExpansion::Operation {
+                reference,
+                operand,
+                operand_word_ast,
+                ..
+            } => {
+                collect_base_prefix_spans_in_var_ref(reference, source, spans);
+                collect_base_prefix_spans_in_arithmetic_fragment(
+                    operand_word_ast.as_ref(),
+                    operand.as_ref(),
+                    source,
+                    spans,
+                );
+            }
+            BourneParameterExpansion::Slice {
+                reference,
+                offset_word_ast,
+                offset_ast,
+                length_word_ast,
+                length_ast,
+                ..
+            } => {
+                collect_base_prefix_spans_in_var_ref(reference, source, spans);
+                if let Some(expression) = offset_ast {
+                    collect_base_prefix_spans_in_arithmetic(expression, source, spans);
+                } else {
+                    collect_base_prefix_spans_in_arithmetic_word(offset_word_ast, source, spans);
+                }
+                if let Some(expression) = length_ast {
+                    collect_base_prefix_spans_in_arithmetic(expression, source, spans);
+                } else if let Some(length_word_ast) = length_word_ast {
+                    collect_base_prefix_spans_in_arithmetic_word(length_word_ast, source, spans);
+                }
+            }
+            BourneParameterExpansion::PrefixMatch { .. } => {}
+        },
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            collect_base_prefix_spans_in_arithmetic_zsh_target(&syntax.target, source, spans);
+            if let Some(operation) = &syntax.operation {
+                match operation {
+                    shuck_ast::ZshExpansionOperation::Slice { .. }
+                    | shuck_ast::ZshExpansionOperation::PatternOperation { .. }
+                    | shuck_ast::ZshExpansionOperation::Defaulting { .. }
+                    | shuck_ast::ZshExpansionOperation::TrimOperation { .. }
+                    | shuck_ast::ZshExpansionOperation::ReplacementOperation { .. }
+                    | shuck_ast::ZshExpansionOperation::Unknown { .. } => {}
+                }
+            }
+        }
+    }
+}
+
 fn collect_base_prefix_spans_in_zsh_target(
     target: &shuck_ast::ZshExpansionTarget,
     source: &str,
@@ -350,6 +421,25 @@ fn collect_base_prefix_spans_in_zsh_target(
         }
         shuck_ast::ZshExpansionTarget::Word(word) => {
             collect_base_prefix_spans_in_word(word, source, spans);
+        }
+        shuck_ast::ZshExpansionTarget::Empty => {}
+    }
+}
+
+fn collect_base_prefix_spans_in_arithmetic_zsh_target(
+    target: &shuck_ast::ZshExpansionTarget,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match target {
+        shuck_ast::ZshExpansionTarget::Reference(reference) => {
+            collect_base_prefix_spans_in_var_ref(reference, source, spans);
+        }
+        shuck_ast::ZshExpansionTarget::Nested(parameter) => {
+            collect_base_prefix_spans_in_arithmetic_parameter_expansion(parameter, source, spans);
+        }
+        shuck_ast::ZshExpansionTarget::Word(word) => {
+            collect_base_prefix_spans_in_arithmetic_word(word, source, spans);
         }
         shuck_ast::ZshExpansionTarget::Empty => {}
     }
@@ -480,14 +570,32 @@ fn collect_base_prefix_spans_in_arithmetic_word_part(
             }
         }
         WordPart::Parameter(parameter) => {
-            collect_base_prefix_spans_in_parameter_expansion(parameter, source, spans);
+            collect_base_prefix_spans_in_arithmetic_parameter_expansion(parameter, source, spans);
         }
-        WordPart::ParameterExpansion { reference, .. }
-        | WordPart::Length(reference)
+        WordPart::ParameterExpansion {
+            reference,
+            operand,
+            operand_word_ast,
+            ..
+        }
+        | WordPart::IndirectExpansion {
+            reference,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            collect_base_prefix_spans_in_var_ref(reference, source, spans);
+            collect_base_prefix_spans_in_arithmetic_fragment(
+                operand_word_ast.as_ref(),
+                operand.as_ref(),
+                source,
+                spans,
+            );
+        }
+        WordPart::Length(reference)
         | WordPart::ArrayAccess(reference)
         | WordPart::ArrayLength(reference)
         | WordPart::ArrayIndices(reference)
-        | WordPart::IndirectExpansion { reference, .. }
         | WordPart::Transformation { reference, .. } => {
             collect_base_prefix_spans_in_var_ref(reference, source, spans);
         }
@@ -551,6 +659,27 @@ fn collect_base_prefix_spans_in_fragment(
         return;
     };
     collect_base_prefix_spans_in_word(word, source, spans);
+}
+
+fn collect_base_prefix_spans_in_arithmetic_fragment(
+    word: Option<&Word>,
+    text: Option<&SourceText>,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let Some(text) = text else {
+        return;
+    };
+    let snippet = text.slice(source);
+    if !snippet.contains('#') {
+        return;
+    }
+
+    let Some(word) = word else {
+        collect_base_prefix_spans_in_text(text.span(), source, spans);
+        return;
+    };
+    collect_base_prefix_spans_in_arithmetic_word(word, source, spans);
 }
 
 fn collect_base_prefix_spans_in_text(span: Span, source: &str, spans: &mut Vec<Span>) {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -203,14 +203,15 @@ fn collect_base_prefix_spans_in_word_part(
             }
         }
         WordPart::ArithmeticExpansion {
-            expression,
+            expression: _,
             expression_ast,
+            expression_word_ast,
             ..
         } => {
             if let Some(expression) = expression_ast {
                 collect_base_prefix_spans_in_arithmetic(expression, source, spans);
             } else {
-                collect_base_prefix_spans_in_text(expression.span(), source, spans);
+                collect_base_prefix_spans_in_arithmetic_word(expression_word_ast, source, spans);
             }
         }
         WordPart::Parameter(parameter) => {
@@ -227,17 +228,17 @@ fn collect_base_prefix_spans_in_word_part(
         }
         WordPart::Substring {
             reference,
-            offset,
+            offset_word_ast,
             offset_ast,
-            length,
+            length_word_ast,
             length_ast,
             ..
         }
         | WordPart::ArraySlice {
             reference,
-            offset,
+            offset_word_ast,
             offset_ast,
-            length,
+            length_word_ast,
             length_ast,
             ..
         } => {
@@ -245,12 +246,12 @@ fn collect_base_prefix_spans_in_word_part(
             if let Some(expression) = offset_ast {
                 collect_base_prefix_spans_in_arithmetic(expression, source, spans);
             } else {
-                collect_base_prefix_spans_in_text(offset.span(), source, spans);
+                collect_base_prefix_spans_in_arithmetic_word(offset_word_ast, source, spans);
             }
             if let Some(expression) = length_ast {
                 collect_base_prefix_spans_in_arithmetic(expression, source, spans);
-            } else if let Some(length) = length {
-                collect_base_prefix_spans_in_text(length.span(), source, spans);
+            } else if let Some(length_word_ast) = length_word_ast {
+                collect_base_prefix_spans_in_arithmetic_word(length_word_ast, source, spans);
             }
         }
         WordPart::Literal(_)
@@ -299,16 +300,22 @@ fn collect_base_prefix_spans_in_parameter_expansion(
             }
             BourneParameterExpansion::Slice {
                 reference,
+                offset_word_ast,
                 offset_ast,
+                length_word_ast,
                 length_ast,
                 ..
             } => {
                 collect_base_prefix_spans_in_var_ref(reference, source, spans);
                 if let Some(expression) = offset_ast {
                     collect_base_prefix_spans_in_arithmetic(expression, source, spans);
+                } else {
+                    collect_base_prefix_spans_in_arithmetic_word(offset_word_ast, source, spans);
                 }
                 if let Some(expression) = length_ast {
                     collect_base_prefix_spans_in_arithmetic(expression, source, spans);
+                } else if let Some(length_word_ast) = length_word_ast {
+                    collect_base_prefix_spans_in_arithmetic_word(length_word_ast, source, spans);
                 }
             }
             BourneParameterExpansion::PrefixMatch { .. } => {}
@@ -390,7 +397,136 @@ fn collect_base_prefix_spans_in_arithmetic(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_base_prefix_spans_in_text(expression.span, source, spans);
+    match &expression.kind {
+        ArithmeticExpr::Number(number) => {
+            collect_base_prefix_spans_in_text(number.span(), source, spans);
+        }
+        ArithmeticExpr::Variable(_) => {}
+        ArithmeticExpr::Indexed { index, .. } => {
+            collect_base_prefix_spans_in_arithmetic(index, source, spans);
+        }
+        ArithmeticExpr::ShellWord(word) => {
+            collect_base_prefix_spans_in_arithmetic_word(word, source, spans);
+        }
+        ArithmeticExpr::Parenthesized { expression } => {
+            collect_base_prefix_spans_in_arithmetic(expression, source, spans);
+        }
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            collect_base_prefix_spans_in_arithmetic(expr, source, spans);
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            collect_base_prefix_spans_in_arithmetic(left, source, spans);
+            collect_base_prefix_spans_in_arithmetic(right, source, spans);
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_base_prefix_spans_in_arithmetic(condition, source, spans);
+            collect_base_prefix_spans_in_arithmetic(then_expr, source, spans);
+            collect_base_prefix_spans_in_arithmetic(else_expr, source, spans);
+        }
+        ArithmeticExpr::Assignment { target, value, .. } => {
+            collect_base_prefix_spans_in_arithmetic_lvalue(target, source, spans);
+            collect_base_prefix_spans_in_arithmetic(value, source, spans);
+        }
+    }
+}
+
+fn collect_base_prefix_spans_in_arithmetic_lvalue(
+    target: &ArithmeticLvalue,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match target {
+        ArithmeticLvalue::Variable(_) => {}
+        ArithmeticLvalue::Indexed { index, .. } => {
+            collect_base_prefix_spans_in_arithmetic(index, source, spans);
+        }
+    }
+}
+
+fn collect_base_prefix_spans_in_arithmetic_word(word: &Word, source: &str, spans: &mut Vec<Span>) {
+    for part in &word.parts {
+        collect_base_prefix_spans_in_arithmetic_word_part(part, source, spans);
+    }
+}
+
+fn collect_base_prefix_spans_in_arithmetic_word_part(
+    part: &WordPartNode,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match &part.kind {
+        WordPart::Literal(_) => {
+            collect_base_prefix_spans_in_text(part.span, source, spans);
+        }
+        WordPart::DoubleQuoted { parts, .. } => {
+            for part in parts {
+                collect_base_prefix_spans_in_arithmetic_word_part(part, source, spans);
+            }
+        }
+        WordPart::ArithmeticExpansion {
+            expression: _,
+            expression_ast,
+            expression_word_ast,
+            ..
+        } => {
+            if let Some(expression) = expression_ast {
+                collect_base_prefix_spans_in_arithmetic(expression, source, spans);
+            } else {
+                collect_base_prefix_spans_in_arithmetic_word(expression_word_ast, source, spans);
+            }
+        }
+        WordPart::Parameter(parameter) => {
+            collect_base_prefix_spans_in_parameter_expansion(parameter, source, spans);
+        }
+        WordPart::ParameterExpansion { reference, .. }
+        | WordPart::Length(reference)
+        | WordPart::ArrayAccess(reference)
+        | WordPart::ArrayLength(reference)
+        | WordPart::ArrayIndices(reference)
+        | WordPart::IndirectExpansion { reference, .. }
+        | WordPart::Transformation { reference, .. } => {
+            collect_base_prefix_spans_in_var_ref(reference, source, spans);
+        }
+        WordPart::Substring {
+            reference,
+            offset_word_ast,
+            offset_ast,
+            length_word_ast,
+            length_ast,
+            ..
+        }
+        | WordPart::ArraySlice {
+            reference,
+            offset_word_ast,
+            offset_ast,
+            length_word_ast,
+            length_ast,
+            ..
+        } => {
+            collect_base_prefix_spans_in_var_ref(reference, source, spans);
+            if let Some(expression) = offset_ast {
+                collect_base_prefix_spans_in_arithmetic(expression, source, spans);
+            } else {
+                collect_base_prefix_spans_in_arithmetic_word(offset_word_ast, source, spans);
+            }
+            if let Some(expression) = length_ast {
+                collect_base_prefix_spans_in_arithmetic(expression, source, spans);
+            } else if let Some(length_word_ast) = length_word_ast {
+                collect_base_prefix_spans_in_arithmetic_word(length_word_ast, source, spans);
+            }
+        }
+        WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
+            collect_base_prefix_spans_in_stmt_seq(body, source, spans);
+        }
+        WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::PrefixMatch { .. } => {}
+    }
 }
 
 fn collect_base_prefix_spans_in_fragment(
@@ -635,4 +771,3 @@ fn double_paren_grouping_anchor(span: Span, source: &str) -> Option<Span> {
 
     Some(Span::at(anchor_start))
 }
-

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1578,6 +1578,30 @@ echo $((42949 - ${1#-} / 100000))
 }
 
 #[test]
+fn collects_base_prefixes_in_arithmetic_parameter_defaults() {
+    let source = "\
+#!/bin/sh
+echo $(( ${foo:-10#1} ))
+";
+    let output = Parser::with_dialect(source, shuck_parser::parser::ShellDialect::Posix)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let file_context = classify_file_context(source, None, ShellDialect::Bash);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+    assert_eq!(
+        facts
+            .base_prefix_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["10#1"]
+    );
+}
+
+#[test]
 fn builds_find_exec_shell_command_facts_for_execdir_shell_targets() {
     let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1561,6 +1561,23 @@ echo ${foo:-${1##*/}}
 }
 
 #[test]
+fn ignores_positional_parameter_trim_in_arithmetic_shell_words() {
+    let source = "\
+#!/bin/sh
+echo $((42949 - ${1#-} / 100000))
+";
+    let output = Parser::with_dialect(source, shuck_parser::parser::ShellDialect::Posix)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let file_context = classify_file_context(source, None, ShellDialect::Bash);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+    assert!(facts.base_prefix_arithmetic_spans().is_empty());
+}
+
+#[test]
 fn builds_find_exec_shell_command_facts_for_execdir_shell_targets() {
     let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
@@ -93,4 +93,19 @@ echo $((42949 - ${1#-} / 100000))
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn reports_parameter_defaults_with_base_prefixes_in_sh_arithmetic() {
+        let source = "\
+#!/bin/sh
+echo $(( ${foo:-10#1} ))
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::BasePrefixInArithmetic),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "10#1");
+    }
 }

--- a/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
@@ -79,4 +79,18 @@ echo ${foo:-${1##*/}}
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_parameter_trim_inside_arithmetic_in_sh() {
+        let source = "\
+#!/bin/sh
+echo $((42949 - ${1#-} / 100000))
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::BasePrefixInArithmetic),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- stop X070 from treating arithmetic parameter trims like `${1#-}` as base-prefix arithmetic
- add targeted fact and rule regressions for the POSIX arithmetic path while preserving real `10#` detections
- remove the X070 reviewed divergence entry now that the underlying false positive is fixed

## Root Cause
The X070 fact builder was raw-scanning arithmetic source text and could misread the `#` operator inside parameter trims as a numeric base prefix. That produced a shuck-only warning in the large corpus and forced a reviewed divergence entry.

## Validation
- cargo test -p shuck-linter base_prefix_in_arithmetic -- --nocapture
- cargo test -p shuck-linter positional_parameter_trim_in_arithmetic_shell_words -- --nocapture
- cargo run -q -p shuck-cli -- check --no-cache /tmp/x070-repro.sh
