### PR TITLE
fix(linter): align X010 with ShellCheck

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x010.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x010.yaml
@@ -1,4 +1,0 @@
-reviewed_divergences:
-- side: shellcheck-only
-  path_contains: termux__termux-packages__
-  reason: The remaining ShellCheck-only SC3009 corpus hits come from sourced Termux package recipes and build helpers that the comparison path collapses to POSIX sh more aggressively than Shuck's project-aware dialect resolution. X010 intentionally stays tied to files Shuck actually treats as sh or dash.

--- a/crates/shuck-linter/src/rules/portability/brace_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/brace_expansion.rs
@@ -60,6 +60,40 @@ echo prefix{a,b}suffix file{1..3}.txt
     }
 
     #[test]
+    fn reports_nested_brace_expansions_individually() {
+        let source = "\
+#!/bin/sh
+echo {EGL,GLES{,2,3}}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BraceExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["{EGL,GLES{,2,3}}", "{,2,3}"]
+        );
+    }
+
+    #[test]
+    fn reports_brace_expansions_with_quoted_members() {
+        let source = "\
+#!/bin/sh
+mkdir -p \"$TERMUX_GODIR\"/{bin,src,doc,lib,\"pkg/tool/$TERMUX_GOLANG_DIRNAME\",pkg/include}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BraceExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["{bin,src,doc,lib,\"pkg/tool/$TERMUX_GOLANG_DIRNAME\",pkg/include}"]
+        );
+    }
+
+    #[test]
     fn ignores_quoted_and_pattern_only_brace_syntax() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/portability/brace_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/brace_expansion.rs
@@ -94,6 +94,23 @@ mkdir -p \"$TERMUX_GODIR\"/{bin,src,doc,lib,\"pkg/tool/$TERMUX_GOLANG_DIRNAME\",
     }
 
     #[test]
