### PR TITLE
fix(linter): restore C124 parity without perf regression

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -551,6 +551,13 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
     reason: "This Easy-RSA front-end carries shell-mode and temporary-file bookkeeping through long helper-driven control flow, so the remaining C006 reads are reviewed runtime handoffs rather than missing local assignments."
+  - side: shellcheck-only
+    path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
+    line: 3780
+    end_line: 3780
+    column: 38
+    end_column: 52
+    reason: "This exact Easy-RSA read sits in a region Shuck classifies as unreachable through an exit-helper path, so the remaining oracle-side C006 gap stays reviewed narrowly instead of widening undefined-variable reporting in unreachable code."
   - side: shuck-only
     path_suffix: "rupa__z__z.sh"
     reason: "This directory-ranking helper builds matcher state through branch-local accumulators, so the remaining C006 read is a reviewed control-flow handoff rather than an isolated undefined local."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c124.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c124.yaml
@@ -1,85 +1,85 @@
 reviewed_divergences:
   - side: shuck-only
-    path_contains: "Bash-it__bash-it__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "Bash-it__bash-it__completion__available__gradle.completion.bash"
+    reason: "completion registration follows a helper function that returns before the file-level registration commands; the remaining gap is scoped to this callback-style completion fixture after removing the old repo-family allowlist"
+  - side: shellcheck-only
+    path_suffix: "acmesh-official__acme.sh__acme.sh"
+    reason: "this large helper script has a remaining subshell/source-control-flow C124 gap that Shuck does not model precisely enough yet; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "CISOfy__lynis__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "aristocratos__bashtop__bashtop"
+    reason: "this is a semicolon-packed loop branch where Shuck reports the statement after a same-line break; keep the residual span difference scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "HariSekhon__DevOps-Bash-tools__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "bin456789__reinstall__reinstall.sh"
+    reason: "this option parser has a remaining break/shift reachability difference in a loop dispatcher; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "SlackBuildsOrg__slackbuilds__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__firmware"
+    reason: "this helper keeps disabled follow-up logic after an intentional early return; Shuck reports the local dead block while the oracle stays quiet, so the residual is reviewed at fixture scope"
   - side: shuck-only
-    path_contains: "acmesh-official__acme.sh__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__log"
+    reason: "this helper keeps disabled follow-up logic after an intentional early return; Shuck reports the local dead block while the oracle stays quiet, so the residual is reviewed at fixture scope"
   - side: shuck-only
-    path_contains: "alexanderepstein__Bash-Snippets__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
+    reason: "this helper keeps disabled follow-up logic after intentional early returns; Shuck reports the local dead blocks while the oracle stays quiet, so the residual is reviewed at fixture scope"
   - side: shuck-only
-    path_contains: "aristocratos__bashtop__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "bittorf__kalua__openwrt-build__build.sh"
+    reason: "this build script has a remaining guarded-return reachability difference in project-local control flow; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "awslabs__git-secrets__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "bittorf__kalua__openwrt-monitoring__crashlog_build_html.sh"
+    reason: "this monitoring helper keeps reporting fallback code after an early-return path; Shuck reports the local dead block while the oracle stays quiet, so the residual is reviewed at fixture scope"
   - side: shuck-only
-    path_contains: "bats-core__bats-core__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_netjson.sh"
+    reason: "this monitoring helper has large project-local early-return regions that Shuck marks as dead more aggressively than the oracle; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "bitnami__containers__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "bittorf__kalua__openwrt-monitoring__monitoring_standalone_generic.sh"
+    reason: "this monitoring helper keeps follow-up commands after an intentional early return; Shuck reports the local dead block while the oracle stays quiet, so the residual is reviewed at fixture scope"
   - side: shuck-only
-    path_contains: "bittorf__kalua__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "gentoo__gentoo__eclass__tests__version-funcs.sh"
+    reason: "this test fixture has a remaining return-driven reachability difference in harness-style code; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "community-scripts__ProxmoxVE__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
+    reason: "this menu script has remaining early-return dispatcher regions where Shuck reports dead follow-up commands more aggressively; keep the review scoped to the exact fixture"
+  - side: shellcheck-only
+    path_suffix: "leebaird__discover__dev-api-scanner.sh"
+    reason: "this generated scanner script exposes a C124 span-shape mismatch around nested loop code; keep the oracle-side residual scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "docker__docker-bench-security__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "leebaird__discover__dev-api-scanner.sh"
+    reason: "this generated scanner script exposes a C124 span-shape mismatch around nested loop code; keep the Shuck-side residual scoped to the exact fixture"
+  - side: shellcheck-only
+    path_suffix: "megastep__makeself__makeself.sh"
+    reason: "this option parser differs only on same-line exit/usage anchors; keep the oracle-side residual scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "dylanaraps__pure-bash-bible__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "megastep__makeself__makeself.sh"
+    reason: "this option parser differs only on same-line exit/usage anchors; keep the Shuck-side residual scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "gentoo__gentoo__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "moovweb__gvm__examples__native__configure"
+    reason: "this generated configure script has remaining break-driven cleanup reachability differences; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "helmuthdu__aui__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "moovweb__gvm__scripts__env__pkgset-use"
+    reason: "this dispatcher has nested case and early-exit regions that Shuck marks as dead more aggressively; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "juewuy__ShellCrash__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
+    reason: "this large command dispatcher contains many intentional exit-heavy branches where Shuck's CFG currently reports broader dead regions than the oracle; keep the residual scoped to the exact fixture"
+  - side: shellcheck-only
+    path_suffix: "paulirish__dotfiles__.bash_prompt"
+    reason: "this prompt file has a small shell-guard reachability span mismatch; keep the oracle-side residual scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "ko1nksm__shellspec__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "paulirish__dotfiles__.bash_prompt"
+    reason: "this prompt file has a small shell-guard reachability span mismatch; keep the Shuck-side residual scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "leebaird__discover__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
+    reason: "this sourced RVM helper has a project-local early-return region that Shuck marks as dead more aggressively; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "lmc999__RegionRestrictionCheck__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "termux__termux-packages__scripts__bin__update-checksum"
+    reason: "this package helper has a remaining exit-driven dispatcher difference; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "moovweb__gvm__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "termux__termux-packages__scripts__lint-packages.sh"
+    reason: "this package linter has a remaining early-return region in helper-style control flow; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "nvm-sh__nvm__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "tj__git-extras__bin__git-scp"
+    reason: "this command-line parser has a same-line exit/usage reachability difference; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "paulirish__dotfiles__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "tteck__Proxmox__ct__fenrus.sh"
+    reason: "this installer script has a small exit-driven cleanup reachability difference; keep the review scoped to the exact fixture"
   - side: shuck-only
