### PR TITLE
refactor(linter): rename parse-result lint entrypoint

### DIFF
--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -94,11 +94,12 @@ fn lint_source(
         )
     });
     let diagnostics = lint_file(
-        &output.file,
+        &output,
         source,
         &indexer,
         settings,
         suppression_index.as_ref(),
+        None,
     );
 
     black_box(diagnostics.len())

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -265,11 +265,12 @@ mod tests {
                 )
             });
             let diagnostics = lint_file(
-                &output.file,
+                &output,
                 file.source,
                 &indexer,
                 &settings,
                 suppression_index.as_ref(),
+                None,
             );
 
             assert!(

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1486,7 +1486,7 @@ fn collect_lint_diagnostics(
             first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
         )
     });
-    shuck_linter::lint_file_at_path_with_parse_result(
+    shuck_linter::lint_file(
         parse_result,
         source,
         &indexer,

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -244,7 +244,7 @@ mod tests {
     use shuck_ast::{AssignmentValue, Command};
     use shuck_benchmark::TEST_FILES;
     use shuck_indexer::Indexer;
-    use shuck_linter::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_result};
+    use shuck_linter::{Diagnostic, LinterSettings, lint_file};
     use shuck_parser::ShellDialect as ParseShellDialect;
 
     use super::*;
@@ -296,14 +296,7 @@ mod tests {
         );
         let indexer = Indexer::new(source, &parse_result);
         let settings = LinterSettings::default().with_analyzed_paths([path.to_path_buf()]);
-        lint_file_at_path_with_parse_result(
-            &parse_result,
-            source,
-            &indexer,
-            &settings,
-            None,
-            Some(path),
-        )
+        lint_file(&parse_result, source, &indexer, &settings, None, Some(path))
     }
 
     fn diagnostic_count(diagnostics: &[Diagnostic], code: &str) -> usize {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -331,17 +331,6 @@ fn parse_error_position(parse_result: &ParseResult) -> Option<(usize, usize)> {
         .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
 }
 
-/// Lints a parsed file and returns diagnostics only.
-pub fn lint_file(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-) -> Vec<Diagnostic> {
-    lint_file_at_path(file, source, indexer, settings, suppression_index, None)
-}
-
 /// Lints a parsed file located at an optional source path.
 pub fn lint_file_at_path(
     file: &File,
@@ -468,7 +457,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
 }
 
 /// Lints an existing parse result located at an optional source path.
-pub fn lint_file_at_path_with_parse_result(
+pub fn lint_file(
     parse_result: &ParseResult,
     source: &str,
     indexer: &Indexer,
@@ -611,7 +600,7 @@ mod tests {
     fn lint(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        lint_file(&output.file, source, &indexer, settings, None)
+        lint_file(&output, source, &indexer, settings, None, None)
     }
 
     fn lint_path(path: &Path, settings: &LinterSettings) -> Vec<Diagnostic> {
@@ -659,15 +648,16 @@ mod tests {
     }
 
     #[test]
-    fn legacy_lint_entrypoints_preserve_parse_rule_diagnostics() {
+    fn lint_file_preserves_parse_rule_diagnostics() {
         let source = "#!/bin/sh\n{ :; } always { :; }\n";
         let parse_result = Parser::new(source).parse();
         let indexer = Indexer::new(source, &parse_result);
         let diagnostics = lint_file(
-            &parse_result.file,
+            &parse_result,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::ZshAlwaysBlock),
+            None,
             None,
         );
 
@@ -1511,7 +1501,7 @@ END
         for (path, dialect) in cases {
             let parse_result = Parser::with_dialect(source, dialect).parse();
             let indexer = Indexer::new(source, &parse_result);
-            let diagnostics = lint_file_at_path_with_parse_result(
+            let diagnostics = lint_file(
                 &parse_result,
                 source,
                 &indexer,
@@ -4092,11 +4082,12 @@ foo=1
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::default(),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4125,11 +4116,12 @@ f() {
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::RedundantReturnStatus),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4156,11 +4148,12 @@ printf '%s\\n' \"$foo\"
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::default(),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4189,11 +4182,12 @@ f() {
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::LocalDeclareCombined),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4219,11 +4213,12 @@ f() {
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::BacktickInCommandPosition),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4249,11 +4244,12 @@ f() {
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::CompoundTestOperator),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4283,11 +4279,12 @@ f
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::LocalVariableInSh),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4313,11 +4310,12 @@ function f { :; }
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::FunctionKeyword),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4343,11 +4341,12 @@ function f { :; }
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::BackslashBeforeCommand),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4373,11 +4372,12 @@ echo \\n
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::LiteralControlEscape),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4403,11 +4403,12 @@ let x=1
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::LetCommand),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4433,11 +4434,12 @@ declare foo=bar
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::DeclareCommand),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4463,11 +4465,12 @@ source ./helpers.sh
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::SourceBuiltinInSh),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4493,11 +4496,12 @@ function f() { :; }
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::FunctionKeywordInSh),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4523,11 +4527,12 @@ arr[$((1+1))]=x
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::ArrayIndexArithmetic),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }
@@ -4555,11 +4560,12 @@ f() {
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         );
         let diagnostics = lint_file(
-            &output.file,
+            &output,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::SourceInsideFunctionInSh),
             Some(&suppressions),
