### PR TITLE
fix(linter): eliminate S001 shellcheck divergences

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -509,6 +509,19 @@ impl<'a> LinterFactsBuilder<'a> {
             assignment_scope_spans: env_prefix_assignment_scope_spans,
             expansion_scope_spans: env_prefix_expansion_scope_spans,
         } = build_env_prefix_scope_spans(self.source, &commands);
+        word_occurrences.extend(pending_arithmetic_word_occurrences.into_iter().map(
+            |pending| WordOccurrence {
+                node_id: pending.node_id,
+                command_id: pending.command_id,
+                nested_word_command: pending.nested_word_command,
+                context: WordFactContext::ArithmeticCommand,
+                host_kind: pending.host_kind,
+                runtime_literal: RuntimeLiteralAnalysis::default(),
+                operand_class: None,
+                enclosing_expansion_context: Some(pending.enclosing_expansion_context),
+                array_assignment_split_scalar_expansion_spans: OnceCell::new(),
+            },
+        ));
         let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
         let mut word_occurrence_ids_by_command =
             vec![SmallVec::<[WordOccurrenceId; 4]>::new(); commands.len()];
@@ -561,21 +574,6 @@ impl<'a> LinterFactsBuilder<'a> {
         );
         let command_parent_ids = build_command_parent_ids(&commands);
         let command_dominance_barrier_flags = build_command_dominance_barrier_flags(&commands);
