### PR TITLE
refactor(ast): centralize static word text helper

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1886,6 +1886,12 @@ impl Word {
         self.parts.iter().any(|part| part.kind.is_quoted())
     }
 
+    /// Returns this word's fully static decoded text when it contains no
+    /// runtime expansions.
+    pub fn try_static_text<'a>(&'a self, source: &'a str) -> Option<Cow<'a, str>> {
+        try_static_word_parts_text(&self.parts, source)
+    }
+
     /// Render this word using exact source slices when available and owned cooked
     /// text only where the parser normalized the input.
     pub fn render(&self, source: &str) -> String {
@@ -1946,6 +1952,46 @@ impl fmt::Display for Word {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_with_source_mode(f, None, RenderMode::Decoded)
     }
+}
+
+/// Returns fully static decoded text for a contiguous slice of word parts when
+/// the slice contains no runtime expansions.
+pub fn try_static_word_parts_text<'a>(
+    parts: &'a [WordPartNode],
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    if let [part] = parts {
+        return try_static_word_part_text(part, source);
+    }
+
+    let mut result = String::new();
+    collect_static_word_parts_text(parts, source, &mut result).then_some(Cow::Owned(result))
+}
+
+fn try_static_word_part_text<'a>(part: &'a WordPartNode, source: &'a str) -> Option<Cow<'a, str>> {
+    match &part.kind {
+        WordPart::Literal(text) => Some(Cow::Borrowed(text.as_str(source, part.span))),
+        WordPart::SingleQuoted { value, .. } => Some(Cow::Borrowed(value.slice(source))),
+        WordPart::DoubleQuoted { parts, .. } => try_static_word_parts_text(parts, source),
+        _ => None,
+    }
+}
+
+fn collect_static_word_parts_text(parts: &[WordPartNode], source: &str, out: &mut String) -> bool {
+    for part in parts {
+        match &part.kind {
+            WordPart::Literal(text) => out.push_str(text.as_str(source, part.span)),
+            WordPart::SingleQuoted { value, .. } => out.push_str(value.slice(source)),
+            WordPart::DoubleQuoted { parts, .. } => {
+                if !collect_static_word_parts_text(parts, source, out) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+
+    true
 }
 
 /// Whether a heredoc body expands shell syntax.
@@ -3446,6 +3492,8 @@ pub enum AssignmentValue {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::*;
 
     fn word(parts: Vec<WordPart>) -> Word {
@@ -3564,6 +3612,56 @@ mod tests {
 
     fn simple_stmt(name: &str, args: Vec<Word>) -> Stmt {
         stmt(Command::Simple(simple_command(name, args)))
+    }
+
+    #[test]
+    fn word_try_static_text_borrows_simple_static_words() {
+        assert!(matches!(
+            Word::literal("plain").try_static_text(""),
+            Some(Cow::Borrowed("plain"))
+        ));
+
+        let single_quoted = word(vec![WordPart::SingleQuoted {
+            value: "single".into(),
+            dollar: false,
+        }]);
+        assert!(matches!(
+            single_quoted.try_static_text(""),
+            Some(Cow::Borrowed("single"))
+        ));
+    }
+
+    #[test]
+    fn word_try_static_text_concatenates_nested_static_parts() {
+        let span = Span::new();
+        let word = Word {
+            parts: vec![
+                WordPartNode::new(WordPart::Literal(LiteralText::owned("foo")), span),
+                WordPartNode::new(
+                    WordPart::DoubleQuoted {
+                        parts: vec![WordPartNode::new(
+                            WordPart::Literal(LiteralText::owned("bar")),
+                            span,
+                        )],
+                        dollar: false,
+                    },
+                    span,
+                ),
+            ],
+            span,
+            brace_syntax: Vec::new(),
+        };
+
+        assert!(matches!(
+            word.try_static_text(""),
+            Some(Cow::Owned(ref value)) if value == "foobar"
+        ));
+    }
+
+    #[test]
+    fn word_try_static_text_rejects_runtime_expansions() {
+        let variable = word(vec![WordPart::Variable("name".into())]);
+        assert!(variable.try_static_text("").is_none());
     }
 
     fn span_for_source(source: &str) -> Span {

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -1016,14 +1016,7 @@ mod tests {
     }
 
     fn static_word_text(word: &Word, source: &str) -> Option<String> {
-        let mut result = String::new();
-        for (part, span) in word.parts_with_spans() {
-            match part {
-                WordPart::Literal(text) => result.push_str(text.as_str(source, span)),
-                _ => return None,
-            }
-        }
-        Some(result)
+        word.try_static_text(source).map(|text| text.into_owned())
     }
 
     fn parameter_access_reference(word: &Word) -> &VarRef {

--- a/crates/shuck-linter/src/rules/common/word.rs
+++ b/crates/shuck-linter/src/rules/common/word.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use shuck_ast::{
     ArithmeticExpr, BourneParameterExpansion, Command, CompoundCommand, ConditionalBinaryOp,
-    ConditionalExpr, Pattern, PatternPart, Word, WordPart, WordPartNode,
+    ConditionalExpr, Pattern, PatternPart, Word, WordPart,
 };
 use shuck_parser::parser::Parser;
 
@@ -63,7 +63,7 @@ impl TestOperandClass {
 }
 
 pub fn static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
-    static_word_parts_text(&word.parts, source)
+    word.try_static_text(source)
 }
 
 pub fn is_shell_variable_name(name: &str) -> bool {
@@ -234,41 +234,6 @@ pub(crate) fn classify_contextual_operand(
     } else {
         TestOperandClass::FixedLiteral
     }
-}
-
-fn static_word_parts_text<'a>(parts: &'a [WordPartNode], source: &'a str) -> Option<Cow<'a, str>> {
-    if let [part] = parts {
-        return static_word_part_text(part, source);
-    }
-
-    let mut result = String::new();
-    collect_static_word_text(parts, source, &mut result).then_some(Cow::Owned(result))
-}
-
-fn static_word_part_text<'a>(part: &'a WordPartNode, source: &'a str) -> Option<Cow<'a, str>> {
-    match &part.kind {
-        WordPart::Literal(text) => Some(Cow::Borrowed(text.as_str(source, part.span))),
-        WordPart::SingleQuoted { value, .. } => Some(Cow::Borrowed(value.slice(source))),
-        WordPart::DoubleQuoted { parts, .. } => static_word_parts_text(parts, source),
-        _ => None,
-    }
-}
-
-fn collect_static_word_text(parts: &[WordPartNode], source: &str, out: &mut String) -> bool {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(text) => out.push_str(text.as_str(source, part.span)),
-            WordPart::SingleQuoted { value, .. } => out.push_str(value.slice(source)),
-            WordPart::DoubleQuoted { parts, .. } => {
-                if !collect_static_word_text(parts, source, out) {
-                    return false;
-                }
-            }
-            _ => return false,
-        }
-    }
-
-    true
 }
 
 pub(crate) fn classify_conditional_operand(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -9,6 +9,7 @@ use shuck_ast::{
     HeredocBodyPartNode, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
     PatternGroupKind, PatternPart, PatternPartNode, Span, Stmt, StmtSeq, Subscript, VarRef, Word,
     WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
+    try_static_word_parts_text,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::{ShellProfile, ZshEmulationMode};
@@ -3405,8 +3406,7 @@ fn static_command_name_text(word: &Word, source: &str) -> Option<String> {
 }
 
 fn static_word_text(word: &Word, source: &str) -> Option<String> {
-    let mut result = String::new();
-    collect_static_word_text(&word.parts, source, &mut result).then_some(result)
+    word.try_static_text(source).map(|text| text.into_owned())
 }
 
 #[derive(Clone, Copy)]
@@ -3832,23 +3832,6 @@ fn normalize_recorded_zsh_option_name(name: &str) -> Option<(String, bool)> {
     Some((normalized, false))
 }
 
-fn collect_static_word_text(parts: &[WordPartNode], source: &str, out: &mut String) -> bool {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(text) => out.push_str(text.as_str(source, part.span)),
-            WordPart::SingleQuoted { value, .. } => out.push_str(value.slice(source)),
-            WordPart::DoubleQuoted { parts, .. } => {
-                if !collect_static_word_text(parts, source, out) {
-                    return false;
-                }
-            }
-            _ => return false,
-        }
-    }
-
-    true
-}
-
 fn classify_dynamic_source_word(word: &Word, source: &str) -> SourceRefKind {
     let mut variable = None;
     let mut tail = String::new();
@@ -3940,8 +3923,7 @@ fn root_word_part_is_dynamic_root(part: &WordPart) -> bool {
 }
 
 fn static_parts_text(parts: &[WordPartNode], source: &str) -> Option<String> {
-    let mut result = String::new();
-    collect_static_word_text(parts, source, &mut result).then_some(result)
+    try_static_word_parts_text(parts, source).map(|text| text.into_owned())
 }
 
 fn static_tail_text_starts_with_slash(
@@ -3949,10 +3931,14 @@ fn static_tail_text_starts_with_slash(
     trailing: &[WordPartNode],
     source: &str,
 ) -> bool {
-    let mut result = String::new();
-    collect_static_word_text(parts, source, &mut result)
-        && collect_static_word_text(trailing, source, &mut result)
-        && result.starts_with('/')
+    let Some(prefix) = try_static_word_parts_text(parts, source) else {
+        return false;
+    };
+    if !prefix.is_empty() {
+        return prefix.starts_with('/');
+    }
+
+    try_static_word_parts_text(trailing, source).is_some_and(|text| text.starts_with('/'))
 }
 
 fn unset_flags_are_valid(flags: &str) -> bool {

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1245,25 +1245,7 @@ fn scope_members_excluding_functions(scopes: &[crate::Scope], root: ScopeId) -> 
 }
 
 fn static_word_text(word: &Word, source: &str) -> Option<String> {
-    let mut result = String::new();
-    collect_static_word_text(&word.parts, source, &mut result).then_some(result)
-}
-
-fn collect_static_word_text(parts: &[WordPartNode], source: &str, out: &mut String) -> bool {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(text) => out.push_str(text.as_str(source, part.span)),
-            WordPart::SingleQuoted { value, .. } => out.push_str(value.slice(source)),
-            WordPart::DoubleQuoted { parts, .. } => {
-                if !collect_static_word_text(parts, source, out) {
-                    return false;
-                }
-            }
-            _ => return false,
-        }
-    }
-
-    true
+    word.try_static_text(source).map(|text| text.into_owned())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add `Word::try_static_text` and a shared `try_static_word_parts_text` helper in `shuck-ast` for expansion-free decoded word text.
- Replace duplicated linter and semantic static-word walkers with calls into the AST-owned helper.
- Add AST-level tests for borrowed static text, nested static concatenation, and runtime-expansion rejection.

## Why

Static word text extraction is a syntax-level AST query, but the logic had been duplicated across the linter and semantic crates. Centralizing it keeps the behavior consistent and removes rule/common ownership of this generic AST operation.

## Validation

- `cargo fmt --all`
- `cargo test -p shuck-ast -p shuck-semantic -p shuck-linter`