+            None,
         );
         assert!(diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -122,7 +122,7 @@ mod tests {
     use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
     use crate::{
         Applicability, Diagnostic, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff,
-        lint_file_at_path_with_parse_result,
+        lint_file,
     };
 
     fn test_posix_snippet_at_path(path: &Path, source: &str) -> Vec<Diagnostic> {
@@ -130,14 +130,7 @@ mod tests {
         let indexer = Indexer::new(source, &parse_result);
         let settings =
             LinterSettings::for_rule(Rule::EscapedUnderscore).with_shell(ShellDialect::Sh);
-        lint_file_at_path_with_parse_result(
-            &parse_result,
-            source,
-            &indexer,
-            &settings,
-            None,
-            Some(path),
-        )
+        lint_file(&parse_result, source, &indexer, &settings, None, Some(path))
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -11,7 +11,7 @@ use shuck_parser::{
     parser::{ParseResult, Parser},
 };
 
-use crate::{Diagnostic, LinterSettings, Rule, ShellDialect, lint_file_at_path_with_parse_result};
+use crate::{Diagnostic, LinterSettings, Rule, ShellDialect, lint_file};
 
 use super::{
     ShellCheckCodeMap, SuppressionAction, SuppressionDirective, SuppressionIndex,
@@ -126,7 +126,7 @@ fn analyze_source(
             first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
         )
     });
-    let diagnostics = lint_file_at_path_with_parse_result(
+    let diagnostics = lint_file(
         &parse_result,
         source,
         &indexer,

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -7,9 +7,7 @@ use shuck_parser::ShellProfile;
 use shuck_parser::parser::{ParseResult, Parser, ShellDialect as ParseShellDialect};
 use similar::TextDiff;
 
-use crate::{
-    Applicability, Diagnostic, LinterSettings, apply_fixes, lint_file_at_path_with_parse_result,
-};
+use crate::{Applicability, Diagnostic, LinterSettings, apply_fixes, lint_file};
 
 fn inferred_shell_profile(
     source: &str,
@@ -50,7 +48,7 @@ pub struct FixTestResult {
 pub fn test_snippet(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
     let parse_result = parse_for_lint(source, settings, None);
     let indexer = Indexer::new(source, &parse_result);
-    lint_file_at_path_with_parse_result(&parse_result, source, &indexer, settings, None, None)
+    lint_file(&parse_result, source, &indexer, settings, None, None)
 }
 
 /// Lint a source string while preserving an explicit path for path-sensitive rules.
@@ -61,7 +59,7 @@ pub fn test_snippet_at_path(
 ) -> Vec<Diagnostic> {
     let parse_result = parse_for_lint(source, settings, Some(path));
     let indexer = Indexer::new(source, &parse_result);
-    lint_file_at_path_with_parse_result(&parse_result, source, &indexer, settings, None, Some(path))
+    lint_file(&parse_result, source, &indexer, settings, None, Some(path))
 }
 
 pub fn test_snippet_with_fix(

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -10,7 +10,7 @@ use shuck_formatter::{
     format_source, source_is_formatted,
 };
 use shuck_indexer::Indexer;
-use shuck_linter::{Diagnostic, LinterSettings, lint_file_at_path_with_parse_result};
+use shuck_linter::{Diagnostic, LinterSettings, lint_file};
 use shuck_parser::{ShellDialect as ParseDialect, parser::{ParseResult, Parser}};
 
 const MAX_FUZZ_INPUT_BYTES: usize = 16 * 1024;
@@ -124,7 +124,7 @@ pub(crate) fn lint_source_with_recovery(
         Some(path) => LinterSettings::default().with_analyzed_paths([path.to_path_buf()]),
         None => LinterSettings::default(),
     };
-    lint_file_at_path_with_parse_result(
+    lint_file(
         &parse_result,
         source,
         &indexer,
@@ -149,7 +149,7 @@ pub(crate) fn lint_source_strict(
     }
     let indexer = Indexer::new(source, &parse_result);
     let settings = LinterSettings::default().with_analyzed_paths([path.to_path_buf()]);
-    lint_file_at_path_with_parse_result(
+    lint_file(
         &parse_result,
         source,
         &indexer,

--- a/specs/005-linter.md
+++ b/specs/005-linter.md
@@ -51,7 +51,7 @@ This gives each category 999 rule slots — more than enough. The scheme is exte
 crates/shuck-linter/
 ├── Cargo.toml
 └── src/
-    ├── lib.rs              # Public API: analyze_file(), lint_file(), LinterSettings
+    ├── lib.rs              # Public API: analyze_file(), lint_file(), lint_file_at_path*, LinterSettings
     ├── registry.rs         # Rule enum, Category enum, code→rule mapping
     ├── rule_set.rs         # Bitset of enabled rules
     ├── rule_selector.rs    # Parsing user selections ("SHC", "SHC001")
@@ -585,26 +585,32 @@ impl LinterSettings {
 The top-level entry point consumed by the CLI:
 
 ```rust
-/// Lint a single parsed file and return diagnostics.
+/// Lint an existing parse result and return diagnostics.
 pub fn lint_file(
-    script: &Script,
+    parse_result: &ParseResult,
     source: &str,
-    semantic: &SemanticModel,
     indexer: &Indexer,
     settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
 ) -> Vec<Diagnostic> {
-    let checker = Checker::new(script, source, semantic, indexer, &settings.rules);
-    let mut diagnostics = checker.check();
+    let analysis = analyze_file_at_path(
+        &parse_result.file,
+        source,
+        indexer,
+        settings,
+        source_path,
+    );
+    let mut diagnostics = analysis.diagnostics;
 
-    // Apply severity overrides
+    // Add parse-aware rule diagnostics, then apply severity overrides,
+    // suppression filtering, per-file ignores, and stable ordering.
+    diagnostics.extend(collect_parse_rule_diagnostics(parse_result, source, settings));
     for diag in &mut diagnostics {
         if let Some(&severity) = settings.severity_overrides.get(&diag.rule) {
             diag.severity = severity;
         }
     }
-
-    // Sort by source position for stable output
-    diagnostics.sort_by_key(|d| (d.span.start.offset, d.span.end.offset));
     diagnostics
 }
 ```
@@ -617,12 +623,12 @@ How the linter fits into `shuck check`:
 Source text
     → shuck-parser::Parser::parse()       → ParseOutput (Script + Comments)
     → shuck-indexer::Indexer::new()        → Indexer
-    → shuck-linter::analyze_file()         → AnalysisResult { semantic, diagnostics }
-    → shuck-linter::lint_file()            → Vec<Diagnostic> (wrapper)
+    → shuck-linter::lint_file()
+                                             → Vec<Diagnostic>
     → CLI formats and prints diagnostics
 ```
 
-The CLI owns the pipeline. The linter is a pure function: `(AST, source, indexer, settings) → AnalysisResult`, with `lint_file` as the diagnostics-only convenience wrapper. No I/O, no caching, no output formatting.
+The CLI owns the pipeline. The linter is a pure function over parsed input, source text, an indexer, and settings. It performs no I/O, caching, or output formatting.
 
 ## Alternatives Considered
 

--- a/specs/006-suppressions.md
+++ b/specs/006-suppressions.md
@@ -252,19 +252,26 @@ This is equivalent to the Go `NextCommandLineRange()` function. It walks all sta
 Following ruff's post-hoc pattern, suppressions are applied **after** the checker runs:
 
 ```rust
-/// Lint a single parsed file and return diagnostics.
+/// Lint an existing parse result and return diagnostics.
 pub fn lint_file(
-    script: &Script,
+    parse_result: &ParseResult,
     source: &str,
-    semantic: &SemanticModel,
     indexer: &Indexer,
     settings: &LinterSettings,
     suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
 ) -> Vec<Diagnostic> {
-    let checker = Checker::new(script, source, semantic, indexer, &settings.rules);
-    let mut diagnostics = checker.check();
+    let analysis = analyze_file_at_path(
+        &parse_result.file,
+        source,
+        indexer,
+        settings,
+        source_path,
+    );
+    let mut diagnostics = analysis.diagnostics;
 
-    // Apply severity overrides
+    // Add parse-aware rule diagnostics, then apply severity overrides.
+    diagnostics.extend(collect_parse_rule_diagnostics(parse_result, source, settings));
     for diag in &mut diagnostics {
         if let Some(&severity) = settings.severity_overrides.get(&diag.rule) {
             diag.severity = severity;
@@ -279,12 +286,12 @@ pub fn lint_file(
         });
     }
 
-    diagnostics.sort_by_key(|d| (d.span.start(), d.span.end()));
+    diagnostics.sort_by_key(|d| (d.span.start.offset, d.span.end.offset));
     diagnostics
 }
 ```
 
-The `SuppressionIndex` is built **before** `lint_file` is called — the caller (CLI pipeline) constructs it from the comment index and passes it in. This keeps the linter crate's dependency on suppression parsing explicit and optional.
+The `SuppressionIndex` is built **before** the linter entry point is called — the caller (CLI pipeline) constructs it from the comment index and passes it in. This keeps the linter crate's dependency on suppression parsing explicit and optional.
 
 ### Data Flow
 
@@ -297,7 +304,8 @@ Source text
     → parse_directives()                   → Vec<SuppressionDirective>
     → SuppressionIndex::new()              → SuppressionIndex
     → shuck-semantic::SemanticModel::new() → SemanticModel
-    → shuck-linter::lint_file()            → Vec<Diagnostic>  (filtered by suppressions)
+    → shuck-linter::lint_file()
+                                             → Vec<Diagnostic>  (filtered by suppressions)
     → CLI formats and prints diagnostics
 ```
 
@@ -358,7 +366,7 @@ Once implemented, verify with:
 - **Shuck whole-file detection**: `# shuck: disable=C001` before the first statement suppresses the rule for all lines.
 - **ShellCheck next-command scope**: `# shellcheck disable=SC2086` on line 5 (after first statement) suppresses only the lines spanned by the next `Stmt` node. A diagnostic on a subsequent statement is not suppressed.
 - **ShellCheck whole-file detection**: `# shellcheck disable=SC2086` before the first statement suppresses the rule for all lines.
-- **Post-hoc filtering**: `lint_file()` with a suppression index filters out diagnostics on suppressed lines while preserving diagnostics on non-suppressed lines.
+- **Post-hoc filtering**: the linter entry point with a suppression index filters out diagnostics on suppressed lines while preserving diagnostics on non-suppressed lines.
 - **Multiple codes**: `# shuck: disable=C001,C002,C003` suppresses all three rules.
 - **Reason stripping**: `# shuck: disable=C001 # legacy code` parses correctly, ignoring the reason.
 - **Unknown codes**: `# shellcheck disable=SC7777` (unmapped) is silently ignored and produces no suppression entries.


### PR DESCRIPTION
## Summary

- remove the old parsed-file-only `lint_file` wrapper and make the parse-result-based API the public `lint_file` entry point
- update CLI, formatter, benchmark, suppression, fuzz, and linter test callsites to use the renamed API
- refresh linter and suppression specs so they document the current `lint_file()` pipeline

## Why

The previous convenience wrapper was only used by tests and benchmarks, and it forced an extra parse in benchmark paths. Renaming the parse-result entry point keeps the public API short while preserving parse-aware diagnostics and avoiding redundant parsing.

## Validation

- `cargo test -p shuck-linter -p shuck-benchmark --lib`
- `cargo check -p shuck-cli -p shuck-formatter -p shuck-benchmark --all-targets`
- `cargo check --manifest-path fuzz/Cargo.toml`
- `git diff --check`