### PR TITLE
refactor(linter): move command normalization into facts

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1960,6 +1960,49 @@ pub fn static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, s
     try_static_word_parts_text(&word.parts, source)
 }
 
+/// Returns a command word's fully static decoded command name when it contains
+/// no runtime expansions.
+///
+/// Unlike [`static_word_text`], this applies the extra backslash decoding used
+/// when a shell parses a command name position.
+pub fn static_command_name_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
+    try_static_command_name_parts_text(&word.parts, source, StaticCommandNameContext::Unquoted)
+}
+
+/// The result of looking for a static shell precommand wrapper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaticCommandWrapperTarget {
+    /// The current word is not a supported precommand wrapper.
+    NotWrapper,
+    /// The current word is a wrapper, and the optional index points at its command target.
+    Wrapper {
+        /// The wrapped command index, or `None` when the wrapper mode does not execute a target.
+        target_index: Option<usize>,
+    },
+}
+
+/// Resolves the target index for common shell precommand wrappers.
+///
+/// This handles wrappers shared by parsing, semantic analysis, and linter facts:
+/// `noglob`, `command`, `builtin`, and `exec`. The callback should return the
+/// already-static text for a word index, or `None` when that word is dynamic.
+pub fn static_command_wrapper_target_index<'a>(
+    word_count: usize,
+    current_index: usize,
+    current_name: &str,
+    mut static_text_at: impl FnMut(usize) -> Option<Cow<'a, str>>,
+) -> StaticCommandWrapperTarget {
+    let target_index = match current_name {
+        "noglob" => next_word_index(word_count, current_index),
+        "command" => command_wrapper_target_index(word_count, current_index, &mut static_text_at),
+        "builtin" => generic_wrapper_target_index(word_count, current_index, &mut static_text_at),
+        "exec" => exec_wrapper_target_index(word_count, current_index, &mut static_text_at),
+        _ => return StaticCommandWrapperTarget::NotWrapper,
+    };
+
+    StaticCommandWrapperTarget::Wrapper { target_index }
+}
+
 /// Returns fully static decoded text for a contiguous slice of word parts when
 /// the slice contains no runtime expansions.
 pub fn try_static_word_parts_text<'a>(
@@ -1998,6 +2041,213 @@ fn collect_static_word_parts_text(parts: &[WordPartNode], source: &str, out: &mu
     }
 
     true
+}
+
+#[derive(Clone, Copy)]
+enum StaticCommandNameContext {
+    Unquoted,
+    DoubleQuoted,
+}
+
+fn try_static_command_name_parts_text<'a>(
+    parts: &'a [WordPartNode],
+    source: &'a str,
+    context: StaticCommandNameContext,
+) -> Option<Cow<'a, str>> {
+    if let [part] = parts {
+        return try_static_command_name_part_text(part, source, context);
+    }
+
+    let mut result = String::new();
+    collect_static_command_name_parts_text(parts, source, context, &mut result)
+        .then_some(Cow::Owned(result))
+}
+
+fn try_static_command_name_part_text<'a>(
+    part: &'a WordPartNode,
+    source: &'a str,
+    context: StaticCommandNameContext,
+) -> Option<Cow<'a, str>> {
+    match &part.kind {
+        WordPart::Literal(text) => Some(decode_static_command_literal(
+            text.as_str(source, part.span),
+            context,
+        )),
+        WordPart::SingleQuoted { value, .. } => Some(Cow::Borrowed(value.slice(source))),
+        WordPart::DoubleQuoted { parts, .. } => try_static_command_name_parts_text(
+            parts,
+            source,
+            StaticCommandNameContext::DoubleQuoted,
+        ),
+        _ => None,
+    }
+}
+
+fn collect_static_command_name_parts_text(
+    parts: &[WordPartNode],
+    source: &str,
+    context: StaticCommandNameContext,
+    out: &mut String,
+) -> bool {
+    for part in parts {
+        match &part.kind {
+            WordPart::Literal(text) => {
+                let decoded =
+                    decode_static_command_literal(text.as_str(source, part.span), context);
+                out.push_str(decoded.as_ref());
+            }
+            WordPart::SingleQuoted { value, .. } => out.push_str(value.slice(source)),
+            WordPart::DoubleQuoted { parts, .. } => {
+                if !collect_static_command_name_parts_text(
+                    parts,
+                    source,
+                    StaticCommandNameContext::DoubleQuoted,
+                    out,
+                ) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+
+    true
+}
+
+fn decode_static_command_literal(text: &str, context: StaticCommandNameContext) -> Cow<'_, str> {
+    if !text.contains('\\') {
+        return Cow::Borrowed(text);
+    }
+
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            result.push(ch);
+            continue;
+        }
+
+        let Some(next) = chars.next() else {
+            result.push('\\');
+            break;
+        };
+
+        match context {
+            StaticCommandNameContext::Unquoted => {
+                if next != '\n' {
+                    result.push(next);
+                }
+            }
+            StaticCommandNameContext::DoubleQuoted => match next {
+                '$' | '`' | '"' | '\\' => result.push(next),
+                '\n' => {}
+                _ => {
+                    result.push('\\');
+                    result.push(next);
+                }
+            },
+        }
+    }
+
+    Cow::Owned(result)
+}
+
+fn next_word_index(word_count: usize, current_index: usize) -> Option<usize> {
+    let index = current_index + 1;
+    (index < word_count).then_some(index)
+}
+
+fn command_wrapper_target_index<'a>(
+    word_count: usize,
+    current_index: usize,
+    static_text_at: &mut impl FnMut(usize) -> Option<Cow<'a, str>>,
+) -> Option<usize> {
+    let mut index = current_index + 1;
+
+    while index < word_count {
+        let Some(arg) = static_text_at(index) else {
+            return Some(index);
+        };
+
+        if arg == "--" {
+            return next_word_index(word_count, index);
+        }
+
+        if arg.starts_with('-') && arg != "-" {
+            if arg
+                .strip_prefix('-')
+                .is_some_and(|flags| flags.chars().any(|flag| matches!(flag, 'v' | 'V')))
+            {
+                return None;
+            }
+            index += 1;
+            continue;
+        }
+
+        return Some(index);
+    }
+
+    None
+}
+
+fn generic_wrapper_target_index<'a>(
+    word_count: usize,
+    current_index: usize,
+    static_text_at: &mut impl FnMut(usize) -> Option<Cow<'a, str>>,
+) -> Option<usize> {
+    let mut index = current_index + 1;
+
+    while index < word_count {
+        let Some(arg) = static_text_at(index) else {
+            return Some(index);
+        };
+
+        if arg == "--" {
+            return next_word_index(word_count, index);
+        }
+
+        if arg.starts_with('-') && arg != "-" {
+            index += 1;
+            continue;
+        }
+
+        return Some(index);
+    }
+
+    None
+}
+
+fn exec_wrapper_target_index<'a>(
+    word_count: usize,
+    current_index: usize,
+    static_text_at: &mut impl FnMut(usize) -> Option<Cow<'a, str>>,
+) -> Option<usize> {
+    let mut index = current_index + 1;
+
+    while index < word_count {
+        let Some(arg) = static_text_at(index) else {
+            return Some(index);
+        };
+
+        if arg == "--" {
+            return next_word_index(word_count, index);
+        }
+
+        if arg == "-a" {
+            index = (index + 2).min(word_count);
+            continue;
+        }
+
+        if arg.starts_with('-') && arg != "-" {
+            index += 1;
+            continue;
+        }
+
+        return Some(index);
+    }
+
+    None
 }
 
 /// Returns whether `name` is a shell variable identifier.

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -2174,14 +2174,26 @@ fn command_wrapper_target_index<'a>(
             return next_word_index(word_count, index);
         }
 
