### PR TITLE
fix(linter): align S044 with shellcheck

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s044.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s044.yaml
@@ -1,13 +1,1 @@
-reviewed_divergences:
-- side: shellcheck-only
-  path_suffix: google__oss-fuzz__projects__sudoers__build.sh
-  reason: These legacy-backtick SC2001 sites match in warning shape, but the pinned oracle anchors the span inside the escaped sed script while shuck reports the full inner pipeline. The remaining difference is reviewed as legacy-backtick location drift.
-- side: shuck-only
-  path_suffix: google__oss-fuzz__projects__sudoers__build.sh
-  reason: These legacy-backtick SC2001 sites match in warning shape, but the pinned oracle anchors the span inside the escaped sed script while shuck reports the full inner pipeline. The remaining difference is reviewed as legacy-backtick location drift.
-- side: shellcheck-only
-  path_suffix: swoodford__aws__ec2-associate-elastic-ip.sh
-  reason: This legacy-backtick SC2001 match lands on the same inner `echo | sed -e` rewrite, but the pinned oracle truncates the anchor inside the escaped sed script while shuck reports the full pipeline. The remaining difference is reviewed as legacy-backtick location drift.
-- side: shuck-only
-  path_suffix: swoodford__aws__ec2-associate-elastic-ip.sh
-  reason: This legacy-backtick SC2001 match lands on the same inner `echo | sed -e` rewrite, but the pinned oracle truncates the anchor inside the escaped sed script while shuck reports the full pipeline. The remaining difference is reviewed as legacy-backtick location drift.
+reviewed_divergences: []

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -839,8 +839,9 @@ value=$(sed 's/[\\.|$(){}?+*^]/\\\\&/g' <<<\"$value\")
 echo \"$value\" | sed 's/a/b/' <<<\"$shadow\"
 CFLAGS=\"`echo \\\"$CFLAGS\\\" | sed \\\"s/ $COVERAGE_FLAGS//\\\"`\"
 OPTFLAG=\"`echo \\\"$CFLAGS\\\" | sed 's/^.*\\(-O[^ ]\\).*$/\\1/'`\"
-EC2_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\1:'`\"
+EC2_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\\\1:'`\"
 ESCAPED_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e \\\"s/foo/bar/\\\"`\"
+FLAGGED_REGION=\"`echo \\\"$EC2_REGION\\\" | sed 's/foo/bar/g'`\"
 echo \"$caps_add\" | sed 's/^/  /' \t
 trimmed=$(sed 's/[[:space:]]*$//' <<<\"$value\")
 literal=$(sed 's/[[:space:]]*$//' <<<literal)
@@ -864,10 +865,11 @@ literal=$(sed 's/[[:space:]]*$//' <<<literal)
                 "echo \"$hostname\" | sed 's/[]\\[\\.^$*+?{}()|]/\\\\&/g'",
                 "sed 's/[\\.|$(){}?+*^]/\\\\&/g' <<<\"$value\"",
                 "echo \"$value\" | sed 's/a/b/' <<<\"$shadow\"",
-                "echo \\\"$CFLAGS\\\" | sed \\\"s/ $COVERAGE_FLAGS//\\\"",
-                "echo \\\"$CFLAGS\\\" | sed 's/^.*\\(-O[^ ]\\).*$/\\1/'",
-                "echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\1:'",
-                "echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e \\\"s/foo/bar/\\\"",
+                "echo \\\"$CFLAGS\\\" | sed \\\"s/ $COVERAGE_FLAGS",
+                "echo \\\"$CFLAGS\\\" | sed 's/^.*\\(-O[^ ]\\).*$/\\1",
+                "echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\",
+                "echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e \\\"s/foo/bar",
+                "echo \\\"$EC2_REGION\\\" | sed 's/foo/bar/",
                 "echo \"$caps_add\" | sed 's/^/  /' \t",
                 "sed 's/[[:space:]]*$//' <<<\"$value\"",
                 "sed 's/[[:space:]]*$//' <<<literal",
@@ -904,6 +906,24 @@ echo \"prefix$(printf %s foo)\" | sed 's/foo/bar/'
 
     with_facts(source, None, |_, facts| {
         assert!(facts.echo_to_sed_substitution_spans().is_empty());
+    });
+}
+
+#[test]
+fn backtick_echo_to_sed_substitution_matches_shellcheck_columns_for_escaped_dollar_patterns() {
+    let source = "\
+#!/bin/bash
+EC2_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\\\1:'`\"
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts.echo_to_sed_substitution_spans();
+        assert_eq!(spans.len(), 1);
+        let span = spans[0];
+        assert_eq!(span.start.line, 2);
+        assert_eq!(span.start.column, 14);
+        assert_eq!(span.end.line, 2);
+        assert_eq!(span.end.column, 76);
     });
 }
 

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -928,6 +928,25 @@ EC2_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\
 }
 
 #[test]
