### PR TITLE
fix(linter): align S045 with shellcheck

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s045.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s045.yaml
@@ -1,18 +1,2 @@
 review_all_divergences: false
-reviewed_divergences:
-- side: shuck-only
-  path_suffix: docker-library__official-images__naughty-commits.sh
-  line: 87
-  reason: This loop-scoped associative map appends through keyed writes after a grouped `declare -A` declaration. The current ShellCheck oracle stays silent on those keyed appends, while Shuck still treats the subscripts as arithmetic-style indexed writes at this site.
-- side: shuck-only
-  path_suffix: docker-library__official-images__naughty-commits.sh
-  line: 90
-  reason: This loop-scoped associative map appends through keyed writes after a grouped `declare -A` declaration. The current ShellCheck oracle stays silent on those keyed appends, while Shuck still treats the subscripts as arithmetic-style indexed writes at this site.
-- side: shuck-only
-  path_suffix: rvm__rvm__scripts__hash
-  line: 32
-  reason: This eval-built arithmetic string mixes dynamic variable names with array-length expansion. The current ShellCheck oracle does not emit SC2004 for that generated expression, while Shuck still reports the dollar-prefixed operands inside the eval payload.
-- side: shuck-only
-  path_suffix: v1s1t0r1sh3r3__airgeddon__airgeddon.sh
-  line: 15602
-  reason: This helper records an interface key in a global associative map immediately after declaring it with `declare -gA`. The current ShellCheck oracle does not flag that keyed write, while Shuck still treats the subscript as indexed arithmetic at this site.
+reviewed_divergences: []

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1476,6 +1476,28 @@ two[$key]+=y
 }
 
 #[test]
+fn ignores_associative_appends_after_parameter_default_subscripts_for_dollar_in_arithmetic() {
+    let source = "\
+#!/bin/bash
+declare -A map=() other=()
+key=name
+: \"${map[$key]:=}\"
+map[$key]+=$'\\n'
+map[$key]+=\"${values[*]}\"
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .dollar_in_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(spans.is_empty(), "unexpected spans: {spans:?}");
+    });
+}
+
+#[test]
 fn ignores_globally_declared_associative_assignment_subscripts_for_dollar_in_arithmetic() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -5055,7 +5055,8 @@ fn collect_wrapped_arithmetic_spans_in_word(
     let mut index = 0usize;
 
     while index + 2 < bytes.len() {
-        if bytes[index] != b'$' || bytes[index + 1] != b'(' || bytes[index + 2] != b'(' {
+        if !is_unescaped_dollar(bytes, index) || bytes[index + 1] != b'(' || bytes[index + 2] != b'('
+        {
             index += 1;
             continue;
         }

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -498,6 +498,19 @@ eval \"rssi=\\\"\\\\$rssi${i}\\\"; i=$(( $i + 1 ))\"\n\
     }
 
     #[test]
+    fn ignores_escaped_arithmetic_openers_in_eval_strings() {
+        let source = "\
+#!/bin/bash
+__array_start=0
+hash_name=name
+eval \"index=\\$((\\${#_hash_${hash_name}_keys[*]} + $__array_start))\"\n\
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DollarInArithmetic));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_dynamic_and_compound_subscript_parameter_accesses_in_arithmetic_expressions() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2862,6 +2862,25 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     }
 
     fn add_parameter_default_binding(&mut self, reference: &VarRef) {
+        let mut attributes = binding_attributes_for_var_ref(reference);
+        if reference.subscript.is_some()
+            && !attributes.contains(BindingAttributes::ASSOC)
+            && self
+                .resolve_reference(
+                    &reference.name,
+                    self.current_scope(),
+                    reference.name_span.start.offset,
+                )
+                .map(|binding_id| {
+                    self.bindings[binding_id.index()]
+                        .attributes
+                        .contains(BindingAttributes::ASSOC)
+                })
+                .unwrap_or(false)
+        {
+            attributes |= BindingAttributes::ARRAY | BindingAttributes::ASSOC;
+        }
+
         self.add_binding(
             &reference.name,
             BindingKind::ParameterDefaultAssignment,
@@ -2870,7 +2889,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             BindingOrigin::ParameterDefaultAssignment {
                 definition_span: reference.span,
             },
-            BindingAttributes::empty(),
+            attributes,
         );
     }
 

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2740,6 +2740,28 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             })
     }
 
+    fn binding_was_cleared_before_lookup(
+        &self,
+        binding: &Binding,
+        lookup_scope: ScopeId,
+        lookup_offset: usize,
+    ) -> bool {
+        for scope in ancestor_scopes(&self.scopes, lookup_scope) {
+            if self.binding_was_cleared_in_scope_between(
+                &binding.name,
+                scope,
+                binding.span.start.offset,
+                lookup_offset,
+            ) {
+                return true;
+            }
+            if scope == binding.scope {
+                break;
+            }
+        }
+        false
+    }
+
     fn has_uncleared_local_binding_in_scope(
         &self,
         name: &Name,
@@ -2890,10 +2912,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 .map(|binding_id| {
                     let binding = &self.bindings[binding_id.index()];
                     binding.attributes.contains(BindingAttributes::ASSOC)
-                        && !self.binding_was_cleared_in_scope_between(
-                            &binding.name,
-                            binding.scope,
-                            binding.span.start.offset,
+                        && !self.binding_was_cleared_before_lookup(
+                            binding,
+                            self.current_scope(),
                             reference.name_span.start.offset,
                         )
                 })

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2724,6 +2724,22 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             })
     }
 