-        match arg.as_ref() {
-            "-p" => {
-                index += 1;
-                continue;
+        if let Some(options) = arg.strip_prefix('-') {
+            if options.is_empty() {
+                return Some(index);
             }
-            "-v" | "-V" => return None,
-            _ if arg.starts_with('-') && arg != "-" => return None,
-            _ => {}
+
+            let mut lookup_mode = false;
+            for option in options.chars() {
+                match option {
+                    'p' => {}
+                    'v' | 'V' => lookup_mode = true,
+                    _ => return None,
+                }
+            }
+
+            if lookup_mode {
+                return None;
+            }
+
+            index += 1;
+            continue;
         }
 
         return Some(index);

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1995,7 +1995,7 @@ pub fn static_command_wrapper_target_index<'a>(
     let target_index = match current_name {
         "noglob" => next_word_index(word_count, current_index),
         "command" => command_wrapper_target_index(word_count, current_index, &mut static_text_at),
-        "builtin" => generic_wrapper_target_index(word_count, current_index, &mut static_text_at),
+        "builtin" => builtin_wrapper_target_index(word_count, current_index, &mut static_text_at),
         "exec" => exec_wrapper_target_index(word_count, current_index, &mut static_text_at),
         _ => return StaticCommandWrapperTarget::NotWrapper,
     };
@@ -2190,12 +2190,12 @@ fn command_wrapper_target_index<'a>(
     None
 }
 
-fn generic_wrapper_target_index<'a>(
+fn builtin_wrapper_target_index<'a>(
     word_count: usize,
     current_index: usize,
     static_text_at: &mut impl FnMut(usize) -> Option<Cow<'a, str>>,
 ) -> Option<usize> {
-    let mut index = current_index + 1;
+    let index = current_index + 1;
 
     while index < word_count {
         let Some(arg) = static_text_at(index) else {
@@ -2207,8 +2207,7 @@ fn generic_wrapper_target_index<'a>(
         }
 
         if arg.starts_with('-') && arg != "-" {
-            index += 1;
-            continue;
+            return None;
         }
 
         return Some(index);
@@ -2234,13 +2233,22 @@ fn exec_wrapper_target_index<'a>(
         }
 
         if arg == "-a" {
-            index = (index + 2).min(word_count);
+            let name_index = index + 1;
+            if name_index >= word_count {
+                return None;
+            }
+            static_text_at(name_index)?;
+            index += 2;
+            continue;
+        }
+
+        if matches!(arg.as_ref(), "-c" | "-l") {
+            index += 1;
             continue;
         }
 
         if arg.starts_with('-') && arg != "-" {
-            index += 1;
-            continue;
+            return None;
         }
 
         return Some(index);

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -2174,15 +2174,14 @@ fn command_wrapper_target_index<'a>(
             return next_word_index(word_count, index);
         }
 
