### PR TITLE
fix(linter): align S054 with shellcheck behavior

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s054.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s054.yaml
@@ -1,17 +1,1 @@
-reviewed_divergences:
-- side: shuck-only
-  path_suffix: 89luca89__distrobox__distrobox-init
-  line: 1886
-  reason: This compatibility probe calls `su --version` while deciding whether to install a wrapper. Direct oracle probes still surface SC2117 for that standalone form, so the missing full-file report here is treated as project-closure oracle noise.
-- side: shuck-only
-  path_suffix: 89luca89__distrobox__distrobox-init
-  line: 1887
-  reason: This compatibility probe calls `su --version` while deciding whether to install a wrapper. Direct oracle probes still surface SC2117 for that standalone form, so the missing full-file report here is treated as project-closure oracle noise.
-- side: shuck-only
-  path_suffix: HariSekhon__DevOps-Bash-tools__install__install_homebrew.sh
-  line: 61
-  reason: This installer switches users while explicitly selecting an interactive shell with `-s /bin/bash`. Shuck intentionally keeps nudging toward login-shell or explicit command forms here, while the current oracle build does not surface SC2117 for shell-selection uses.
-- side: shuck-only
-  path_suffix: sickcodes__Docker-OSX__tests__test.sh
-  line: 168
-  reason: This test harness passes the command as trailing argv after the target user instead of using `-c`. Shuck intentionally keeps preferring explicit command or login forms for S054, while the oracle does not surface SC2117 for this argv-forwarding style.
+reviewed_divergences: []

--- a/crates/shuck-linter/resources/test/fixtures/style/S054.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S054.sh
@@ -1,13 +1,24 @@
 #!/bin/sh
+su
 su librenms
+su -m
+su --pty
 su -
 su -c
+su -s
 su -l
 su -l root
 su -c id root
 su --login root
 su --command id root
 su - root
+su -m root
+su -- root
+su root -m
+su root -c
+su root -c id
+su root >/dev/null 2>&1
+su root | cat
+su --version
 command su librenms
 sudo su librenms