+    fn binding_was_cleared_in_scope_between(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        binding_offset: usize,
+        lookup_offset: usize,
+    ) -> bool {
+        self.cleared_variables
+            .get(&(scope, name.clone()))
+            .is_some_and(|cleared_offsets| {
+                cleared_offsets.iter().any(|cleared_offset| {
+                    *cleared_offset > binding_offset && *cleared_offset < lookup_offset
+                })
+            })
+    }
+
     fn has_uncleared_local_binding_in_scope(
         &self,
         name: &Name,
@@ -2872,9 +2888,14 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     reference.name_span.start.offset,
                 )
                 .map(|binding_id| {
-                    self.bindings[binding_id.index()]
-                        .attributes
-                        .contains(BindingAttributes::ASSOC)
+                    let binding = &self.bindings[binding_id.index()];
+                    binding.attributes.contains(BindingAttributes::ASSOC)
+                        && !self.binding_was_cleared_in_scope_between(
+                            &binding.name,
+                            binding.scope,
+                            binding.span.start.offset,
+                            reference.name_span.start.offset,
+                        )
                 })
                 .unwrap_or(false)
         {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2752,11 +2752,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             } else {
                 0
             };
+            let clear_upper_bound = if self.completed_scopes.contains(&scope) {
+                usize::MAX
+            } else {
+                lookup_offset
+            };
             if self.binding_was_cleared_in_scope_between(
                 &binding.name,
                 scope,
                 clear_lower_bound,
-                lookup_offset,
+                clear_upper_bound,
             ) {
                 return true;
             }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2747,10 +2747,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         lookup_offset: usize,
     ) -> bool {
         for scope in ancestor_scopes(&self.scopes, lookup_scope) {
+            let clear_lower_bound = if scope == binding.scope {
+                binding.span.start.offset
+            } else {
+                0
+            };
             if self.binding_was_cleared_in_scope_between(
                 &binding.name,
                 scope,
-                binding.span.start.offset,
+                clear_lower_bound,
                 lookup_offset,
             ) {
                 return true;

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -7745,6 +7745,31 @@ f
     }
 
     #[test]
+    fn deferred_parameter_default_after_global_unset_does_not_inherit_later_global_assoc() {
+        let source = "\
+#!/bin/bash
+f() {
+  : \"${map[$key]:=}\"
+}
+declare -A map
+unset map
+f
+";
+        let model = model(source);
+
+        let binding = model
+            .bindings()
+            .iter()
+            .rev()
+            .find(|binding| {
+                binding.name == "map" && binding.kind == BindingKind::ParameterDefaultAssignment
+            })
+            .expect("expected parameter-default map binding");
+        assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+        assert!(!binding.attributes.contains(BindingAttributes::ASSOC));
+    }
+
+    #[test]
     fn escaped_parameter_replacement_patterns_do_not_register_variable_reads() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -7720,6 +7720,31 @@ f
     }
 
     #[test]
+    fn deferred_parameter_default_after_function_unset_does_not_inherit_later_global_assoc() {
+        let source = "\
+#!/bin/bash
+f() {
+  unset map
+  : \"${map[$key]:=}\"
+}
+declare -A map
+f
+";
+        let model = model(source);
+
+        let binding = model
+            .bindings()
+            .iter()
+            .rev()
+            .find(|binding| {
+                binding.name == "map" && binding.kind == BindingKind::ParameterDefaultAssignment
+            })
+            .expect("expected parameter-default map binding");
+        assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+        assert!(!binding.attributes.contains(BindingAttributes::ASSOC));
+    }
+
+    #[test]
     fn escaped_parameter_replacement_patterns_do_not_register_variable_reads() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -7695,6 +7695,31 @@ unset map
     }
 
     #[test]
