### PR TITLE
fix(linter): align C094 with ShellCheck oracle

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -189,8 +189,9 @@ impl<'a> LinterFactsBuilder<'a> {
                 substitution_facts: Vec::new().into_boxed_slice(),
                 options,
                 scope_read_source_words: Vec::new().into_boxed_slice(),
-                scope_read_source_names: Vec::new().into_boxed_slice(),
-                scope_write_target_names: Vec::new().into_boxed_slice(),
+                scope_name_read_uses: Vec::new().into_boxed_slice(),
+                scope_heredoc_name_read_uses: Vec::new().into_boxed_slice(),
+                scope_name_write_uses: Vec::new().into_boxed_slice(),
                 declaration_assignment_probes,
                 glued_closing_bracket_operand_span,
                 glued_closing_bracket_insert_offset,
@@ -388,26 +389,21 @@ impl<'a> LinterFactsBuilder<'a> {
         let case_pattern_impossible_spans =
             build_case_pattern_impossible_spans(&commands, self.source);
         let pipelines = build_pipeline_facts(&commands, &command_ids_by_span);
-        let scope_read_source_words = build_scope_read_source_words(
-            &commands,
-            &pipelines,
-            &if_condition_command_ids,
-            source,
-        );
-        for (fact, words) in commands.iter_mut().zip(scope_read_source_words) {
-            fact.scope_read_source_words = words;
-        }
-        let scope_read_source_names =
-            build_scope_read_source_names(&commands, &pipelines, self.semantic, self.source);
-        let scope_write_target_names =
-            build_scope_write_target_names(&commands, self.semantic, self.source);
-        for ((fact, read_names), write_names) in commands
+        let scope_read_source_words =
+            build_scope_read_source_words(&commands, &pipelines, &if_condition_command_ids, source);
+        let (scope_name_read_uses, scope_heredoc_name_read_uses, scope_name_write_uses) =
+            build_scope_name_uses(&commands, &pipelines, source);
+        for ((((fact, words), name_reads), heredoc_name_reads), name_writes) in commands
             .iter_mut()
-            .zip(scope_read_source_names)
-            .zip(scope_write_target_names)
+            .zip(scope_read_source_words)
+            .zip(scope_name_read_uses)
+            .zip(scope_heredoc_name_read_uses)
+            .zip(scope_name_write_uses)
         {
-            fact.scope_read_source_names = read_names;
-            fact.scope_write_target_names = write_names;
+            fact.scope_read_source_words = words;
+            fact.scope_name_read_uses = name_reads;
+            fact.scope_heredoc_name_read_uses = heredoc_name_reads;
+            fact.scope_name_write_uses = name_writes;
         }
         let lists = build_list_facts(&commands, &command_ids_by_span, self.source);
         let completion_registered_function_command_flags =

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -32,79 +32,16 @@ impl<'a> PathWordFact<'a> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PathNameKind {
-    Literal,
-    Parameter,
-    RedirectLiteral,
-    QuotedRedirectLiteral,
-    RedirectParameter,
-    HeredocParameter,
-    GeneratedLiteral,
-    GeneratedParameter,
-    BindingTarget,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PathNameFact {
-    name: Box<str>,
-    kind: PathNameKind,
-    span: Span,
-    binding_id: Option<BindingId>,
-    initialized_local_scope: Option<ScopeId>,
-}
-
-impl PathNameFact {
-    pub fn new(name: impl Into<Box<str>>, kind: PathNameKind, span: Span) -> Self {
-        Self {
-            name: name.into(),
-            kind,
-            span,
-            binding_id: None,
-            initialized_local_scope: None,
-        }
-    }
-
-    pub(crate) fn with_semantics(
-        name: impl Into<Box<str>>,
-        kind: PathNameKind,
-        span: Span,
-        binding_id: Option<BindingId>,
-        initialized_local_scope: Option<ScopeId>,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            kind,
-            span,
-            binding_id,
-            initialized_local_scope,
-        }
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn kind(&self) -> PathNameKind {
-        self.kind
-    }
-
-    pub fn span(&self) -> Span {
-        self.span
-    }
-
-    pub(crate) fn binding_id(&self) -> Option<BindingId> {
-        self.binding_id
-    }
-
-    pub(crate) fn initialized_local_scope(&self) -> Option<ScopeId> {
-        self.initialized_local_scope
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ReadCommandFacts {
     pub uses_raw_input: bool,
+    target_name_uses: Box<[ComparableNameUse]>,
+}
+
+impl ReadCommandFacts {
+    pub(crate) fn target_name_uses(&self) -> &[ComparableNameUse] {
+        &self.target_name_uses
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -704,6 +641,7 @@ impl<'a> CommandOptionFacts<'a> {
                 .effective_name_is("read")
                 .then(|| ReadCommandFacts {
                     uses_raw_input: read_uses_raw_input(normalized.body_args(), source),
+                    target_name_uses: read_target_name_uses(normalized.body_args(), source),
                 }),
             su: normalized
                 .effective_name_is("su")
@@ -841,6 +779,108 @@ fn read_uses_raw_input(args: &[&Word], source: &str) -> bool {
     }
 
     false
+}
+
+fn read_target_name_uses(args: &[&Word], source: &str) -> Box<[ComparableNameUse]> {
+    let mut targets = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            if word_starts_with_literal_dash(word, source) {
+                return Vec::new().into_boxed_slice();
+            }
+
+            for target in &args[index..] {
+                targets.extend(comparable_name_uses(target, source));
+            }
+            break;
+        };
+
+        if text == "--" {
+            for target in &args[index + 1..] {
+                targets.extend(comparable_name_uses(target, source));
+            }
+            break;
+        }
+
+        if !text.starts_with('-') || text == "-" {
+            for target in &args[index..] {
+                targets.extend(comparable_name_uses(target, source));
+            }
+            break;
+        }
+
+        let mut chars = text[1..].char_indices().peekable();
+        let mut saw_array_target = false;
+        while let Some((flag_offset, flag)) = chars.next() {
+            if flag == 'a' {
+                let attached_start = flag_offset + 2;
+                if attached_start < text.len() {
+                    if let Some(target) =
+                        read_attached_array_target_name_use(word, source, &text[attached_start..])
+                    {
+                        targets.push(target);
+                    }
+                } else if let Some(target) = args.get(index + 1) {
+                    targets.extend(comparable_name_uses(target, source));
+                    index += 1;
+                }
+                saw_array_target = true;
+                break;
+            }
+
+            if option_takes_argument(flag) {
+                if chars.peek().is_none() {
+                    index += 1;
+                }
+                break;
+            }
+        }
+
+        if saw_array_target {
+            break;
+        }
+
+        index += 1;
+    }
+
+    targets.into_boxed_slice()
+}
+
+fn read_attached_array_target_name_use(
+    word: &Word,
+    source: &str,
+    target_text: &str,
+) -> Option<ComparableNameUse> {
+    if !comparable_name_text(target_text) {
+        return None;
+    }
+
+    let target_span = word
+        .span
+        .slice(source)
+        .rfind(target_text)
+        .map(|start| {
+            read_option_attached_target_span(word.span, source, start, start + target_text.len())
+        })
+        .unwrap_or(word.span);
+
+    Some(ComparableNameUse {
+        span: target_span,
+        key: ComparableNameKey(target_text.into()),
+        kind: ComparableNameUseKind::Literal,
+    })
+}
+
+fn read_option_attached_target_span(span: Span, source: &str, start: usize, end: usize) -> Span {
+    let start_pos = span
+        .start
+        .advanced_by(&source[span.start.offset..span.start.offset + start]);
+    let end_pos = span
+        .start
+        .advanced_by(&source[span.start.offset..span.start.offset + end]);
+    Span::from_positions(start_pos, end_pos)
 }
 
 fn parse_echo_command<'a>(args: &[&'a Word], source: &str) -> EchoCommandFacts<'a> {
@@ -2026,10 +2066,6 @@ fn same_command_file_operand_words<'a>(
             })
             .into_boxed_slice()
         }
-        Some("basename") => basename_file_operand_words(args, source).into_boxed_slice(),
-        Some("dirname") => {
-            collect_file_operand_words_after_prefix(args, source, 0, |_| None).into_boxed_slice()
-        }
         Some("jq") => jq_file_operand_words(args, source).into_boxed_slice(),
         Some("bsdtar") | Some("tar") => {
             collect_file_operand_words_after_prefix(args, source, 0, |text| match text {
@@ -2066,76 +2102,6 @@ fn awk_has_file_program_source(args: &[&Word], source: &str) -> bool {
                 || text.starts_with("--file=")
                 || short_option_cluster_contains_flag(text.as_ref(), 'f')
         })
-}
-
-fn basename_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
-    let mut operands = Vec::new();
-    let mut index = 0usize;
-    let mut options_open = true;
-    let mut skip_suffix_arg = false;
-    let mut multiple_names = false;
-
-    while let Some(word) = args.get(index) {
-        if skip_suffix_arg {
-            skip_suffix_arg = false;
-            index += 1;
-            continue;
-        }
-
-        let Some(text) = static_word_text(word, source) else {
-            if options_open && word_starts_with_literal_dash(word, source) {
-                index += 1;
-                continue;
-            }
-
-            options_open = false;
-            operands.push(*word);
-            index += 1;
-            continue;
-        };
-
-        if options_open && text == "--" {
-            options_open = false;
-            index += 1;
-            continue;
-        }
-
-        if options_open && text.starts_with('-') && text != "-" {
-            match text.as_ref() {
-                "-a" | "--multiple" => multiple_names = true,
-                "-s" | "--suffix" => {
-                    multiple_names = true;
-                    skip_suffix_arg = true;
-                }
-                _ if text.starts_with("--suffix=") => multiple_names = true,
-                _ if text.starts_with('-') && !text.starts_with("--") => {
-                    let cluster = &text.as_ref()[1..];
-                    if cluster.contains('a') {
-                        multiple_names = true;
-                    }
-                    if let Some(suffix_flag) = cluster.find('s') {
-                        multiple_names = true;
-                        if suffix_flag + 1 == cluster.len() {
-                            skip_suffix_arg = true;
-                        }
-                    }
-                }
-                _ => {}
-            }
-            index += 1;
-            continue;
-        }
-
-        options_open = false;
-        operands.push(*word);
-        index += 1;
-    }
-
-    if multiple_names {
-        operands
-    } else {
-        operands.into_iter().take(1).collect()
-    }
 }
 
 fn short_option_cluster_contains_flag(text: &str, flag: char) -> bool {

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -792,21 +792,21 @@ fn read_target_name_uses(args: &[&Word], source: &str) -> Box<[ComparableNameUse
             }
 
             for target in &args[index..] {
-                targets.extend(comparable_read_target_name_uses(target, source));
+                targets.extend(comparable_name_uses(target, source));
             }
             break;
         };
 
         if text == "--" {
             for target in &args[index + 1..] {
-                targets.extend(comparable_read_target_name_uses(target, source));
+                targets.extend(comparable_name_uses(target, source));
             }
             break;
         }
 
         if !text.starts_with('-') || text == "-" {
             for target in &args[index..] {
-                targets.extend(comparable_read_target_name_uses(target, source));
+                targets.extend(comparable_name_uses(target, source));
             }
             break;
         }
