### PR TITLE
fix(linter): align C125 with ShellCheck

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c125.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c125.yaml
@@ -1,13 +1,1 @@
-reviewed_divergences:
-- side: shuck-only
-  path_suffix: CISOfy__lynis__extras__build-lynis.sh
-  line: 298
-  reason: This packaging helper only descends into the `debian/` tree inside the satisfied `if` branch, but the unconditional `cd ..` afterward makes C125's current scope-local pairing heuristic over-approximate a manual restore that is not guaranteed on every path.
-- side: shellcheck-only
-  path_suffix: moovweb__gvm__examples__native__configure
-  line: 8237
-  reason: This generated configure probe repeats the same `cd out` / teardown / `cd ..` cleanup shape in multiple libtool checks. C125 intentionally keeps one manual-restore note per probe scope, while the current ShellCheck oracle still surfaces this duplicate generated cleanup site.
-- side: shellcheck-only
-  path_suffix: moovweb__gvm__examples__native__configure
-  line: 8292
-  reason: This generated configure probe repeats the same `cd out` / teardown / `cd ..` cleanup shape in multiple libtool checks. C125 intentionally keeps one manual-restore note per probe scope, while the current ShellCheck oracle still surfaces this duplicate generated cleanup site.
+reviewed_divergences: []

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change_in_function.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, CommandId, LinterFacts, Rule, Violation};
 use shuck_semantic::{ScopeId, ScopeKind};
 
 use super::unchecked_directory_change::{report_span, supports_directory_change_rules};
@@ -31,12 +31,13 @@ pub fn unchecked_directory_change_in_function(checker: &mut Checker) {
 
     let semantic = checker.semantic();
     let source = checker.source();
-    let mut pending_unchecked_cd_by_scope = HashMap::<ScopeId, usize>::new();
-    let mut reported_scope = std::collections::HashSet::<ScopeId>::new();
+    let mut pending_unchecked_cd_by_scope = HashMap::<(ScopeId, Option<CommandId>), usize>::new();
+    let mut reported_regions = std::collections::HashSet::<(ScopeId, Option<CommandId>)>::new();
     let mut reports = Vec::new();
 
     for fact in checker.facts().commands() {
         let scope = semantic.scope_at(fact.stmt().span.start.offset);
+        let barrier = nearest_dominance_barrier(checker.facts(), fact.id());
         if fact.is_nested_word_command()
             && !matches!(semantic.scope_kind(scope), ScopeKind::CommandSubstitution)
         {
@@ -53,11 +54,14 @@ pub fn unchecked_directory_change_in_function(checker: &mut Checker) {
             .flow_context_at(&fact.stmt().span)
             .map(|context| !context.exit_status_checked)
             .unwrap_or(true);
-        let pending_unchecked_cd = pending_unchecked_cd_by_scope.entry(scope).or_default();
+        let pending_key = (scope, barrier);
+        let pending_unchecked_cd = pending_unchecked_cd_by_scope
+            .entry(pending_key)
+            .or_default();
 
         if directory_change.is_manual_restore_candidate() {
             if *pending_unchecked_cd > 0 {
-                if unchecked && fact.wrappers().is_empty() && reported_scope.insert(scope) {
+                if unchecked && fact.wrappers().is_empty() && reported_regions.insert(pending_key) {
                     reports.push((directory_change.command_name(), report_span(fact, source)));
                 }
                 *pending_unchecked_cd -= 1;
@@ -73,6 +77,17 @@ pub fn unchecked_directory_change_in_function(checker: &mut Checker) {
     for (command, span) in reports {
         checker.report(UncheckedDirectoryChangeInFunction { command }, span);
     }
+}
+
+fn nearest_dominance_barrier(facts: &LinterFacts<'_>, id: CommandId) -> Option<CommandId> {
+    let mut parent = facts.command_parent_id(id);
+    while let Some(parent_id) = parent {
+        if facts.command_is_dominance_barrier(parent_id) {
+            return Some(parent_id);
+        }
+        parent = facts.command_parent_id(parent_id);
+    }
+    None
 }
 
 #[cfg(test)]
@@ -175,7 +190,7 @@ f() {
     }
 
     #[test]
-    fn only_reports_the_first_manual_restore_per_scope() {
+    fn only_reports_the_first_manual_restore_per_linear_region() {
         let source = "\
 #!/bin/sh
 f() {
@@ -194,6 +209,26 @@ f() {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "cd ..");
+    }
+
+    #[test]
+    fn ignores_restore_outside_conditional_entry_region() {
+        let source = "\
+#!/bin/sh
+f() {
+\tif [ -d /tmp ]; then
+\t\tcd /tmp
+\t\tpwd
+\tfi
+\tcd ..
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UncheckedDirectoryChangeInFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- align C125 pairing with ShellCheck by scoping pending directory changes to the nearest control-flow barrier
- remove the old reviewed-divergence metadata for C125
- add regression coverage for conditional branch restores

## Root cause
C125 previously paired an unchecked `cd` with a later manual restore across the whole semantic scope. That over-reported when the initial `cd` lived inside a conditional branch, and the documented metadata masked the mismatch. The rule now treats each nearest dominance barrier as its own linear region, matching the oracle while keeping one report per region.

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter unchecked_directory_change_in_function`
- `cargo test -p shuck-linter rule_uncheckeddirectorychangeinfunction_path_new_c125_sh_expects`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C125` reports `implementation_diffs=0` and `reviewed_divergences=0`; it still exits nonzero due to two unrelated parser harness failures.
