### PR TITLE
refactor(linter): split word helpers by layer

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1889,7 +1889,7 @@ impl Word {
     /// Returns this word's fully static decoded text when it contains no
     /// runtime expansions.
     pub fn try_static_text<'a>(&'a self, source: &'a str) -> Option<Cow<'a, str>> {
-        try_static_word_parts_text(&self.parts, source)
+        static_word_text(self, source)
     }
 
     /// Render this word using exact source slices when available and owned cooked
@@ -1954,6 +1954,12 @@ impl fmt::Display for Word {
     }
 }
 
+/// Returns a word's fully static decoded text when it contains no runtime
+/// expansions.
+pub fn static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
+    try_static_word_parts_text(&word.parts, source)
+}
+
 /// Returns fully static decoded text for a contiguous slice of word parts when
 /// the slice contains no runtime expansions.
 pub fn try_static_word_parts_text<'a>(
@@ -1992,6 +1998,59 @@ fn collect_static_word_parts_text(parts: &[WordPartNode], source: &str, out: &mu
     }
 
     true
+}
+
+/// Returns whether `name` is a shell variable identifier.
+pub fn is_shell_variable_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {
+            chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        }
+        _ => false,
+    }
+}
+
+/// Returns whether the word is a single variable-like expansion part.
+pub fn word_is_standalone_variable_like(word: &Word) -> bool {
+    match word.parts.as_slice() {
+        [part] => matches!(
+            part.kind,
+            WordPart::Variable(_)
+                | WordPart::Parameter(_)
+                | WordPart::ParameterExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayAccess(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::ArrayIndices(_)
+                | WordPart::Substring { .. }
+                | WordPart::ArraySlice { .. }
+                | WordPart::IndirectExpansion { .. }
+                | WordPart::PrefixMatch { .. }
+                | WordPart::Transformation { .. }
+        ),
+        _ => false,
+    }
+}
+
+/// Returns whether the word captures only the previous command status.
+pub fn word_is_standalone_status_capture(word: &Word) -> bool {
+    matches!(word.parts.as_slice(), [part] if is_standalone_status_capture_part(&part.kind))
+}
+
+fn is_standalone_status_capture_part(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => name.as_str() == "?",
+        WordPart::DoubleQuoted { parts, .. } => {
+            matches!(parts.as_slice(), [part] if is_standalone_status_capture_part(&part.kind))
+        }
+        WordPart::Parameter(parameter) => matches!(
+            parameter.bourne(),
+            Some(BourneParameterExpansion::Access { reference })
+                if reference.name.as_str() == "?" && reference.subscript.is_none()
+        ),
+        _ => false,
+    }
 }
 
 /// Whether a heredoc body expands shell syntax.
