### PR TITLE
fix(linter): broaden X062 arithmetic operator coverage

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x062.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x062.yaml
@@ -1,15 +1,1 @@
-reviewed_divergences:
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__scripts__build__termux_step_massage.sh"
-    line: 329
-    end_line: 329
-    column: 9
-    end_column: 11
-    reason: "This SC3018 site is the `c++` operator in a standalone arithmetic command guarded with `|| :`, not an arithmetic-for header. That behavior is outside X062's rule definition."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__scripts__build__termux_step_massage.sh"
-    line: 369
-    end_line: 369
-    column: 9
-    end_column: 11
-    reason: "This SC3018 site is the `c++` operator in a standalone arithmetic command guarded with `|| :`, not an arithmetic-for header. That behavior is outside X062's rule definition."
+reviewed_divergences: []

--- a/crates/shuck-linter/resources/test/fixtures/portability/X062.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X062.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
 for ((i = 0; i < 3; i++)); do echo "$i"; done
+((++count))
+echo "$((items--))"

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -748,6 +748,9 @@ fn collect_arithmetic_update_operator_spans_in_assignment(
                                 spans,
                             );
                         }
+                        collect_arithmetic_update_operator_spans_in_subscript_words(
+                            key, semantic, source, spans,
+                        );
                         collect_arithmetic_update_operator_spans_in_word(
                             value, semantic, source, spans,
                         );
@@ -1044,6 +1047,23 @@ fn collect_arithmetic_update_operator_spans_in_subscript(
     if let Some(expression) = subscript.arithmetic_ast.as_ref() {
         collect_arithmetic_update_operator_spans(Some(expression), source, spans);
     }
+}
+
+fn collect_arithmetic_update_operator_spans_in_subscript_words(
+    subscript: &Subscript,
+    semantic: &SemanticModel,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    query::visit_subscript_words(Some(subscript), source, &mut |word| {
+        collect_arithmetic_update_operator_spans_from_parts_impl(
+            &word.parts,
+            semantic,
+            source,
+            spans,
+            true,
+        );
+    });
 }
 
 fn collect_arithmetic_update_operator_spans(

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -476,27 +476,242 @@ fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str)
         .collect()
 }
 