-su librenms -c id

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -46,12 +46,12 @@ impl ReadCommandFacts {
 
 #[derive(Debug, Clone, Copy)]
 pub struct SuCommandFacts {
-    has_login_or_command_flag: bool,
+    has_login_flag: bool,
 }
 
 impl SuCommandFacts {
-    pub fn has_login_or_command_flag(self) -> bool {
-        self.has_login_or_command_flag
+    pub fn has_login_flag(self) -> bool {
+        self.has_login_flag
     }
 }
 
@@ -1251,70 +1251,40 @@ fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
 
 fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
     let mut pending_option_arg = false;
-    let mut saw_user = false;
-    let mut index = 0usize;
-
-    while let Some(word) = args.get(index) {
+    for word in args {
         let Some(text) = static_word_text(word, source) else {
             if pending_option_arg {
                 pending_option_arg = false;
-            } else if saw_user {
-                break;
-            } else {
-                saw_user = true;
             }
-            index += 1;
             continue;
         };
 
         if pending_option_arg {
             pending_option_arg = false;
-            index += 1;
             continue;
         }
 
         match text.as_ref() {
             "-" | "-l" | "--login" => {
                 return SuCommandFacts {
-                    has_login_or_command_flag: true,
+                    has_login_flag: true,
                 };
             }
             "--" => {
                 break;
             }
-            "--command" => {
-                if args.get(index + 1).is_some() {
-                    return SuCommandFacts {
-                        has_login_or_command_flag: true,
-                    };
-                }
-            }
-            _ if text.starts_with("--command=") => {
-                if text.len() > "--command=".len() {
-                    return SuCommandFacts {
-                        has_login_or_command_flag: true,
-                    };
-                }
-            }
             _ if su_long_option_takes_argument(text.as_ref()) => {
                 pending_option_arg = true;
-                index += 1;
                 continue;
             }
             _ => {}
         }
 
         if text.starts_with("--") {
-            index += 1;
             continue;
         }
 
         if !text.starts_with('-') {
-            if saw_user {
-                break;
-            }
-            saw_user = true;
-            index += 1;
             continue;
         }
 
@@ -1323,14 +1293,7 @@ fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
             match flag {
                 'l' => {
                     return SuCommandFacts {
-                        has_login_or_command_flag: true,
-                    };
-                }
-                'c' => {
-                    if flags.peek().is_some() || args.get(index + 1).is_some() {
-                        return SuCommandFacts {
-                            has_login_or_command_flag: true,
-                        };
+                        has_login_flag: true,
                     }
                 }
                 flag if su_short_option_takes_argument(flag) => {
@@ -1342,24 +1305,26 @@ fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
                 _ => {}
             }
         }
-
-        index += 1;
     }
 
     SuCommandFacts {
-        has_login_or_command_flag: false,
+        has_login_flag: false,
     }
 }
 
 fn su_long_option_takes_argument(text: &str) -> bool {
     matches!(
         text,
-        "--group" | "--supp-group" | "--shell" | "--whitelist-environment"
+        "--command"
+            | "--group"
+            | "--shell"
+            | "--supp-group"
+            | "--whitelist-environment"
     )
 }
 
 fn su_short_option_takes_argument(flag: char) -> bool {
-    matches!(flag, 'C' | 'g' | 'G' | 's' | 'w')
+    matches!(flag, 'C' | 'c' | 'g' | 'G' | 's' | 'w')
 }
 
 fn ssh_remote_args<'a>(args: &'a [&'a Word], source: &str) -> Option<&'a [&'a Word]> {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -2292,7 +2292,7 @@ read -a \"items\" trailing
 }
 
 #[test]
-fn summarizes_su_login_and_command_forms() {
+fn summarizes_su_login_forms() {
     let source = "\
 #!/bin/bash
 su root
@@ -2301,6 +2301,7 @@ su \"$user\" -s /bin/sh -c \"$cmd\"
 su -s /bin/sh root
 su -
 su --login root
+su -l
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
@@ -2308,20 +2309,21 @@ su --login root
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
-    let su_flags = facts
+    let su_login_flags = facts
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("su"))
-        .map(|fact| fact.options().su().map(|su| su.has_login_or_command_flag()))
+        .map(|fact| fact.options().su().map(|su| su.has_login_flag()))
         .collect::<Vec<_>>();
 
     assert_eq!(
-        su_flags,
+        su_login_flags,
         vec![
             Some(false),
-            Some(true),
-            Some(true),
             Some(false),
+            Some(false),
+            Some(false),
+            Some(true),
             Some(true),
             Some(true)
         ]
@@ -2329,11 +2331,14 @@ su --login root
 }
 
 #[test]
-fn keeps_incomplete_su_command_flags_unsafe() {
+fn keeps_only_login_aliases_marked_as_login_forms() {
     let source = "\
 #!/bin/bash
 su -c
 su --command
+su -m root
+su -- root
+su root -s /bin/sh
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
@@ -2341,58 +2346,23 @@ su --command
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
-    let su_flags = facts
+    let su_login_flags = facts
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("su"))
-        .map(|fact| fact.options().su().map(|su| su.has_login_or_command_flag()))
+        .map(|fact| fact.options().su().map(|su| su.has_login_flag()))
         .collect::<Vec<_>>();
 
-    assert_eq!(su_flags, vec![Some(false), Some(false)]);
-}
-
-#[test]
-fn stops_treating_su_args_after_double_dash_as_flags() {
-    let source = "\
-#!/bin/bash
-su -- root echo -c hi
-";
-    let output = Parser::new(source).parse().unwrap();
-    let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
-    let file_context = classify_file_context(source, None, ShellDialect::Bash);
-    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
-
-    let su_flags = facts
-        .commands()
-        .iter()
-        .filter(|fact| fact.effective_name_is("su"))
-        .map(|fact| fact.options().su().map(|su| su.has_login_or_command_flag()))
-        .collect::<Vec<_>>();
-
-    assert_eq!(su_flags, vec![Some(false)]);
-}
-
-#[test]
-fn stops_treating_su_forwarded_command_args_as_flags() {
-    let source = "\
-#!/bin/bash
-su root bash -c 'id'
-";
-    let output = Parser::new(source).parse().unwrap();
-    let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
-    let file_context = classify_file_context(source, None, ShellDialect::Bash);
-    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
-
-    let su_flags = facts
-        .commands()
-        .iter()
-        .filter(|fact| fact.effective_name_is("su"))
-        .map(|fact| fact.options().su().map(|su| su.has_login_or_command_flag()))
-        .collect::<Vec<_>>();
-
-    assert_eq!(su_flags, vec![Some(false)]);
+    assert_eq!(
+        su_login_flags,
+        vec![
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false)
+        ]
+    );
 }
 
 #[test]

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S054_S054.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S054_S054.sh.snap
@@ -1,15 +1,44 @@
 ---
 source: crates/shuck-linter/src/rules/style/mod.rs
-assertion_line: 112
 ---
 S054 use `su -l` or `su -c` when switching users
  --> <source>:2:1
   |
-2 | su librenms
+2 | su
+  |
+
+S054 use `su -l` or `su -c` when switching users
+ --> <source>:3:1
+  |
+3 | su librenms
   |
 
 S054 use `su -l` or `su -c` when switching users
  --> <source>:4:1
   |
-4 | su -c
+4 | su -m
   |
+
+S054 use `su -l` or `su -c` when switching users
+ --> <source>:5:1
+  |
+5 | su --pty
+  |
+
+S054 use `su -l` or `su -c` when switching users
+ --> <source>:7:1
+  |
+7 | su -c
+  |
+
+S054 use `su -l` or `su -c` when switching users
+ --> <source>:8:1
+  |
+8 | su -s
+  |
+
+S054 use `su -l` or `su -c` when switching users
+  --> <source>:22:1
+   |
+22 | su --version
+   |

--- a/crates/shuck-linter/src/rules/style/su_without_flag.rs
+++ b/crates/shuck-linter/src/rules/style/su_without_flag.rs
@@ -1,4 +1,5 @@
 use crate::{Checker, Rule, Violation};
+use rustc_hash::FxHashSet;
 
 pub struct SuWithoutFlag;
 
@@ -13,16 +14,27 @@ impl Violation for SuWithoutFlag {
 }
 
 pub fn su_without_flag(checker: &mut Checker) {
+    let piped_command_ids = checker
+        .facts()
+        .pipelines()
+        .iter()
+        .flat_map(|pipeline| {
+            pipeline
+                .segments()
+                .iter()
+                .map(|segment| segment.command_id())
+        })
+        .collect::<FxHashSet<_>>();
+
     let spans = checker
         .facts()
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("su") && fact.wrappers().is_empty())
-        .filter(|fact| {
-            fact.options()
-                .su()
-                .is_some_and(|su| !su.has_login_or_command_flag())
-        })
+        .filter(|fact| fact.options().su().is_some_and(|su| !su.has_login_flag()))
+        .filter(|fact| !piped_command_ids.contains(&fact.id()))
+        .filter(|fact| fact.redirects().is_empty())
+        .filter(|fact| fact.body_args().len() < 2)
         .map(|fact| fact.span_in_source(checker.source()))
         .collect::<Vec<_>>();
 
@@ -38,11 +50,16 @@ mod tests {
     fn reports_plain_su_invocations_without_login_or_command_flags() {
         let source = "\
 #!/bin/bash
+su
 su librenms
+su -m
+su --pty
 su -c
 su --command
-su -- root echo -c hi
-su root bash -c 'id'
+su -s
+su --version
+su --help
+su --
 command su librenms
 sudo su librenms
 ";
@@ -54,17 +71,22 @@ sudo su librenms
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec![
+                "su",
                 "su librenms",
+                "su -m",
+                "su --pty",
                 "su -c",
                 "su --command",
-                "su -- root echo -c hi",
-                "su root bash -c 'id'"
+                "su -s",
+                "su --version",
+                "su --help",
+                "su --"
             ]
         );
     }
 
     #[test]
-    fn ignores_login_and_command_forms() {
+    fn ignores_login_and_explicit_multi_word_forms() {
         let source = "\
 #!/bin/bash
 su -
@@ -74,8 +96,17 @@ su --login root
 su -c id root
 su -cid root
 su --command id root
+su -m root
+su --pty root
+su -s /bin/sh
 su - root
+su -- root
+su root -m
 su root -c id
+su root -c
+su root -s /bin/sh
+su root bash -c 'id'
+su -- root echo -c hi
 su alice -
 su \"$user\" -c \"$cmd\"
 su \"$user\" -s /bin/sh -c \"$cmd\"
@@ -87,21 +118,17 @@ bundle_dir=$(su \"$user\" -s \"$SHELL\" -c \"echo ~/.bundle\")
     }
 
     #[test]
-    fn still_reports_forms_without_login_or_command_flags() {
+    fn ignores_pipelined_and_redirected_su_invocations() {
         let source = "\
 #!/bin/bash
-su -m root
-su -s /bin/sh root
-su alice -- -
+su root >/dev/null 2>&1
+su --version >/dev/null 2>&1
+su root | cat
+cat file | su root
+! su --version | grep -q util-linux
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SuWithoutFlag));
 
-        assert_eq!(
-            diagnostics
-                .iter()
-                .map(|diagnostic| diagnostic.span.slice(source))
-                .collect::<Vec<_>>(),
-            vec!["su -m root", "su -s /bin/sh root", "su alice -- -"]
-        );
+        assert!(diagnostics.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- align `S054` with ShellCheck 0.11.0 by only warning on bare or underspecified `su` invocations
- stop flagging explicit multi-word, piped, or redirected `su` forms that the oracle treats as acceptable
- remove the stale `S054` reviewed-divergence metadata and refresh the rule fixtures and snapshots

## Testing
- `cargo test -p shuck-linter su_`
- `INSTA_UPDATE=always cargo test -p shuck-linter rule_suwithoutflag_path_new_s054_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S054 SHUCK_LARGE_CORPUS_KEEP_GOING=1`

## Notes
- The targeted large-corpus run reached `reviewed_divergences=0` and `warnings=0` for `S054`.
- That run still exits nonzero because of 5 unrelated parser harness failures already present elsewhere in the corpus.