-        word_occurrences.extend(
-            pending_arithmetic_word_occurrences
-                .into_iter()
-                .map(|pending| WordOccurrence {
-                    node_id: pending.node_id,
-                    command_id: pending.command_id,
-                    nested_word_command: pending.nested_word_command,
-                    context: WordFactContext::ArithmeticCommand,
-                    host_kind: pending.host_kind,
-                    runtime_literal: RuntimeLiteralAnalysis::default(),
-                    operand_class: None,
-                    enclosing_expansion_context: Some(pending.enclosing_expansion_context),
-                    array_assignment_split_scalar_expansion_spans: OnceCell::new(),
-                }),
-        );
 
         LinterFacts {
             source,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -60,6 +60,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut word_nodes = Vec::new();
         let mut word_node_ids_by_span = FxHashMap::default();
         let mut word_occurrences = Vec::new();
+        let mut pending_arithmetic_word_occurrences = Vec::new();
         let mut compound_assignment_value_word_spans = FxHashSet::default();
         let mut array_assignment_split_word_ids = Vec::new();
         let mut assoc_binding_visibility_memo = FxHashMap::default();
@@ -144,6 +145,7 @@ impl<'a> LinterFactsBuilder<'a> {
                     word_nodes: &mut word_nodes,
                     word_node_ids_by_span: &mut word_node_ids_by_span,
                     word_occurrences: &mut word_occurrences,
+                    pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
                     compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
                     array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
                     assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
@@ -559,6 +561,21 @@ impl<'a> LinterFactsBuilder<'a> {
         );
         let command_parent_ids = build_command_parent_ids(&commands);
         let command_dominance_barrier_flags = build_command_dominance_barrier_flags(&commands);
+        word_occurrences.extend(
+            pending_arithmetic_word_occurrences
+                .into_iter()
+                .map(|pending| WordOccurrence {
+                    node_id: pending.node_id,
+                    command_id: pending.command_id,
+                    nested_word_command: pending.nested_word_command,
+                    context: WordFactContext::ArithmeticCommand,
+                    host_kind: pending.host_kind,
+                    runtime_literal: RuntimeLiteralAnalysis::default(),
+                    operand_class: None,
+                    enclosing_expansion_context: Some(pending.enclosing_expansion_context),
+                    array_assignment_split_scalar_expansion_spans: OnceCell::new(),
+                }),
+        );
 
         LinterFacts {
             source,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -169,7 +169,7 @@ fn build_function_cli_dispatch_facts(
         if case_subject_variable_name(&case_command.word) != Some("1") {
             continue;
         }
-        if !stmt_is_top_level_status_exit(trailing_exit_stmt) {
+        if !stmt_is_top_level_exit(trailing_exit_stmt) {
             continue;
         }
 
@@ -209,7 +209,7 @@ fn build_function_cli_dispatch_facts(
     facts
 }
 
-fn stmt_is_top_level_status_exit(stmt: &Stmt) -> bool {
+fn stmt_is_top_level_exit(stmt: &Stmt) -> bool {
     if stmt.negated || matches!(stmt.terminator, Some(StmtTerminator::Background(_))) {
         return false;
     }
@@ -224,10 +224,7 @@ fn stmt_is_top_level_status_exit(stmt: &Stmt) -> bool {
         return false;
     }
 
-    command
-        .code
-        .as_ref()
-        .is_some_and(word_is_standalone_status_capture)
+    true
 }
 
 fn build_function_parameter_fallback_spans(

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -322,6 +322,19 @@ impl<'a> LinterFacts<'a> {
                 self.word_occurrences
                     .iter()
                     .enumerate()
+                    .filter(|(_, occurrence)| occurrence.context != WordFactContext::ArithmeticCommand)
+                    .map(|(index, _)| self.word_occurrence_ref(WordOccurrenceId::new(index))),
+            ),
+        }
+    }
+
+    pub fn arithmetic_command_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
+        WordOccurrenceIter {
+            inner: Box::new(
+                self.word_occurrences
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, occurrence)| occurrence.context == WordFactContext::ArithmeticCommand)
                     .map(|(index, _)| self.word_occurrence_ref(WordOccurrenceId::new(index))),
             ),
         }

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -167,7 +167,7 @@ value=\"`greet`\"
 }
 
 #[test]
-fn function_cli_dispatch_facts_track_case_positional_entrypoints_with_top_level_exit_status() {
+fn function_cli_dispatch_facts_track_case_positional_entrypoints_with_top_level_exit() {
     let source = "\
 #!/bin/sh
 start() { echo hi; }
@@ -209,7 +209,38 @@ exit $?
 }
 
 #[test]
-fn function_cli_dispatch_facts_ignore_case_positional_entrypoints_without_top_level_exit_status() {
+fn function_cli_dispatch_facts_track_case_positional_entrypoints_with_literal_top_level_exit() {
+    let source = "\
+#!/bin/sh
+start() { echo hi; }
+case \"$1\" in
+  start) $1 ;;
+esac
+exit 0
+";
+
+    with_facts(source, None, |_, facts| {
+        let header = facts
+            .function_headers()
+            .iter()
+            .find(|header| {
+                header
+                    .static_name_entry()
+                    .is_some_and(|(candidate, _)| candidate == "start")
+            })
+            .expect("expected start header");
+        let scope = header.function_scope().expect("expected function scope");
+
+        assert!(
+            facts
+                .function_cli_dispatch_facts(scope)
+                .exported_from_case_cli()
+        );
+    });
+}
+
+#[test]
+fn function_cli_dispatch_facts_ignore_case_positional_entrypoints_without_top_level_exit() {
     let source = "\
 #!/bin/sh
 start() { echo hi; }

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1776,6 +1776,30 @@ fn indexes_pending_arithmetic_word_facts_by_span() {
 }
 
 #[test]
+fn indexes_arithmetic_word_facts_inside_parameter_replacement_operands() {
+    let source = "#!/bin/bash\nprintf '%s\\n' \"${value/foo/$(( $name + 1 ))}\"\n";
+
+    with_facts(source, None, |_, facts| {
+        let arithmetic = facts
+            .arithmetic_command_word_facts()
+            .find(|fact| fact.span().slice(source) == "$name")
+            .expect("expected arithmetic word fact");
+
+        assert!(arithmetic.is_arithmetic_command());
+        assert_eq!(
+            arithmetic.host_expansion_context(),
+            Some(ExpansionContext::CommandArgument)
+        );
+        assert_eq!(
+            facts
+                .word_fact(arithmetic.span(), arithmetic.context())
+                .map(|fact| fact.span().slice(source)),
+            Some("$name")
+        );
+    });
+}
+
+#[test]
 fn ignores_dynamic_and_compound_subscript_parameter_accesses_in_arithmetic() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1750,6 +1750,32 @@ fn ignores_quoted_dollar_words_in_arithmetic_command_contexts() {
 }
 
 #[test]
+fn indexes_pending_arithmetic_word_facts_by_span() {
+    let source = "#!/bin/bash\nprintf '%s\\n' $(( $name + 1 ))\n";
+
+    with_facts(source, None, |_, facts| {
+        let arithmetic = facts
+            .arithmetic_command_word_facts()
+            .find(|fact| fact.span().slice(source) == "$name")
+            .expect("expected arithmetic word fact");
+
+        assert!(arithmetic.is_arithmetic_command());
+        assert_eq!(
+            facts
+                .word_fact(arithmetic.span(), arithmetic.context())
+                .map(|fact| fact.span().slice(source)),
+            Some("$name")
+        );
+        assert_eq!(
+            facts
+                .any_word_fact(arithmetic.span())
+                .map(|fact| fact.span().slice(source)),
+            Some("$name")
+        );
+    });
+}
+
+#[test]
 fn ignores_dynamic_and_compound_subscript_parameter_accesses_in_arithmetic() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1800,6 +1800,27 @@ fn indexes_arithmetic_word_facts_inside_parameter_replacement_operands() {
 }
 
 #[test]
+fn indexes_arithmetic_word_facts_inside_parameter_default_operands() {
+    let source = "\
+#!/bin/bash
+printf '%s\\n' \"${value:-$(( $default + 1 ))}\" \"${value:=$(( $assign + 1 ))}\" \"${value:+$(( $replace + 1 ))}\" \"${value:?$(( $error + 1 ))}\"
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .arithmetic_command_word_facts()
+            .map(|fact| fact.span().slice(source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(spans, vec!["$default", "$assign", "$replace", "$error"]);
+        assert!(facts.arithmetic_command_word_facts().all(|fact| {
+            fact.host_expansion_context() == Some(ExpansionContext::CommandArgument)
+                && facts.word_fact(fact.span(), fact.context()).is_some()
+        }));
+    });
+}
+
+#[test]
 fn ignores_dynamic_and_compound_subscript_parameter_accesses_in_arithmetic() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -178,6 +178,7 @@ pub struct WordOccurrence {
     host_kind: WordFactHostKind,
     runtime_literal: RuntimeLiteralAnalysis,
     operand_class: Option<TestOperandClass>,
+    enclosing_expansion_context: Option<ExpansionContext>,
     array_assignment_split_scalar_expansion_spans: OnceCell<Box<[Span]>>,
 }
 
@@ -252,6 +253,11 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
             WordFactContext::CaseSubject => None,
             WordFactContext::ArithmeticCommand => None,
         }
+    }
+
+    pub fn host_expansion_context(self) -> Option<ExpansionContext> {
+        self.expansion_context()
+            .or(self.occurrence().enclosing_expansion_context)
     }
 
     pub fn is_case_subject(self) -> bool {
@@ -1765,6 +1771,7 @@ struct WordFactOutputs<'out, 'a> {
     word_nodes: &'out mut Vec<WordNode<'a>>,
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
+    pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
@@ -1772,6 +1779,14 @@ struct WordFactOutputs<'out, 'a> {
     pattern_literal_spans: &'out mut Vec<Span>,
     arithmetic: &'out mut ArithmeticFactSummary,
     surface: &'out mut SurfaceFragmentSink<'a>,
+}
+
+struct PendingArithmeticWordOccurrence {
+    node_id: WordNodeId,
+    command_id: CommandId,
+    nested_word_command: bool,
+    host_kind: WordFactHostKind,
+    enclosing_expansion_context: ExpansionContext,
 }
 
 fn derive_word_fact_data(word: &Word, source: &str) -> WordNodeDerived {
@@ -1853,9 +1868,11 @@ struct WordFactCollector<'out, 'a, 'norm> {
     word_nodes: &'out mut Vec<WordNode<'a>>,
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
+    pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     seen: FxHashSet<(FactSpan, WordFactContext, WordFactHostKind)>,
+    seen_pending_arithmetic: FxHashSet<(FactSpan, ExpansionContext, WordFactHostKind)>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pattern_literal_spans: &'out mut Vec<Span>,
@@ -1883,9 +1900,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             word_nodes: outputs.word_nodes,
             word_node_ids_by_span: outputs.word_node_ids_by_span,
             word_occurrences: outputs.word_occurrences,
+            pending_arithmetic_word_occurrences: outputs.pending_arithmetic_word_occurrences,
             array_assignment_split_word_ids: outputs.array_assignment_split_word_ids,
             assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
             seen: FxHashSet::default(),
+            seen_pending_arithmetic: FxHashSet::default(),
             compound_assignment_value_word_spans: outputs.compound_assignment_value_word_spans,
             case_pattern_expansions: outputs.case_pattern_expansions,
             pattern_literal_spans: outputs.pattern_literal_spans,
@@ -2756,9 +2775,116 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             host_kind,
             runtime_literal,
             operand_class,
+            enclosing_expansion_context: None,
             array_assignment_split_scalar_expansion_spans: OnceCell::new(),
         });
+        if let WordFactContext::Expansion(enclosing_expansion_context) = context {
+            self.collect_pending_arithmetic_word_occurrences(
+                word,
+                enclosing_expansion_context,
+                host_kind,
+            );
+        }
         (Some(id), opened_double_quote)
+    }
+
+    fn collect_pending_arithmetic_word_occurrences(
+        &mut self,
+        word: &'a Word,
+        enclosing_expansion_context: ExpansionContext,
+        host_kind: WordFactHostKind,
+    ) {
+        self.collect_pending_arithmetic_word_occurrences_in_parts(
+            &word.parts,
+            enclosing_expansion_context,
+            host_kind,
+        );
+    }
+
+    fn collect_pending_arithmetic_word_occurrences_in_parts(
+        &mut self,
+        parts: &'a [WordPartNode],
+        enclosing_expansion_context: ExpansionContext,
+        host_kind: WordFactHostKind,
+    ) {
+        for part in parts {
+            match &part.kind {
+                WordPart::DoubleQuoted { parts, .. } => self
+                    .collect_pending_arithmetic_word_occurrences_in_parts(
+                        parts,
+                        enclosing_expansion_context,
+                        host_kind,
+                    ),
+                WordPart::ArithmeticExpansion {
+                    expression_ast,
+                    expression_word_ast,
+                    ..
+                } => {
+                    if let Some(expression) = expression_ast.as_ref() {
+                        query::visit_arithmetic_words(expression, &mut |word| {
+                            self.push_pending_arithmetic_word_occurrence(
+                                word,
+                                enclosing_expansion_context,
+                                host_kind,
+                            );
+                        });
+                    } else {
+                        self.push_pending_arithmetic_word_occurrence(
+                            expression_word_ast,
+                            enclosing_expansion_context,
+                            host_kind,
+                        );
+                    }
+                }
+                WordPart::Literal(_)
+                | WordPart::SingleQuoted { .. }
+                | WordPart::Variable(_)
+                | WordPart::Parameter(_)
+                | WordPart::CommandSubstitution { .. }
+                | WordPart::ParameterExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayAccess(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::ArrayIndices(_)
+                | WordPart::Substring { .. }
+                | WordPart::ArraySlice { .. }
+                | WordPart::IndirectExpansion { .. }
+                | WordPart::PrefixMatch { .. }
+                | WordPart::ProcessSubstitution { .. }
+                | WordPart::Transformation { .. }
+                | WordPart::ZshQualifiedGlob(_) => {}
+            }
+        }
+    }
+
+    fn push_pending_arithmetic_word_occurrence(
+        &mut self,
+        word: &'a Word,
+        enclosing_expansion_context: ExpansionContext,
+        host_kind: WordFactHostKind,
+    ) {
+        let key = FactSpan::new(word.span);
+        if !self
+            .seen_pending_arithmetic
+            .insert((key, enclosing_expansion_context, host_kind))
+        {
+            return;
+        }
+
+        let node_id = self.intern_word_node(word);
+        self.pending_arithmetic_word_occurrences
+            .push(PendingArithmeticWordOccurrence {
+                node_id,
+                command_id: self.command_id,
+                nested_word_command: self.nested_word_command,
+                host_kind,
+                enclosing_expansion_context,
+            });
+        self.collect_pending_arithmetic_word_occurrences(
+            word,
+            enclosing_expansion_context,
+            host_kind,
+        );
     }
 
     fn collect_arithmetic_summary(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2845,12 +2845,18 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         enclosing_expansion_context,
                         host_kind,
                     ),
-                WordPart::ParameterExpansion { operator, .. }
+                WordPart::ParameterExpansion {
+                    operator,
+                    operand_word_ast,
+                    ..
+                }
                 | WordPart::IndirectExpansion {
                     operator: Some(operator),
+                    operand_word_ast,
                     ..
                 } => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
                     operator,
+                    operand_word_ast.as_ref(),
                     enclosing_expansion_context,
                     host_kind,
                 ),
@@ -2881,13 +2887,19 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     ) {
         match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(
-                BourneParameterExpansion::Operation { operator, .. }
+                BourneParameterExpansion::Operation {
+                    operator,
+                    operand_word_ast,
+                    ..
+                }
                 | BourneParameterExpansion::Indirect {
                     operator: Some(operator),
+                    operand_word_ast,
                     ..
                 },
             ) => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
                 operator,
+                operand_word_ast.as_ref(),
                 enclosing_expansion_context,
                 host_kind,
             ),
@@ -2917,6 +2929,16 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 }
 
                 if let Some(operation) = syntax.operation.as_ref()
