### PR TITLE
fix(linter): align S015 and restore large-corpus parity

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c003.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c003.yaml
@@ -1,0 +1,5 @@
+reviewed_divergences:
+  - side: shellcheck-only
+    path_suffix: "v1s1t0r1sh3r3__airgeddon__airgeddon.sh"
+    line: 15648
+    reason: "This helper pins a repo-local database file through a source directive while still building the actual path from runtime script-folder state. ShellCheck keeps a file-input warning for this exact corpus site, and we keep that residual reviewed narrowly instead of broadening C003 around project-local source hints."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s015.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s015.yaml
@@ -1,15 +1,1 @@
-reviewed_divergences:
-- side: shuck-only
-  path_suffix: termux__termux-packages__scripts__utils__termux_reuse_pr_build_artifacts.sh
-  line: 258
-  end_line: 258
-  column: 18
-  end_column: 33
-  reason: This GraphQL-query builder iterates `"${COMMITS[@]}"`, which keeps one loop item per commit. Direct oracle probes stay quiet on that loop shape, so the remaining corpus-only miss is reviewed narrowly instead of widening S015 again.
-- side: shuck-only
-  path_suffix: HariSekhon__DevOps-Bash-tools__aws__aws_s3_bucket.sh
-  line: 112
-  end_line: 112
-  column: 16
-  end_column: 37
-  reason: This JSON-building helper loops over `"${arns_to_block[@]}"`, which preserves one item per array element. A standalone oracle probe stays quiet on that shape, so the remaining full-file hit is treated as project-closure noise rather than a live S015 bug.
+reviewed_divergences: []

--- a/crates/shuck-linter/src/facts/loop_headers.rs
+++ b/crates/shuck-linter/src/facts/loop_headers.rs
@@ -2,6 +2,7 @@
 pub struct LoopHeaderWordFact<'a> {
     word: &'a Word,
     classification: WordClassification,
+    has_all_elements_array_expansion: bool,
     has_unquoted_command_substitution: bool,
     contains_line_oriented_substitution: bool,
     contains_ls_substitution: bool,