-fn build_arithmetic_for_update_operator_spans(
-    commands: &[CommandFact<'_>],
-    source: &str,
-) -> Vec<Span> {
+fn build_arithmetic_update_operator_spans(body: &StmtSeq, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
 
-    for fact in commands {
-        let Command::Compound(CompoundCommand::ArithmeticFor(command)) = fact.command() else {
-            continue;
-        };
-
-        collect_arithmetic_update_operator_spans(command.init_ast.as_ref(), source, &mut spans);
-        collect_arithmetic_update_operator_spans(
-            command.condition_ast.as_ref(),
-            source,
-            &mut spans,
-        );
-        collect_arithmetic_update_operator_spans(command.step_ast.as_ref(), source, &mut spans);
+    for visit in query::iter_commands(
+        body,
+        CommandWalkOptions {
+            descend_nested_word_commands: true,
+        },
+    ) {
+        collect_arithmetic_update_operator_spans_in_command(visit.command, source, &mut spans);
+        for redirect in visit.redirects {
+            if let Some(word) = redirect.word_target() {
+                collect_arithmetic_update_operator_spans_in_word(word, source, &mut spans);
+            }
+        }
     }
 
+    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup();
     spans
+}
+
+fn collect_arithmetic_update_operator_spans_in_command(
+    command: &Command,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match command {
+        Command::Simple(command) => {
+            for assignment in &command.assignments {
+                collect_arithmetic_update_operator_spans_in_assignment(assignment, source, spans);
+            }
+            collect_arithmetic_update_operator_spans_in_word(&command.name, source, spans);
+            for word in &command.args {
+                collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+            }
+        }
+        Command::Builtin(command) => match command {
+            BuiltinCommand::Break(command) => {
+                for assignment in &command.assignments {
+                    collect_arithmetic_update_operator_spans_in_assignment(
+                        assignment, source, spans,
+                    );
+                }
+                if let Some(word) = &command.depth {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+                for word in &command.extra_args {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+            }
+            BuiltinCommand::Continue(command) => {
+                for assignment in &command.assignments {
+                    collect_arithmetic_update_operator_spans_in_assignment(
+                        assignment, source, spans,
+                    );
+                }
+                if let Some(word) = &command.depth {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+                for word in &command.extra_args {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+            }
+            BuiltinCommand::Return(command) => {
+                for assignment in &command.assignments {
+                    collect_arithmetic_update_operator_spans_in_assignment(
+                        assignment, source, spans,
+                    );
+                }
+                if let Some(word) = &command.code {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+                for word in &command.extra_args {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+            }
+            BuiltinCommand::Exit(command) => {
+                for assignment in &command.assignments {
+                    collect_arithmetic_update_operator_spans_in_assignment(
+                        assignment, source, spans,
+                    );
+                }
+                if let Some(word) = &command.code {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+                for word in &command.extra_args {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+            }
+        },
+        Command::Decl(command) => {
+            for assignment in &command.assignments {
+                collect_arithmetic_update_operator_spans_in_assignment(assignment, source, spans);
+            }
+            for operand in &command.operands {
+                match operand {
+                    DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
+                        collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    }
+                    DeclOperand::Assignment(assignment) => {
+                        collect_arithmetic_update_operator_spans_in_assignment(
+                            assignment, source, spans,
+                        );
+                    }
+                    DeclOperand::Name(_) => {}
+                }
+            }
+        }
+        Command::Compound(command) => match command {
+            CompoundCommand::For(command) => {
+                if let Some(words) = &command.words {
+                    for word in words {
+                        collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    }
+                }
+            }
+            CompoundCommand::Repeat(command) => {
+                collect_arithmetic_update_operator_spans_in_word(&command.count, source, spans);
+            }
+            CompoundCommand::Foreach(command) => {
+                for word in &command.words {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+            }
+            CompoundCommand::Arithmetic(command) => {
+                collect_arithmetic_update_operator_spans(command.expr_ast.as_ref(), source, spans);
+            }
+            CompoundCommand::ArithmeticFor(command) => {
+                collect_arithmetic_update_operator_spans(command.init_ast.as_ref(), source, spans);
+                collect_arithmetic_update_operator_spans(
+                    command.condition_ast.as_ref(),
+                    source,
+                    spans,
+                );
+                collect_arithmetic_update_operator_spans(command.step_ast.as_ref(), source, spans);
+            }
+            CompoundCommand::Case(command) => {
+                collect_arithmetic_update_operator_spans_in_word(&command.word, source, spans);
+                for item in &command.cases {
+                    for pattern in &item.patterns {
+                        collect_arithmetic_update_operator_spans_in_pattern(pattern, source, spans);
+                    }
+                }
+            }
+            CompoundCommand::Select(command) => {
+                for word in &command.words {
+                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                }
+            }
+            CompoundCommand::If(_)
+            | CompoundCommand::Conditional(_)
+            | CompoundCommand::While(_)
+            | CompoundCommand::Until(_)
+            | CompoundCommand::Subshell(_)
+            | CompoundCommand::BraceGroup(_)
+            | CompoundCommand::Always(_)
+            | CompoundCommand::Coproc(_)
+            | CompoundCommand::Time(_) => {}
+        },
+        Command::Binary(_) | Command::Function(_) | Command::AnonymousFunction(_) => {}
+    }
+}
+
+fn collect_arithmetic_update_operator_spans_in_assignment(
+    assignment: &Assignment,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_arithmetic_update_operator_spans_in_var_ref(&assignment.target, source, spans);
+
+    match &assignment.value {
+        AssignmentValue::Scalar(word) => {
+            collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+        }
+        AssignmentValue::Compound(array) => {
+            for element in &array.elements {
+                match element {
+                    ArrayElem::Sequential(word) => {
+                        collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    }
+                    ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
+                        if array.kind != ArrayKind::Associative {
+                            collect_arithmetic_update_operator_spans_in_subscript(
+                                Some(key),
+                                source,
+                                spans,
+                            );
+                        }
+                        collect_arithmetic_update_operator_spans_in_word(value, source, spans);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_arithmetic_update_operator_spans_in_word(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_arithmetic_update_operator_spans_from_parts(&word.parts, source, spans);
+}
+
+fn collect_arithmetic_update_operator_spans_in_pattern(
+    pattern: &Pattern,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for (part, _) in pattern.parts_with_spans() {
+        match part {
+            PatternPart::Group { patterns, .. } => {
+                for pattern in patterns {
+                    collect_arithmetic_update_operator_spans_in_pattern(pattern, source, spans);
+                }
+            }
+            PatternPart::Word(word) => {
+                collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+            }
+            PatternPart::Literal(_)
+            | PatternPart::AnyString
+            | PatternPart::AnyChar
+            | PatternPart::CharClass(_) => {}
+        }
+    }
+}
+
+fn collect_arithmetic_update_operator_spans_in_subscript(
+    subscript: Option<&Subscript>,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    if let Some(expression) = subscript.and_then(|subscript| subscript.arithmetic_ast.as_ref()) {
+        collect_arithmetic_update_operator_spans(Some(expression), source, spans);
+    }
 }
 
 fn collect_arithmetic_update_operator_spans(
@@ -635,4 +850,3 @@ fn double_paren_grouping_anchor(span: Span, source: &str) -> Option<Span> {
 
     Some(Span::at(anchor_start))
 }
-

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -629,13 +629,19 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     }
                 }
             }
+            CompoundCommand::Conditional(command) => {
+                collect_arithmetic_update_operator_spans_in_conditional_expr(
+                    &command.expression,
+                    source,
+                    spans,
+                );
+            }
             CompoundCommand::Select(command) => {
                 for word in &command.words {
                     collect_arithmetic_update_operator_spans_in_word(word, source, spans);
                 }
             }
             CompoundCommand::If(_)
-            | CompoundCommand::Conditional(_)
             | CompoundCommand::While(_)
             | CompoundCommand::Until(_)
             | CompoundCommand::Subshell(_)
@@ -708,6 +714,50 @@ fn collect_arithmetic_update_operator_spans_in_pattern(
             | PatternPart::AnyString
             | PatternPart::AnyChar
             | PatternPart::CharClass(_) => {}
+        }
+    }
+}
+
+fn collect_arithmetic_update_operator_spans_in_conditional_expr(
+    expression: &ConditionalExpr,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match expression {
+        ConditionalExpr::Binary(expr) => {
+            collect_arithmetic_update_operator_spans_in_conditional_expr(
+                &expr.left,
+                source,
+                spans,
+            );
+            collect_arithmetic_update_operator_spans_in_conditional_expr(
+                &expr.right,
+                source,
+                spans,
+            );
+        }
+        ConditionalExpr::Unary(expr) => {
+            collect_arithmetic_update_operator_spans_in_conditional_expr(
+                &expr.expr,
+                source,
+                spans,
+            );
+        }
+        ConditionalExpr::Parenthesized(expr) => {
+            collect_arithmetic_update_operator_spans_in_conditional_expr(
+                &expr.expr,
+                source,
+                spans,
+            );
+        }
+        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
+            collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+        }
+        ConditionalExpr::Pattern(pattern) => {
+            collect_arithmetic_update_operator_spans_in_pattern(pattern, source, spans);
+        }
+        ConditionalExpr::VarRef(reference) => {
+            collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
         }
     }
 }

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -476,7 +476,11 @@ fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str)
         .collect()
 }
 
-fn build_arithmetic_update_operator_spans(body: &StmtSeq, source: &str) -> Vec<Span> {
+fn build_arithmetic_update_operator_spans(
+    body: &StmtSeq,
+    semantic: &SemanticModel,
+    source: &str,
+) -> Vec<Span> {
     let mut spans = Vec::new();
 
     for visit in query::iter_commands(
@@ -485,7 +489,12 @@ fn build_arithmetic_update_operator_spans(body: &StmtSeq, source: &str) -> Vec<S
             descend_nested_word_commands: true,
         },
     ) {
-        collect_arithmetic_update_operator_spans_in_command(visit.command, source, &mut spans);
+        collect_arithmetic_update_operator_spans_in_command(
+            visit.command,
+            semantic,
+            source,
+            &mut spans,
+        );
         for redirect in visit.redirects {
             if let Some(word) = redirect.word_target() {
                 collect_arithmetic_update_operator_spans_in_word(word, source, &mut spans);
@@ -494,6 +503,7 @@ fn build_arithmetic_update_operator_spans(body: &StmtSeq, source: &str) -> Vec<S
             {
                 collect_arithmetic_update_operator_spans_in_heredoc_body(
                     &heredoc.body.parts,
+                    semantic,
                     source,
                     &mut spans,
                 );
@@ -508,13 +518,16 @@ fn build_arithmetic_update_operator_spans(body: &StmtSeq, source: &str) -> Vec<S
 
 fn collect_arithmetic_update_operator_spans_in_command(
     command: &Command,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
     match command {
         Command::Simple(command) => {
             for assignment in &command.assignments {
-                collect_arithmetic_update_operator_spans_in_assignment(assignment, source, spans);
+                collect_arithmetic_update_operator_spans_in_assignment(
+                    assignment, semantic, source, spans,
+                );
             }
             collect_arithmetic_update_operator_spans_in_word(&command.name, source, spans);
             for word in &command.args {
@@ -525,7 +538,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Break(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, source, spans,
+                        assignment, semantic, source, spans,
                     );
                 }
                 if let Some(word) = &command.depth {
@@ -538,7 +551,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Continue(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, source, spans,
+                        assignment, semantic, source, spans,
                     );
                 }
                 if let Some(word) = &command.depth {
@@ -551,7 +564,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Return(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, source, spans,
+                        assignment, semantic, source, spans,
                     );
                 }
                 if let Some(word) = &command.code {
@@ -564,7 +577,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Exit(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, source, spans,
+                        assignment, semantic, source, spans,
                     );
                 }
                 if let Some(word) = &command.code {
@@ -577,7 +590,9 @@ fn collect_arithmetic_update_operator_spans_in_command(
         },
         Command::Decl(command) => {
             for assignment in &command.assignments {
-                collect_arithmetic_update_operator_spans_in_assignment(assignment, source, spans);
+                collect_arithmetic_update_operator_spans_in_assignment(
+                    assignment, semantic, source, spans,
+                );
             }
             for operand in &command.operands {
                 match operand {
@@ -586,7 +601,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     }
                     DeclOperand::Assignment(assignment) => {
                         collect_arithmetic_update_operator_spans_in_assignment(
-                            assignment, source, spans,
+                            assignment, semantic, source, spans,
                         );
                     }
                     DeclOperand::Name(_) => {}
@@ -656,10 +671,21 @@ fn collect_arithmetic_update_operator_spans_in_command(
 
 fn collect_arithmetic_update_operator_spans_in_assignment(
     assignment: &Assignment,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_arithmetic_update_operator_spans_in_var_ref(&assignment.target, source, spans);
+    collect_arithmetic_update_operator_spans_in_assignment_target(
+        &assignment.target,
+        semantic,
+        source,
+        spans,
+    );
+    let target_is_contextual_assoc = var_ref_name_has_visible_assoc_binding_at(
+        &assignment.target,
+        semantic,
+        assignment.target.name_span,
+    );
 
     match &assignment.value {
         AssignmentValue::Scalar(word) => {
@@ -672,7 +698,9 @@ fn collect_arithmetic_update_operator_spans_in_assignment(
                         collect_arithmetic_update_operator_spans_in_word(word, source, spans);
                     }
                     ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
-                        if array.kind != ArrayKind::Associative {
+                        if array.kind != ArrayKind::Associative
+                            && !(array.kind == ArrayKind::Contextual && target_is_contextual_assoc)
+                        {
                             collect_arithmetic_update_operator_spans_in_subscript(
                                 Some(key),
                                 source,
@@ -685,6 +713,55 @@ fn collect_arithmetic_update_operator_spans_in_assignment(
             }
         }
     }
+}
+
+fn collect_arithmetic_update_operator_spans_in_assignment_target(
+    reference: &VarRef,
+    semantic: &SemanticModel,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    if !var_ref_subscript_has_assoc_semantics(reference, semantic) {
+        collect_arithmetic_update_operator_spans_in_subscript(
+            reference.subscript.as_ref(),
+            source,
+            spans,
+        );
+    }
+    query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
+        collect_arithmetic_update_operator_spans_from_parts(&word.parts, source, spans);
+    });
+}
+
+fn var_ref_subscript_has_assoc_semantics(reference: &VarRef, semantic: &SemanticModel) -> bool {
+    let Some(subscript) = reference.subscript.as_ref() else {
+        return false;
+    };
+    if matches!(
+        subscript.interpretation,
+        shuck_ast::SubscriptInterpretation::Associative
+    ) {
+        return true;
+    }
+    if !matches!(
+        subscript.interpretation,
+        shuck_ast::SubscriptInterpretation::Contextual
+    ) {
+        return false;
+    }
+
+    var_ref_name_has_visible_assoc_binding_at(reference, semantic, subscript.span())
+}
+
+fn var_ref_name_has_visible_assoc_binding_at(
+    reference: &VarRef,
+    semantic: &SemanticModel,
+    scope_span: Span,
+) -> bool {
+    let current_scope = semantic.scope_at(scope_span.start.offset);
+    semantic
+        .visible_binding_for_assoc_lookup(&reference.name, current_scope, reference.name_span)
+        .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
 }
 
 fn collect_arithmetic_update_operator_spans_in_word(
@@ -764,6 +841,7 @@ fn collect_arithmetic_update_operator_spans_in_conditional_expr(
 
 fn collect_arithmetic_update_operator_spans_in_heredoc_body(
     parts: &[shuck_ast::HeredocBodyPartNode],
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
@@ -786,12 +864,12 @@ fn collect_arithmetic_update_operator_spans_in_heredoc_body(
             }
             shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
                 collect_arithmetic_update_operator_spans_in_nested_command_body(
-                    body, source, spans,
+                    body, semantic, source, spans,
                 );
             }
             shuck_ast::HeredocBodyPart::Parameter(parameter) => {
                 collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_commands(
-                    parameter, source, spans,
+                    parameter, semantic, source, spans,
                 );
             }
             shuck_ast::HeredocBodyPart::Literal(_) | shuck_ast::HeredocBodyPart::Variable(_) => {}
@@ -801,6 +879,7 @@ fn collect_arithmetic_update_operator_spans_in_heredoc_body(
 
 fn collect_arithmetic_update_operator_spans_in_nested_command_body(
     body: &StmtSeq,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
@@ -810,7 +889,7 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
             descend_nested_word_commands: true,
         },
     ) {
-        collect_arithmetic_update_operator_spans_in_command(visit.command, source, spans);
+        collect_arithmetic_update_operator_spans_in_command(visit.command, semantic, source, spans);
         for redirect in visit.redirects {
             if let Some(word) = redirect.word_target() {
                 collect_arithmetic_update_operator_spans_in_word(word, source, spans);
@@ -819,6 +898,7 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
             {
                 collect_arithmetic_update_operator_spans_in_heredoc_body(
                     &heredoc.body.parts,
+                    semantic,
                     source,
                     spans,
                 );

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -489,6 +489,14 @@ fn build_arithmetic_update_operator_spans(body: &StmtSeq, source: &str) -> Vec<S
         for redirect in visit.redirects {
             if let Some(word) = redirect.word_target() {
                 collect_arithmetic_update_operator_spans_in_word(word, source, &mut spans);
+            } else if let Some(heredoc) = redirect.heredoc()
+                && heredoc.delimiter.expands_body
+            {
+                collect_arithmetic_update_operator_spans_in_heredoc_body(
+                    &heredoc.body.parts,
+                    source,
+                    &mut spans,
+                );
             }
         }
     }
@@ -700,6 +708,64 @@ fn collect_arithmetic_update_operator_spans_in_pattern(
             | PatternPart::AnyString
             | PatternPart::AnyChar
             | PatternPart::CharClass(_) => {}
+        }
+    }
+}
+
+fn collect_arithmetic_update_operator_spans_in_heredoc_body(
+    parts: &[shuck_ast::HeredocBodyPartNode],
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for part in parts {
+        match &part.kind {
+            shuck_ast::HeredocBodyPart::ArithmeticExpansion {
+                expression_ast,
+                expression_word_ast,
+                ..
+            } => {
+                if let Some(expression_ast) = expression_ast.as_ref() {
+                    collect_arithmetic_update_operator_spans(Some(expression_ast), source, spans);
+                } else {
+                    collect_arithmetic_update_operator_spans_in_word(
+                        expression_word_ast,
+                        source,
+                        spans,
+                    );
+                }
+            }
+            shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
+                for stmt in &body.stmts {
+                    collect_arithmetic_update_operator_spans_in_command(
+                        &stmt.command,
+                        source,
+                        spans,
+                    );
+                    for redirect in &stmt.redirects {
+                        if let Some(word) = redirect.word_target() {
+                            collect_arithmetic_update_operator_spans_in_word(
+                                word,
+                                source,
+                                spans,
+                            );
+                        } else if let Some(heredoc) = redirect.heredoc()
+                            && heredoc.delimiter.expands_body
+                        {
+                            collect_arithmetic_update_operator_spans_in_heredoc_body(
+                                &heredoc.body.parts,
+                                source,
+                                spans,
+                            );
+                        }
+                    }
+                }
+            }
+            shuck_ast::HeredocBodyPart::Parameter(parameter) => {
+                collect_arithmetic_update_operator_spans_in_parameter_expansion(
+                    parameter, source, spans,
+                );
+            }
+            shuck_ast::HeredocBodyPart::Literal(_) | shuck_ast::HeredocBodyPart::Variable(_) => {}
         }
     }
 }

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -497,7 +497,9 @@ fn build_arithmetic_update_operator_spans(
         );
         for redirect in visit.redirects {
             if let Some(word) = redirect.word_target() {
-                collect_arithmetic_update_operator_spans_in_word(word, source, &mut spans);
+                collect_arithmetic_update_operator_spans_in_word(
+                    word, semantic, source, &mut spans,
+                );
             } else if let Some(heredoc) = redirect.heredoc()
                 && heredoc.delimiter.expands_body
             {
@@ -529,9 +531,9 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     assignment, semantic, source, spans,
                 );
             }
-            collect_arithmetic_update_operator_spans_in_word(&command.name, source, spans);
+            collect_arithmetic_update_operator_spans_in_word(&command.name, semantic, source, spans);
             for word in &command.args {
-                collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
             }
         }
         Command::Builtin(command) => match command {
@@ -542,10 +544,14 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     );
                 }
                 if let Some(word) = &command.depth {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
                 for word in &command.extra_args {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
             }
             BuiltinCommand::Continue(command) => {
@@ -555,10 +561,14 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     );
                 }
                 if let Some(word) = &command.depth {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
                 for word in &command.extra_args {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
             }
             BuiltinCommand::Return(command) => {
@@ -568,10 +578,14 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     );
                 }
                 if let Some(word) = &command.code {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
                 for word in &command.extra_args {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
             }
             BuiltinCommand::Exit(command) => {
@@ -581,10 +595,14 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     );
                 }
                 if let Some(word) = &command.code {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
                 for word in &command.extra_args {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
             }
         },
@@ -597,7 +615,9 @@ fn collect_arithmetic_update_operator_spans_in_command(
             for operand in &command.operands {
                 match operand {
                     DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                        collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                        collect_arithmetic_update_operator_spans_in_word(
+                            word, semantic, source, spans,
+                        );
                     }
                     DeclOperand::Assignment(assignment) => {
                         collect_arithmetic_update_operator_spans_in_assignment(
@@ -612,16 +632,25 @@ fn collect_arithmetic_update_operator_spans_in_command(
             CompoundCommand::For(command) => {
                 if let Some(words) = &command.words {
                     for word in words {
-                        collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                        collect_arithmetic_update_operator_spans_in_word(
+                            word, semantic, source, spans,
+                        );
                     }
                 }
             }
             CompoundCommand::Repeat(command) => {
-                collect_arithmetic_update_operator_spans_in_word(&command.count, source, spans);
+                collect_arithmetic_update_operator_spans_in_word(
+                    &command.count,
+                    semantic,
+                    source,
+                    spans,
+                );
             }
             CompoundCommand::Foreach(command) => {
                 for word in &command.words {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
             }
             CompoundCommand::Arithmetic(command) => {
@@ -637,23 +666,33 @@ fn collect_arithmetic_update_operator_spans_in_command(
                 collect_arithmetic_update_operator_spans(command.step_ast.as_ref(), source, spans);
             }
             CompoundCommand::Case(command) => {
-                collect_arithmetic_update_operator_spans_in_word(&command.word, source, spans);
+                collect_arithmetic_update_operator_spans_in_word(
+                    &command.word,
+                    semantic,
+                    source,
+                    spans,
+                );
                 for item in &command.cases {
                     for pattern in &item.patterns {
-                        collect_arithmetic_update_operator_spans_in_pattern(pattern, source, spans);
+                        collect_arithmetic_update_operator_spans_in_pattern(
+                            pattern, semantic, source, spans,
+                        );
                     }
                 }
             }
             CompoundCommand::Conditional(command) => {
                 collect_arithmetic_update_operator_spans_in_conditional_expr(
                     &command.expression,
+                    semantic,
                     source,
                     spans,
                 );
             }
             CompoundCommand::Select(command) => {
                 for word in &command.words {
-                    collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word, semantic, source, spans,
+                    );
                 }
             }
             CompoundCommand::If(_)
@@ -689,13 +728,15 @@ fn collect_arithmetic_update_operator_spans_in_assignment(
 
     match &assignment.value {
         AssignmentValue::Scalar(word) => {
-            collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+            collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
         }
         AssignmentValue::Compound(array) => {
             for element in &array.elements {
                 match element {
                     ArrayElem::Sequential(word) => {
-                        collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                        collect_arithmetic_update_operator_spans_in_word(
+                            word, semantic, source, spans,
+                        );
                     }
                     ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
                         if array.kind != ArrayKind::Associative
@@ -707,7 +748,9 @@ fn collect_arithmetic_update_operator_spans_in_assignment(
                                 spans,
                             );
                         }
-                        collect_arithmetic_update_operator_spans_in_word(value, source, spans);
+                        collect_arithmetic_update_operator_spans_in_word(
+                            value, semantic, source, spans,
+                        );
                     }
                 }
             }
@@ -729,7 +772,7 @@ fn collect_arithmetic_update_operator_spans_in_assignment_target(
         );
     }
     query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
-        collect_arithmetic_update_operator_spans_from_parts(&word.parts, source, spans);
+        collect_arithmetic_update_operator_spans_from_parts(&word.parts, semantic, source, spans);
     });
 }
 
@@ -766,14 +809,16 @@ fn var_ref_name_has_visible_assoc_binding_at(
 
 fn collect_arithmetic_update_operator_spans_in_word(
     word: &Word,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_arithmetic_update_operator_spans_from_parts(&word.parts, source, spans);
+    collect_arithmetic_update_operator_spans_from_parts(&word.parts, semantic, source, spans);
 }
 
 fn collect_arithmetic_update_operator_spans_in_pattern(
     pattern: &Pattern,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
@@ -781,11 +826,13 @@ fn collect_arithmetic_update_operator_spans_in_pattern(
         match part {
             PatternPart::Group { patterns, .. } => {
                 for pattern in patterns {
-                    collect_arithmetic_update_operator_spans_in_pattern(pattern, source, spans);
+                    collect_arithmetic_update_operator_spans_in_pattern(
+                        pattern, semantic, source, spans,
+                    );
                 }
             }
             PatternPart::Word(word) => {
-                collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
             }
             PatternPart::Literal(_)
             | PatternPart::AnyString
@@ -797,6 +844,7 @@ fn collect_arithmetic_update_operator_spans_in_pattern(
 
 fn collect_arithmetic_update_operator_spans_in_conditional_expr(
     expression: &ConditionalExpr,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
@@ -804,11 +852,13 @@ fn collect_arithmetic_update_operator_spans_in_conditional_expr(
         ConditionalExpr::Binary(expr) => {
             collect_arithmetic_update_operator_spans_in_conditional_expr(
                 &expr.left,
+                semantic,
                 source,
                 spans,
             );
             collect_arithmetic_update_operator_spans_in_conditional_expr(
                 &expr.right,
+                semantic,
                 source,
                 spans,
             );
@@ -816,6 +866,7 @@ fn collect_arithmetic_update_operator_spans_in_conditional_expr(
         ConditionalExpr::Unary(expr) => {
             collect_arithmetic_update_operator_spans_in_conditional_expr(
                 &expr.expr,
+                semantic,
                 source,
                 spans,
             );
@@ -823,18 +874,23 @@ fn collect_arithmetic_update_operator_spans_in_conditional_expr(
         ConditionalExpr::Parenthesized(expr) => {
             collect_arithmetic_update_operator_spans_in_conditional_expr(
                 &expr.expr,
+                semantic,
                 source,
                 spans,
             );
         }
         ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-            collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+            collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
         }
         ConditionalExpr::Pattern(pattern) => {
-            collect_arithmetic_update_operator_spans_in_pattern(pattern, source, spans);
+            collect_arithmetic_update_operator_spans_in_pattern(
+                pattern, semantic, source, spans,
+            );
         }
         ConditionalExpr::VarRef(reference) => {
-            collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
+            collect_arithmetic_update_operator_spans_in_var_ref(
+                reference, semantic, source, spans,
+            );
         }
     }
 }
@@ -857,6 +913,7 @@ fn collect_arithmetic_update_operator_spans_in_heredoc_body(
                 } else {
                     collect_arithmetic_update_operator_spans_in_word(
                         expression_word_ast,
+                        semantic,
                         source,
                         spans,
                     );
@@ -892,7 +949,7 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
         collect_arithmetic_update_operator_spans_in_command(visit.command, semantic, source, spans);
         for redirect in visit.redirects {
             if let Some(word) = redirect.word_target() {
-                collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+                collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
             } else if let Some(heredoc) = redirect.heredoc()
                 && heredoc.delimiter.expands_body
             {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -785,37 +785,44 @@ fn collect_arithmetic_update_operator_spans_in_heredoc_body(
                 }
             }
             shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
-                for stmt in &body.stmts {
-                    collect_arithmetic_update_operator_spans_in_command(
-                        &stmt.command,
-                        source,
-                        spans,
-                    );
-                    for redirect in &stmt.redirects {
-                        if let Some(word) = redirect.word_target() {
-                            collect_arithmetic_update_operator_spans_in_word(
-                                word,
-                                source,
-                                spans,
-                            );
-                        } else if let Some(heredoc) = redirect.heredoc()
-                            && heredoc.delimiter.expands_body
-                        {
-                            collect_arithmetic_update_operator_spans_in_heredoc_body(
-                                &heredoc.body.parts,
-                                source,
-                                spans,
-                            );
-                        }
-                    }
-                }
+                collect_arithmetic_update_operator_spans_in_nested_command_body(
+                    body, source, spans,
+                );
             }
             shuck_ast::HeredocBodyPart::Parameter(parameter) => {
-                collect_arithmetic_update_operator_spans_in_parameter_expansion(
+                collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_commands(
                     parameter, source, spans,
                 );
             }
             shuck_ast::HeredocBodyPart::Literal(_) | shuck_ast::HeredocBodyPart::Variable(_) => {}
+        }
+    }
+}
+
+fn collect_arithmetic_update_operator_spans_in_nested_command_body(
+    body: &StmtSeq,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for visit in query::iter_commands(
+        body,
+        CommandWalkOptions {
+            descend_nested_word_commands: true,
+        },
+    ) {
+        collect_arithmetic_update_operator_spans_in_command(visit.command, source, spans);
+        for redirect in visit.redirects {
+            if let Some(word) = redirect.word_target() {
+                collect_arithmetic_update_operator_spans_in_word(word, source, spans);
+            } else if let Some(heredoc) = redirect.heredoc()
+                && heredoc.delimiter.expands_body
+            {
+                collect_arithmetic_update_operator_spans_in_heredoc_body(
+                    &heredoc.body.parts,
+                    source,
+                    spans,
+                );
+            }
         }
     }
 }
@@ -825,7 +832,16 @@ fn collect_arithmetic_update_operator_spans_in_subscript(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    if let Some(expression) = subscript.and_then(|subscript| subscript.arithmetic_ast.as_ref()) {
+    let Some(subscript) = subscript else {
+        return;
+    };
+    if matches!(
+        subscript.interpretation,
+        shuck_ast::SubscriptInterpretation::Associative
+    ) {
+        return;
+    }
+    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
         collect_arithmetic_update_operator_spans(Some(expression), source, spans);
     }
 }

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -801,10 +801,73 @@ fn var_ref_name_has_visible_assoc_binding_at(
     semantic: &SemanticModel,
     scope_span: Span,
 ) -> bool {
+    if let Some(visible) =
+        var_ref_name_has_visible_assoc_binding_in_nearest_scope(reference, semantic, scope_span)
+    {
+        return visible;
+    }
+
+    var_ref_name_has_visible_assoc_binding_from_named_callers(&reference.name, semantic, scope_span)
+}
+
+fn var_ref_name_has_visible_assoc_binding_in_nearest_scope(
+    reference: &VarRef,
+    semantic: &SemanticModel,
+    scope_span: Span,
+) -> Option<bool> {
     let current_scope = semantic.scope_at(scope_span.start.offset);
     semantic
         .visible_binding_for_assoc_lookup(&reference.name, current_scope, reference.name_span)
-        .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+        .map(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+}
+
+fn var_ref_name_has_visible_assoc_binding_from_named_callers(
+    name: &Name,
+    semantic: &SemanticModel,
+    scope_span: Span,
+) -> bool {
+    let Some(function_names) = named_function_scope_names(semantic, scope_span.start.offset) else {
+        return false;
+    };
+
+    let mut seen = FxHashSet::default();
+    let mut worklist = function_names.to_vec();
+
+    while let Some(function_name) = worklist.pop() {
+        if !seen.insert(function_name.clone()) {
+            continue;
+        }
+
+        for call_site in semantic.call_sites_for(&function_name) {
+            let current_scope = semantic.scope_at(call_site.name_span.start.offset);
+            if let Some(binding) =
+                semantic.visible_binding_for_assoc_lookup(name, current_scope, call_site.name_span)
+            {
+                if binding.attributes.contains(BindingAttributes::ASSOC) {
+                    return true;
+                }
+                continue;
+            }
+
+            if let Some(caller_names) = named_function_scope_names(semantic, call_site.name_span.start.offset) {
+                worklist.extend(caller_names.iter().cloned());
+            }
+        }
+    }
+
+    false
+}
+
+fn named_function_scope_names(semantic: &SemanticModel, offset: usize) -> Option<&[Name]> {
+    let scope = semantic.scope_at(offset);
+    semantic
+        .ancestor_scopes(scope)
+        .find_map(|scope_id| match &semantic.scope(scope_id).kind {
+            shuck_semantic::ScopeKind::Function(shuck_semantic::FunctionScopeKind::Named(
+                names,
+            )) => Some(names.as_slice()),
+            _ => None,
+        })
 }
 
 fn collect_arithmetic_update_operator_spans_in_word(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -464,8 +464,8 @@ impl<'a> LinterFactsBuilder<'a> {
             &positional_parameters,
         );
         let double_paren_grouping_spans = build_double_paren_grouping_spans(&commands, self.source);
-        let arithmetic_for_update_operator_spans =
-            build_arithmetic_for_update_operator_spans(&commands, self.source);
+        let arithmetic_update_operator_spans =
+            build_arithmetic_update_operator_spans(&self.file.body, self.source);
         let base_prefix_arithmetic_spans =
             build_base_prefix_arithmetic_spans(&self.file.body, self.source);
         let subscript_index_reference_spans =
@@ -663,7 +663,7 @@ impl<'a> LinterFactsBuilder<'a> {
             positional_parameter_fragments: positional_parameters,
             positional_parameter_operator_spans,
             double_paren_grouping_spans,
-            arithmetic_for_update_operator_spans,
+            arithmetic_update_operator_spans,
             base_prefix_arithmetic_spans,
             escape_scan_matches,
             echo_backslash_escape_word_spans,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -153,8 +153,12 @@ impl<'a> LinterFactsBuilder<'a> {
                     surface: &mut surface_fragments,
                 },
             );
-            let redirect_facts =
-                build_redirect_facts(visit.redirects, self.source, command_zsh_options.as_ref());
+            let redirect_facts = build_redirect_facts(
+                visit.redirects,
+                Some(self.semantic),
+                self.source,
+                command_zsh_options.as_ref(),
+            );
             let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
             let declaration_assignment_probes = build_declaration_assignment_probes(
                 visit.command,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -465,7 +465,7 @@ impl<'a> LinterFactsBuilder<'a> {
         );
         let double_paren_grouping_spans = build_double_paren_grouping_spans(&commands, self.source);
         let arithmetic_update_operator_spans =
-            build_arithmetic_update_operator_spans(&self.file.body, self.source);
+            build_arithmetic_update_operator_spans(&self.file.body, self.semantic, self.source);
         let base_prefix_arithmetic_spans =
             build_base_prefix_arithmetic_spans(&self.file.body, self.source);
         let subscript_index_reference_spans =

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -93,7 +93,7 @@ pub struct LinterFacts<'a> {
     positional_parameter_fragments: Vec<PositionalParameterFragmentFact>,
     positional_parameter_operator_spans: Vec<Span>,
     double_paren_grouping_spans: Vec<Span>,
-    arithmetic_for_update_operator_spans: Vec<Span>,
+    arithmetic_update_operator_spans: Vec<Span>,
     base_prefix_arithmetic_spans: Vec<Span>,
     escape_scan_matches: Vec<EscapeScanMatch>,
     echo_backslash_escape_word_spans: Vec<Span>,
@@ -706,8 +706,8 @@ impl<'a> LinterFacts<'a> {
         &self.double_paren_grouping_spans
     }
 
-    pub fn arithmetic_for_update_operator_spans(&self) -> &[Span] {
-        &self.arithmetic_for_update_operator_spans
+    pub fn arithmetic_update_operator_spans(&self) -> &[Span] {
+        &self.arithmetic_update_operator_spans
     }
 
     pub fn base_prefix_arithmetic_spans(&self) -> &[Span] {

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -36,6 +36,7 @@ impl<'a> RedirectFact<'a> {
 
 fn build_redirect_facts<'a>(
     redirects: &'a [Redirect],
+    semantic: Option<&SemanticModel>,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
 ) -> Box<[RedirectFact<'a>]> {
@@ -50,11 +51,14 @@ fn build_redirect_facts<'a>(
                 .word_target()
                 .map_or_else(Vec::new, |word| {
                     let mut spans = Vec::new();
-                    collect_arithmetic_update_operator_spans_from_parts(
-                        &word.parts,
-                        source,
-                        &mut spans,
-                    );
+                    if let Some(semantic) = semantic {
+                        collect_arithmetic_update_operator_spans_from_parts(
+                            &word.parts,
+                            semantic,
+                            source,
+                            &mut spans,
+                        );
+                    }
                     spans
                 })
                 .into_boxed_slice(),
@@ -123,4 +127,3 @@ fn redirect_operator_text(kind: RedirectKind) -> &'static str {
         RedirectKind::OutputBoth => "&>",
     }
 }
-

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -619,7 +619,7 @@ fn summarize_compound_stmt_redirects(
     redirects: &[Redirect],
     source: &str,
 ) -> RedirectSummary {
-    let redirect_facts = build_redirect_facts(redirects, source, None);
+    let redirect_facts = build_redirect_facts(redirects, None, source, None);
     if redirect_facts.is_empty() {
         return summary;
     }
@@ -661,7 +661,7 @@ fn summarize_command_redirects<'a>(
     if let Some(id) = command_id_for_command(command, command_ids_by_span) {
         summarize_redirect_facts(command_fact(commands, id).redirect_facts())
     } else {
-        let redirect_facts = build_redirect_facts(redirects, source, None);
+        let redirect_facts = build_redirect_facts(redirects, None, source, None);
         summarize_redirect_facts(&redirect_facts)
     }
 }

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -3868,26 +3868,31 @@ fn collect_arithmetic_expansion_spans_from_parts(
 
 fn collect_arithmetic_update_operator_spans_from_parts(
     parts: &[WordPartNode],
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_arithmetic_update_operator_spans_from_parts_impl(parts, source, spans, None);
+    collect_arithmetic_update_operator_spans_from_parts_impl(
+        parts, semantic, source, spans, false,
+    );
 }
 
 fn collect_arithmetic_update_operator_spans_from_parts_impl(
     parts: &[WordPartNode],
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
-    nested_command_semantic: Option<&SemanticModel>,
+    include_nested_commands: bool,
 ) {
     for part in parts {
         match &part.kind {
             WordPart::DoubleQuoted { parts, .. } => {
                 collect_arithmetic_update_operator_spans_from_parts_impl(
                     parts,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 )
             }
             WordPart::ArithmeticExpansion {
@@ -3900,18 +3905,20 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                 } else {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &expression_word_ast.parts,
+                        semantic,
                         source,
                         spans,
-                        nested_command_semantic,
+                        include_nested_commands,
                     );
                 }
             }
             WordPart::Parameter(parameter) => {
                 collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     parameter,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 )
             }
             WordPart::ParameterExpansion {
@@ -3921,15 +3928,17 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
             } => {
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
                 collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                     operator,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
             }
             WordPart::Length(reference)
@@ -3940,9 +3949,10 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
             | WordPart::Transformation { reference, .. } => {
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 )
             }
             WordPart::Substring {
@@ -3963,18 +3973,20 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
             } => {
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
                 if let Some(expression) = offset_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
                 } else {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &offset_word_ast.parts,
+                        semantic,
                         source,
                         spans,
-                        nested_command_semantic,
+                        include_nested_commands,
                     );
                 }
                 if let Some(expression) = length_ast {
@@ -3982,9 +3994,10 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                 } else if let Some(length_word_ast) = length_word_ast {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &length_word_ast.parts,
+                        semantic,
                         source,
                         spans,
-                        nested_command_semantic,
+                        include_nested_commands,
                     );
                 }
             }
@@ -3995,7 +4008,7 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
             | WordPart::ZshQualifiedGlob(_) => {}
             WordPart::CommandSubstitution { body, .. }
             | WordPart::ProcessSubstitution { body, .. } => {
-                if let Some(semantic) = nested_command_semantic {
+                if include_nested_commands {
                     collect_arithmetic_update_operator_spans_in_nested_command_body(
                         body, semantic, source, spans,
                     );
@@ -4007,25 +4020,36 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
 
 fn collect_arithmetic_update_operator_spans_in_var_ref(
     reference: &VarRef,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_arithmetic_update_operator_spans_in_var_ref_impl(reference, source, spans, None);
+    collect_arithmetic_update_operator_spans_in_var_ref_impl(
+        reference, semantic, source, spans, false,
+    );
 }
 
 fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
     reference: &VarRef,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
-    nested_command_semantic: Option<&SemanticModel>,
+    include_nested_commands: bool,
 ) {
-    collect_arithmetic_update_operator_spans_in_subscript(reference.subscript.as_ref(), source, spans);
+    if !var_ref_subscript_has_assoc_semantics(reference, semantic) {
+        collect_arithmetic_update_operator_spans_in_subscript(
+            reference.subscript.as_ref(),
+            source,
+            spans,
+        );
+    }
     query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
         collect_arithmetic_update_operator_spans_from_parts_impl(
             &word.parts,
+            semantic,
             source,
             spans,
-            nested_command_semantic,
+            include_nested_commands,
         );
     });
 }
@@ -4037,18 +4061,16 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_c
     spans: &mut Vec<Span>,
 ) {
     collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
-        parameter,
-        source,
-        spans,
-        Some(semantic),
+        parameter, semantic, source, spans, true,
     );
 }
 
 fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
     parameter: &ParameterExpansion,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
-    nested_command_semantic: Option<&SemanticModel>,
+    include_nested_commands: bool,
 ) {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
@@ -4058,9 +4080,10 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
             | BourneParameterExpansion::Transformation { reference, .. } => {
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
             }
             BourneParameterExpansion::Indirect {
@@ -4071,22 +4094,27 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
             } => {
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
                 if let Some(operator) = operator.as_ref() {
                     collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
-                        operator, source, spans,
-                        nested_command_semantic,
+                        operator,
+                        semantic,
+                        source,
+                        spans,
+                        include_nested_commands,
                     );
                 }
                 if let Some(operand_word_ast) = operand_word_ast.as_ref() {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
+                        semantic,
                         source,
                         spans,
-                        nested_command_semantic,
+                        include_nested_commands,
                     );
                 }
             }
@@ -4098,20 +4126,25 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
             } => {
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
                 collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
-                    operator, source, spans,
-                    nested_command_semantic,
+                    operator,
+                    semantic,
+                    source,
+                    spans,
+                    include_nested_commands,
                 );
                 if let Some(operand_word_ast) = operand_word_ast.as_ref() {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
+                        semantic,
                         source,
                         spans,
-                        nested_command_semantic,
+                        include_nested_commands,
                     );
                 }
             }
@@ -4125,18 +4158,20 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
             } => {
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
                 if let Some(expression) = offset_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
                 } else {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &offset_word_ast.parts,
+                        semantic,
                         source,
                         spans,
-                        nested_command_semantic,
+                        include_nested_commands,
                     );
                 }
                 if let Some(expression) = length_ast {
@@ -4144,9 +4179,10 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                 } else if let Some(length_word_ast) = length_word_ast {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &length_word_ast.parts,
+                        semantic,
                         source,
                         spans,
-                        nested_command_semantic,
+                        include_nested_commands,
                     );
                 }
             }
@@ -4156,23 +4192,28 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
             ZshExpansionTarget::Reference(reference) => {
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
             }
             ZshExpansionTarget::Nested(parameter) => {
                 collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
-                    parameter, source, spans,
-                    nested_command_semantic,
+                    parameter,
+                    semantic,
+                    source,
+                    spans,
+                    include_nested_commands,
                 );
             }
             ZshExpansionTarget::Word(word) => {
                 collect_arithmetic_update_operator_spans_from_parts_impl(
                     &word.parts,
+                    semantic,
                     source,
                     spans,
-                    nested_command_semantic,
+                    include_nested_commands,
                 );
             }
             ZshExpansionTarget::Empty => {}
@@ -4182,9 +4223,10 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
 
 fn collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
     operator: &ParameterOp,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
-    nested_command_semantic: Option<&SemanticModel>,
+    include_nested_commands: bool,
 ) {
     match operator {
         ParameterOp::ReplaceFirst {
@@ -4196,9 +4238,10 @@ fn collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
             ..
         } => collect_arithmetic_update_operator_spans_from_parts_impl(
             &replacement_word_ast.parts,
+            semantic,
             source,
             spans,
-            nested_command_semantic,
+            include_nested_commands,
         ),
         ParameterOp::UseDefault
         | ParameterOp::AssignDefault

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -3966,6 +3966,7 @@ fn collect_arithmetic_update_operator_spans_in_var_ref(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
+    collect_arithmetic_update_operator_spans_in_subscript(reference.subscript.as_ref(), source, spans);
     query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
         collect_arithmetic_update_operator_spans_from_parts(&word.parts, source, spans);
     });

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -3871,14 +3871,14 @@ fn collect_arithmetic_update_operator_spans_from_parts(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_arithmetic_update_operator_spans_from_parts_impl(parts, source, spans, false);
+    collect_arithmetic_update_operator_spans_from_parts_impl(parts, source, spans, None);
 }
 
 fn collect_arithmetic_update_operator_spans_from_parts_impl(
     parts: &[WordPartNode],
     source: &str,
     spans: &mut Vec<Span>,
-    include_nested_commands: bool,
+    nested_command_semantic: Option<&SemanticModel>,
 ) {
     for part in parts {
         match &part.kind {
@@ -3887,7 +3887,7 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                     parts,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 )
             }
             WordPart::ArithmeticExpansion {
@@ -3902,14 +3902,16 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                         &expression_word_ast.parts,
                         source,
                         spans,
-                        include_nested_commands,
+                        nested_command_semantic,
                     );
                 }
             }
             WordPart::Parameter(parameter) => {
                 collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
-                    parameter, source, spans,
-                    include_nested_commands,
+                    parameter,
+                    source,
+                    spans,
+                    nested_command_semantic,
                 )
             }
             WordPart::ParameterExpansion {
@@ -3921,11 +3923,13 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                     reference,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
                 collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
-                    operator, source, spans,
-                    include_nested_commands,
+                    operator,
+                    source,
+                    spans,
+                    nested_command_semantic,
                 );
             }
             WordPart::Length(reference)
@@ -3938,7 +3942,7 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                     reference,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 )
             }
             WordPart::Substring {
@@ -3961,7 +3965,7 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                     reference,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
                 if let Some(expression) = offset_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
@@ -3970,7 +3974,7 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                         &offset_word_ast.parts,
                         source,
                         spans,
-                        include_nested_commands,
+                        nested_command_semantic,
                     );
                 }
                 if let Some(expression) = length_ast {
@@ -3980,7 +3984,7 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
                         &length_word_ast.parts,
                         source,
                         spans,
-                        include_nested_commands,
+                        nested_command_semantic,
                     );
                 }
             }
@@ -3991,9 +3995,9 @@ fn collect_arithmetic_update_operator_spans_from_parts_impl(
             | WordPart::ZshQualifiedGlob(_) => {}
             WordPart::CommandSubstitution { body, .. }
             | WordPart::ProcessSubstitution { body, .. } => {
-                if include_nested_commands {
+                if let Some(semantic) = nested_command_semantic {
                     collect_arithmetic_update_operator_spans_in_nested_command_body(
-                        body, source, spans,
+                        body, semantic, source, spans,
                     );
                 }
             }
@@ -4006,14 +4010,14 @@ fn collect_arithmetic_update_operator_spans_in_var_ref(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_arithmetic_update_operator_spans_in_var_ref_impl(reference, source, spans, false);
+    collect_arithmetic_update_operator_spans_in_var_ref_impl(reference, source, spans, None);
 }
 
 fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
     reference: &VarRef,
     source: &str,
     spans: &mut Vec<Span>,
-    include_nested_commands: bool,
+    nested_command_semantic: Option<&SemanticModel>,
 ) {
     collect_arithmetic_update_operator_spans_in_subscript(reference.subscript.as_ref(), source, spans);
     query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
@@ -4021,18 +4025,22 @@ fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
             &word.parts,
             source,
             spans,
-            include_nested_commands,
+            nested_command_semantic,
         );
     });
 }
 
 fn collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_commands(
     parameter: &ParameterExpansion,
+    semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
     collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
-        parameter, source, spans, true,
+        parameter,
+        source,
+        spans,
+        Some(semantic),
     );
 }
 
@@ -4040,7 +4048,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
     parameter: &ParameterExpansion,
     source: &str,
     spans: &mut Vec<Span>,
-    include_nested_commands: bool,
+    nested_command_semantic: Option<&SemanticModel>,
 ) {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
@@ -4052,7 +4060,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     reference,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
             }
             BourneParameterExpansion::Indirect {
@@ -4065,12 +4073,12 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     reference,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
                 if let Some(operator) = operator.as_ref() {
                     collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                         operator, source, spans,
-                        include_nested_commands,
+                        nested_command_semantic,
                     );
                 }
                 if let Some(operand_word_ast) = operand_word_ast.as_ref() {
@@ -4078,7 +4086,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                         &operand_word_ast.parts,
                         source,
                         spans,
-                        include_nested_commands,
+                        nested_command_semantic,
                     );
                 }
             }
@@ -4092,18 +4100,18 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     reference,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
                 collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                     operator, source, spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
                 if let Some(operand_word_ast) = operand_word_ast.as_ref() {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
                         source,
                         spans,
-                        include_nested_commands,
+                        nested_command_semantic,
                     );
                 }
             }
@@ -4119,7 +4127,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     reference,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
                 if let Some(expression) = offset_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
@@ -4128,7 +4136,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                         &offset_word_ast.parts,
                         source,
                         spans,
-                        include_nested_commands,
+                        nested_command_semantic,
                     );
                 }
                 if let Some(expression) = length_ast {
@@ -4138,7 +4146,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                         &length_word_ast.parts,
                         source,
                         spans,
-                        include_nested_commands,
+                        nested_command_semantic,
                     );
                 }
             }
@@ -4150,13 +4158,13 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     reference,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
             }
             ZshExpansionTarget::Nested(parameter) => {
                 collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     parameter, source, spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
             }
             ZshExpansionTarget::Word(word) => {
@@ -4164,7 +4172,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     &word.parts,
                     source,
                     spans,
-                    include_nested_commands,
+                    nested_command_semantic,
                 );
             }
             ZshExpansionTarget::Empty => {}
