### PR TITLE
fix(linter): align S041 function body checks with ShellCheck

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s041.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s041.yaml
@@ -1,16 +1,1 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_contains: "Bash-it__bash-it__"
-    reason: "Shuck treats a bare compound command in function position as a missing-braces portability issue. The nix ShellCheck 0.11.0 oracle in this repo does not emit SC2276 for the small probes we checked, including subshell and bare test/if forms, so these repo-family hits are intentionally recorded as reviewed shuck-only divergence."
-  - side: shuck-only
-    path_contains: "SlackBuildsOrg__slackbuilds__"
-    reason: "Shuck treats a bare compound command in function position as a missing-braces portability issue. The nix ShellCheck 0.11.0 oracle in this repo does not emit SC2276 for the small probes we checked, including subshell and bare test/if forms, so these repo-family hits are intentionally recorded as reviewed shuck-only divergence."
-  - side: shuck-only
-    path_contains: "asdf-vm__asdf__"
-    reason: "Shuck treats a bare compound command in function position as a missing-braces portability issue. The nix ShellCheck 0.11.0 oracle in this repo does not emit SC2276 for the small probes we checked, including subshell and bare test/if forms, so these repo-family hits are intentionally recorded as reviewed shuck-only divergence."
-  - side: shuck-only
-    path_contains: "megastep__makeself__"
-    reason: "Shuck treats a bare compound command in function position as a missing-braces portability issue. The nix ShellCheck 0.11.0 oracle in this repo does not emit SC2276 for the small probes we checked, including subshell and bare test/if forms, so these repo-family hits are intentionally recorded as reviewed shuck-only divergence."
-  - side: shuck-only
-    path_contains: "rvm__rvm__"
-    reason: "Shuck treats a bare compound command in function position as a missing-braces portability issue. The nix ShellCheck 0.11.0 oracle in this repo does not emit SC2276 for the small probes we checked, including subshell and bare test/if forms, so these repo-family hits are intentionally recorded as reviewed shuck-only divergence."
+reviewed_divergences: []

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -648,7 +648,11 @@ fn word_part_is_plain_positional_parameter(part: &WordPart, target: &str) -> boo
 
 fn function_body_without_braces_span(function: &FunctionDef) -> Option<Span> {
     match &function.body.command {
-        Command::Compound(CompoundCommand::BraceGroup(_)) => None,
+        Command::Compound(
+            CompoundCommand::BraceGroup(_)
+            | CompoundCommand::Subshell(_)
+            | CompoundCommand::Arithmetic(_),
+        ) => None,
         Command::Compound(_) => Some(function.body.span),
         Command::Simple(_)
         | Command::Decl(_)

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -337,6 +337,13 @@ fn builds_function_style_spans() {
     let source = "\
 #!/bin/bash
 f() [[ -n \"$x\" ]]
+p() if true; then :; fi
+q() case x in x) :;; esac
+r() for x in y; do :; done
+s() while true; do :; done
+t() until false; do :; done
+u() ( echo hi )
+v() (( x++ ))
 g() {
   if cond; then
     false
@@ -393,7 +400,14 @@ o() {
                 .iter()
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["[[ -n \"$x\" ]]"]
+            vec![
+                "[[ -n \"$x\" ]]",
+                "if true; then :; fi\n",
+                "case x in x) :;; esac\n",
+                "for x in y; do :; done",
+                "while true; do :; done\n",
+                "until false; do :; done\n",
+            ]
         );
         assert_eq!(
             facts

--- a/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
+++ b/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
@@ -39,7 +39,8 @@ mod tests {
         let source = "\
 #!/bin/bash
 f() [[ -n \"$x\" ]]
-g() ( echo hi )
+g() if true; then :; fi
+h() case x in x) :;; esac
 ";
         let diagnostics = test_snippet(
             source,
@@ -51,16 +52,22 @@ g() ( echo hi )
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["[[ -n \"$x\" ]]", "echo hi )"]
+            vec![
+                "[[ -n \"$x\" ]]",
+                "if true; then :; fi\n",
+                "case x in x) :;; esac\n",
+            ]
         );
     }
 
     #[test]
-    fn ignores_braced_function_bodies() {
+    fn ignores_function_bodies_shellcheck_accepts() {
         let source = "\
 #!/bin/bash
 f() { [[ -n \"$x\" ]]; }
 g() { ( echo hi ); }
+h() ( echo hi )
+i() (( x++ ))
 ";
         let diagnostics = test_snippet(
             source,

--- a/docs/rules/S041.yaml
+++ b/docs/rules/S041.yaml
@@ -10,8 +10,8 @@ shells:
   - bash
   - dash
   - ksh
-description: A function body is a bare compound command instead of a brace group.
-rationale: "Wrap the function body in `{ ... }` for portability."
+description: A function body uses an unbraced compound command that should be brace-wrapped.
+rationale: "Wrap these function bodies in `{ ... }` for compatibility; subshell and arithmetic function bodies are accepted."
 safe_fix: true
 fix_description: "Wrap the existing compound function body in `{ ...; }` without changing the inner command."
 source:


### PR DESCRIPTION
## Summary
- Stop S041 from flagging subshell and arithmetic function bodies, matching the pinned ShellCheck oracle.
- Remove the stale broad S041 reviewed-divergence metadata and update focused fact/rule coverage.
- Refresh the S041 rule description to describe the narrower behavior.

## Validation
- `cargo test -p shuck-linter function_body_without_braces`
- `cargo test -p shuck-linter builds_function_style_spans`
- `cargo test -p shuck-linter rules::style::tests::rules`
- `git diff --check`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S041` now reports `implementation_diffs=0` and `reviewed_divergences=0`; the command still exits nonzero due to 5 pre-existing parser harness failures unrelated to S041.

## Note
- `./docs/rules/validate.sh` could not complete in this worktree because `../shell-checks` is missing.