### PR TITLE
fix(linter): align S067 with ShellCheck

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s067.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s067.yaml
@@ -1,7 +1,1 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "docker__docker-bench-security__tests__7_docker_swarm_configuration.sh"
-    reason: "This test-harness fixture probes swarm listeners with a quoted grep pattern that begins with `*`. The current ShellCheck run does not emit SC2063 here, while Shuck still reports the regex-vs-glob mismatch."
-  - side: shuck-only
-    path_suffix: "dylanaraps__neofetch__neofetch"
-    reason: "This larger project-closure fixture searches terminal font strings with a quoted grep pattern that begins with `*`. The current ShellCheck run stays silent on SC2063 in this script, while Shuck keeps the grep-pattern warning."
+reviewed_divergences: []

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -311,6 +311,8 @@ pub struct GrepPatternFact<'a> {
     word: &'a Word,
     static_text: Option<Box<str>>,
     source_kind: GrepPatternSourceKind,
+    is_first_pattern: bool,
+    follows_separate_option_argument: bool,
     starts_with_glob_style_star: bool,
     has_glob_style_star_confusion: bool,
     glob_style_star_replacement_spans: Box<[Span]>,
@@ -331,6 +333,14 @@ impl<'a> GrepPatternFact<'a> {
 
     pub fn source_kind(&self) -> GrepPatternSourceKind {
         self.source_kind
+    }
+
+    pub fn is_first_pattern(&self) -> bool {
+        self.is_first_pattern
+    }
+
+    pub fn follows_separate_option_argument(&self) -> bool {
+        self.follows_separate_option_argument
     }
 
     pub fn starts_with_glob_style_star(&self) -> bool {
@@ -1860,6 +1870,7 @@ fn split_brace_alternatives(text: &str) -> Vec<&str> {
 fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommandFacts<'a>> {
     let mut index = 0usize;
     let mut pending_dynamic_option_arg = false;
+    let mut saw_separate_option_argument = false;
     let mut uses_only_matching = false;
     let mut uses_fixed_strings = false;
     let mut explicit_pattern_source = false;
@@ -1927,6 +1938,8 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                     pattern_word,
                     source,
                     GrepPatternSourceKind::LongOptionSeparate,
+                    patterns.is_empty(),
+                    saw_separate_option_argument,
                 ));
                 index += 2;
             } else {
@@ -1942,6 +1955,8 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                 source,
                 "--regexp=".len(),
                 GrepPatternSourceKind::LongOptionAttached,
+                patterns.is_empty(),
+                saw_separate_option_argument,
             ));
             index += 1;
             continue;
@@ -1949,6 +1964,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
         if text == "--file" {
             explicit_pattern_source = true;
+            saw_separate_option_argument |= args.get(index + 1).is_some();
             index += if args.get(index + 1).is_some() { 2 } else { 1 };
             continue;
         }
@@ -1960,13 +1976,10 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
         }
 
         if text.starts_with("--") {
-            index += if grep_long_option_takes_argument(text.as_ref())
-                && args.get(index + 1).is_some()
-            {
-                2
-            } else {
-                1
-            };
+            let consumes_next =
+                grep_long_option_takes_argument(text.as_ref()) && args.get(index + 1).is_some();
+            saw_separate_option_argument |= consumes_next;
+            index += if consumes_next { 2 } else { 1 };
             continue;
         }
 
@@ -1977,6 +1990,8 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                     pattern_word,
                     source,
                     GrepPatternSourceKind::ShortOptionSeparate,