+                    && let Some(operand_word) = operation.operand_word_ast()
+                {
+                    self.collect_pending_arithmetic_word_occurrences(
+                        operand_word,
+                        enclosing_expansion_context,
+                        host_kind,
+                    );
+                }
+
+                if let Some(operation) = syntax.operation.as_ref()
                     && let Some(replacement_word) = operation.replacement_word_ast()
                 {
                     self.collect_pending_arithmetic_word_occurrences(
@@ -2932,9 +2954,25 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     fn collect_pending_arithmetic_word_occurrences_in_parameter_operator(
         &mut self,
         operator: &'a ParameterOp,
+        operand_word_ast: Option<&'a Word>,
         enclosing_expansion_context: ExpansionContext,
         host_kind: WordFactHostKind,
     ) {
+        if matches!(
+            operator,
+            ParameterOp::UseDefault
+                | ParameterOp::AssignDefault
+                | ParameterOp::UseReplacement
+                | ParameterOp::Error
+        ) && let Some(operand_word) = operand_word_ast
+        {
+            self.collect_pending_arithmetic_word_occurrences(
+                operand_word,
+                enclosing_expansion_context,
+                host_kind,
+            );
+        }
+
         if let Some(replacement_word) = operator.replacement_word_ast() {
             self.collect_pending_arithmetic_word_occurrences(
                 replacement_word,

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2839,24 +2839,108 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         );
                     }
                 }
+                WordPart::Parameter(parameter) => self
+                    .collect_pending_arithmetic_word_occurrences_in_parameter_expansion(
+                        parameter,
+                        enclosing_expansion_context,
+                        host_kind,
+                    ),
+                WordPart::ParameterExpansion { operator, .. }
+                | WordPart::IndirectExpansion {
+                    operator: Some(operator),
+                    ..
+                } => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
+                    operator,
+                    enclosing_expansion_context,
+                    host_kind,
+                ),
                 WordPart::Literal(_)
                 | WordPart::SingleQuoted { .. }
                 | WordPart::Variable(_)
-                | WordPart::Parameter(_)
                 | WordPart::CommandSubstitution { .. }
-                | WordPart::ParameterExpansion { .. }
                 | WordPart::Length(_)
                 | WordPart::ArrayAccess(_)
                 | WordPart::ArrayLength(_)
                 | WordPart::ArrayIndices(_)
                 | WordPart::Substring { .. }
                 | WordPart::ArraySlice { .. }
-                | WordPart::IndirectExpansion { .. }
+                | WordPart::IndirectExpansion { operator: None, .. }
                 | WordPart::PrefixMatch { .. }
                 | WordPart::ProcessSubstitution { .. }
                 | WordPart::Transformation { .. }
                 | WordPart::ZshQualifiedGlob(_) => {}
             }
