### PR TITLE
fix(linter): align S017 brace fanout behavior

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s017.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s017.yaml
@@ -1,4 +1,0 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "dylanaraps__neofetch__neofetch"
-    reason: "This brace-expansion template combines variable prefixes with literal fanout to build candidate config paths, and the oracle does not report SC2206 for that pattern."

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -576,6 +576,7 @@ impl<'a> LinterFactsBuilder<'a> {
 
         LinterFacts {
             source,
+            shell: self.shell,
             commands,
             structural_command_ids,
             command_ids_by_span,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1,5 +1,6 @@
 pub struct LinterFacts<'a> {
     source: &'a str,
+    shell: ShellDialect,
     commands: Vec<CommandFact<'a>>,
     structural_command_ids: Vec<CommandId>,
     #[cfg_attr(not(test), allow(dead_code))]
@@ -484,6 +485,7 @@ impl<'a> LinterFacts<'a> {
             .brace_syntax()
             .iter()
             .copied()
+            .filter(|_| shell_has_brace_expansion(self.shell))
             .filter(|brace| brace.expands())
             .map(|brace| brace.span)
             .collect::<Vec<_>>();
@@ -865,6 +867,13 @@ impl<'a> LinterFacts<'a> {
     pub fn conditional_portability(&self) -> &ConditionalPortabilityFacts {
         &self.conditional_portability
     }
+}
+
+fn shell_has_brace_expansion(shell: ShellDialect) -> bool {
+    matches!(
+        shell,
+        ShellDialect::Bash | ShellDialect::Ksh | ShellDialect::Mksh | ShellDialect::Zsh
+    )
 }
 
 fn assignment_value_span(value: &AssignmentValue) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -477,10 +477,16 @@ impl<'a> LinterFacts<'a> {
         id: WordOccurrenceId,
     ) -> Box<[Span]> {
         let fact = self.word_occurrence_ref(id);
+        let word = occurrence_word(&self.word_nodes, self.word_occurrence(id));
         let mut split_sensitive_spans = fact.unquoted_scalar_expansion_spans().to_vec();
-        let use_replacement_spans = collect_array_assignment_use_replacement_expansion_spans(
-            occurrence_word(&self.word_nodes, self.word_occurrence(id)),
-        );
+        let use_replacement_spans = collect_array_assignment_use_replacement_expansion_spans(word);
+        let brace_expansion_spans = word
+            .brace_syntax()
+            .iter()
+            .copied()
+            .filter(|brace| brace.expands())
+            .map(|brace| brace.span)
+            .collect::<Vec<_>>();
 
         if !word_occurrence_is_double_quoted_command_substitution_only(
             &self.word_nodes,
@@ -501,7 +507,12 @@ impl<'a> LinterFacts<'a> {
             }
         }
 
-        split_sensitive_spans.retain(|span| !use_replacement_spans.contains(span));
+        split_sensitive_spans.retain(|span| {
+            !use_replacement_spans.contains(span)
+                && !brace_expansion_spans
+                    .iter()
+                    .any(|brace_span| contains_span(*brace_span, *span))
+        });
         sort_and_dedup_spans(&mut split_sensitive_spans);
         split_sensitive_spans.into_boxed_slice()
     }

--- a/crates/shuck-linter/src/facts/tests/support.rs
+++ b/crates/shuck-linter/src/facts/tests/support.rs
@@ -4,7 +4,7 @@ use shuck_indexer::Indexer;
 use shuck_parser::parser::{Parser, ShellDialect as ParseShellDialect};
 use shuck_semantic::SemanticModel;
 
-use crate::{LinterFacts, ShellDialect, classify_file_context};
+use crate::{AmbientShellOptions, LinterFacts, ShellDialect, classify_file_context};
 
 pub(super) fn with_facts_dialect(
     source: &str,
@@ -17,7 +17,15 @@ pub(super) fn with_facts_dialect(
     let indexer = Indexer::new(source, &output);
     let semantic = SemanticModel::build(&output.file, source, &indexer);
     let file_context = classify_file_context(source, path, shell);
-    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+    let facts = LinterFacts::build_with_shell_and_ambient_shell_options(
+        &output.file,
+        source,
+        &semantic,
+        &indexer,
+        &file_context,
+        shell,
+        AmbientShellOptions::default(),
+    );
     visit(&output, &facts);
 }
 

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -2680,6 +2680,34 @@ arr=($prefix{a,b} {a,b}$suffix {pre$inside,other})
 }
 
 #[test]
+fn array_assignment_split_facts_keep_brace_literal_expansions_for_sh() {
+    let source = "\
+# shellcheck shell=sh
+arr=({pre$inside,other})
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Bash,
+        ShellDialect::Sh,
+        |_, facts| {
+            let split_sensitive = facts
+                .array_assignment_split_word_facts()
+                .flat_map(|fact| {
+                    fact.array_assignment_split_scalar_expansion_spans()
+                        .iter()
+                        .map(|span| span.slice(source).to_owned())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(split_sensitive, vec!["$inside"]);
+        },
+    );
+}
+
+#[test]
 fn surface_facts_track_parameter_operations_in_expanding_heredocs() {
     let source = "\
 cat <<EOF

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -2657,6 +2657,29 @@ arr=(${flag:+-f} ${flag:+$fallback} ${name:+\"$name\" \"$regex\"} ${items[@]+\"$
 }
 
 #[test]
+fn array_assignment_split_facts_ignore_expansions_inside_brace_fanout() {
+    let source = "\
+#!/bin/bash
+arr=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)
+arr=($prefix{a,b} {a,b}$suffix {pre$inside,other})
+";
+
+    with_facts(source, None, |_, facts| {
+        let split_sensitive = facts
+            .array_assignment_split_word_facts()
+            .flat_map(|fact| {
+                fact.array_assignment_split_scalar_expansion_spans()
+                    .iter()
+                    .map(|span| span.slice(source).to_owned())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(split_sensitive, vec!["$prefix", "$suffix"]);
+    });
+}
+
+#[test]
 fn surface_facts_track_parameter_operations_in_expanding_heredocs() {
     let source = "\
 cat <<EOF

--- a/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
@@ -58,7 +58,7 @@ fn is_excluded_special_parameter_span(span: Span, source: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_unquoted_expansions_in_array_assignments() {
@@ -210,6 +210,26 @@ arr=($prefix{a,b} {a,b}$suffix {pre$inside,other})
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$prefix", "$suffix"]
+        );
+    }
+
+    #[test]
+    fn reports_expansions_inside_literal_braces_for_sh() {
+        let source = "\
+# shellcheck shell=sh
+arr=({pre$inside,other})
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedArraySplit).with_shell(ShellDialect::Sh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$inside"]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
@@ -194,4 +194,22 @@ arr=(${flag:+-f} ${flag:+$fallback} ${name:+\"$name\" \"$regex\"} ${items[@]+\"$
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn ignores_expansions_inside_brace_expansion_templates() {
+        let source = "\
+#!/bin/bash
+arr=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)
+arr=($prefix{a,b} {a,b}$suffix {pre$inside,other})
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedArraySplit));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$prefix", "$suffix"]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- align S017 with the ShellCheck oracle for scalar expansions inside brace-expansion fanout templates
- keep S017 warnings for unquoted scalar expansions adjacent to brace fanout
- remove the old S017 corpus divergence metadata because the rule now matches the oracle

## Validation

- cargo test -p shuck-linter array_assignment_split_facts_ignore_expansions_inside_brace_fanout
- cargo test -p shuck-linter ignores_expansions_inside_brace_expansion_templates
- cargo test -p shuck-linter rules::style::tests
- make test
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S017 SHUCK_LARGE_CORPUS_KEEP_GOING=1

Note: the targeted large-corpus command reports implementation_diffs=0 and reviewed_divergences=0 for S017, but still exits nonzero due to two pre-existing parser harness failures outside S017.