@@ -823,7 +823,7 @@ fn read_target_name_uses(args: &[&Word], source: &str) -> Box<[ComparableNameUse
                         targets.push(target);
                     }
                 } else if let Some(target) = args.get(index + 1) {
-                    targets.extend(comparable_read_target_name_uses(target, source));
+                    targets.extend(comparable_name_uses(target, source));
                     index += 1;
                 }
                 saw_array_target = true;

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -792,21 +792,21 @@ fn read_target_name_uses(args: &[&Word], source: &str) -> Box<[ComparableNameUse
             }
 
             for target in &args[index..] {
-                targets.extend(comparable_name_uses(target, source));
+                targets.extend(comparable_read_target_name_uses(target, source));
             }
             break;
         };
 
         if text == "--" {
             for target in &args[index + 1..] {
-                targets.extend(comparable_name_uses(target, source));
+                targets.extend(comparable_read_target_name_uses(target, source));
             }
             break;
         }
 
         if !text.starts_with('-') || text == "-" {
             for target in &args[index..] {
-                targets.extend(comparable_name_uses(target, source));
+                targets.extend(comparable_read_target_name_uses(target, source));
             }
             break;
         }
@@ -823,7 +823,7 @@ fn read_target_name_uses(args: &[&Word], source: &str) -> Box<[ComparableNameUse
                         targets.push(target);
                     }
                 } else if let Some(target) = args.get(index + 1) {
-                    targets.extend(comparable_name_uses(target, source));
+                    targets.extend(comparable_read_target_name_uses(target, source));
                     index += 1;
                 }
                 saw_array_target = true;

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -10,8 +10,9 @@ pub struct CommandFact<'a> {
     substitution_facts: Box<[SubstitutionFact]>,
     options: CommandOptionFacts<'a>,
     scope_read_source_words: Box<[PathWordFact<'a>]>,
-    scope_read_source_names: Box<[PathNameFact]>,
-    scope_write_target_names: Box<[PathNameFact]>,
+    scope_name_read_uses: Box<[ComparableNameUse]>,
+    scope_heredoc_name_read_uses: Box<[ComparableNameUse]>,
+    scope_name_write_uses: Box<[ComparableNameUse]>,
     declaration_assignment_probes: Box<[DeclarationAssignmentProbe]>,
     glued_closing_bracket_operand_span: Option<Span>,
     glued_closing_bracket_insert_offset: Option<usize>,
@@ -78,12 +79,16 @@ impl<'a> CommandFact<'a> {
         &self.scope_read_source_words
     }
 
-    pub fn scope_read_source_names(&self) -> &[PathNameFact] {
-        &self.scope_read_source_names
+    pub(crate) fn scope_name_read_uses(&self) -> &[ComparableNameUse] {
+        &self.scope_name_read_uses
     }
 
-    pub fn scope_write_target_names(&self) -> &[PathNameFact] {
-        &self.scope_write_target_names
+    pub(crate) fn scope_heredoc_name_read_uses(&self) -> &[ComparableNameUse] {
+        &self.scope_heredoc_name_read_uses
+    }
+
+    pub(crate) fn scope_name_write_uses(&self) -> &[ComparableNameUse] {
+        &self.scope_name_write_uses
     }
 
     pub fn declaration_assignment_probes(&self) -> &[DeclarationAssignmentProbe] {
@@ -555,18 +560,45 @@ fn build_scope_read_source_words<'a>(
         .collect()
 }
 
-fn build_scope_read_source_names(
-    commands: &[CommandFact<'_>],
-    pipelines: &[PipelineFact<'_>],
-    semantic: &SemanticModel,
+type ScopeNameUseBuckets = Vec<Box<[ComparableNameUse]>>;
+type ScopeNameUseSets = (
+    ScopeNameUseBuckets,
+    ScopeNameUseBuckets,
+    ScopeNameUseBuckets,
+);
+
+fn build_scope_name_uses<'a>(
+    commands: &[CommandFact<'a>],
+    pipelines: &[PipelineFact<'a>],
     source: &str,
-) -> Vec<Box<[PathNameFact]>> {
-    let mut names_by_command = vec![Vec::new(); commands.len()];
+) -> ScopeNameUseSets {
+    let mut reads_by_command = vec![Vec::new(); commands.len()];
+    let mut heredoc_reads_by_command = vec![Vec::new(); commands.len()];
+    let mut writes_by_command = vec![Vec::new(); commands.len()];
 
     for command in commands {
-        let mut names = scope_read_source_name_facts(command, commands, semantic, source);
-        dedup_path_names(&mut names);
-        names_by_command[command.id().index()] = names;
+        let mut read_uses = own_scope_name_read_uses(command, source);
+        if command_has_file_output_redirect(command) {
+            read_uses.extend(nested_scope_name_read_uses(commands, command, source));
+        }
+        dedup_name_uses(&mut read_uses);
+        reads_by_command[command.id().index()] = read_uses;
+
+        let mut heredoc_read_uses = own_scope_heredoc_name_read_uses(command, source);
+        if command_has_file_output_redirect(command) || command_has_file_input_redirect(command) {
+            heredoc_read_uses.extend(nested_scope_heredoc_name_read_uses(
+                commands, command, source,
+            ));
+        }
+        dedup_name_uses(&mut heredoc_read_uses);
+        heredoc_reads_by_command[command.id().index()] = heredoc_read_uses;
+
+        let mut write_uses = own_scope_name_write_uses(command, source);
+        if command_has_file_input_redirect(command) {
+            write_uses.extend(nested_scope_name_write_uses(commands, command, source));
+        }
+        dedup_name_uses(&mut write_uses);
+        writes_by_command[command.id().index()] = write_uses;
     }
 
     for pipeline in pipelines {
@@ -584,342 +616,42 @@ fn build_scope_read_source_names(
             continue;
         }
 
+        let mut pipeline_reads = commands
+            .iter()
+            .filter(|command| contains_span(pipeline.span(), command.span()))
+            .flat_map(|command| own_scope_name_read_uses(command, source))
+            .collect::<Vec<_>>();
+        dedup_name_uses(&mut pipeline_reads);
+        let mut pipeline_heredoc_reads = commands
+            .iter()
+            .filter(|command| contains_span(pipeline.span(), command.span()))
+            .flat_map(|command| own_scope_heredoc_name_read_uses(command, source))
+            .collect::<Vec<_>>();
+        dedup_name_uses(&mut pipeline_heredoc_reads);
+
         for writer_id in writer_ids {
-            let Some(writer) = commands.get(writer_id.index()) else {
-                continue;
-            };
-            let mut scoped_names = commands
-                .iter()
-                .filter(|command| contains_span(pipeline.span(), command.span()))
-                .flat_map(|command| own_read_source_name_facts(command, semantic, source))
-                .collect::<Vec<_>>();
-            remove_names_inside_spans(
-                &mut scoped_names,
-                &command_file_output_redirect_target_spans(writer),
-            );
-            names_by_command[writer_id.index()].extend(scoped_names);
-            dedup_path_names(&mut names_by_command[writer_id.index()]);
+            reads_by_command[writer_id.index()].extend(pipeline_reads.iter().cloned());
+            dedup_name_uses(&mut reads_by_command[writer_id.index()]);
+            heredoc_reads_by_command[writer_id.index()]
+                .extend(pipeline_heredoc_reads.iter().cloned());
+            dedup_name_uses(&mut heredoc_reads_by_command[writer_id.index()]);
         }
     }
 
-    names_by_command
-        .into_iter()
-        .map(Vec::into_boxed_slice)
-        .collect()
-}
-
-fn build_scope_write_target_names(
-    commands: &[CommandFact<'_>],
-    semantic: &SemanticModel,
-    source: &str,
-) -> Vec<Box<[PathNameFact]>> {
-    commands
-        .iter()
-        .map(|command| {
-            let mut names = direct_output_target_name_facts(command, semantic, source);
-            names.extend(generated_output_target_name_facts(
-                command, commands, semantic, source,
-            ));
-            names.extend(binding_target_name_facts(command, semantic));
-            if command_has_file_input_redirect(command) {
-                names.extend(scope_heredoc_reference_name_facts(
-                    command, commands, semantic, source,
-                ));
-            }
-            if command_is_multiline_if(command, source) {
-                names.retain(|name| !path_name_write_hidden_by_prior_assignment(name, semantic));
-            }
-            dedup_path_names(&mut names);
-            names.into_boxed_slice()
-        })
-        .collect()
-}
-
-fn scope_read_source_name_facts(
-    command: &CommandFact<'_>,
-    commands: &[CommandFact<'_>],
-    semantic: &SemanticModel,
-    source: &str,
-) -> Vec<PathNameFact> {
-    let mut names = own_read_source_name_facts(command, semantic, source);
-    if command_has_file_output_redirect(command) {
-        names.extend(
-            commands
-                .iter()
-                .filter(|other| {
-                    other.id() != command.id() && contains_span(command.span(), other.span())
-                })
-                .flat_map(|other| own_read_source_name_facts(other, semantic, source)),
-        );
-    }
-    remove_names_inside_spans(&mut names, &command_file_output_redirect_target_spans(command));
-    names
-}
-
-fn own_read_source_name_facts(
-    command: &CommandFact<'_>,
-    semantic: &SemanticModel,
-    source: &str,
-) -> Vec<PathNameFact> {
-    let mut names = own_scope_read_source_words(command, &FxHashSet::default(), source)
-        .into_iter()
-        .filter_map(|path_word| {
-            let (literal_kind, parameter_kind) = path_word_name_kinds(path_word.context());
-            path_name_fact_from_word(
-                path_word.word(),
-                source,
-                semantic,
-                path_word.context(),
-                command.zsh_options(),
-                literal_kind,
-                parameter_kind,
-            )
-        })
-        .collect::<Vec<_>>();
-    names.extend(heredoc_reference_name_facts(
-        command,
-        semantic,
-        source,
-        PathNameKind::HeredocParameter,
-    ));
-    remove_names_inside_spans(&mut names, &command_file_output_redirect_target_spans(command));
-    dedup_path_names(&mut names);
-    names
-}
-
-fn direct_output_target_name_facts(
-    command: &CommandFact<'_>,
-    semantic: &SemanticModel,
-    source: &str,
-) -> Vec<PathNameFact> {
-    command
-        .redirect_facts()
-        .iter()
-        .filter(|redirect| redirect_is_file_output(redirect.redirect().kind))
-        .filter_map(|redirect| {
-            let target = redirect.redirect().word_target()?;
-            let context = ExpansionContext::from_redirect_kind(redirect.redirect().kind)?;
-            path_name_fact_from_word(
-                target,
-                source,
-                semantic,
-                context,
-                command.zsh_options(),
-                PathNameKind::Literal,
-                PathNameKind::Parameter,
-            )
-        })
-        .collect()
-}
-
-fn generated_output_target_name_facts(
-    command: &CommandFact<'_>,
-    commands: &[CommandFact<'_>],
-    semantic: &SemanticModel,
-    source: &str,
-) -> Vec<PathNameFact> {
-    let target_spans = command_file_output_redirect_target_spans(command);
-    if target_spans.is_empty() {
-        return Vec::new();
-    }
-
-    target_spans
-        .iter()
-        .flat_map(|target_span| {
-            let target_is_fully_quoted = span_is_fully_double_quoted(*target_span, source);
-            commands
-                .iter()
-                .filter(move |other| {
-                    other.id() != command.id() && contains_span(*target_span, other.span())
-                })
-                .map(move |other| (target_is_fully_quoted, other))
-        })
-        .flat_map(|(target_is_fully_quoted, other)| {
-            other.file_operand_words().iter().filter_map(move |word| {
-                if !target_is_fully_quoted && word_is_fully_quoted(word, source) {
-                    return None;
-                }
-                path_name_fact_from_word(
-                    word,
-                    source,
-                    semantic,
-                    ExpansionContext::CommandArgument,
-                    other.zsh_options(),
-                    PathNameKind::GeneratedLiteral,
-                    PathNameKind::GeneratedParameter,
-                )
-            })
-        })
-        .collect()
-}
-
-fn binding_target_name_facts(
-    command: &CommandFact<'_>,
-    semantic: &SemanticModel,
-) -> Vec<PathNameFact> {
-    semantic
-        .bindings()
-        .iter()
-        .filter(|binding| {
-            matches!(binding.kind, BindingKind::ReadTarget | BindingKind::GetoptsTarget)
-                && contains_span(command.span(), binding.span)
-        })
-        .map(|binding| {
-            PathNameFact::new(
-                binding.name.as_str(),
-                PathNameKind::BindingTarget,
-                binding.span,
-            )
-        })
-        .collect()
-}
-
-fn scope_heredoc_reference_name_facts(
-    command: &CommandFact<'_>,
-    commands: &[CommandFact<'_>],
-    semantic: &SemanticModel,
-    source: &str,
-) -> Vec<PathNameFact> {
-    commands
-        .iter()
-        .filter(|other| contains_span(command.span(), other.span()))
-        .flat_map(|other| {
-            heredoc_reference_name_facts(other, semantic, source, PathNameKind::GeneratedParameter)
-        })
-        .collect()
-}
-
-fn heredoc_reference_name_facts(
-    command: &CommandFact<'_>,
-    semantic: &SemanticModel,
-    source: &str,
-    kind: PathNameKind,
-) -> Vec<PathNameFact> {
-    let heredoc_spans = command
-        .redirects()
-        .iter()
-        .filter_map(|redirect| {
-            let heredoc = redirect.heredoc()?;
-            heredoc.delimiter.expands_body.then_some(heredoc.body.span)
-        })
-        .collect::<Vec<_>>();
-    if heredoc_spans.is_empty() {
-        return Vec::new();
-    }
-
-    semantic
-        .references()
-        .iter()
-        .filter(|reference| {
-            heredoc_spans
-                .iter()
-                .any(|span| contains_span(*span, reference.span))
-        })
-        .map(|reference| {
-            PathNameFact::new(
-                reference.name.as_str(),
-                kind,
-                trim_to_parameter_name_span(reference.span, source, reference.name.as_str()),
-            )
-        })
-        .collect()
-}
-
-fn path_name_fact_from_word(
-    word: &Word,
-    source: &str,
-    semantic: &SemanticModel,
-    context: ExpansionContext,
-    options: Option<&ZshOptionState>,
-    literal_kind: PathNameKind,
-    parameter_kind: PathNameKind,
-) -> Option<PathNameFact> {
-    let comparable = comparable_path(word, source, context, options)?;
-    let literal_kind =
-        if literal_kind == PathNameKind::RedirectLiteral && word_is_fully_quoted(word, source) {
-            PathNameKind::QuotedRedirectLiteral
-        } else {
-            literal_kind
-        };
-    path_name_fact_from_key(
-        comparable.key(),
-        semantic,
-        literal_kind,
-        parameter_kind,
-        comparable.span(),
+    (
+        reads_by_command
+            .into_iter()
+            .map(Vec::into_boxed_slice)
+            .collect(),
+        heredoc_reads_by_command
+            .into_iter()
+            .map(Vec::into_boxed_slice)
+            .collect(),
+        writes_by_command
+            .into_iter()
+            .map(Vec::into_boxed_slice)
+            .collect(),
     )
-}
-
-fn path_name_fact_from_key(
-    key: &ComparablePathKey,
-    semantic: &SemanticModel,
-    literal_kind: PathNameKind,
-    parameter_kind: PathNameKind,
-    span: Span,
-) -> Option<PathNameFact> {
-    match key {
-        ComparablePathKey::Literal(name) if is_shell_identifier_like(name) => {
-            Some(PathNameFact::new(name.as_ref(), literal_kind, span))
-        }
-        ComparablePathKey::Parameter(name) => Some(PathNameFact::with_semantics(
-            name.as_ref(),
-            parameter_kind,
-            span,
-            semantic
-                .visible_binding(&Name::from(name.as_ref()), span)
-                .map(|binding| binding.id),
-            initialized_local_scope_for_name(semantic, name.as_ref(), span),
-        )),
-        ComparablePathKey::Literal(_) | ComparablePathKey::Template(_) => None,
-    }
-}
-
-fn initialized_local_scope_for_name(
-    semantic: &SemanticModel,
-    name: &str,
-    span: Span,
-) -> Option<ScopeId> {
-    let function_scope = enclosing_function_scope(semantic, span.start.offset)?;
-    semantic
-        .bindings()
-        .iter()
-        .any(|binding| {
-            binding.name.as_str() == name
-                && binding.scope == function_scope
-                && binding.span.start.offset <= span.start.offset
-                && binding
-                    .attributes
-                    .contains(BindingAttributes::LOCAL | BindingAttributes::DECLARATION_INITIALIZED)
-        })
-        .then_some(function_scope)
-}
-
-fn command_file_output_redirect_target_spans(command: &CommandFact<'_>) -> Vec<Span> {
-    command
-        .redirect_facts()
-        .iter()
-        .filter(|redirect| redirect_is_file_output(redirect.redirect().kind))
-        .filter_map(|redirect| redirect.redirect().word_target().map(|word| word.span))
-        .collect()
-}
-
-fn remove_names_inside_spans(names: &mut Vec<PathNameFact>, spans: &[Span]) {
-    if spans.is_empty() {
-        return;
-    }
-
-    names.retain(|name| !spans.iter().any(|span| contains_span(*span, name.span())));
-}
-
-fn dedup_path_names(names: &mut Vec<PathNameFact>) {
-    let mut seen = FxHashSet::<(Box<str>, PathNameKind, FactSpan)>::default();
-    names.retain(|name| {
-        seen.insert((
-            name.name().into(),
-            name.kind(),
-            FactSpan::new(name.span()),
-        ))
-    });
 }
 
 fn own_scope_read_source_words<'a>(
@@ -939,10 +671,67 @@ fn own_scope_read_source_words<'a>(
         })
         .collect::<Vec<_>>();
     words.extend(command_redirect_read_source_words(command, source));
+    words.extend(command_simple_test_path_words(command, source));
     if !if_condition_command_ids.contains(&command.id()) {
         words.extend(command_conditional_path_words(command, source));
     }
     words
+}
+
+fn own_scope_name_read_uses(command: &CommandFact<'_>, _source: &str) -> Vec<ComparableNameUse> {
+    let mut uses = Vec::new();
+
+    for redirect in command.redirect_facts() {
+        match redirect.redirect().kind {
+            RedirectKind::Input => {
+                uses.extend(redirect.comparable_name_uses().iter().cloned());
+            }
+            RedirectKind::ReadWrite => {}
+            RedirectKind::HereDoc | RedirectKind::HereDocStrip => {}
+            RedirectKind::Output
+            | RedirectKind::Clobber
+            | RedirectKind::Append
+            | RedirectKind::HereString
+            | RedirectKind::DupOutput
+            | RedirectKind::DupInput
+            | RedirectKind::OutputBoth => {}
+        }
+    }
+
+    uses
+}
+
+fn own_scope_heredoc_name_read_uses(
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Vec<ComparableNameUse> {
+    let mut uses = Vec::new();
+
+    for redirect in command.redirect_facts() {
+        if !matches!(
+            redirect.redirect().kind,
+            RedirectKind::HereDoc | RedirectKind::HereDocStrip
+        ) {
+            continue;
+        }
+        if let Some(heredoc) = redirect.redirect().heredoc()
+            && heredoc.delimiter.expands_body
+        {
+            uses.extend(comparable_heredoc_name_uses(&heredoc.body, source));
+        }
+    }
+
+    uses
+}
+
+fn own_scope_name_write_uses(command: &CommandFact<'_>, _source: &str) -> Vec<ComparableNameUse> {
+    let mut uses = Vec::new();
+
+    if let Some(read) = command.options().read() {
+        uses.extend(read.target_name_uses().iter().cloned());
+    }
+
+    uses
 }
 
 fn nested_scope_read_source_words<'a>(
@@ -953,10 +742,44 @@ fn nested_scope_read_source_words<'a>(
 ) -> Vec<PathWordFact<'a>> {
     commands
         .iter()
-        .filter(|other| {
-            other.id() != command.id() && contains_span(command.span(), other.span())
-        })
+        .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
         .flat_map(|other| own_scope_read_source_words(other, if_condition_command_ids, source))
+        .collect()
+}
+
+fn nested_scope_name_read_uses(
+    commands: &[CommandFact<'_>],
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Vec<ComparableNameUse> {
+    commands
+        .iter()
+        .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
+        .flat_map(|other| own_scope_name_read_uses(other, source))
+        .collect()
+}
+
+fn nested_scope_heredoc_name_read_uses(
+    commands: &[CommandFact<'_>],
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Vec<ComparableNameUse> {
+    commands
+        .iter()
+        .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
+        .flat_map(|other| own_scope_heredoc_name_read_uses(other, source))
+        .collect()
+}
+
+fn nested_scope_name_write_uses(
+    commands: &[CommandFact<'_>],
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Vec<ComparableNameUse> {
+    commands
+        .iter()
+        .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
+        .flat_map(|other| own_scope_name_write_uses(other, source))
         .collect()
 }
 
@@ -965,10 +788,20 @@ fn dedup_path_words(words: &mut Vec<PathWordFact<'_>>) {
     words.retain(|fact| seen.insert((FactSpan::new(fact.word().span), fact.context())));
 }
 
+fn dedup_name_uses(uses: &mut Vec<ComparableNameUse>) {
+    let mut seen = FxHashSet::<(ComparableNameKey, FactSpan)>::default();
+    uses.retain(|name_use| seen.insert((name_use.key().clone(), FactSpan::new(name_use.span()))));
+}
+
 fn command_has_file_output_redirect(command: &CommandFact<'_>) -> bool {
     command.redirect_facts().iter().any(|redirect| {
-        redirect_is_file_output(redirect.redirect().kind)
-            && redirect
+        matches!(
+            redirect.redirect().kind,
+            RedirectKind::Output
+                | RedirectKind::Clobber
+                | RedirectKind::Append
+                | RedirectKind::OutputBoth
+        ) && redirect
             .analysis()
             .is_some_and(|analysis| analysis.is_file_target())
     })
@@ -985,116 +818,6 @@ fn command_has_file_input_redirect(command: &CommandFact<'_>) -> bool {
     })
 }
 
-fn redirect_is_file_output(kind: RedirectKind) -> bool {
-    matches!(
-        kind,
-        RedirectKind::Output
-            | RedirectKind::Clobber
-            | RedirectKind::Append
-            | RedirectKind::OutputBoth
-    )
-}
-
-fn is_shell_identifier_like(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-
-    (first == '_' || first.is_ascii_alphabetic())
-        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-}
-
-fn path_name_write_hidden_by_prior_assignment(
-    name: &PathNameFact,
-    semantic: &SemanticModel,
-) -> bool {
-    if !matches!(
-        name.kind(),
-        PathNameKind::Parameter | PathNameKind::RedirectParameter
-    ) {
-        return false;
-    }
-
-    let Some(function_scope) = enclosing_function_scope(semantic, name.span().start.offset) else {
-        return false;
-    };
-
-    semantic.bindings().iter().any(|binding| {
-        binding.name.as_str() == name.name()
-            && binding.scope == function_scope
-            && binding.span.start.offset <= name.span().start.offset
-            && matches!(
-                &binding.origin,
-                shuck_semantic::BindingOrigin::Assignment { .. }
-            )
-    })
-}
-
-fn command_is_multiline_if(command: &CommandFact<'_>, source: &str) -> bool {
-    if !matches!(command.command(), Command::Compound(CompoundCommand::If(_))) {
-        return false;
-    }
-
-    let text = command.span().slice(source).trim_start();
-    let Some(rest) = text.strip_prefix("if") else {
-        return false;
-    };
-    let rest = rest.trim_start_matches([' ', '\t']);
-    rest.starts_with('\n') || rest.starts_with("\r\n")
-}
-
-fn path_word_name_kinds(context: ExpansionContext) -> (PathNameKind, PathNameKind) {
-    match context {
-        ExpansionContext::RedirectTarget(RedirectKind::Input | RedirectKind::ReadWrite)
-        | ExpansionContext::HereString => {
-            (PathNameKind::RedirectLiteral, PathNameKind::RedirectParameter)
-        }
-        ExpansionContext::CommandName
-        | ExpansionContext::CommandArgument
-        | ExpansionContext::AssignmentValue
-        | ExpansionContext::DeclarationAssignmentValue
-        | ExpansionContext::RedirectTarget(_)
-        | ExpansionContext::DescriptorDupTarget(_)
-        | ExpansionContext::ForList
-        | ExpansionContext::SelectList
-        | ExpansionContext::CasePattern
-        | ExpansionContext::ConditionalPattern
-        | ExpansionContext::StringTestOperand
-        | ExpansionContext::RegexOperand
-        | ExpansionContext::ConditionalVarRefSubscript
-        | ExpansionContext::ParameterPattern
-        | ExpansionContext::TrapAction => (PathNameKind::Literal, PathNameKind::Parameter),
-    }
-}
-
-fn span_is_fully_double_quoted(span: Span, source: &str) -> bool {
-    let text = span.slice(source).trim();
-    text.len() >= 2 && text.starts_with('"') && text.ends_with('"')
-}
-
-fn word_is_fully_quoted(word: &Word, source: &str) -> bool {
-    let text = word.span.slice(source).trim();
-    text.len() >= 2
-        && matches!(
-            (text.as_bytes().first(), text.as_bytes().last()),
-            (Some(b'"'), Some(b'"')) | (Some(b'\''), Some(b'\''))
-        )
-}
-
-fn trim_to_parameter_name_span(span: Span, source: &str, name: &str) -> Span {
-    let text = span.slice(source);
-    let Some(relative_start) = text.find(name) else {
-        return span;
-    };
-
-    let relative_end = relative_start + name.len();
-    Span::from_positions(
-        span.start.advanced_by(&text[..relative_start]),
-        span.start.advanced_by(&text[..relative_end]),
-    )
-}
-
 fn command_file_operand_words<'a>(command: &CommandFact<'a>) -> Vec<&'a Word> {
     command.file_operand_words().to_vec()
 }
@@ -1109,7 +832,7 @@ fn command_redirect_read_source_words<'a>(
         .filter_map(|redirect| {
             if !matches!(
                 redirect.redirect().kind,
-                RedirectKind::Input | RedirectKind::ReadWrite | RedirectKind::HereString
+                RedirectKind::Input | RedirectKind::ReadWrite
             ) {
                 return None;
             }
@@ -1129,45 +852,39 @@ fn command_redirect_read_source_words<'a>(
         .collect()
 }
 
+fn command_simple_test_path_words<'a>(
+    command: &CommandFact<'a>,
+    source: &str,
+) -> Vec<PathWordFact<'a>> {
+    let Some(simple_test) = command.simple_test() else {
+        return Vec::new();
+    };
+
+    simple_test
+        .operator_expression_operand_words(source)
+        .into_iter()
+        .map(|word| {
+            PathWordFact::new(
+                word,
+                ExpansionContext::StringTestOperand,
+                source,
+                command.zsh_options(),
+            )
+        })
+        .collect()
+}
+
 fn command_conditional_path_words<'a>(
     command: &CommandFact<'a>,
     source: &str,
 ) -> Vec<PathWordFact<'a>> {
     let mut words = Vec::new();
 
-    if let Some(simple_test) = command.simple_test() {
-        words.extend(simple_test_read_source_words(
-            simple_test,
-            source,
-            command.zsh_options(),
-        ));
-    }
-
     if let Some(conditional) = command.conditional() {
         for node in conditional.nodes() {
             match node {
-                ConditionalNodeFact::BareWord(bare) => {
-                    if let Some(word) = bare.operand().word() {
-                        words.push(PathWordFact::new(
-                            word,
-                            ExpansionContext::StringTestOperand,
-                            source,
-                            command.zsh_options(),
-                        ));
-                    }
-                }
-                ConditionalNodeFact::Unary(unary) => {
-                    if let Some(word) = unary.operand().word() {
-                        words.push(PathWordFact::new(
-                            word,
-                            ExpansionContext::StringTestOperand,
-                            source,
-                            command.zsh_options(),
-                        ));
-                    }
-                }
                 ConditionalNodeFact::Binary(binary)
-                    if binary.operator_family() != ConditionalOperatorFamily::Logical =>
+                    if binary.operator_family() == ConditionalOperatorFamily::StringBinary =>
                 {
                     if let Some(word) = binary.left().word() {
                         words.push(PathWordFact::new(
@@ -1187,64 +904,13 @@ fn command_conditional_path_words<'a>(
                     }
                 }
                 ConditionalNodeFact::Binary(_) => {}
-                ConditionalNodeFact::Other(_) => {}
+                ConditionalNodeFact::BareWord(_) | ConditionalNodeFact::Other(_) => {}
+                ConditionalNodeFact::Unary(_) => {}
             }
         }
-    }
-
-    if let Command::Compound(CompoundCommand::Case(case)) = command.command() {
-        words.push(PathWordFact::new(
-            &case.word,
-            ExpansionContext::StringTestOperand,
-            source,
-            command.zsh_options(),
-        ));
     }
 
     words
-}
-
-fn simple_test_read_source_words<'a>(
-    simple_test: &SimpleTestFact<'a>,
-    source: &str,
-    zsh_options: Option<&ZshOptionState>,
-) -> Vec<PathWordFact<'a>> {
-    let operands = simple_test.effective_operands();
-    let mut words = Vec::new();
-
-    match simple_test.effective_shape() {
-        SimpleTestShape::Truthy => {
-            if let Some(word) = operands.first() {
-                words.push(*word);
-            }
-        }
-        SimpleTestShape::Unary => {
-            if let Some(word) = operands.get(1) {
-                words.push(*word);
-            }
-        }
-        SimpleTestShape::Binary => {
-            if let Some(word) = operands.first() {
-                words.push(*word);
-            }
-            if let Some(word) = operands.get(2) {
-                words.push(*word);
-            }
-        }
-        SimpleTestShape::Empty | SimpleTestShape::Other => {}
-    }
-
-    words
-        .into_iter()
-        .map(|word| {
-            PathWordFact::new(
-            word,
-            ExpansionContext::StringTestOperand,
-            source,
-            zsh_options,
-        )
-        })
-        .collect()
 }
 
 fn contains_span(outer: Span, inner: Span) -> bool {

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -832,7 +832,7 @@ fn command_redirect_read_source_words<'a>(
         .filter_map(|redirect| {
             if !matches!(
                 redirect.redirect().kind,
-                RedirectKind::Input | RedirectKind::ReadWrite
+                RedirectKind::Input | RedirectKind::ReadWrite | RedirectKind::HereString
             ) {
                 return None;
             }

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -175,9 +175,9 @@ pub(crate) mod statements {
 pub(crate) mod command_options {
     pub use super::{
         CommandOptionFacts, ExitCommandFacts, FindCommandFacts, FindExecCommandFacts,
-        FindExecShellCommandFacts, GrepPatternSourceKind, PathNameFact, PathNameKind, PathWordFact,
-        PrintfCommandFacts, ReadCommandFacts, RmCommandFacts, SshCommandFacts,
-        SudoFamilyCommandFacts, UnsetCommandFacts, WaitCommandFacts, XargsCommandFacts,
+        FindExecShellCommandFacts, GrepPatternSourceKind, PathWordFact, PrintfCommandFacts,
+        ReadCommandFacts, RmCommandFacts, SshCommandFacts, SudoFamilyCommandFacts,
+        UnsetCommandFacts, WaitCommandFacts, XargsCommandFacts,
     };
 }
 

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -177,13 +177,28 @@ pub(crate) fn comparable_name_uses(word: &Word, source: &str) -> Box<[Comparable
     if let Some(name_use) = standalone_comparable_name_use(word, source) {
         uses.push(name_use);
     }
-    let allow_quoted_derived_words = analyze_word(word, source, None).quote == WordQuote::FullyQuoted;
+    let allow_quoted_derived_words =
+        analyze_word(word, source, None).quote == WordQuote::FullyQuoted;
     collect_command_substitution_comparable_name_uses_in_parts(
         &word.parts,
         source,
         allow_quoted_derived_words,
         &mut uses,
     );
+    dedup_comparable_name_uses(&mut uses);
+    uses.into_boxed_slice()
+}
+
+pub(crate) fn comparable_read_target_name_uses(
+    word: &Word,
+    source: &str,
+) -> Box<[ComparableNameUse]> {
+    let mut uses = comparable_name_uses(word, source).into_vec();
+    if let Some(text) = static_word_text(word, source)
+        && comparable_name_text(text.as_ref())
+    {
+        uses.push(literal_comparable_name_use(word.span, text.as_ref()));
+    }
     dedup_comparable_name_uses(&mut uses);
     uses.into_boxed_slice()
 }
@@ -346,11 +361,7 @@ fn standalone_comparable_name_use(word: &Word, source: &str) -> Option<Comparabl
         && comparable_name_text(text.as_ref())
         && analyze_word(word, source, None).quote == WordQuote::Unquoted
     {
-        return Some(ComparableNameUse {
-            span: word.span,
-            key: ComparableNameKey(text.into_owned().into_boxed_str()),
-            kind: ComparableNameUseKind::Literal,
-        });
+        return Some(literal_comparable_name_use(word.span, text.as_ref()));
     }
 
     standalone_comparable_parameter_name(&word.parts).map(|name| ComparableNameUse {
@@ -358,6 +369,14 @@ fn standalone_comparable_name_use(word: &Word, source: &str) -> Option<Comparabl
         key: ComparableNameKey(name.into()),
         kind: ComparableNameUseKind::Parameter,
     })
+}
+
+fn literal_comparable_name_use(span: Span, text: &str) -> ComparableNameUse {
+    ComparableNameUse {
+        span,
+        key: ComparableNameKey(text.into()),
+        kind: ComparableNameUseKind::Literal,
+    }
 }
 
 fn standalone_comparable_parameter_name(parts: &[WordPartNode]) -> Option<&str> {

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -415,10 +415,6 @@ fn comparable_name_from_parameter(parameter: &ParameterExpansion) -> Option<&str
 
 fn comparable_name_text(text: &str) -> bool {
     is_shell_variable_name(text)
-        && !matches!(
-            text,
-            "dev" | "proc" | "stdin" | "stdout" | "stderr" | "tty" | "null"
-        )
 }
 
 fn dedup_comparable_name_uses(uses: &mut Vec<ComparableNameUse>) {

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -189,6 +189,13 @@ pub(crate) fn comparable_name_uses(word: &Word, source: &str) -> Box<[Comparable
     uses.into_boxed_slice()
 }
 
+pub(crate) fn comparable_read_target_name_uses(
+    word: &Word,
+    source: &str,
+) -> Box<[ComparableNameUse]> {
+    comparable_name_uses_with_quoted_literals(word, source)
+}
+
 pub(crate) fn comparable_heredoc_name_uses(
     heredoc: &shuck_ast::HeredocBody,
     source: &str,
@@ -345,6 +352,7 @@ fn collect_command_substitution_comparable_name_uses(
 fn standalone_comparable_name_use(word: &Word, source: &str) -> Option<ComparableNameUse> {
     if let Some(text) = static_word_text(word, source)
         && comparable_name_text(text.as_ref())
+        && analyze_word(word, source, None).quote == WordQuote::Unquoted
     {
         return Some(literal_comparable_name_use(word.span, text.as_ref()));
     }
@@ -362,6 +370,20 @@ fn literal_comparable_name_use(span: Span, text: &str) -> ComparableNameUse {
         key: ComparableNameKey(text.into()),
         kind: ComparableNameUseKind::Literal,
     }
+}
+
+fn comparable_name_uses_with_quoted_literals(
+    word: &Word,
+    source: &str,
+) -> Box<[ComparableNameUse]> {
+    let mut uses = comparable_name_uses(word, source).into_vec();
+    if let Some(text) = static_word_text(word, source)
+        && comparable_name_text(text.as_ref())
+    {
+        uses.push(literal_comparable_name_use(word.span, text.as_ref()));
+    }
+    dedup_comparable_name_uses(&mut uses);
+    uses.into_boxed_slice()
 }
 
 fn standalone_comparable_parameter_name(parts: &[WordPartNode]) -> Option<&str> {
@@ -661,7 +683,21 @@ fn build_redirect_facts<'a>(
             }),
             comparable_name_uses: redirect
                 .word_target()
-                .map_or_else(Vec::new, |word| comparable_name_uses(word, source).into_vec())
+                .map_or_else(Vec::new, |word| match redirect.kind {
+                    RedirectKind::Output
+                    | RedirectKind::Clobber
+                    | RedirectKind::Append
+                    | RedirectKind::OutputBoth => {
+                        comparable_name_uses_with_quoted_literals(word, source).into_vec()
+                    }
+                    RedirectKind::Input
+                    | RedirectKind::ReadWrite
+                    | RedirectKind::HereDoc
+                    | RedirectKind::HereDocStrip
+                    | RedirectKind::HereString
+                    | RedirectKind::DupOutput
+                    | RedirectKind::DupInput => comparable_name_uses(word, source).into_vec(),
+                })
                 .into_boxed_slice(),
         })
         .collect::<Vec<_>>()

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -189,20 +189,6 @@ pub(crate) fn comparable_name_uses(word: &Word, source: &str) -> Box<[Comparable
     uses.into_boxed_slice()
 }
 
-pub(crate) fn comparable_read_target_name_uses(
-    word: &Word,
-    source: &str,
-) -> Box<[ComparableNameUse]> {
-    let mut uses = comparable_name_uses(word, source).into_vec();
-    if let Some(text) = static_word_text(word, source)
-        && comparable_name_text(text.as_ref())
-    {
-        uses.push(literal_comparable_name_use(word.span, text.as_ref()));
-    }
-    dedup_comparable_name_uses(&mut uses);
-    uses.into_boxed_slice()
-}
-
 pub(crate) fn comparable_heredoc_name_uses(
     heredoc: &shuck_ast::HeredocBody,
     source: &str,
@@ -359,7 +345,6 @@ fn collect_command_substitution_comparable_name_uses(
 fn standalone_comparable_name_use(word: &Word, source: &str) -> Option<ComparableNameUse> {
     if let Some(text) = static_word_text(word, source)
         && comparable_name_text(text.as_ref())
-        && analyze_word(word, source, None).quote == WordQuote::Unquoted
     {
         return Some(literal_comparable_name_use(word.span, text.as_ref()));
     }

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -66,6 +66,12 @@ pub(crate) enum ComparablePathKey {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ComparablePathMatchKey {
+    key: ComparablePathKey,
+    quote: WordQuote,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum ComparablePathPart {
     Literal(Box<str>),
     Parameter(Box<str>),
@@ -75,6 +81,7 @@ pub(crate) enum ComparablePathPart {
 pub(crate) struct ComparablePath {
     span: Span,
     key: ComparablePathKey,
+    quote: WordQuote,
 }
 
 impl ComparablePath {
@@ -84,6 +91,48 @@ impl ComparablePath {
 
     pub(crate) fn key(&self) -> &ComparablePathKey {
         &self.key
+    }
+
+    pub(crate) fn match_key(&self) -> ComparablePathMatchKey {
+        ComparablePathMatchKey {
+            key: self.key.clone(),
+            quote: self.quote,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ComparableNameKey(Box<str>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ComparableNameUseKind {
+    Literal,
+    Parameter,
+    Derived,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ComparableNameUse {
+    span: Span,
+    key: ComparableNameKey,
+    kind: ComparableNameUseKind,
+}
+
+impl ComparableNameUse {
+    pub(crate) fn span(&self) -> Span {
+        self.span
+    }
+
+    pub(crate) fn key(&self) -> &ComparableNameKey {
+        &self.key
+    }
+
+    pub(crate) fn kind(&self) -> ComparableNameUseKind {
+        self.kind
+    }
+
+    fn mark_derived(&mut self) {
+        self.kind = ComparableNameUseKind::Derived;
     }
 }
 
@@ -119,7 +168,250 @@ pub(crate) fn comparable_path(
     Some(ComparablePath {
         span: word.span,
         key,
+        quote: analysis.quote,
     })
+}
+
+pub(crate) fn comparable_name_uses(word: &Word, source: &str) -> Box<[ComparableNameUse]> {
+    let mut uses = Vec::new();
+    if let Some(name_use) = standalone_comparable_name_use(word, source) {
+        uses.push(name_use);
+    }
+    let allow_quoted_derived_words = analyze_word(word, source, None).quote == WordQuote::FullyQuoted;
+    collect_command_substitution_comparable_name_uses_in_parts(
+        &word.parts,
+        source,
+        allow_quoted_derived_words,
+        &mut uses,
+    );
+    dedup_comparable_name_uses(&mut uses);
+    uses.into_boxed_slice()
+}
+
+pub(crate) fn comparable_heredoc_name_uses(
+    heredoc: &shuck_ast::HeredocBody,
+    source: &str,
+) -> Box<[ComparableNameUse]> {
+    let mut uses = Vec::new();
+    for part in &heredoc.parts {
+        match &part.kind {
+            shuck_ast::HeredocBodyPart::Variable(name) => {
+                if comparable_name_text(name.as_str()) {
+                    uses.push(ComparableNameUse {
+                        span: heredoc_variable_name_span(part.span, source),
+                        key: ComparableNameKey(name.as_str().into()),
+                        kind: ComparableNameUseKind::Parameter,
+                    });
+                }
+            }
+            shuck_ast::HeredocBodyPart::Parameter(parameter) => {
+                if let Some(name) = comparable_name_from_parameter(parameter) {
+                    uses.push(ComparableNameUse {
+                        span: part.span,
+                        key: ComparableNameKey(name.into()),
+                        kind: ComparableNameUseKind::Parameter,
+                    });
+                }
+            }
+            shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
+                collect_command_substitution_comparable_name_uses(body, source, true, &mut uses);
+            }
+            shuck_ast::HeredocBodyPart::ArithmeticExpansion {
+                expression_word_ast,
+                ..
+            } => {
+                if let Some(name_use) = standalone_comparable_name_use(expression_word_ast, source)
+                {
+                    uses.push(name_use);
+                }
+            }
+            shuck_ast::HeredocBodyPart::Literal(_) => {}
+        }
+    }
+    dedup_comparable_name_uses(&mut uses);
+    uses.into_boxed_slice()
+}
+
+fn collect_command_substitution_comparable_name_uses_in_parts(
+    parts: &[WordPartNode],
+    source: &str,
+    allow_quoted_derived_words: bool,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => {
+                collect_command_substitution_comparable_name_uses_in_parts(
+                    parts,
+                    source,
+                    allow_quoted_derived_words,
+                    uses,
+                );
+            }
+            WordPart::CommandSubstitution { body, .. } => {
+                collect_command_substitution_comparable_name_uses(
+                    body,
+                    source,
+                    allow_quoted_derived_words,
+                    uses,
+                );
+            }
+            WordPart::ArithmeticExpansion {
+                expression_word_ast,
+                ..
+            } => {
+                if let Some(name_use) = standalone_comparable_name_use(expression_word_ast, source)
+                {
+                    uses.push(name_use);
+                }
+            }
+            WordPart::ParameterExpansion {
+                operand_word_ast, ..
+            }
+            | WordPart::IndirectExpansion {
+                operand_word_ast, ..
+            } => {
+                if let Some(word) = operand_word_ast {
+                    collect_command_substitution_comparable_name_uses_in_parts(
+                        &word.parts,
+                        source,
+                        allow_quoted_derived_words,
+                        uses,
+                    );
+                }
+            }
+            WordPart::Substring {
+                offset_word_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPart::ArraySlice {
+                offset_word_ast,
+                length_word_ast,
+                ..
+            } => {
+                if let Some(name_use) = standalone_comparable_name_use(offset_word_ast, source) {
+                    uses.push(name_use);
+                }
+                if let Some(word) = length_word_ast
+                    && let Some(name_use) = standalone_comparable_name_use(word, source)
+                {
+                    uses.push(name_use);
+                }
+            }
+            WordPart::Literal(_)
+            | WordPart::ZshQualifiedGlob(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::Parameter(_)
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. } => {}
+        }
+    }
+}
+
+fn collect_command_substitution_comparable_name_uses(
+    body: &StmtSeq,
+    source: &str,
+    allow_quoted_derived_words: bool,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    for visit in iter_commands(
+        body,
+        CommandWalkOptions {
+            descend_nested_word_commands: true,
+        },
+    ) {
+        visit_command_argument_words_for_substitutions(visit.command, source, &mut |word| {
+            if !allow_quoted_derived_words
+                && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
+            {
+                return;
+            }
+            if let Some(mut name_use) = standalone_comparable_name_use(word, source) {
+                name_use.mark_derived();
+                uses.push(name_use);
+            }
+        });
+    }
+}
+
+fn standalone_comparable_name_use(word: &Word, source: &str) -> Option<ComparableNameUse> {
+    if let Some(text) = static_word_text(word, source)
+        && comparable_name_text(text.as_ref())
+        && analyze_word(word, source, None).quote == WordQuote::Unquoted
+    {
+        return Some(ComparableNameUse {
+            span: word.span,
+            key: ComparableNameKey(text.into_owned().into_boxed_str()),
+            kind: ComparableNameUseKind::Literal,
+        });
+    }
+
+    standalone_comparable_parameter_name(&word.parts).map(|name| ComparableNameUse {
+        span: word.span,
+        key: ComparableNameKey(name.into()),
+        kind: ComparableNameUseKind::Parameter,
+    })
+}
+
+fn standalone_comparable_parameter_name(parts: &[WordPartNode]) -> Option<&str> {
+    match parts {
+        [part] => comparable_name_from_word_part(part),
+        _ => None,
+    }
+}
+
+fn comparable_name_from_word_part(part: &WordPartNode) -> Option<&str> {
+    match &part.kind {
+        WordPart::Variable(name) if comparable_name_text(name.as_str()) => Some(name.as_str()),
+        WordPart::Parameter(parameter) => comparable_name_from_parameter(parameter),
+        WordPart::DoubleQuoted { parts, .. } => standalone_comparable_parameter_name(parts),
+        _ => None,
+    }
+}
+
+fn comparable_name_from_parameter(parameter: &ParameterExpansion) -> Option<&str> {
+    match parameter.bourne()? {
+        BourneParameterExpansion::Access { reference }
+            if reference.subscript.is_none() && comparable_name_text(reference.name.as_str()) =>
+        {
+            Some(reference.name.as_str())
+        }
+        _ => None,
+    }
+}
+
+fn comparable_name_text(text: &str) -> bool {
+    is_shell_variable_name(text)
+        && !matches!(
+            text,
+            "dev" | "proc" | "stdin" | "stdout" | "stderr" | "tty" | "null"
+        )
+}
+
+fn dedup_comparable_name_uses(uses: &mut Vec<ComparableNameUse>) {
+    let mut seen = FxHashSet::<(ComparableNameKey, FactSpan)>::default();
+    uses.retain(|name_use| seen.insert((name_use.key.clone(), FactSpan::new(name_use.span))));
+}
+
+fn heredoc_variable_name_span(span: Span, source: &str) -> Span {
+    let Some(text) = source.get(span.start.offset..span.end.offset) else {
+        return span;
+    };
+    let Some(relative_start) = text.find('$') else {
+        return span;
+    };
+    let start_offset = span.start.offset + relative_start + '$'.len_utf8();
+    let Some(start) = position_at_offset(source, start_offset) else {
+        return span;
+    };
+    Span::from_positions(start, span.end)
 }
 
 fn comparable_path_key_is_special_device(key: &ComparablePathKey) -> bool {
@@ -242,6 +534,7 @@ pub struct RedirectFact<'a> {
     arithmetic_update_operator_spans: Box<[Span]>,
     analysis: Option<RedirectTargetAnalysis>,
     comparable_path: Option<ComparablePath>,
+    comparable_name_uses: Box<[ComparableNameUse]>,
 }
 
 impl<'a> RedirectFact<'a> {
@@ -271,6 +564,10 @@ impl<'a> RedirectFact<'a> {
 
     pub(crate) fn comparable_path(&self) -> Option<&ComparablePath> {
         self.comparable_path.as_ref()
+    }
+
+    pub(crate) fn comparable_name_uses(&self) -> &[ComparableNameUse] {
+        &self.comparable_name_uses
     }
 }
 
@@ -358,6 +655,10 @@ fn build_redirect_facts<'a>(
                 ExpansionContext::from_redirect_kind(redirect.kind)
                     .and_then(|context| comparable_path(word, source, context, zsh_options))
             }),
+            comparable_name_uses: redirect
+                .word_target()
+                .map_or_else(Vec::new, |word| comparable_name_uses(word, source).into_vec())
+                .into_boxed_slice(),
         })
         .collect::<Vec<_>>()
         .into_boxed_slice()

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -150,7 +150,7 @@ impl<'a> SimpleTestFact<'a> {
             .collect()
     }
 
-    pub fn operator_expression_operand_words(&'a self, source: &str) -> Vec<&'a Word> {
+    pub fn operator_expression_operand_words(&self, source: &str) -> Vec<&'a Word> {
         simple_test_operator_expression_operand_words(self, source)
     }
 
@@ -520,7 +520,7 @@ fn simple_test_expressions<'a>(
 }
 
 fn simple_test_operator_expression_operand_words<'a>(
-    simple_test: &'a SimpleTestFact<'a>,
+    simple_test: &SimpleTestFact<'a>,
     source: &str,
 ) -> Vec<&'a Word> {
     let operands = simple_test.effective_operands();
@@ -553,7 +553,7 @@ fn simple_test_operator_expression_operand_words<'a>(
 }
 
 fn collect_simple_test_operator_expression_operand_words<'a>(
-    simple_test: &'a SimpleTestFact<'a>,
+    simple_test: &SimpleTestFact<'a>,
     start: usize,
     end: usize,
     source: &str,

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -2249,6 +2249,49 @@ read -- -a name
 }
 
 #[test]
+fn summarizes_quoted_read_target_names() {
+    let source = "\
+#!/bin/bash
+read \"path\" 'name'
+read -a \"items\" trailing
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let file_context = classify_file_context(source, None, ShellDialect::Bash);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+    let reads = facts
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("read"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        reads[0]
+            .options()
+            .read()
+            .expect("expected quoted read facts")
+            .target_name_uses()
+            .iter()
+            .map(|name_use| name_use.span().slice(source))
+            .collect::<Vec<_>>(),
+        vec!["\"path\"", "'name'"]
+    );
+    assert_eq!(
+        reads[1]
+            .options()
+            .read()
+            .expect("expected quoted read -a facts")
+            .target_name_uses()
+            .iter()
+            .map(|name_use| name_use.span().slice(source))
+            .collect::<Vec<_>>(),
+        vec!["\"items\""]
+    );
+}
+
+#[test]
 fn summarizes_su_login_and_command_forms() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -2170,6 +2170,85 @@ fn summarizes_builtin_wrapped_reads() {
 }
 
 #[test]
+fn summarizes_read_array_targets_without_trailing_names() {
+    let source = "\
+#!/bin/bash
+read first second
+read -a arr name
+read -aarr name
+read -ar name
+read -- -a name
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let file_context = classify_file_context(source, None, ShellDialect::Bash);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+    let reads = facts
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("read"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        reads[0]
+            .options()
+            .read()
+            .expect("expected plain read facts")
+            .target_name_uses()
+            .iter()
+            .map(|name_use| name_use.span().slice(source))
+            .collect::<Vec<_>>(),
+        vec!["first", "second"]
+    );
+    assert_eq!(
+        reads[1]
+            .options()
+            .read()
+            .expect("expected read -a facts")
+            .target_name_uses()
+            .iter()
+            .map(|name_use| name_use.span().slice(source))
+            .collect::<Vec<_>>(),
+        vec!["arr"]
+    );
+    assert_eq!(
+        reads[2]
+            .options()
+            .read()
+            .expect("expected read -aNAME facts")
+            .target_name_uses()
+            .iter()
+            .map(|name_use| name_use.span().slice(source))
+            .collect::<Vec<_>>(),
+        vec!["arr"]
+    );
+    assert_eq!(
+        reads[3]
+            .options()
+            .read()
+            .expect("expected read -ar facts")
+            .target_name_uses()
+            .iter()
+            .map(|name_use| name_use.span().slice(source))
+            .collect::<Vec<_>>(),
+        vec!["r"]
+    );
+    assert_eq!(
+        reads[4]
+            .options()
+            .read()
+            .expect("expected read -- facts")
+            .target_name_uses()
+            .iter()
+            .map(|name_use| name_use.span().slice(source))
+            .collect::<Vec<_>>(),
+        vec!["name"]
+    );
+}
+
+#[test]
 fn summarizes_su_login_and_command_forms() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -36,7 +36,7 @@ impl ExpansionContext {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WordQuote {
     FullyQuoted,
     Mixed,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -56,7 +56,6 @@ pub use context::{
 pub use diagnostic::{Diagnostic, Severity};
 /// Command-substitution classification exposed by fact APIs.
 pub use facts::CommandSubstitutionKind;
-pub(crate) use facts::ComparablePathKey;
 /// Extracted structural facts available to rules and callers.
 pub use facts::{
     BacktickFragmentFact, CommandFact, CommandOptionFacts, ConditionalBareWordFact,
@@ -66,10 +65,10 @@ pub use facts::{
     ExpansionContext, ExpansionHazards, ExpansionValueShape, FindCommandFacts,
     FindExecCommandFacts, FindExecShellCommandFacts, ForHeaderFact, FunctionCallArityFacts,
     FunctionHeaderFact, GrepPatternSourceKind, LegacyArithmeticFragmentFact, ListFact,
-    ListOperatorFact, LoopHeaderWordFact, PathNameFact, PathNameKind, PathWordFact, PipelineFact,
-    PipelineOperatorFact, PipelineSegmentFact, PositionalParameterFragmentFact, PrintfCommandFacts,
-    ReadCommandFacts, RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis,
-    RedirectTargetKind, RmCommandFacts, RuntimeLiteralAnalysis, SelectHeaderFact, SimpleTestFact,
+    ListOperatorFact, LoopHeaderWordFact, PathWordFact, PipelineFact, PipelineOperatorFact,
+    PipelineSegmentFact, PositionalParameterFragmentFact, PrintfCommandFacts, ReadCommandFacts,
+    RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis, RedirectTargetKind,
+    RmCommandFacts, RuntimeLiteralAnalysis, SelectHeaderFact, SimpleTestFact,
     SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax, SingleQuotedFragmentFact,
     SshCommandFacts, StatementFact, SubstitutionFact, SubstitutionHostKind,
     SubstitutionOutputIntent, SudoFamilyCommandFacts, SudoFamilyInvoker, TestOperandClass,
@@ -81,6 +80,9 @@ pub use facts::{
 pub use facts::{
     CommandId, DeclarationKind, FactSpan, LinterFacts, NormalizedCommand, NormalizedDeclaration,
     WrapperKind,
+};
+pub(crate) use facts::{
+    ComparableNameKey, ComparableNameUseKind, ComparablePathKey, ComparablePathMatchKey,
 };
 /// Autofix types and fix application helpers.
 pub use fix::{Applicability, AppliedFixes, Edit, Fix, FixAvailability, apply_fixes};

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -559,4 +559,24 @@ read -r KALUA_REPO_URL <'KALUA_REPO_URL'
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn reports_plain_names_that_look_like_special_devices() {
+        let source = "\
+#!/bin/bash
+read -r stdin < stdin
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectClobbersInput),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["stdin", "stdin"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -502,4 +502,24 @@ read -a arr < arr
             vec!["arr", "arr"]
         );
     }
+
+    #[test]
+    fn reports_quoted_read_targets_that_match_input_paths() {
+        let source = "\
+#!/bin/bash
+read \"path\" < path
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectClobbersInput),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"path\"", "path"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -545,4 +545,18 @@ EOF
             vec!["SGINGRESS1", "\"SGINGRESS1\""]
         );
     }
+
+    #[test]
+    fn ignores_quoted_input_redirect_names_for_read_targets() {
+        let source = "\
+#!/bin/bash
+read -r KALUA_REPO_URL <'KALUA_REPO_URL'
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectClobbersInput),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -2,7 +2,8 @@ use rustc_hash::FxHashMap;
 use shuck_ast::{RedirectKind, Span};
 
 use crate::{
-    Checker, ComparablePathKey, ExpansionContext, PathNameFact, PathNameKind, Rule, Violation,
+    Checker, ComparableNameKey, ComparableNameUseKind, ComparablePathKey, ComparablePathMatchKey,
+    ExpansionContext, Rule, Violation,
 };
 
 pub struct RedirectClobbersInput;
@@ -32,11 +33,21 @@ fn clobber_spans_for_command(fact: &crate::CommandFact<'_>) -> Vec<Span> {
         return Vec::new();
     }
 
-    let mut read_paths: FxHashMap<ComparablePathKey, Vec<Span>> = FxHashMap::default();
-    let mut write_paths: FxHashMap<ComparablePathKey, Vec<Span>> = FxHashMap::default();
-    let mut readwrite_paths: FxHashMap<ComparablePathKey, Vec<Span>> = FxHashMap::default();
-    let mut read_names: FxHashMap<Box<str>, Vec<PathNameFact>> = FxHashMap::default();
-    let mut write_names: FxHashMap<Box<str>, Vec<PathNameFact>> = FxHashMap::default();
+    let mut read_paths: FxHashMap<RedirectPathMatchKey, Vec<Span>> = FxHashMap::default();
+    let mut write_paths: FxHashMap<RedirectPathMatchKey, Vec<Span>> = FxHashMap::default();
+    let mut readwrite_paths: FxHashMap<RedirectPathMatchKey, Vec<Span>> = FxHashMap::default();
+    let mut input_read_names: FxHashMap<ComparableNameKey, Vec<Span>> = FxHashMap::default();
+    let mut literal_input_read_names: FxHashMap<ComparableNameKey, Vec<Span>> =
+        FxHashMap::default();
+    let mut parameter_input_read_names: FxHashMap<ComparableNameKey, Vec<Span>> =
+        FxHashMap::default();
+    let mut heredoc_read_names: FxHashMap<ComparableNameKey, Vec<Span>> = FxHashMap::default();
+    let mut literal_write_names: FxHashMap<ComparableNameKey, Vec<Span>> = FxHashMap::default();
+    let mut derived_write_names: FxHashMap<ComparableNameKey, Vec<Span>> = FxHashMap::default();
+    let mut literal_read_target_write_names: FxHashMap<ComparableNameKey, Vec<Span>> =
+        FxHashMap::default();
+    let mut parameter_read_target_write_names: FxHashMap<ComparableNameKey, Vec<Span>> =
+        FxHashMap::default();
     let own_readwrite_spans = fact
         .redirect_facts()
         .iter()
@@ -45,11 +56,37 @@ fn clobber_spans_for_command(fact: &crate::CommandFact<'_>) -> Vec<Span> {
         .collect::<Vec<_>>();
 
     for redirect in fact.redirect_facts() {
+        if matches!(
+            redirect.redirect().kind,
+            RedirectKind::Output
+                | RedirectKind::Clobber
+                | RedirectKind::Append
+                | RedirectKind::OutputBoth
+        ) {
+            for name_use in redirect.comparable_name_uses() {
+                match name_use.kind() {
+                    ComparableNameUseKind::Literal => {
+                        literal_write_names
+                            .entry(name_use.key().clone())
+                            .or_default()
+                            .push(name_use.span());
+                    }
+                    ComparableNameUseKind::Derived => {
+                        derived_write_names
+                            .entry(name_use.key().clone())
+                            .or_default()
+                            .push(name_use.span());
+                    }
+                    ComparableNameUseKind::Parameter => {}
+                }
+            }
+        }
+
         let Some(comparable) = redirect.comparable_path() else {
             continue;
         };
 
-        let key = comparable.key().clone();
+        let key = redirect_path_match_key(comparable.key(), comparable.match_key());
         match redirect.redirect().kind {
             RedirectKind::Input => {
                 read_paths.entry(key).or_default().push(comparable.span());
@@ -86,23 +123,59 @@ fn clobber_spans_for_command(fact: &crate::CommandFact<'_>) -> Vec<Span> {
         };
 
         read_paths
-            .entry(comparable.key().clone())
+            .entry(redirect_path_match_key(
+                comparable.key(),
+                comparable.match_key(),
+            ))
             .or_default()
             .push(comparable.span());
     }
 
-    for source_name in fact.scope_read_source_names() {
-        read_names
-            .entry(source_name.name().into())
+    for name_use in fact.scope_name_read_uses() {
+        input_read_names
+            .entry(name_use.key().clone())
             .or_default()
-            .push(source_name.clone());
+            .push(name_use.span());
+        match name_use.kind() {
+            ComparableNameUseKind::Literal => {
+                literal_input_read_names
+                    .entry(name_use.key().clone())
+                    .or_default()
+                    .push(name_use.span());
+            }
+            ComparableNameUseKind::Parameter => {
+                parameter_input_read_names
+                    .entry(name_use.key().clone())
+                    .or_default()
+                    .push(name_use.span());
+            }
+            ComparableNameUseKind::Derived => {}
+        }
     }
 
-    for target_name in fact.scope_write_target_names() {
-        write_names
-            .entry(target_name.name().into())
+    for name_use in fact.scope_heredoc_name_read_uses() {
+        heredoc_read_names
+            .entry(name_use.key().clone())
             .or_default()
-            .push(target_name.clone());
+            .push(name_use.span());
+    }
+
+    for name_use in fact.scope_name_write_uses() {
+        match name_use.kind() {
+            ComparableNameUseKind::Literal => {
+                literal_read_target_write_names
+                    .entry(name_use.key().clone())
+                    .or_default()
+                    .push(name_use.span());
+            }
+            ComparableNameUseKind::Parameter => {
+                parameter_read_target_write_names
+                    .entry(name_use.key().clone())
+                    .or_default()
+                    .push(name_use.span());
+            }
+            ComparableNameUseKind::Derived => {}
+        }
     }
 
     let mut spans = Vec::new();
@@ -121,103 +194,105 @@ fn clobber_spans_for_command(fact: &crate::CommandFact<'_>) -> Vec<Span> {
         }
     }
 
-    for (name, read_spans) in &read_names {
-        let Some(write_spans) = write_names.get(name) else {
+    for (key, read_spans) in &input_read_names {
+        let Some(write_spans) = derived_write_names.get(key) else {
             continue;
         };
-        let name_spans = matching_name_spans_shellcheck_style(read_spans, write_spans);
-        if name_spans.is_empty() {
+
+        spans.extend(read_spans.iter().copied());
+        spans.extend(write_spans.iter().copied());
+    }
+
+    extend_matching_name_spans(
+        &literal_input_read_names,
+        &literal_read_target_write_names,
+        &mut spans,
+    );
+    extend_matching_name_spans(
+        &literal_input_read_names,
+        &parameter_read_target_write_names,
+        &mut spans,
+    );
+    extend_matching_name_spans(
+        &parameter_input_read_names,
+        &parameter_read_target_write_names,
+        &mut spans,
+    );
+
+    for (key, read_spans) in &heredoc_read_names {
+        let Some(write_spans) = literal_write_names.get(key) else {
+            continue;
+        };
+
+        spans.extend(read_spans.iter().copied());
+        spans.extend(write_spans.iter().copied());
+    }
+
+    for (key, read_spans) in &heredoc_read_names {
+        if !has_name_write_signal(
+            key,
+            &literal_write_names,
+            &derived_write_names,
+            &literal_read_target_write_names,
+            &parameter_read_target_write_names,
+        ) {
             continue;
         }
 
-        spans.extend(name_spans);
+        let Some(input_spans) = input_read_names.get(key) else {
+            continue;
+        };
+
+        spans.extend(read_spans.iter().copied());
+        spans.extend(input_spans.iter().copied());
     }
 
     spans
 }
 
-fn matching_name_spans_shellcheck_style(
-    read_spans: &[PathNameFact],
-    write_spans: &[PathNameFact],
-) -> Vec<Span> {
-    let mut spans = Vec::new();
-    for read in read_spans {
-        for write in write_spans {
-            if path_name_facts_match(read, write) {
-                spans.push(read.span());
-                spans.push(write.span());
-            }
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum RedirectPathMatchKey {
+    Literal(ComparablePathKey),
+    Exact(ComparablePathMatchKey),
+}
+
+fn redirect_path_match_key(
+    key: &ComparablePathKey,
+    exact: ComparablePathMatchKey,
+) -> RedirectPathMatchKey {
+    match key {
+        ComparablePathKey::Literal(_) => RedirectPathMatchKey::Literal(key.clone()),
+        ComparablePathKey::Parameter(_) | ComparablePathKey::Template(_) => {
+            RedirectPathMatchKey::Exact(exact)
         }
     }
-    spans
 }
 
-fn path_name_facts_match(read: &PathNameFact, write: &PathNameFact) -> bool {
-    read.span() != write.span()
-        && path_name_kinds_match(read.kind(), write.kind())
-        && parameter_name_bindings_match(read, write)
+fn has_name_write_signal(
+    key: &ComparableNameKey,
+    literal_write_names: &FxHashMap<ComparableNameKey, Vec<Span>>,
+    derived_write_names: &FxHashMap<ComparableNameKey, Vec<Span>>,
+    literal_read_target_write_names: &FxHashMap<ComparableNameKey, Vec<Span>>,
+    parameter_read_target_write_names: &FxHashMap<ComparableNameKey, Vec<Span>>,
+) -> bool {
+    literal_write_names.contains_key(key)
+        || derived_write_names.contains_key(key)
+        || literal_read_target_write_names.contains_key(key)
+        || parameter_read_target_write_names.contains_key(key)
 }
 
-fn parameter_name_bindings_match(read: &PathNameFact, write: &PathNameFact) -> bool {
-    if !path_name_kind_is_parameter(read.kind()) || !path_name_kind_is_parameter(write.kind()) {
-        return true;
-    }
+fn extend_matching_name_spans(
+    left: &FxHashMap<ComparableNameKey, Vec<Span>>,
+    right: &FxHashMap<ComparableNameKey, Vec<Span>>,
+    spans: &mut Vec<Span>,
+) {
+    for (key, left_spans) in left {
+        let Some(right_spans) = right.get(key) else {
+            continue;
+        };
 
-    match (read.binding_id(), write.binding_id()) {
-        (Some(read), Some(write)) if read == write => true,
-        _ => initialized_local_scopes_match(read, write),
-    }
-}
-
-fn initialized_local_scopes_match(read: &PathNameFact, write: &PathNameFact) -> bool {
-    match (
-        read.initialized_local_scope(),
-        write.initialized_local_scope(),
-    ) {
-        (Some(read), Some(write)) => read == write,
-        (None, None) => true,
-        (Some(_), None) | (None, Some(_)) => false,
-    }
-}
-
-fn path_name_kind_is_parameter(kind: PathNameKind) -> bool {
-    matches!(
-        kind,
-        PathNameKind::Parameter
-            | PathNameKind::RedirectParameter
-            | PathNameKind::HeredocParameter
-            | PathNameKind::GeneratedParameter
-    )
-}
-
-fn path_name_kinds_match(read_kind: PathNameKind, write_kind: PathNameKind) -> bool {
-    match write_kind {
-        PathNameKind::Literal => matches!(
-            read_kind,
-            PathNameKind::Literal
-                | PathNameKind::Parameter
-                | PathNameKind::RedirectLiteral
-                | PathNameKind::RedirectParameter
-                | PathNameKind::HeredocParameter
-        ),
-        PathNameKind::Parameter => {
-            matches!(
-                read_kind,
-                PathNameKind::Parameter | PathNameKind::RedirectParameter
-            )
-        }
-        PathNameKind::RedirectLiteral
-        | PathNameKind::QuotedRedirectLiteral
-        | PathNameKind::RedirectParameter
-        | PathNameKind::HeredocParameter => false,
-        PathNameKind::GeneratedLiteral => matches!(read_kind, PathNameKind::RedirectLiteral),
-        PathNameKind::GeneratedParameter => {
-            matches!(
-                read_kind,
-                PathNameKind::RedirectLiteral | PathNameKind::RedirectParameter
-            )
-        }
-        PathNameKind::BindingTarget => matches!(read_kind, PathNameKind::RedirectLiteral),
+        spans.extend(left_spans.iter().copied());
+        spans.extend(right_spans.iter().copied());
     }
 }
 
@@ -267,6 +342,27 @@ printf '%s\\0' **/* | bsdtar --null --files-from - --exclude .MTREE | gzip -c -f
     }
 
     #[test]
+    fn reports_literal_redirect_paths_across_quote_forms() {
+        let source = "\
+#!/bin/bash
+cat < \"foo\" > foo
+cat < bar > 'bar'
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectClobbersInput),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"foo\"", "foo", "bar", "'bar'"]
+        );
+    }
+
+    #[test]
     fn ignores_commands_without_matching_read_and_write_paths() {
         let source = "\
 #!/bin/bash
@@ -284,23 +380,9 @@ jq --args '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
 jq --jsonargs '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
 jq --indent 2 --args '$ARGS.positional[0]' \"$cfg\" >\"$cfg\"
 jq -nc '.x=1' \"$cfg\" >\"$cfg\"
-cat < \"$suffix\" > \"$(basename \"$name\" \"$suffix\")\"
-cat < \"$suffix\" > \"$(basename -s \"$suffix\" \"$name\")\"
-cat < \"$suffix\" > \"$(basename --suffix=\"$suffix\" \"$name\")\"
-read quoted_input_path < \"quoted_input_path\"
-while read quoted_loop_path; do
-  :
-done < \"quoted_loop_path\"
-{
-  f() {
-    local OUT=
-    if [ \"$OUT\" = 0 ]; then
-      OUT=x
-    fi
-    printf '%s\\n' \"$OUT\"
-  }
-  f
-} | sort >> \"$OUT\"
+cat < $src > \"$src\"
+cat < \"$src\" > $src
+{ [ \"$OUT\" = \"0\" ]; } >>$OUT
 ";
         let diagnostics = test_snippet(
             source,
@@ -311,43 +393,38 @@ done < \"quoted_loop_path\"
     }
 
     #[test]
-    fn reports_shellcheck_compatible_name_collisions() {
+    fn ignores_heredoc_and_input_name_reuse_without_a_write_signal() {
         let source = "\
 #!/bin/bash
-gzip -9c < \"$src\" > \"$pkg/usr/man/man1/$(basename \"$src\").gz\"
-sort <<< \"$OUT\" > \"$OUT\"
-read input_path < input_path
-while read loop_path; do
-  :
-done < loop_path
-while read heredoc_path; do
-  cat <<EOF
-$heredoc_path
+cat <<EOF < foo
+$foo
 EOF
-done < heredoc_path
-while read iplist; do
-  cat <<EOF >> json2
-\"$iplist/32\"
-EOF
-done < iplist
-(
-  cat <<EOF
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectClobbersInput),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_shellcheck_compatible_name_reuse_patterns() {
+        let source = "\
+#!/bin/bash
+while read iplist; do :; done < iplist
+read -r iplist < iplist
+{ cat <<EOT
 $SGINGRESS1
-EOF
-) > SGINGRESS1
-{ [ \"$OUT\" -lt \"$crit_border\" ] && :; } | sort >> \"$OUT\"
-{ case \"$MODE\" in on) :;; esac; } | sort > \"$MODE\"
-{
-  g() {
-    local OUT
-    [ \"$OUT\" = 0 ] && :
-  }
-  g
-} | sort >> \"$OUT\"
-f() {
-  local out=/tmp/f
-  sort \"$out\" > \"$out\"
-}
+EOT
+} > SGINGRESS1
+gzip -9c < \"$file\" > \"$(basename \"$file\").gz\"
+while read name; do cat <<EOT2
+$name
+EOT2
+done < name
+{ [ $OUT -lt 1 ]; } >>$OUT
+{ [ \"$OUT\" = \"0\" ]; } >>\"$OUT\"
 ";
         let diagnostics = test_snippet(
             source,
@@ -360,31 +437,69 @@ f() {
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec![
-                "\"$src\"",
-                "\"$src\"",
-                "\"$OUT\"",
-                "\"$OUT\"",
-                "input_path",
-                "input_path",
-                "loop_path",
-                "loop_path",
-                "heredoc_path",
-                "heredoc_path",
-                "heredoc_path",
+                "iplist",
                 "iplist",
                 "iplist",
                 "iplist",
                 "SGINGRESS1",
                 "SGINGRESS1",
+                "\"$file\"",
+                "\"$file\"",
+                "name",
+                "name",
+                "name",
+                "$OUT",
+                "$OUT",
                 "\"$OUT\"",
                 "\"$OUT\"",
-                "\"$MODE\"",
-                "\"$MODE\"",
-                "\"$OUT\"",
-                "\"$OUT\"",
-                "\"$out\"",
-                "\"$out\"",
             ]
+        );
+    }
+
+    #[test]
+    fn ignores_name_reuse_when_oracle_keeps_derived_paths_quiet() {
+        let source = "\
+#!/bin/bash
+cat < \"$file\" > \"$file.bak\"
+cat < \"$file\" > \"out/$file\"
+cat < \"$dir/in\" > \"$dir/out\"
+cat \"$file\" > \"$(basename \"$file\").gz\"
+while read line; do :; done < iplist
+while read -r x; do :; done < <(for x in \"$root\"; do find \"$x\"; done)
+read linkdest < \"$linkdest\"
+cat > \"$PRGNAM\" <<EOF2
+$PRGNAM
+EOF2
+for i in man/*.1; do gzip -9c < $i > $PKGMAN1/$(basename \"$i\").gz; done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectClobbersInput),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_trailing_read_names_after_array_targets() {
+        let source = "\
+#!/bin/bash
+read -a arr name < name
+read -aarr name < name
+read -ar name < name
+read -a arr < arr
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectClobbersInput),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["arr", "arr"]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -522,4 +522,27 @@ read \"path\" < path
             vec!["\"path\"", "path"]
         );
     }
+
+    #[test]
+    fn reports_quoted_literal_redirect_targets_that_match_heredoc_names() {
+        let source = "\
+#!/bin/bash
+{ cat <<EOF
+$SGINGRESS1
+EOF
+} > \"SGINGRESS1\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectClobbersInput),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["SGINGRESS1", "\"SGINGRESS1\""]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Align C094 behavior with the ShellCheck SC2094 oracle instead of preserving the previous documented divergence.
- Add quote-aware comparable path matching and name-based facts for read targets, heredoc bodies, derived redirect names, and simple-test operands in redirected scopes.
- Remove the C094 corpus divergence metadata now that targeted parity is clean.

## Root Cause

C094 was intentionally narrower than ShellCheck for several name-reuse patterns, so the corpus harness needed reviewed divergences to suppress ShellCheck-only findings. Treating ShellCheck as the source of truth requires modeling those name and derived-path cases in shared facts rather than filtering them away.

## Validation

- `cargo test -p shuck-linter redirect_clobbers_input -- --nocapture`
- `cargo test -p shuck-linter`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C094` reached `implementation_diffs=0` and `reviewed_divergences=0`; it still exits nonzero because of 5 existing unrelated parser harness failures.