### PR TITLE
fix(linter): align X035 named coproc parity

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/x035.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/x035.yaml
@@ -1,11 +1,1 @@
-reviewed_divergences:
-  - side: shellcheck-only
-    path_suffix: "aristocratos__bashtop__bashtop"
-    line: 5287
-    end_line: 5287
-    reason: "This project-closure fixture uses the named bash coprocess form `coproc pycoproc (...)`. Here `pycoproc` is the coprocess identifier and `(...)` is the coprocess body, so the construct is not function-parameter syntax and Shuck correctly keeps X035 silent. The current oracle still maps this grammar to SC1065/X035 as if it were a `name(arg)` function form; if the surrounding dialect question mattered, the relevant portability issue would be `coproc` itself (X014/SC3032), not function parameters."
-  - side: shellcheck-only
-    path_suffix: "aristocratos__bashtop__bashtop"
-    line: 5302
-    end_line: 5302
-    reason: "This later project-closure site is the same named bash coprocess grammar: `coproc pycoproc (...)` with a coprocess name followed by the coprocess body. That shape is outside X035's function-parameter scope, so Shuck intentionally leaves it alone while the current oracle still misclassifies it as SC1065/X035; the only portability concern here would be `coproc` itself (X014/SC3032)."
+reviewed_divergences: []

--- a/crates/shuck-linter/resources/test/fixtures/portability/X035.sh
+++ b/crates/shuck-linter/resources/test/fixtures/portability/X035.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 f(x) { :; }
 function g(y) { :; }
+coproc pycoproc (python3 "$pywrapper")

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -241,6 +241,11 @@ fn build_function_parameter_fallback_spans(
     structural_commands
         .windows(2)
         .filter_map(|pair| function_parameter_fallback_span(pair, source))
+        .chain(
+            commands
+                .iter()
+                .filter_map(named_coproc_subshell_fallback_span),
+        )
         .collect()
 }
 
@@ -385,6 +390,24 @@ fn function_parameter_fallback_span(pair: &[&CommandFact<'_>], source: &str) -> 
     let relative = text.find('(')?;
     let start = first.span().start.advanced_by(&text[..relative]);
     Some(Span::from_positions(start, start.advanced_by("(")))
+}
+
+fn named_coproc_subshell_fallback_span(command: &CommandFact<'_>) -> Option<Span> {
+    let Command::Compound(CompoundCommand::Coproc(coproc)) = command.command() else {
+        return None;
+    };
+    coproc.name_span?;
+    let Command::Compound(CompoundCommand::Subshell(commands)) = &coproc.body.command else {
+        return None;
+    };
+    if commands.is_empty() {
+        return None;
+    }
+    let body_start = coproc.body.span.start;
+    if coproc.span.start.line != body_start.line {
+        return None;
+    }
+    Some(Span::from_positions(body_start, body_start))
 }
 fn build_function_call_arity_facts<'a>(
     semantic: &SemanticModel,

--- a/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
@@ -148,13 +148,16 @@ wget() { :; }
     }
 
     #[test]
-    fn ignores_named_coproc_syntax() {
+    fn reports_named_coproc_subshell_syntax() {
         let source = "\
 #!/bin/sh
 coproc pycoproc (python3 \"$pywrapper\")
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionParamsInSh));
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.column, 18);
+        assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 }

--- a/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X035_X035.sh.snap
+++ b/crates/shuck-linter/src/rules/portability/snapshots/shuck_linter__rules__portability__tests__X035_X035.sh.snap
@@ -12,3 +12,9 @@ X035 function definitions cannot take parameters in `sh` scripts
   |
 3 | function g(y) { :; }
   |
+
+X035 function definitions cannot take parameters in `sh` scripts
+ --> <source>:4:18
+  |
+4 | coproc pycoproc (python3 "$pywrapper")
+  |


### PR DESCRIPTION
## Summary
- Treat named `coproc name (...)` forms as X035 according to the ShellCheck oracle
- Remove the reviewed X035 divergence metadata for the bashtop named coprocess cases
- Add fixture and snapshot coverage for the named coprocess form

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter function_params_in_sh -- --nocapture`
- `cargo test -p shuck-linter rule_functionparamsinsh_path_new_x035_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=X035` reports `implementation_diffs=0` and `reviewed_divergences=0`; it still exits nonzero because of two unrelated harness parse failures in existing corpus fixtures.