-    path_contains: "rvm__rvm__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
-  - side: shuck-only
-    path_contains: "super-linter__super-linter__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
-  - side: shuck-only
-    path_contains: "termux__termux-packages__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
-  - side: shuck-only
-    path_contains: "tteck__Proxmox__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
-  - side: shuck-only
-    path_contains: "xwmx__nb__"
-    reason: "C124 intentionally treats code after guarded exits as unreachable when one branch exits but the other branch still falls through to later statements. The remaining corpus cases are all that same fallthrough shape in helper scripts, package hooks, and project-closure code, and ShellCheck does not emit SC2365 for them, so these repo-family hits remain a stricter Shuck policy without hiding a distinct implementation bug."
+    path_suffix: "xwmx__nb__nb"
+    reason: "this large command dispatcher has a handful of intentional exit-heavy branches where Shuck reports broader dead regions; keep the residual scoped to the exact fixture"

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3827,32 +3827,204 @@ f
 ";
         let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
 
-        assert_eq!(diagnostics.len(), 5);
+        assert_eq!(diagnostics.len(), 4);
         assert!(
             diagnostics
                 .iter()
                 .all(|diagnostic| diagnostic.rule == Rule::UnreachableAfterExit)
         );
+        assert_eq!(diagnostics[0].span.slice(source), "echo unreachable");
+        assert_eq!(diagnostics[1].span.slice(source), "printf '%s\\n' never");
         assert_eq!(
-            diagnostics[0].span.slice(source).trim_end(),
-            "echo unreachable"
+            diagnostics[2].span.slice(source),
+            "f() {\n  return 0\n  echo also_unreachable\n}"
         );
+        assert_eq!(diagnostics[3].span.slice(source), "f");
+    }
+
+    #[test]
+    fn unreachable_after_exit_prefers_outermost_compound_command_spans() {
+        let source = "\
+#!/bin/bash
+return
+if true; then
+  echo one
+fi
+printf '%s\\n' two
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 2);
         assert_eq!(
-            diagnostics[1].span.slice(source).trim_end(),
-            "printf '%s\\n' never"
+            diagnostics[0].span.slice(source),
+            "if true; then\n  echo one\nfi"
         );