+                    patterns.is_empty(),
+                    saw_separate_option_argument,
                 ));
                 index += 2;
             } else {
@@ -1987,6 +2002,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
         if text == "-f" {
             explicit_pattern_source = true;
+            saw_separate_option_argument |= args.get(index + 1).is_some();
             index += if args.get(index + 1).is_some() { 2 } else { 1 };
             continue;
         }
@@ -2014,12 +2030,16 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                         source,
                         2,
                         GrepPatternSourceKind::ShortOptionAttached,
+                        patterns.is_empty(),
+                        saw_separate_option_argument,
                     ));
                 } else if let Some(pattern_word) = args.get(index + 1) {
                     patterns.push(grep_pattern_fact(
                         pattern_word,
                         source,
                         GrepPatternSourceKind::ShortOptionSeparate,
+                        patterns.is_empty(),
+                        saw_separate_option_argument,
                     ));
                     consume_next_argument = true;
                 }
@@ -2039,6 +2059,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
         index += 1;
         if consume_next_argument {
+            saw_separate_option_argument = true;
             index += 1;
         }
     }
@@ -2048,6 +2069,8 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
             pattern_word,
             source,
             GrepPatternSourceKind::ImplicitOperand,
+            patterns.is_empty(),
+            saw_separate_option_argument,
         ));
     }
 
@@ -2501,8 +2524,17 @@ fn grep_pattern_fact<'a>(
     word: &'a Word,
     source: &str,
     source_kind: GrepPatternSourceKind,
+    is_first_pattern: bool,
+    follows_separate_option_argument: bool,
 ) -> GrepPatternFact<'a> {
-    grep_prefixed_pattern_fact(word, source, 0, source_kind)
+    grep_prefixed_pattern_fact(
+        word,
+        source,
+        0,
+        source_kind,
+        is_first_pattern,
+        follows_separate_option_argument,
+    )
 }
 
 fn grep_prefixed_pattern_fact<'a>(
@@ -2510,6 +2542,8 @@ fn grep_prefixed_pattern_fact<'a>(
     source: &str,
     prefix_len: usize,
     source_kind: GrepPatternSourceKind,
+    is_first_pattern: bool,
+    follows_separate_option_argument: bool,
 ) -> GrepPatternFact<'a> {
     let (static_text, glob_style_star_replacement_spans) =
         cooked_static_word_text_with_source_spans(word, source)
@@ -2532,6 +2566,8 @@ fn grep_prefixed_pattern_fact<'a>(
         word,
         static_text,
         source_kind,
+        is_first_pattern,
+        follows_separate_option_argument,
         starts_with_glob_style_star,
         has_glob_style_star_confusion,
         glob_style_star_replacement_spans,

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -1886,6 +1886,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
 
             if pending_dynamic_option_arg {
                 pending_dynamic_option_arg = false;
+                saw_separate_option_argument = true;
                 index += 1;
                 continue;
             }
@@ -1901,6 +1902,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
         if !text.starts_with('-') || text == "-" {
             if pending_dynamic_option_arg {
                 pending_dynamic_option_arg = false;
+                saw_separate_option_argument = true;
                 index += 1;
                 continue;
             }

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1489,6 +1489,7 @@ grep -m 1 '*implicit-after-option' data.txt
 grep -m1 '*implicit-after-attached-option' data.txt
 grep -A 1 -e '*explicit-after-option' data.txt
 grep -e '*explicit-before-option' -A 1 data.txt
+grep -$dynamic_option 1 -e '*explicit-after-dynamic-option' data.txt
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
@@ -1520,6 +1521,7 @@ grep -e '*explicit-before-option' -A 1 data.txt
             ("'*implicit-after-attached-option'", true, false),
             ("'*explicit-after-option'", true, true),
             ("'*explicit-before-option'", true, false),
+            ("'*explicit-after-dynamic-option'", true, true),
         ]
     );
 }

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1481,6 +1481,50 @@ grep --regexp='*start' data.txt
 }
 
 #[test]