+fn backtick_echo_to_sed_substitution_keeps_utf8_trim_offsets_on_char_boundaries() {
+    let source = "\
+#!/bin/bash
+A=\"`echo \\\"$A\\\" | sed 's/foo\\\\$/é/'`\"
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts.echo_to_sed_substitution_spans();
+        assert_eq!(spans.len(), 1);
+        let span = spans[0];
+        assert_eq!(span.start.line, 2);
+        assert_eq!(span.start.column, 5);
+        assert_eq!(span.end.line, 2);
+        assert_eq!(span.end.column, 33);
+        assert_eq!(span.slice(source), "echo \\\"$A\\\" | sed 's/foo\\\\$/");
+    });
+}
+
+#[test]
 fn preserves_dynamic_unset_operands_after_option_parsing_stops() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2156,8 +2156,8 @@ fn sc2001_like_backtick_sed_script_end(args: &[&Word], source: &str) -> Option<P
         _ => return None,
     };
 
-    let trim_len = sc2001_like_backtick_sed_script_trim_len(script_words, source)?;
-    let end_offset = raw_script_end.checked_sub(trim_len)?;
+    let trim_chars = sc2001_like_backtick_sed_script_trim_chars(script_words, source)?;
+    let end_offset = rewind_offset_by_chars(source, raw_script_end, trim_chars)?;
     position_at_offset(source, end_offset)
 }
 
@@ -2174,7 +2174,10 @@ fn backtick_sed_script_content_end_offset(text: &str, end_offset: usize) -> Opti
     }
 }
 