+    fn parameter_default_subscript_after_function_unset_does_not_inherit_global_assoc() {
+        let source = "\
+#!/bin/bash
+declare -A map
+f() {
+  unset map
+  : \"${map[$key]:=}\"
+}
+f
+";
+        let model = model(source);
+
+        let binding = model
+            .bindings()
+            .iter()
+            .rev()
+            .find(|binding| {
+                binding.name == "map" && binding.kind == BindingKind::ParameterDefaultAssignment
+            })
+            .expect("expected parameter-default map binding");
+        assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+        assert!(!binding.attributes.contains(BindingAttributes::ASSOC));
+    }
+
+    #[test]
     fn escaped_parameter_replacement_patterns_do_not_register_variable_reads() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -7673,6 +7673,28 @@ printf '%s\\n' \"$((box[m_width]))\" \"$((box[$dynamic_key]))\"
     }
 
     #[test]
+    fn parameter_default_subscript_after_unset_does_not_inherit_associative_attributes() {
+        let source = "\
+#!/bin/bash
+declare -A map
+unset map
+: \"${map[$key]:=}\"
+";
+        let model = model(source);
+
+        let binding = model
+            .bindings()
+            .iter()
+            .rev()
+            .find(|binding| {
+                binding.name == "map" && binding.kind == BindingKind::ParameterDefaultAssignment
+            })
+            .expect("expected parameter-default map binding");
+        assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+        assert!(!binding.attributes.contains(BindingAttributes::ASSOC));
+    }
+
+    #[test]
     fn escaped_parameter_replacement_patterns_do_not_register_variable_reads() {
         let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- Align S045 with ShellCheck for eval-built arithmetic by ignoring escaped `$((...))` payloads while still reporting unescaped arithmetic expansions.
- Preserve associative-array attributes when `${map[$key]:=}` creates a parameter-default binding, preventing later appends from being misclassified as indexed arithmetic.
- Remove the stale S045 corpus divergence metadata so the rule is checked directly against the oracle.

## Root Cause
S045 was treating escaped eval payloads as active arithmetic and parameter-default bindings were dropping the existing associative-array classification for subscripted variables.

## Validation
- `cargo test -p shuck-linter dollar_in_arithmetic -- --nocapture`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S045` now reports `implementation_diffs=0` and `reviewed_divergences=0`; the command still exits nonzero due to two unrelated parser harness failures in existing corpus fixtures.