@@ -3662,6 +3721,69 @@ mod tests {
     fn word_try_static_text_rejects_runtime_expansions() {
         let variable = word(vec![WordPart::Variable("name".into())]);
         assert!(variable.try_static_text("").is_none());
+    }
+
+    #[test]
+    fn shell_variable_name_helper_matches_identifier_rules() {
+        assert!(is_shell_variable_name("name"));
+        assert!(is_shell_variable_name("_name123"));
+        assert!(!is_shell_variable_name("1name"));
+        assert!(!is_shell_variable_name("name-value"));
+    }
+
+    #[test]
+    fn word_is_standalone_variable_like_matches_single_expansion_words() {
+        assert!(word_is_standalone_variable_like(&word(vec![
+            WordPart::Variable("name".into())
+        ])));
+        assert!(word_is_standalone_variable_like(&word(vec![
+            WordPart::Length(plain_ref("name"))
+        ])));
+        assert!(!word_is_standalone_variable_like(&word(vec![
+            WordPart::Literal(LiteralText::owned("prefix")),
+            WordPart::Variable("name".into()),
+        ])));
+        assert!(!word_is_standalone_variable_like(&word(vec![
+            WordPart::DoubleQuoted {
+                parts: vec![WordPartNode::new(
+                    WordPart::Variable("name".into()),
+                    Span::new(),
+                )],
+                dollar: false,
+            }
+        ])));
+    }
+
+    #[test]
+    fn word_is_standalone_status_capture_handles_plain_quoted_and_parameter_forms() {
+        assert!(word_is_standalone_status_capture(&word(vec![
+            WordPart::Variable("?".into())
+        ])));
+        assert!(word_is_standalone_status_capture(&word(vec![
+            WordPart::DoubleQuoted {
+                parts: vec![WordPartNode::new(
+                    WordPart::Variable("?".into()),
+                    Span::new(),
+                )],
+                dollar: false,
+            }
+        ])));
+        assert!(word_is_standalone_status_capture(&word(vec![
+            WordPart::Parameter(ParameterExpansion {
+                syntax: ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access {
+                    reference: plain_ref("?"),
+                }),
+                span: Span::new(),
+                raw_body: "?".into(),
+            })
+        ])));
+        assert!(!word_is_standalone_status_capture(&word(vec![
+            WordPart::Variable("name".into())
+        ])));
+        assert!(!word_is_standalone_status_capture(&word(vec![
+            WordPart::Literal(LiteralText::owned("status=")),
+            WordPart::Variable("?".into()),
+        ])));
     }
 
     fn span_for_source(source: &str) -> Span {

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -1,12 +1,12 @@
 use rustc_hash::FxHashSet;
-use shuck_ast::{ConditionalBinaryOp, ConditionalUnaryOp, Span};
+use shuck_ast::{ConditionalBinaryOp, ConditionalUnaryOp, Span, static_word_text};
 
 use super::{
     CommandFact, CommandId, ConditionalFact, ConditionalNodeFact, FactSpan, SimpleTestFact,
     SimpleTestSyntax, WordNode, WordOccurrence, word_spans,
 };
+use crate::facts::occurrence_word;
 use crate::rules::common::expansion::ExpansionContext;
-use crate::{facts::occurrence_word, static_word_text};
 
 #[derive(Debug, Clone, Default)]
 pub struct ConditionalPortabilityFacts {

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -474,7 +474,7 @@ fn c107_arithmetic_expr_is_zero_literal(
 }
 
 fn c107_status_word_span(word: &Word) -> Option<Span> {
-    crate::word_is_standalone_status_capture(word).then_some(word.span)
+    word_is_standalone_status_capture(word).then_some(word.span)
 }
 
 fn c107_word_is_zero_literal(word: &Word, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -227,7 +227,7 @@ fn stmt_is_top_level_status_exit(stmt: &Stmt) -> bool {
     command
         .code
         .as_ref()
-        .is_some_and(crate::word_is_standalone_status_capture)
+        .is_some_and(word_is_standalone_status_capture)
 }
 
 fn build_function_parameter_fallback_spans(
@@ -807,7 +807,7 @@ fn terminal_redundant_return_status_span(commands: &StmtSeq) -> Option<Span> {
         return None;
     }
     let code = command.code.as_ref()?;
-    crate::word_is_standalone_status_capture(code).then_some(code.span)
+    word_is_standalone_status_capture(code).then_some(code.span)
 }
 
 fn stmt_is_terminal_status_propagating_command(stmt: &Stmt) -> bool {

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -44,7 +44,7 @@ use crate::rules::common::{
     query::{self, CommandSubstitutionKind, CommandVisit, CommandWalkOptions},
     word::{
         TestOperandClass, WordClassification, WordQuote, classify_conditional_operand,
-        classify_contextual_operand, classify_word, static_word_text,
+        classify_contextual_operand, classify_word,
     },
 };
 use crate::suppression::shellcheck_directive_can_apply_to_following_command;
@@ -60,7 +60,8 @@ use shuck_ast::{
     ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position,
     Redirect, RedirectKind, SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq,
     StmtTerminator, Subscript, TextRange, VarRef, WhileCommand, Word, WordPart, WordPartNode,
-    ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob,
+    ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob, is_shell_variable_name, static_word_text,
+    word_is_standalone_status_capture,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2986,16 +2986,6 @@ fn text_contains_shell_quoting_literals(
     false
 }
 
-fn is_shell_variable_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(first) if first == '_' || first.is_ascii_alphabetic() => {
-            chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-        }
-        _ => false,
-    }
-}
-
 fn is_scannable_simple_arithmetic_subscript_text(text: &str) -> bool {
     let trimmed = text.trim();
     !trimmed.is_empty()

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -98,14 +98,10 @@ pub use rules::common::expansion::{
 pub use rules::common::query::CommandSubstitutionKind;
 #[allow(unused_imports)]
 pub(crate) use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
+#[allow(unused_imports)]
+pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 /// Word and test-classification types exposed by fact APIs.
 pub use rules::common::word::{TestOperandClass, WordClassification};
-#[allow(unused_imports)]
-pub(crate) use rules::common::word::{
-    conditional_binary_op_is_string_match, is_shell_variable_name, static_word_text,
-    text_is_self_contained_arithmetic_expression, text_looks_like_nontrivial_arithmetic_expression,
-    word_is_standalone_status_capture, word_is_standalone_variable_like,
-};
 /// Linter configuration and per-file ignore types.
 pub use settings::{
     AmbientShellOptions, C001RuleOptions, CompiledPerFileIgnoreList, LinterRuleOptions,

--- a/crates/shuck-linter/src/rules/common/command.rs
+++ b/crates/shuck-linter/src/rules/common/command.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use shuck_ast::{
     Assignment, BuiltinCommand, Command, DeclClause, DeclOperand, Redirect, SimpleCommand, Span,
-    Word,
+    Word, static_word_text,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -552,10 +552,6 @@ fn static_command_name_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'
 
 fn command_basename(name: &str) -> &str {
     name.rsplit('/').next().unwrap_or(name)
-}
-
-fn static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
-    super::word::static_word_text(word, source)
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/common/expansion.rs
+++ b/crates/shuck-linter/src/rules/common/expansion.rs
@@ -1,11 +1,9 @@
 use shuck_ast::{
     BourneParameterExpansion, ParameterExpansion, ParameterExpansionSyntax, PrefixMatchKind,
     Redirect, RedirectKind, Span, SubscriptSelector, Word, WordPart, WordPartNode,
-    ZshExpansionOperation,
+    ZshExpansionOperation, static_word_text,
 };
 use shuck_semantic::{OptionValue, ZshOptionState};
-
-use super::word::static_word_text;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ExpansionContext {

--- a/crates/shuck-linter/src/rules/common/query.rs
+++ b/crates/shuck-linter/src/rules/common/query.rs
@@ -1015,7 +1015,7 @@ mod tests {
         output.file.body
     }
 
-    fn static_word_text(word: &Word, source: &str) -> Option<String> {
+    fn static_word_owned_text(word: &Word, source: &str) -> Option<String> {
         word.try_static_text(source).map(|text| text.into_owned())
     }
 
@@ -1050,7 +1050,7 @@ mod tests {
                 return None;
             };
 
-            static_word_text(&command.name, source)
+            static_word_owned_text(&command.name, source)
         })
         .collect::<Vec<_>>();
 
@@ -1065,7 +1065,7 @@ mod tests {
                 return None;
             };
 
-            static_word_text(&command.name, source)
+            static_word_owned_text(&command.name, source)
         })
         .collect::<Vec<_>>();
 
@@ -1094,7 +1094,7 @@ fi
                 let Command::Simple(command) = visit.command else {
                     return;
                 };
-                let Some(name) = static_word_text(&command.name, source) else {
+                let Some(name) = static_word_owned_text(&command.name, source) else {
                     return;
                 };
                 if name == ":" {
@@ -1158,7 +1158,7 @@ done
                 let Command::Simple(command) = visit.command else {
                     return;
                 };
-                let Some(name) = static_word_text(&command.name, source) else {
+                let Some(name) = static_word_owned_text(&command.name, source) else {
                     return;
                 };
                 if name == ":" {
@@ -1201,7 +1201,7 @@ printf '%s\\n' ${value:-$(expr $(nproc) + 1)}
                 let Command::Simple(command) = visit.command else {
                     return;
                 };
-                let Some(name) = static_word_text(&command.name, source) else {
+                let Some(name) = static_word_owned_text(&command.name, source) else {
                     return;
                 };
                 visits.push((name, context.nested_word_command));
@@ -1230,7 +1230,7 @@ printf '%s\\n' ${value:-$(expr $(nproc) + 1)}
             .expect("expected pipeline segments")
             .into_iter()
             .map(|stmt| match &stmt.command {
-                Command::Simple(command) => static_word_text(&command.name, source).unwrap(),
+                Command::Simple(command) => static_word_owned_text(&command.name, source).unwrap(),
                 _ => "<non-simple>".to_owned(),
             })
             .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -2,7 +2,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand, FunctionDef, Name,
     ParameterExpansion, ParameterExpansionSyntax, ParameterOp, RedirectKind, SourceText, Span,
-    Stmt, StmtSeq, StmtTerminator, VarRef, Word, WordPart, WordPartNode,
+    Stmt, StmtSeq, StmtTerminator, VarRef, Word, WordPart, WordPartNode, static_word_text,
+    word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 use shuck_semantic::{
     AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, LoopValueOrigin, ScopeId,
@@ -12,10 +13,7 @@ use shuck_semantic::{BindingId, BlockId, ReferenceId, ReferenceKind};
 
 use crate::{FactSpan, LinterFacts};
 
-use super::{
-    expansion::{ExpansionContext, analyze_literal_runtime},
-    word::static_word_text,
-};
+use super::expansion::{ExpansionContext, analyze_literal_runtime};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SafeValueQuery {
@@ -342,7 +340,7 @@ impl<'a> SafeValueIndex<'a> {
             command.body_args().iter().any(|word| word.span == at)
                 && command
                     .body_name_word()
-                    .is_some_and(crate::word_is_standalone_variable_like)
+                    .is_some_and(word_is_standalone_variable_like)
         })
     }
 
@@ -558,7 +556,7 @@ impl<'a> SafeValueIndex<'a> {
                     .and_then(|value| value.scalar_word());
                 if case_cli_scope == Some(binding.scope)
                     && matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
-                    && scalar_word.is_some_and(crate::word_is_standalone_status_capture)
+                    && scalar_word.is_some_and(word_is_standalone_status_capture)
                 {
                     false
                 } else {

--- a/crates/shuck-linter/src/rules/common/word.rs
+++ b/crates/shuck-linter/src/rules/common/word.rs
@@ -1,10 +1,4 @@
-use std::borrow::Cow;
-
-use shuck_ast::{
-    ArithmeticExpr, BourneParameterExpansion, Command, CompoundCommand, ConditionalBinaryOp,
-    ConditionalExpr, Pattern, PatternPart, Word, WordPart,
-};
-use shuck_parser::parser::Parser;
+use shuck_ast::{ConditionalBinaryOp, ConditionalExpr, Pattern, PatternPart, Word};
 
 pub use super::expansion::{
     ExpansionContext, WordExpansionKind, WordLiteralness, WordQuote, WordSubstitutionShape,
@@ -62,102 +56,6 @@ impl TestOperandClass {
     }
 }
 
-pub fn static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
-    word.try_static_text(source)
-}
-
-pub fn is_shell_variable_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(first) if first == '_' || first.is_ascii_alphabetic() => {
-            chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-        }
-        _ => false,
-    }
-}
-
-pub fn text_looks_like_nontrivial_arithmetic_expression(text: &str) -> bool {
-    let text = text.trim();
-    if text.is_empty() {
-        return false;
-    }
-
-    let source = format!("(( {text} ))");
-    let file = Parser::new(&source).parse();
-    if file.is_err() {
-        return false;
-    }
-
-    let Some(statement) = file.file.body.first() else {
-        return false;
-    };
-
-    let Command::Compound(CompoundCommand::Arithmetic(command)) = &statement.command else {
-        return false;
-    };
-
-    command.expr_ast.as_ref().is_some_and(|expr| {
-        !matches!(
-            expr.kind,
-            ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_)
-        )
-    })
-}
-
-pub fn text_is_self_contained_arithmetic_expression(text: &str) -> bool {
-    let text = text.trim();
-    if text.is_empty() {
-        return false;
-    }
-
-    let source = format!("(( {text} ))");
-    let file = Parser::new(&source).parse();
-    if file.is_err() {
-        return false;
-    }
-
-    let Some(statement) = file.file.body.first() else {
-        return false;
-    };
-
-    let Command::Compound(CompoundCommand::Arithmetic(command)) = &statement.command else {
-        return false;
-    };
-
-    command
-        .expr_ast
-        .as_ref()
-        .is_some_and(arithmetic_expr_is_self_contained)
-}
-
-fn arithmetic_expr_is_self_contained(expr: &shuck_ast::ArithmeticExprNode) -> bool {
-    match &expr.kind {
-        ArithmeticExpr::Number(_) => true,
-        ArithmeticExpr::Variable(_)
-        | ArithmeticExpr::Indexed { .. }
-        | ArithmeticExpr::ShellWord(_)
-        | ArithmeticExpr::Assignment { .. } => false,
-        ArithmeticExpr::Parenthesized { expression } => {
-            arithmetic_expr_is_self_contained(expression)
-        }
-        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
-            arithmetic_expr_is_self_contained(expr)
-        }
-        ArithmeticExpr::Binary { left, right, .. } => {
-            arithmetic_expr_is_self_contained(left) && arithmetic_expr_is_self_contained(right)
-        }
-        ArithmeticExpr::Conditional {
-            condition,
-            then_expr,
-            else_expr,
-        } => {
-            arithmetic_expr_is_self_contained(condition)
-                && arithmetic_expr_is_self_contained(then_expr)
-                && arithmetic_expr_is_self_contained(else_expr)
-        }
-    }
-}
-
 pub fn conditional_binary_op_is_string_match(op: ConditionalBinaryOp) -> bool {
     matches!(
         op,
@@ -165,46 +63,6 @@ pub fn conditional_binary_op_is_string_match(op: ConditionalBinaryOp) -> bool {
             | ConditionalBinaryOp::PatternEq
             | ConditionalBinaryOp::PatternNe
     )
-}
-
-pub fn word_is_standalone_variable_like(word: &Word) -> bool {
-    match word.parts.as_slice() {
-        [part] => matches!(
-            part.kind,
-            WordPart::Variable(_)
-                | WordPart::Parameter(_)
-                | WordPart::ParameterExpansion { .. }
-                | WordPart::Length(_)
-                | WordPart::ArrayAccess(_)
-                | WordPart::ArrayLength(_)
-                | WordPart::ArrayIndices(_)
-                | WordPart::Substring { .. }
-                | WordPart::ArraySlice { .. }
-                | WordPart::IndirectExpansion { .. }
-                | WordPart::PrefixMatch { .. }
-                | WordPart::Transformation { .. }
-        ),
-        _ => false,
-    }
-}
-
-pub fn word_is_standalone_status_capture(word: &Word) -> bool {
-    matches!(word.parts.as_slice(), [part] if is_standalone_status_capture_part(&part.kind))
-}
-
-fn is_standalone_status_capture_part(part: &WordPart) -> bool {
-    match part {
-        WordPart::Variable(name) => name.as_str() == "?",
-        WordPart::DoubleQuoted { parts, .. } => {
-            matches!(parts.as_slice(), [part] if is_standalone_status_capture_part(&part.kind))
-        }
-        WordPart::Parameter(parameter) => matches!(
-            parameter.bourne(),
-            Some(BourneParameterExpansion::Access { reference })
-                if reference.name.as_str() == "?" && reference.subscript.is_none()
-        ),
-        _ => false,
-    }
 }
 
 pub(crate) fn classify_word(word: &Word, source: &str) -> WordClassification {
@@ -291,17 +149,13 @@ fn classify_pattern_operand(pattern: &Pattern, source: &str) -> TestOperandClass
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
-
-    use shuck_ast::{BuiltinCommand, Command, CompoundCommand};
+    use shuck_ast::{Command, CompoundCommand};
     use shuck_parser::parser::Parser;
 
     use super::{
         ExpansionContext, TestOperandClass, WordExpansionKind, WordLiteralness, WordQuote,
         WordSubstitutionShape, classify_conditional_operand, classify_contextual_operand,
-        classify_word, is_shell_variable_name, static_word_text,
-        text_is_self_contained_arithmetic_expression,
-        text_looks_like_nontrivial_arithmetic_expression, word_is_standalone_status_capture,
+        classify_word,
     };
 
     fn parse_commands(source: &str) -> shuck_ast::StmtSeq {
@@ -365,130 +219,6 @@ mod tests {
     }
 
     #[test]
-    fn static_word_text_keeps_nested_command_names_in_prefixed_quoted_substitutions() {
-        let source = "\
-echo \"\\\"$BUILDSCRIPT\\\" --library $(test \"${PKG_DIR%/*}\" = \"gpkg\" && echo \"glibc\" || echo \"bionic\")\"\n";
-        let commands = parse_commands(source);
-        let Command::Simple(command) = &commands[0].command else {
-            panic!("expected simple command");
-        };
-        let Some(body) = command.args[0]
-            .parts
-            .iter()
-            .find_map(|part| match &part.kind {
-                shuck_ast::WordPart::DoubleQuoted { parts, .. } => {
-                    parts.iter().find_map(|part| match &part.kind {
-                        shuck_ast::WordPart::CommandSubstitution { body, .. } => Some(body),
-                        _ => None,
-                    })
-                }
-                _ => None,
-            })
-        else {
-            panic!("expected command substitution inside quoted word");
-        };
-
-        let Command::Binary(or_chain) = &body[0].command else {
-            panic!("expected short-circuit binary command");
-        };
-        let Command::Binary(and_chain) = &or_chain.left.command else {
-            panic!("expected left-hand && chain");
-        };
-        let Command::Simple(test_command) = &and_chain.left.command else {
-            panic!("expected test command");
-        };
-        let Command::Simple(then_echo) = &and_chain.right.command else {
-            panic!("expected then echo");
-        };
-        let Command::Simple(else_echo) = &or_chain.right.command else {
-            panic!("expected else echo");
-        };
-
-        assert_eq!(
-            static_word_text(&test_command.name, source).as_deref(),
-            Some("test")
-        );
-        assert_eq!(
-            static_word_text(&then_echo.name, source).as_deref(),
-            Some("echo")
-        );
-        assert_eq!(
-            static_word_text(&else_echo.name, source).as_deref(),
-            Some("echo")
-        );
-    }
-
-    #[test]
-    fn static_word_text_borrows_literal_and_single_quoted_words() {
-        let source = "printf plain 'single' \"double\"\n";
-        let commands = parse_commands(source);
-        let Command::Simple(command) = &commands[0].command else {
-            panic!("expected simple command");
-        };
-
-        assert!(matches!(
-            static_word_text(&command.args[0], source),
-            Some(Cow::Borrowed("plain"))
-        ));
-        assert!(matches!(
-            static_word_text(&command.args[1], source),
-            Some(Cow::Borrowed("single"))
-        ));
-        assert!(matches!(
-            static_word_text(&command.args[2], source),
-            Some(Cow::Borrowed("double"))
-        ));
-    }
-
-    #[test]
-    fn static_word_text_cooks_concatenated_words_only_when_needed() {
-        let source = "printf \"pre${x}post\" \"ab$cd\" foo\"bar\"\n";
-        let commands = parse_commands(source);
-        let Command::Simple(command) = &commands[0].command else {
-            panic!("expected simple command");
-        };
-
-        assert!(static_word_text(&command.args[0], source).is_none());
-        assert!(static_word_text(&command.args[1], source).is_none());
-        assert!(matches!(
-            static_word_text(&command.args[2], source),
-            Some(Cow::Owned(ref value)) if value == "foobar"
-        ));
-    }
-
-    #[test]
-    fn shell_variable_name_helper_matches_identifier_rules() {
-        assert!(is_shell_variable_name("name"));
-        assert!(is_shell_variable_name("_name123"));
-        assert!(!is_shell_variable_name("1name"));
-        assert!(!is_shell_variable_name("name-value"));
-    }
-
-    #[test]
-    fn arithmetic_text_helper_requires_nontrivial_expressions() {
-        assert!(text_looks_like_nontrivial_arithmetic_expression("1 + 2"));
-        assert!(text_looks_like_nontrivial_arithmetic_expression("arr[1]"));
-        assert!(text_looks_like_nontrivial_arithmetic_expression("++count"));
-        assert!(!text_looks_like_nontrivial_arithmetic_expression("123"));
-        assert!(!text_looks_like_nontrivial_arithmetic_expression("name"));
-        assert!(!text_looks_like_nontrivial_arithmetic_expression(
-            "latest value"
-        ));
-    }
-
-    #[test]
-    fn arithmetic_text_helper_distinguishes_self_contained_expressions() {
-        assert!(text_is_self_contained_arithmetic_expression("1 + 2"));
-        assert!(text_is_self_contained_arithmetic_expression("(1 + 2)"));
-        assert!(!text_is_self_contained_arithmetic_expression("name"));
-        assert!(!text_is_self_contained_arithmetic_expression("arr[1]"));
-        assert!(!text_is_self_contained_arithmetic_expression("foo + 1"));
-        assert!(!text_is_self_contained_arithmetic_expression(
-            "latest value"
-        ));
-    }
-
-    #[test]
     fn classify_word_reports_scalar_and_array_expansions() {
         let source = "printf $foo ${arr[@]} ${arr[0]} ${arr[@]:1}\n";
         let commands = parse_commands(source);
@@ -512,48 +242,6 @@ echo \"\\\"$BUILDSCRIPT\\\" --library $(test \"${PKG_DIR%/*}\" = \"gpkg\" && ech
             classify_word(&command.args[3], source).expansion_kind,
             WordExpansionKind::Array
         );
-    }
-
-    #[test]
-    fn word_is_standalone_status_capture_handles_plain_and_quoted_forms() {
-        let source = "return $?; return \"$?\"; return ${?+0}; return ${?:-1}; return $foo\n";
-        let commands = parse_commands(source);
-
-        let Command::Builtin(BuiltinCommand::Return(plain)) = &commands[0].command else {
-            panic!("expected return builtin");
-        };
-        assert!(word_is_standalone_status_capture(
-            plain.code.as_ref().unwrap()
-        ));
-
-        let Command::Builtin(BuiltinCommand::Return(quoted)) = &commands[1].command else {
-            panic!("expected return builtin");
-        };
-        assert!(word_is_standalone_status_capture(
-            quoted.code.as_ref().unwrap()
-        ));
-
-        let Command::Builtin(BuiltinCommand::Return(operator_default)) = &commands[2].command
-        else {
-            panic!("expected return builtin");
-        };
-        assert!(!word_is_standalone_status_capture(
-            operator_default.code.as_ref().unwrap()
-        ));
-
-        let Command::Builtin(BuiltinCommand::Return(operator_assign)) = &commands[3].command else {
-            panic!("expected return builtin");
-        };
-        assert!(!word_is_standalone_status_capture(
-            operator_assign.code.as_ref().unwrap()
-        ));
-
-        let Command::Builtin(BuiltinCommand::Return(other)) = &commands[4].command else {
-            panic!("expected return builtin");
-        };
-        assert!(!word_is_standalone_status_capture(
-            other.code.as_ref().unwrap()
-        ));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
@@ -1,9 +1,9 @@
 use rustc_hash::FxHashSet;
-use shuck_ast::{Assignment, AssignmentValue, BuiltinCommand, Command, DeclOperand, Span};
-
-use crate::{
-    Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote, static_word_text,
+use shuck_ast::{
+    Assignment, AssignmentValue, BuiltinCommand, Command, DeclOperand, Span, static_word_text,
 };
+
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote};
 
 pub struct AssignmentLooksLikeComparison;
 

--- a/crates/shuck-linter/src/rules/correctness/broken_test_common.rs
+++ b/crates/shuck-linter/src/rules/correctness/broken_test_common.rs
@@ -1,6 +1,6 @@
-use shuck_ast::Span;
+use shuck_ast::{Span, static_word_text};
 
-use crate::{Checker, static_word_text};
+use crate::Checker;
 
 pub(super) fn malformed_bracket_test_spans(checker: &Checker<'_>) -> Vec<Span> {
     checker

--- a/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
@@ -1,8 +1,9 @@
+use shuck_ast::{ConditionalBinaryOp, static_word_text};
+
 use crate::{
     Checker, ConditionalNodeFact, ConditionalOperatorFamily, Edit, Fix, FixAvailability, Rule,
-    SimpleTestOperatorFamily, SimpleTestShape, Violation, static_word_text,
+    SimpleTestOperatorFamily, SimpleTestShape, Violation,
 };
-use shuck_ast::ConditionalBinaryOp;
 
 pub struct ConstantComparisonTest;
 

--- a/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
@@ -1,6 +1,8 @@
+use shuck_ast::word_is_standalone_variable_like;
+
 use crate::{
     Checker, ConditionalNodeFact, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation,
-    WordQuote, conditional_binary_op_is_string_match, word_is_standalone_variable_like,
+    WordQuote, conditional_binary_op_is_string_match,
 };
 
 pub struct GlobInStringComparison;

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
@@ -1,4 +1,6 @@
-use crate::{Checker, Rule, SimpleTestShape, SimpleTestSyntax, Violation, static_word_text};
+use shuck_ast::static_word_text;
+
+use crate::{Checker, Rule, SimpleTestShape, SimpleTestSyntax, Violation};
 
 pub struct GlobInTestComparison;
 

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
@@ -1,9 +1,8 @@
-use shuck_ast::{ConditionalUnaryOp, Span, Word};
+use shuck_ast::{ConditionalUnaryOp, Span, Word, static_word_text};
 
 use crate::facts::word_spans;
 use crate::{
-    Checker, ConditionalFact, ConditionalNodeFact, Rule, SimpleTestFact, SimpleTestShape,
-    Violation, static_word_text,
+    Checker, ConditionalFact, ConditionalNodeFact, Rule, SimpleTestFact, SimpleTestShape, Violation,
 };
 
 pub struct GlobInTestDirectory;

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -1,10 +1,9 @@
-use shuck_ast::{ConditionalBinaryOp, RedirectKind, Span};
+use shuck_ast::{ConditionalBinaryOp, RedirectKind, Span, static_word_text};
 use shuck_semantic::{BindingAttributes, BindingId};
 
 use crate::{
     Checker, CommandFact, ConditionalBinaryFact, ConditionalNodeFact, ConditionalOperandFact, Edit,
     Fix, FixAvailability, RedirectFact, Rule, SimpleTestSyntax, Violation, WordOccurrenceRef,
-    static_word_text,
 };
 
 pub struct GreaterThanInTest;

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -88,7 +88,7 @@ fn command_has_separator_before(
         .body_args()
         .iter()
         .take_while(|word| word.span != target_span)
-        .filter_map(|word| crate::rules::common::word::static_word_text(word, source))
+        .filter_map(|word| shuck_ast::static_word_text(word, source))
         .any(|arg| arg == "--")
 }
 

--- a/crates/shuck-linter/src/rules/correctness/literal_unary_string_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/literal_unary_string_test.rs
@@ -1,9 +1,9 @@
-use shuck_ast::{ConditionalUnaryOp, Word};
+use shuck_ast::{ConditionalUnaryOp, Word, static_word_text};
 
 use crate::facts::word_spans;
 use crate::{
     Checker, ConditionalNodeFact, ConditionalOperatorFamily, Edit, Fix, FixAvailability, Rule,
-    Violation, static_word_text,
+    Violation,
 };
 
 pub struct LiteralUnaryStringTest;

--- a/crates/shuck-linter/src/rules/correctness/malformed_arithmetic_in_condition.rs
+++ b/crates/shuck-linter/src/rules/correctness/malformed_arithmetic_in_condition.rs
@@ -1,10 +1,9 @@
-use shuck_ast::Span;
+use shuck_ast::{ConditionalBinaryOp, Span, static_word_text};
 
 use crate::{
     Checker, ConditionalNodeFact, ExpansionContext, Rule, SimpleTestShape, Violation,
-    WordFactContext, WordQuote, static_word_text,
+    WordFactContext, WordQuote,
 };
-use shuck_ast::ConditionalBinaryOp;
 
 pub struct MalformedArithmeticInCondition;
 

--- a/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
@@ -1,7 +1,7 @@
-use shuck_ast::{Command, StmtTerminator};
+use shuck_ast::{Command, StmtTerminator, static_word_text};
 
 use crate::context::FileContextTag;
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
 
 pub struct NonShellSyntaxInScript;
 

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
@@ -1,7 +1,6 @@
-use crate::{
-    Checker, Edit, Fix, FixAvailability, Rule, TestOperandClass, Violation, WordQuote,
-    static_word_text,
-};
+use shuck_ast::static_word_text;
+
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, TestOperandClass, Violation, WordQuote};
 
 pub struct QuotedBashRegex;
 

--- a/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
@@ -177,7 +177,7 @@ fn conditional_operand_looks_like_quoted_pipeline(
         .zip(operand.word_classification())
         .and_then(|(word, classification)| {
             (classification.quote == WordQuote::FullyQuoted && classification.is_fixed_literal())
-                .then(|| crate::static_word_text(word, source))
+                .then(|| shuck_ast::static_word_text(word, source))
         })
         .flatten()
         .as_deref()

--- a/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
+++ b/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
@@ -1,13 +1,11 @@
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{Command, DeclOperand, Name, Span, Word};
+use shuck_ast::{Command, DeclOperand, Name, Span, Word, static_word_text};
 use shuck_semantic::{
     Binding, BindingAttributes, BindingId, BindingKind, Reference, ReferenceKind,
 };
 
 use crate::facts::{CommandId, word_spans};
-use crate::{
-    Checker, ExpansionContext, SimpleTestShape, SimpleTestSyntax, WordFactContext, static_word_text,
-};
+use crate::{Checker, ExpansionContext, SimpleTestShape, SimpleTestSyntax, WordFactContext};
 
 pub(crate) struct ShellQuotingReuseAnalysis {
     pub assignment_spans: Vec<Span>,

--- a/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
@@ -1,6 +1,6 @@
-use shuck_ast::DeclOperand;
+use shuck_ast::{DeclOperand, static_word_text};
 
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
 
 pub struct SpacedAssignment;
 

--- a/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
@@ -1,10 +1,8 @@
-use shuck_ast::{ConditionalBinaryOp, Name, Span};
+use shuck_ast::{ConditionalBinaryOp, Name, Span, is_shell_variable_name, static_word_text};
+use shuck_parser::text_is_self_contained_arithmetic_expression;
 use shuck_semantic::{BindingAttributes, BindingKind};
 
-use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperandFact, Rule, Violation, WordQuote,
-    is_shell_variable_name, static_word_text, text_is_self_contained_arithmetic_expression,
-};
+use crate::{Checker, ConditionalNodeFact, ConditionalOperandFact, Rule, Violation, WordQuote};
 
 pub struct StringComparedWithEq;
 

--- a/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
@@ -1,7 +1,6 @@
-use crate::{
-    Checker, ConditionalBinaryFact, ConditionalNodeFact, Rule, Violation, static_word_text,
-};
-use shuck_ast::{ConditionalBinaryOp, Span};
+use shuck_ast::{ConditionalBinaryOp, Span, static_word_text};
+
+use crate::{Checker, ConditionalBinaryFact, ConditionalNodeFact, Rule, Violation};
 
 pub struct StringComparisonForVersion;
 

--- a/crates/shuck-linter/src/rules/correctness/syntax.rs
+++ b/crates/shuck-linter/src/rules/correctness/syntax.rs
@@ -1,6 +1,4 @@
-use shuck_ast::{Assignment, SimpleCommand, Word};
-
-pub(crate) use crate::static_word_text;
+use shuck_ast::{Assignment, SimpleCommand, Word, static_word_text};
 
 fn simple_command_name(command: &SimpleCommand, source: &str) -> Option<String> {
     static_word_text(&command.name, source).map(|text| text.into_owned())

--- a/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Position, Span};
+use shuck_ast::{Position, Span, static_word_text};
 
 use crate::{
     Checker, ConditionalNodeFact, ConditionalOperatorFamily, ExpansionContext, Rule,
@@ -102,7 +102,7 @@ fn conditional_operand_tilde_span(
             return None;
         }
 
-        return crate::static_word_text(word, source)
+        return static_word_text(word, source)
             .filter(|text| text.starts_with("~/"))
             .and_then(|_| quoted_tilde_span(word.span, source));
     }

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -1,6 +1,5 @@
-use shuck_ast::Span;
+use shuck_ast::{Span, static_word_text};
 
-use crate::rules::style::syntax::static_word_text;
 use crate::{Checker, CommandFact, PipelineFact, Rule, Violation};
 
 pub struct GrepCountPipeline;

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
@@ -1,6 +1,6 @@
-use shuck_ast::{RedirectKind, Span};
+use shuck_ast::{RedirectKind, Span, static_word_text};
 
-use crate::{Checker, RedirectFact, Rule, ShellDialect, Violation, static_word_text};
+use crate::{Checker, RedirectFact, Rule, ShellDialect, Violation};
 
 pub struct AmpersandRedirectInSh;
 

--- a/crates/shuck-linter/src/rules/portability/csh_syntax_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/csh_syntax_in_sh.rs
@@ -1,7 +1,7 @@
-use shuck_ast::Span;
+use shuck_ast::{Span, static_word_text};
 
 use super::targets_non_zsh_shell;
-use crate::{Checker, Rule, Violation, static_word_text};
+use crate::{Checker, Rule, Violation};
 
 pub struct CshSyntaxInSh;
 

--- a/crates/shuck-linter/src/rules/portability/signal_name_in_trap.rs
+++ b/crates/shuck-linter/src/rules/portability/signal_name_in_trap.rs
@@ -1,9 +1,9 @@
-use shuck_ast::{Span, Word};
+use shuck_ast::{Span, Word, static_word_text};
 
 use super::trap_common::parse_trap_args;
 use crate::{
     Checker, Fix, FixAvailability, Rule, ShellDialect, Violation,
-    leading_static_word_prefix_fix_in_source, static_word_text,
+    leading_static_word_prefix_fix_in_source,
 };
 
 const SIG_PREFIX_LEN: usize = 3;

--- a/crates/shuck-linter/src/rules/portability/sourced_with_args.rs
+++ b/crates/shuck-linter/src/rules/portability/sourced_with_args.rs
@@ -1,5 +1,7 @@
+use shuck_ast::static_word_text;
+
 use crate::context::FileContextTag;
-use crate::{Checker, Rule, ShellDialect, Violation, static_word_text};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct SourcedWithArgs;
 

--- a/crates/shuck-linter/src/rules/portability/tr_common.rs
+++ b/crates/shuck-linter/src/rules/portability/tr_common.rs
@@ -1,6 +1,6 @@
-use shuck_ast::Span;
+use shuck_ast::{Span, static_word_text};
 
-use crate::{Checker, ShellDialect, static_word_text};
+use crate::{Checker, ShellDialect};
 
 pub(super) fn tr_exact_operand_spans(checker: &Checker<'_>, exact_text: &str) -> Vec<Span> {
     if !matches!(

--- a/crates/shuck-linter/src/rules/portability/trap_common.rs
+++ b/crates/shuck-linter/src/rules/portability/trap_common.rs
@@ -1,6 +1,4 @@
-use shuck_ast::Word;
-
-use crate::static_word_text;
+use shuck_ast::{Word, static_word_text};
 
 pub(crate) struct ParsedTrapArgs<'a> {
     pub(crate) signal_words: &'a [&'a Word],

--- a/crates/shuck-linter/src/rules/portability/trap_err.rs
+++ b/crates/shuck-linter/src/rules/portability/trap_err.rs
@@ -1,5 +1,7 @@
+use shuck_ast::static_word_text;
+
 use super::trap_common::parse_trap_args;
-use crate::{Checker, Rule, ShellDialect, Violation, static_word_text};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct TrapErr;
 

--- a/crates/shuck-linter/src/rules/style/syntax.rs
+++ b/crates/shuck-linter/src/rules/style/syntax.rs
@@ -1,6 +1,4 @@
-use shuck_ast::Command;
-
-pub(crate) use crate::static_word_text;
+use shuck_ast::{Command, static_word_text};
 
 pub fn is_simple_command_named(command: &Command, source: &str, name: &str) -> bool {
     match command {

--- a/crates/shuck-linter/src/rules/style/trap_signal_numbers.rs
+++ b/crates/shuck-linter/src/rules/style/trap_signal_numbers.rs
@@ -1,7 +1,7 @@
-use shuck_ast::{Span, Word};
+use shuck_ast::{Span, Word, static_word_text};
 
 use crate::rules::portability::trap_common::parse_trap_args;
-use crate::{Checker, Rule, ShellDialect, Violation, static_word_text};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct TrapSignalNumbers;
 

--- a/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
@@ -1,6 +1,6 @@
-use crate::{
-    Checker, CommandFact, ExpansionContext, Rule, Violation, WordFactContext, static_word_text,
-};
+use shuck_ast::static_word_text;
+
+use crate::{Checker, CommandFact, ExpansionContext, Rule, Violation, WordFactContext};
 
 pub struct UnquotedPathInMkdir;
 

--- a/crates/shuck-linter/src/rules/style/unquoted_tr_class.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_tr_class.rs
@@ -1,6 +1,6 @@
-use crate::{
-    Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote, static_word_text,
-};
+use shuck_ast::static_word_text;
+
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote};
 
 pub struct UnquotedTrClass;
 

--- a/crates/shuck-linter/src/rules/style/unquoted_tr_range.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_tr_range.rs
@@ -1,4 +1,6 @@
-use crate::{Checker, Rule, Violation, static_word_text};
+use shuck_ast::static_word_text;
+
+use crate::{Checker, Rule, Violation};
 
 pub struct UnquotedTrRange;
 

--- a/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
@@ -1,6 +1,7 @@
+use shuck_ast::static_word_text;
+
 use crate::{
     Checker, ExpansionContext, Rule, SimpleTestShape, SimpleTestSyntax, Violation, WordFactContext,
-    static_word_text,
 };
 
 pub struct UnquotedVariableInTest;

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -14,4 +14,7 @@ pub mod parser;
 /// Error types returned by parser operations.
 pub use error::{Error, Result};
 /// Shell dialect, profile, and option types exposed by the parser.
-pub use parser::{OptionValue, ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState};
+pub use parser::{
+    OptionValue, ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState,
+    text_is_self_contained_arithmetic_expression, text_looks_like_nontrivial_arithmetic_expression,
+};

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -184,6 +184,91 @@ impl ParseResult {
     }
 }
 
+/// Returns whether `text` parses as a nontrivial arithmetic expression.
+pub fn text_looks_like_nontrivial_arithmetic_expression(text: &str) -> bool {
+    let text = text.trim();
+    if text.is_empty() {
+        return false;
+    }
+
+    let source = format!("(( {text} ))");
+    let file = Parser::new(&source).parse();
+    if file.is_err() {
+        return false;
+    }
+
+    let Some(statement) = file.file.body.first() else {
+        return false;
+    };
+
+    let AstCommand::Compound(CompoundCommand::Arithmetic(command)) = &statement.command else {
+        return false;
+    };
+
+    command.expr_ast.as_ref().is_some_and(|expr| {
+        !matches!(
+            expr.kind,
+            ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_)
+        )
+    })
+}
+
+/// Returns whether `text` parses as an arithmetic expression without variable
+/// references or assignments.
+pub fn text_is_self_contained_arithmetic_expression(text: &str) -> bool {
+    let text = text.trim();
+    if text.is_empty() {
+        return false;
+    }
+
+    let source = format!("(( {text} ))");
+    let file = Parser::new(&source).parse();
+    if file.is_err() {
+        return false;
+    }
+
+    let Some(statement) = file.file.body.first() else {
+        return false;
+    };
+
+    let AstCommand::Compound(CompoundCommand::Arithmetic(command)) = &statement.command else {
+        return false;
+    };
+
+    command
+        .expr_ast
+        .as_ref()
+        .is_some_and(arithmetic_expr_is_self_contained)
+}
+
+fn arithmetic_expr_is_self_contained(expr: &ArithmeticExprNode) -> bool {
+    match &expr.kind {
+        ArithmeticExpr::Number(_) => true,
+        ArithmeticExpr::Variable(_)
+        | ArithmeticExpr::Indexed { .. }
+        | ArithmeticExpr::ShellWord(_)
+        | ArithmeticExpr::Assignment { .. } => false,
+        ArithmeticExpr::Parenthesized { expression } => {
+            arithmetic_expr_is_self_contained(expression)
+        }
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            arithmetic_expr_is_self_contained(expr)
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            arithmetic_expr_is_self_contained(left) && arithmetic_expr_is_self_contained(right)
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            arithmetic_expr_is_self_contained(condition)
+                && arithmetic_expr_is_self_contained(then_expr)
+                && arithmetic_expr_is_self_contained(else_expr)
+        }
+    }
+}
+
 #[cfg(feature = "benchmarking")]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[doc(hidden)]

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -536,6 +536,30 @@ fn parser_backed_parameter_fragments_keep_word_asts() {
     );
 }
 
+#[test]
+fn arithmetic_text_helper_requires_nontrivial_expressions() {
+    assert!(text_looks_like_nontrivial_arithmetic_expression("1 + 2"));
+    assert!(text_looks_like_nontrivial_arithmetic_expression("arr[1]"));
+    assert!(text_looks_like_nontrivial_arithmetic_expression("++count"));
+    assert!(!text_looks_like_nontrivial_arithmetic_expression("123"));
+    assert!(!text_looks_like_nontrivial_arithmetic_expression("name"));
+    assert!(!text_looks_like_nontrivial_arithmetic_expression(
+        "latest value"
+    ));
+}
+
+#[test]
+fn arithmetic_text_helper_distinguishes_self_contained_expressions() {
+    assert!(text_is_self_contained_arithmetic_expression("1 + 2"));
+    assert!(text_is_self_contained_arithmetic_expression("(1 + 2)"));
+    assert!(!text_is_self_contained_arithmetic_expression("name"));
+    assert!(!text_is_self_contained_arithmetic_expression("arr[1]"));
+    assert!(!text_is_self_contained_arithmetic_expression("foo + 1"));
+    assert!(!text_is_self_contained_arithmetic_expression(
+        "latest value"
+    ));
+}
+
 mod commands;
 mod heredocs;
 mod redirects;

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -9,7 +9,7 @@ use shuck_ast::{
     HeredocBodyPartNode, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
     PatternGroupKind, PatternPart, PatternPartNode, Span, Stmt, StmtSeq, Subscript, VarRef, Word,
     WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
-    try_static_word_parts_text,
+    static_word_text, try_static_word_parts_text,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::{ShellProfile, ZshEmulationMode};
@@ -2508,7 +2508,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
 
             if nameref_mode {
-                let name = Name::from(text.as_str());
+                let name = Name::from(text.as_ref());
                 let Some(binding_id) =
                     self.resolve_reference(&name, self.current_scope(), argument.span.start.offset)
                 else {
@@ -2523,7 +2523,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
 
             self.cleared_variables.insert(
-                (self.current_scope(), Name::from(text.as_str())),
+                (self.current_scope(), Name::from(text.as_ref())),
                 argument.span.start.offset,
             );
         }
@@ -2535,7 +2535,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
 
         if let Some(text) = static_word_text(word, self.source) {
-            return SourceRefKind::Literal(text);
+            return SourceRefKind::Literal(text.into_owned());
         }
 
         classify_dynamic_source_word(word, self.source)
@@ -3391,7 +3391,7 @@ fn simple_command_has_name(command: &shuck_ast::SimpleCommand, source: &str) -> 
 
 fn named_target_word(word: &Word, source: &str) -> Option<(Name, Span)> {
     let text = static_word_text(word, source)?;
-    is_name(&text).then_some((Name::from(text), word.span))
+    is_name(&text).then_some((Name::from(text.as_ref()), word.span))
 }
 
 fn static_command_name_text(word: &Word, source: &str) -> Option<String> {
@@ -3403,10 +3403,6 @@ fn static_command_name_text(word: &Word, source: &str) -> Option<String> {
         &mut result,
     )
     .then_some(result)
-}
-
-fn static_word_text(word: &Word, source: &str) -> Option<String> {
-    word.try_static_text(source).map(|text| text.into_owned())
 }
 
 #[derive(Clone, Copy)]
@@ -3506,7 +3502,7 @@ fn recorded_simple_command_info(
     let static_args = command
         .args
         .iter()
-        .map(|word| static_word_text(word, source))
+        .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
         .collect::<Vec<_>>()
         .into_boxed_slice();
     let source_path_template = static_callee
@@ -3571,7 +3567,7 @@ fn normalize_recorded_zsh_effect_command(words: &[&Word], source: &str) -> Optio
             continue;
         }
 
-        match text.as_str() {
+        match text.as_ref() {
             "noglob" => {
                 index += 1;
                 continue;
@@ -3588,7 +3584,7 @@ fn normalize_recorded_zsh_effect_command(words: &[&Word], source: &str) -> Optio
                 index = skip_recorded_exec_wrapper_options(words, source, index + 1);
                 continue;
             }
-            _ => return Some((text, index)),
+            _ => return Some((text.into_owned(), index)),
         }
     }
 
@@ -3686,7 +3682,7 @@ fn parse_emulate_effects(args: &[&Word], source: &str) -> Vec<RecordedZshCommand
             continue;
         };
 
-        match text.as_str() {
+        match text.as_ref() {
             "--" => {
                 break;
             }
@@ -3770,7 +3766,7 @@ fn parse_set_builtin_option_updates(args: &[&Word], source: &str) -> Vec<Recorde
             continue;
         };
 
-        match text.as_str() {
+        match text.as_ref() {
             "-o" | "+o" => {
                 let enable = text.starts_with('-');
                 if let Some(name) = args

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -5,7 +5,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     ArithmeticExpr, ArithmeticExprNode, BourneParameterExpansion, Command, File, Name,
     ParameterExpansion, ParameterExpansionSyntax, Span, StmtSeq, VarRef, Word, WordPart,
-    WordPartNode,
+    WordPartNode, static_word_text,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
@@ -1242,10 +1242,6 @@ fn scope_members_excluding_functions(scopes: &[crate::Scope], root: ScopeId) -> 
         }
     }
     members
-}
-
-fn static_word_text(word: &Word, source: &str) -> Option<String> {
-    word.try_static_text(source).map(|text| text.into_owned())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Move AST-shape word helpers into `shuck-ast`, including static word text, shell variable name checks, and standalone word-shape predicates.
- Move parser-backed arithmetic snippet classifiers into `shuck-parser`.
- Remove linter-root compatibility shims and update linter, semantic, and rule call sites to import helpers from their owning crates directly.

## Why

`rules/common/word.rs` was carrying syntax and parser utility logic that belongs lower in the stack. This keeps linter common code focused on linter-specific word classification while making shared syntax/parser helpers available from the crates that own the behavior.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p shuck-ast -p shuck-parser -p shuck-semantic -p shuck-linter`