@@ -23,6 +24,10 @@ impl<'a> LoopHeaderWordFact<'a> {
 
     pub fn has_command_substitution(&self) -> bool {
         self.classification.has_command_substitution()
+    }
+
+    pub fn has_all_elements_array_expansion(&self) -> bool {
+        self.has_all_elements_array_expansion
     }
 
     pub fn has_unquoted_command_substitution(&self) -> bool {
@@ -194,6 +199,10 @@ fn build_loop_header_word_facts<'a>(
             LoopHeaderWordFact {
                 word,
                 classification,
+                has_all_elements_array_expansion:
+                    word_spans::word_has_all_elements_array_expansion_syntax(word)
+                        || !word_spans::all_elements_array_expansion_part_spans(word, source)
+                            .is_empty(),
                 has_unquoted_command_substitution: classification.has_command_substitution()
                     && !word_spans::unquoted_command_substitution_part_spans(word).is_empty(),
                 contains_line_oriented_substitution: word_contains_line_oriented_substitution(

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -35,6 +35,33 @@ conditional=$( [[ -n $value ]] && printf '%s\\n' ok )
 }
 
 #[test]
+fn loop_header_words_track_all_elements_array_expansions_inside_wrapped_command_substitutions() {
+    let source = "\
+#!/bin/bash
+COMMITS=(abc def)
+WORKFLOW_COMMITS_QUERY=\"
+query {
+  repository(owner: \\\"termux\\\", name: \\\"termux-packages\\\") {
+  $(
+    for commit in \"${COMMITS[@]}\"; do
+      echo \"_${commit::7}: object(oid: \\\"${commit}\\\") { ...workflowRun }\"
+    done
+  )
+  }
+}
+\"
+";
+
+    with_facts(source, None, |_, facts| {
+        let header = facts
+            .for_headers()
+            .first()
+            .expect("expected nested for header");
+        assert!(header.words()[0].has_all_elements_array_expansion());
+    });
+}
+
+#[test]
 fn identifies_command_substitutions_that_echo_plain_text_or_expansions() {
     let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/facts/word_spans.rs
+++ b/crates/shuck-linter/src/facts/word_spans.rs
@@ -78,6 +78,10 @@ pub fn all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec
     spans
 }
 
+pub fn word_has_all_elements_array_expansion_syntax(word: &Word) -> bool {
+    parts_have_all_elements_array_expansion_syntax(&word.parts)
+}
+
 pub fn direct_all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_direct_all_elements_array_expansion_spans(&word.parts, source, &mut spans);
@@ -964,6 +968,42 @@ fn collect_all_elements_array_expansion_spans(
             _ => {}
         }
     }
+}
+
+fn parts_have_all_elements_array_expansion_syntax(parts: &[WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::SingleQuoted { .. } => false,
+        WordPart::DoubleQuoted { parts, .. } => {
+            parts_have_all_elements_array_expansion_syntax(parts)
+        }
+        WordPart::Variable(name) => name.as_str() == "@",
+        WordPart::ArrayAccess(reference) | WordPart::ArrayIndices(reference) => {
+            var_ref_uses_all_elements_at_splat(reference)
+        }
+        WordPart::ArraySlice { reference, .. } => var_ref_uses_all_elements_at_splat(reference),
+        WordPart::PrefixMatch {
+            kind: PrefixMatchKind::At,
+            ..
+        } => true,
+        WordPart::PrefixMatch {
+            kind: PrefixMatchKind::Star,
+            ..
+        } => false,
+        WordPart::Parameter(parameter) => {
+            parameter_uses_unquoted_all_elements_array_expansion(parameter)
+        }
+        WordPart::Literal(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. }
+        | WordPart::Substring { .. }
+        | WordPart::ArrayLength(_)
+        | WordPart::ZshQualifiedGlob(_) => false,
+    })
 }
 
 fn collect_unquoted_all_elements_array_expansion_spans(

--- a/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
+++ b/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
@@ -35,14 +35,28 @@ pub fn untracked_source_file(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use shuck_indexer::Indexer;
     use shuck_parser::parser::Parser;
+    use shuck_semantic::SourcePathResolver;
     use tempfile::tempdir;
 
     use crate::test::test_snippet_at_path;
     use crate::{LinterSettings, Rule, lint_file_at_path_with_resolver};
+
+    struct TestSourceResolver {
+        helper: PathBuf,
+    }
+
+    impl SourcePathResolver for TestSourceResolver {
+        fn resolve_candidate_paths(&self, _source_path: &Path, candidate: &str) -> Vec<PathBuf> {
+            (candidate == "./known_pins.db")
+                .then_some(self.helper.clone())
+                .into_iter()
+                .collect()
+        }
+    }
 
     #[test]
     fn reports_missing_literal_source() {
@@ -94,6 +108,124 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "./helper.sh");
+    }
+
+    #[test]
+    fn reports_directive_pinned_dynamic_source_when_helper_is_not_an_input() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("known_pins.db");
+        let source = "\
+#!/bin/bash
+scriptfolder=\"$(dirname \"$0\")/\"
+known_pins_dbfile=\"known_pins.db\"
+# shellcheck source=./known_pins.db
+source \"${scriptfolder}${known_pins_dbfile}\"
+";
+        fs::write(&helper, "echo ok\n").unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"${scriptfolder}${known_pins_dbfile}\""
+        );
+    }
+
+    #[test]
+    fn reports_no_space_shellcheck_source_directive_when_helper_is_missing() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "\
+#!/bin/bash
+scriptfolder=\"$(dirname \"$0\")/\"
+known_pins_dbfile=\"known_pins.db\"
+#shellcheck source=./known_pins.db
+source \"${scriptfolder}${known_pins_dbfile}\"
+";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"${scriptfolder}${known_pins_dbfile}\""
+        );
+    }
+
+    #[test]
+    fn reports_directive_pinned_dynamic_source_inside_function_when_helper_is_missing() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let source = "\
+#!/bin/bash
+known_pins_dbfile=\"known_pins.db\"
+function wps_pin_database_prerequisites() {
+  #shellcheck source=./known_pins.db
+  source \"${scriptfolder}${known_pins_dbfile}\"
+}
+";
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"${scriptfolder}${known_pins_dbfile}\""
+        );
+    }
+
+    #[test]
+    fn reports_directive_pinned_dynamic_source_with_resolver_when_helper_is_not_an_input() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("known_pins.db");
+        let source = "\
+#!/bin/bash
+scriptfolder=\"$(dirname \"$0\")/\"
+known_pins_dbfile=\"known_pins.db\"
+# shellcheck source=./known_pins.db
+source \"${scriptfolder}${known_pins_dbfile}\"
+";
+        fs::write(&main, source).unwrap();
+        fs::write(&helper, "echo ok\n").unwrap();
+
+        let parse_result = Parser::with_dialect(source, shuck_parser::ShellDialect::Bash)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(source, &parse_result);
+        let resolver = TestSourceResolver {
+            helper: helper.clone(),
+        };
+
+        let diagnostics = lint_file_at_path_with_resolver(
+            &parse_result.file,
+            source,
+            &indexer,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
+            None,
+            Some(&main),
+            Some(&resolver),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "\"${scriptfolder}${known_pins_dbfile}\""
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
+++ b/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
@@ -14,7 +14,6 @@ impl Violation for QuotedDollarStarLoop {
 }
 
 pub fn quoted_dollar_star_loop(checker: &mut Checker) {
-    let source = checker.source();
     let spans = checker
         .facts()
         .for_headers()
@@ -27,8 +26,7 @@ pub fn quoted_dollar_star_loop(checker: &mut Checker) {
             let classification = word.classification();
             if classification.quote != WordQuote::FullyQuoted
                 || classification.is_fixed_literal()
-                || !word_spans::all_elements_array_expansion_part_spans(word.word(), source)
-                    .is_empty()
+                || word.has_all_elements_array_expansion()
             {
                 return None;
             }
@@ -122,6 +120,73 @@ select item in \"$*\"; do
   break
 done
 printf '%s\\n' \"$*\" \"${arr[*]}\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedDollarStarLoop),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_nested_for_loops_over_quoted_at_expansions() {
+        let source = "\
+#!/bin/bash
+COMMITS=(a b)
+arns_to_block=(one two)
+query=\"$(
+  for commit in \"${COMMITS[@]}\"; do
+    printf '%s\\n' \"$commit\"
+  done
+)\"
+json=$(
+  for arn in \"${arns_to_block[@]}\"; do
+    printf '%s\\n' \"$arn\"
+  done
+)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedDollarStarLoop),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_corpus_wrapped_quoted_at_expansions() {
+        let source = "\
+#!/bin/bash
+COMMITS=(abc def)
+WORKFLOW_COMMITS_QUERY=\"
+query {
+  repository(owner: \\\"termux\\\", name: \\\"termux-packages\\\") {
+  $(
+    for commit in \"${COMMITS[@]}\"; do
+      echo \"_${commit::7}: object(oid: \\\"${commit}\\\") { ...workflowRun }\"
+    done
+  )
+  }
+}
+\"
+
+arns_to_block=(one two)
+aws s3api put-bucket-policy --bucket \"$bucket\" --policy \"$(cat <<EOF
+{
+  \\\"Principal\\\": {
+    \\\"AWS\\\": [
+$(
+  for arn in \"${arns_to_block[@]}\"; do
+    printf '%10s\\\"%s\\\",\\n' \"\" \"$arn\"
+  done |
+  sed '$ s/,$//'
+)
+    ]
+  }
+}
+EOF
+)\"
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -702,7 +702,7 @@ impl<'a> Parser<'a> {
             ));
     }
 