+        }
+    }
+
+    fn collect_pending_arithmetic_word_occurrences_in_parameter_expansion(
+        &mut self,
+        parameter: &'a ParameterExpansion,
+        enclosing_expansion_context: ExpansionContext,
+        host_kind: WordFactHostKind,
+    ) {
+        match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(
+                BourneParameterExpansion::Operation { operator, .. }
+                | BourneParameterExpansion::Indirect {
+                    operator: Some(operator),
+                    ..
+                },
+            ) => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
+                operator,
+                enclosing_expansion_context,
+                host_kind,
+            ),
+            ParameterExpansionSyntax::Bourne(
+                BourneParameterExpansion::Access { .. }
+                | BourneParameterExpansion::Length { .. }
+                | BourneParameterExpansion::Indices { .. }
+                | BourneParameterExpansion::Indirect { operator: None, .. }
+                | BourneParameterExpansion::PrefixMatch { .. }
+                | BourneParameterExpansion::Slice { .. }
+                | BourneParameterExpansion::Transformation { .. },
+            ) => {}
+            ParameterExpansionSyntax::Zsh(syntax) => {
+                match &syntax.target {
+                    ZshExpansionTarget::Nested(parameter) => self
+                        .collect_pending_arithmetic_word_occurrences_in_parameter_expansion(
+                            parameter,
+                            enclosing_expansion_context,
+                            host_kind,
+                        ),
+                    ZshExpansionTarget::Word(word) => self.collect_pending_arithmetic_word_occurrences(
+                        word,
+                        enclosing_expansion_context,
+                        host_kind,
+                    ),
+                    ZshExpansionTarget::Reference(_) | ZshExpansionTarget::Empty => {}
+                }
+
+                if let Some(operation) = syntax.operation.as_ref()
+                    && let Some(replacement_word) = operation.replacement_word_ast()
+                {
+                    self.collect_pending_arithmetic_word_occurrences(
+                        replacement_word,
+                        enclosing_expansion_context,
+                        host_kind,
+                    );
+                }
+            }
+        }
+    }
+
+    fn collect_pending_arithmetic_word_occurrences_in_parameter_operator(
+        &mut self,
+        operator: &'a ParameterOp,
+        enclosing_expansion_context: ExpansionContext,
+        host_kind: WordFactHostKind,
+    ) {
+        if let Some(replacement_word) = operator.replacement_word_ast() {
+            self.collect_pending_arithmetic_word_occurrences(
+                replacement_word,
+                enclosing_expansion_context,
+                host_kind,
+            );
         }
     }
 

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1691,6 +1691,7 @@ pub(crate) fn benchmark_collect_word_facts(
     let mut word_nodes = Vec::new();
     let mut word_node_ids_by_span = FxHashMap::default();
     let mut word_occurrences = Vec::new();
+    let mut pending_arithmetic_word_occurrences = Vec::new();
     let mut compound_assignment_value_word_spans = FxHashSet::default();
     let mut array_assignment_split_word_ids = Vec::new();
     let mut assoc_binding_visibility_memo = FxHashMap::default();
@@ -1728,6 +1729,7 @@ pub(crate) fn benchmark_collect_word_facts(
                 word_nodes: &mut word_nodes,
                 word_node_ids_by_span: &mut word_node_ids_by_span,
                 word_occurrences: &mut word_occurrences,
+                pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
                 compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
                 array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
                 assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
@@ -1742,6 +1744,7 @@ pub(crate) fn benchmark_collect_word_facts(
     let surface_fragments = surface_fragments.finish();
 
     word_occurrences.len()
+        + pending_arithmetic_word_occurrences.len()
         + word_nodes.len()
         + compound_assignment_value_word_spans.len()
         + array_assignment_split_word_ids.len()

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -1244,7 +1244,7 @@ printf '%s\\n' \"${value/old/$(expr $(nproc) + 1)}\"\n\
                 let Command::Simple(command) = visit.command else {
                     return;
                 };
-                let Some(name) = static_word_text(&command.name, source) else {
+                let Some(name) = static_word_owned_text(&command.name, source) else {
                     return;
                 };
                 visits.push((name, context.nested_word_command));

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -775,14 +775,23 @@ fn collect_parameter_expansion_visits<'a, F>(
                 reference,
                 operand_word_ast,
                 ..
+            } => {
+                collect_var_ref_word_visits(reference, options, context, visitor);
+                if let Some(word) = operand_word_ast.as_ref() {
+                    collect_word_visits(word, options, context, visitor);
+                }
             }
-            | BourneParameterExpansion::Operation {
+            BourneParameterExpansion::Operation {
                 reference,
+                operator,
                 operand_word_ast,
                 ..
             } => {
                 collect_var_ref_word_visits(reference, options, context, visitor);
                 if let Some(word) = operand_word_ast.as_ref() {
+                    collect_word_visits(word, options, context, visitor);
+                }
+                if let Some(word) = operator.replacement_word_ast() {
                     collect_word_visits(word, options, context, visitor);
                 }
             }
@@ -1202,6 +1211,40 @@ printf '%s\\n' ${value:-$(expr $(nproc) + 1)}
                     return;
                 };
                 let Some(name) = static_word_owned_text(&command.name, source) else {
+                    return;
+                };
+                visits.push((name, context.nested_word_command));
+            },
+        );
+
+        assert_eq!(
+            visits,
+            vec![
+                ("printf".to_owned(), false),
+                ("expr".to_owned(), true),
+                ("nproc".to_owned(), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn walk_commands_descends_into_parameter_replacement_words() {
+        let source = "\
+printf '%s\\n' \"${value/old/$(expr $(nproc) + 1)}\"\n\
+";
+        let commands = parse_commands(source);
+        let mut visits = Vec::new();
+
+        walk_commands(
+            &commands,
+            CommandWalkOptions {
+                descend_nested_word_commands: true,
+            },
+            &mut |visit, context| {
+                let Command::Simple(command) = visit.command else {
+                    return;
+                };
+                let Some(name) = static_word_text(&command.name, source) else {
                     return;
                 };
                 visits.push((name, context.nested_word_command));

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -70,10 +70,11 @@ pub struct SafeValueIndex<'a> {
     analysis: &'a SemanticAnalysis<'a>,
     facts: &'a LinterFacts<'a>,
     source: &'a str,
+    case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
     definite_uninitialized_refs: FxHashSet<FactSpan>,
     maybe_uninitialized_refs: FxHashSet<FactSpan>,
-    memo: FxHashMap<(FactSpan, SafeValueQuery, Option<ScopeId>), bool>,
-    visiting: FxHashSet<(FactSpan, SafeValueQuery, Option<ScopeId>)>,
+    memo: FxHashMap<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>), bool>,
+    visiting: FxHashSet<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>)>,
     helper_binding_memo: FxHashMap<(Name, ScopeId, FactSpan), Box<[BindingId]>>,
     helper_binding_visiting: FxHashSet<(Name, ScopeId, FactSpan)>,
 }
@@ -97,12 +98,15 @@ impl<'a> SafeValueIndex<'a> {
             .filter(|uninitialized| uninitialized.certainty == UninitializedCertainty::Possible)
             .map(|uninitialized| FactSpan::new(semantic.reference(uninitialized.reference).span))
             .collect();
+        let case_cli_reachable_function_scopes =
+            build_case_cli_reachable_function_scopes(semantic, facts);
 
         Self {
             semantic,
             analysis,
             facts,
             source,
+            case_cli_reachable_function_scopes,
             definite_uninitialized_refs,
             maybe_uninitialized_refs,
             memo: FxHashMap::default(),
@@ -113,6 +117,9 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     pub fn part_is_safe(&mut self, part: &WordPart, span: Span, query: SafeValueQuery) -> bool {
+        if self.span_is_after_unconditional_inline_terminator(span) {
+            return false;
+        }
         match part {
             WordPart::ZshQualifiedGlob(_) => query == SafeValueQuery::Quoted,
             WordPart::Parameter(parameter) => self.parameter_part_is_safe(parameter, span, query),
@@ -168,6 +175,9 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     pub fn word_is_safe(&mut self, word: &Word, query: SafeValueQuery) -> bool {
+        if self.span_is_after_unconditional_inline_terminator(word.span) {
+            return false;
+        }
         let Some(analysis) = self
             .facts
             .any_word_fact(word.span)
@@ -190,6 +200,9 @@ impl<'a> SafeValueIndex<'a> {
         fact: crate::WordOccurrenceRef<'_, 'a>,
         query: SafeValueQuery,
     ) -> bool {
+        if self.span_is_after_unconditional_inline_terminator(fact.span()) {
+            return false;
+        }
         let analysis = fact.analysis();
         if query != SafeValueQuery::Quoted
             && (analysis.array_valued || analysis.hazards.command_or_process_substitution)
@@ -219,6 +232,9 @@ impl<'a> SafeValueIndex<'a> {
     fn name_is_safe(&mut self, name: &Name, at: Span, query: SafeValueQuery) -> bool {
         if safe_special_parameter(name) {
             return true;
+        }
+        if self.case_cli_reachable_call_path_keeps_argument_bindings_unsafe(at, query) {
+            return safe_numeric_shell_variable(name);
         }
 
         let mut bindings = self.safe_bindings_for_name(name, at);
@@ -264,6 +280,11 @@ impl<'a> SafeValueIndex<'a> {
         {
             return false;
         }
+        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+            && !self.helper_outer_bindings_cover_all_caller_paths(name, at, &bindings)
+        {
+            return false;
+        }
         if self
             .definite_uninitialized_refs
             .contains(&FactSpan::new(at))
@@ -292,7 +313,7 @@ impl<'a> SafeValueIndex<'a> {
 
         bindings
             .into_iter()
-            .all(|binding_id| self.binding_is_safe(binding_id, query, case_cli_scope))
+            .all(|binding_id| self.binding_is_safe(binding_id, at, query, case_cli_scope))
     }
 
     fn case_cli_dispatch_scope_at(&self, offset: usize) -> Option<ScopeId> {
@@ -307,6 +328,25 @@ impl<'a> SafeValueIndex<'a> {
 
     pub fn in_case_cli_dispatch_entrypoint(&self, offset: usize) -> bool {
         self.case_cli_dispatch_scope_at(offset).is_some()
+    }
+
+    fn case_cli_reachable_function_scope_at(&self, offset: usize) -> Option<ScopeId> {
+        let scope = self.enclosing_function_scope_at(offset)?;
+        self.case_cli_reachable_function_scopes
+            .contains(&scope)
+            .then_some(scope)
+    }
+
+    fn case_cli_reachable_call_path_keeps_argument_bindings_unsafe(
+        &self,
+        at: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+            && !self.span_is_within_command_name(at)
+            && self
+                .case_cli_reachable_function_scope_at(at.start.offset)
+                .is_some()
     }
 
     fn case_cli_dispatch_outer_bindings_can_stay_safe(
@@ -344,6 +384,14 @@ impl<'a> SafeValueIndex<'a> {
         })
     }
 
+    fn span_is_within_command_name(&self, at: Span) -> bool {
+        self.facts.commands().iter().any(|command| {
+            command
+                .body_name_word()
+                .is_some_and(|word| span_contains(word.span, at))
+        })
+    }
+
     fn binding_is_blocked_by_exit_like_function_call(
         &self,
         binding_id: BindingId,
@@ -376,6 +424,17 @@ impl<'a> SafeValueIndex<'a> {
                                         || call_span.end.offset <= binding.span.start.offset)
                             }
                     })
+        })
+    }
+
+    fn span_is_after_unconditional_inline_terminator(&self, at: Span) -> bool {
+        self.facts.commands().iter().any(|command| {
+            command.span().end.offset <= at.start.offset
+                && self.command_runs_in_unconditional_flow(command.id(), at)
+                && matches!(
+                    command.command(),
+                    Command::Builtin(BuiltinCommand::Exit(_) | BuiltinCommand::Return(_))
+                )
         })
     }
 
@@ -524,6 +583,7 @@ impl<'a> SafeValueIndex<'a> {
     fn binding_is_safe(
         &mut self,
         binding_id: BindingId,
+        at: Span,
         query: SafeValueQuery,
         case_cli_scope: Option<ScopeId>,
     ) -> bool {
@@ -535,7 +595,7 @@ impl<'a> SafeValueIndex<'a> {
             return true;
         }
 
-        let key = (binding_key, query, case_cli_scope);
+        let key = (binding_key, FactSpan::new(at), query, case_cli_scope);
         if let Some(result) = self.memo.get(&key) {
             return *result;
         }
@@ -564,8 +624,8 @@ impl<'a> SafeValueIndex<'a> {
                 }
             }
             BindingOrigin::LoopVariable {
+                definition_span,
                 items: LoopValueOrigin::StaticWords,
-                ..
             } => {
                 let words = self
                     .facts
@@ -574,6 +634,7 @@ impl<'a> SafeValueIndex<'a> {
                     .map(|words| words.to_vec());
                 words.is_some_and(|words| {
                     !words.is_empty()
+                        && self.loop_variable_reference_stays_within_body(*definition_span, at)
                         && words.into_iter().all(|word| {
                             !word_contains_special_parameter_slice(word)
                                 && self.word_is_safe(word, query)
@@ -603,6 +664,20 @@ impl<'a> SafeValueIndex<'a> {
         self.name_is_safe(&reference.name, at, query)
     }
 
+    fn loop_variable_reference_stays_within_body(&self, definition_span: Span, at: Span) -> bool {
+        self.facts.for_headers().iter().any(|header| {
+            header
+                .command()
+                .targets
+                .iter()
+                .any(|target| target.span == definition_span)
+                && span_contains(header.command().body.span, at)
+        }) || self.facts.select_headers().iter().any(|header| {
+            header.command().variable_span == definition_span
+                && span_contains(header.command().body.span, at)
+        })
+    }
+
     fn indirect_name_is_safe(
         &mut self,
         reference: &VarRef,
@@ -630,11 +705,29 @@ impl<'a> SafeValueIndex<'a> {
                 && targets
                     .iter()
                     .copied()
-                    .all(|target| self.binding_is_safe(target, query, case_cli_scope))
+                    .all(|target| self.binding_is_safe(target, at, query, case_cli_scope))
         })
     }
 
     fn safe_bindings_for_name(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
+        let mut bindings = self.visible_bindings_for_name_without_helpers(name, at);
+        let mut helper_bindings = self.called_helper_bindings_for_name(name, at);
+        helper_bindings.extend(self.top_level_transitive_helper_bindings_before(name, at));
+        helper_bindings
+            .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        helper_bindings.dedup();
+        if bindings.is_empty() {
+            bindings = helper_bindings;
+        } else if !helper_bindings.is_empty() {
+            bindings.extend(helper_bindings);
+            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings.dedup();
+        }
+
+        bindings
+    }
+
+    fn visible_bindings_for_name_without_helpers(&self, name: &Name, at: Span) -> Vec<BindingId> {
         let mut bindings = self.analysis.reaching_bindings_for_name(name, at);
         if bindings.len() == 1 {
             let mut expanded = self
@@ -648,14 +741,6 @@ impl<'a> SafeValueIndex<'a> {
                 bindings = expanded;
             }
         }
-        let helper_bindings = self.called_helper_bindings_for_name(name, at);
-        if bindings.is_empty() {
-            bindings = helper_bindings;
-        } else if !helper_bindings.is_empty() {
-            bindings.extend(helper_bindings);
-            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
-            bindings.dedup();
-        }
 
         bindings
     }
@@ -666,6 +751,25 @@ impl<'a> SafeValueIndex<'a> {
             .ancestor_scopes(self.semantic.scope_at(at.start.offset))
             .flat_map(|scope| self.called_helper_bindings_before(name, scope, at))
             .collect::<Vec<_>>();
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.dedup();
+        bindings
+    }
+
+    fn top_level_transitive_helper_bindings_before(&self, name: &Name, at: Span) -> Vec<BindingId> {
+        if self.enclosing_function_scope_at(at.start.offset).is_some() {
+            return Vec::new();
+        }
+
+        let mut bindings = Vec::new();
+        let mut seen_scopes = FxHashSet::default();
+        self.collect_transitive_helper_bindings_before(
+            name,
+            self.semantic.scope_at(at.start.offset),
+            at.start.offset,
+            &mut seen_scopes,
+            &mut bindings,
+        );
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         bindings.dedup();
         bindings
@@ -728,7 +832,7 @@ impl<'a> SafeValueIndex<'a> {
         for site in caller_sites {
             saw_caller = true;
             let branch = self
-                .called_helper_bindings_before(name, site.scope, site.span)
+                .caller_branch_bindings_before(name, site.scope, site.span)
                 .into_iter()
                 .collect::<FxHashSet<_>>();
             if branch.is_empty() {
@@ -738,6 +842,113 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         saw_caller.then_some(union)
+    }
+
+    fn helper_outer_bindings_cover_all_caller_paths(
+        &mut self,
+        name: &Name,
+        at: Span,
+        bindings: &[BindingId],
+    ) -> bool {
+        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+            return true;
+        };
+        if !bindings
+            .iter()
+            .copied()
+            .any(|binding_id| self.semantic.binding(binding_id).scope != helper_scope)
+        {
+            return true;
+        }
+
+        let caller_sites = self.named_function_call_sites(helper_scope);
+        if caller_sites.is_empty() {
+            return true;
+        }
+
+        caller_sites.into_iter().all(|(scope, span)| {
+            let branch = self.caller_branch_bindings_before(name, scope, span);
+            if branch.is_empty() {
+                return false;
+            }
+
+            let helper_branch = self
+                .called_helper_bindings_before(name, scope, span)
+                .into_iter()
+                .collect::<FxHashSet<_>>();
+            let direct_branch = branch
+                .into_iter()
+                .filter(|binding_id| !helper_branch.contains(binding_id))
+                .collect::<Vec<_>>();
+
+            direct_branch.is_empty()
+                || self.bindings_cover_all_paths_to_callsite(
+                    &direct_branch,
+                    self.command_for_name_word_span(span)
+                        .map_or(span, |command| command.span()),
+                )
+        })
+    }
+
+    fn named_function_call_sites(&self, scope: ScopeId) -> Vec<(ScopeId, Span)> {
+        let Some(function_kind) = self.named_function_kind(scope) else {
+            return Vec::new();
+        };
+
+        let mut caller_sites = Vec::new();
+        let mut seen_sites = FxHashSet::default();
+        for function_name in function_kind.static_names() {
+            for site in self.semantic.call_sites_for(function_name) {
+                if site.scope == scope {
+                    continue;
+                }
+                if seen_sites.insert((site.scope, site.span.start.offset, site.span.end.offset)) {
+                    caller_sites.push((site.scope, site.span));
+                }
+            }
+        }
+
+        caller_sites
+    }
+
+    fn caller_branch_bindings_before(
+        &mut self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> Vec<BindingId> {
+        let mut branch = self.visible_bindings_for_name_without_helpers(name, at);
+        branch.extend(self.caller_visible_bindings_before(name, scope, at));
+        branch.extend(self.called_helper_bindings_before(name, scope, at));
+        branch.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        branch.dedup();
+        branch
+    }
+
+    fn caller_visible_bindings_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> Vec<BindingId> {
+        let visible_scopes = self
+            .semantic
+            .ancestor_scopes(scope)
+            .collect::<FxHashSet<_>>();
+        let mut bindings = self
+            .semantic
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter(|binding_id| {
+                let binding = self.semantic.binding(*binding_id);
+                visible_scopes.contains(&binding.scope)
+                    && binding.span.end.offset <= at.start.offset
+            })
+            .collect::<Vec<_>>();
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.dedup();
+        bindings
     }
 
     fn helper_bindings_called_in_scope_before(
@@ -777,11 +988,97 @@ impl<'a> SafeValueIndex<'a> {
         bindings
     }
 
+    fn collect_transitive_helper_bindings_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        limit_offset: usize,
+        seen_scopes: &mut FxHashSet<ScopeId>,
+        bindings: &mut Vec<BindingId>,
+    ) {
+        for callee_scope in self.direct_called_function_scopes_before(scope, limit_offset) {
+            if !seen_scopes.insert(callee_scope) {
+                continue;
+            }
+
+            bindings.extend(self.semantic.bindings_for(name).iter().copied().filter(
+                |binding_id| {
+                    let binding = self.semantic.binding(*binding_id);
+                    binding.scope == callee_scope
+                        && !binding.attributes.contains(BindingAttributes::LOCAL)
+                },
+            ));
+
+            if let Some(limit_offset) = self.function_scope_end_offset(callee_scope) {
+                self.collect_transitive_helper_bindings_before(
+                    name,
+                    callee_scope,
+                    limit_offset,
+                    seen_scopes,
+                    bindings,
+                );
+            }
+        }
+    }
+
+    fn direct_called_function_scopes_before(
+        &self,
+        scope: ScopeId,
+        limit_offset: usize,
+    ) -> Vec<ScopeId> {
+        let mut scopes = Vec::new();
+        let mut seen_scopes = FxHashSet::default();
+
+        for header in self.facts.function_headers() {
+            let Some(callee_scope) = header.function_scope() else {
+                continue;
+            };
+            let Some(function_kind) = self.named_function_kind(callee_scope) else {
+                continue;
+            };
+            let Some(definition_command) = self.function_definition_command(header.function())
+            else {
+                continue;
+            };
+
+            let called_before = function_kind.static_names().iter().any(|function_name| {
+                self.semantic
+                    .call_sites_for(function_name)
+                    .iter()
+                    .any(|site| {
+                        site.scope == scope
+                            && self.call_site_dominates_offset(site.span, limit_offset)
+                            && self.definition_command_resolves_at_call(
+                                definition_command.id(),
+                                site.span,
+                            )
+                    })
+            });
+            if called_before && seen_scopes.insert(callee_scope) {
+                scopes.push(callee_scope);
+            }
+        }
+
+        scopes
+    }
+
+    fn function_scope_end_offset(&self, scope: ScopeId) -> Option<usize> {
+        self.facts
+            .function_headers()
+            .iter()
+            .find(|header| header.function_scope() == Some(scope))
+            .map(|header| header.function().span.end.offset)
+    }
+
     fn call_site_dominates_use(&self, call_span: Span, name: &Name, at: Span) -> bool {
-        if call_span.start.offset >= at.start.offset {
+        let _ = name;
+        self.call_site_dominates_offset(call_span, at.start.offset)
+    }
+
+    fn call_site_dominates_offset(&self, call_span: Span, limit_offset: usize) -> bool {
+        if call_span.start.offset >= limit_offset {
             return false;
         }
-        let _ = name;
 
         let Some(mut command_id) = self.facts.innermost_command_id_at(call_span.start.offset)
         else {
@@ -797,7 +1094,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut current = self.facts.command_parent_id(command_id);
         while let Some(command_id) = current {
             let command = self.facts.command(command_id);
-            if command.span().end.offset > at.start.offset {
+            if command.span().end.offset > limit_offset {
                 break;
             }
             if command.span().start.offset < call_span.start.offset
@@ -954,6 +1251,67 @@ impl<'a> SafeValueIndex<'a> {
                 continue;
             }
             if block_id == reference_block {
+                return false;
+            }
+            for (successor, _) in cfg.successors(block_id) {
+                stack.push(*successor);
+            }
+        }
+
+        true
+    }
+
+    fn bindings_cover_all_paths_to_callsite(
+        &self,
+        bindings: &[BindingId],
+        call_span: Span,
+    ) -> bool {
+        let cfg = self.analysis.cfg();
+        let call_blocks = cfg
+            .blocks()
+            .iter()
+            .filter(|block| block.commands.contains(&call_span))
+            .map(|block| block.id)
+            .collect::<FxHashSet<_>>();
+        if call_blocks.is_empty() {
+            return true;
+        }
+
+        let cover_blocks = bindings
+            .iter()
+            .copied()
+            .filter_map(|binding_id| {
+                let binding_block = self.block_for_binding(binding_id)?;
+                if call_blocks.contains(&binding_block)
+                    && self.binding_is_guarded_before_reference(binding_id, call_span)
+                {
+                    None
+                } else {
+                    Some(binding_block)
+                }
+            })
+            .collect::<FxHashSet<_>>();
+        if !cover_blocks.is_disjoint(&call_blocks) {
+            return true;
+        }
+
+        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let binding_scopes = bindings
+            .iter()
+            .copied()
+            .map(|binding_id| self.semantic.binding(binding_id).scope)
+            .collect::<Vec<_>>();
+        let mut stack =
+            vec![self.flow_entry_block_for_binding_scopes(&binding_scopes, call_span.start.offset)];
+        let mut seen = FxHashSet::default();
+        while let Some(block_id) = stack.pop() {
+            if cover_blocks.contains(&block_id)
+                || unreachable.contains(&block_id)
+                || !seen.insert(block_id)
+            {
+                continue;
+            }
+            if call_blocks.contains(&block_id) {
                 return false;
             }
             for (successor, _) in cfg.successors(block_id) {
@@ -1200,6 +1558,10 @@ fn literal_is_regex_safe(text: &str) -> bool {
     !escaped
 }
 
+fn span_contains(container: Span, inner: Span) -> bool {
+    container.start.offset <= inner.start.offset && inner.end.offset <= container.end.offset
+}
+
 fn source_text_needs_parse(text: &str) -> bool {
     text.chars()
         .any(|character| matches!(character, '$' | '`' | '\\' | '\'' | '"'))
@@ -1229,6 +1591,69 @@ fn source_text_literal_value(text: &str) -> Option<SourceTextLiteral<'_>> {
     }
 
     None
+}
+
+fn build_case_cli_reachable_function_scopes(
+    semantic: &SemanticModel,
+    facts: &LinterFacts<'_>,
+) -> FxHashSet<ScopeId> {
+    let dispatcher_offset = facts
+        .function_headers()
+        .iter()
+        .filter_map(|header| {
+            let scope = header.function_scope()?;
+            facts
+                .function_cli_dispatch_facts(scope)
+                .dispatcher_span()
+                .map(|span| span.start.offset)
+        })
+        .min();
+    let top_level_exit_offset = facts
+        .commands()
+        .iter()
+        .filter(|command| {
+            facts.command_parent_id(command.id()).is_none()
+                && semantic
+                    .ancestor_scopes(semantic.scope_at(command.span().start.offset))
+                    .all(|scope| !matches!(semantic.scope(scope).kind, ScopeKind::Function(_)))
+                && command_fact_is_standalone_exit(command)
+        })
+        .map(|command| command.span().start.offset)
+        .min();
+
+    facts
+        .function_headers()
+        .iter()
+        .filter_map(|header| {
+            let scope = header.function_scope()?;
+            let nested = semantic
+                .ancestor_scopes(scope)
+                .skip(1)
+                .any(|ancestor| matches!(semantic.scope(ancestor).kind, ScopeKind::Function(_)));
+            (nested
+                || dispatcher_offset
+                    .is_some_and(|offset| header.function().span.start.offset < offset)
+                || top_level_exit_offset
+                    .is_some_and(|offset| header.function().span.start.offset < offset))
+            .then_some(scope)
+        })
+        .collect()
+}
+
+fn command_fact_is_standalone_exit(command: &crate::facts::CommandFact<'_>) -> bool {
+    if command.stmt().negated
+        || matches!(
+            command.stmt().terminator,
+            Some(StmtTerminator::Background(_))
+        )
+    {
+        return false;
+    }
+
+    let Command::Builtin(BuiltinCommand::Exit(exit)) = command.command() else {
+        return false;
+    };
+    exit.extra_args.is_empty() && exit.assignments.is_empty() && command.stmt().redirects.is_empty()
 }
 
 fn safe_special_parameter(name: &Name) -> bool {
@@ -1437,7 +1862,7 @@ mod tests {
     use shuck_indexer::Indexer;
     use shuck_parser::parser::Parser;
     use shuck_semantic::{
-        ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind,
+        BindingOrigin, ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind,
         SemanticBuildOptions, SemanticModel,
     };
 
@@ -2168,6 +2593,56 @@ value=\"$(free ${humanreadable} | awk '{print $2}')\"
     }
 
     #[test]
+    fn static_loop_variables_after_multiline_loops_stay_unsafe() {
+        let source = "\
+#!/bin/sh
+for i in castool chdman; do
+  [ -e $i ] && install -s -m0755 -oroot -groot $i $PKG/usr/games/
+done
+[ -e split ] && install -s -m0755 -oroot -groot $i $PKG/usr/games/$PRGNAM-split
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let after_loop_use = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$i"
+                    && fact.span().start.line == 5
+            })
+            .expect("expected post-loop $i word fact");
+        let binding_id = safe_values
+            .safe_bindings_for_name(&Name::new("i"), after_loop_use.span())
+            .into_iter()
+            .next()
+            .expect("expected reaching loop binding");
+        let definition_span = match semantic.binding(binding_id).origin {
+            BindingOrigin::LoopVariable {
+                definition_span, ..
+            } => definition_span,
+            ref other => panic!("expected loop-variable binding, got {other:?}"),
+        };
+
+        assert!(
+            !safe_values
+                .loop_variable_reference_stays_within_body(definition_span, after_loop_use.span())
+        );
+        let (part, part_span) = after_loop_use
+            .parts_with_spans()
+            .next()
+            .expect("expected single-part loop variable word");
+        assert!(!safe_values.part_is_safe(part, part_span, SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(after_loop_use, SafeValueQuery::Argv));
+    }
+
+    #[test]
     fn nested_command_substitution_arguments_with_dynamic_values_stay_unsafe() {
         let source = "\
 #!/bin/sh
@@ -2587,12 +3062,164 @@ exit $?
             "expected the status binding to belong to the case-cli scope"
         );
 
-        assert!(!safe_values.binding_is_safe(binding_id, SafeValueQuery::Argv, case_cli_scope));
-        assert!(safe_values.binding_is_safe(binding_id, SafeValueQuery::Argv, None));
+        assert!(!safe_values.binding_is_safe(
+            binding_id,
+            dispatched_use.span(),
+            SafeValueQuery::Argv,
+            case_cli_scope
+        ));
+        assert!(safe_values.binding_is_safe(
+            binding_id,
+            dispatched_use.span(),
+            SafeValueQuery::Argv,
+            None
+        ));
     }
 
     #[test]
-    fn case_cli_dispatch_entry_functions_keep_nested_scope_safe_bindings() {
+    fn case_cli_dispatch_entry_functions_keep_local_command_names_but_not_arguments_safe() {
+        let source = "\
+#!/bin/sh
+start() {
+  local n=0
+  echo $n
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit $?
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$n"
+            })
+            .expect("expected case-cli local command argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_cli_dispatch_entry_functions_with_literal_exit_keep_local_arguments_unsafe() {
+        let source = "\
+#!/bin/sh
+start() {
+  local n=0
+  echo $n
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit 0
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$n"
+            })
+            .expect("expected case-cli local command argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_cli_dispatch_reachable_helpers_keep_local_arguments_unsafe() {
+        let source = "\
+#!/bin/sh
+foo() {
+  local n=0
+  echo $n
+}
+
+bound() { foo; }
+renew() { foo; }
+deconfig() { :; }
+
+case \"$1\" in
+  deconfig|renew|bound) $1 ;;
+esac
+exit $?
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$n"
+            })
+            .expect("expected case-cli helper command argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_cli_dispatch_broadens_into_pre_dispatch_functions_even_when_patterns_skip_them() {
+        let source = "\
+#!/bin/sh
+foo() {
+  local n=0
+  echo $n
+}
+
+bar() { :; }
+
+case \"$1\" in
+  bar) $1 ;;
+esac
+exit $?
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$n"
+            })
+            .expect("expected pre-dispatch function command argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn case_cli_dispatch_entry_functions_keep_nested_command_names_but_not_arguments_safe() {
         let source = "\
 #!/bin/sh
 start() {
@@ -2635,8 +3262,107 @@ exit $?
 
         assert!(command_name.is_nested_word_command());
         assert!(command_arg.is_nested_word_command());
-        assert!(safe_values.word_occurrence_is_safe(command_name, SafeValueQuery::Argv));
-        assert!(safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn top_level_exit_broadens_function_arguments_without_dispatch() {
+        let source = "\
+#!/bin/sh
+start() {
+  local n=0
+  echo $n
+}
+exit 0
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$n"
+            })
+            .expect("expected function-local argument before top-level exit");
+
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn nested_function_arguments_stay_unsafe_without_top_level_exit() {
+        let source = "\
+#!/bin/bash
+outer() {
+  inner() {
+    local good=0
+    return $good
+  }
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$good"
+            })
+            .expect("expected nested-function return argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn transitive_helper_calls_make_top_level_unsafe_bindings_visible() {
+        let source = "\
+#!/bin/bash
+DISK_SIZE=\"32G\"
+
+advanced_settings() {
+  DISK_SIZE=\"$(get_size)\"
+}
+
+start_script() {
+  advanced_settings
+}
+
+start_script
+if [ -n \"$DISK_SIZE\" ]; then
+  qm resize 100 scsi0 ${DISK_SIZE} >/dev/null
+fi
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let command_arg = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${DISK_SIZE}"
+            })
+            .expect("expected top-level helper-derived argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(command_arg, SafeValueQuery::Argv));
     }
 
     #[test]
@@ -2714,6 +3440,130 @@ unsafe_path
                     && fact.span().slice(source) == "${flag}"
             })
             .expect("expected shared helper-derived command argument fact");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn helper_globals_inherit_caller_visible_bindings() {
+        let source = "\
+#!/bin/sh
+SERVERNUM=99
+find_free_servernum() {
+  i=$SERVERNUM
+  while [ -f /tmp/.X$i-lock ]; do
+    i=$(($i + 1))
+  done
+  echo $i
+}
+set -- -n '1 2' -a --
+while :; do
+  case \"$1\" in
+    -a|--auto-servernum) SERVERNUM=$(find_free_servernum) ;;
+    -n|--server-num) SERVERNUM=\"$2\"; shift ;;
+    --) shift; break ;;
+    *) break ;;
+  esac
+  shift
+done
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let unsafe_words = facts
+            .word_facts()
+            .iter()
+            .filter(|fact| {
+                fact.span().slice(source).contains("$i") && matches!(fact.span().start.line, 5 | 8)
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(unsafe_words.len(), 2, "expected both helper-body $i uses");
+        assert!(
+            unsafe_words
+                .iter()
+                .all(|fact| !safe_values.word_occurrence_is_safe(*fact, SafeValueQuery::Argv))
+        );
+    }
+
+    #[test]
+    fn helper_globals_with_mixed_safe_and_unsafe_caller_branches_stay_unsafe() {
+        let source = "\
+#!/bin/sh
+if [ -n \"$2\" ]; then
+  UIPORT=\"$2\"
+else
+  UIPORT=\"8080\"
+fi
+do_start() {
+  grep $UIPORT /dev/null
+}
+do_start
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$UIPORT"
+            })
+            .expect("expected helper command argument fact");
+        let (part, part_span) = word_fact
+            .parts_with_spans()
+            .find(|(_, span)| span.slice(source) == "$UIPORT")
+            .expect("expected UIPORT expansion part");
+        let name = Name::from("UIPORT");
+        let bindings = safe_values.safe_bindings_for_name(&name, part_span);
+
+        assert_eq!(
+            bindings.len(),
+            2,
+            "expected both caller-visible UIPORT bindings"
+        );
+        assert!(safe_values.bindings_cover_all_paths_to_reference(&bindings, &name, part_span));
+        assert!(!safe_values.part_is_safe(part, part_span, SafeValueQuery::Argv));
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn helper_globals_with_conditionally_initialized_caller_bindings_stay_unsafe() {
+        let source = "\
+#!/bin/bash
+[ \"$1\" = 64 ] && extra=ENABLE_LIB64=1
+run_make() {
+  make $extra
+}
+run_make
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$extra"
+            })
+            .expect("expected helper command argument fact");
 
         assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
@@ -3033,6 +3883,36 @@ echo x >> ${OPENBSD_CONTENTS}
         assert!(
             !safe_values.word_occurrence_is_safe(redirect_target, SafeValueQuery::RedirectTarget)
         );
+    }
+
+    #[test]
+    fn inline_returns_make_later_safe_bindings_unsafe() {
+        let source = "\
+#!/bin/sh
+helper() {
+  safe=foo
+  return 0
+  echo /tmp/$safe
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Sh);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "/tmp/$safe"
+            })
+            .expect("expected mixed path command argument");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1365,6 +1365,23 @@ template=\"${template/IMG_DOWNLOAD_SIZE/$(stat -c %s ${image_file}.xz)}\"
     }
 
     #[test]
+    fn reports_dynamic_values_inside_parameter_replacement_arithmetic_expansions() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"${template/IMG_OFFSET/$(( $(cat file) $1 step ))}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$1"]
+        );
+    }
+
+    #[test]
     fn reports_dynamic_values_inside_arithmetic_shell_words() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1382,6 +1382,23 @@ printf '%s\\n' \"${template/IMG_OFFSET/$(( $(cat file) $1 step ))}\"
     }
 
     #[test]
+    fn reports_dynamic_values_inside_parameter_default_arithmetic_expansions() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"${value:-$(( $(cat file) $1 step ))}\" \"${value:=$(( $2 + 1 ))}\" \"${value:+$(( $3 + 1 ))}\" \"${value:?$(( $4 + 1 ))}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$1", "$2", "$3", "$4"]
+        );
+    }
+
+    #[test]
     fn reports_dynamic_values_inside_arithmetic_shell_words() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -35,20 +35,23 @@ pub fn unquoted_expansion(checker: &mut Checker) {
 
     let mut spans = Vec::new();
     for fact in checker.facts().word_facts() {
-        let Some(context) = fact.expansion_context() else {
-            continue;
-        };
-        if !should_check_context(context, checker.shell()) {
-            continue;
-        }
-
-        report_word_expansions(
-            &mut spans,
+        collect_word_fact_reports(
+            checker,
+            &colon_command_ids,
             &mut safe_values,
+            &mut spans,
             source,
             fact,
-            context,
-            colon_command_ids.contains(&fact.command_id()),
+        );
+    }
+    for fact in checker.facts().arithmetic_command_word_facts() {
+        collect_word_fact_reports(
+            checker,
+            &colon_command_ids,
+            &mut safe_values,
+            &mut spans,
+            source,
+            fact,
         );
     }
 
@@ -57,6 +60,31 @@ pub fn unquoted_expansion(checker: &mut Checker) {
     for span in spans {
         checker.report_dedup(UnquotedExpansion, span);
     }
+}
+
+fn collect_word_fact_reports(
+    checker: &Checker,
+    colon_command_ids: &FxHashSet<crate::facts::core::CommandId>,
+    safe_values: &mut SafeValueIndex<'_>,
+    spans: &mut Vec<shuck_ast::Span>,
+    source: &str,
+    fact: WordOccurrenceRef<'_, '_>,
+) {
+    let Some(context) = fact.host_expansion_context() else {
+        return;
+    };
+    if !should_check_context(context, checker.shell()) {
+        return;
+    }
+
+    report_word_expansions(
+        spans,
+        safe_values,
+        source,
+        fact,
+        context,
+        colon_command_ids.contains(&fact.command_id()),
+    );
 }
 
 fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool {
@@ -621,6 +649,27 @@ wrapper() {
     }
 
     #[test]
+    fn reports_unquoted_expansions_after_inline_returns_in_same_function_body() {
+        let source = "\
+#!/bin/sh
+wrapper() {
+  SAFE=foo
+  return 0
+  echo /tmp/$SAFE
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$SAFE"]
+        );
+    }
+
+    #[test]
     fn reports_unquoted_expansions_after_deferred_exit_like_calls_resolved_by_later_helpers() {
         let source = "\
 #!/bin/sh
@@ -853,6 +902,112 @@ exit $?
     }
 
     #[test]
+    fn reports_case_cli_dispatch_entry_function_local_arguments() {
+        let source = "\
+#!/bin/sh
+start() {
+  local n=0
+  echo $n
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit $?
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$n"]
+        );
+    }
+
+    #[test]
+    fn reports_case_cli_dispatch_entry_function_local_arguments_with_literal_exit() {
+        let source = "\
+#!/bin/sh
+start() {
+  local n=0
+  echo $n
+}
+
+case \"$1\" in
+  start) $1 ;;
+esac
+exit 0
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$n"]
+        );
+    }
+
+    #[test]
+    fn reports_case_cli_reachable_helper_local_arguments() {
+        let source = "\
+#!/bin/sh
+foo() {
+  local n=0
+  echo $n
+}
+
+bound() { foo; }
+renew() { foo; }
+deconfig() { :; }
+
+case \"$1\" in
+  deconfig|renew|bound) $1 ;;
+esac
+exit $?
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$n"]
+        );
+    }
+
+    #[test]
+    fn reports_case_cli_pre_dispatch_function_local_arguments() {
+        let source = "\
+#!/bin/sh
+foo() {
+  local n=0
+  echo $n
+}
+
+bar() { :; }
+
+case \"$1\" in
+  bar) $1 ;;
+esac
+exit $?
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$n"]
+        );
+    }
+
+    #[test]
     fn does_not_broaden_dynamic_case_dispatch_without_top_level_exit_status() {
         let source = "\
 #!/bin/sh
@@ -871,6 +1026,49 @@ esac
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_function_local_arguments_before_plain_top_level_exit() {
+        let source = "\
+#!/bin/sh
+start() {
+  local n=0
+  echo $n
+}
+exit 0
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$n"]
+        );
+    }
+
+    #[test]
+    fn reports_nested_function_return_arguments_without_top_level_exit() {
+        let source = "\
+#!/bin/bash
+outer() {
+  inner() {
+    local good=0
+    return $good
+  }
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$good"]
+        );
     }
 
     #[test]
@@ -1142,6 +1340,44 @@ echo \"MD5SUM=\\\"$( md5sum $PRGNAM-$VERSION.tar.xz | cut -d' ' -f1 )\\\"\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$VERSION"]
+        );
+    }
+
+    #[test]
+    fn reports_dynamic_values_inside_parameter_replacement_command_substitutions() {
+        let source = "\
+#!/bin/bash
+image_file='foo bar'
+template='IMG_EXTRACT_SIZE IMG_SHA256 IMG_DOWNLOAD_SIZE'
+template=\"${template/IMG_EXTRACT_SIZE/$(stat -c %s $image_file)}\"
+template=\"${template/IMG_SHA256/$(sha256sum $image_file | cut -d' ' -f1)}\"
+template=\"${template/IMG_DOWNLOAD_SIZE/$(stat -c %s ${image_file}.xz)}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$image_file", "$image_file", "${image_file}"]
+        );
+    }
+
+    #[test]
+    fn reports_dynamic_values_inside_arithmetic_shell_words() {
+        let source = "\
+#!/bin/sh
+printf '%s' \"$(( $(cat file) $1 step ))\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$1"]
         );
     }
 