-        if arg.starts_with('-') && arg != "-" {
-            if arg
-                .strip_prefix('-')
-                .is_some_and(|flags| flags.chars().any(|flag| matches!(flag, 'v' | 'V')))
-            {
-                return None;
+        match arg.as_ref() {
+            "-p" => {
+                index += 1;
+                continue;
             }
-            index += 1;
-            continue;
+            "-v" | "-V" => return None,
+            _ if arg.starts_with('-') && arg != "-" => return None,
+            _ => {}
         }
 
         return Some(index);

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -2196,24 +2196,23 @@ fn builtin_wrapper_target_index<'a>(
     static_text_at: &mut impl FnMut(usize) -> Option<Cow<'a, str>>,
 ) -> Option<usize> {
     let index = current_index + 1;
-
-    while index < word_count {
-        let Some(arg) = static_text_at(index) else {
-            return Some(index);
-        };
-
-        if arg == "--" {
-            return next_word_index(word_count, index);
-        }
-
-        if arg.starts_with('-') && arg != "-" {
-            return None;
-        }
-
-        return Some(index);
+    if index >= word_count {
+        return None;
     }
 
-    None
+    let Some(arg) = static_text_at(index) else {
+        return Some(index);
+    };
+
+    if arg == "--" {
+        return next_word_index(word_count, index);
+    }
+
+    if arg.starts_with('-') && arg != "-" {
+        return None;
+    }
+
+    Some(index)
 }
 
 fn exec_wrapper_target_index<'a>(

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -2231,23 +2231,31 @@ fn exec_wrapper_target_index<'a>(
             return next_word_index(word_count, index);
         }
 
-        if arg == "-a" {
-            let name_index = index + 1;
-            if name_index >= word_count {
-                return None;
+        if let Some(options) = arg.strip_prefix('-') {
+            if options.is_empty() {
+                return Some(index);
             }
-            static_text_at(name_index)?;
-            index += 2;
-            continue;
-        }
 
-        if matches!(arg.as_ref(), "-c" | "-l") {
-            index += 1;
-            continue;
-        }
+            let mut consumed_words = 1;
+            for (offset, option) in options.char_indices() {
+                match option {
+                    'c' | 'l' => {}
+                    'a' => {
+                        let has_attached_name = offset + option.len_utf8() < options.len();
+                        if !has_attached_name {
+                            if index + consumed_words >= word_count {
+                                return None;
+                            }
+                            consumed_words += 1;
+                        }
+                        break;
+                    }
+                    _ => return None,
+                }
+            }
 
-        if arg.starts_with('-') && arg != "-" {
-            return None;
+            index += consumed_words;
+            continue;
         }
 
         return Some(index);

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -9,6 +9,7 @@
 
 mod conditional_portability;
 mod escape_scan;
+mod normalized_commands;
 mod presence;
 pub(crate) mod surface;
 #[cfg(test)]
@@ -20,6 +21,7 @@ use self::word_spans::{expansion_part_spans, word_unbraced_variable_before_brack
 use self::{
     conditional_portability::{ConditionalPortabilityInputs, build_conditional_portability_facts},
     escape_scan::{EscapeScanContext, EscapeScanInputs, build_escape_scan_matches},
+    normalized_commands as command,
     presence::build_presence_tested_names,
     surface::{
         CaseModificationFragmentFact, CasePatternExpansionFact, DollarDoubleQuotedFragmentFact,
@@ -34,9 +36,8 @@ use self::{
     },
 };
 use crate::context::ContextRegionKind;
-use crate::rules::common::{
-    command::{self, DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind},
-    query::{self, CommandSubstitutionKind, CommandVisit, CommandWalkOptions},
+use crate::rules::common::query::{
+    self, CommandSubstitutionKind, CommandVisit, CommandWalkOptions,
 };
 use crate::suppression::shellcheck_directive_can_apply_to_following_command;
 use crate::{AmbientShellOptions, FileContext};
@@ -64,6 +65,11 @@ use std::{borrow::Cow, cell::OnceCell, ops::ControlFlow};
 
 pub use self::conditional_portability::ConditionalPortabilityFacts;
 pub(crate) use self::escape_scan::{EscapeScanMatch, EscapeScanSourceKind};
+#[cfg(feature = "benchmarking")]
+pub(crate) use self::normalized_commands::normalize_command;
+pub use self::normalized_commands::{
+    DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind,
+};
 pub use self::surface::{
     BacktickFragmentFact, LegacyArithmeticFragmentFact, PositionalParameterFragmentFact,
     SingleQuotedFragmentFact,

--- a/crates/shuck-linter/src/facts/normalized_commands.rs
+++ b/crates/shuck-linter/src/facts/normalized_commands.rs
@@ -558,6 +558,27 @@ mod tests {
                 ("printf", Some("'%s\\n'")),
             ),
             (
+                "exec -cl printf '%s\\n' hi\n",
+                Some("exec"),
+                Some("printf"),
+                vec![WrapperKind::Exec],
+                ("printf", Some("'%s\\n'")),
+            ),
+            (
+                "exec -lc printf '%s\\n' hi\n",
+                Some("exec"),
+                Some("printf"),
+                vec![WrapperKind::Exec],
+                ("printf", Some("'%s\\n'")),
+            ),
+            (
+                "exec -la shuck printf '%s\\n' hi\n",
+                Some("exec"),
+                Some("printf"),
+                vec![WrapperKind::Exec],
+                ("printf", Some("'%s\\n'")),
+            ),
+            (
                 "busybox awk '{print $1}'\n",
                 Some("busybox"),
                 Some("awk"),

--- a/crates/shuck-linter/src/facts/normalized_commands.rs
+++ b/crates/shuck-linter/src/facts/normalized_commands.rs
@@ -537,6 +537,13 @@ mod tests {
                 ("printf", Some("'%s\\n'")),
             ),
             (
+                "command -pp printf '%s\\n' hi\n",
+                Some("command"),
+                Some("printf"),
+                vec![WrapperKind::Command],
+                ("printf", Some("'%s\\n'")),
+            ),
+            (
                 "noglob rm *.txt\n",
                 Some("noglob"),
                 Some("rm"),

--- a/crates/shuck-linter/src/facts/normalized_commands.rs
+++ b/crates/shuck-linter/src/facts/normalized_commands.rs
@@ -686,15 +686,20 @@ mod tests {
     }
 
     #[test]
-    fn normalize_command_does_not_peel_unsupported_command_options() {
-        let source = "command -x printf '%s\\n' hi\n";
-        let command = parse_first_command(source);
-        let normalized = normalize_command(&command, source);
+    fn normalize_command_does_not_peel_unsupported_wrapper_options() {
+        for (source, wrapper) in [
+            ("command -x printf '%s\\n' hi\n", WrapperKind::Command),
+            ("builtin -x read var\n", WrapperKind::Builtin),
+            ("exec -x printf '%s\\n' hi\n", WrapperKind::Exec),
+        ] {
+            let command = parse_first_command(source);
+            let normalized = normalize_command(&command, source);
 
-        assert_eq!(normalized.literal_name.as_deref(), Some("command"));
-        assert_eq!(normalized.effective_name.as_deref(), None);
-        assert_eq!(normalized.wrappers, vec![WrapperKind::Command]);
-        assert!(normalized.body_words.is_empty());
+            assert!(normalized.literal_name.is_some(), "{source}");
+            assert_eq!(normalized.effective_name.as_deref(), None, "{source}");
+            assert_eq!(normalized.wrappers, vec![wrapper], "{source}");
+            assert!(normalized.body_words.is_empty(), "{source}");
+        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/normalized_commands.rs
+++ b/crates/shuck-linter/src/facts/normalized_commands.rs
@@ -2,7 +2,8 @@ use std::borrow::Cow;
 
 use shuck_ast::{
     Assignment, BuiltinCommand, Command, DeclClause, DeclOperand, Redirect, SimpleCommand, Span,
-    Word, static_word_text,
+    StaticCommandWrapperTarget, Word, static_command_name_text,
+    static_command_wrapper_target_index, static_word_text,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -316,22 +317,12 @@ fn resolve_command_resolution(
     source: &str,
 ) -> Option<CommandResolution> {
     match current_name {
-        "noglob" => Some(CommandResolution::Wrapper {
-            kind: WrapperKind::Noglob,
-            target_index: words.get(current_index + 1).map(|_| current_index + 1),
-        }),
-        "command" => Some(CommandResolution::Wrapper {
-            kind: WrapperKind::Command,
-            target_index: command_wrapper_target_index(words, current_index, source),
-        }),
-        "builtin" => Some(CommandResolution::Wrapper {
-            kind: WrapperKind::Builtin,
-            target_index: words.get(current_index + 1).map(|_| current_index + 1),
-        }),
-        "exec" => Some(CommandResolution::Wrapper {
-            kind: WrapperKind::Exec,
-            target_index: exec_wrapper_target_index(words, current_index, source),
-        }),
+        "noglob" | "command" | "builtin" | "exec" => Some(resolve_shared_wrapper(
+            words,
+            current_index,
+            current_name,
+            source,
+        )),
         "busybox" => Some(CommandResolution::Wrapper {
             kind: WrapperKind::Busybox,
             target_index: words.get(current_index + 1).map(|_| current_index + 1),
@@ -354,51 +345,28 @@ fn resolve_command_resolution(
     }
 }
 
-fn command_wrapper_target_index(
+fn resolve_shared_wrapper(
     words: &[&Word],
     current_index: usize,
+    current_name: &str,
     source: &str,
-) -> Option<usize> {
-    let mut index = current_index + 1;
+) -> CommandResolution {
+    let kind = match current_name {
+        "noglob" => WrapperKind::Noglob,
+        "command" => WrapperKind::Command,
+        "builtin" => WrapperKind::Builtin,
+        "exec" => WrapperKind::Exec,
+        _ => unreachable!("caller only passes shared wrappers"),
+    };
+    let StaticCommandWrapperTarget::Wrapper { target_index } =
+        static_command_wrapper_target_index(words.len(), current_index, current_name, |index| {
+            static_word_text(words[index], source)
+        })
+    else {
+        unreachable!("shared wrapper name should resolve to a wrapper target");
+    };
 
-    while index < words.len() {
-        let Some(arg) = static_word_text(words[index], source) else {
-            return Some(index);
-        };
-
-        match arg.as_ref() {
-            "--" => return words.get(index + 1).map(|_| index + 1),
-            "-p" => index += 1,
-            "-v" | "-V" => return None,
-            _ if arg.starts_with('-') => return None,
-            _ => return Some(index),
-        }
-    }
-
-    None
-}
-
-fn exec_wrapper_target_index(words: &[&Word], current_index: usize, source: &str) -> Option<usize> {
-    let mut index = current_index + 1;
-
-    while index < words.len() {
-        let Some(arg) = static_word_text(words[index], source) else {
-            return Some(index);
-        };
-
-        match arg.as_ref() {
-            "--" => return words.get(index + 1).map(|_| index + 1),
-            "-c" | "-l" => index += 1,
-            "-a" => {
-                static_word_text(words.get(index + 1)?, source)?;
-                index += 2;
-            }
-            _ if arg.starts_with('-') => return None,
-            _ => return Some(index),
-        }
-    }
-
-    None
+    CommandResolution::Wrapper { kind, target_index }
 }
 
 fn find_exec_target_index(
@@ -539,14 +507,6 @@ fn builtin_span(command: &BuiltinCommand) -> Span {
         BuiltinCommand::Continue(command) => command.span,
         BuiltinCommand::Return(command) => command.span,
         BuiltinCommand::Exit(command) => command.span,
-    }
-}
-
-fn static_command_name_text<'a>(word: &'a Word, source: &'a str) -> Option<Cow<'a, str>> {
-    let text = static_word_text(word, source)?;
-    match text.strip_prefix('\\') {
-        Some(stripped) => Some(Cow::Owned(stripped.to_owned())),
-        None => Some(text),
     }
 }
 

--- a/crates/shuck-linter/src/facts/normalized_commands.rs
+++ b/crates/shuck-linter/src/facts/normalized_commands.rs
@@ -686,6 +686,18 @@ mod tests {
     }
 
     #[test]
+    fn normalize_command_does_not_peel_unsupported_command_options() {
+        let source = "command -x printf '%s\\n' hi\n";
+        let command = parse_first_command(source);
+        let normalized = normalize_command(&command, source);
+
+        assert_eq!(normalized.literal_name.as_deref(), Some("command"));
+        assert_eq!(normalized.effective_name.as_deref(), None);
+        assert_eq!(normalized.wrappers, vec![WrapperKind::Command]);
+        assert!(normalized.body_words.is_empty());
+    }
+
+    #[test]
     fn normalize_command_canonicalizes_escaped_static_names() {
         for (source, expected) in [
             ("\\cd /tmp\n", "cd"),

--- a/crates/shuck-linter/src/facts/tests/mod.rs
+++ b/crates/shuck-linter/src/facts/tests/mod.rs
@@ -15,8 +15,8 @@ use super::{
     build_innermost_command_ids_by_offset, parse_assignment_word,
     precomputed_command_id_for_offset,
 };
+use crate::WrapperKind;
 use crate::facts::surface::PositionalParameterFragmentKind;
-use crate::rules::common::command::WrapperKind;
 use crate::{LinterFacts, ShellDialect, classify_file_context};
 
 mod assignments;

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -76,7 +76,10 @@ pub use facts::{
     WordQuote, WordSubstitutionShape, XargsCommandFacts, leading_literal_word_prefix,
 };
 /// Fact collection types and stable identifiers into those collections.
-pub use facts::{CommandId, FactSpan, LinterFacts};
+pub use facts::{
+    CommandId, DeclarationKind, FactSpan, LinterFacts, NormalizedCommand, NormalizedDeclaration,
+    WrapperKind,
+};
 /// Autofix types and fix application helpers.
 pub use fix::{Applicability, AppliedFixes, Edit, Fix, FixAvailability, apply_fixes};
 pub(crate) use fix_helpers::leading_static_word_prefix_fix_in_source;
@@ -88,10 +91,6 @@ pub use rule_metadata::{RuleMetadata, ShellCheckLevel, rule_metadata, rule_metad
 pub use rule_selector::{RuleSelector, SelectorParseError};
 /// Sets of enabled or disabled rules.
 pub use rule_set::RuleSet;
-/// Command normalization helper types exposed by fact APIs.
-pub use rules::common::command::{
-    DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind,
-};
 /// Command-substitution classification exposed by fact APIs.
 pub use rules::common::query::CommandSubstitutionKind;
 #[allow(unused_imports)]
@@ -161,10 +160,8 @@ pub fn analyze_file(
 #[doc(hidden)]
 #[must_use]
 pub fn benchmark_normalize_commands(file: &File, source: &str) -> usize {
-    use crate::rules::common::{
-        command::normalize_command,
-        query::{self, CommandWalkOptions},
-    };
+    use crate::facts::normalize_command;
+    use crate::rules::common::query::{self, CommandWalkOptions};
 
     query::iter_commands_with_context(
         &file.body,

--- a/crates/shuck-linter/src/rules/common/mod.rs
+++ b/crates/shuck-linter/src/rules/common/mod.rs
@@ -1,4 +1,3 @@
-pub mod command;
 pub mod query;
 pub mod safe_value;
 pub mod word;

--- a/crates/shuck-linter/src/rules/portability/sourced_with_args.rs
+++ b/crates/shuck-linter/src/rules/portability/sourced_with_args.rs
@@ -1,4 +1,4 @@
-use shuck_ast::static_word_text;
+use shuck_ast::static_command_name_text;
 
 use crate::context::FileContextTag;
 use crate::{Checker, Rule, ShellDialect, Violation};
@@ -42,11 +42,6 @@ pub fn sourced_with_args(checker: &mut Checker) {
 
 fn targets_posix_dot_shell(shell: ShellDialect) -> bool {
     matches!(shell, ShellDialect::Sh | ShellDialect::Dash)
-}
-
-fn static_command_name_text(word: &shuck_ast::Word, source: &str) -> Option<String> {
-    let text = static_word_text(word, source)?;
-    Some(text.strip_prefix('\\').unwrap_or(text.as_ref()).to_owned())
 }
 
 #[cfg(test)]

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -41,12 +41,13 @@ use shuck_ast::{
     LiteralText, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
     PatternGroupKind, PatternPart, PatternPartNode, Position, PrefixMatchKind, Redirect,
     RedirectKind, RedirectTarget, RepeatCommand, RepeatSyntax, ReturnCommand as AstReturnCommand,
-    SelectCommand, SimpleCommand as AstSimpleCommand, SourceText, Span, Stmt, StmtSeq,
-    StmtTerminator, Subscript, SubscriptInterpretation, SubscriptKind, SubscriptSelector, TextSize,
-    TimeCommand, TokenKind, UntilCommand, VarRef, WhileCommand, Word, WordPart, WordPartNode,
-    ZshDefaultingOp, ZshExpansionOperation, ZshExpansionTarget, ZshGlobQualifier,
-    ZshGlobQualifierGroup, ZshGlobQualifierKind, ZshGlobSegment, ZshInlineGlobControl, ZshModifier,
-    ZshParameterExpansion, ZshPatternOp, ZshQualifiedGlob, ZshReplacementOp, ZshTrimOp,
+    SelectCommand, SimpleCommand as AstSimpleCommand, SourceText, Span, StaticCommandWrapperTarget,
+    Stmt, StmtSeq, StmtTerminator, Subscript, SubscriptInterpretation, SubscriptKind,
+    SubscriptSelector, TextSize, TimeCommand, TokenKind, UntilCommand, VarRef, WhileCommand, Word,
+    WordPart, WordPartNode, ZshDefaultingOp, ZshExpansionOperation, ZshExpansionTarget,
+    ZshGlobQualifier, ZshGlobQualifierGroup, ZshGlobQualifierKind, ZshGlobSegment,
+    ZshInlineGlobControl, ZshModifier, ZshParameterExpansion, ZshPatternOp, ZshQualifiedGlob,
+    ZshReplacementOp, ZshTrimOp, static_command_wrapper_target_index,
 };
 
 use crate::error::{Error, Result};
@@ -1333,84 +1334,22 @@ fn normalize_prescan_command(words: &[String]) -> Option<(&str, usize)> {
             index += 1;
             continue;
         }
-        match word.as_str() {
-            "noglob" => {
-                index += 1;
+        match static_command_wrapper_target_index(words.len(), index, word, |word_index| {
+            Some(Cow::Borrowed(words[word_index].as_str()))
+        }) {
+            StaticCommandWrapperTarget::NotWrapper => {}
+            StaticCommandWrapperTarget::Wrapper {
+                target_index: Some(target_index),
+            } => {
+                index = target_index;
                 continue;
             }
-            "command" => {
-                index = skip_prescan_command_wrapper_options(words, index + 1)?;
-                continue;
-            }
-            "builtin" => {
-                index = skip_prescan_wrapper_options(words, index + 1);
-                continue;
-            }
-            "exec" => {
-                index = skip_prescan_exec_wrapper_options(words, index + 1);
-                continue;
-            }
-            _ => {}
+            StaticCommandWrapperTarget::Wrapper { target_index: None } => return None,
         }
         return Some((word.as_str(), index + 1));
     }
 
     None
-}
-
-fn skip_prescan_command_wrapper_options(words: &[String], mut index: usize) -> Option<usize> {
-    while let Some(word) = words.get(index) {
-        if word == "--" {
-            index += 1;
-            break;
-        }
-        if word.starts_with('-') && word != "-" {
-            if word
-                .strip_prefix('-')
-                .is_some_and(|flags| flags.chars().any(|flag| matches!(flag, 'v' | 'V')))
-            {
-                return None;
-            }
-            index += 1;
-            continue;
-        }
-        break;
-    }
-    Some(index)
-}
-
-fn skip_prescan_wrapper_options(words: &[String], mut index: usize) -> usize {
-    while let Some(word) = words.get(index) {
-        if word == "--" {
-            index += 1;
-            break;
-        }
-        if word.starts_with('-') && word != "-" {
-            index += 1;
-            continue;
-        }
-        break;
-    }
-    index
-}
-
-fn skip_prescan_exec_wrapper_options(words: &[String], mut index: usize) -> usize {
-    while let Some(word) = words.get(index) {
-        if word == "--" {
-            index += 1;
-            break;
-        }
-        if word == "-a" {
-            index = (index + 2).min(words.len());
-            continue;
-        }
-        if word.starts_with('-') && word != "-" {
-            index += 1;
-            continue;
-        }
-        break;
-    }
-    index
 }
 
 fn is_prescan_assignment_word(word: &str) -> bool {

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3495,6 +3495,7 @@ repeat 2 echo global
 fn test_parse_zsh_wrapped_unsetopt_short_repeat_demotes_repeat_to_simple_command() {
     for source in [
         "command unsetopt short_repeat\nrepeat 2 echo hi\n",
+        "command -pp unsetopt short_repeat\nrepeat 2 echo hi\n",
         "exec -cl unsetopt short_repeat\nrepeat 2 echo hi\n",
         "exec -lc unsetopt short_repeat\nrepeat 2 echo hi\n",
         "exec -la shuck unsetopt short_repeat\nrepeat 2 echo hi\n",
@@ -3529,20 +3530,25 @@ fn test_parse_zsh_plain_subshell_does_not_leak_short_repeat_prescan() {
 
 #[test]
 fn test_parse_zsh_command_v_does_not_fake_short_repeat_effects() {
-    let source = "command -v unsetopt short_repeat\nrepeat 2 echo global\n";
-    let output = Parser::with_dialect(source, ShellDialect::Zsh)
-        .parse()
-        .unwrap()
-        .file;
+    for source in [
+        "command -v unsetopt short_repeat\nrepeat 2 echo global\n",
+        "command -pv unsetopt short_repeat\nrepeat 2 echo global\n",
+        "command -pV unsetopt short_repeat\nrepeat 2 echo global\n",
+    ] {
+        let output = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
 
-    let command = expect_simple(&output.body[0]);
-    assert_eq!(command.name.render(source), "command");
+        let command = expect_simple(&output.body[0]);
+        assert_eq!(command.name.render(source), "command", "{source}");
 
-    let (compound, _) = expect_compound(&output.body[1]);
-    let AstCompoundCommand::Repeat(repeat) = compound else {
-        panic!("expected top-level repeat command");
-    };
-    assert_eq!(repeat.count.render(source), "2");
+        let (compound, _) = expect_compound(&output.body[1]);
+        let AstCompoundCommand::Repeat(repeat) = compound else {
+            panic!("expected top-level repeat command for {source}");
+        };
+        assert_eq!(repeat.count.render(source), "2", "{source}");
+    }
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3540,21 +3540,32 @@ fn test_parse_zsh_command_v_does_not_fake_short_repeat_effects() {
 }
 
 #[test]
-fn test_parse_zsh_command_unknown_option_does_not_fake_short_repeat_effects() {
-    let source = "command -x unsetopt short_repeat\nrepeat 2 echo global\n";
-    let output = Parser::with_dialect(source, ShellDialect::Zsh)
-        .parse()
-        .unwrap()
-        .file;
+fn test_parse_zsh_unknown_precommand_options_do_not_fake_short_repeat_effects() {
+    for source in [
+        "command -x unsetopt short_repeat\nrepeat 2 echo global\n",
+        "builtin -x unsetopt short_repeat\nrepeat 2 echo global\n",
+        "exec -x unsetopt short_repeat\nrepeat 2 echo global\n",
+    ] {
+        let output = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
 
-    let command = expect_simple(&output.body[0]);
-    assert_eq!(command.name.render(source), "command");
+        let command = expect_simple(&output.body[0]);
+        assert!(
+            matches!(
+                command.name.render(source).as_str(),
+                "command" | "builtin" | "exec"
+            ),
+            "{source}"
+        );
 
-    let (compound, _) = expect_compound(&output.body[1]);
-    let AstCompoundCommand::Repeat(repeat) = compound else {
-        panic!("expected top-level repeat command");
-    };
-    assert_eq!(repeat.count.render(source), "2");
+        let (compound, _) = expect_compound(&output.body[1]);
+        let AstCompoundCommand::Repeat(repeat) = compound else {
+            panic!("expected top-level repeat command for {source}");
+        };
+        assert_eq!(repeat.count.render(source), "2", "{source}");
+    }
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3540,6 +3540,24 @@ fn test_parse_zsh_command_v_does_not_fake_short_repeat_effects() {
 }
 
 #[test]
+fn test_parse_zsh_command_unknown_option_does_not_fake_short_repeat_effects() {
+    let source = "command -x unsetopt short_repeat\nrepeat 2 echo global\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let command = expect_simple(&output.body[0]);
+    assert_eq!(command.name.render(source), "command");
+
+    let (compound, _) = expect_compound(&output.body[1]);
+    let AstCompoundCommand::Repeat(repeat) = compound else {
+        panic!("expected top-level repeat command");
+    };
+    assert_eq!(repeat.count.render(source), "2");
+}
+
+#[test]
 fn test_parse_zsh_function_subshell_body_does_not_leak_short_repeat_prescan() {
     let source = "f() ( unsetopt short_repeat )\nrepeat 2 echo global\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3493,14 +3493,20 @@ repeat 2 echo global
 
 #[test]
 fn test_parse_zsh_wrapped_unsetopt_short_repeat_demotes_repeat_to_simple_command() {
-    let source = "command unsetopt short_repeat\nrepeat 2 echo hi\n";
-    let output = Parser::with_dialect(source, ShellDialect::Zsh)
-        .parse()
-        .unwrap()
-        .file;
+    for source in [
+        "command unsetopt short_repeat\nrepeat 2 echo hi\n",
+        "exec -cl unsetopt short_repeat\nrepeat 2 echo hi\n",
+        "exec -lc unsetopt short_repeat\nrepeat 2 echo hi\n",
+        "exec -la shuck unsetopt short_repeat\nrepeat 2 echo hi\n",
+    ] {
+        let output = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
 
-    let command = expect_simple(&output.body[1]);
-    assert_eq!(command.name.render(source), "repeat");
+        let command = expect_simple(&output.body[1]);
+        assert_eq!(command.name.render(source), "repeat", "{source}");
+    }
 }
 
 #[test]

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -7,9 +7,10 @@ use shuck_ast::{
     AssignmentValue, BinaryCommand, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command,
     CompoundCommand, ConditionalExpr, DeclOperand, File, FunctionDef, HeredocBody, HeredocBodyPart,
     HeredocBodyPartNode, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
-    PatternGroupKind, PatternPart, PatternPartNode, Span, Stmt, StmtSeq, Subscript, VarRef, Word,
-    WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
-    static_word_text, try_static_word_parts_text,
+    PatternGroupKind, PatternPart, PatternPartNode, Span, StaticCommandWrapperTarget, Stmt,
+    StmtSeq, Subscript, VarRef, Word, WordPart, WordPartNode, ZshExpansionOperation,
+    ZshExpansionTarget, ZshGlobSegment, static_command_name_text,
+    static_command_wrapper_target_index, static_word_text, try_static_word_parts_text,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::{ShellProfile, ZshEmulationMode};
@@ -339,7 +340,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         if let Some(name) = static_command_name_text(&command.name, self.source)
             && !name.is_empty()
         {
-            let callee = Name::from(name.as_str());
+            let callee = Name::from(name.as_ref());
             let scope = self.current_scope();
             let call_site = CallSite {
                 callee: callee.clone(),
@@ -3394,84 +3395,6 @@ fn named_target_word(word: &Word, source: &str) -> Option<(Name, Span)> {
     is_name(&text).then_some((Name::from(text.as_ref()), word.span))
 }
 
-fn static_command_name_text(word: &Word, source: &str) -> Option<String> {
-    let mut result = String::new();
-    collect_static_command_name_parts(
-        &word.parts,
-        source,
-        StaticCommandNameContext::Unquoted,
-        &mut result,
-    )
-    .then_some(result)
-}
-
-#[derive(Clone, Copy)]
-enum StaticCommandNameContext {
-    Unquoted,
-    DoubleQuoted,
-}
-
-fn collect_static_command_name_parts(
-    parts: &[WordPartNode],
-    source: &str,
-    context: StaticCommandNameContext,
-    out: &mut String,
-) -> bool {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(text) => {
-                decode_static_command_literal(text.as_str(source, part.span), context, out);
-            }
-            WordPart::SingleQuoted { value, .. } => out.push_str(value.slice(source)),
-            WordPart::DoubleQuoted { parts, .. } => {
-                if !collect_static_command_name_parts(
-                    parts,
-                    source,
-                    StaticCommandNameContext::DoubleQuoted,
-                    out,
-                ) {
-                    return false;
-                }
-            }
-            _ => return false,
-        }
-    }
-
-    true
-}
-
-fn decode_static_command_literal(text: &str, context: StaticCommandNameContext, out: &mut String) {
-    let mut chars = text.chars();
-
-    while let Some(ch) = chars.next() {
-        if ch != '\\' {
-            out.push(ch);
-            continue;
-        }
-
-        let Some(next) = chars.next() else {
-            out.push('\\');
-            break;
-        };
-
-        match context {
-            StaticCommandNameContext::Unquoted => {
-                if next != '\n' {
-                    out.push(next);
-                }
-            }
-            StaticCommandNameContext::DoubleQuoted => match next {
-                '$' | '`' | '"' | '\\' => out.push(next),
-                '\n' => {}
-                _ => {
-                    out.push('\\');
-                    out.push(next);
-                }
-            },
-        }
-    }
-}
-
 fn recorded_command_info(
     command: &Command,
     source: &str,
@@ -3498,7 +3421,8 @@ fn recorded_simple_command_info(
     let words = std::iter::once(&command.name)
         .chain(command.args.iter())
         .collect::<Vec<_>>();
-    let mut static_callee = static_command_name_text(&command.name, source);
+    let mut static_callee =
+        static_command_name_text(&command.name, source).map(|name| name.into_owned());
     let static_args = command
         .args
         .iter()
@@ -3514,7 +3438,7 @@ fn recorded_simple_command_info(
     if static_callee.as_deref() == Some("noglob") {
         static_callee = words
             .get(1)
-            .and_then(|word| static_command_name_text(word, source));
+            .and_then(|word| static_command_name_text(word, source).map(|name| name.into_owned()));
     }
 
     let mut info = RecordedCommandInfo {
@@ -3567,96 +3491,21 @@ fn normalize_recorded_zsh_effect_command(words: &[&Word], source: &str) -> Optio
             continue;
         }
 
-        match text.as_ref() {
-            "noglob" => {
-                index += 1;
+        match static_command_wrapper_target_index(words.len(), index, text.as_ref(), |word_index| {
+            static_word_text(words[word_index], source)
+        }) {
+            StaticCommandWrapperTarget::NotWrapper => return Some((text.into_owned(), index)),
+            StaticCommandWrapperTarget::Wrapper {
+                target_index: Some(target_index),
+            } => {
+                index = target_index;
                 continue;
             }
-            "command" => {
-                index = skip_recorded_command_wrapper_options(words, source, index + 1)?;
-                continue;
-            }
-            "builtin" => {
-                index = skip_recorded_wrapper_options(words, source, index + 1);
-                continue;
-            }
-            "exec" => {
-                index = skip_recorded_exec_wrapper_options(words, source, index + 1);
-                continue;
-            }
-            _ => return Some((text.into_owned(), index)),
+            StaticCommandWrapperTarget::Wrapper { target_index: None } => return None,
         }
     }
 
     None
-}
-
-fn skip_recorded_command_wrapper_options(
-    words: &[&Word],
-    source: &str,
-    mut index: usize,
-) -> Option<usize> {
-    while let Some(word) = words.get(index) {
-        let Some(text) = static_word_text(word, source) else {
-            break;
-        };
-        if text == "--" {
-            index += 1;
-            break;
-        }
-        if text.starts_with('-') && text != "-" {
-            if text
-                .strip_prefix('-')
-                .is_some_and(|flags| flags.chars().any(|flag| matches!(flag, 'v' | 'V')))
-            {
-                return None;
-            }
-            index += 1;
-            continue;
-        }
-        break;
-    }
-    Some(index)
-}
-
-fn skip_recorded_wrapper_options(words: &[&Word], source: &str, mut index: usize) -> usize {
-    while let Some(word) = words.get(index) {
-        let Some(text) = static_word_text(word, source) else {
-            break;
-        };
-        if text == "--" {
-            index += 1;
-            break;
-        }
-        if text.starts_with('-') && text != "-" {
-            index += 1;
-            continue;
-        }
-        break;
-    }
-    index
-}
-
-fn skip_recorded_exec_wrapper_options(words: &[&Word], source: &str, mut index: usize) -> usize {
-    while let Some(word) = words.get(index) {
-        let Some(text) = static_word_text(word, source) else {
-            break;
-        };
-        if text == "--" {
-            index += 1;
-            break;
-        }
-        if text == "-a" {
-            index = (index + 2).min(words.len());
-            continue;
-        }
-        if text.starts_with('-') && text != "-" {
-            index += 1;
-            continue;
-        }
-        break;
-    }
-    index
 }
 
 fn is_recorded_assignment_word(word: &str) -> bool {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -7739,6 +7739,20 @@ print *
     }
 
     #[test]
+    fn zsh_option_analysis_tracks_command_repeated_p_wrapper() {
+        let source = "\
+command -pp setopt no_glob
+print *
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected wrapped zsh option effects");
+
+        assert_eq!(options.glob, OptionValue::Off);
+    }
+
+    #[test]
     fn zsh_option_analysis_tracks_exec_bundled_option_wrappers() {
         for source in [
             "\
@@ -7765,16 +7779,27 @@ print *
 
     #[test]
     fn zsh_option_analysis_ignores_command_lookup_modes() {
-        let source = "\
+        for source in [
+            "\
 command -v setopt no_glob
 print *
-";
-        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
-        let options = model
-            .zsh_options_at(source.find("print").unwrap())
-            .expect("expected wrapped zsh options");
+",
+            "\
+command -pv setopt no_glob
+print *
+",
+            "\
+command -pV setopt no_glob
+print *
+",
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let options = model
+                .zsh_options_at(source.find("print").unwrap())
+                .expect("expected wrapped zsh options");
 
-        assert_eq!(options.glob, OptionValue::On);
+            assert_eq!(options.glob, OptionValue::On, "{source}");
+        }
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -7751,4 +7751,18 @@ print *
 
         assert_eq!(options.glob, OptionValue::On);
     }
+
+    #[test]
+    fn zsh_option_analysis_ignores_unsupported_command_options() {
+        let source = "\
+command -x setopt no_glob
+print *
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected wrapped zsh options");
+
+        assert_eq!(options.glob, OptionValue::On);
+    }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -7739,6 +7739,31 @@ print *
     }
 
     #[test]
+    fn zsh_option_analysis_tracks_exec_bundled_option_wrappers() {
+        for source in [
+            "\
+exec -cl setopt no_glob
+print *
+",
+            "\
+exec -lc setopt no_glob
+print *
+",
+            "\
+exec -la shuck setopt no_glob
+print *
+",
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let options = model
+                .zsh_options_at(source.find("print").unwrap())
+                .expect("expected wrapped zsh option effects");
+
+            assert_eq!(options.glob, OptionValue::Off, "{source}");
+        }
+    }
+
+    #[test]
     fn zsh_option_analysis_ignores_command_lookup_modes() {
         let source = "\
 command -v setopt no_glob

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -7753,16 +7753,27 @@ print *
     }
 
     #[test]
-    fn zsh_option_analysis_ignores_unsupported_command_options() {
-        let source = "\
+    fn zsh_option_analysis_ignores_unsupported_precommand_options() {
+        for source in [
+            "\
 command -x setopt no_glob
 print *
-";
-        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
-        let options = model
-            .zsh_options_at(source.find("print").unwrap())
-            .expect("expected wrapped zsh options");
+",
+            "\
+builtin -x setopt no_glob
+print *
+",
+            "\
+exec -x setopt no_glob
+print *
+",
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let options = model
+                .zsh_options_at(source.find("print").unwrap())
+                .expect("expected wrapped zsh options");
 
-        assert_eq!(options.glob, OptionValue::On);
+            assert_eq!(options.glob, OptionValue::On, "{source}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Move linter normalized-command types and normalization logic from `rules/common` into the facts module.
- Add shared AST utilities for static command-name decoding and common precommand wrapper target resolution.
- Reuse the shared wrapper logic in parser zsh prescan and semantic zsh-effect recording.

## Impact

This keeps normalized command concepts owned by linter facts while removing duplicated wrapper peeling from parser and semantic code paths.

## Validation

- `cargo check -p shuck-ast -p shuck-parser -p shuck-semantic -p shuck-linter`
- `cargo test -p shuck-ast -p shuck-parser -p shuck-semantic -p shuck-linter`
- `cargo check -p shuck-linter --features benchmarking`