### PR TITLE
fix(linter): align X004 spans with ShellCheck

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x004.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x004.yaml
@@ -1,7 +1,1 @@
-reviewed_divergences:
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__munin-node__rc.munin-node"
-    reason: "ShellCheck anchors this bare `function name {}` helper to the full multi-line body, while shuck reports the same X004 finding on the header span only. The remaining difference is range-only."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__munin-node__rc.munin-node"
-    reason: "ShellCheck anchors this bare `function name {}` helper to the full multi-line body, while shuck reports the same X004 finding on the header span only. The remaining difference is range-only."
+reviewed_divergences: []

--- a/crates/shuck-linter/src/rules/portability/function_keyword.rs
+++ b/crates/shuck-linter/src/rules/portability/function_keyword.rs
@@ -22,8 +22,32 @@ pub fn function_keyword(checker: &mut Checker) {
         .function_headers()
         .iter()
         .filter(|header| header.uses_function_keyword() && !header.has_trailing_parens())
-        .map(|header| header.span_in_source(checker.source()))
+        .map(|header| header.function_span_in_source(checker.source()))
         .collect::<Vec<_>>();
 
     checker.report_all(spans, || FunctionKeyword);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_function_keyword_without_parens_over_full_function_span() {
+        let source = "\
+#!/bin/sh
+function greet
+{
+  printf '%s\\n' hi
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionKeyword));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "function greet\n{\n  printf '%s\\n' hi\n}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- report X004 over the full function definition span to match the SC2113 oracle
- remove the stale X004 reviewed divergence now that the corpus comparison matches
- add a focused unit test for the multi-line `function name { ... }` span

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter function_keyword -- --nocapture`
- `cargo test -p shuck-linter rules::portability::tests::rules -- --nocapture`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X004` reports `implementation_diffs=0` and `reviewed_divergences=0`; it still exits nonzero because of five existing parse harness failures unrelated to X004.