@@ -1434,6 +1670,26 @@ done
     }
 
     #[test]
+    fn reports_static_loop_variables_after_the_loop_body() {
+        let source = "\
+#!/bin/bash
+for i in castool chdman; do
+  :
+done
+install $i /tmp
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$i"]
+        );
+    }
+
+    #[test]
     fn reports_loop_variables_derived_from_expanded_values() {
         let source = "\
 #!/bin/bash
@@ -1673,6 +1929,36 @@ fn_backup_compression
     }
 
     #[test]
+    fn reports_top_level_arguments_after_transitively_unsafe_helper_calls() {
+        let source = "\
+#!/bin/bash
+DISK_SIZE=\"32G\"
+
+advanced_settings() {
+  DISK_SIZE=\"$(get_size)\"
+}
+
+start_script() {
+  advanced_settings
+}
+
+start_script
+if [ -n \"$DISK_SIZE\" ]; then
+  qm resize 100 scsi0 ${DISK_SIZE} >/dev/null
+fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${DISK_SIZE}"]
+        );
+    }
+
+    #[test]
     fn reports_helper_initialized_bindings_when_other_callers_skip_the_helper() {
         let source = "\
 #!/bin/bash
@@ -1704,6 +1990,86 @@ unsafe_path
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${flag}"]
+        );
+    }
+
+    #[test]
+    fn reports_helper_globals_with_unsafe_caller_visible_bindings() {
+        let source = "\
+#!/bin/sh
+SERVERNUM=99
+find_free_servernum() {
+  i=$SERVERNUM
+  while [ -f /tmp/.X$i-lock ]; do
+    i=$(($i + 1))
+  done
+  echo $i
+}
+set -- -n '1 2' -a --
+while :; do
+  case \"$1\" in
+    -a|--auto-servernum) SERVERNUM=$(find_free_servernum) ;;
+    -n|--server-num) SERVERNUM=\"$2\"; shift ;;
+    --) shift; break ;;
+    *) break ;;
+  esac
+  shift
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$i", "$i"]
+        );
+    }
+
+    #[test]
+    fn reports_helper_globals_with_mixed_safe_and_unsafe_caller_branches() {
+        let source = "\
+#!/bin/sh
+if [ -n \"$2\" ]; then
+  UIPORT=\"$2\"
+else
+  UIPORT=\"8080\"
+fi
+do_start() {
+  grep $UIPORT /dev/null
+}
+do_start
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$UIPORT"]
+        );
+    }
+
+    #[test]
+    fn reports_helper_globals_with_conditionally_initialized_caller_bindings() {
+        let source = "\
+#!/bin/bash
+[ \"$1\" = 64 ] && extra=ENABLE_LIB64=1
+run_make() {
+  make $extra
+}
+run_make
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$extra"]
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the remaining ShellCheck-only `S001` / `SC2086` divergences by expanding the linter facts and safe-value analysis used by unquoted expansion checking.

Key changes:
- Descend into additional shell word shapes, including nested command substitutions in parameter replacement operands and arithmetic-command words.
- Match ShellCheck's less-trusting behavior for argv safety in function bodies reached through CLI-style dispatch, standalone top-level exits, nested functions, and transitive helper call paths.
- Tighten helper/global binding propagation so unsafe cross-function state is reported without regressing known-safe option-flag flows.

## Root Cause

`S001` was suppressing some unquoted expansions because `SafeValueIndex` trusted static-looking bindings too broadly. A few corpus patterns made those bindings less reliable: service-style dispatch wrappers, functions defined before top-level exits, nested function definitions, and file-scope uses populated by helper call chains.

## Validation

- `cargo fmt`
- `cargo test -p shuck-linter unquoted_expansion`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001 SHUCK_LARGE_CORPUS_KEEP_GOING=1`

The full `S001` corpus comparison now prints no `shellcheck-only S001/SC2086` lines. The corpus harness still exits nonzero because of 3 existing harness failures unrelated to `S001` diagnostics.