+fn grep_pattern_facts_track_shellcheck_style_pattern_position() {
+    let source = "\
+#!/bin/bash
+grep -e '*first' -e '*second' data.txt
+grep -m 1 '*implicit-after-option' data.txt
+grep -m1 '*implicit-after-attached-option' data.txt
+grep -A 1 -e '*explicit-after-option' data.txt
+grep -e '*explicit-before-option' -A 1 data.txt
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let file_context = classify_file_context(source, None, ShellDialect::Bash);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+
+    let grep_patterns = facts
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("grep"))
+        .filter_map(|fact| fact.options().grep())
+        .flat_map(|grep| grep.patterns().iter())
+        .map(|pattern| {
+            (
+                pattern.span().slice(source),
+                pattern.is_first_pattern(),
+                pattern.follows_separate_option_argument(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        grep_patterns,
+        vec![
+            ("'*first'", true, false),
+            ("'*second'", false, false),
+            ("'*implicit-after-option'", true, true),
+            ("'*implicit-after-attached-option'", true, false),
+            ("'*explicit-after-option'", true, true),
+            ("'*explicit-before-option'", true, false),
+        ]
+    );
+}
+
+#[test]
 fn grep_pattern_facts_track_glob_style_star_confusion() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/leading_glob_in_grep_pattern.rs
+++ b/crates/shuck-linter/src/rules/style/leading_glob_in_grep_pattern.rs
@@ -22,6 +22,8 @@ pub fn leading_glob_in_grep_pattern(checker: &mut Checker) {
         .filter(|grep| !grep.uses_fixed_strings)
         .flat_map(|grep| grep.patterns().iter())
         .filter(|pattern| pattern.source_kind().uses_separate_pattern_word())
+        .filter(|pattern| pattern.is_first_pattern())
+        .filter(|pattern| !pattern.follows_separate_option_argument())
         .filter(|pattern| pattern.starts_with_glob_style_star())
         .map(|pattern| pattern.span())
         .collect::<Vec<_>>();
@@ -46,6 +48,7 @@ grep *CMD \"$AUDIT_FILE\"
 grep -e '*LABEL' \"$AUDIT_FILE\"
 grep --regexp '*EXPOSE' \"$AUDIT_FILE\"
 grep -v '^*' \"$AUDIT_FILE\"
+grep --max-count=1 '*ONE' \"$AUDIT_FILE\"
 ";
         let diagnostics = test_snippet(
             source,
@@ -66,6 +69,7 @@ grep -v '^*' \"$AUDIT_FILE\"
                 "'*LABEL'",
                 "'*EXPOSE'",
                 "'^*'",
+                "'*ONE'",
             ]
         );
     }
@@ -79,6 +83,10 @@ grep '.*MAINTAINER' \"$AUDIT_FILE\"
 grep -F '*MAINTAINER' \"$AUDIT_FILE\"
 grep -e'*MAINTAINER' \"$AUDIT_FILE\"
 grep --regexp='*MAINTAINER' \"$AUDIT_FILE\"
+grep -e 'LABEL' -e '*MAINTAINER' \"$AUDIT_FILE\"
+grep -m 1 '*MAINTAINER' \"$AUDIT_FILE\"
+grep --max-count 1 --regexp '*MAINTAINER' \"$AUDIT_FILE\"
+grep -A 1 -e '*MAINTAINER' \"$AUDIT_FILE\"
 grep '^*$' \"$AUDIT_FILE\"
 grep '^*foo' \"$AUDIT_FILE\"
 grep \"$pattern\" \"$AUDIT_FILE\"


### PR DESCRIPTION
## Summary
- align S067 with ShellCheck's narrower SC2063 behavior for leading `*` grep patterns
- add grep pattern facts for first-pattern position and prior separate option arguments
- remove the stale S067 reviewed-divergence corpus metadata

## Root Cause
S067 had intentionally kept reporting two cases where the current ShellCheck oracle stays silent. The rule needed to challenge that local divergence and use the oracle behavior instead of Shuck's broader policy.

## Validation
- `cargo test -p shuck-linter grep_pattern_facts_track_shellcheck_style_pattern_position --lib`
- `cargo test -p shuck-linter leading_glob_in_grep_pattern --lib`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S067` reports `implementation_diffs=0` and `reviewed_divergences=0`; it still exits nonzero because of two unrelated parse harness failures in the large corpus.