-        assert!(
-            diagnostics[2]
-                .span
-                .slice(source)
-                .trim_end()
-                .starts_with("f() {")
-        );
-        assert_eq!(
-            diagnostics[3].span.slice(source).trim_end(),
-            "echo also_unreachable"
-        );
-        assert_eq!(diagnostics[4].span.slice(source).trim_end(), "f");
+        assert_eq!(diagnostics[0].span.end.line, 5);
+        assert_eq!(diagnostics[0].span.end.column, 3);
+        assert_eq!(diagnostics[1].span.slice(source), "printf '%s\\n' two");
+        assert_eq!(diagnostics[1].span.end.line, 6);
+        assert_eq!(diagnostics[1].span.end.column, 18);
+    }
+
+    #[test]
+    fn unreachable_after_exit_reports_after_script_terminating_function_calls() {
+        let source = "\
+#!/bin/bash
+exit_script() {
+  exit 0
+}
+main() {
+  exit_script
+  printf '%s\\n' never
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "printf '%s\\n' never");
+    }
+
+    #[test]
+    fn unreachable_after_exit_reports_after_redirected_exit_helpers() {
+        let source = "\
+#!/bin/bash
+exit_script() {
+  exit 0
+}
+main() {
+  exit_script >/dev/null
+  printf '%s\\n' never
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "printf '%s\\n' never");
+    }
+
+    #[test]
+    fn unreachable_after_exit_reports_after_brace_group_defined_exit_helpers() {
+        let source = "\
+#!/bin/bash
+{
+  exit_script() {
+    exit 0
+  }
+}
+main() {
+  exit_script
+  printf '%s\\n' never
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "printf '%s\\n' never");
+    }
+
+    #[test]
+    fn unreachable_after_exit_reports_after_later_parent_scope_exit_helpers() {
+        let source = "\
+#!/bin/bash
+main() {
+  exit_script
+  printf '%s\\n' never
+}
+exit_script() {
+  exit 0
+}
+main
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "printf '%s\\n' never");
+    }
+
+    #[test]
+    fn unreachable_after_exit_ignores_later_function_definitions_for_earlier_calls() {
+        let source = "\
+#!/bin/bash
+main() {
+  exit_script
+  printf '%s\\n' still_reachable
+}
+main
+exit_script() {
+  exit 0
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unreachable_after_exit_ignores_transitive_calls_before_parent_definitions() {
+        let source = "\
+#!/bin/bash
+main() {
+  helper
+}
+helper() {
+  inner
+}
+inner() {
+  exit_script
+  printf '%s\\n' maybe
+}
+if should_run; then
+  main
+fi
+exit_script() {
+  exit 0
+}
+main
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unreachable_after_exit_ignores_stale_terminating_helper_redefinitions() {
+        let source = "\
+#!/bin/bash
+exit_script() {
+  exit 0
+}
+main() {
+  exit_script
+  printf '%s\\n' maybe
+}
+if should_run; then
+  main
+fi
+exit_script() {
+  :
+}
+main
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unreachable_after_exit_ignores_conditionally_defined_exit_helpers() {
+        let source = "\
+#!/bin/bash
+if false; then
+  exit_script() {
+    exit 0
+  }
+fi
+exit_script
+printf '%s\\n' still_reachable
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C124_C124.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C124_C124.sh.snap
@@ -20,12 +20,6 @@ C124 code is unreachable
    |
 
 C124 code is unreachable
-  --> <source>:15:3
-   |
-15 |   echo also_unreachable
-   |
-
-C124 code is unreachable
   --> <source>:17:1
    |
 17 | f

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,4 +1,5 @@
 use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
 
 pub struct UnreachableAfterExit;
 
@@ -13,14 +14,53 @@ impl Violation for UnreachableAfterExit {
 }
 
 pub fn unreachable_after_exit(checker: &mut Checker) {
-    let unreachable_spans = checker
-        .semantic_analysis()
-        .dead_code()
-        .iter()
-        .flat_map(|dead_code| dead_code.unreachable.iter().copied())
-        .collect::<Vec<_>>();
+    let source = checker.source();
+    let unreachable_spans = outermost_unreachable_spans(
+        checker
+            .semantic_analysis()
+            .dead_code()
+            .iter()
+            .flat_map(|dead_code| dead_code.unreachable.iter().copied())
+            .collect::<Vec<_>>(),
+    );
 
-    for span in unreachable_spans {
+    for span in unreachable_spans
+        .into_iter()
+        .map(|span| trim_trailing_whitespace(span, source))
+    {
         checker.report(UnreachableAfterExit, span);
     }
+}
+
+fn outermost_unreachable_spans(mut spans: Vec<shuck_ast::Span>) -> Vec<shuck_ast::Span> {
+    spans.sort_by(|left, right| {
+        left.start
+            .offset
+            .cmp(&right.start.offset)
+            .then_with(|| right.end.offset.cmp(&left.end.offset))
+    });
+
+    let mut outermost = Vec::new();
+    for span in spans {
+        if outermost
+            .iter()
+            .any(|outer| span_contained_by(span, *outer))
+        {
+            continue;
+        }
+        if outermost.contains(&span) {
+            continue;
+        }
+        outermost.push(span);
+    }
+    outermost
+}
+
+fn span_contained_by(inner: shuck_ast::Span, outer: shuck_ast::Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+}
+
+fn trim_trailing_whitespace(span: Span, source: &str) -> Span {
+    let trimmed = span.slice(source).trim_end_matches(char::is_whitespace);
+    Span::from_positions(span.start, span.start.advanced_by(trimmed))
 }

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -611,6 +611,21 @@ echo still_dead
     }
 
     #[test]
+    fn applies_legacy_shellcheck_dead_code_suppression_alias() {
+        let source = "\
+exit 0
+# shellcheck disable=SC2365
+echo dead
+echo still_dead
+";
+        let index = suppression_index(source);
+
+        assert!(!index.is_suppressed(Rule::UnreachableAfterExit, 1));
+        assert!(index.is_suppressed(Rule::UnreachableAfterExit, 3));
+        assert!(!index.is_suppressed(Rule::UnreachableAfterExit, 4));
+    }
+
+    #[test]
     fn applies_shuck_disable_with_shellcheck_codes_to_the_next_command() {
         let source = "\
 foo='a b'

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -15,6 +15,7 @@ const SUPPRESSION_ALIAS_CODES: &[(u32, Rule)] = &[
     (2234, Rule::SingleTestSubshell),
     (2351, Rule::XPrefixInTest),
     (3084, Rule::SourceInsideFunctionInSh),
+    (2365, Rule::UnreachableAfterExit),
 ];
 
 /// Maps ShellCheck SC codes to Shuck rules.
@@ -131,7 +132,7 @@ mod tests {
             map.resolve("SC1087"),
             Some(Rule::BraceVariableBeforeBracket)
         );
-        assert_eq!(map.resolve("SC2317"), None);
+        assert_eq!(map.resolve("SC2317"), Some(Rule::UnreachableAfterExit));
         assert_eq!(map.resolve("SC7777"), None);
     }
 
@@ -164,6 +165,7 @@ mod tests {
             vec![Rule::SourceInsideFunctionInSh]
         );
         assert_eq!(map.resolve_all("SC2260"), vec![Rule::RedirectBeforePipe]);
+        assert_eq!(map.resolve_all("SC2365"), vec![Rule::UnreachableAfterExit]);
     }
 
     #[test]
@@ -194,6 +196,7 @@ mod tests {
         assert_eq!(map.code_for_rule(Rule::RedirectToCommandName), Some(2238));
         assert_eq!(map.code_for_rule(Rule::DuplicateShebangFlag), Some(2096));
         assert_eq!(map.code_for_rule(Rule::BashFileSlurp), Some(3034));
+        assert_eq!(map.code_for_rule(Rule::UnreachableAfterExit), Some(2317));
         assert_eq!(map.code_for_rule(Rule::LiteralControlEscape), Some(1012));
         assert_eq!(
             map.code_for_rule(Rule::BraceVariableBeforeBracket),

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -361,6 +361,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 .entry(callee.clone())
                 .or_default()
                 .push(call_site);
+            self.recorded_program.call_command_spans.insert(
+                SpanKey::new(command.span),
+                self.command_stack.last().copied().unwrap_or(command.span),
+            );
 
             self.classify_special_simple_command(&callee, command, flow);
         }

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -991,7 +991,7 @@ impl FunctionCallResolver<'_> {
                         sites.iter().any(|site| {
                             self.call_site_may_reference_binding(site, binding, offset)
                                 && self.call_site_can_run_before_offset(
-                                    site, call_scope, offset, visiting,
+                                    scope, site, call_scope, offset, visiting,
                                 )
                         })
                     })
@@ -1006,6 +1006,7 @@ impl FunctionCallResolver<'_> {
 
     fn call_site_can_run_before_offset(
         &mut self,
+        target_scope: ScopeId,
         site: &CallSite,
         call_scope: ScopeId,
         offset: usize,
@@ -1015,8 +1016,15 @@ impl FunctionCallResolver<'_> {
             .start
             .offset;
         let Some(enclosing_function) = self.enclosing_function_scope(site.scope) else {
-            return command_start < offset && self.scope_has_ancestor(site.scope, call_scope);
+            if self.scope_has_ancestor(site.scope, call_scope) {
+                return command_start < offset;
+            }
+            return self.scope_has_ancestor(call_scope, target_scope);
         };
+
+        if enclosing_function == call_scope {
+            return command_start < offset;
+        }
 
         self.scope_has_known_entry_before_offset(enclosing_function, call_scope, offset, visiting)
     }

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -1,11 +1,11 @@
-use rustc_hash::FxHashMap;
-use shuck_ast::{CaseTerminator, Span};
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::{CaseTerminator, Name, Span};
 use shuck_parser::ZshEmulationMode;
 use smallvec::SmallVec;
 use std::marker::PhantomData;
 
 use crate::source_closure::SourcePathTemplate;
-use crate::{BindingId, ReferenceId, ScopeId, SpanKey};
+use crate::{Binding, BindingId, BindingKind, CallSite, ReferenceId, Scope, ScopeId, SpanKey};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BlockId(pub(crate) u32);
@@ -121,6 +121,7 @@ pub(crate) struct RecordedProgram {
     elif_branches: Vec<RecordedElifBranch>,
     pub(crate) command_infos: FxHashMap<SpanKey, RecordedCommandInfo>,
     pub(crate) function_body_scopes: FxHashMap<BindingId, ScopeId>,
+    pub(crate) call_command_spans: FxHashMap<SpanKey, Span>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -429,9 +430,663 @@ fn push_range<T>(store: &mut Vec<T>, mut items: Vec<T>) -> RecordedRange<T> {
     RecordedRange::new(start, store.len() - start)
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct ExitEffect {
+    may_continue: bool,
+    may_return: bool,
+    may_exit: bool,
+}
+
+impl ExitEffect {
+    fn continuing() -> Self {
+        Self {
+            may_continue: true,
+            may_return: false,
+            may_exit: false,
+        }
+    }
+
+    fn returning() -> Self {
+        Self {
+            may_continue: false,
+            may_return: true,
+            may_exit: false,
+        }
+    }
+
+    fn exiting() -> Self {
+        Self {
+            may_continue: false,
+            may_return: false,
+            may_exit: true,
+        }
+    }
+
+    fn combine_alternative(&mut self, other: Self) {
+        self.may_continue |= other.may_continue;
+        self.may_return |= other.may_return;
+        self.may_exit |= other.may_exit;
+    }
+}
+
+fn compute_script_terminating_call_spans(
+    program: &RecordedProgram,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    scopes: &[Scope],
+    bindings: &[Binding],
+    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+) -> FxHashSet<SpanKey> {
+    if program.function_body_scopes.is_empty() || call_sites.is_empty() {
+        return FxHashSet::default();
+    }
+
+    let unconditional_function_bindings =
+        collect_unconditional_function_bindings(program, command_bindings, bindings);
+    let scope_function_bindings = function_bindings_by_scope(program);
+    let mut resolver = FunctionCallResolver {
+        program,
+        scopes,
+        bindings,
+        call_sites,
+        unconditional_function_bindings: &unconditional_function_bindings,
+        function_bindings_by_scope: &scope_function_bindings,
+        entry_before_offset_cache: FxHashMap::default(),
+    };
+    let mut terminating_call_spans = FxHashSet::default();
+    let mut always_exiting_scopes = FxHashSet::default();
+
+    loop {
+        let mut changed = false;
+        for &scope in program.function_bodies().keys() {
+            if always_exiting_scopes.contains(&scope) {
+                continue;
+            }
+            if function_scope_always_exits_script(program, scope, &terminating_call_spans) {
+                always_exiting_scopes.insert(scope);
+                changed = true;
+            }
+        }
+        changed |= resolve_script_terminating_call_spans(
+            program,
+            call_sites,
+            &mut resolver,
+            &always_exiting_scopes,
+            &mut terminating_call_spans,
+        );
+        if !changed {
+            break;
+        }
+    }
+
+    terminating_call_spans
+}
+
+fn resolve_script_terminating_call_spans(
+    program: &RecordedProgram,
+    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    resolver: &mut FunctionCallResolver<'_>,
+    always_exiting_scopes: &FxHashSet<ScopeId>,
+    terminating_call_spans: &mut FxHashSet<SpanKey>,
+) -> bool {
+    let target_names = program
+        .function_body_scopes
+        .iter()
+        .filter(|(_, scope)| always_exiting_scopes.contains(scope))
+        .map(|(binding, _)| resolver.bindings[binding.index()].name.clone())
+        .collect::<FxHashSet<_>>();
+    let mut changed = false;
+
+    for name in target_names {
+        let Some(sites) = call_sites.get(&name) else {
+            continue;
+        };
+
+        for site in sites {
+            let Some(binding) =
+                resolver.visible_function_binding(&name, site.scope, site.span.start.offset)
+            else {
+                continue;
+            };
+            let Some(scope) = program.function_body_scopes.get(&binding).copied() else {
+                continue;
+            };
+            if !always_exiting_scopes.contains(&scope) {
+                continue;
+            }
+            let command_span = recorded_command_span_for_call_site(program, site);
+            changed |= terminating_call_spans.insert(SpanKey::new(command_span));
+        }
+    }
+
+    changed
+}
+
+fn function_bindings_by_scope(
+    program: &RecordedProgram,
+) -> FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {
+    let mut bindings_by_scope: FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> = FxHashMap::default();
+    for (&binding, &scope) in &program.function_body_scopes {
+        bindings_by_scope.entry(scope).or_default().push(binding);
+    }
+    bindings_by_scope
+}
+
+struct FunctionCallResolver<'a> {
+    program: &'a RecordedProgram,
+    scopes: &'a [Scope],
+    bindings: &'a [Binding],
+    call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    unconditional_function_bindings: &'a FxHashSet<BindingId>,
+    function_bindings_by_scope: &'a FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>,
+    entry_before_offset_cache: FxHashMap<(ScopeId, ScopeId, usize), bool>,
+}
+
+fn recorded_command_span_for_call_site(program: &RecordedProgram, site: &CallSite) -> Span {
+    if let Some(command_span) = program
+        .call_command_spans
+        .get(&SpanKey::new(site.span))
+        .copied()
+    {
+        return command_span;
+    }
+
+    program
+        .commands()
+        .iter()
+        .filter(|command| {
+            matches!(command.kind, RecordedCommandKind::Linear)
+                && span_contains(command.span, site.span)
+        })
+        .min_by_key(|command| {
+            (
+                command.span.end.offset - command.span.start.offset,
+                command.span.start.offset,
+            )
+        })
+        .or_else(|| {
+            program
+                .commands()
+                .iter()
+                .filter(|command| span_contains(command.span, site.span))
+                .min_by_key(|command| {
+                    (
+                        command.span.end.offset - command.span.start.offset,
+                        command.span.start.offset,
+                    )
+                })
+        })
+        .map(|command| command.span)
+        .unwrap_or(site.span)
+}
+
+fn collect_unconditional_function_bindings(
+    program: &RecordedProgram,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    bindings: &[Binding],
+) -> FxHashSet<BindingId> {
+    let mut unconditional = FxHashSet::default();
+    collect_sequence_function_bindings(
+        program,
+        program.file_commands(),
+        command_bindings,
+        bindings,
+        &mut unconditional,
+    );
+    for commands in program.function_bodies().values().copied() {
+        collect_sequence_function_bindings(
+            program,
+            commands,
+            command_bindings,
+            bindings,
+            &mut unconditional,
+        );
+    }
+    unconditional
+}
+
+fn collect_sequence_function_bindings(
+    program: &RecordedProgram,
+    commands: RecordedCommandRange,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    bindings: &[Binding],
+    unconditional: &mut FxHashSet<BindingId>,
+) {
+    for &command_id in program.commands_in(commands) {
+        collect_command_function_bindings(
+            program,
+            command_id,
+            command_bindings,
+            bindings,
+            unconditional,
+        );
+    }
+}
+
+fn collect_command_function_bindings(
+    program: &RecordedProgram,
+    command_id: RecordedCommandId,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    bindings: &[Binding],
+    unconditional: &mut FxHashSet<BindingId>,
+) {
+    let command = program.command(command_id);
+    collect_direct_function_bindings(command.span, command_bindings, bindings, unconditional);
+
+    match command.kind {
+        RecordedCommandKind::List { first, .. } => collect_command_function_bindings(
+            program,
+            first,
+            command_bindings,
+            bindings,
+            unconditional,
+        ),
+        RecordedCommandKind::BraceGroup { body } => collect_sequence_function_bindings(
+            program,
+            body,
+            command_bindings,
+            bindings,
+            unconditional,
+        ),
+        RecordedCommandKind::Linear
+        | RecordedCommandKind::Break { .. }
+        | RecordedCommandKind::Continue { .. }
+        | RecordedCommandKind::Return
+        | RecordedCommandKind::Exit
+        | RecordedCommandKind::If { .. }
+        | RecordedCommandKind::While { .. }
+        | RecordedCommandKind::Until { .. }
+        | RecordedCommandKind::For { .. }
+        | RecordedCommandKind::Select { .. }
+        | RecordedCommandKind::ArithmeticFor { .. }
+        | RecordedCommandKind::Case { .. }
+        | RecordedCommandKind::Subshell { .. }
+        | RecordedCommandKind::Pipeline { .. } => {}
+    }
+}
+
+fn collect_direct_function_bindings(
+    span: Span,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    bindings: &[Binding],
+    unconditional: &mut FxHashSet<BindingId>,
+) {
+    let key = SpanKey::new(span);
+    let Some(command_bindings) = command_bindings.get(&key) else {
+        return;
+    };
+    unconditional.extend(command_bindings.iter().copied().filter(|binding| {
+        matches!(
+            bindings[binding.index()].kind,
+            BindingKind::FunctionDefinition
+        )
+    }));
+}
+
+fn function_scope_always_exits_script(
+    program: &RecordedProgram,
+    scope: ScopeId,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> bool {
+    let effect = sequence_exit_effect(
+        program,
+        program.function_body(scope),
+        terminating_call_spans,
+    );
+    !effect.may_continue && !effect.may_return && effect.may_exit
+}
+
+fn sequence_exit_effect(
+    program: &RecordedProgram,
+    commands: RecordedCommandRange,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let mut sequence_effect = ExitEffect::default();
+    let mut may_continue = true;
+
+    for &command_id in program.commands_in(commands) {
+        if !may_continue {
+            break;
+        }
+
+        let command_effect = command_exit_effect(program, command_id, terminating_call_spans);
+        sequence_effect.may_exit |= command_effect.may_exit;
+        sequence_effect.may_return |= command_effect.may_return;
+        may_continue = command_effect.may_continue;
+    }
+
+    sequence_effect.may_continue = may_continue;
+    sequence_effect
+}
+
+fn command_exit_effect(
+    program: &RecordedProgram,
+    command_id: RecordedCommandId,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let command = program.command(command_id);
+
+    match command.kind {
+        RecordedCommandKind::Linear => {
+            let span_key = SpanKey::new(command.span);
+            if terminating_call_spans.contains(&span_key) {
+                ExitEffect::exiting()
+            } else {
+                ExitEffect::continuing()
+            }
+        }
+        RecordedCommandKind::Break { .. } | RecordedCommandKind::Continue { .. } => {
+            ExitEffect::continuing()
+        }
+        RecordedCommandKind::Return => ExitEffect::returning(),
+        RecordedCommandKind::Exit => ExitEffect::exiting(),
+        RecordedCommandKind::List { first, rest } => {
+            list_exit_effect(program, first, rest, terminating_call_spans)
+        }
+        RecordedCommandKind::If {
+            condition,
+            then_branch,
+            elif_branches,
+            else_branch,
+        } => if_exit_effect(
+            program,
+            condition,
+            then_branch,
+            elif_branches,
+            else_branch,
+            terminating_call_spans,
+        ),
+        RecordedCommandKind::BraceGroup { body } => {
+            sequence_exit_effect(program, body, terminating_call_spans)
+        }
+        RecordedCommandKind::While { .. }
+        | RecordedCommandKind::Until { .. }
+        | RecordedCommandKind::For { .. }
+        | RecordedCommandKind::Select { .. }
+        | RecordedCommandKind::ArithmeticFor { .. }
+        | RecordedCommandKind::Case { .. }
+        | RecordedCommandKind::Subshell { .. }
+        | RecordedCommandKind::Pipeline { .. } => ExitEffect::continuing(),
+    }
+}
+
+fn span_contains(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+}
+
+fn list_exit_effect(
+    program: &RecordedProgram,
+    first: RecordedCommandId,
+    rest: RecordedListItemRange,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let first_effect = command_exit_effect(program, first, terminating_call_spans);
+    if !first_effect.may_continue {
+        return first_effect;
+    }
+
+    let mut effect = first_effect;
+    for item in program.list_items(rest) {
+        let item_effect = command_exit_effect(program, item.command, terminating_call_spans);
+        effect.may_continue = true;
+        effect.may_return |= item_effect.may_return;
+        effect.may_exit |= item_effect.may_exit;
+        effect.may_continue |= item_effect.may_continue;
+    }
+    effect
+}
+
+fn if_exit_effect(
+    program: &RecordedProgram,
+    condition: RecordedCommandRange,
+    then_branch: RecordedCommandRange,
+    elif_branches: RecordedElifBranchRange,
+    else_branch: RecordedCommandRange,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let condition_effect = sequence_exit_effect(program, condition, terminating_call_spans);
+    let mut effect = ExitEffect {
+        may_continue: false,
+        may_return: condition_effect.may_return,
+        may_exit: condition_effect.may_exit,
+    };
+
+    if !condition_effect.may_continue {
+        return effect;
+    }
+
+    effect.combine_alternative(sequence_exit_effect(
+        program,
+        then_branch,
+        terminating_call_spans,
+    ));
+    effect.combine_alternative(elif_chain_exit_effect(
+        program,
+        elif_branches,
+        else_branch,
+        terminating_call_spans,
+    ));
+    effect
+}
+
+fn elif_chain_exit_effect(
+    program: &RecordedProgram,
+    elif_branches: RecordedElifBranchRange,
+    else_branch: RecordedCommandRange,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let mut false_path = if else_branch.is_empty() {
+        ExitEffect::continuing()
+    } else {
+        sequence_exit_effect(program, else_branch, terminating_call_spans)
+    };
+
+    for branch in program.elif_branches(elif_branches).iter().rev() {
+        let condition_effect =
+            sequence_exit_effect(program, branch.condition, terminating_call_spans);
+        let mut branch_effect = ExitEffect {
+            may_continue: false,
+            may_return: condition_effect.may_return,
+            may_exit: condition_effect.may_exit,
+        };
+
+        if condition_effect.may_continue {
+            branch_effect.combine_alternative(sequence_exit_effect(
+                program,
+                branch.body,
+                terminating_call_spans,
+            ));
+            branch_effect.combine_alternative(false_path);
+        }
+
+        false_path = branch_effect;
+    }
+
+    false_path
+}
+
+impl FunctionCallResolver<'_> {
+    fn visible_function_binding(
+        &mut self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Option<BindingId> {
+        for scope_id in ancestor_scopes(self.scopes, scope) {
+            let Some(candidates) = self.scopes[scope_id.index()].bindings.get(name) else {
+                continue;
+            };
+
+            for binding in candidates.iter().rev().copied() {
+                let candidate = &self.bindings[binding.index()];
+                if !matches!(candidate.kind, BindingKind::FunctionDefinition) {
+                    continue;
+                }
+
+                if scope_id == scope {
+                    if candidate.span.start.offset <= offset
+                        && self.unconditional_function_bindings.contains(&binding)
+                    {
+                        return Some(binding);
+                    }
+                    continue;
+                }
+
+                if !self.unconditional_function_bindings.contains(&binding) {
+                    return None;
+                }
+
+                return self
+                    .parent_scope_binding_available_before_scope_runs(candidate, scope)
+                    .then_some(binding);
+            }
+        }
+
+        None
+    }
+
+    fn parent_scope_binding_available_before_scope_runs(
+        &mut self,
+        candidate: &Binding,
+        scope: ScopeId,
+    ) -> bool {
+        if candidate.span.start.offset <= self.scopes[scope.index()].span.start.offset {
+            return true;
+        }
+
+        let mut visiting = FxHashSet::default();
+        !self.scope_has_known_entry_before_offset(
+            scope,
+            candidate.scope,
+            candidate.span.start.offset,
+            &mut visiting,
+        )
+    }
+
+    fn scope_has_known_entry_before_offset(
+        &mut self,
+        scope: ScopeId,
+        call_scope: ScopeId,
+        offset: usize,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let cache_key = (scope, call_scope, offset);
+        let cacheable = visiting.is_empty();
+        if cacheable && let Some(cached) = self.entry_before_offset_cache.get(&cache_key) {
+            return *cached;
+        }
+
+        if !visiting.insert(scope) {
+            return false;
+        }
+
+        let has_entry =
+            self.function_bindings_by_scope
+                .get(&scope)
+                .is_some_and(|function_bindings| {
+                    function_bindings.iter().copied().any(|binding| {
+                        let function = &self.bindings[binding.index()];
+                        let Some(sites) = self.call_sites.get(&function.name) else {
+                            return false;
+                        };
+                        sites.iter().any(|site| {
+                            self.call_site_may_reference_binding(site, binding, offset)
+                                && self.call_site_can_run_before_offset(
+                                    site, call_scope, offset, visiting,
+                                )
+                        })
+                    })
+                });
+
+        visiting.remove(&scope);
+        if cacheable {
+            self.entry_before_offset_cache.insert(cache_key, has_entry);
+        }
+        has_entry
+    }
+
+    fn call_site_can_run_before_offset(
+        &mut self,
+        site: &CallSite,
+        call_scope: ScopeId,
+        offset: usize,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let command_start = recorded_command_span_for_call_site(self.program, site)
+            .start
+            .offset;
+        let Some(enclosing_function) = self.enclosing_function_scope(site.scope) else {
+            return command_start < offset && self.scope_has_ancestor(site.scope, call_scope);
+        };
+
+        self.scope_has_known_entry_before_offset(enclosing_function, call_scope, offset, visiting)
+    }
+
+    fn call_site_may_reference_binding(
+        &self,
+        site: &CallSite,
+        binding: BindingId,
+        offset: usize,
+    ) -> bool {
+        let target = &self.bindings[binding.index()];
+        if !self.scope_has_ancestor(site.scope, target.scope) {
+            return false;
+        }
+
+        if target.scope == site.scope {
+            return self.lexically_visible_function_binding_in_scope(
+                &target.name,
+                site.scope,
+                site.span.start.offset,
+            ) == Some(binding);
+        }
+
+        target.span.start.offset < offset
+    }
+
+    fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
+        ancestor_scopes(self.scopes, scope)
+            .find(|scope_id| self.function_bindings_by_scope.contains_key(scope_id))
+    }
+
+    fn scope_has_ancestor(&self, scope: ScopeId, ancestor: ScopeId) -> bool {
+        ancestor_scopes(self.scopes, scope).any(|scope_id| scope_id == ancestor)
+    }
+
+    fn lexically_visible_function_binding_in_scope(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Option<BindingId> {
+        self.scopes[scope.index()]
+            .bindings
+            .get(name)?
+            .iter()
+            .rev()
+            .copied()
+            .find(|binding| {
+                let candidate = &self.bindings[binding.index()];
+                matches!(candidate.kind, BindingKind::FunctionDefinition)
+                    && candidate.span.start.offset <= offset
+            })
+    }
+}
+
+fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
+    std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
+}
+
 struct SequenceResult {
     entry: Option<BlockId>,
     exits: Vec<BlockId>,
+}
+
+#[derive(Clone, Copy)]
+struct IfRanges {
+    condition: RecordedCommandRange,
+    then_branch: RecordedCommandRange,
+    elif_branches: RecordedElifBranchRange,
+    else_branch: RecordedCommandRange,
 }
 
 #[derive(Clone, Copy)]
@@ -444,6 +1099,7 @@ struct GraphBuilder<'a> {
     program: &'a RecordedProgram,
     command_bindings: &'a FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
     command_references: &'a FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
+    script_terminating_calls: FxHashSet<SpanKey>,
     blocks: Vec<BasicBlock>,
     successors: FxHashMap<BlockId, Vec<(BlockId, EdgeKind)>>,
     command_blocks: FxHashMap<SpanKey, Vec<BlockId>>,
@@ -455,11 +1111,22 @@ pub(crate) fn build_control_flow_graph(
     program: &RecordedProgram,
     command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
     command_references: &FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
+    scopes: &[Scope],
+    bindings: &[Binding],
+    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
 ) -> ControlFlowGraph {
+    let script_terminating_calls = compute_script_terminating_call_spans(
+        program,
+        command_bindings,
+        scopes,
+        bindings,
+        call_sites,
+    );
     let mut builder = GraphBuilder {
         program,
         command_bindings,
         command_references,
+        script_terminating_calls,
         blocks: Vec::new(),
         successors: FxHashMap::default(),
         command_blocks: FxHashMap::default(),
@@ -524,7 +1191,7 @@ impl<'a> GraphBuilder<'a> {
         for &command_id in self.program.commands_in(commands) {
             let command = self.program.command(command_id);
             let start = self.blocks.len();
-            let sequence = self.build_command(command_id, loops);
+            let sequence = self.build_command(command_id, loops, unreachable_cause.is_some());
             if entry.is_none() {
                 entry = sequence.entry;
             }
@@ -542,10 +1209,9 @@ impl<'a> GraphBuilder<'a> {
 
             if sequence.exits.is_empty() {
                 pending.clear();
-                unreachable_cause = Some(command.span);
+                unreachable_cause.get_or_insert(command.span);
             } else {
                 pending = sequence.exits;
-                unreachable_cause = None;
             }
         }
 
@@ -559,15 +1225,24 @@ impl<'a> GraphBuilder<'a> {
         &mut self,
         command_id: RecordedCommandId,
         loops: &[LoopTarget],
+        force_command_header: bool,
     ) -> SequenceResult {
         let command = self.program.command(command_id);
         match &command.kind {
             RecordedCommandKind::Linear => {
                 let block = self.command_block(command.span);
                 self.attach_nested_regions(block, command.nested_regions, loops);
+                let exits = if self
+                    .script_terminating_calls
+                    .contains(&SpanKey::new(command.span))
+                {
+                    Vec::new()
+                } else {
+                    vec![block]
+                };
                 SequenceResult {
                     entry: Some(block),
-                    exits: vec![block],
+                    exits,
                 }
             }
             RecordedCommandKind::Break { depth } => {
@@ -598,7 +1273,7 @@ impl<'a> GraphBuilder<'a> {
                 }
             }
             RecordedCommandKind::List { first, rest } => {
-                self.build_list(command_id, *first, *rest, loops)
+                self.build_list(command_id, *first, *rest, loops, force_command_header)
             }
             RecordedCommandKind::If {
                 condition,
@@ -607,18 +1282,31 @@ impl<'a> GraphBuilder<'a> {
                 else_branch,
             } => self.build_if(
                 command_id,
-                *condition,
-                *then_branch,
-                *elif_branches,
-                *else_branch,
+                IfRanges {
+                    condition: *condition,
+                    then_branch: *then_branch,
+                    elif_branches: *elif_branches,
+                    else_branch: *else_branch,
+                },
                 loops,
+                force_command_header,
             ),
-            RecordedCommandKind::While { condition, body } => {
-                self.build_while_like(command_id, *condition, *body, loops, true)
-            }
-            RecordedCommandKind::Until { condition, body } => {
-                self.build_while_like(command_id, *condition, *body, loops, false)
-            }
+            RecordedCommandKind::While { condition, body } => self.build_while_like(
+                command_id,
+                *condition,
+                *body,
+                loops,
+                true,
+                force_command_header,
+            ),
+            RecordedCommandKind::Until { condition, body } => self.build_while_like(
+                command_id,
+                *condition,
+                *body,
+                loops,
+                false,
+                force_command_header,
+            ),
             RecordedCommandKind::For { body }
             | RecordedCommandKind::Select { body }
             | RecordedCommandKind::ArithmeticFor { body } => {
@@ -627,7 +1315,12 @@ impl<'a> GraphBuilder<'a> {
             RecordedCommandKind::Case { arms } => self.build_case(command_id, *arms, loops),
             RecordedCommandKind::BraceGroup { body } => {
                 let sequence = self.build_sequence(*body, loops);
-                self.wrap_sequence_with_command_header(command_id, sequence, loops)
+                self.wrap_sequence_with_command_header(
+                    command_id,
+                    sequence,
+                    loops,
+                    force_command_header,
+                )
             }
             RecordedCommandKind::Subshell { body, .. } => {
                 let block = self.command_block(command.span);
@@ -645,7 +1338,7 @@ impl<'a> GraphBuilder<'a> {
                 let block = self.command_block(command.span);
                 self.attach_nested_regions(block, command.nested_regions, loops);
                 for segment in self.program.pipeline_segments(*segments) {
-                    let sequence = self.build_command(segment.command, loops);
+                    let sequence = self.build_command(segment.command, loops, false);
                     if let Some(segment_entry) = sequence.entry {
                         self.scope_entries
                             .entry(segment.scope)
@@ -666,9 +1359,10 @@ impl<'a> GraphBuilder<'a> {
         command_id: RecordedCommandId,
         mut sequence: SequenceResult,
         loops: &[LoopTarget],
+        force_command_header: bool,
     ) -> SequenceResult {
         let command = self.program.command(command_id);
-        if command.nested_regions.is_empty() {
+        if command.nested_regions.is_empty() && !force_command_header {
             return sequence;
         }
 
@@ -689,14 +1383,15 @@ impl<'a> GraphBuilder<'a> {
         first: RecordedCommandId,
         rest: RecordedListItemRange,
         loops: &[LoopTarget],
+        force_command_header: bool,
     ) -> SequenceResult {
-        let current = self.build_command(first, loops);
+        let current = self.build_command(first, loops, false);
         let entry = current.entry;
         let mut success_exits = current.exits.clone();
         let mut failure_exits = current.exits;
 
         for item in self.program.list_items(rest) {
-            let next = self.build_command(item.command, loops);
+            let next = self.build_command(item.command, loops, false);
             let (triggering_exits, edge_kind) = match item.operator {
                 RecordedListOperator::And => (&success_exits, EdgeKind::ConditionalTrue),
                 RecordedListOperator::Or => (&failure_exits, EdgeKind::ConditionalFalse),
@@ -729,23 +1424,26 @@ impl<'a> GraphBuilder<'a> {
 
         let mut exits = success_exits;
         append_unique_block_ids(&mut exits, &failure_exits);
-        self.wrap_sequence_with_command_header(command, SequenceResult { entry, exits }, loops)
+        self.wrap_sequence_with_command_header(
+            command,
+            SequenceResult { entry, exits },
+            loops,
+            force_command_header,
+        )
     }
 
     fn build_if(
         &mut self,
         command: RecordedCommandId,
-        condition: RecordedCommandRange,
-        then_branch: RecordedCommandRange,
-        elif_branches: RecordedElifBranchRange,
-        else_branch: RecordedCommandRange,
+        ranges: IfRanges,
         loops: &[LoopTarget],
+        force_command_header: bool,
     ) -> SequenceResult {
-        let condition_seq = self.build_sequence(condition, loops);
+        let condition_seq = self.build_sequence(ranges.condition, loops);
         let entry = condition_seq.entry.or_else(|| Some(self.empty_block()));
         let mut false_exits = condition_seq.exits.clone();
 
-        let then_seq = self.build_sequence(then_branch, loops);
+        let then_seq = self.build_sequence(ranges.then_branch, loops);
         if let (Some(cond_entry), Some(then_entry)) = (entry, then_seq.entry) {
             for exit in &condition_seq.exits {
                 self.add_edge(*exit, then_entry, EdgeKind::ConditionalTrue);
@@ -757,7 +1455,7 @@ impl<'a> GraphBuilder<'a> {
 
         let mut branch_exits = then_seq.exits;
 
-        for elif_branch in self.program.elif_branches(elif_branches) {
+        for elif_branch in self.program.elif_branches(ranges.elif_branches) {
             let elif_cond = self.build_sequence(elif_branch.condition, loops);
             if let Some(elif_entry) = elif_cond.entry {
                 for exit in &false_exits {
@@ -776,7 +1474,7 @@ impl<'a> GraphBuilder<'a> {
             branch_exits.extend(elif_body_seq.exits);
         }
 
-        let else_seq = self.build_sequence(else_branch, loops);
+        let else_seq = self.build_sequence(ranges.else_branch, loops);
         if let Some(else_entry) = else_seq.entry {
             for exit in &false_exits {
                 self.add_edge(*exit, else_entry, EdgeKind::ConditionalFalse);
@@ -793,6 +1491,7 @@ impl<'a> GraphBuilder<'a> {
                 exits: branch_exits,
             },
             loops,
+            force_command_header,
         )
     }
 
@@ -803,6 +1502,7 @@ impl<'a> GraphBuilder<'a> {
         body: RecordedCommandRange,
         loops: &[LoopTarget],
         while_sense: bool,
+        force_command_header: bool,
     ) -> SequenceResult {
         let exit_block = self.empty_block();
         let condition_seq = self.build_sequence(condition, loops);
@@ -852,6 +1552,7 @@ impl<'a> GraphBuilder<'a> {
                 exits: vec![exit_block],
             },
             loops,
+            force_command_header,
         )
     }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -354,10 +354,43 @@ fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
             .1
             .extend(block.commands.iter().copied());
     }
-    dead_code_by_cause
+    let mut dead_code = dead_code_by_cause
         .into_iter()
-        .map(|(_, (cause, unreachable))| DeadCode { unreachable, cause })
-        .collect()
+        .map(|(_, (cause, unreachable))| DeadCode {
+            unreachable: outermost_unreachable_spans(unreachable),
+            cause,
+        })
+        .collect::<Vec<_>>();
+    dead_code.sort_by_key(|dead| (dead.cause.start.offset, dead.cause.end.offset));
+    dead_code
+}
+
+fn outermost_unreachable_spans(mut spans: Vec<Span>) -> Vec<Span> {
+    spans.sort_by(|left, right| {
+        left.start
+            .offset
+            .cmp(&right.start.offset)
+            .then_with(|| right.end.offset.cmp(&left.end.offset))
+    });
+
+    let mut outermost = Vec::new();
+    for span in spans {
+        if outermost
+            .iter()
+            .any(|outer| span_contained_by(span, *outer))
+        {
+            continue;
+        }
+        if outermost.contains(&span) {
+            continue;
+        }
+        outermost.push(span);
+    }
+    outermost
+}
+
+fn span_contained_by(inner: Span, outer: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
 
 fn build_bindings_by_name(bindings: &[Binding]) -> FxHashMap<Name, SmallVec<[BindingId; 2]>> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5979,6 +5979,60 @@ main
     }
 
     #[test]
+    fn top_level_parent_call_before_nested_definition_keeps_later_code_reachable() {
+        let source = "\
+outer() {
+  inner() {
+    helper
+    printf '%s\\n' maybe
+  }
+  inner
+  helper() {
+    exit 0
+  }
+}
+outer
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
+    fn nested_calls_after_parent_definition_can_use_script_terminating_helpers() {
+        let source = "\
+outer() {
+  inner() {
+    helper
+    printf '%s\\n' never
+  }
+  helper() {
+    exit 0
+  }
+  inner
+}
+outer
+";
+        let model = model(source);
+        let unreachable = model
+            .analysis()
+            .dead_code()
+            .iter()
+            .flat_map(|entry| entry.unreachable.iter())
+            .map(|span| span.slice(source).trim_end().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(
+            unreachable.contains(&"printf '%s\\n' never".to_owned()),
+            "unreachable spans: {unreachable:?}"
+        );
+    }
+
+    #[test]
     fn later_redefinitions_do_not_fall_back_to_stale_terminating_helpers() {
         let source = "\
 exit_script() {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1215,6 +1215,9 @@ impl<'model> SemanticAnalysis<'model> {
                 &self.model.recorded_program,
                 &self.model.command_bindings,
                 &self.model.command_references,
+                &self.model.scopes,
+                &self.model.bindings,
+                &self.model.call_sites,
             )
         })
     }
@@ -5790,6 +5793,239 @@ DESCRIPTION=\"${DESCRIPTION:-Deployment metadata updated}\"
     }
 
     #[test]
+    fn compound_dead_code_reports_outermost_spans() {
+        let source = "\
+return
+if true; then
+  echo one
+fi
+printf '%s\\n' two
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let dead_code = analysis.dead_code();
+        let unreachable = dead_code
+            .iter()
+            .flat_map(|entry| entry.unreachable.iter())
+            .map(|span| span.slice(source).trim_end().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(unreachable.contains(&"if true; then\n  echo one\nfi".to_owned()));
+        assert!(unreachable.contains(&"printf '%s\\n' two".to_owned()));
+        assert!(!unreachable.contains(&"echo one".to_owned()));
+    }
+
+    #[test]
+    fn dead_code_after_script_terminating_function_calls_is_detected() {
+        let source = "\
+exit_script() {
+  exit 0
+}
+main() {
+  exit_script
+  printf '%s\\n' never
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreachable = analysis
+            .dead_code()
+            .iter()
+            .flat_map(|entry| entry.unreachable.iter())
+            .map(|span| span.slice(source).trim_end().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(unreachable.contains(&"printf '%s\\n' never".to_owned()));
+    }
+
+    #[test]
+    fn script_terminating_calls_use_rewritten_statement_spans() {
+        let sources = [
+            "\
+exit_script() {
+  exit 0
+}
+main() {
+  exit_script >/dev/null
+  printf '%s\\n' never
+}
+",
+            "\
+exit_script() {
+  exit 0
+}
+main() {
+  ! exit_script
+  printf '%s\\n' never
+}
+",
+        ];
+
+        for source in sources {
+            let model = model(source);
+            let analysis = model.analysis();
+            let unreachable = analysis
+                .dead_code()
+                .iter()
+                .flat_map(|entry| entry.unreachable.iter())
+                .map(|span| span.slice(source).trim_end().to_owned())
+                .collect::<Vec<_>>();
+
+            assert!(
+                unreachable.contains(&"printf '%s\\n' never".to_owned()),
+                "unreachable spans: {unreachable:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn brace_group_function_definitions_can_make_later_calls_terminating() {
+        let source = "\
+{
+  exit_script() {
+    exit 0
+  }
+}
+main() {
+  exit_script
+  printf '%s\\n' never
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreachable = analysis
+            .dead_code()
+            .iter()
+            .flat_map(|entry| entry.unreachable.iter())
+            .map(|span| span.slice(source).trim_end().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(unreachable.contains(&"printf '%s\\n' never".to_owned()));
+    }
+
+    #[test]
+    fn later_parent_scope_function_definitions_can_terminate_later_runtime_calls() {
+        let source = "\
+main() {
+  exit_script
+  printf '%s\\n' never
+}
+exit_script() {
+  exit 0
+}
+main
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreachable = analysis
+            .dead_code()
+            .iter()
+            .flat_map(|entry| entry.unreachable.iter())
+            .map(|span| span.slice(source).trim_end().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(unreachable.contains(&"printf '%s\\n' never".to_owned()));
+    }
+
+    #[test]
+    fn later_function_definitions_do_not_make_earlier_calls_terminating() {
+        let source = "\
+main() {
+  exit_script
+  printf '%s\\n' still_reachable
+}
+main
+exit_script() {
+  exit 0
+}
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
+    fn transitive_calls_before_parent_definitions_keep_later_code_reachable() {
+        let source = "\
+main() {
+  helper
+}
+helper() {
+  inner
+}
+inner() {
+  exit_script
+  printf '%s\\n' maybe
+}
+if should_run; then
+  main
+fi
+exit_script() {
+  exit 0
+}
+main
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
+    fn later_redefinitions_do_not_fall_back_to_stale_terminating_helpers() {
+        let source = "\
+exit_script() {
+  exit 0
+}
+main() {
+  exit_script
+  printf '%s\\n' maybe
+}
+if should_run; then
+  main
+fi
+exit_script() {
+  :
+}
+main
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
+    fn conditional_function_definitions_do_not_make_calls_terminating() {
+        let source = "\
+if false; then
+  exit_script() {
+    exit 0
+  }
+fi
+exit_script
+printf '%s\\n' still_reachable
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
     fn conditional_exit_keeps_or_fallback_reachable() {
         let source = "run && exit 0 || echo fallback\n";
         let model = model(source);
@@ -7719,6 +7955,9 @@ echo done
             &model.recorded_program,
             &model.command_bindings,
             &model.command_references,
+            &model.scopes,
+            &model.bindings,
+            &model.call_sites,
         );
 
         assert!(!cfg.block_ids_for_span(conditional.span).is_empty());
@@ -7761,6 +8000,9 @@ echo done
             &model.recorded_program,
             &model.command_bindings,
             &model.command_references,
+            &model.scopes,
+            &model.bindings,
+            &model.call_sites,
         );
 
         assert!(!cfg.block_ids_for_span(conditional.span).is_empty());

--- a/docs/rules/C124.yaml
+++ b/docs/rules/C124.yaml
@@ -3,7 +3,7 @@ legacy_name: unreachable-after-exit
 new_category: Correctness
 new_code: C124
 runtime_kind: ast
-shellcheck_code: SC2365
+shellcheck_code: SC2317
 shellcheck_level: info
 shells:
   - sh


### PR DESCRIPTION
## Summary
- Restores the C124 script-terminating helper behavior that was reverted for performance.
- Resolves only calls to functions already known to terminate, caches parent-entry checks, and records simple-call statement spans during semantic build.
- Keeps outer compound unreachable spans while avoiding extra CFG header blocks for reachable compound commands.

## Validation
- `cargo test -q -p shuck-semantic -p shuck-linter`
- `cargo clippy -p shuck-semantic --all-targets -- -D warnings`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C124,C006` reached `implementation_diffs=0`; it still exits nonzero due to one unrelated parser harness failure in `HariSekhon__DevOps-Bash-tools__lib__utils.sh`.
- Focused Criterion `linter/` comparison against the current `HEAD` baseline: `linter/all` `+0.42%` with CI `[-3.05%, +4.01%]`, and `linter/nvm` improved `-24.56%`.