+    fn reports_brace_expansions_even_when_quoted_members_contain_closing_braces() {
+        let source = "\
+#!/bin/sh
+echo {\"}\",a}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BraceExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![r#"{"}",a}"#]
+        );
+    }
+
+    #[test]
     fn ignores_quoted_and_pattern_only_brace_syntax() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1644,19 +1644,7 @@ impl<'a> Lexer<'a> {
                     // plain literals like foo{bar} and brace expansions stay intact.
                     Self::push_capture_char(&mut word, ch);
                     self.advance();
-                    let mut depth = 1;
-                    while let Some(c) = self.peek_char() {
-                        Self::push_capture_char(&mut word, c);
-                        self.advance();
-                        if c == '{' {
-                            depth += 1;
-                        } else if c == '}' {
-                            depth -= 1;
-                            if depth == 0 {
-                                break;
-                            }
-                        }
-                    }
+                    self.consume_mid_word_brace_segment(&mut word);
                 } else {
                     // Unmatched literal braces in regexes like ^{ should not swallow
                     // trailing delimiters such as ]] or then.
@@ -1708,21 +1696,7 @@ impl<'a> Lexer<'a> {
                             && self.current_word_surface_is_single_char(start, &word, '{')
                             && self.escaped_brace_sequence_looks_like_brace_expansion()
                         {
-                            let mut depth = 1;
-                            while let Some(c) = self.peek_char() {
-                                Self::push_capture_char(&mut word, c);
-                                self.advance();
-                                match c {
-                                    '{' => depth += 1,
-                                    '}' => {
-                                        depth -= 1;
-                                        if depth == 0 {
-                                            break;
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
+                            self.consume_mid_word_brace_segment(&mut word);
                         }
                     }
                 } else {
@@ -3456,8 +3430,13 @@ impl<'a> Lexer<'a> {
         }
 
         let mut depth = 1;
+        let mut paren_depth = 0usize;
         let mut has_comma = false;
         let mut has_dot_dot = false;
+        let mut escaped = false;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut in_backtick = false;
         let mut prev_char = None;
         let mut scanned = 0usize;
 
@@ -3466,25 +3445,136 @@ impl<'a> Lexer<'a> {
             if scanned > MAX_LOOKAHEAD {
                 return false;
             }
+
+            let brace_surface_active = !in_single && !in_double && !in_backtick;
+            let at_top_level = depth == 1 && paren_depth == 0 && brace_surface_active;
+
             match ch {
-                '{' => depth += 1,
-                '}' => {
+                _ if escaped => {
+                    escaped = false;
+                }
+                '\\' => escaped = true,
+                '\'' if !in_double && !in_backtick => in_single = !in_single,
+                '"' if !in_single && !in_backtick => in_double = !in_double,
+                '`' if !in_single && !in_double => in_backtick = !in_backtick,
+                '(' if brace_surface_active && (paren_depth > 0 || prev_char == Some('$')) => {
+                    paren_depth += 1
+                }
+                ')' if brace_surface_active && paren_depth > 0 => paren_depth -= 1,
+                '{' if !in_single && !in_double && !in_backtick => depth += 1,
+                '}' if !in_single && !in_double && !in_backtick => {
                     depth -= 1;
                     if depth == 0 {
                         // Found matching }, check if we have brace expansion markers
                         return has_comma || has_dot_dot;
                     }
                 }
-                ',' if depth == 1 => has_comma = true,
-                '.' if prev_char == Some('.') && depth == 1 => has_dot_dot = true,
+                ',' if at_top_level => has_comma = true,
+                '.' if at_top_level && prev_char == Some('.') => has_dot_dot = true,
                 // Brace groups have whitespace/newlines/semicolons at depth 1
-                ' ' | '\t' | '\n' | ';' if depth == 1 => return false,
+                ' ' | '\t' | '\n' | ';' if at_top_level => return false,
                 _ => {}
             }
             prev_char = Some(ch);
         }
 
         false
+    }
+
+    fn consume_mid_word_brace_segment(&mut self, word: &mut Option<String>) {
+        let mut brace_depth = 1usize;
+        let mut paren_depth = 0usize;
+        let mut escaped = false;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut in_backtick = false;
+        let mut prev_char = None;
+
+        while let Some(ch) = self.peek_char() {
+            Self::push_capture_char(word, ch);
+            self.advance();
+
+            if escaped {
+                escaped = false;
+                prev_char = Some(ch);
+                continue;
+            }
+
+            match ch {
+                '\\' => escaped = true,
+                '\'' if !in_double && !in_backtick => in_single = !in_single,
+                '"' if !in_single && !in_backtick => in_double = !in_double,
+                '`' if !in_single && !in_double => in_backtick = !in_backtick,
+                '(' if !in_single
+                    && !in_double
+                    && !in_backtick
+                    && (paren_depth > 0 || prev_char == Some('$')) =>
+                {
+                    paren_depth += 1
+                }
+                ')' if !in_single && !in_double && !in_backtick && paren_depth > 0 => {
+                    paren_depth -= 1
+                }
+                '{' if !in_single && !in_double && !in_backtick => brace_depth += 1,
+                '}' if !in_single && !in_double && !in_backtick => {
+                    brace_depth -= 1;
+                    if brace_depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+
+            prev_char = Some(ch);
+        }
+    }
+
+    fn consume_brace_word_body(&mut self, word: &mut String) {
+        let mut brace_depth = 1usize;
+        let mut paren_depth = 0usize;
+        let mut escaped = false;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut in_backtick = false;
+        let mut prev_char = None;
+
+        while let Some(ch) = self.peek_char() {
+            word.push(ch);
+            self.advance();
+
+            if escaped {
+                escaped = false;
+                prev_char = Some(ch);
+                continue;
+            }
+
+            match ch {
+                '\\' => escaped = true,
+                '\'' if !in_double && !in_backtick => in_single = !in_single,
+                '"' if !in_single && !in_backtick => in_double = !in_double,
+                '`' if !in_single && !in_double => in_backtick = !in_backtick,
+                '(' if !in_single
+                    && !in_double
+                    && !in_backtick
+                    && (paren_depth > 0 || prev_char == Some('$')) =>
+                {
+                    paren_depth += 1
+                }
+                ')' if !in_single && !in_double && !in_backtick && paren_depth > 0 => {
+                    paren_depth -= 1
+                }
+                '{' if !in_single && !in_double && !in_backtick => brace_depth += 1,
+                '}' if !in_single && !in_double && !in_backtick => {
+                    brace_depth -= 1;
+                    if brace_depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+
+            prev_char = Some(ch);
+        }
     }
 
     /// Check whether a mid-word `{...}` segment can stay attached to the current
@@ -3545,7 +3635,7 @@ impl<'a> Lexer<'a> {
                     paren_depth -= 1
                 }
                 '{' if !in_single && !in_double && !in_backtick => brace_depth += 1,
-                '}' => {
+                '}' if !in_single && !in_double && !in_backtick => {
                     brace_depth -= 1;
                     if brace_depth == 0 {
                         return true;
@@ -3626,21 +3716,7 @@ impl<'a> Lexer<'a> {
             return None;
         }
 
-        let mut depth = 1;
-        while let Some(ch) = self.peek_char() {
-            word.push(ch);
-            self.advance();
-            match ch {
-                '{' => depth += 1,
-                '}' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
+        self.consume_brace_word_body(&mut word);
 
         while let Some(ch) = self.peek_char() {
             if Self::is_word_char(ch) {
@@ -3673,21 +3749,7 @@ impl<'a> Lexer<'a> {
         }
 
         // Read until matching }
-        let mut depth = 1;
-        while let Some(ch) = self.peek_char() {
-            word.push(ch);
-            self.advance();
-            match ch {
-                '{' => depth += 1,
-                '}' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
+        self.consume_brace_word_body(&mut word);
 
         // Continue reading any suffix after the brace pattern
         while let Some(ch) = self.peek_char() {
@@ -3696,21 +3758,7 @@ impl<'a> Lexer<'a> {
                     // Another brace pattern - include it
                     word.push(ch);
                     self.advance();
-                    let mut inner_depth = 1;
-                    while let Some(c) = self.peek_char() {
-                        word.push(c);
-                        self.advance();
-                        match c {
-                            '{' => inner_depth += 1,
-                            '}' => {
-                                inner_depth -= 1;
-                                if inner_depth == 0 {
-                                    break;
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
+                    self.consume_brace_word_body(&mut word);
                 } else {
                     word.push(ch);
                     self.advance();
@@ -4835,6 +4883,16 @@ mod tests {
 
         assert_next_token(&mut lexer, TokenKind::Word, Some("echo"));
         assert_next_token(&mut lexer, TokenKind::QuotedWord, Some("hello world"));
+        assert!(lexer.next_lexed_token().is_none());
+    }
+
+    #[test]
+    fn test_brace_expansion_token_ignores_quoted_closers() {
+        let mut lexer = Lexer::new("echo {\"}\",a}\n");
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("echo"));
+        assert_next_token(&mut lexer, TokenKind::Word, Some(r#"{"}",a}"#));
+        assert_next_token(&mut lexer, TokenKind::Newline, None);
         assert!(lexer.next_lexed_token().is_none());
     }
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1696,7 +1696,21 @@ impl<'a> Lexer<'a> {
                             && self.current_word_surface_is_single_char(start, &word, '{')
                             && self.escaped_brace_sequence_looks_like_brace_expansion()
                         {
-                            self.consume_mid_word_brace_segment(&mut word);
+                            let mut depth = 1;
+                            while let Some(c) = self.peek_char() {
+                                Self::push_capture_char(&mut word, c);
+                                self.advance();
+                                match c {
+                                    '{' => depth += 1,
+                                    '}' => {
+                                        depth -= 1;
+                                        if depth == 0 {
+                                            break;
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
                         }
                     }
                 } else {

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -3467,7 +3467,7 @@ impl<'a> Lexer<'a> {
                 _ if escaped => {
                     escaped = false;
                 }
-                '\\' => escaped = true,
+                '\\' if !in_single => escaped = true,
                 '\'' if !in_double && !in_backtick => in_single = !in_single,
                 '"' if !in_single && !in_backtick => in_double = !in_double,
                 '`' if !in_single && !in_double => in_backtick = !in_backtick,
@@ -3515,7 +3515,7 @@ impl<'a> Lexer<'a> {
             }
 
             match ch {
-                '\\' => escaped = true,
+                '\\' if !in_single => escaped = true,
                 '\'' if !in_double && !in_backtick => in_single = !in_single,
                 '"' if !in_single && !in_backtick => in_double = !in_double,
                 '`' if !in_single && !in_double => in_backtick = !in_backtick,
@@ -3563,7 +3563,7 @@ impl<'a> Lexer<'a> {
             }
 
             match ch {
-                '\\' => escaped = true,
+                '\\' if !in_single => escaped = true,
                 '\'' if !in_double && !in_backtick => in_single = !in_single,
                 '"' if !in_single && !in_backtick => in_double = !in_double,
                 '`' if !in_single && !in_double => in_backtick = !in_backtick,
@@ -4906,6 +4906,17 @@ mod tests {
 
         assert_next_token(&mut lexer, TokenKind::Word, Some("echo"));
         assert_next_token(&mut lexer, TokenKind::Word, Some(r#"{"}",a}"#));
+        assert_next_token(&mut lexer, TokenKind::Newline, None);
+        assert!(lexer.next_lexed_token().is_none());
+    }
+
+    #[test]
+    fn test_brace_expansion_token_preserves_single_quoted_backslash_member_boundary() {
+        let mut lexer = Lexer::new("echo {'a\\',b} next\n");
+
+        assert_next_token(&mut lexer, TokenKind::Word, Some("echo"));
+        assert_next_token(&mut lexer, TokenKind::Word, Some(r#"{'a\',b}"#));
+        assert_next_token(&mut lexer, TokenKind::Word, Some("next"));
         assert_next_token(&mut lexer, TokenKind::Newline, None);
         assert!(lexer.next_lexed_token().is_none());
     }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2276,7 +2276,9 @@ impl<'a> Parser<'a> {
             }
 
             let has_brace_text = match &part.kind {
-                WordPart::Literal(text) => text.syntax_str(self.input, part.span).contains(['{', '}']),
+                WordPart::Literal(text) => {
+                    text.syntax_str(self.input, part.span).contains(['{', '}'])
+                }
                 WordPart::SingleQuoted { .. }
                 | WordPart::DoubleQuoted { .. }
                 | WordPart::ZshQualifiedGlob(_) => part.span.slice(self.input).contains(['{', '}']),
@@ -2447,7 +2449,9 @@ impl<'a> Parser<'a> {
         fn quote_context(state: Option<QuoteState>) -> BraceQuoteContext {
             match state {
                 None => BraceQuoteContext::Unquoted,
-                Some(QuoteState::Single | QuoteState::AnsiSingle) => BraceQuoteContext::SingleQuoted,
+                Some(QuoteState::Single | QuoteState::AnsiSingle) => {
+                    BraceQuoteContext::SingleQuoted
+                }
                 Some(QuoteState::Double) => BraceQuoteContext::DoubleQuoted,
             }
         }
@@ -2757,11 +2761,11 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-                let brace_start = position;
-                if let Some(len) = Self::template_placeholder_len(text, index, quote_context) {
-                    let brace_end = brace_start.advanced_by(&text[index..index + len]);
-                    out.push(BraceSyntax {
-                        kind: BraceSyntaxKind::TemplatePlaceholder,
+            let brace_start = position;
+            if let Some(len) = Self::template_placeholder_len(text, index, quote_context) {
+                let brace_end = brace_start.advanced_by(&text[index..index + len]);
+                out.push(BraceSyntax {
+                    kind: BraceSyntaxKind::TemplatePlaceholder,
                     span: Span::from_positions(brace_start, brace_end),
                     quote_context,
                 });
@@ -2770,29 +2774,29 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-                if let Some((len, kind)) = Self::brace_construct_len(text, index, quote_context) {
-                    let brace_end = brace_start.advanced_by(&text[index..index + len]);
-                    out.push(BraceSyntax {
-                        kind,
-                        span: Span::from_positions(brace_start, brace_end),
-                        quote_context,
-                    });
-                    if len > 2 {
-                        let inner_start = index + '{'.len_utf8();
-                        let inner_end = index + len - '}'.len_utf8();
-                        if inner_start < inner_end {
-                            let inner_base = brace_start.advanced_by("{");
-                            Self::scan_brace_syntax_text(
-                                &text[inner_start..inner_end],
-                                inner_base,
-                                quote_context,
-                                out,
-                            );
-                        }
+            if let Some((len, kind)) = Self::brace_construct_len(text, index, quote_context) {
+                let brace_end = brace_start.advanced_by(&text[index..index + len]);
+                out.push(BraceSyntax {
+                    kind,
+                    span: Span::from_positions(brace_start, brace_end),
+                    quote_context,
+                });
+                if len > 2 {
+                    let inner_start = index + '{'.len_utf8();
+                    let inner_end = index + len - '}'.len_utf8();
+                    if inner_start < inner_end {
+                        let inner_base = brace_start.advanced_by("{");
+                        Self::scan_brace_syntax_text(
+                            &text[inner_start..inner_end],
+                            inner_base,
+                            quote_context,
+                            out,
+                        );
                     }
-                    position = brace_end;
-                    index += len;
-                    continue;
+                }
+                position = brace_end;
+                index += len;
+                continue;
             }
 
             position.advance('{');

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2215,19 +2215,29 @@ impl<'a> Parser<'a> {
         quote_context: BraceQuoteContext,
         out: &mut Vec<BraceSyntax>,
     ) {
-        let mut chars = Vec::new();
-        self.collect_brace_scan_chars_from_parts(parts, &mut chars);
-        Self::scan_brace_syntax_chars(&chars, quote_context, out);
-
         for part in parts {
             match &part.kind {
+                WordPart::Literal(text) => Self::scan_brace_syntax_text(
+                    text.syntax_str(self.input, part.span),
+                    part.span.start,
+                    quote_context,
+                    out,
+                ),
+                WordPart::SingleQuoted { .. } => Self::scan_brace_syntax_text(
+                    part.span.slice(self.input),
+                    part.span.start,
+                    BraceQuoteContext::SingleQuoted,
+                    out,
+                ),
+                WordPart::DoubleQuoted { parts, .. } => self.collect_brace_syntax_from_parts(
+                    parts,
+                    BraceQuoteContext::DoubleQuoted,
+                    out,
+                ),
                 WordPart::ZshQualifiedGlob(glob) => {
                     self.collect_brace_syntax_from_zsh_qualified_glob(glob, quote_context, out)
                 }
-                WordPart::Literal(_)
-                | WordPart::SingleQuoted { .. }
-                | WordPart::DoubleQuoted { .. }
-                | WordPart::Variable(_)
+                WordPart::Variable(_)
                 | WordPart::CommandSubstitution { .. }
                 | WordPart::ArithmeticExpansion { .. }
                 | WordPart::Parameter(_)
@@ -2244,6 +2254,56 @@ impl<'a> Parser<'a> {
                 | WordPart::Transformation { .. } => {}
             }
         }
+
+        if self.needs_cross_part_brace_scan(parts) {
+            let mut chars = Vec::new();
+            self.collect_brace_scan_chars_from_parts(parts, &mut chars);
+            Self::scan_brace_syntax_chars(&chars, quote_context, out);
+        }
+    }
+
+    fn needs_cross_part_brace_scan(&self, parts: &[WordPartNode]) -> bool {
+        if parts.len() < 2 {
+            return false;
+        }
+
+        let mut cursor = parts[0].span.start.offset;
+        for part in parts {
+            if part.span.start.offset > cursor
+                && self.input[cursor..part.span.start.offset].contains(['{', '}'])
+            {
+                return true;
+            }
+
+            let has_brace_text = match &part.kind {
+                WordPart::Literal(text) => text.syntax_str(self.input, part.span).contains(['{', '}']),
+                WordPart::SingleQuoted { .. }
+                | WordPart::DoubleQuoted { .. }
+                | WordPart::ZshQualifiedGlob(_) => part.span.slice(self.input).contains(['{', '}']),
+                WordPart::Variable(_)
+                | WordPart::CommandSubstitution { .. }
+                | WordPart::ArithmeticExpansion { .. }
+                | WordPart::Parameter(_)
+                | WordPart::ParameterExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayAccess(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::ArrayIndices(_)
+                | WordPart::Substring { .. }
+                | WordPart::ArraySlice { .. }
+                | WordPart::IndirectExpansion { .. }
+                | WordPart::PrefixMatch { .. }
+                | WordPart::ProcessSubstitution { .. }
+                | WordPart::Transformation { .. } => false,
+            };
+            if has_brace_text {
+                return true;
+            }
+
+            cursor = part.span.end.offset;
+        }
+
+        false
     }
 
     fn collect_brace_scan_chars_from_parts(
@@ -2361,6 +2421,7 @@ impl<'a> Parser<'a> {
         #[derive(Clone, Copy, PartialEq, Eq)]
         enum QuoteState {
             Single,
+            AnsiSingle,
             Double,
         }
 
@@ -2386,7 +2447,7 @@ impl<'a> Parser<'a> {
         fn quote_context(state: Option<QuoteState>) -> BraceQuoteContext {
             match state {
                 None => BraceQuoteContext::Unquoted,
-                Some(QuoteState::Single) => BraceQuoteContext::SingleQuoted,
+                Some(QuoteState::Single | QuoteState::AnsiSingle) => BraceQuoteContext::SingleQuoted,
                 Some(QuoteState::Double) => BraceQuoteContext::DoubleQuoted,
             }
         }
@@ -2450,7 +2511,11 @@ impl<'a> Parser<'a> {
         while index < chars.len() {
             let ch = chars[index].0;
 
-            if matches!(quote_state, None | Some(QuoteState::Double)) && ch == '\\' {
+            if matches!(
+                quote_state,
+                None | Some(QuoteState::AnsiSingle) | Some(QuoteState::Double)
+            ) && ch == '\\'
+            {
                 if let Some(candidate) = stack.last_mut() {
                     candidate.prev_char = None;
                 }
@@ -2481,7 +2546,11 @@ impl<'a> Parser<'a> {
             match quote_state {
                 None => match ch {
                     '\'' => {
-                        quote_state = Some(QuoteState::Single);
+                        quote_state = if index > 0 && chars[index - 1].0 == '$' {
+                            Some(QuoteState::AnsiSingle)
+                        } else {
+                            Some(QuoteState::Single)
+                        };
                         for candidate in &mut stack {
                             if matches!(candidate.quote_context, BraceQuoteContext::Unquoted) {
                                 candidate.saw_quote_boundary = true;
@@ -2499,6 +2568,16 @@ impl<'a> Parser<'a> {
                     _ => {}
                 },
                 Some(QuoteState::Single) => {
+                    if ch == '\'' {
+                        quote_state = None;
+                        for candidate in &mut stack {
+                            if matches!(candidate.quote_context, BraceQuoteContext::Unquoted) {
+                                candidate.saw_quote_boundary = true;
+                            }
+                        }
+                    }
+                }
+                Some(QuoteState::AnsiSingle) => {
                     if ch == '\'' {
                         quote_state = None;
                         for candidate in &mut stack {
@@ -2678,11 +2757,11 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            let brace_start = position;
-            if let Some(len) = Self::template_placeholder_len(text, index, quote_context) {
-                let brace_end = brace_start.advanced_by(&text[index..index + len]);
-                out.push(BraceSyntax {
-                    kind: BraceSyntaxKind::TemplatePlaceholder,
+                let brace_start = position;
+                if let Some(len) = Self::template_placeholder_len(text, index, quote_context) {
+                    let brace_end = brace_start.advanced_by(&text[index..index + len]);
+                    out.push(BraceSyntax {
+                        kind: BraceSyntaxKind::TemplatePlaceholder,
                     span: Span::from_positions(brace_start, brace_end),
                     quote_context,
                 });
@@ -2691,16 +2770,29 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if let Some((len, kind)) = Self::brace_construct_len(text, index, quote_context) {
-                let brace_end = brace_start.advanced_by(&text[index..index + len]);
-                out.push(BraceSyntax {
-                    kind,
-                    span: Span::from_positions(brace_start, brace_end),
-                    quote_context,
-                });
-                position = brace_end;
-                index += len;
-                continue;
+                if let Some((len, kind)) = Self::brace_construct_len(text, index, quote_context) {
+                    let brace_end = brace_start.advanced_by(&text[index..index + len]);
+                    out.push(BraceSyntax {
+                        kind,
+                        span: Span::from_positions(brace_start, brace_end),
+                        quote_context,
+                    });
+                    if len > 2 {
+                        let inner_start = index + '{'.len_utf8();
+                        let inner_end = index + len - '}'.len_utf8();
+                        if inner_start < inner_end {
+                            let inner_base = brace_start.advanced_by("{");
+                            Self::scan_brace_syntax_text(
+                                &text[inner_start..inner_end],
+                                inner_base,
+                                quote_context,
+                                out,
+                            );
+                        }
+                    }
+                    position = brace_end;
+                    index += len;
+                    continue;
             }
 
             position.advance('{');

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2464,6 +2464,25 @@ impl<'a> Parser<'a> {
             }
         }
 
+        fn quote_context_is_active(context: BraceQuoteContext, state: Option<QuoteState>) -> bool {
+            match context {
+                BraceQuoteContext::Unquoted => state.is_none(),
+                BraceQuoteContext::SingleQuoted => {
+                    matches!(state, Some(QuoteState::Single | QuoteState::AnsiSingle))
+                }
+                BraceQuoteContext::DoubleQuoted => matches!(state, Some(QuoteState::Double)),
+            }
+        }
+
+        fn last_active_candidate_index(
+            stack: &[Candidate],
+            state: Option<QuoteState>,
+        ) -> Option<usize> {
+            stack
+                .iter()
+                .rposition(|candidate| quote_context_is_active(candidate.quote_context, state))
+        }
+
         fn template_placeholder_end(
             chars: &[(char, Position)],
             start: usize,
@@ -2528,8 +2547,8 @@ impl<'a> Parser<'a> {
                 None | Some(QuoteState::AnsiSingle) | Some(QuoteState::Double)
             ) && ch == '\\'
             {
-                if let Some(candidate) = stack.last_mut() {
-                    candidate.prev_char = None;
+                if let Some(candidate_index) = last_active_candidate_index(&stack, quote_state) {
+                    stack[candidate_index].prev_char = None;
                 }
                 index += 1;
                 if index < chars.len() {
@@ -2548,8 +2567,8 @@ impl<'a> Parser<'a> {
                     span: brace_span(chars[index].1, chars[end_index - 1]),
                     quote_context: current_quote_context,
                 });
-                if let Some(candidate) = stack.last_mut() {
-                    candidate.prev_char = None;
+                if let Some(candidate_index) = last_active_candidate_index(&stack, quote_state) {
+                    stack[candidate_index].prev_char = None;
                 }
                 index = end_index;
                 continue;
@@ -2626,7 +2645,9 @@ impl<'a> Parser<'a> {
                     continue;
                 }
                 '}' => {
-                    if let Some(candidate) = stack.pop() {
+                    if let Some(candidate_index) = last_active_candidate_index(&stack, quote_state)
+                    {
+                        let candidate = stack.remove(candidate_index);
                         let kind = if matches!(candidate.quote_context, BraceQuoteContext::Unquoted)
                             && candidate.saw_unquoted_whitespace
                         {
@@ -2650,13 +2671,11 @@ impl<'a> Parser<'a> {
                     }
                 }
                 _ => {
-                    if let Some(candidate) = stack.last_mut() {
-                        let counts_as_top_level = match candidate.quote_context {
-                            BraceQuoteContext::Unquoted => quote_state.is_none(),
-                            BraceQuoteContext::SingleQuoted | BraceQuoteContext::DoubleQuoted => {
-                                true
-                            }
-                        };
+                    if let Some(candidate_index) = last_active_candidate_index(&stack, quote_state)
+                    {
+                        let candidate = &mut stack[candidate_index];
+                        let counts_as_top_level =
+                            quote_context_is_active(candidate.quote_context, quote_state);
 
                         if counts_as_top_level {
                             match ch {
@@ -2679,8 +2698,8 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            if let Some(candidate) = stack.last_mut() {
-                candidate.prev_char = Some(ch);
+            if let Some(candidate_index) = last_active_candidate_index(&stack, quote_state) {
+                stack[candidate_index].prev_char = Some(ch);
             }
 
             index += 1;
@@ -2739,76 +2758,106 @@ impl<'a> Parser<'a> {
         quote_context: BraceQuoteContext,
         out: &mut Vec<BraceSyntax>,
     ) {
-        let bytes = text.as_bytes();
-        let mut index = 0;
-        let mut position = base;
+        #[derive(Clone, Copy)]
+        struct ScanFrame<'a> {
+            text: &'a str,
+            index: usize,
+            position: Position,
+        }
 
-        while index < bytes.len() {
-            let next_special = if matches!(quote_context, BraceQuoteContext::Unquoted) {
-                memchr2(b'{', b'\\', &bytes[index..]).map(|relative| index + relative)
-            } else {
-                memchr(b'{', &bytes[index..]).map(|relative| index + relative)
-            };
+        let mut work = vec![ScanFrame {
+            text,
+            index: 0,
+            position: base,
+        }];
 
-            let Some(next_index) = next_special else {
-                return;
-            };
+        while let Some(mut frame) = work.pop() {
+            let bytes = frame.text.as_bytes();
 
-            if next_index > index {
-                position = position.advanced_by(&text[index..next_index]);
-                index = next_index;
-            }
+            while frame.index < bytes.len() {
+                let next_special = if matches!(quote_context, BraceQuoteContext::Unquoted) {
+                    memchr2(b'{', b'\\', &bytes[frame.index..])
+                        .map(|relative| frame.index + relative)
+                } else {
+                    memchr(b'{', &bytes[frame.index..]).map(|relative| frame.index + relative)
+                };
 
-            if matches!(quote_context, BraceQuoteContext::Unquoted) && bytes[index] == b'\\' {
-                let escaped_start = index;
-                index += 1;
-                if let Some(next) = text[index..].chars().next() {
-                    index += next.len_utf8();
+                let Some(next_index) = next_special else {
+                    break;
+                };
+
+                if next_index > frame.index {
+                    frame.position = frame
+                        .position
+                        .advanced_by(&frame.text[frame.index..next_index]);
+                    frame.index = next_index;
                 }
-                position = position.advanced_by(&text[escaped_start..index]);
-                continue;
-            }
 
-            let brace_start = position;
-            if let Some(len) = Self::template_placeholder_len(text, index, quote_context) {
-                let brace_end = brace_start.advanced_by(&text[index..index + len]);
-                out.push(BraceSyntax {
-                    kind: BraceSyntaxKind::TemplatePlaceholder,
-                    span: Span::from_positions(brace_start, brace_end),
-                    quote_context,
-                });
-                position = brace_end;
-                index += len;
-                continue;
-            }
-
-            if let Some((len, kind)) = Self::brace_construct_len(text, index, quote_context) {
-                let brace_end = brace_start.advanced_by(&text[index..index + len]);
-                out.push(BraceSyntax {
-                    kind,
-                    span: Span::from_positions(brace_start, brace_end),
-                    quote_context,
-                });
-                if len > 2 {
-                    let inner_start = index + '{'.len_utf8();
-                    let inner_end = index + len - '}'.len_utf8();
-                    if inner_start < inner_end {
-                        let inner_base = brace_start.advanced_by("{");
-                        Self::scan_brace_syntax_text(
-                            &text[inner_start..inner_end],
-                            inner_base,
-                            quote_context,
-                            out,
-                        );
+                if matches!(quote_context, BraceQuoteContext::Unquoted)
+                    && bytes[frame.index] == b'\\'
+                {
+                    let escaped_start = frame.index;
+                    frame.index += 1;
+                    if let Some(next) = frame.text[frame.index..].chars().next() {
+                        frame.index += next.len_utf8();
                     }
+                    frame.position = frame
+                        .position
+                        .advanced_by(&frame.text[escaped_start..frame.index]);
+                    continue;
                 }
-                position = brace_end;
-                index += len;
-                continue;
-            }
 
-            position.advance('{');
-            index += '{'.len_utf8();
+                let brace_start = frame.position;
+                if let Some(len) =
+                    Self::template_placeholder_len(frame.text, frame.index, quote_context)
+                {
+                    let brace_end =
+                        brace_start.advanced_by(&frame.text[frame.index..frame.index + len]);
+                    out.push(BraceSyntax {
+                        kind: BraceSyntaxKind::TemplatePlaceholder,
+                        span: Span::from_positions(brace_start, brace_end),
+                        quote_context,
+                    });
+                    frame.position = brace_end;
+                    frame.index += len;
+                    continue;
+                }
+
+                if let Some((len, kind)) =
+                    Self::brace_construct_len(frame.text, frame.index, quote_context)
+                {
+                    let brace_end =
+                        brace_start.advanced_by(&frame.text[frame.index..frame.index + len]);
+                    out.push(BraceSyntax {
+                        kind,
+                        span: Span::from_positions(brace_start, brace_end),
+                        quote_context,
+                    });
+
+                    frame.position = brace_end;
+                    frame.index += len;
+
+                    if len > 2 {
+                        let inner_start = frame.index - len + '{'.len_utf8();
+                        let inner_end = frame.index - '}'.len_utf8();
+                        if inner_start < inner_end {
+                            let inner_base = brace_start.advanced_by("{");
+                            work.push(frame);
+                            work.push(ScanFrame {
+                                text: &frame.text[inner_start..inner_end],
+                                index: 0,
+                                position: inner_base,
+                            });
+                            break;
+                        }
+                    }
+
+                    continue;
+                }
+
+                frame.position.advance('{');
+                frame.index += '{'.len_utf8();
+            }
         }
     }
 

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2296,10 +2296,10 @@ impl<'a> Parser<'a> {
         let mut cursor_position = span.start;
 
         for part in parts {
-            if part.span.start.offset > cursor_offset {
-                if let Some(raw) = self.input.get(cursor_offset..part.span.start.offset) {
-                    Self::push_brace_scan_text(raw, cursor_position, out);
-                }
+            if part.span.start.offset > cursor_offset
+                && let Some(raw) = self.input.get(cursor_offset..part.span.start.offset)
+            {
+                Self::push_brace_scan_text(raw, cursor_position, out);
             }
 
             match &part.kind {
@@ -2338,10 +2338,10 @@ impl<'a> Parser<'a> {
             cursor_position = part.span.end;
         }
 
-        if cursor_offset < span.end.offset {
-            if let Some(raw) = self.input.get(cursor_offset..span.end.offset) {
-                Self::push_brace_scan_text(raw, cursor_position, out);
-            }
+        if cursor_offset < span.end.offset
+            && let Some(raw) = self.input.get(cursor_offset..span.end.offset)
+        {
+            Self::push_brace_scan_text(raw, cursor_position, out);
         }
     }
 

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2343,7 +2343,9 @@ impl<'a> Parser<'a> {
                 | WordPart::IndirectExpansion { .. }
                 | WordPart::PrefixMatch { .. }
                 | WordPart::ProcessSubstitution { .. }
-                | WordPart::Transformation { .. } => {}
+                | WordPart::Transformation { .. } => {
+                    Self::push_brace_scan_boundary(part.span.start, out);
+                }
             }
         }
     }
@@ -2393,7 +2395,9 @@ impl<'a> Parser<'a> {
                 | WordPart::IndirectExpansion { .. }
                 | WordPart::PrefixMatch { .. }
                 | WordPart::ProcessSubstitution { .. }
-                | WordPart::Transformation { .. } => {}
+                | WordPart::Transformation { .. } => {
+                    Self::push_brace_scan_boundary(part.span.start, out);
+                }
             }
 
             cursor_offset = part.span.end.offset;
@@ -2413,6 +2417,10 @@ impl<'a> Parser<'a> {
             out.push((ch, position));
             position.advance(ch);
         }
+    }
+
+    fn push_brace_scan_boundary(position: Position, out: &mut Vec<(char, Position)>) {
+        out.push(('\0', position));
     }
 
     fn scan_brace_syntax_chars(

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2197,6 +2197,15 @@ impl<'a> Parser<'a> {
         }
         let mut brace_syntax = Vec::new();
         self.collect_brace_syntax_from_parts(parts, BraceQuoteContext::Unquoted, &mut brace_syntax);
+        brace_syntax.sort_by_key(|brace| (brace.span.start.offset, brace.span.end.offset));
+        brace_syntax.dedup_by_key(|brace| {
+            (
+                brace.span.start.offset,
+                brace.span.end.offset,
+                brace.quote_context,
+                brace.kind,
+            )
+        });
         brace_syntax
     }
 
@@ -2206,28 +2215,58 @@ impl<'a> Parser<'a> {
         quote_context: BraceQuoteContext,
         out: &mut Vec<BraceSyntax>,
     ) {
+        let mut chars = Vec::new();
+        self.collect_brace_scan_chars_from_parts(parts, &mut chars);
+        Self::scan_brace_syntax_chars(&chars, quote_context, out);
+
         for part in parts {
             match &part.kind {
-                WordPart::Literal(text) => Self::scan_brace_syntax_text(
-                    text.as_str(self.input, part.span),
-                    part.span.start,
-                    quote_context,
-                    out,
-                ),
                 WordPart::ZshQualifiedGlob(glob) => {
                     self.collect_brace_syntax_from_zsh_qualified_glob(glob, quote_context, out)
                 }
-                WordPart::SingleQuoted { value, .. } => Self::scan_brace_syntax_text(
-                    value.slice(self.input),
-                    value.span().start,
-                    BraceQuoteContext::SingleQuoted,
-                    out,
-                ),
-                WordPart::DoubleQuoted { parts, .. } => self.collect_brace_syntax_from_parts(
-                    parts,
-                    BraceQuoteContext::DoubleQuoted,
-                    out,
-                ),
+                WordPart::Literal(_)
+                | WordPart::SingleQuoted { .. }
+                | WordPart::DoubleQuoted { .. }
+                | WordPart::Variable(_)
+                | WordPart::CommandSubstitution { .. }
+                | WordPart::ArithmeticExpansion { .. }
+                | WordPart::Parameter(_)
+                | WordPart::ParameterExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayAccess(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::ArrayIndices(_)
+                | WordPart::Substring { .. }
+                | WordPart::ArraySlice { .. }
+                | WordPart::IndirectExpansion { .. }
+                | WordPart::PrefixMatch { .. }
+                | WordPart::ProcessSubstitution { .. }
+                | WordPart::Transformation { .. } => {}
+            }
+        }
+    }
+
+    fn collect_brace_scan_chars_from_parts(
+        &self,
+        parts: &[WordPartNode],
+        out: &mut Vec<(char, Position)>,
+    ) {
+        for part in parts {
+            match &part.kind {
+                WordPart::Literal(text) => {
+                    Self::push_brace_scan_text(
+                        text.syntax_str(self.input, part.span),
+                        part.span.start,
+                        out,
+                    );
+                }
+                WordPart::SingleQuoted { .. } => {
+                    Self::push_brace_scan_text(part.span.slice(self.input), part.span.start, out);
+                }
+                WordPart::DoubleQuoted { parts, .. } => {
+                    self.collect_brace_scan_chars_from_double_quoted_part(part.span, parts, out);
+                }
+                WordPart::ZshQualifiedGlob(_) => {}
                 WordPart::Variable(_)
                 | WordPart::CommandSubstitution { .. }
                 | WordPart::ArithmeticExpansion { .. }
@@ -2244,6 +2283,316 @@ impl<'a> Parser<'a> {
                 | WordPart::ProcessSubstitution { .. }
                 | WordPart::Transformation { .. } => {}
             }
+        }
+    }
+
+    fn collect_brace_scan_chars_from_double_quoted_part(
+        &self,
+        span: Span,
+        parts: &[WordPartNode],
+        out: &mut Vec<(char, Position)>,
+    ) {
+        let mut cursor_offset = span.start.offset;
+        let mut cursor_position = span.start;
+
+        for part in parts {
+            if part.span.start.offset > cursor_offset {
+                if let Some(raw) = self.input.get(cursor_offset..part.span.start.offset) {
+                    Self::push_brace_scan_text(raw, cursor_position, out);
+                }
+            }
+
+            match &part.kind {
+                WordPart::Literal(text) => {
+                    Self::push_brace_scan_text(
+                        text.syntax_str(self.input, part.span),
+                        part.span.start,
+                        out,
+                    );
+                }
+                WordPart::SingleQuoted { .. } => {
+                    Self::push_brace_scan_text(part.span.slice(self.input), part.span.start, out);
+                }
+                WordPart::DoubleQuoted { parts, .. } => {
+                    self.collect_brace_scan_chars_from_double_quoted_part(part.span, parts, out);
+                }
+                WordPart::ZshQualifiedGlob(_) => {}
+                WordPart::Variable(_)
+                | WordPart::CommandSubstitution { .. }
+                | WordPart::ArithmeticExpansion { .. }
+                | WordPart::Parameter(_)
+                | WordPart::ParameterExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayAccess(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::ArrayIndices(_)
+                | WordPart::Substring { .. }
+                | WordPart::ArraySlice { .. }
+                | WordPart::IndirectExpansion { .. }
+                | WordPart::PrefixMatch { .. }
+                | WordPart::ProcessSubstitution { .. }
+                | WordPart::Transformation { .. } => {}
+            }
+
+            cursor_offset = part.span.end.offset;
+            cursor_position = part.span.end;
+        }
+
+        if cursor_offset < span.end.offset {
+            if let Some(raw) = self.input.get(cursor_offset..span.end.offset) {
+                Self::push_brace_scan_text(raw, cursor_position, out);
+            }
+        }
+    }
+
+    fn push_brace_scan_text(text: &str, start: Position, out: &mut Vec<(char, Position)>) {
+        let mut position = start;
+        for ch in text.chars() {
+            out.push((ch, position));
+            position.advance(ch);
+        }
+    }
+
+    fn scan_brace_syntax_chars(
+        chars: &[(char, Position)],
+        initial_quote_context: BraceQuoteContext,
+        out: &mut Vec<BraceSyntax>,
+    ) {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum QuoteState {
+            Single,
+            Double,
+        }
+
+        #[derive(Clone, Copy)]
+        struct Candidate {
+            start: Position,
+            quote_context: BraceQuoteContext,
+            has_comma: bool,
+            has_dot_dot: bool,
+            saw_unquoted_whitespace: bool,
+            saw_quote_boundary: bool,
+            prev_char: Option<char>,
+        }
+
+        fn quote_state(context: BraceQuoteContext) -> Option<QuoteState> {
+            match context {
+                BraceQuoteContext::Unquoted => None,
+                BraceQuoteContext::SingleQuoted => Some(QuoteState::Single),
+                BraceQuoteContext::DoubleQuoted => Some(QuoteState::Double),
+            }
+        }
+
+        fn quote_context(state: Option<QuoteState>) -> BraceQuoteContext {
+            match state {
+                None => BraceQuoteContext::Unquoted,
+                Some(QuoteState::Single) => BraceQuoteContext::SingleQuoted,
+                Some(QuoteState::Double) => BraceQuoteContext::DoubleQuoted,
+            }
+        }
+
+        fn template_placeholder_end(
+            chars: &[(char, Position)],
+            start: usize,
+            quote_context: BraceQuoteContext,
+        ) -> Option<usize> {
+            if chars.get(start)?.0 != '{' || chars.get(start + 1)?.0 != '{' {
+                return None;
+            }
+
+            let mut index = start + 2;
+            let mut depth = 1usize;
+
+            while index < chars.len() {
+                if matches!(quote_context, BraceQuoteContext::Unquoted) && chars[index].0 == '\\' {
+                    index += 1;
+                    if index < chars.len() {
+                        index += 1;
+                    }
+                    continue;
+                }
+
+                if chars.get(index).is_some_and(|(ch, _)| *ch == '{')
+                    && chars.get(index + 1).is_some_and(|(ch, _)| *ch == '{')
+                {
+                    depth += 1;
+                    index += 2;
+                    continue;
+                }
+
+                if chars.get(index).is_some_and(|(ch, _)| *ch == '}')
+                    && chars.get(index + 1).is_some_and(|(ch, _)| *ch == '}')
+                {
+                    depth -= 1;
+                    index += 2;
+                    if depth == 0 {
+                        return Some(index);
+                    }
+                    continue;
+                }
+
+                index += 1;
+            }
+
+            None
+        }
+
+        fn brace_span(start: Position, end: (char, Position)) -> Span {
+            let mut end_position = end.1;
+            end_position.advance(end.0);
+            Span::from_positions(start, end_position)
+        }
+
+        let mut index = 0usize;
+        let mut quote_state = quote_state(initial_quote_context);
+        let mut stack = Vec::<Candidate>::new();
+
+        while index < chars.len() {
+            let ch = chars[index].0;
+
+            if matches!(quote_state, None | Some(QuoteState::Double)) && ch == '\\' {
+                if let Some(candidate) = stack.last_mut() {
+                    candidate.prev_char = None;
+                }
+                index += 1;
+                if index < chars.len() {
+                    index += 1;
+                }
+                continue;
+            }
+
+            let current_quote_context = quote_context(quote_state);
+            if ch == '{'
+                && let Some(end_index) =
+                    template_placeholder_end(chars, index, current_quote_context)
+            {
+                out.push(BraceSyntax {
+                    kind: BraceSyntaxKind::TemplatePlaceholder,
+                    span: brace_span(chars[index].1, chars[end_index - 1]),
+                    quote_context: current_quote_context,
+                });
+                if let Some(candidate) = stack.last_mut() {
+                    candidate.prev_char = None;
+                }
+                index = end_index;
+                continue;
+            }
+
+            match quote_state {
+                None => match ch {
+                    '\'' => {
+                        quote_state = Some(QuoteState::Single);
+                        for candidate in &mut stack {
+                            if matches!(candidate.quote_context, BraceQuoteContext::Unquoted) {
+                                candidate.saw_quote_boundary = true;
+                            }
+                        }
+                    }
+                    '"' => {
+                        quote_state = Some(QuoteState::Double);
+                        for candidate in &mut stack {
+                            if matches!(candidate.quote_context, BraceQuoteContext::Unquoted) {
+                                candidate.saw_quote_boundary = true;
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+                Some(QuoteState::Single) => {
+                    if ch == '\'' {
+                        quote_state = None;
+                        for candidate in &mut stack {
+                            if matches!(candidate.quote_context, BraceQuoteContext::Unquoted) {
+                                candidate.saw_quote_boundary = true;
+                            }
+                        }
+                    }
+                }
+                Some(QuoteState::Double) => {
+                    if ch == '"' {
+                        quote_state = None;
+                        for candidate in &mut stack {
+                            if matches!(candidate.quote_context, BraceQuoteContext::Unquoted) {
+                                candidate.saw_quote_boundary = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            match ch {
+                '{' => {
+                    stack.push(Candidate {
+                        start: chars[index].1,
+                        quote_context: current_quote_context,
+                        has_comma: false,
+                        has_dot_dot: false,
+                        saw_unquoted_whitespace: false,
+                        saw_quote_boundary: false,
+                        prev_char: Some(ch),
+                    });
+                    index += 1;
+                    continue;
+                }
+                '}' => {
+                    if let Some(candidate) = stack.pop() {
+                        let kind = if matches!(candidate.quote_context, BraceQuoteContext::Unquoted)
+                            && candidate.saw_unquoted_whitespace
+                        {
+                            BraceSyntaxKind::Literal
+                        } else if candidate.has_comma {
+                            BraceSyntaxKind::Expansion(BraceExpansionKind::CommaList)
+                        } else if candidate.has_dot_dot {
+                            BraceSyntaxKind::Expansion(BraceExpansionKind::Sequence)
+                        } else {
+                            BraceSyntaxKind::Literal
+                        };
+                        if !matches!(kind, BraceSyntaxKind::Literal)
+                            || !candidate.saw_quote_boundary
+                        {
+                            out.push(BraceSyntax {
+                                kind,
+                                span: brace_span(candidate.start, chars[index]),
+                                quote_context: candidate.quote_context,
+                            });
+                        }
+                    }
+                }
+                _ => {
+                    if let Some(candidate) = stack.last_mut() {
+                        let counts_as_top_level = match candidate.quote_context {
+                            BraceQuoteContext::Unquoted => quote_state.is_none(),
+                            BraceQuoteContext::SingleQuoted | BraceQuoteContext::DoubleQuoted => {
+                                true
+                            }
+                        };
+
+                        if counts_as_top_level {
+                            match ch {
+                                ',' => candidate.has_comma = true,
+                                '.' if candidate.prev_char == Some('.') => {
+                                    candidate.has_dot_dot = true;
+                                }
+                                c if matches!(
+                                    candidate.quote_context,
+                                    BraceQuoteContext::Unquoted
+                                ) && quote_state.is_none()
+                                    && c.is_whitespace() =>
+                                {
+                                    candidate.saw_unquoted_whitespace = true;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(candidate) = stack.last_mut() {
+                candidate.prev_char = Some(ch);
+            }
+
+            index += 1;
         }
     }
 

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2296,6 +2296,20 @@ fn test_parse_word_with_mid_word_brace_segment_ignores_quoted_closers() {
 }
 
 #[test]
+fn test_parse_brace_expansion_with_single_quoted_backslash_member_keeps_following_args() {
+    let input = "echo {'a\\',b} next\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    assert_eq!(command.args.len(), 2);
+    assert_eq!(command.args[0].span.slice(input), r#"{'a\',b}"#);
+    assert_eq!(command.args[1].span.slice(input), "next");
+    assert!(command.args[0].has_active_brace_expansion());
+}
+
+#[test]
 fn test_brace_syntax_handles_deeply_nested_braces_without_recursion() {
     let depth = 8192usize;
     let mut input = String::with_capacity(depth * 3 + 2);

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2269,6 +2269,61 @@ fn test_brace_syntax_does_not_merge_dots_across_skipped_expansion_parts() {
 }
 
 #[test]
+fn test_brace_syntax_ignores_quoted_closers_when_balancing_cross_part_lists() {
+    let input = r#"{"}",a}"#;
+    let word = Parser::parse_word_string(input);
+
+    assert_eq!(brace_slices(&word, input), vec![input]);
+    assert_eq!(
+        word.brace_syntax()[0].kind,
+        BraceSyntaxKind::Expansion(BraceExpansionKind::CommaList)
+    );
+    assert!(word.has_active_brace_expansion());
+}
+
+#[test]
+fn test_parse_word_with_mid_word_brace_segment_ignores_quoted_closers() {
+    let input = "echo {\"}\",a}\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    assert_eq!(command.args.len(), 1);
+    assert_eq!(command.args[0].span.slice(input), r#"{"}",a}"#);
+    assert_eq!(brace_slices(&command.args[0], input), vec![r#"{"}",a}"#]);
+    assert!(command.args[0].has_active_brace_expansion());
+}
+
+#[test]
+fn test_brace_syntax_handles_deeply_nested_braces_without_recursion() {
+    let depth = 8192usize;
+    let mut input = String::with_capacity(depth * 3 + 2);
+    for _ in 0..depth {
+        input.push('{');
+        input.push('a');
+    }
+    input.push(',');
+    input.push('b');
+    for _ in 0..depth {
+        input.push('}');
+    }
+
+    let word = Parser::parse_word_string(&input);
+
+    assert_eq!(word.brace_syntax().len(), depth);
+    assert_eq!(
+        word.brace_syntax()
+            .iter()
+            .filter(|brace| brace.expands())
+            .count(),
+        1
+    );
+    assert_eq!(brace_slices(&word, &input).last().copied(), Some("{a,b}"));
+    assert!(word.has_active_brace_expansion());
+}
+
+#[test]
 fn test_dollar_quoted_words_preserve_quote_variants() {
     let input = "printf $'line\\n' $\"prefix $HOME\"\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2241,6 +2241,20 @@ fn test_brace_syntax_ignores_escaped_unquoted_braces() {
 }
 
 #[test]
+fn test_brace_syntax_keeps_ansi_c_escaped_quotes_inside_single_quoted_regions() {
+    let input = r#"$'foo\'{a,b}'"#;
+    let word = Parser::parse_word_string(input);
+
+    assert_eq!(brace_slices(&word, input), vec!["{a,b}"]);
+    assert!(
+        word.brace_syntax()
+            .iter()
+            .all(|brace| brace.treated_literally())
+    );
+    assert!(!word.has_active_brace_expansion());
+}
+
+#[test]
 fn test_dollar_quoted_words_preserve_quote_variants() {
     let input = "printf $'line\\n' $\"prefix $HOME\"\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2178,6 +2178,62 @@ fn test_brace_syntax_marks_template_placeholders_inside_quotes() {
 }
 
 #[test]
+fn test_brace_syntax_marks_nested_expansions_separately() {
+    let input = "{EGL,GLES{,2,3}}";
+    let word = Parser::parse_word_string(input);
+
+    assert_eq!(
+        brace_slices(&word, input),
+        vec!["{EGL,GLES{,2,3}}", "{,2,3}"]
+    );
+    assert!(word.brace_syntax().iter().all(|brace| brace.expands()));
+}
+
+#[test]
+fn test_brace_syntax_marks_all_nested_comma_lists() {
+    let input =
+        "usr/include/{sys/{capability,shm,sem},{glob,iconv,spawn,zlib,zconf},KHR/khrplatform}.h";
+    let word = Parser::parse_word_string(input);
+
+    assert_eq!(
+        brace_slices(&word, input),
+        vec![
+            "{sys/{capability,shm,sem},{glob,iconv,spawn,zlib,zconf},KHR/khrplatform}",
+            "{capability,shm,sem}",
+            "{glob,iconv,spawn,zlib,zconf}",
+        ]
+    );
+}
+
+#[test]
+fn test_brace_syntax_spans_quoted_members_inside_unquoted_lists() {
+    let input =
+        "\"$TERMUX_GODIR\"/{bin,src,doc,lib,\"pkg/tool/$TERMUX_GOLANG_DIRNAME\",pkg/include}";
+    let word = Parser::parse_word_string(input);
+
+    assert_eq!(
+        brace_slices(&word, input),
+        vec!["{bin,src,doc,lib,\"pkg/tool/$TERMUX_GOLANG_DIRNAME\",pkg/include}"]
+    );
+    assert!(word.has_active_brace_expansion());
+}
+
+#[test]
+fn test_brace_syntax_does_not_treat_double_open_braces_as_template_placeholders_when_they_expand() {
+    let input = "lib{{pthread,resolv,ffi_pic}.a,rt.so}";
+    let word = Parser::parse_word_string(input);
+
+    assert_eq!(
+        brace_slices(&word, input),
+        vec![
+            "{{pthread,resolv,ffi_pic}.a,rt.so}",
+            "{pthread,resolv,ffi_pic}"
+        ]
+    );
+    assert!(word.brace_syntax().iter().all(|brace| brace.expands()));
+}
+
+#[test]
 fn test_brace_syntax_ignores_escaped_unquoted_braces() {
     let word = Parser::parse_word_string("\\{a,b\\}");
     assert!(word.brace_syntax().is_empty());

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -2255,6 +2255,20 @@ fn test_brace_syntax_keeps_ansi_c_escaped_quotes_inside_single_quoted_regions() 
 }
 
 #[test]
+fn test_brace_syntax_does_not_merge_dots_across_skipped_expansion_parts() {
+    let input = "{1.$x.3}";
+    let word = Parser::parse_word_string(input);
+
+    assert_eq!(brace_slices(&word, input), vec!["{1.$x.3}"]);
+    assert!(
+        word.brace_syntax()
+            .iter()
+            .all(|brace| brace.treated_literally())
+    );
+    assert!(!word.has_active_brace_expansion());
+}
+
+#[test]
 fn test_dollar_quoted_words_preserve_quote_variants() {
     let input = "printf $'line\\n' $\"prefix $HOME\"\n";
     let script = Parser::new(input).parse().unwrap().file;


### PR DESCRIPTION
## Summary
- align X010 brace expansion detection with the ShellCheck oracle instead of relying on reviewed-divergence metadata
- teach the parser's brace syntax collector to recognize nested brace expansions and active brace lists that span quoted members
- remove the stale X010 reviewed-divergence metadata entry now that the rule matches the oracle

## Root cause
X010 depends on parser-owned brace syntax metadata. The previous collector scanned parts too locally, so it missed nested comma lists and some brace expansions that crossed word-part and quote boundaries. That left real ShellCheck-matching X010 cases undocumented in Shuck and the corpus metadata had been papering over the gap.

## Validation
- `cargo test -p shuck-parser test_brace_syntax_`
- `cargo test -p shuck-linter brace_expansion`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X010`

The targeted large-corpus run still exits non-zero because of 5 pre-existing unrelated harness parse failures, but X010 itself is clean in the summary:
- `implementation_diffs=0`
- `reviewed_divergences=0`
