### PR TITLE
refactor(linter): move traversal helpers into facts

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1,7 +1,7 @@
 fn build_base_prefix_arithmetic_spans(body: &StmtSeq, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
 
-    for visit in query::iter_commands(
+    for visit in iter_commands(
         body,
         CommandWalkOptions {
             descend_nested_word_commands: true,
@@ -748,7 +748,7 @@ fn build_arithmetic_update_operator_spans(
 ) -> Vec<Span> {
     let mut spans = Vec::new();
 
-    for visit in query::iter_commands(
+    for visit in iter_commands(
         body,
         CommandWalkOptions {
             descend_nested_word_commands: true,
@@ -1039,7 +1039,7 @@ fn collect_arithmetic_update_operator_spans_in_assignment_target(
             spans,
         );
     }
-    query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
+    visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
         collect_arithmetic_update_operator_spans_from_parts(&word.parts, semantic, source, spans);
     });
 }
@@ -1271,7 +1271,7 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    for visit in query::iter_commands(
+    for visit in iter_commands(
         body,
         CommandWalkOptions {
             descend_nested_word_commands: true,
@@ -1320,7 +1320,7 @@ fn collect_arithmetic_update_operator_spans_in_subscript_words(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    query::visit_subscript_words(Some(subscript), source, &mut |word| {
+    visit_subscript_words(Some(subscript), source, &mut |word| {
         collect_arithmetic_update_operator_spans_from_parts_impl(
             &word.parts,
             semantic,

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -64,11 +64,11 @@ fn parameter_uses_replacement_operator(parameter: &ParameterExpansion) -> bool {
 
 
 fn collect_broken_assoc_key_spans(command: &Command, source: &str, spans: &mut Vec<Span>) {
-    for assignment in query::command_assignments(command) {
+    for assignment in command_assignments(command) {
         collect_broken_assoc_key_spans_in_assignment(assignment, source, spans);
     }
 
-    for operand in query::declaration_operands(command) {
+    for operand in declaration_operands(command) {
         let DeclOperand::Assignment(assignment) = operand else {
             continue;
         };
@@ -171,13 +171,13 @@ fn has_unclosed_assoc_key_prefix(word: &Word, source: &str) -> bool {
 }
 
 fn collect_comma_array_assignment_spans(command: &Command, source: &str, spans: &mut Vec<Span>) {
-    for assignment in query::command_assignments(command) {
+    for assignment in command_assignments(command) {
         if let Some(span) = comma_array_assignment_span(assignment, source) {
             spans.push(span);
         }
     }
 
-    for operand in query::declaration_operands(command) {
+    for operand in declaration_operands(command) {
         let DeclOperand::Assignment(assignment) = operand else {
             continue;
         };
@@ -192,13 +192,13 @@ fn collect_ifs_literal_backslash_assignment_value_spans(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    for assignment in query::command_assignments(command) {
+    for assignment in command_assignments(command) {
         if let Some(span) = ifs_literal_backslash_assignment_value_span(assignment, source) {
             spans.push(span);
         }
     }
 
-    for operand in query::declaration_operands(command) {
+    for operand in declaration_operands(command) {
         let DeclOperand::Assignment(assignment) = operand else {
             continue;
         };

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -388,7 +388,7 @@ fn build_env_prefix_scope_spans(source: &str, commands: &[CommandFact<'_>]) -> E
             continue;
         }
 
-        let assignments = query::command_assignments(command.command());
+        let assignments = command_assignments(command.command());
         let broken_legacy_bracket_tail = match command.command() {
             Command::Simple(simple) => broken_legacy_bracket_tail(simple, source),
             Command::Builtin(_)
@@ -1638,7 +1638,7 @@ fn has_intervening_persistent_reset(
 }
 
 fn command_prefix_assignments_reset_name(command: &Command, name: &Name) -> bool {
-    query::command_assignments(command)
+    command_assignments(command)
         .iter()
         .any(|assignment| assignment.target.name == *name)
 }
@@ -2290,7 +2290,7 @@ fn collect_binding_values<'a>(
 ) {
     let assignments = match command {
         Command::Simple(simple) if simple.name.span.slice(source).is_empty() => &simple.assignments,
-        Command::Builtin(_) | Command::Decl(_) => query::command_assignments(command),
+        Command::Builtin(_) | Command::Decl(_) => command_assignments(command),
         Command::Simple(_)
         | Command::Binary(_)
         | Command::Compound(_)
@@ -2312,7 +2312,7 @@ fn collect_binding_values<'a>(
         }
     }
 
-    for operand in query::declaration_operands(command) {
+    for operand in declaration_operands(command) {
         let DeclOperand::Assignment(assignment) = operand else {
             continue;
         };

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -77,7 +77,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut condition_status_capture_spans = Vec::new();
         let mut condition_command_substitution_spans = Vec::new();
 
-        for traversed in query::iter_commands_with_context(
+        for traversed in iter_commands_with_context(
             &self.file.body,
             CommandWalkOptions {
                 descend_nested_word_commands: true,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -187,7 +187,7 @@ impl<'a> CommandFact<'a> {
             return false;
         };
         let raw = span.slice(source);
-        raw != "[" || !query::command_assignments(self.command()).is_empty()
+        raw != "[" || !command_assignments(self.command()).is_empty()
     }
 
     pub fn body_args(&self) -> &[&'a Word] {

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -1893,7 +1893,7 @@ fn collect_status_parameter_spans_in_assignment(
                         collect_status_parameter_spans_in_word(word, source, spans);
                     }
                     ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
-                        query::visit_subscript_words(Some(key), source, &mut |word| {
+                        visit_subscript_words(Some(key), source, &mut |word| {
                             collect_status_parameter_spans_in_word(word, source, spans);
                         });
                         collect_status_parameter_spans_in_word(value, source, spans);
@@ -1913,7 +1913,7 @@ fn collect_status_parameter_spans_in_var_ref(
         spans.push(reference.span);
     }
 
-    query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
+    visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
         collect_status_parameter_spans_in_word(word, source, spans);
     });
 }
@@ -1952,7 +1952,7 @@ fn collect_status_parameter_spans_in_word_part(
             ..
         } => {
             if let Some(expression) = expression_ast {
-                query::visit_arithmetic_words(expression, &mut |word| {
+                visit_arithmetic_words(expression, &mut |word| {
                     collect_status_parameter_spans_in_word(word, source, spans);
                 });
             } else {
@@ -2016,7 +2016,7 @@ fn collect_status_parameter_spans_in_word_part(
             }
             collect_status_parameter_spans_in_var_ref(reference, source, spans);
             if let Some(offset_ast) = offset_ast {
-                query::visit_arithmetic_words(offset_ast, &mut |word| {
+                visit_arithmetic_words(offset_ast, &mut |word| {
                     collect_status_parameter_spans_in_word(word, source, spans);
                 });
             } else {
@@ -2024,7 +2024,7 @@ fn collect_status_parameter_spans_in_word_part(
             }
             match (length_ast.as_ref(), length_word_ast.as_ref()) {
                 (Some(length_ast), _) => {
-                    query::visit_arithmetic_words(length_ast, &mut |word| {
+                    visit_arithmetic_words(length_ast, &mut |word| {
                         collect_status_parameter_spans_in_word(word, source, spans);
                     });
                 }
@@ -2081,7 +2081,7 @@ fn collect_status_parameter_spans_in_parameter_expansion(
             } => {
                 collect_status_parameter_spans_in_var_ref(reference, source, spans);
                 if let Some(offset_ast) = offset_ast {
-                    query::visit_arithmetic_words(offset_ast, &mut |word| {
+                    visit_arithmetic_words(offset_ast, &mut |word| {
                         collect_status_parameter_spans_in_word(word, source, spans);
                     });
                 } else {
@@ -2090,7 +2090,7 @@ fn collect_status_parameter_spans_in_parameter_expansion(
 
                 match (length_ast.as_ref(), length_word_ast.as_ref()) {
                     (Some(length_ast), _) => {
-                        query::visit_arithmetic_words(length_ast, &mut |word| {
+                        visit_arithmetic_words(length_ast, &mut |word| {
                             collect_status_parameter_spans_in_word(word, source, spans);
                         });
                     }

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -36,9 +36,6 @@ use self::{
     },
 };
 use crate::context::ContextRegionKind;
-use crate::rules::common::query::{
-    self, CommandSubstitutionKind, CommandVisit, CommandWalkOptions,
-};
 use crate::suppression::shellcheck_directive_can_apply_to_following_command;
 use crate::{AmbientShellOptions, FileContext};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -48,12 +45,13 @@ use shuck_ast::{
     BackgroundOperator, BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext,
     BraceSyntaxKind, BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command,
     CommandSubstitutionSyntax, CompoundCommand, ConditionalBinaryOp, ConditionalExpr,
-    ConditionalUnaryOp, DeclClause, DeclOperand, File, ForCommand, FunctionDef, Name,
-    ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position,
-    PrefixMatchKind, Redirect, RedirectKind, SelectCommand, SimpleCommand, SourceText, Span, Stmt,
-    StmtSeq, StmtTerminator, Subscript, SubscriptSelector, TextRange, VarRef, WhileCommand, Word,
-    WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
-    ZshQualifiedGlob, is_shell_variable_name, static_word_text, word_is_standalone_status_capture,
+    ConditionalUnaryOp, DeclClause, DeclOperand, File, ForCommand, FunctionDef,
+    HeredocBodyPartNode, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
+    PatternPart, Position, PrefixMatchKind, Redirect, RedirectKind, SelectCommand, SimpleCommand,
+    SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript, SubscriptSelector, TextRange,
+    VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget,
+    ZshGlobSegment, ZshQualifiedGlob, is_shell_variable_name, static_word_text,
+    word_is_standalone_status_capture,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
@@ -75,6 +73,7 @@ pub use self::surface::{
     SingleQuotedFragmentFact,
 };
 
+include!("traversal.rs");
 include!("core.rs");
 include!("simple_tests.rs");
 include!("conditionals.rs");
@@ -97,6 +96,25 @@ include!("heredocs.rs");
 include!("braces.rs");
 include!("arithmetic.rs");
 include!("words.rs");
+
+#[cfg(feature = "benchmarking")]
+pub(crate) fn benchmark_normalize_commands(file: &File, source: &str) -> usize {
+    iter_commands_with_context(
+        &file.body,
+        CommandWalkOptions {
+            descend_nested_word_commands: true,
+        },
+    )
+    .map(|traversed| {
+        let normalized = normalize_command(traversed.visit.command, source);
+        normalized.wrappers.len()
+            + normalized.body_words.len()
+            + usize::from(normalized.literal_name.is_some())
+            + usize::from(normalized.effective_name.is_some())
+            + usize::from(normalized.declaration.is_some())
+    })
+    .sum()
+}
 
 #[allow(unused_imports)]
 pub(crate) mod core {
@@ -124,7 +142,7 @@ pub(crate) mod redirects {
 
 #[allow(unused_imports)]
 pub(crate) mod substitutions {
-    pub use super::{SubstitutionFact, SubstitutionHostKind};
+    pub use super::{CommandSubstitutionKind, SubstitutionFact, SubstitutionHostKind};
 }
 
 #[allow(unused_imports)]

--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -141,7 +141,7 @@ pub(super) fn build_pipeline_facts<'a>(
                 return None;
             }
 
-            let segments = query::pipeline_segments(fact.command())?;
+            let segments = pipeline_segments(fact.command())?;
             Some(PipelineFact {
                 key: fact.key(),
                 command,
@@ -154,6 +154,35 @@ pub(super) fn build_pipeline_facts<'a>(
             })
         })
         .collect()
+}
+
+fn pipeline_segments(command: &Command) -> Option<Vec<&Stmt>> {
+    let Command::Binary(command) = command else {
+        return None;
+    };
+    if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) {
+        return None;
+    }
+
+    let mut segments = Vec::new();
+    collect_pipeline_segments(command, &mut segments);
+    Some(segments)
+}
+
+fn collect_pipeline_segments<'a>(command: &'a BinaryCommand, segments: &mut Vec<&'a Stmt>) {
+    match &command.left.command {
+        Command::Binary(left) if matches!(left.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
+            collect_pipeline_segments(left, segments);
+        }
+        _ => segments.push(&command.left),
+    }
+
+    match &command.right.command {
+        Command::Binary(right) if matches!(right.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
+            collect_pipeline_segments(right, segments);
+        }
+        _ => segments.push(&command.right),
+    }
 }
 
 fn pipeline_operator_facts(command: &BinaryCommand) -> Box<[PipelineOperatorFact]> {
@@ -204,3 +233,39 @@ fn build_pipeline_segment_fact<'a>(
     }
 }
 
+#[cfg(test)]
+mod pipeline_tests {
+    use shuck_ast::{Command, StmtSeq, Word};
+    use shuck_parser::parser::Parser;
+
+    use super::pipeline_segments;
+
+    fn parse_commands(source: &str) -> StmtSeq {
+        let output = Parser::new(source).parse().unwrap();
+        output.file.body
+    }
+
+    fn static_word_owned_text(word: &Word, source: &str) -> Option<String> {
+        word.try_static_text(source).map(|text| text.into_owned())
+    }
+
+    #[test]
+    fn pipeline_segments_flattens_pipe_chains() {
+        let source = "printf '%s\\n' a | command kill 0 | tee out.txt\n";
+        let commands = parse_commands(source);
+        let Command::Binary(command) = &commands[0].command else {
+            panic!("expected binary command");
+        };
+
+        let segments = pipeline_segments(&Command::Binary(command.clone()))
+            .expect("expected pipeline segments")
+            .into_iter()
+            .map(|stmt| match &stmt.command {
+                Command::Simple(command) => static_word_owned_text(&command.name, source).unwrap(),
+                _ => "<non-simple>".to_owned(),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(segments, vec!["printf", "command", "tee"]);
+    }
+}

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -1,4 +1,11 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandSubstitutionKind {
+    Command,
+    ProcessInput,
+    ProcessOutput,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubstitutionOutputIntent {
     Captured,
     Discarded,
@@ -503,7 +510,7 @@ fn classify_substitution_body<'a>(
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> SubstitutionBodyFacts {
-    let visits = query::iter_commands(
+    let visits = iter_commands(
         body,
         CommandWalkOptions {
             descend_nested_word_commands: false,
@@ -1352,8 +1359,8 @@ fn visit_command_subscript_words_for_substitutions(
     source: &str,
     visitor: &mut impl FnMut(SubstitutionHostKind, &Word),
 ) {
-    for assignment in query::command_assignments(command) {
-        query::visit_var_ref_subscript_words_with_source(&assignment.target, source, &mut |word| {
+    for assignment in command_assignments(command) {
+        visit_var_ref_subscript_words_with_source(&assignment.target, source, &mut |word| {
             visitor(SubstitutionHostKind::AssignmentTargetSubscript, word);
         });
 
@@ -1362,7 +1369,7 @@ fn visit_command_subscript_words_for_substitutions(
                 if let shuck_ast::ArrayElem::Keyed { key, .. }
                 | shuck_ast::ArrayElem::KeyedAppend { key, .. } = element
                 {
-                    query::visit_subscript_words(Some(key), source, &mut |word| {
+                    visit_subscript_words(Some(key), source, &mut |word| {
                         visitor(SubstitutionHostKind::ArrayKeySubscript, word);
                     });
                 }
@@ -1370,15 +1377,15 @@ fn visit_command_subscript_words_for_substitutions(
         }
     }
 
-    for operand in query::declaration_operands(command) {
+    for operand in declaration_operands(command) {
         match operand {
             DeclOperand::Name(reference) => {
-                query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
+                visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
                     visitor(SubstitutionHostKind::DeclarationNameSubscript, word);
                 });
             }
             DeclOperand::Assignment(assignment) => {
-                query::visit_var_ref_subscript_words_with_source(
+                visit_var_ref_subscript_words_with_source(
                     &assignment.target,
                     source,
                     &mut |word| {
@@ -1391,7 +1398,7 @@ fn visit_command_subscript_words_for_substitutions(
                         if let shuck_ast::ArrayElem::Keyed { key, .. }
                         | shuck_ast::ArrayElem::KeyedAppend { key, .. } = element
                         {
-                            query::visit_subscript_words(Some(key), source, &mut |word| {
+                            visit_subscript_words(Some(key), source, &mut |word| {
                                 visitor(SubstitutionHostKind::ArrayKeySubscript, word);
                             });
                         }
@@ -1409,7 +1416,7 @@ fn visit_assignments_for_substitutions(
     visitor: &mut impl FnMut(&Word),
 ) {
     for assignment in assignments {
-        query::visit_var_ref_subscript_words_with_source(&assignment.target, source, visitor);
+        visit_var_ref_subscript_words_with_source(&assignment.target, source, visitor);
 
         match &assignment.value {
             AssignmentValue::Scalar(word) => visitor(word),
@@ -1419,7 +1426,7 @@ fn visit_assignments_for_substitutions(
                         shuck_ast::ArrayElem::Sequential(word) => visitor(word),
                         shuck_ast::ArrayElem::Keyed { key, value }
                         | shuck_ast::ArrayElem::KeyedAppend { key, value } => {
-                            query::visit_subscript_words(Some(key), source, visitor);
+                            visit_subscript_words(Some(key), source, visitor);
                             visitor(value);
                         }
                     }
@@ -1474,7 +1481,7 @@ fn visit_decl_operand_words_for_substitutions(
     match operand {
         DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => visitor(word),
         DeclOperand::Name(reference) => {
-            query::visit_var_ref_subscript_words_with_source(reference, source, visitor);
+            visit_var_ref_subscript_words_with_source(reference, source, visitor);
         }
         DeclOperand::Assignment(assignment) => {
             visit_assignments_for_substitutions(std::slice::from_ref(assignment), source, visitor);
@@ -1528,7 +1535,7 @@ fn visit_conditional_words_for_substitutions(
         ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => visitor(word),
         ConditionalExpr::Pattern(pattern) => visit_pattern_for_substitutions(pattern, visitor),
         ConditionalExpr::VarRef(reference) => {
-            query::visit_var_ref_subscript_words_with_source(reference, source, visitor);
+            visit_var_ref_subscript_words_with_source(reference, source, visitor);
         }
     }
 }

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -681,7 +681,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         &mut self.facts.positional_parameter_operator_spans,
                     );
                     if let Some(expression_ast) = expression_ast.as_ref() {
-                        query::visit_arithmetic_words(expression_ast, &mut |word| {
+                        visit_arithmetic_words(expression_ast, &mut |word| {
                             self.collect_word(word, context);
                         });
                     } else {
@@ -702,7 +702,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         &mut self.facts.positional_parameter_operator_spans,
                     );
                     if let Some(expression_ast) = expression_ast.as_ref() {
-                        query::visit_arithmetic_words(expression_ast, &mut |word| {
+                        visit_arithmetic_words(expression_ast, &mut |word| {
                             self.collect_word(word, context);
                         });
                     } else {
@@ -922,7 +922,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         &mut self.facts.positional_parameter_operator_spans,
                     );
                     if let Some(expression_ast) = expression_ast.as_ref() {
-                        query::visit_arithmetic_words(expression_ast, &mut |word| {
+                        visit_arithmetic_words(expression_ast, &mut |word| {
                             self.collect_word(word, context);
                         });
                     } else {
@@ -943,7 +943,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         &mut self.facts.positional_parameter_operator_spans,
                     );
                     if let Some(expression_ast) = expression_ast.as_ref() {
-                        query::visit_arithmetic_words(expression_ast, &mut |word| {
+                        visit_arithmetic_words(expression_ast, &mut |word| {
                             self.collect_word(word, context);
                         });
                     } else {
@@ -2035,7 +2035,7 @@ fn arithmetic_expr_has_positional_parameter_operator(
     source: &str,
 ) -> bool {
     let mut should_report = false;
-    query::visit_arithmetic_words(expression, &mut |word| {
+    visit_arithmetic_words(expression, &mut |word| {
         if word_has_unquoted_positional_parameter_operator_neighbors(word, source) {
             should_report = true;
         }

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -1,17 +1,11 @@
-use shuck_ast::{
-    ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
-    BinaryCommand, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand,
-    ConditionalExpr, DeclOperand, FunctionDef, HeredocBodyPartNode, ParameterExpansion,
-    ParameterExpansionSyntax, Pattern, PatternPart, Redirect, Stmt, StmtSeq, Subscript, VarRef,
-    Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment,
-};
+// Private AST traversal used only while building linter facts.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct WalkContext {
-    pub(crate) loop_depth: usize,
+struct WalkContext {
+    loop_depth: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ConditionKind {
+enum ConditionKind {
     If,
     Elif,
     While,
@@ -19,44 +13,33 @@ pub(crate) enum ConditionKind {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct CommandTraversalContext {
-    pub(crate) walk: WalkContext,
-    pub(crate) nested_word_command: bool,
-    pub(crate) condition_kind: Option<ConditionKind>,
-    pub(crate) in_if_condition: bool,
-    pub(crate) in_elif_condition: bool,
+struct CommandTraversalContext {
+    walk: WalkContext,
+    nested_word_command: bool,
+    condition_kind: Option<ConditionKind>,
+    in_if_condition: bool,
+    in_elif_condition: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct CommandWalkOptions {
-    pub(crate) descend_nested_word_commands: bool,
+struct CommandWalkOptions {
+    descend_nested_word_commands: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct CommandVisit<'a> {
-    pub(crate) stmt: &'a Stmt,
-    pub(crate) command: &'a Command,
-    pub(crate) redirects: &'a [Redirect],
+struct CommandVisit<'a> {
+    stmt: &'a Stmt,
+    command: &'a Command,
+    redirects: &'a [Redirect],
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct TraversedCommandVisit<'a> {
-    pub(crate) visit: CommandVisit<'a>,
-    pub(crate) context: CommandTraversalContext,
+struct TraversedCommandVisit<'a> {
+    visit: CommandVisit<'a>,
+    context: CommandTraversalContext,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CommandSubstitutionKind {
-    Command,
-    ProcessInput,
-    ProcessOutput,
-}
-
-// Structural traversal helpers stay crate-visible so `facts.rs` owns repeated
-// AST walks. Rule implementations should consume `Checker::facts()` instead of
-// calling these walkers directly, while `facts.rs` can opt into the streaming
-// walker when it needs traversal context without a second whole-file pass.
-pub(crate) fn walk_commands<'a, F>(
+fn walk_commands<'a, F>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
     visitor: &mut F,
@@ -71,7 +54,7 @@ pub(crate) fn walk_commands<'a, F>(
     );
 }
 
-pub(crate) fn iter_commands_with_context<'a>(
+fn iter_commands_with_context<'a>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
 ) -> impl Iterator<Item = TraversedCommandVisit<'a>> {
@@ -82,24 +65,11 @@ pub(crate) fn iter_commands_with_context<'a>(
     visits.into_iter()
 }
 
-pub(crate) fn iter_commands<'a>(
+fn iter_commands<'a>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
 ) -> impl Iterator<Item = CommandVisit<'a>> {
     iter_commands_with_context(commands, options).map(|visit| visit.visit)
-}
-
-pub(crate) fn pipeline_segments(command: &Command) -> Option<Vec<&Stmt>> {
-    let Command::Binary(command) = command else {
-        return None;
-    };
-    if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) {
-        return None;
-    }
-
-    let mut segments = Vec::new();
-    collect_pipeline_segments(command, &mut segments);
-    Some(segments)
 }
 
 fn zsh_glob_patterns(glob: &shuck_ast::ZshQualifiedGlob) -> impl Iterator<Item = &Pattern> + '_ {
@@ -109,7 +79,7 @@ fn zsh_glob_patterns(glob: &shuck_ast::ZshQualifiedGlob) -> impl Iterator<Item =
     })
 }
 
-pub(crate) fn command_assignments(command: &Command) -> &[Assignment] {
+fn command_assignments(command: &Command) -> &[Assignment] {
     match command {
         Command::Simple(command) => &command.assignments,
         Command::Builtin(command) => builtin_assignments(command),
@@ -121,7 +91,7 @@ pub(crate) fn command_assignments(command: &Command) -> &[Assignment] {
     }
 }
 
-pub(crate) fn declaration_operands(command: &Command) -> &[DeclOperand] {
+fn declaration_operands(command: &Command) -> &[DeclOperand] {
     match command {
         Command::Decl(command) => &command.operands,
         Command::Simple(_)
@@ -133,27 +103,14 @@ pub(crate) fn declaration_operands(command: &Command) -> &[DeclOperand] {
     }
 }
 
-pub(crate) fn visit_arithmetic_words<'a>(
+fn visit_arithmetic_words<'a>(
     expression: &'a ArithmeticExprNode,
     visitor: &mut impl FnMut(&'a Word),
 ) {
     visit_arithmetic_words_in_expr(expression, visitor);
 }
 
-pub(crate) fn visit_var_ref_subscript_words<'a>(
-    reference: &'a VarRef,
-    visitor: &mut impl FnMut(&'a Word),
-) {
-    visit_optional_arithmetic_words(
-        reference
-            .subscript
-            .as_ref()
-            .and_then(|subscript| subscript.arithmetic_ast.as_ref()),
-        visitor,
-    );
-}
-
-pub(crate) fn visit_var_ref_subscript_words_with_source<'a>(
+fn visit_var_ref_subscript_words_with_source<'a>(
     reference: &'a VarRef,
     _source: &'a str,
     visitor: &mut impl FnMut(&'a Word),
@@ -161,7 +118,7 @@ pub(crate) fn visit_var_ref_subscript_words_with_source<'a>(
     visit_subscript_words(reference.subscript.as_ref(), _source, visitor);
 }
 
-pub(crate) fn visit_subscript_words<'a>(
+fn visit_subscript_words<'a>(
     subscript: Option<&'a Subscript>,
     _source: &'a str,
     visitor: &mut impl FnMut(&'a Word),
@@ -219,15 +176,6 @@ fn visit_arithmetic_words_in_expr<'a>(
             visit_arithmetic_lvalue_words(target, visitor);
             visit_arithmetic_words_in_expr(value, visitor);
         }
-    }
-}
-
-fn visit_optional_arithmetic_words<'a>(
-    expression: Option<&'a ArithmeticExprNode>,
-    visitor: &mut impl FnMut(&'a Word),
-) {
-    if let Some(expression) = expression {
-        visit_arithmetic_words_in_expr(expression, visitor);
     }
 }
 
@@ -402,22 +350,6 @@ fn nested_word_context(context: CommandTraversalContext) -> CommandTraversalCont
     CommandTraversalContext {
         nested_word_command: true,
         ..context
-    }
-}
-
-fn collect_pipeline_segments<'a>(command: &'a BinaryCommand, segments: &mut Vec<&'a Stmt>) {
-    match &command.left.command {
-        Command::Binary(left) if matches!(left.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_segments(left, segments);
-        }
-        _ => segments.push(&command.left),
-    }
-
-    match &command.right.command {
-        Command::Binary(right) if matches!(right.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_segments(right, segments);
-        }
-        _ => segments.push(&command.right),
     }
 }
 
@@ -997,7 +929,7 @@ fn collect_heredoc_body_part_visits<'a, F>(
                 }
             }
             shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
-                collect_command_visits(body, options, context, visitor);
+                collect_command_visits(&body, options, context, visitor);
             }
             shuck_ast::HeredocBodyPart::Literal(_)
             | shuck_ast::HeredocBodyPart::Variable(_)
@@ -1007,7 +939,7 @@ fn collect_heredoc_body_part_visits<'a, F>(
 }
 
 #[cfg(test)]
-mod tests {
+mod traversal_tests {
     use shuck_ast::{
         BourneParameterExpansion, Command, ParameterExpansionSyntax, StmtSeq, VarRef, Word,
         WordPart,
@@ -1015,8 +947,8 @@ mod tests {
     use shuck_parser::parser::Parser;
 
     use super::{
-        CommandWalkOptions, ConditionKind, iter_commands, pipeline_segments,
-        visit_var_ref_subscript_words_with_source, walk_commands,
+        CommandWalkOptions, ConditionKind, iter_commands, visit_var_ref_subscript_words_with_source,
+        walk_commands,
     };
 
     fn parse_commands(source: &str) -> StmtSeq {
@@ -1259,26 +1191,6 @@ printf '%s\\n' \"${value/old/$(expr $(nproc) + 1)}\"\n\
                 ("nproc".to_owned(), true),
             ]
         );
-    }
-
-    #[test]
-    fn pipeline_segments_flattens_pipe_chains() {
-        let source = "printf '%s\\n' a | command kill 0 | tee out.txt\n";
-        let commands = parse_commands(source);
-        let Command::Binary(command) = &commands[0].command else {
-            panic!("expected binary command");
-        };
-
-        let segments = pipeline_segments(&Command::Binary(command.clone()))
-            .expect("expected pipeline segments")
-            .into_iter()
-            .map(|stmt| match &stmt.command {
-                Command::Simple(command) => static_word_owned_text(&command.name, source).unwrap(),
-                _ => "<non-simple>".to_owned(),
-            })
-            .collect::<Vec<_>>();
-
-        assert_eq!(segments, vec!["printf", "command", "tee"]);
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -929,7 +929,7 @@ fn collect_heredoc_body_part_visits<'a, F>(
                 }
             }
             shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
-                collect_command_visits(&body, options, context, visitor);
+                collect_command_visits(body, options, context, visitor);
             }
             shuck_ast::HeredocBodyPart::Literal(_)
             | shuck_ast::HeredocBodyPart::Variable(_)

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2612,7 +2612,7 @@ pub(crate) fn benchmark_collect_word_facts(
     let mut arithmetic_summary = ArithmeticFactSummary::default();
     let mut surface_fragments = SurfaceFragmentSink::new(source);
 
-    for (next_command_id, traversed) in query::iter_commands_with_context(
+    for (next_command_id, traversed) in iter_commands_with_context(
         &file.body,
         CommandWalkOptions {
             descend_nested_word_commands: true,
@@ -3198,14 +3198,14 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     }
 
     fn collect_expansion_assignment_value_words(&mut self, command: &'a Command) {
-        for assignment in query::command_assignments(command) {
+        for assignment in command_assignments(command) {
             self.collect_expansion_assignment_words(
                 assignment,
                 WordFactContext::Expansion(ExpansionContext::AssignmentValue),
             );
         }
 
-        for operand in query::declaration_operands(command) {
+        for operand in declaration_operands(command) {
             match operand {
                 DeclOperand::Name(reference) => {
                     self.surface.record_var_ref_subscript(reference);
@@ -3214,7 +3214,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         Some(reference.name_span),
                         reference.subscript.as_ref(),
                     );
-                    query::visit_var_ref_subscript_words_with_source(
+                    visit_var_ref_subscript_words_with_source(
                         reference,
                         self.source,
                         &mut |word| {
@@ -3264,7 +3264,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             Some(assignment.target.name_span),
             assignment.target.subscript.as_ref(),
         );
-        query::visit_var_ref_subscript_words_with_source(
+        visit_var_ref_subscript_words_with_source(
             &assignment.target,
             self.source,
             &mut |word| {
@@ -3317,7 +3317,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                                 Some(assignment.target.name_span),
                                 Some(key),
                             );
-                            query::visit_subscript_words(Some(key), self.source, &mut |word| {
+                            visit_subscript_words(Some(key), self.source, &mut |word| {
                                 collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
                                     &word.parts,
                                     self.source,
@@ -3511,7 +3511,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             }
             ConditionalExpr::VarRef(reference) => {
                 self.surface.record_var_ref_subscript(reference);
-                query::visit_var_ref_subscript_words_with_source(
+                visit_var_ref_subscript_words_with_source(
                     reference,
                     self.source,
                     &mut |word| {
@@ -3746,7 +3746,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     ..
                 } => {
                     if let Some(expression) = expression_ast.as_ref() {
-                        query::visit_arithmetic_words(expression, &mut |word| {
+                        visit_arithmetic_words(expression, &mut |word| {
                             self.push_pending_arithmetic_word_occurrence(
                                 word,
                                 enclosing_expansion_context,
@@ -4324,7 +4324,7 @@ fn collect_arithmetic_command_spans(
     dollar_spans: &mut Vec<Span>,
     command_substitution_spans: &mut Vec<Span>,
 ) {
-    query::visit_arithmetic_words(expression, &mut |word| {
+    visit_arithmetic_words(expression, &mut |word| {
         collect_arithmetic_context_spans_in_word(
             word,
             source,
@@ -4341,7 +4341,7 @@ fn collect_slice_arithmetic_expression_spans(
     dollar_spans: &mut Vec<Span>,
     command_substitution_spans: &mut Vec<Span>,
 ) {
-    query::visit_arithmetic_words(expression, &mut |word| {
+    visit_arithmetic_words(expression, &mut |word| {
         collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
             &word.parts,
             source,
@@ -4962,7 +4962,7 @@ fn collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
             } => {
                 let mut ignored_command_substitution_spans = Vec::new();
                 if let Some(expression) = expression_ast {
-                    query::visit_arithmetic_words(expression, &mut |word| {
+                    visit_arithmetic_words(expression, &mut |word| {
                         collect_arithmetic_context_spans_in_word(
                             word,
                             source,
@@ -5087,7 +5087,7 @@ fn collect_arithmetic_expansion_spans_from_parts(
                 ..
             } => {
                 if let Some(expression) = expression_ast {
-                    query::visit_arithmetic_words(expression, &mut |word| {
+                    visit_arithmetic_words(expression, &mut |word| {
                         collect_arithmetic_context_spans_in_word(
                             word,
                             source,
@@ -5399,7 +5399,7 @@ fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
             spans,
         );
     }
-    query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
+    visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
         collect_arithmetic_update_operator_spans_from_parts_impl(
             &word.parts,
             semantic,
@@ -5621,7 +5621,7 @@ fn collect_arithmetic_spans_in_var_ref(
     dollar_spans: &mut Vec<Span>,
     command_substitution_spans: &mut Vec<Span>,
 ) {
-    query::visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
+    visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
         collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
             &word.parts,
             source,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -54,6 +54,8 @@ pub use context::{
 };
 /// Rule diagnostics and severity levels.
 pub use diagnostic::{Diagnostic, Severity};
+/// Command-substitution classification exposed by fact APIs.
+pub use facts::CommandSubstitutionKind;
 pub(crate) use facts::ComparablePathKey;
 /// Extracted structural facts available to rules and callers.
 pub use facts::{
@@ -91,8 +93,6 @@ pub use rule_metadata::{RuleMetadata, ShellCheckLevel, rule_metadata, rule_metad
 pub use rule_selector::{RuleSelector, SelectorParseError};
 /// Sets of enabled or disabled rules.
 pub use rule_set::RuleSet;
-/// Command-substitution classification exposed by fact APIs.
-pub use rules::common::query::CommandSubstitutionKind;
 #[allow(unused_imports)]
 pub(crate) use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
 #[allow(unused_imports)]
@@ -160,24 +160,7 @@ pub fn analyze_file(
 #[doc(hidden)]
 #[must_use]
 pub fn benchmark_normalize_commands(file: &File, source: &str) -> usize {
-    use crate::facts::normalize_command;
-    use crate::rules::common::query::{self, CommandWalkOptions};
-
-    query::iter_commands_with_context(
-        &file.body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    )
-    .map(|traversed| {
-        let normalized = normalize_command(traversed.visit.command, source);
-        normalized.wrappers.len()
-            + normalized.body_words.len()
-            + usize::from(normalized.literal_name.is_some())
-            + usize::from(normalized.effective_name.is_some())
-            + usize::from(normalized.declaration.is_some())
-    })
-    .sum()
+    facts::benchmark_normalize_commands(file, source)
 }
 
 #[cfg(feature = "benchmarking")]

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -1,7 +1,6 @@
-use shuck_ast::{Command, CompoundCommand, File, Position, Span};
+use shuck_ast::{Command, CompoundCommand, File, Position, Span, Stmt, StmtSeq};
 use shuck_parser::parser::{ParseDiagnostic, ParseResult};
 
-use crate::rules::common::query::{self, CommandWalkOptions};
 use crate::rules::correctness::c_prototype_fragment::CPrototypeFragment;
 use crate::rules::correctness::dangling_else::DanglingElse;
 use crate::rules::correctness::if_bracket_glued::IfBracketGlued;
@@ -673,30 +672,99 @@ fn missing_done_belongs_to_for_loop(file: &File, source: &str) -> bool {
     let eof_offset = file.span.end.offset;
     let mut trailing_loop_kind = None;
 
-    for visit in query::iter_commands(&file.body, CommandWalkOptions::default()) {
-        if visit.stmt.span.end.offset != eof_offset {
-            continue;
+    walk_commands(&file.body, &mut |stmt| {
+        if stmt.span.end.offset != eof_offset {
+            return;
         }
 
-        let is_for_loop = match visit.command {
+        let is_for_loop = match &stmt.command {
             Command::Compound(CompoundCommand::For(_)) => true,
             Command::Compound(CompoundCommand::While(_) | CompoundCommand::Until(_)) => false,
-            _ => continue,
+            _ => return,
         };
 
-        let start_offset = visit.stmt.span.start.offset;
+        let start_offset = stmt.span.start.offset;
         if trailing_loop_kind
             .as_ref()
             .is_none_or(|(best_start, _)| start_offset >= *best_start)
         {
             trailing_loop_kind = Some((start_offset, is_for_loop));
         }
-    }
+    });
 
     trailing_loop_kind
         .map(|(_, is_for_loop)| is_for_loop)
         .or_else(|| missing_done_loop_kind_from_source(source))
         .unwrap_or(false)
+}
+
+fn walk_commands(commands: &StmtSeq, visit: &mut impl FnMut(&Stmt)) {
+    for stmt in commands.iter() {
+        walk_command(stmt, visit);
+    }
+}
+
+fn walk_command(stmt: &Stmt, visit: &mut impl FnMut(&Stmt)) {
+    visit(stmt);
+
+    match &stmt.command {
+        Command::Binary(command) => {
+            walk_command(&command.left, visit);
+            walk_command(&command.right, visit);
+        }
+        Command::Compound(command) => walk_compound_command(command, visit),
+        Command::Function(function) => walk_command(&function.body, visit),
+        Command::AnonymousFunction(function) => walk_command(&function.body, visit),
+        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => {}
+    }
+}
+
+fn walk_compound_command(command: &CompoundCommand, visit: &mut impl FnMut(&Stmt)) {
+    match command {
+        CompoundCommand::If(command) => {
+            walk_commands(&command.condition, visit);
+            walk_commands(&command.then_branch, visit);
+            for (condition, body) in &command.elif_branches {
+                walk_commands(condition, visit);
+                walk_commands(body, visit);
+            }
+            if let Some(body) = &command.else_branch {
+                walk_commands(body, visit);
+            }
+        }
+        CompoundCommand::For(command) => walk_commands(&command.body, visit),
+        CompoundCommand::Repeat(command) => walk_commands(&command.body, visit),
+        CompoundCommand::Foreach(command) => walk_commands(&command.body, visit),
+        CompoundCommand::ArithmeticFor(command) => walk_commands(&command.body, visit),
+        CompoundCommand::While(command) => {
+            walk_commands(&command.condition, visit);
+            walk_commands(&command.body, visit);
+        }
+        CompoundCommand::Until(command) => {
+            walk_commands(&command.condition, visit);
+            walk_commands(&command.body, visit);
+        }
+        CompoundCommand::Case(command) => {
+            for case in &command.cases {
+                walk_commands(&case.body, visit);
+            }
+        }
+        CompoundCommand::Select(command) => walk_commands(&command.body, visit),
+        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
+            walk_commands(commands, visit);
+        }
+        CompoundCommand::Always(command) => {
+            walk_commands(&command.body, visit);
+            walk_commands(&command.always_body, visit);
+        }
+        CompoundCommand::Time(command) => {
+            if let Some(command) = &command.command {
+                walk_command(command, visit);
+            }
+        }
+        CompoundCommand::Coproc(command) => walk_command(&command.body, visit),
+        CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => {}
+    }
 }
 
 fn missing_done_loop_kind_from_source(source: &str) -> Option<bool> {

--- a/crates/shuck-linter/src/rules/common/mod.rs
+++ b/crates/shuck-linter/src/rules/common/mod.rs
@@ -1,3 +1,2 @@
-pub mod query;
 pub mod safe_value;
 pub mod word;

--- a/crates/shuck-linter/src/rules/mod.rs
+++ b/crates/shuck-linter/src/rules/mod.rs
@@ -76,4 +76,42 @@ mod architecture_tests {
             violations.join("\n"),
         );
     }
+
+    #[test]
+    fn rules_common_has_no_query_module() {
+        let query_module = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules/common/query.rs");
+
+        assert!(
+            !query_module.exists(),
+            "rule-facing traversal helpers must live in facts, not rules/common/query.rs",
+        );
+    }
+
+    #[test]
+    fn facts_traversal_helpers_stay_private() {
+        let traversal_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/facts/traversal.rs");
+        let source = fs::read_to_string(&traversal_path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", traversal_path.display()));
+        let forbidden_visibility = [
+            "pub(crate) struct CommandVisit",
+            "pub(crate) struct CommandWalkOptions",
+            "pub(crate) fn walk_commands",
+            "pub(crate) fn iter_commands",
+            "pub(crate) fn iter_commands_with_context",
+            "pub(crate) fn visit_arithmetic_words",
+            "pub(crate) fn visit_var_ref_subscript_words",
+            "pub(crate) fn visit_subscript_words",
+        ];
+        let violations = forbidden_visibility
+            .iter()
+            .copied()
+            .filter(|token| source.contains(token))
+            .collect::<Vec<_>>();
+
+        assert!(
+            violations.is_empty(),
+            "facts traversal helpers should stay private to the facts module:\n{}",
+            violations.join("\n"),
+        );
+    }
 }

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -1,10 +1,13 @@
-use shuck_ast::{CaseItem, Command, CompoundCommand, File, StmtSeq, TextRange, TextSize};
+use shuck_ast::{
+    ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
+    BourneParameterExpansion, BuiltinCommand, CaseItem, Command, CompoundCommand, ConditionalExpr,
+    DeclOperand, File, FunctionDef, HeredocBodyPartNode, ParameterExpansion,
+    ParameterExpansionSyntax, Pattern, PatternPart, Redirect, Stmt, StmtSeq, TextRange, TextSize,
+    VarRef, Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment,
+};
 use shuck_indexer::{CommentIndex, IndexedComment};
 
-use crate::{
-    Rule, code_to_rule,
-    rules::common::query::{CommandWalkOptions, iter_commands},
-};
+use crate::{Rule, code_to_rule};
 
 use super::ShellCheckCodeMap;
 
@@ -213,223 +216,217 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
         return true;
     }
 
-    iter_commands(
-        &file.body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    )
-    .any(|visit| match visit.command {
-        Command::Compound(CompoundCommand::If(command)) => {
-            let if_header = command.condition.first().is_some_and(|stmt| {
-                next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                    && command_start_segment_matches(
-                        source,
-                        visit.stmt.span.start.offset,
-                        context.comment_start,
-                        "if",
-                    )
-            });
-
-            let then_header = body_header_matches(
-                source,
-                command.condition.span.end.offset,
-                &command.then_branch,
-                &context,
-                "then",
-            ) || body_opener_matches(
-                source,
-                command.condition.span.end.offset,
-                &command.then_branch,
-                &context,
-                '{',
-            );
-
-            let mut previous_branch_end = command.then_branch.span.end.offset;
-            let mut elif_header = false;
-            let mut elif_body_header = false;
-            for (condition, branch) in &command.elif_branches {
-                elif_header |= condition.first().is_some_and(|stmt| {
+    command_visits(&file.body)
+        .into_iter()
+        .any(|visit| match visit.command {
+            Command::Compound(CompoundCommand::If(command)) => {
+                let if_header = command.condition.first().is_some_and(|stmt| {
                     next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                        && gap_segment_ends_with_keyword(
+                        && command_start_segment_matches(
                             source,
-                            previous_branch_end,
+                            visit.stmt.span.start.offset,
                             context.comment_start,
-                            "elif",
+                            "if",
                         )
                 });
-                elif_body_header |= body_header_matches(
+
+                let then_header = body_header_matches(
                     source,
-                    condition.span.end.offset,
-                    branch,
+                    command.condition.span.end.offset,
+                    &command.then_branch,
                     &context,
                     "then",
                 ) || body_opener_matches(
                     source,
-                    condition.span.end.offset,
-                    branch,
+                    command.condition.span.end.offset,
+                    &command.then_branch,
                     &context,
                     '{',
                 );
-                previous_branch_end = branch.span.end.offset;
+
+                let mut previous_branch_end = command.then_branch.span.end.offset;
+                let mut elif_header = false;
+                let mut elif_body_header = false;
+                for (condition, branch) in &command.elif_branches {
+                    elif_header |= condition.first().is_some_and(|stmt| {
+                        next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                            && gap_segment_ends_with_keyword(
+                                source,
+                                previous_branch_end,
+                                context.comment_start,
+                                "elif",
+                            )
+                    });
+                    elif_body_header |= body_header_matches(
+                        source,
+                        condition.span.end.offset,
+                        branch,
+                        &context,
+                        "then",
+                    ) || body_opener_matches(
+                        source,
+                        condition.span.end.offset,
+                        branch,
+                        &context,
+                        '{',
+                    );
+                    previous_branch_end = branch.span.end.offset;
+                }
+
+                let else_header = command.else_branch.as_ref().is_some_and(|branch| {
+                    branch.first().is_some_and(|stmt| {
+                        next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                            && (gap_segment_ends_with_keyword(
+                                source,
+                                previous_branch_end,
+                                context.comment_start,
+                                "else",
+                            ) || gap_segment_ends_with_char(
+                                source,
+                                previous_branch_end,
+                                context.comment_start,
+                                '{',
+                            ))
+                    })
+                });
+
+                if_header || then_header || elif_header || elif_body_header || else_header
             }
-
-            let else_header = command.else_branch.as_ref().is_some_and(|branch| {
-                branch.first().is_some_and(|stmt| {
+            Command::Compound(CompoundCommand::For(command)) => {
+                body_header_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    "do",
+                ) || body_opener_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    '{',
+                )
+            }
+            Command::Compound(CompoundCommand::Repeat(command)) => {
+                body_header_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    "do",
+                ) || body_opener_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    '{',
+                )
+            }
+            Command::Compound(CompoundCommand::Foreach(command)) => {
+                body_header_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    "do",
+                ) || body_opener_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    '{',
+                )
+            }
+            Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
+                body_header_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    "do",
+                ) || body_opener_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    '{',
+                )
+            }
+            Command::Compound(CompoundCommand::While(command)) => {
+                loop_header_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.condition,
+                    context,
+                    "while",
+                ) || body_header_matches(
+                    source,
+                    command.condition.span.end.offset,
+                    &command.body,
+                    &context,
+                    "do",
+                ) || body_opener_matches(
+                    source,
+                    command.condition.span.end.offset,
+                    &command.body,
+                    &context,
+                    '{',
+                )
+            }
+            Command::Compound(CompoundCommand::Until(command)) => {
+                loop_header_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.condition,
+                    context,
+                    "until",
+                ) || body_header_matches(
+                    source,
+                    command.condition.span.end.offset,
+                    &command.body,
+                    &context,
+                    "do",
+                ) || body_opener_matches(
+                    source,
+                    command.condition.span.end.offset,
+                    &command.body,
+                    &context,
+                    '{',
+                )
+            }
+            Command::Compound(CompoundCommand::Select(command)) => {
+                body_header_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    "do",
+                ) || body_opener_matches(
+                    source,
+                    visit.stmt.span.start.offset,
+                    &command.body,
+                    &context,
+                    '{',
+                )
+            }
+            Command::Compound(CompoundCommand::Subshell(body)) => {
+                body.first().is_some_and(|stmt| {
                     next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                        && (gap_segment_ends_with_keyword(
-                            source,
-                            previous_branch_end,
-                            context.comment_start,
-                            "else",
-                        ) || gap_segment_ends_with_char(
-                            source,
-                            previous_branch_end,
-                            context.comment_start,
-                            '{',
-                        ))
+                        && context.prefix.trim_end().ends_with('(')
                 })
-            });
-
-            if_header || then_header || elif_header || elif_body_header || else_header
-        }
-        Command::Compound(CompoundCommand::For(command)) => {
-            body_header_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                "do",
-            ) || body_opener_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                '{',
-            )
-        }
-        Command::Compound(CompoundCommand::Repeat(command)) => {
-            body_header_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                "do",
-            ) || body_opener_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                '{',
-            )
-        }
-        Command::Compound(CompoundCommand::Foreach(command)) => {
-            body_header_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                "do",
-            ) || body_opener_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                '{',
-            )
-        }
-        Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
-            body_header_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                "do",
-            ) || body_opener_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                '{',
-            )
-        }
-        Command::Compound(CompoundCommand::While(command)) => {
-            loop_header_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.condition,
-                context,
-                "while",
-            ) || body_header_matches(
-                source,
-                command.condition.span.end.offset,
-                &command.body,
-                &context,
-                "do",
-            ) || body_opener_matches(
-                source,
-                command.condition.span.end.offset,
-                &command.body,
-                &context,
-                '{',
-            )
-        }
-        Command::Compound(CompoundCommand::Until(command)) => {
-            loop_header_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.condition,
-                context,
-                "until",
-            ) || body_header_matches(
-                source,
-                command.condition.span.end.offset,
-                &command.body,
-                &context,
-                "do",
-            ) || body_opener_matches(
-                source,
-                command.condition.span.end.offset,
-                &command.body,
-                &context,
-                '{',
-            )
-        }
-        Command::Compound(CompoundCommand::Select(command)) => {
-            body_header_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                "do",
-            ) || body_opener_matches(
-                source,
-                visit.stmt.span.start.offset,
-                &command.body,
-                &context,
-                '{',
-            )
-        }
-        Command::Compound(CompoundCommand::Subshell(body)) => body.first().is_some_and(|stmt| {
-            next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                && context.prefix.trim_end().ends_with('(')
-        }),
-        Command::Compound(CompoundCommand::BraceGroup(body)) => body.first().is_some_and(|stmt| {
-            next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                && context.prefix.trim_end().ends_with('{')
-        }),
-        _ => false,
-    })
+            }
+            Command::Compound(CompoundCommand::BraceGroup(body)) => {
+                body.first().is_some_and(|stmt| {
+                    next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                        && context.prefix.trim_end().ends_with('{')
+                })
+            }
+            _ => false,
+        })
 }
 
 fn is_case_label_directive(comment: &NormalizedComment<'_>, file: &File) -> bool {
-    iter_commands(
-        &file.body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    )
-    .any(|visit| {
+    command_visits(&file.body).into_iter().any(|visit| {
         let Command::Compound(CompoundCommand::Case(command)) = visit.command else {
             return false;
         };
@@ -439,6 +436,565 @@ fn is_case_label_directive(comment: &NormalizedComment<'_>, file: &File) -> bool
             .iter()
             .any(|case| case_label_directive(case, comment))
     })
+}
+
+#[derive(Clone, Copy)]
+struct DirectiveCommandVisit<'a> {
+    stmt: &'a Stmt,
+    command: &'a Command,
+}
+
+fn command_visits(commands: &StmtSeq) -> Vec<DirectiveCommandVisit<'_>> {
+    let mut visits = Vec::new();
+    collect_command_visits(commands, &mut visits);
+    visits
+}
+
+fn collect_command_visits<'a>(commands: &'a StmtSeq, visits: &mut Vec<DirectiveCommandVisit<'a>>) {
+    for stmt in commands.iter() {
+        collect_command_visit(stmt, visits);
+    }
+}
+
+fn collect_command_visit<'a>(stmt: &'a Stmt, visits: &mut Vec<DirectiveCommandVisit<'a>>) {
+    visits.push(DirectiveCommandVisit {
+        stmt,
+        command: &stmt.command,
+    });
+
+    match &stmt.command {
+        Command::Simple(command) => {
+            collect_assignment_visits(&command.assignments, visits);
+            collect_word_visits(&command.name, visits);
+            collect_word_slice_visits(&command.args, visits);
+        }
+        Command::Builtin(command) => collect_builtin_visits(command, visits),
+        Command::Decl(command) => {
+            collect_assignment_visits(&command.assignments, visits);
+            for operand in &command.operands {
+                match operand {
+                    DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
+                        collect_word_visits(word, visits);
+                    }
+                    DeclOperand::Name(_) => {}
+                    DeclOperand::Assignment(assignment) => {
+                        collect_assignment_visit(assignment, visits);
+                    }
+                }
+            }
+        }
+        Command::Binary(command) => {
+            collect_command_visit(&command.left, visits);
+            collect_command_visit(&command.right, visits);
+        }
+        Command::Compound(command) => collect_compound_visits(command, visits),
+        Command::Function(FunctionDef { header, body, .. }) => {
+            for entry in &header.entries {
+                collect_word_visits(&entry.word, visits);
+            }
+            collect_command_visit(body, visits);
+        }
+        Command::AnonymousFunction(function) => {
+            collect_word_slice_visits(&function.args, visits);
+            collect_command_visit(&function.body, visits);
+        }
+    }
+
+    collect_redirect_visits(&stmt.redirects, visits);
+}
+
+fn collect_builtin_visits<'a>(
+    command: &'a BuiltinCommand,
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    match command {
+        BuiltinCommand::Break(command) => {
+            collect_assignment_visits(&command.assignments, visits);
+            if let Some(word) = &command.depth {
+                collect_word_visits(word, visits);
+            }
+            collect_word_slice_visits(&command.extra_args, visits);
+        }
+        BuiltinCommand::Continue(command) => {
+            collect_assignment_visits(&command.assignments, visits);
+            if let Some(word) = &command.depth {
+                collect_word_visits(word, visits);
+            }
+            collect_word_slice_visits(&command.extra_args, visits);
+        }
+        BuiltinCommand::Return(command) => {
+            collect_assignment_visits(&command.assignments, visits);
+            if let Some(word) = &command.code {
+                collect_word_visits(word, visits);
+            }
+            collect_word_slice_visits(&command.extra_args, visits);
+        }
+        BuiltinCommand::Exit(command) => {
+            collect_assignment_visits(&command.assignments, visits);
+            if let Some(word) = &command.code {
+                collect_word_visits(word, visits);
+            }
+            collect_word_slice_visits(&command.extra_args, visits);
+        }
+    }
+}
+
+fn collect_compound_visits<'a>(
+    command: &'a CompoundCommand,
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    match command {
+        CompoundCommand::If(command) => {
+            collect_command_visits(&command.condition, visits);
+            collect_command_visits(&command.then_branch, visits);
+            for (condition, body) in &command.elif_branches {
+                collect_command_visits(condition, visits);
+                collect_command_visits(body, visits);
+            }
+            if let Some(body) = &command.else_branch {
+                collect_command_visits(body, visits);
+            }
+        }
+        CompoundCommand::For(command) => {
+            if let Some(words) = &command.words {
+                collect_word_slice_visits(words, visits);
+            }
+            collect_command_visits(&command.body, visits);
+        }
+        CompoundCommand::Repeat(command) => {
+            collect_word_visits(&command.count, visits);
+            collect_command_visits(&command.body, visits);
+        }
+        CompoundCommand::Foreach(command) => {
+            collect_word_slice_visits(&command.words, visits);
+            collect_command_visits(&command.body, visits);
+        }
+        CompoundCommand::ArithmeticFor(command) => collect_command_visits(&command.body, visits),
+        CompoundCommand::While(command) => {
+            collect_command_visits(&command.condition, visits);
+            collect_command_visits(&command.body, visits);
+        }
+        CompoundCommand::Until(command) => {
+            collect_command_visits(&command.condition, visits);
+            collect_command_visits(&command.body, visits);
+        }
+        CompoundCommand::Case(command) => {
+            collect_word_visits(&command.word, visits);
+            for case in &command.cases {
+                collect_pattern_slice_visits(&case.patterns, visits);
+                collect_command_visits(&case.body, visits);
+            }
+        }
+        CompoundCommand::Select(command) => {
+            collect_word_slice_visits(&command.words, visits);
+            collect_command_visits(&command.body, visits);
+        }
+        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
+            collect_command_visits(commands, visits);
+        }
+        CompoundCommand::Always(command) => {
+            collect_command_visits(&command.body, visits);
+            collect_command_visits(&command.always_body, visits);
+        }
+        CompoundCommand::Arithmetic(_) => {}
+        CompoundCommand::Time(command) => {
+            if let Some(command) = &command.command {
+                collect_command_visit(command, visits);
+            }
+        }
+        CompoundCommand::Conditional(command) => {
+            collect_conditional_visits(&command.expression, visits);
+        }
+        CompoundCommand::Coproc(command) => collect_command_visit(&command.body, visits),
+    }
+}
+
+fn collect_assignment_visits<'a>(
+    assignments: &'a [Assignment],
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    for assignment in assignments {
+        collect_assignment_visit(assignment, visits);
+    }
+}
+
+fn collect_assignment_visit<'a>(
+    assignment: &'a Assignment,
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    match &assignment.value {
+        AssignmentValue::Scalar(word) => collect_word_visits(word, visits),
+        AssignmentValue::Compound(array) => {
+            for element in &array.elements {
+                match element {
+                    ArrayElem::Sequential(word) => collect_word_visits(word, visits),
+                    ArrayElem::Keyed { value, .. } | ArrayElem::KeyedAppend { value, .. } => {
+                        collect_word_visits(value, visits);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_word_slice_visits<'a>(words: &'a [Word], visits: &mut Vec<DirectiveCommandVisit<'a>>) {
+    for word in words {
+        collect_word_visits(word, visits);
+    }
+}
+
+fn collect_pattern_slice_visits<'a>(
+    patterns: &'a [Pattern],
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    for pattern in patterns {
+        collect_pattern_visits(pattern, visits);
+    }
+}
+
+fn collect_pattern_visits<'a>(pattern: &'a Pattern, visits: &mut Vec<DirectiveCommandVisit<'a>>) {
+    for (part, _) in pattern.parts_with_spans() {
+        match part {
+            PatternPart::Group { patterns, .. } => collect_pattern_slice_visits(patterns, visits),
+            PatternPart::Word(word) => collect_word_visits(word, visits),
+            PatternPart::Literal(_)
+            | PatternPart::AnyString
+            | PatternPart::AnyChar
+            | PatternPart::CharClass(_) => {}
+        }
+    }
+}
+
+fn collect_word_visits<'a>(word: &'a Word, visits: &mut Vec<DirectiveCommandVisit<'a>>) {
+    collect_word_part_visits(&word.parts, visits);
+}
+
+fn collect_word_part_visits<'a>(
+    parts: &'a [WordPartNode],
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPart::ZshQualifiedGlob(glob) => {
+                for pattern in zsh_glob_patterns(glob) {
+                    collect_pattern_visits(pattern, visits);
+                }
+            }
+            WordPart::DoubleQuoted { parts, .. } => collect_word_part_visits(parts, visits),
+            WordPart::ArithmeticExpansion { expression_ast, .. } => {
+                if let Some(expression_ast) = expression_ast.as_ref() {
+                    visit_arithmetic_words(expression_ast, &mut |word| {
+                        collect_word_visits(word, visits);
+                    });
+                }
+            }
+            WordPart::CommandSubstitution { body, .. }
+            | WordPart::ProcessSubstitution { body, .. } => collect_command_visits(body, visits),
+            WordPart::Parameter(parameter) => collect_parameter_expansion_visits(parameter, visits),
+            WordPart::ParameterExpansion {
+                reference,
+                operand_word_ast,
+                ..
+            }
+            | WordPart::IndirectExpansion {
+                reference,
+                operand_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, visits);
+                if let Some(word) = operand_word_ast.as_ref() {
+                    collect_word_visits(word, visits);
+                }
+            }
+            WordPart::Length(reference)
+            | WordPart::ArrayAccess(reference)
+            | WordPart::ArrayLength(reference)
+            | WordPart::ArrayIndices(reference)
+            | WordPart::Transformation { reference, .. } => {
+                collect_var_ref_word_visits(reference, visits);
+            }
+            WordPart::Substring {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPart::ArraySlice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, visits);
+                if let Some(expression) = offset_ast.as_ref() {
+                    visit_arithmetic_words(expression, &mut |word| {
+                        collect_word_visits(word, visits);
+                    });
+                } else {
+                    collect_word_visits(offset_word_ast, visits);
+                }
+                if let Some(expression) = length_ast.as_ref() {
+                    visit_arithmetic_words(expression, &mut |word| {
+                        collect_word_visits(word, visits);
+                    });
+                } else if let Some(word) = length_word_ast.as_ref() {
+                    collect_word_visits(word, visits);
+                }
+            }
+            WordPart::Literal(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::PrefixMatch { .. } => {}
+        }
+    }
+}
+
+fn zsh_glob_patterns(glob: &shuck_ast::ZshQualifiedGlob) -> impl Iterator<Item = &Pattern> + '_ {
+    glob.segments.iter().filter_map(|segment| match segment {
+        ZshGlobSegment::Pattern(pattern) => Some(pattern),
+        ZshGlobSegment::InlineControl(_) => None,
+    })
+}
+
+fn collect_var_ref_word_visits<'a>(
+    reference: &'a VarRef,
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    let Some(subscript) = reference.subscript.as_ref() else {
+        return;
+    };
+    if subscript.selector().is_some() {
+        return;
+    }
+    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
+        visit_arithmetic_words(expression, &mut |word| {
+            collect_word_visits(word, visits);
+        });
+    } else if let Some(word) = subscript.word_ast() {
+        collect_word_visits(word, visits);
+    }
+}
+
+fn collect_parameter_expansion_visits<'a>(
+    parameter: &'a ParameterExpansion,
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+            BourneParameterExpansion::Access { reference }
+            | BourneParameterExpansion::Length { reference }
+            | BourneParameterExpansion::Indices { reference }
+            | BourneParameterExpansion::Transformation { reference, .. } => {
+                collect_var_ref_word_visits(reference, visits);
+            }
+            BourneParameterExpansion::Indirect {
+                reference,
+                operand_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, visits);
+                if let Some(word) = operand_word_ast.as_ref() {
+                    collect_word_visits(word, visits);
+                }
+            }
+            BourneParameterExpansion::Operation {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, visits);
+                if let Some(word) = operand_word_ast.as_ref() {
+                    collect_word_visits(word, visits);
+                }
+                if let Some(word) = operator.replacement_word_ast() {
+                    collect_word_visits(word, visits);
+                }
+            }
+            BourneParameterExpansion::Slice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                collect_var_ref_word_visits(reference, visits);
+                if let Some(expression) = offset_ast.as_ref() {
+                    visit_arithmetic_words(expression, &mut |word| {
+                        collect_word_visits(word, visits);
+                    });
+                } else {
+                    collect_word_visits(offset_word_ast, visits);
+                }
+                if let Some(expression) = length_ast.as_ref() {
+                    visit_arithmetic_words(expression, &mut |word| {
+                        collect_word_visits(word, visits);
+                    });
+                } else if let Some(word) = length_word_ast.as_ref() {
+                    collect_word_visits(word, visits);
+                }
+            }
+            BourneParameterExpansion::PrefixMatch { .. } => {}
+        },
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            collect_zsh_target_visits(&syntax.target, visits);
+
+            for modifier in &syntax.modifiers {
+                if let Some(word) = modifier.argument_word_ast() {
+                    collect_word_visits(word, visits);
+                }
+            }
+
+            if let Some(operation) = &syntax.operation {
+                match operation {
+                    shuck_ast::ZshExpansionOperation::PatternOperation { .. }
+                    | shuck_ast::ZshExpansionOperation::Defaulting { .. }
+                    | shuck_ast::ZshExpansionOperation::TrimOperation { .. }
+                    | shuck_ast::ZshExpansionOperation::Unknown { .. } => {
+                        if let Some(word) = operation.operand_word_ast() {
+                            collect_word_visits(word, visits);
+                        }
+                    }
+                    shuck_ast::ZshExpansionOperation::ReplacementOperation { .. } => {
+                        if let Some(word) = operation.pattern_word_ast() {
+                            collect_word_visits(word, visits);
+                        }
+                        if let Some(word) = operation.replacement_word_ast() {
+                            collect_word_visits(word, visits);
+                        }
+                    }
+                    shuck_ast::ZshExpansionOperation::Slice { .. } => {
+                        if let Some(word) = operation.offset_word_ast() {
+                            collect_word_visits(word, visits);
+                        }
+                        if let Some(word) = operation.length_word_ast() {
+                            collect_word_visits(word, visits);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_zsh_target_visits<'a>(
+    target: &'a ZshExpansionTarget,
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    match target {
+        ZshExpansionTarget::Reference(reference) => collect_var_ref_word_visits(reference, visits),
+        ZshExpansionTarget::Nested(parameter) => {
+            collect_parameter_expansion_visits(parameter, visits);
+        }
+        ZshExpansionTarget::Word(word) => collect_word_visits(word, visits),
+        ZshExpansionTarget::Empty => {}
+    }
+}
+
+fn collect_redirect_visits<'a>(
+    redirects: &'a [Redirect],
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    for redirect in redirects {
+        if let Some(word) = redirect.word_target() {
+            collect_word_visits(word, visits);
+        } else if let Some(heredoc) = redirect.heredoc()
+            && heredoc.delimiter.expands_body
+        {
+            collect_heredoc_body_part_visits(&heredoc.body.parts, visits);
+        }
+    }
+}
+
+fn collect_heredoc_body_part_visits<'a>(
+    parts: &'a [HeredocBodyPartNode],
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    for part in parts {
+        match &part.kind {
+            shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
+                if let Some(expression_ast) = expression_ast.as_ref() {
+                    visit_arithmetic_words(expression_ast, &mut |word| {
+                        collect_word_visits(word, visits);
+                    });
+                }
+            }
+            shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
+                collect_command_visits(body, visits);
+            }
+            shuck_ast::HeredocBodyPart::Literal(_)
+            | shuck_ast::HeredocBodyPart::Variable(_)
+            | shuck_ast::HeredocBodyPart::Parameter(_) => {}
+        }
+    }
+}
+
+fn collect_conditional_visits<'a>(
+    expression: &'a ConditionalExpr,
+    visits: &mut Vec<DirectiveCommandVisit<'a>>,
+) {
+    match expression {
+        ConditionalExpr::Binary(expr) => {
+            collect_conditional_visits(&expr.left, visits);
+            collect_conditional_visits(&expr.right, visits);
+        }
+        ConditionalExpr::Unary(expr) => collect_conditional_visits(&expr.expr, visits),
+        ConditionalExpr::Parenthesized(expr) => collect_conditional_visits(&expr.expr, visits),
+        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
+            collect_word_visits(word, visits);
+        }
+        ConditionalExpr::Pattern(pattern) => collect_pattern_visits(pattern, visits),
+        ConditionalExpr::VarRef(_) => {}
+    }
+}
+
+fn visit_arithmetic_words<'a>(
+    expression: &'a ArithmeticExprNode,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    match &expression.kind {
+        ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
+        ArithmeticExpr::Indexed { index, .. } => visit_arithmetic_words(index, visitor),
+        ArithmeticExpr::ShellWord(word) => visitor(word),
+        ArithmeticExpr::Parenthesized { expression } => {
+            visit_arithmetic_words(expression, visitor);
+        }
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            visit_arithmetic_words(expr, visitor);
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            visit_arithmetic_words(left, visitor);
+            visit_arithmetic_words(right, visitor);
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            visit_arithmetic_words(condition, visitor);
+            visit_arithmetic_words(then_expr, visitor);
+            visit_arithmetic_words(else_expr, visitor);
+        }
+        ArithmeticExpr::Assignment { target, value, .. } => {
+            visit_arithmetic_lvalue_words(target, visitor);
+            visit_arithmetic_words(value, visitor);
+        }
+    }
+}
+
+fn visit_arithmetic_lvalue_words<'a>(
+    target: &'a ArithmeticLvalue,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    match target {
+        ArithmeticLvalue::Variable(_) => {}
+        ArithmeticLvalue::Indexed { index, .. } => visit_arithmetic_words(index, visitor),
+    }
 }
 
 fn case_label_directive(case: &CaseItem, comment: &NormalizedComment<'_>) -> bool {

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -1,12 +1,12 @@
 use rustc_hash::FxHashMap;
 use shuck_ast::{
-    ArrayElem, Assignment, AssignmentValue, BuiltinCommand, Command, CompoundCommand,
-    ConditionalExpr, DeclOperand, File, FunctionDef, HeredocBodyPartNode, Pattern, PatternPart,
-    Redirect, Span, Stmt, StmtSeq, TextSize, Word, WordPart, WordPartNode,
+    ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
+    BuiltinCommand, Command, CompoundCommand, ConditionalExpr, DeclOperand, File, FunctionDef,
+    HeredocBodyPartNode, Pattern, PatternPart, Redirect, Span, Stmt, StmtSeq, TextSize, VarRef,
+    Word, WordPart, WordPartNode,
 };
 
 use crate::Rule;
-use crate::rules::common::query;
 
 use super::{SuppressionAction, SuppressionDirective};
 
@@ -403,7 +403,7 @@ where
             WordPart::DoubleQuoted { parts, .. } => walk_word_parts(parts, visit),
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
                 if let Some(expression_ast) = expression_ast.as_ref() {
-                    query::visit_arithmetic_words(expression_ast, &mut |word| {
+                    visit_arithmetic_words(expression_ast, &mut |word| {
                         walk_word(word, visit);
                     });
                 }
@@ -438,7 +438,7 @@ where
         match &part.kind {
             shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
                 if let Some(expression_ast) = expression_ast.as_ref() {
-                    query::visit_arithmetic_words(expression_ast, &mut |word| {
+                    visit_arithmetic_words(expression_ast, &mut |word| {
                         walk_word(word, visit);
                     });
                 }
@@ -467,10 +467,64 @@ where
         ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => walk_word(word, visit),
         ConditionalExpr::Pattern(pattern) => walk_pattern(pattern, visit),
         ConditionalExpr::VarRef(reference) => {
-            query::visit_var_ref_subscript_words(reference, &mut |word| {
+            visit_var_ref_subscript_words(reference, &mut |word| {
                 walk_word(word, visit);
             });
         }
+    }
+}
+
+fn visit_var_ref_subscript_words<'a>(reference: &'a VarRef, visitor: &mut impl FnMut(&'a Word)) {
+    if let Some(expression) = reference
+        .subscript
+        .as_ref()
+        .and_then(|subscript| subscript.arithmetic_ast.as_ref())
+    {
+        visit_arithmetic_words(expression, visitor);
+    }
+}
+
+fn visit_arithmetic_words<'a>(
+    expression: &'a ArithmeticExprNode,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    match &expression.kind {
+        ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
+        ArithmeticExpr::Indexed { index, .. } => visit_arithmetic_words(index, visitor),
+        ArithmeticExpr::ShellWord(word) => visitor(word),
+        ArithmeticExpr::Parenthesized { expression } => {
+            visit_arithmetic_words(expression, visitor);
+        }
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            visit_arithmetic_words(expr, visitor);
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            visit_arithmetic_words(left, visitor);
+            visit_arithmetic_words(right, visitor);
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            visit_arithmetic_words(condition, visitor);
+            visit_arithmetic_words(then_expr, visitor);
+            visit_arithmetic_words(else_expr, visitor);
+        }
+        ArithmeticExpr::Assignment { target, value, .. } => {
+            visit_arithmetic_lvalue_words(target, visitor);
+            visit_arithmetic_words(value, visitor);
+        }
+    }
+}
+
+fn visit_arithmetic_lvalue_words<'a>(
+    target: &'a ArithmeticLvalue,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    match target {
+        ArithmeticLvalue::Variable(_) => {}
+        ArithmeticLvalue::Indexed { index, .. } => visit_arithmetic_words(index, visitor),
     }
 }
 


### PR DESCRIPTION
## Summary
- Move rule-facing traversal helpers out of `rules/common/query.rs` and into facts-private traversal.
- Move `CommandSubstitutionKind` into `facts/substitutions` while preserving the root re-export.
- Localize parse-diagnostic and suppression traversal helpers, and add architecture tests to keep rules off traversal APIs.

## Tests
- `cargo test -p shuck-linter`
- `cargo test -p shuck-linter architecture_tests`
- `cargo test -p shuck-linter suppression::`
- `cargo test -p shuck-linter parse`
- `cargo test -p shuck-linter suppression::directive`