### PR TITLE
test(linter): cover X035 coproc divergence

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x035.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x035.yaml
@@ -3,9 +3,9 @@ reviewed_divergences:
     path_suffix: "aristocratos__bashtop__bashtop"
     line: 5287
     end_line: 5287
-    reason: "This helper uses bash `coproc` syntax in a file that is compared through the project-closure harness. The oracle collapses that path into a false X035 report on the process-coprocess call, but Shuck correctly leaves the bash construct alone."
+    reason: "This project-closure fixture uses the named bash coprocess form `coproc pycoproc (...)`. Here `pycoproc` is the coprocess identifier and `(...)` is the coprocess body, so the construct is not function-parameter syntax and Shuck correctly keeps X035 silent. The current oracle still maps this grammar to SC1065/X035 as if it were a `name(arg)` function form; if the surrounding dialect question mattered, the relevant portability issue would be `coproc` itself (X014/SC3032), not function parameters."
   - side: shellcheck-only
     path_suffix: "aristocratos__bashtop__bashtop"
     line: 5302
     end_line: 5302
-    reason: "This later `coproc` invocation is the same bash-only construct in the same project-closure fixture, and the current oracle still turns it into a false X035 hit. Shuck correctly accepts the bash syntax here."
+    reason: "This later project-closure site is the same named bash coprocess grammar: `coproc pycoproc (...)` with a coprocess name followed by the coprocess body. That shape is outside X035's function-parameter scope, so Shuck intentionally leaves it alone while the current oracle still misclassifies it as SC1065/X035; the only portability concern here would be `coproc` itself (X014/SC3032)."

--- a/crates/shuck-linter/src/rules/portability/coproc.rs
+++ b/crates/shuck-linter/src/rules/portability/coproc.rs
@@ -49,6 +49,18 @@ mod tests {
     }
 
     #[test]
+    fn reports_named_coproc_command_span() {
+        let source = "#!/bin/sh\ncoproc pycoproc (python3 \"$pywrapper\")\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::Coproc));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "coproc pycoproc (python3 \"$pywrapper\")"
+        );
+    }
+
+    #[test]
     fn ignores_bash_scripts() {
         let source = "#!/bin/bash\ncoproc cat\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
@@ -146,4 +146,15 @@ wget() { :; }
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
+
+    #[test]
+    fn ignores_named_coproc_syntax() {
+        let source = "\
+#!/bin/sh
+coproc pycoproc (python3 \"$pywrapper\")
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionParamsInSh));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
 }


### PR DESCRIPTION
## Summary
- add regression coverage proving X035 stays quiet for named `coproc` syntax
- add X014 coverage proving named `coproc` still reports the portability warning in `sh`
- clarify the `X035` corpus metadata so future readers know `coproc name (...)` is named coprocess grammar, not function-parameter syntax

## Why
The remaining `X035` corpus divergence comes from ShellCheck reporting `SC1065` on the named bash coprocess form `coproc pycoproc (...)` in the `bashtop` project-closure fixture. Shuck is correct to leave `X035` silent there because the parentheses belong to the coprocess body, not to a `name(arg)` function declaration. If portability matters for that construct, the relevant warning is `coproc` itself (`X014`/`SC3032`).

## Validation
- `cargo test -p shuck-linter`
- `cargo test -p shuck-cli --test large_corpus reviewed_divergence_classification_matches_exact_shellcheck_record -- --nocapture`
- `cargo test -p shuck-cli --test large_corpus load_all_rule_corpus_metadata_keeps_c001_review_entries_and_scoped_entries -- --nocapture`