-fn sc2001_like_backtick_sed_script_trim_len(script_words: &[&Word], source: &str) -> Option<usize> {
+fn sc2001_like_backtick_sed_script_trim_chars(
+    script_words: &[&Word],
+    source: &str,
+) -> Option<usize> {
     let uses_backtick_escaped_double_quotes =
         backtick_sed_script_uses_escaped_double_quotes(script_words, source);
     let text = sed_script_text(
@@ -2196,26 +2199,26 @@ fn sc2001_like_backtick_sed_script_trim_len(script_words: &[&Word], source: &str
     let replacement = &text[replacement_start..replacement_end];
     let flags = &text[replacement_end + delimiter_len..];
 
-    let mut trim_len = if flags.is_empty() {
+    let mut trim_chars = if flags.is_empty() {
         if uses_backtick_escaped_double_quotes && replacement_start == replacement_end {
-            delimiter_len * 2
+            2
         } else {
-            delimiter_len
+            1
         }
     } else {
-        flags.len()
+        flags.chars().count()
     };
 
-    // ShellCheck trims one additional byte for these legacy backtick sed sites
+    // ShellCheck trims one additional character for these legacy backtick sed sites
     // when the match pattern itself ends with an escaped dollar.
     if pattern.ends_with(r"\$") {
-        trim_len += 1;
+        trim_chars += 1;
         if replacement.starts_with(r"\\") {
-            trim_len += 1;
+            trim_chars += 1;
         }
     }
 
-    Some(trim_len)
+    Some(trim_chars)
 }
 
 fn backtick_sed_script_uses_escaped_double_quotes(script_words: &[&Word], source: &str) -> bool {
@@ -2229,6 +2232,20 @@ fn backtick_sed_script_uses_escaped_double_quotes(script_words: &[&Word], source
         }
         _ => false,
     }
+}
+
+fn rewind_offset_by_chars(source: &str, mut offset: usize, count: usize) -> Option<usize> {
+    if offset > source.len() || !source.is_char_boundary(offset) {
+        return None;
+    }
+
+    for _ in 0..count {
+        let prefix = source.get(..offset)?;
+        let (_, ch) = prefix.char_indices().next_back()?;
+        offset = offset.checked_sub(ch.len_utf8())?;
+    }
+
+    Some(offset)
 }
 
 fn command_has_sc2001_like_sed_script(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2078,9 +2078,13 @@ fn sc2001_like_pipeline_span<'a>(
         return None;
     }
 
-    Some(pipeline_span_with_shellcheck_tail(
-        commands, pipeline, source,
-    ))
+    if command_is_inside_backtick_fragment(right, backticks)
+        && word_occurrence_is_backtick_escaped_double_quoted_dynamic(nodes, word_fact, source)
+    {
+        return sc2001_like_backtick_pipeline_span(commands, pipeline, right, source);
+    }
+
+    Some(pipeline_span_with_shellcheck_tail(commands, pipeline, source))
 }
 
 fn sc2001_like_here_string_span(
@@ -2105,11 +2109,126 @@ fn sc2001_like_here_string_span(
         return None;
     }
 
+    if command_is_inside_backtick_fragment(command, backticks) {
+        return sc2001_like_backtick_command_span(command, source);
+    }
+
     command_span_with_redirects_and_shellcheck_tail(command, source)
 }
 
 fn command_is_plain_named(command: &CommandFact<'_>, name: &str) -> bool {
     command.effective_name_is(name) && command.wrappers().is_empty()
+}
+
+fn sc2001_like_backtick_pipeline_span(
+    commands: &[CommandFact<'_>],
+    pipeline: &PipelineFact<'_>,
+    sed_command: &CommandFact<'_>,
+    source: &str,
+) -> Option<Span> {
+    let first_segment = pipeline.first_segment()?;
+    let first = command_fact(commands, first_segment.command_id());
+    let start = first.body_name_word()?.span.start;
+    let end = sc2001_like_backtick_sed_script_end(sed_command.body_args(), source)?;
+    Some(Span::from_positions(start, end))
+}
+
+fn sc2001_like_backtick_command_span(command: &CommandFact<'_>, source: &str) -> Option<Span> {
+    let start = command.body_name_word()?.span.start;
+    let end = sc2001_like_backtick_sed_script_end(command.body_args(), source)?;
+    Some(Span::from_positions(start, end))
+}
+
+fn sc2001_like_backtick_sed_script_end(args: &[&Word], source: &str) -> Option<Position> {
+    let script_words = match args {
+        [flag, words @ ..] if static_word_text(flag, source).as_deref() == Some("-e") => words,
+        _ => args,
+    };
+
+    let raw_script_end = match script_words {
+        [script] => backtick_sed_script_content_end_offset(script.span.slice(source), script.span.end.offset)?,
+        [first, .., last]
+            if first.span.slice(source).starts_with("\\\"")
+                && last.span.slice(source).ends_with("\\\"") =>
+        {
+            last.span.end.offset.checked_sub(2)?
+        }
+        _ => return None,
+    };
+
+    let trim_len = sc2001_like_backtick_sed_script_trim_len(script_words, source)?;
+    let end_offset = raw_script_end.checked_sub(trim_len)?;
+    position_at_offset(source, end_offset)
+}
+
+fn backtick_sed_script_content_end_offset(text: &str, end_offset: usize) -> Option<usize> {
+    if text.len() >= 4 && text.starts_with("\\\"") && text.ends_with("\\\"") {
+        end_offset.checked_sub(2)
+    } else if text.len() >= 2
+        && ((text.starts_with('"') && text.ends_with('"'))
+            || (text.starts_with('\'') && text.ends_with('\'')))
+    {
+        end_offset.checked_sub(1)
+    } else {
+        Some(end_offset)
+    }
+}
+
+fn sc2001_like_backtick_sed_script_trim_len(script_words: &[&Word], source: &str) -> Option<usize> {
+    let uses_backtick_escaped_double_quotes =
+        backtick_sed_script_uses_escaped_double_quotes(script_words, source);
+    let text = sed_script_text(
+        script_words,
+        source,
+        SedScriptQuoteMode::AllowBacktickEscapedDoubleQuotes,
+    )?;
+    let text = text.as_ref();
+
+    let remainder = text.strip_prefix('s')?;
+    let delimiter = remainder.chars().next()?;
+    let delimiter_len = delimiter.len_utf8();
+
+    let pattern_start = 1 + delimiter_len;
+    let (pattern_end, _) = find_sed_substitution_section(text, pattern_start, delimiter)?;
+    let replacement_start = pattern_end + delimiter_len;
+    let (replacement_end, _) = find_sed_substitution_section(text, replacement_start, delimiter)?;
+    let pattern = &text[pattern_start..pattern_end];
+    let replacement = &text[replacement_start..replacement_end];
+    let flags = &text[replacement_end + delimiter_len..];
+
+    let mut trim_len = if flags.is_empty() {
+        if uses_backtick_escaped_double_quotes && replacement_start == replacement_end {
+            delimiter_len * 2
+        } else {
+            delimiter_len
+        }
+    } else {
+        flags.len()
+    };
+
+    // ShellCheck trims one additional byte for these legacy backtick sed sites
+    // when the match pattern itself ends with an escaped dollar.
+    if pattern.ends_with(r"\$") {
+        trim_len += 1;
+        if replacement.starts_with(r"\\") {
+            trim_len += 1;
+        }
+    }
+
+    Some(trim_len)
+}
+
+fn backtick_sed_script_uses_escaped_double_quotes(script_words: &[&Word], source: &str) -> bool {
+    match script_words {
+        [script] => {
+            let text = script.span.slice(source);
+            text.len() >= 4 && text.starts_with("\\\"") && text.ends_with("\\\"")
+        }
+        [first, .., last] => {
+            first.span.slice(source).starts_with("\\\"") && last.span.slice(source).ends_with("\\\"")
+        }
+        _ => false,
+    }
 }
 
 fn command_has_sc2001_like_sed_script(

--- a/crates/shuck-linter/src/rules/style/echo_to_sed_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/echo_to_sed_substitution.rs
@@ -22,3 +22,28 @@ pub fn echo_to_sed_substitution(checker: &mut Checker) {
         || EchoToSedSubstitution,
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LinterSettings;
+    use crate::test::test_snippet;
+
+    #[test]
+    fn reports_shellcheck_columns_for_escaped_dollar_backtick_patterns() {
+        let source = "\
+#!/bin/bash
+EC2_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\\\1:'`\"
+";
+
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::EchoToSedSubstitution),
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 14);
+        assert_eq!(diagnostics[0].span.end.line, 2);
+        assert_eq!(diagnostics[0].span.end.column, 76);
+    }
+}


### PR DESCRIPTION
## Summary
- align S044 backtick `echo | sed` spans with ShellCheck's source-of-truth anchoring
- add regression coverage for quoted, escaped-dollar, and backreference variants
- remove the old reviewed divergences for `s044.yaml`

## Testing
- `cargo test -p shuck-linter facts::tests::commands::builds_echo_to_sed_substitution_spans -- --exact`
- `cargo test -p shuck-linter rules::style::echo_to_sed_substitution::tests::reports_shellcheck_columns_for_escaped_dollar_backtick_patterns -- --exact`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S044`
- the targeted corpus run still exits non-zero because of 5 unrelated existing harness parse failures, but `S044` itself now reports `implementation_diffs=0` and `reviewed_divergences=0`