-    fn split_current_double_right_paren(&mut self) {
+    pub(super) fn split_current_double_right_paren(&mut self) {
         let (left_span, right_span) = Self::split_double_right_paren(self.current_span);
         self.set_current_kind(TokenKind::RightParen, left_span);
         self.synthetic_tokens

--- a/crates/shuck-parser/src/parser/tests/redirects.rs
+++ b/crates/shuck-parser/src/parser/tests/redirects.rs
@@ -116,6 +116,83 @@ fn test_parse_named_fd_redirect_read_write() {
 }
 
 #[test]
+fn test_parse_process_substitution_argument_with_here_string_inside_outer_process_substitution() {
+    let input = "\
+readarray -t deps < <(
+  grep -Fx \\
+    -f <(echo \"${packages[@]}\") \\
+    - <<< \"${changed[@]}\"
+) || :
+";
+    let script = Parser::with_dialect(input, ShellDialect::Bash)
+        .parse()
+        .unwrap()
+        .file;
+
+    let stmt = &script.body[0];
+    let AstCommand::Binary(binary) = &stmt.command else {
+        panic!("expected binary command");
+    };
+    assert_eq!(binary.op, BinaryOp::Or);
+
+    let readarray = expect_simple(&binary.left);
+    assert_eq!(readarray.name.render(input), "readarray");
+
+    let outer_target = binary.left.redirects[0]
+        .word_target()
+        .expect("expected process substitution redirect target");
+    let WordPart::ProcessSubstitution { body, is_input } = &outer_target.parts[0].kind else {
+        panic!("expected outer process substitution");
+    };
+    assert!(*is_input);
+
+    let inner = expect_simple(&body[0]);
+    assert_eq!(inner.name.render(input), "grep");
+    assert!(
+        inner.args.iter().any(|arg| arg
+            .parts
+            .iter()
+            .any(|part| matches!(part.kind, WordPart::ProcessSubstitution { .. }))),
+        "expected inner process substitution argument"
+    );
+    assert_eq!(body[0].redirects.len(), 1);
+    assert_eq!(body[0].redirects[0].kind, RedirectKind::HereString);
+}
+
+#[test]
+fn test_parse_nested_process_substitutions_inside_while_redirect_in_if_body() {
+    let input = "\
+if [[ $enabled == true ]]; then
+  local -a implicit_tasks
+  while IFS='' read -r line; do
+    implicit_tasks+=(\"$line\")
+  done < <(comm -23 <(printf \"%s\\n\" \"${subproject_tasks[@]}\" | sort) \\
+    <(printf \"%s\\n\" \"${root_tasks[@]}\" | sort))
+  for task in \"${implicit_tasks[@]}\"; do
+    gradle_all_tasks+=(\"$task\")
+  done
+fi
+";
+    Parser::with_dialect(input, ShellDialect::Bash)
+        .parse()
+        .unwrap();
+}
+
+#[test]
+fn test_parse_multiline_double_bracket_if_with_quoted_command_substitution_and_backgrounded_subshell()
+ {
+    let input = "\
+if [[ $gradle_files_checksum != \"$(cat \"$cache_dir/$cache_name.md5\")\" ||
+  ! -f \"$cache_dir/$gradle_files_checksum\" ]]; then
+  (__gradle-generate-tasks-cache &> /dev/null &)
+fi
+";
+    Parser::with_dialect(input, ShellDialect::Bash)
+        .parse()
+        .unwrap();
+}
+
+#[test]
 fn test_redirect_only_command_parses() {
     let input = ">myfile\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/redirects.rs
+++ b/crates/shuck-parser/src/parser/tests/redirects.rs
@@ -193,6 +193,19 @@ fi
 }
 
 #[test]
+fn test_extra_right_paren_after_process_substitution_is_not_swallowed() {
+    let input = "echo <(true))\n";
+    let error = Parser::with_dialect(input, ShellDialect::Bash)
+        .parse()
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("expected command"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn test_redirect_only_command_parses() {
     let input = ">myfile\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2850,8 +2850,16 @@ impl<'a> Parser<'a> {
                 let mut depth = 1;
                 let close_span = loop {
                     match self.current_token_kind {
-                        Some(TokenKind::LeftParen) => {
-                            depth += 1;
+                        Some(
+                            TokenKind::LeftParen
+                            | TokenKind::DoubleLeftParen
+                            | TokenKind::ProcessSubIn
+                            | TokenKind::ProcessSubOut,
+                        ) => {
+                            depth += match self.current_token_kind {
+                                Some(TokenKind::DoubleLeftParen) => 2,
+                                _ => 1,
+                            };
                             self.advance();
                         }
                         Some(TokenKind::RightParen) => {
@@ -2862,6 +2870,25 @@ impl<'a> Parser<'a> {
                                 break close_span;
                             }
                             self.advance();
+                        }
+                        Some(TokenKind::DoubleRightParen) => {
+                            let (first_span, second_span) =
+                                Self::split_double_right_paren(self.current_span);
+                            match depth {
+                                0 => unreachable!("process substitution depth cannot underflow"),
+                                1 => {
+                                    self.advance();
+                                    break first_span;
+                                }
+                                2 => {
+                                    self.advance();
+                                    break second_span;
+                                }
+                                _ => {
+                                    depth -= 2;
+                                    self.advance();
+                                }
+                            }
                         }
                         None => {
                             return Err(Error::parse(

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2872,14 +2872,15 @@ impl<'a> Parser<'a> {
                             self.advance();
                         }
                         Some(TokenKind::DoubleRightParen) => {
-                            let (first_span, second_span) =
+                            if depth == 1 {
+                                self.split_current_double_right_paren();
+                                continue;
+                            }
+
+                            let (_, second_span) =
                                 Self::split_double_right_paren(self.current_span);
                             match depth {
                                 0 => unreachable!("process substitution depth cannot underflow"),
-                                1 => {
-                                    self.advance();
-                                    break first_span;
-                                }
                                 2 => {
                                     self.advance();
                                     break second_span;


### PR DESCRIPTION
## Summary
- align S015 with ShellCheck for wrapped quoted `@` loop words by using loop-header all-elements expansion facts
- fix nested process substitution parsing when outer `<(...)` bodies end with adjacent `))`, which was tripping the large-corpus strict parser path
- add parser and C003 regression coverage, and review the remaining airgeddon C003 corpus-only delta at exact fixture scope

## Testing
- cargo fmt
- cargo test -p shuck-linter quoted_dollar_star_loop -- --nocapture
- cargo test -p shuck-linter loop_header_words_track_all_elements_array_expansions_inside_wrapped_command_substitutions -- --nocapture
- cargo test -p shuck-linter untracked_source_file -- --nocapture
- cargo test -p shuck-parser process_substitution -- --nocapture
- cargo test -p shuck-parser
- make test-large-corpus