@@ -4176,7 +4184,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
     operator: &ParameterOp,
     source: &str,
     spans: &mut Vec<Span>,
-    include_nested_commands: bool,
+    nested_command_semantic: Option<&SemanticModel>,
 ) {
     match operator {
         ParameterOp::ReplaceFirst {
@@ -4190,7 +4198,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
             &replacement_word_ast.parts,
             source,
             spans,
-            include_nested_commands,
+            nested_command_semantic,
         ),
         ParameterOp::UseDefault
         | ParameterOp::AssignDefault

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -3871,10 +3871,24 @@ fn collect_arithmetic_update_operator_spans_from_parts(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
+    collect_arithmetic_update_operator_spans_from_parts_impl(parts, source, spans, false);
+}
+
+fn collect_arithmetic_update_operator_spans_from_parts_impl(
+    parts: &[WordPartNode],
+    source: &str,
+    spans: &mut Vec<Span>,
+    include_nested_commands: bool,
+) {
     for part in parts {
         match &part.kind {
             WordPart::DoubleQuoted { parts, .. } => {
-                collect_arithmetic_update_operator_spans_from_parts(parts, source, spans)
+                collect_arithmetic_update_operator_spans_from_parts_impl(
+                    parts,
+                    source,
+                    spans,
+                    include_nested_commands,
+                )
             }
             WordPart::ArithmeticExpansion {
                 expression_ast,
@@ -3884,16 +3898,18 @@ fn collect_arithmetic_update_operator_spans_from_parts(
                 if let Some(expression) = expression_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
                 } else {
-                    collect_arithmetic_update_operator_spans_from_parts(
+                    collect_arithmetic_update_operator_spans_from_parts_impl(
                         &expression_word_ast.parts,
                         source,
                         spans,
+                        include_nested_commands,
                     );
                 }
             }
             WordPart::Parameter(parameter) => {
-                collect_arithmetic_update_operator_spans_in_parameter_expansion(
+                collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     parameter, source, spans,
+                    include_nested_commands,
                 )
             }
             WordPart::ParameterExpansion {
@@ -3901,9 +3917,15 @@ fn collect_arithmetic_update_operator_spans_from_parts(
                 operator,
                 ..
             } => {
-                collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
-                collect_arithmetic_update_operator_spans_in_parameter_operator(
+                collect_arithmetic_update_operator_spans_in_var_ref_impl(
+                    reference,
+                    source,
+                    spans,
+                    include_nested_commands,
+                );
+                collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                     operator, source, spans,
+                    include_nested_commands,
                 );
             }
             WordPart::Length(reference)
@@ -3912,7 +3934,12 @@ fn collect_arithmetic_update_operator_spans_from_parts(
             | WordPart::ArrayIndices(reference)
             | WordPart::IndirectExpansion { reference, .. }
             | WordPart::Transformation { reference, .. } => {
-                collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans)
+                collect_arithmetic_update_operator_spans_in_var_ref_impl(
+                    reference,
+                    source,
+                    spans,
+                    include_nested_commands,
+                )
             }
             WordPart::Substring {
                 reference,
@@ -3930,33 +3957,46 @@ fn collect_arithmetic_update_operator_spans_from_parts(
                 length_word_ast,
                 ..
             } => {
-                collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
+                collect_arithmetic_update_operator_spans_in_var_ref_impl(
+                    reference,
+                    source,
+                    spans,
+                    include_nested_commands,
+                );
                 if let Some(expression) = offset_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
                 } else {
-                    collect_arithmetic_update_operator_spans_from_parts(
+                    collect_arithmetic_update_operator_spans_from_parts_impl(
                         &offset_word_ast.parts,
                         source,
                         spans,
+                        include_nested_commands,
                     );
                 }
                 if let Some(expression) = length_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
                 } else if let Some(length_word_ast) = length_word_ast {
-                    collect_arithmetic_update_operator_spans_from_parts(
+                    collect_arithmetic_update_operator_spans_from_parts_impl(
                         &length_word_ast.parts,
                         source,
                         spans,
+                        include_nested_commands,
                     );
                 }
             }
             WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
             | WordPart::Variable(_)
-            | WordPart::CommandSubstitution { .. }
             | WordPart::PrefixMatch { .. }
-            | WordPart::ProcessSubstitution { .. }
             | WordPart::ZshQualifiedGlob(_) => {}
+            WordPart::CommandSubstitution { body, .. }
+            | WordPart::ProcessSubstitution { body, .. } => {
+                if include_nested_commands {
+                    collect_arithmetic_update_operator_spans_in_nested_command_body(
+                        body, source, spans,
+                    );
+                }
+            }
         }
     }
 }
@@ -3966,16 +4006,41 @@ fn collect_arithmetic_update_operator_spans_in_var_ref(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
+    collect_arithmetic_update_operator_spans_in_var_ref_impl(reference, source, spans, false);
+}
+
+fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
+    reference: &VarRef,
+    source: &str,
+    spans: &mut Vec<Span>,
+    include_nested_commands: bool,
+) {
     collect_arithmetic_update_operator_spans_in_subscript(reference.subscript.as_ref(), source, spans);
     query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
-        collect_arithmetic_update_operator_spans_from_parts(&word.parts, source, spans);
+        collect_arithmetic_update_operator_spans_from_parts_impl(
+            &word.parts,
+            source,
+            spans,
+            include_nested_commands,
+        );
     });
 }
 
-fn collect_arithmetic_update_operator_spans_in_parameter_expansion(
+fn collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_commands(
     parameter: &ParameterExpansion,
     source: &str,
     spans: &mut Vec<Span>,
+) {
+    collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
+        parameter, source, spans, true,
+    );
+}
+
+fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
+    parameter: &ParameterExpansion,
+    source: &str,
+    spans: &mut Vec<Span>,
+    include_nested_commands: bool,
 ) {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
@@ -3983,7 +4048,12 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion(
             | BourneParameterExpansion::Length { reference }
             | BourneParameterExpansion::Indices { reference }
             | BourneParameterExpansion::Transformation { reference, .. } => {
-                collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
+                collect_arithmetic_update_operator_spans_in_var_ref_impl(
+                    reference,
+                    source,
+                    spans,
+                    include_nested_commands,
+                );
             }
             BourneParameterExpansion::Indirect {
                 reference,
@@ -3991,17 +4061,24 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion(
                 operand_word_ast,
                 ..
             } => {
-                collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
+                collect_arithmetic_update_operator_spans_in_var_ref_impl(
+                    reference,
+                    source,
+                    spans,
+                    include_nested_commands,
+                );
                 if let Some(operator) = operator.as_ref() {
-                    collect_arithmetic_update_operator_spans_in_parameter_operator(
+                    collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                         operator, source, spans,
+                        include_nested_commands,
                     );
                 }
                 if let Some(operand_word_ast) = operand_word_ast.as_ref() {
-                    collect_arithmetic_update_operator_spans_from_parts(
+                    collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
                         source,
                         spans,
+                        include_nested_commands,
                     );
                 }
             }
@@ -4011,15 +4088,22 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion(
                 operand_word_ast,
                 ..
             } => {
-                collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
-                collect_arithmetic_update_operator_spans_in_parameter_operator(
+                collect_arithmetic_update_operator_spans_in_var_ref_impl(
+                    reference,
+                    source,
+                    spans,
+                    include_nested_commands,
+                );
+                collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                     operator, source, spans,
+                    include_nested_commands,
                 );
                 if let Some(operand_word_ast) = operand_word_ast.as_ref() {
-                    collect_arithmetic_update_operator_spans_from_parts(
+                    collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
                         source,
                         spans,
+                        include_nested_commands,
                     );
                 }
             }
@@ -4031,23 +4115,30 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion(
                 length_word_ast,
                 ..
             } => {
-                collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
+                collect_arithmetic_update_operator_spans_in_var_ref_impl(
+                    reference,
+                    source,
+                    spans,
+                    include_nested_commands,
+                );
                 if let Some(expression) = offset_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
                 } else {
-                    collect_arithmetic_update_operator_spans_from_parts(
+                    collect_arithmetic_update_operator_spans_from_parts_impl(
                         &offset_word_ast.parts,
                         source,
                         spans,
+                        include_nested_commands,
                     );
                 }
                 if let Some(expression) = length_ast {
                     collect_arithmetic_update_operator_spans(Some(expression), source, spans);
                 } else if let Some(length_word_ast) = length_word_ast {
-                    collect_arithmetic_update_operator_spans_from_parts(
+                    collect_arithmetic_update_operator_spans_from_parts_impl(
                         &length_word_ast.parts,
                         source,
                         spans,
+                        include_nested_commands,
                     );
                 }
             }
@@ -4055,25 +4146,37 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion(
         },
         ParameterExpansionSyntax::Zsh(syntax) => match &syntax.target {
             ZshExpansionTarget::Reference(reference) => {
-                collect_arithmetic_update_operator_spans_in_var_ref(reference, source, spans);
+                collect_arithmetic_update_operator_spans_in_var_ref_impl(
+                    reference,
+                    source,
+                    spans,
+                    include_nested_commands,
+                );
             }
             ZshExpansionTarget::Nested(parameter) => {
-                collect_arithmetic_update_operator_spans_in_parameter_expansion(
+                collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     parameter, source, spans,
+                    include_nested_commands,
                 );
             }
             ZshExpansionTarget::Word(word) => {
-                collect_arithmetic_update_operator_spans_from_parts(&word.parts, source, spans);
+                collect_arithmetic_update_operator_spans_from_parts_impl(
+                    &word.parts,
+                    source,
+                    spans,
+                    include_nested_commands,
+                );
             }
             ZshExpansionTarget::Empty => {}
         },
     }
 }
 
-fn collect_arithmetic_update_operator_spans_in_parameter_operator(
+fn collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
     operator: &ParameterOp,
     source: &str,
     spans: &mut Vec<Span>,
+    include_nested_commands: bool,
 ) {
     match operator {
         ParameterOp::ReplaceFirst {
@@ -4083,10 +4186,11 @@ fn collect_arithmetic_update_operator_spans_in_parameter_operator(
         | ParameterOp::ReplaceAll {
             replacement_word_ast,
             ..
-        } => collect_arithmetic_update_operator_spans_from_parts(
+        } => collect_arithmetic_update_operator_spans_from_parts_impl(
             &replacement_word_ast.parts,
             source,
             spans,
+            include_nested_commands,
         ),
         ParameterOp::UseDefault
         | ParameterOp::AssignDefault

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -113,6 +113,23 @@ mod tests {
     }
 
     #[test]
+    fn anchors_on_update_operators_inside_double_bracket_operands() {
+        let source = "#!/bin/sh\n[[ \"$((i++))\" -gt 0 && \"$((j--))\" -lt 3 ]]\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["++", "--"]
+        );
+    }
+
+    #[test]
     fn ignores_associative_array_keys_that_look_like_updates() {
         let source = "#!/bin/sh\nlocal -A tools=([c++]=CXX)\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -96,6 +96,23 @@ mod tests {
     }
 
     #[test]
+    fn anchors_on_update_operators_inside_assignment_target_subscripts() {
+        let source = "#!/bin/sh\narr[i++]=x\narr[--j]=y\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["++", "--"]
+        );
+    }
+
+    #[test]
     fn ignores_associative_array_keys_that_look_like_updates() {
         let source = "#!/bin/sh\nlocal -A tools=([c++]=CXX)\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -191,6 +191,56 @@ mod tests {
     }
 
     #[test]
+    fn ignores_caller_associative_reference_subscripts_that_look_like_updates() {
+        let source = "\
+#!/bin/sh
+helper() {
+  echo \"${tools[c++]}\"
+  [[ ${tools[d--]} ]]
+}
+main() {
+  declare -A tools
+  helper
+}
+main
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_shadowed_caller_associative_reference_subscripts_that_look_like_updates() {
+        let source = "\
+#!/bin/sh
+helper() {
+  local tools
+  echo \"${tools[c++]}\"
+}
+main() {
+  declare -A tools
+  helper
+}
+main
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["++"]
+        );
+    }
+
+    #[test]
     fn ignores_bash_scripts() {
         let source = "#!/bin/bash\nfor ((++i; j < 3; k--)); do :; done\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -96,6 +96,23 @@ mod tests {
     }
 
     #[test]
+    fn anchors_on_update_operators_inside_heredoc_parameter_command_substitutions() {
+        let source = "#!/bin/sh\ncat <<EOF\n${value:-$(printf '%s' \"$((i++))\")}\nEOF\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["++"]
+        );
+    }
+
+    #[test]
     fn anchors_on_update_operators_inside_assignment_target_subscripts() {
         let source = "#!/bin/sh\narr[i++]=x\narr[--j]=y\n";
         let diagnostics = test_snippet(
@@ -132,6 +149,17 @@ mod tests {
     #[test]
     fn ignores_associative_array_keys_that_look_like_updates() {
         let source = "#!/bin/sh\nlocal -A tools=([c++]=CXX)\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_associative_assignment_target_subscripts_that_look_like_updates() {
+        let source = "#!/bin/sh\nlocal -A tools[c++]=CXX\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -180,6 +180,17 @@ mod tests {
     }
 
     #[test]
+    fn ignores_contextual_associative_reference_subscripts_that_look_like_updates() {
+        let source = "#!/bin/sh\ndeclare -A tools\necho \"${tools[c++]}\"\n[[ ${tools[d--]} ]]\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_bash_scripts() {
         let source = "#!/bin/bash\nfor ((++i; j < 3; k--)); do :; done\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -130,6 +130,23 @@ mod tests {
     }
 
     #[test]
+    fn anchors_on_update_operators_inside_compound_assignment_key_words() {
+        let source = "#!/bin/sh\narr=([$((i++))]=x [$(printf '%s' \"$((j--))\")]=y)\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["++", "--"]
+        );
+    }
+
+    #[test]
     fn anchors_on_update_operators_inside_double_bracket_operands() {
         let source = "#!/bin/sh\n[[ \"$((i++))\" -gt 0 && \"$((j--))\" -lt 3 ]]\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -79,6 +79,23 @@ mod tests {
     }
 
     #[test]
+    fn anchors_on_update_operators_inside_expanding_heredoc_bodies() {
+        let source = "#!/bin/sh\ncat <<EOF\n$((++i))\n$(printf '%s' \"$((j--))\")\nEOF\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["++", "--"]
+        );
+    }
+
+    #[test]
     fn ignores_associative_array_keys_that_look_like_updates() {
         let source = "#!/bin/sh\nlocal -A tools=([c++]=CXX)\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -169,6 +169,17 @@ mod tests {
     }
 
     #[test]
+    fn ignores_contextual_associative_assignment_target_subscripts_that_look_like_updates() {
+        let source = "#!/bin/sh\ndeclare -A tools\ntools[c++]=CXX\ntools=([d--]=DASH)\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_bash_scripts() {
         let source = "#!/bin/bash\nfor ((++i; j < 3; k--)); do :; done\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -8,7 +8,7 @@ impl Violation for CStyleForArithmeticInSh {
     }
 
     fn message(&self) -> String {
-        "C-style `for ((...))` arithmetic operators are not portable in `sh` scripts".to_owned()
+        "arithmetic `++` and `--` operators are not portable in `sh` scripts".to_owned()
     }
 }
 
@@ -17,10 +17,7 @@ pub fn c_style_for_arithmetic_in_sh(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
-        .facts()
-        .arithmetic_for_update_operator_spans()
-        .to_vec();
+    let spans = checker.facts().arithmetic_update_operator_spans().to_vec();
 
     checker.report_all(spans, || CStyleForArithmeticInSh);
 }
@@ -45,6 +42,51 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["++", "--"]
         );
+    }
+
+    #[test]
+    fn anchors_on_update_operators_inside_standalone_arithmetic() {
+        let source = "#!/bin/sh\n((++i))\n((j--))\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["++", "--"]
+        );
+    }
+
+    #[test]
+    fn anchors_on_update_operators_inside_arithmetic_expansions() {
+        let source = "#!/bin/sh\necho \"$((++i)) $((j--))\"\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["++", "--"]
+        );
+    }
+
+    #[test]
+    fn ignores_associative_array_keys_that_look_like_updates() {
+        let source = "#!/bin/sh\nlocal -A tools=([c++]=CXX)\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+        );
+
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X062_X062.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X062_X062.sh.snap
@@ -1,9 +1,20 @@
 ---
 source: crates/shuck-linter/src/rules/portability/mod.rs
-assertion_line: 106
 ---
-X062 C-style `for ((...))` arithmetic operators are not portable in `sh` scripts
+X062 arithmetic `++` and `--` operators are not portable in `sh` scripts
  --> <source>:3:22
   |
 3 | for ((i = 0; i < 3; i++)); do echo "$i"; done
+  |
+
+X062 arithmetic `++` and `--` operators are not portable in `sh` scripts
+ --> <source>:4:3
+  |
+4 | ((++count))
+  |
+
+X062 arithmetic `++` and `--` operators are not portable in `sh` scripts
+ --> <source>:5:15
+  |
+5 | echo "$((items--))"
   |

--- a/docs/rules/X062.yaml
+++ b/docs/rules/X062.yaml
@@ -8,10 +8,10 @@ shellcheck_level: warning
 shells:
   - sh
   - dash
-description: A C-style for loop with arithmetic uses bashism syntax in POSIX sh.
-rationale: Use a while loop for portable iteration.
+description: Bash-style arithmetic increment and decrement operators are used in POSIX sh.
+rationale: Use explicit arithmetic assignments for `++` and `--`, and rewrite `for ((...))` loops when you need a portable iteration construct.
 safe_fix: false
-fix_description: Rewrite the C-style loop as a `while` loop and spell each reported `++` or `--` as an explicit arithmetic assignment.
+fix_description: Replace each reported `++` or `--` with an explicit arithmetic assignment, and rewrite `for ((...))` loops into a portable `while` form when needed.
 source:
   shell_checks_rule: rules/SH-269.yaml
   shell_checks_example: examples/269.sh


### PR DESCRIPTION
## Summary
- broaden X062 so it reports non-portable `++` and `--` operators across `sh` arithmetic contexts, including arithmetic commands and arithmetic expansions
- keep associative array keys from being misclassified as arithmetic updates
- remove the X062 reviewed divergence metadata and refresh the rule docs and snapshots

## Testing
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X062` (targeted X062 diff is clean: `implementation_diffs=0`, `reviewed_divergences=0`; the run still ends nonzero because of 5 pre-existing unrelated harness failures)
