### PR TITLE
perf(parser): inline small word parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,7 @@ name = "shuck-ast"
 version = "0.0.19"
 dependencies = [
  "compact_str",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/shuck-ast/Cargo.toml
+++ b/crates/shuck-ast/Cargo.toml
@@ -15,5 +15,6 @@ readme = "README.md"
 
 [dependencies]
 compact_str = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -9,6 +9,7 @@ use crate::{
     Name,
     span::{Position, Span, TextRange},
 };
+use smallvec::{SmallVec, smallvec};
 use std::{
     borrow::Cow,
     fmt,
@@ -374,9 +375,9 @@ pub struct Subscript {
     pub kind: SubscriptKind,
     pub interpretation: SubscriptInterpretation,
     /// Parsed word view of the original subscript syntax.
-    pub word_ast: Option<Word>,
+    pub word_ast: Option<Box<Word>>,
     /// Typed arithmetic view of this subscript when it parses as arithmetic.
-    pub arithmetic_ast: Option<ArithmeticExprNode>,
+    pub arithmetic_ast: Option<Box<ArithmeticExprNode>>,
 }
 
 impl Subscript {
@@ -408,7 +409,7 @@ impl Subscript {
     }
 
     pub fn word_ast(&self) -> Option<&Word> {
-        self.word_ast.as_ref()
+        self.word_ast.as_deref()
     }
 }
 
@@ -417,7 +418,7 @@ impl Subscript {
 pub struct VarRef {
     pub name: Name,
     pub name_span: Span,
-    pub subscript: Option<Subscript>,
+    pub subscript: Option<Box<Subscript>>,
     pub span: Span,
 }
 
@@ -425,13 +426,13 @@ impl VarRef {
     pub fn has_array_selector(&self) -> bool {
         self.subscript
             .as_ref()
-            .is_some_and(Subscript::is_array_selector)
+            .is_some_and(|subscript| subscript.is_array_selector())
     }
 
     pub fn is_source_backed(&self) -> bool {
         self.subscript
             .as_ref()
-            .is_none_or(Subscript::is_source_backed)
+            .is_none_or(|subscript| subscript.is_source_backed())
     }
 }
 
@@ -988,7 +989,7 @@ pub enum ArithmeticExpr {
         index: Box<ArithmeticExprNode>,
     },
     /// Shell-evaluated primary such as `$x`, `${x}`, `"3"`, or `$(cmd)`.
-    ShellWord(Word),
+    ShellWord(Box<Word>),
     Parenthesized {
         expression: Box<ArithmeticExprNode>,
     },
@@ -1352,7 +1353,7 @@ pub enum BourneParameterExpansion {
         reference: VarRef,
         operator: Option<ParameterOp>,
         operand: Option<SourceText>,
-        operand_word_ast: Option<Word>,
+        operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     PrefixMatch {
@@ -1361,18 +1362,18 @@ pub enum BourneParameterExpansion {
     },
     Slice {
         reference: VarRef,
-        offset: SourceText,
-        offset_ast: Option<ArithmeticExprNode>,
-        offset_word_ast: Word,
-        length: Option<SourceText>,
-        length_ast: Option<ArithmeticExprNode>,
-        length_word_ast: Option<Word>,
+        offset: Box<SourceText>,
+        offset_ast: Option<Box<ArithmeticExprNode>>,
+        offset_word_ast: Box<Word>,
+        length: Option<Box<SourceText>>,
+        length_ast: Option<Box<ArithmeticExprNode>>,
+        length_word_ast: Option<Box<Word>>,
     },
     Operation {
         reference: VarRef,
         operator: ParameterOp,
         operand: Option<SourceText>,
-        operand_word_ast: Option<Word>,
+        operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     Transformation {
@@ -1389,7 +1390,7 @@ impl BourneParameterExpansion {
             }
             | Self::Operation {
                 operand_word_ast, ..
-            } => operand_word_ast.as_ref(),
+            } => operand_word_ast.as_deref(),
             Self::Access { .. }
             | Self::Length { .. }
             | Self::Indices { .. }
@@ -1418,7 +1419,7 @@ impl BourneParameterExpansion {
         match self {
             Self::Slice {
                 length_word_ast, ..
-            } => length_word_ast.as_ref(),
+            } => length_word_ast.as_deref(),
             Self::Access { .. }
             | Self::Length { .. }
             | Self::Indices { .. }
@@ -1443,7 +1444,7 @@ pub struct ZshParameterExpansion {
 pub enum ZshExpansionTarget {
     Reference(VarRef),
     Nested(Box<ParameterExpansion>),
-    Word(Word),
+    Word(Box<Word>),
     Empty,
 }
 
@@ -1451,14 +1452,14 @@ pub enum ZshExpansionTarget {
 pub struct ZshModifier {
     pub name: char,
     pub argument: Option<SourceText>,
-    pub argument_word_ast: Option<Word>,
+    pub argument_word_ast: Option<Box<Word>>,
     pub argument_delimiter: Option<char>,
     pub span: Span,
 }
 
 impl ZshModifier {
     pub fn argument_word_ast(&self) -> Option<&Word> {
-        self.argument_word_ast.as_ref()
+        self.argument_word_ast.as_deref()
     }
 }
 
@@ -1467,35 +1468,35 @@ pub enum ZshExpansionOperation {
     PatternOperation {
         kind: ZshPatternOp,
         operand: SourceText,
-        operand_word_ast: Word,
+        operand_word_ast: Box<Word>,
     },
     Defaulting {
         kind: ZshDefaultingOp,
         operand: SourceText,
-        operand_word_ast: Word,
+        operand_word_ast: Box<Word>,
         colon_variant: bool,
     },
     TrimOperation {
         kind: ZshTrimOp,
         operand: SourceText,
-        operand_word_ast: Word,
+        operand_word_ast: Box<Word>,
     },
     ReplacementOperation {
         kind: ZshReplacementOp,
         pattern: SourceText,
-        pattern_word_ast: Word,
+        pattern_word_ast: Box<Word>,
         replacement: Option<SourceText>,
-        replacement_word_ast: Option<Word>,
+        replacement_word_ast: Option<Box<Word>>,
     },
     Slice {
-        offset: SourceText,
-        offset_word_ast: Word,
-        length: Option<SourceText>,
-        length_word_ast: Option<Word>,
+        offset: Box<SourceText>,
+        offset_word_ast: Box<Word>,
+        length: Option<Box<SourceText>>,
+        length_word_ast: Option<Box<Word>>,
     },
     Unknown {
         text: SourceText,
-        word_ast: Word,
+        word_ast: Box<Word>,
     },
 }
 
@@ -1534,7 +1535,7 @@ impl ZshExpansionOperation {
             Self::ReplacementOperation {
                 replacement_word_ast,
                 ..
-            } => replacement_word_ast.as_ref(),
+            } => replacement_word_ast.as_deref(),
             Self::PatternOperation { .. }
             | Self::Defaulting { .. }
             | Self::TrimOperation { .. }
@@ -1560,7 +1561,7 @@ impl ZshExpansionOperation {
         match self {
             Self::Slice {
                 length_word_ast, ..
-            } => length_word_ast.as_ref(),
+            } => length_word_ast.as_deref(),
             Self::PatternOperation { .. }
             | Self::Defaulting { .. }
             | Self::TrimOperation { .. }
@@ -1736,10 +1737,13 @@ impl WordPartNode {
     }
 }
 
+/// Inline-optimized storage for the parts that make up a shell word.
+pub type WordParts = SmallVec<[WordPartNode; 2]>;
+
 /// A word (potentially with expansions).
 #[derive(Debug, Clone)]
 pub struct Word {
-    pub parts: Vec<WordPartNode>,
+    pub parts: WordParts,
     /// Source span of this word
     pub span: Span,
     /// Parser-owned brace surface classification for this word.
@@ -1755,7 +1759,7 @@ impl Word {
     /// Create a simple literal word with an explicit source span.
     pub fn literal_with_span(s: impl Into<String>, span: Span) -> Self {
         Self {
-            parts: vec![WordPartNode::new(
+            parts: smallvec![WordPartNode::new(
                 WordPart::Literal(LiteralText::owned(s.into())),
                 span,
             )],
@@ -1772,7 +1776,7 @@ impl Word {
     /// Create a quoted literal word with an explicit source span.
     pub fn quoted_literal_with_span(s: impl Into<String>, span: Span) -> Self {
         Self {
-            parts: vec![WordPartNode::new(
+            parts: smallvec![WordPartNode::new(
                 WordPart::SingleQuoted {
                     value: SourceText::cooked(span, s.into()),
                     dollar: false,
@@ -1787,7 +1791,7 @@ impl Word {
     /// Create a source-backed literal word.
     pub fn source_literal_with_spans(span: Span, part_span: Span) -> Self {
         Self {
-            parts: vec![WordPartNode::new(
+            parts: smallvec![WordPartNode::new(
                 WordPart::Literal(LiteralText::source()),
                 part_span,
             )],
@@ -1799,7 +1803,7 @@ impl Word {
     /// Create a quoted source-backed literal word.
     pub fn quoted_source_literal_with_spans(span: Span, part_span: Span) -> Self {
         Self {
-            parts: vec![WordPartNode::new(
+            parts: smallvec![WordPartNode::new(
                 WordPart::SingleQuoted {
                     value: SourceText::source(part_span),
                     dollar: false,
@@ -2632,7 +2636,7 @@ pub enum PatternPart {
         kind: PatternGroupKind,
         patterns: Vec<Pattern>,
     },
-    Word(Word),
+    Word(Box<Word>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2735,7 +2739,7 @@ pub enum WordPart {
     /// Literal text
     Literal(LiteralText),
     /// Zsh glob with one classic trailing qualifier group such as `*(.)`.
-    ZshQualifiedGlob(ZshQualifiedGlob),
+    ZshQualifiedGlob(Box<ZshQualifiedGlob>),
     /// Single-quoted literal content, including `$'...'` ANSI-C quoting.
     SingleQuoted { value: SourceText, dollar: bool },
     /// Double-quoted content with nested expansions.
@@ -2747,72 +2751,72 @@ pub enum WordPart {
     Variable(Name),
     /// Command substitution ($(...)) or legacy backticks.
     CommandSubstitution {
-        body: StmtSeq,
+        body: Box<StmtSeq>,
         syntax: CommandSubstitutionSyntax,
     },
     /// Arithmetic expansion ($((...)) or legacy $[...]).
     ArithmeticExpansion {
         expression: SourceText,
         /// Typed arithmetic view of `expression`.
-        expression_ast: Option<ArithmeticExprNode>,
+        expression_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `expression`.
-        expression_word_ast: Word,
+        expression_word_ast: Box<Word>,
         syntax: ArithmeticExpansionSyntax,
     },
     /// Unified parameter-expansion family for `${...}` forms.
-    Parameter(ParameterExpansion),
+    Parameter(Box<ParameterExpansion>),
     /// Parameter expansion with operator ${var:-default}, ${var:=default}, etc.
     /// `colon_variant` distinguishes `:-` (unset-or-empty) from `-` (unset-only).
     ParameterExpansion {
-        reference: VarRef,
-        operator: ParameterOp,
-        operand: Option<SourceText>,
-        operand_word_ast: Option<Word>,
+        reference: Box<VarRef>,
+        operator: Box<ParameterOp>,
+        operand: Option<Box<SourceText>>,
+        operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     /// Length expansion ${#var}
-    Length(VarRef),
+    Length(Box<VarRef>),
     /// Array element access `${arr[index]}` or `${arr[@]}` or `${arr[*]}`
-    ArrayAccess(VarRef),
+    ArrayAccess(Box<VarRef>),
     /// Array length `${#arr[@]}` or `${#arr[*]}`
-    ArrayLength(VarRef),
+    ArrayLength(Box<VarRef>),
     /// Array indices `${!arr[@]}` or `${!arr[*]}`
-    ArrayIndices(VarRef),
+    ArrayIndices(Box<VarRef>),
     /// Substring extraction `${var:offset}` or `${var:offset:length}`
     Substring {
-        reference: VarRef,
-        offset: SourceText,
+        reference: Box<VarRef>,
+        offset: Box<SourceText>,
         /// Typed arithmetic view of `offset` when it parses as arithmetic.
-        offset_ast: Option<ArithmeticExprNode>,
+        offset_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `offset`.
-        offset_word_ast: Word,
-        length: Option<SourceText>,
+        offset_word_ast: Box<Word>,
+        length: Option<Box<SourceText>>,
         /// Typed arithmetic view of `length` when it parses as arithmetic.
-        length_ast: Option<ArithmeticExprNode>,
+        length_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `length`.
-        length_word_ast: Option<Word>,
+        length_word_ast: Option<Box<Word>>,
     },
     /// Array slice `${arr[@]:offset:length}`
     ArraySlice {
-        reference: VarRef,
-        offset: SourceText,
+        reference: Box<VarRef>,
+        offset: Box<SourceText>,
         /// Typed arithmetic view of `offset` when it parses as arithmetic.
-        offset_ast: Option<ArithmeticExprNode>,
+        offset_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `offset`.
-        offset_word_ast: Word,
-        length: Option<SourceText>,
+        offset_word_ast: Box<Word>,
+        length: Option<Box<SourceText>>,
         /// Typed arithmetic view of `length` when it parses as arithmetic.
-        length_ast: Option<ArithmeticExprNode>,
+        length_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `length`.
-        length_word_ast: Option<Word>,
+        length_word_ast: Option<Box<Word>>,
     },
     /// Indirect expansion `${!var}` - expands to value of variable named by var's value
     /// Optionally composed with an operator: `${!var:-default}`, `${!var:=val}`, etc.
     IndirectExpansion {
-        reference: VarRef,
-        operator: Option<ParameterOp>,
-        operand: Option<SourceText>,
-        operand_word_ast: Option<Word>,
+        reference: Box<VarRef>,
+        operator: Option<Box<ParameterOp>>,
+        operand: Option<Box<SourceText>>,
+        operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     /// Prefix matching `${!prefix*}` or `${!prefix@}` - names of variables with given prefix
@@ -2820,12 +2824,15 @@ pub enum WordPart {
     /// Process substitution <(cmd) or >(cmd)
     ProcessSubstitution {
         /// The commands to run
-        body: StmtSeq,
+        body: Box<StmtSeq>,
         /// True for <(cmd), false for >(cmd)
         is_input: bool,
     },
     /// Parameter transformation `${var@op}` where op is Q, E, P, A, K, a, u, U, L
-    Transformation { reference: VarRef, operator: char },
+    Transformation {
+        reference: Box<VarRef>,
+        operator: char,
+    },
 }
 
 impl WordPart {
@@ -3145,7 +3152,7 @@ fn fmt_word_part_with_source_mode(
             operand,
             colon_variant,
             ..
-        } => match operator {
+        } => match operator.as_ref() {
             ParameterOp::UseDefault => {
                 let c = if *colon_variant { ":" } else { "" };
                 write!(f, "${{")?;
@@ -3154,7 +3161,7 @@ fn fmt_word_part_with_source_mode(
                     f,
                     "{}-{}}}",
                     c,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             }
             ParameterOp::AssignDefault => {
@@ -3165,7 +3172,7 @@ fn fmt_word_part_with_source_mode(
                     f,
                     "{}={}}}",
                     c,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             }
             ParameterOp::UseReplacement => {
@@ -3176,7 +3183,7 @@ fn fmt_word_part_with_source_mode(
                     f,
                     "{}+{}}}",
                     c,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             }
             ParameterOp::Error => {
@@ -3187,7 +3194,7 @@ fn fmt_word_part_with_source_mode(
                     f,
                     "{}?{}}}",
                     c,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             }
             ParameterOp::RemovePrefixShort { pattern } => {
@@ -3334,7 +3341,7 @@ fn fmt_word_part_with_source_mode(
             fmt_var_ref_with_source(&mut reference_syntax, reference, source)?;
             if let Some(op) = operator {
                 let c = if *colon_variant { ":" } else { "" };
-                let op_char = match op {
+                let op_char = match op.as_ref() {
                     ParameterOp::UseDefault => "-",
                     ParameterOp::AssignDefault => "=",
                     ParameterOp::UseReplacement => "+",
@@ -3347,7 +3354,7 @@ fn fmt_word_part_with_source_mode(
                     reference_syntax,
                     c,
                     op_char,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             } else {
                 write!(f, "${{!{}}}", reference_syntax)?
@@ -3482,7 +3489,7 @@ fn part_is_source_backed(part: &WordPart) -> bool {
         } => {
             reference.is_source_backed()
                 && operator_is_source_backed(operator)
-                && operand.as_ref().is_none_or(SourceText::is_source_backed)
+                && operand.as_deref().is_none_or(SourceText::is_source_backed)
         }
         WordPart::Length(reference)
         | WordPart::ArrayAccess(reference)
@@ -3507,7 +3514,7 @@ fn part_is_source_backed(part: &WordPart) -> bool {
         } => {
             reference.is_source_backed()
                 && operator.is_none()
-                && operand.as_ref().is_none_or(SourceText::is_source_backed)
+                && operand.as_deref().is_none_or(SourceText::is_source_backed)
         }
         WordPart::CommandSubstitution { .. }
         | WordPart::Variable(_)
@@ -3675,13 +3682,13 @@ pub enum ParameterOp {
     ReplaceFirst {
         pattern: Pattern,
         replacement: SourceText,
-        replacement_word_ast: Word,
+        replacement_word_ast: Box<Word>,
     },
     /// // pattern replacement (all occurrences)
     ReplaceAll {
         pattern: Pattern,
         replacement: SourceText,
-        replacement_word_ast: Word,
+        replacement_word_ast: Box<Word>,
     },
     /// ^ uppercase first char
     UpperFirst,
@@ -3895,14 +3902,14 @@ mod tests {
         VarRef {
             name: name.into(),
             name_span: span,
-            subscript: Some(Subscript {
+            subscript: Some(Box::new(Subscript {
                 text: index.into(),
                 raw: None,
                 kind: SubscriptKind::Ordinary,
                 interpretation: SubscriptInterpretation::Contextual,
                 word_ast: None,
                 arithmetic_ast: None,
-            }),
+            })),
             span,
         }
     }
@@ -3912,14 +3919,14 @@ mod tests {
         VarRef {
             name: name.into(),
             name_span: span,
-            subscript: Some(Subscript {
+            subscript: Some(Box::new(Subscript {
                 text: selector.as_char().to_string().into(),
                 raw: None,
                 kind: SubscriptKind::Selector(selector),
                 interpretation: SubscriptInterpretation::Contextual,
                 word_ast: None,
                 arithmetic_ast: None,
-            }),
+            })),
             span,
         }
     }
@@ -4008,7 +4015,8 @@ mod tests {
                     },
                     span,
                 ),
-            ],
+            ]
+            .into(),
             span,
             brace_syntax: Vec::new(),
         };
@@ -4059,7 +4067,8 @@ mod tests {
                     },
                     span,
                 ),
-            ],
+            ]
+            .into(),
             span,
             brace_syntax: Vec::new(),
         };
@@ -4084,7 +4093,7 @@ mod tests {
             WordPart::Variable("name".into())
         ])));
         assert!(word_is_standalone_variable_like(&word(vec![
-            WordPart::Length(plain_ref("name"))
+            WordPart::Length(Box::new(plain_ref("name")))
         ])));
         assert!(!word_is_standalone_variable_like(&word(vec![
             WordPart::Literal(LiteralText::owned("prefix")),
@@ -4116,13 +4125,13 @@ mod tests {
             }
         ])));
         assert!(word_is_standalone_status_capture(&word(vec![
-            WordPart::Parameter(ParameterExpansion {
+            WordPart::Parameter(Box::new(ParameterExpansion {
                 syntax: ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access {
                     reference: plain_ref("?"),
                 }),
                 span: Span::new(),
                 raw_body: "?".into(),
-            })
+            }))
         ])));
         assert!(!word_is_standalone_status_capture(&word(vec![
             WordPart::Variable("name".into())
@@ -4246,12 +4255,12 @@ mod tests {
                 ),
                 WordPartNode::new(
                     WordPart::ParameterExpansion {
-                        reference: plain_ref("PREFIXED_VERSION"),
-                        operator: ParameterOp::UseDefault,
-                        operand: Some("$PROVIDED_VERSION".into()),
-                        operand_word_ast: Some(word(vec![WordPart::Variable(
+                        reference: Box::new(plain_ref("PREFIXED_VERSION")),
+                        operator: Box::new(ParameterOp::UseDefault),
+                        operand: Some(Box::new("$PROVIDED_VERSION".into())),
+                        operand_word_ast: Some(Box::new(word(vec![WordPart::Variable(
                             "PROVIDED_VERSION".into(),
-                        )])),
+                        )]))),
                         colon_variant: true,
                     },
                     Span::new(),
@@ -4285,7 +4294,7 @@ mod tests {
             },
         );
         let w = Word {
-            parts: vec![WordPartNode::new(WordPart::Variable("1".into()), span)],
+            parts: vec![WordPartNode::new(WordPart::Variable("1".into()), span)].into(),
             span,
             brace_syntax: Vec::new(),
         };
@@ -4311,7 +4320,8 @@ mod tests {
             parts: vec![WordPartNode::new(
                 WordPart::Literal(LiteralText::source()),
                 span,
-            )],
+            )]
+            .into(),
             span,
             brace_syntax: Vec::new(),
         };
@@ -4335,7 +4345,8 @@ mod tests {
                     dollar: false,
                 },
                 span,
-            )],
+            )]
+            .into(),
             span,
             brace_syntax: Vec::new(),
         };
@@ -4371,7 +4382,8 @@ mod tests {
                     dollar: false,
                 },
                 span,
-            )],
+            )]
+            .into(),
             span,
             brace_syntax: Vec::new(),
         };
@@ -4393,7 +4405,7 @@ mod tests {
         let w = word(vec![WordPart::ArithmeticExpansion {
             expression: "1+2".into(),
             expression_ast: None,
-            expression_word_ast: Word::literal("1+2"),
+            expression_word_ast: Box::new(Word::literal("1+2")),
             syntax: ArithmeticExpansionSyntax::DollarParenParen,
         }]);
         assert_eq!(format!("{w}"), "$((1+2))");
@@ -4401,44 +4413,46 @@ mod tests {
 
     #[test]
     fn word_display_length() {
-        let w = word(vec![WordPart::Length(plain_ref("var"))]);
+        let w = word(vec![WordPart::Length(Box::new(plain_ref("var")))]);
         assert_eq!(format!("{w}"), "${#var}");
     }
 
     #[test]
     fn word_display_array_access() {
-        let w = word(vec![WordPart::ArrayAccess(indexed_ref("arr", "0"))]);
+        let w = word(vec![WordPart::ArrayAccess(Box::new(indexed_ref(
+            "arr", "0",
+        )))]);
         assert_eq!(format!("{w}"), "${arr[0]}");
     }
 
     #[test]
     fn word_display_array_length() {
-        let w = word(vec![WordPart::ArrayLength(selector_ref(
+        let w = word(vec![WordPart::ArrayLength(Box::new(selector_ref(
             "arr",
             SubscriptSelector::At,
-        ))]);
+        )))]);
         assert_eq!(format!("{w}"), "${#arr[@]}");
     }
 
     #[test]
     fn word_display_array_indices() {
-        let w = word(vec![WordPart::ArrayIndices(selector_ref(
+        let w = word(vec![WordPart::ArrayIndices(Box::new(selector_ref(
             "arr",
             SubscriptSelector::At,
-        ))]);
+        )))]);
         assert_eq!(format!("{w}"), "${!arr[@]}");
     }
 
     #[test]
     fn word_display_substring_with_length() {
         let w = word(vec![WordPart::Substring {
-            reference: plain_ref("var"),
-            offset: "2".into(),
+            reference: Box::new(plain_ref("var")),
+            offset: Box::new("2".into()),
             offset_ast: None,
-            offset_word_ast: Word::literal("2"),
-            length: Some("3".into()),
+            offset_word_ast: Box::new(Word::literal("2")),
+            length: Some(Box::new("3".into())),
             length_ast: None,
-            length_word_ast: Some(Word::literal("3")),
+            length_word_ast: Some(Box::new(Word::literal("3"))),
         }]);
         assert_eq!(format!("{w}"), "${var:2:3}");
     }
@@ -4446,10 +4460,10 @@ mod tests {
     #[test]
     fn word_display_substring_without_length() {
         let w = word(vec![WordPart::Substring {
-            reference: plain_ref("var"),
-            offset: "2".into(),
+            reference: Box::new(plain_ref("var")),
+            offset: Box::new("2".into()),
             offset_ast: None,
-            offset_word_ast: Word::literal("2"),
+            offset_word_ast: Box::new(Word::literal("2")),
             length: None,
             length_ast: None,
             length_word_ast: None,
@@ -4460,13 +4474,13 @@ mod tests {
     #[test]
     fn word_display_array_slice_with_length() {
         let w = word(vec![WordPart::ArraySlice {
-            reference: selector_ref("arr", SubscriptSelector::At),
-            offset: "1".into(),
+            reference: Box::new(selector_ref("arr", SubscriptSelector::At)),
+            offset: Box::new("1".into()),
             offset_ast: None,
-            offset_word_ast: Word::literal("1"),
-            length: Some("2".into()),
+            offset_word_ast: Box::new(Word::literal("1")),
+            length: Some(Box::new("2".into())),
             length_ast: None,
-            length_word_ast: Some(Word::literal("2")),
+            length_word_ast: Some(Box::new(Word::literal("2"))),
         }]);
         assert_eq!(format!("{w}"), "${arr[@]:1:2}");
     }
@@ -4474,10 +4488,10 @@ mod tests {
     #[test]
     fn word_display_array_slice_without_length() {
         let w = word(vec![WordPart::ArraySlice {
-            reference: selector_ref("arr", SubscriptSelector::At),
-            offset: "1".into(),
+            reference: Box::new(selector_ref("arr", SubscriptSelector::At)),
+            offset: Box::new("1".into()),
             offset_ast: None,
-            offset_word_ast: Word::literal("1"),
+            offset_word_ast: Box::new(Word::literal("1")),
             length: None,
             length_ast: None,
             length_word_ast: None,
@@ -4488,7 +4502,7 @@ mod tests {
     #[test]
     fn word_display_indirect_expansion() {
         let w = word(vec![WordPart::IndirectExpansion {
-            reference: plain_ref("ref"),
+            reference: Box::new(plain_ref("ref")),
             operator: None,
             operand: None,
             operand_word_ast: None,
@@ -4517,19 +4531,19 @@ mod tests {
 
     #[test]
     fn word_render_syntax_preserves_raw_quoted_subscript() {
-        let w = word(vec![WordPart::ArrayAccess(VarRef {
+        let w = word(vec![WordPart::ArrayAccess(Box::new(VarRef {
             name: "assoc".into(),
             name_span: Span::new(),
-            subscript: Some(Subscript {
+            subscript: Some(Box::new(Subscript {
                 text: "key".into(),
                 raw: Some("\"key\"".into()),
                 kind: SubscriptKind::Ordinary,
                 interpretation: SubscriptInterpretation::Associative,
                 word_ast: None,
                 arithmetic_ast: None,
-            }),
+            })),
             span: Span::new(),
-        })]);
+        }))]);
         assert_eq!(format!("{w}"), "${assoc[\"key\"]}");
         assert_eq!(w.render_syntax(""), "${assoc[\"key\"]}");
     }
@@ -4537,7 +4551,7 @@ mod tests {
     #[test]
     fn word_display_transformation() {
         let w = word(vec![WordPart::Transformation {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: 'Q',
         }]);
         assert_eq!(format!("{w}"), "${var@Q}");
@@ -4628,10 +4642,10 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_use_default_colon() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::UseDefault,
-            operand: Some("fallback".into()),
-            operand_word_ast: Some(Word::literal("fallback")),
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::UseDefault),
+            operand: Some(Box::new("fallback".into())),
+            operand_word_ast: Some(Box::new(Word::literal("fallback"))),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:-fallback}");
@@ -4640,10 +4654,10 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_use_default_no_colon() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::UseDefault,
-            operand: Some("fallback".into()),
-            operand_word_ast: Some(Word::literal("fallback")),
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::UseDefault),
+            operand: Some(Box::new("fallback".into())),
+            operand_word_ast: Some(Box::new(Word::literal("fallback"))),
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var-fallback}");
@@ -4652,10 +4666,10 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_assign_default() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::AssignDefault,
-            operand: Some("val".into()),
-            operand_word_ast: Some(Word::literal("val")),
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::AssignDefault),
+            operand: Some(Box::new("val".into())),
+            operand_word_ast: Some(Box::new(Word::literal("val"))),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:=val}");
@@ -4664,10 +4678,10 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_use_replacement() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::UseReplacement,
-            operand: Some("alt".into()),
-            operand_word_ast: Some(Word::literal("alt")),
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::UseReplacement),
+            operand: Some(Box::new("alt".into())),
+            operand_word_ast: Some(Box::new(Word::literal("alt"))),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:+alt}");
@@ -4676,10 +4690,10 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_error() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::Error,
-            operand: Some("msg".into()),
-            operand_word_ast: Some(Word::literal("msg")),
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::Error),
+            operand: Some(Box::new("msg".into())),
+            operand_word_ast: Some(Box::new(Word::literal("msg"))),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:?msg}");
@@ -4689,10 +4703,10 @@ mod tests {
     fn word_display_parameter_expansion_prefix_suffix() {
         // RemovePrefixShort
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::RemovePrefixShort {
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::RemovePrefixShort {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
-            },
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4701,10 +4715,10 @@ mod tests {
 
         // RemovePrefixLong
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::RemovePrefixLong {
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::RemovePrefixLong {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
-            },
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4713,10 +4727,10 @@ mod tests {
 
         // RemoveSuffixShort
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::RemoveSuffixShort {
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::RemoveSuffixShort {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
-            },
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4725,10 +4739,10 @@ mod tests {
 
         // RemoveSuffixLong
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::RemoveSuffixLong {
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::RemoveSuffixLong {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
-            },
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4739,12 +4753,12 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_replace() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::ReplaceFirst {
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::ReplaceFirst {
                 pattern: pattern(vec![PatternPart::Literal("old".into())]),
                 replacement: "new".into(),
-                replacement_word_ast: Word::literal("new"),
-            },
+                replacement_word_ast: Box::new(Word::literal("new")),
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4752,12 +4766,12 @@ mod tests {
         assert_eq!(format!("{w}"), "${var/old/new}");
 
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
-            operator: ParameterOp::ReplaceAll {
+            reference: Box::new(plain_ref("var")),
+            operator: Box::new(ParameterOp::ReplaceAll {
                 pattern: pattern(vec![PatternPart::Literal("old".into())]),
                 replacement: "new".into(),
-                replacement_word_ast: Word::literal("new"),
-            },
+                replacement_word_ast: Box::new(Word::literal("new")),
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4769,8 +4783,8 @@ mod tests {
     fn word_display_parameter_expansion_case() {
         let check = |op: ParameterOp, expected: &str| {
             let w = word(vec![WordPart::ParameterExpansion {
-                reference: plain_ref("var"),
-                operator: op,
+                reference: Box::new(plain_ref("var")),
+                operator: Box::new(op),
                 operand: None,
                 operand_word_ast: None,
                 colon_variant: false,

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -2391,13 +2391,13 @@ pub enum HeredocBodyPart {
     Literal(LiteralText),
     Variable(Name),
     CommandSubstitution {
-        body: StmtSeq,
+        body: Box<StmtSeq>,
         syntax: CommandSubstitutionSyntax,
     },
     ArithmeticExpansion {
         expression: SourceText,
-        expression_ast: Option<ArithmeticExprNode>,
-        expression_word_ast: Word,
+        expression_ast: Option<Box<ArithmeticExprNode>>,
+        expression_word_ast: Box<Word>,
         syntax: ArithmeticExpansionSyntax,
     },
     Parameter(Box<ParameterExpansion>),
@@ -3853,7 +3853,7 @@ pub struct Assignment {
 #[derive(Debug, Clone)]
 pub enum AssignmentValue {
     /// Scalar value: VAR=value
-    Scalar(Word),
+    Scalar(Box<Word>),
     /// Array value: VAR=(a b c)
     Compound(ArrayExpr),
 }
@@ -4829,7 +4829,7 @@ mod tests {
         let cmd = SimpleCommand {
             assignments: vec![assignment(
                 plain_ref("FOO"),
-                AssignmentValue::Scalar(Word::literal("bar")),
+                AssignmentValue::Scalar(Box::new(Word::literal("bar"))),
             )],
             ..simple_command("env", vec![])
         };
@@ -4866,7 +4866,7 @@ mod tests {
                 extra_args: vec![],
                 assignments: vec![assignment(
                     plain_ref("FOO"),
-                    AssignmentValue::Scalar(Word::literal("bar")),
+                    AssignmentValue::Scalar(Box::new(Word::literal("bar"))),
                 )],
                 span: Span::new(),
             })),
@@ -5021,7 +5021,10 @@ mod tests {
 
     #[test]
     fn assignment_scalar() {
-        let a = assignment(plain_ref("X"), AssignmentValue::Scalar(Word::literal("1")));
+        let a = assignment(
+            plain_ref("X"),
+            AssignmentValue::Scalar(Box::new(Word::literal("1"))),
+        );
         assert_eq!(a.target.name, "X");
         assert!(a.target.subscript.is_none());
         assert!(!a.append);
@@ -5052,7 +5055,7 @@ mod tests {
     fn assignment_append() {
         let mut a = assignment(
             plain_ref("PATH"),
-            AssignmentValue::Scalar(Word::literal("/usr/bin")),
+            AssignmentValue::Scalar(Box::new(Word::literal("/usr/bin"))),
         );
         a.append = true;
         assert!(a.append);
@@ -5062,7 +5065,7 @@ mod tests {
     fn assignment_indexed() {
         let a = assignment(
             indexed_ref("arr", "0"),
-            AssignmentValue::Scalar(Word::literal("val")),
+            AssignmentValue::Scalar(Box::new(Word::literal("val"))),
         );
         assert_eq!(
             a.target

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -42,6 +42,7 @@ const LARGE_CORPUS_DEFAULT_SHUCK_TIMEOUT: Duration = Duration::from_secs(30);
 const LARGE_CORPUS_AUTOSCALED_SHUCK_TIMEOUT_BUFFER: Duration = Duration::from_secs(15);
 const LARGE_CORPUS_MAX_AUTOSCALED_SHUCK_TIMEOUT: Duration = Duration::from_secs(150);
 const LARGE_CORPUS_AUTOSCALED_SHUCK_LINES_PER_SEC: usize = 175;
+const LARGE_CORPUS_TIMEOUT_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
 const LARGE_CORPUS_CACHE_DIR_NAME: &str = ".cache/large-corpus";
 const LARGE_CORPUS_MAX_WORKER_COUNT: usize = 4;
 const LARGE_CORPUS_TIMEOUT_FAILURE_CAP: usize = 5;
@@ -370,10 +371,13 @@ where
     F: FnOnce() -> T + Send + 'static,
 {
     let (sender, receiver) = mpsc::sync_channel(1);
-    thread::spawn(move || {
-        let result = work();
-        let _ = sender.send(result);
-    });
+    thread::Builder::new()
+        .stack_size(LARGE_CORPUS_TIMEOUT_WORKER_STACK_SIZE)
+        .spawn(move || {
+            let result = work();
+            let _ = sender.send(result);
+        })
+        .map_err(|err| format!("{label} worker thread failed to start: {err}"))?;
 
     match receiver.recv_timeout(timeout) {
         Ok(result) => Ok(result),

--- a/crates/shuck-formatter/src/simplify.rs
+++ b/crates/shuck-formatter/src/simplify.rs
@@ -1927,7 +1927,7 @@ fn strip_redundant_conditional_quotes(expression: &mut ConditionalExpr, source: 
     };
     let parts = parts.clone();
     *word = Word {
-        parts,
+        parts: parts.into(),
         span: word.span,
         brace_syntax: Vec::new(),
     };
@@ -1971,7 +1971,8 @@ fn tighten_literal_quotes(word: &mut Word, source: &str) -> usize {
                 dollar: false,
             },
             word.span,
-        )],
+        )]
+        .into(),
         span: word.span,
         brace_syntax: Vec::new(),
     };

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -432,8 +432,8 @@ fn render_word_part(
         } => render_parameter_expansion(
             rendered,
             reference,
-            operator.clone(),
-            operand.as_ref(),
+            *operator.clone(),
+            operand.as_deref(),
             *colon_variant,
             source,
             options,
@@ -477,10 +477,16 @@ fn render_word_part(
             rendered.push_str("${");
             push_var_ref(rendered, reference, source, options);
             rendered.push(':');
-            push_arithmetic_source_text(rendered, offset, offset_ast.as_ref(), source, options);
+            push_arithmetic_source_text(rendered, offset, offset_ast.as_deref(), source, options);
             if let Some(length) = length {
                 rendered.push(':');
-                push_arithmetic_source_text(rendered, length, length_ast.as_ref(), source, options);
+                push_arithmetic_source_text(
+                    rendered,
+                    length,
+                    length_ast.as_deref(),
+                    source,
+                    options,
+                );
             }
             rendered.push('}');
         }
@@ -497,7 +503,7 @@ fn render_word_part(
                 if *colon_variant {
                     rendered.push(':');
                 }
-                rendered.push_str(parameter_defaulting_operator(operator.clone()));
+                rendered.push_str(parameter_defaulting_operator(*operator.clone()));
                 if let Some(operand) = operand {
                     rendered.push_str(operand.slice(source));
                 }
@@ -1236,10 +1242,16 @@ fn push_parameter_word(
             rendered.push_str("${");
             push_var_ref(rendered, reference, source, options);
             rendered.push(':');
-            push_arithmetic_source_text(rendered, offset, offset_ast.as_ref(), source, options);
+            push_arithmetic_source_text(rendered, offset, offset_ast.as_deref(), source, options);
             if let Some(length) = length {
                 rendered.push(':');
-                push_arithmetic_source_text(rendered, length, length_ast.as_ref(), source, options);
+                push_arithmetic_source_text(
+                    rendered,
+                    length,
+                    length_ast.as_deref(),
+                    source,
+                    options,
+                );
             }
             rendered.push('}');
         }

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -554,7 +554,7 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_var_ref_subscript(&mut self, reference: &VarRef) {
-        self.visit_subscript(reference.subscript.as_ref());
+        self.visit_subscript(reference.subscript.as_deref());
     }
 
     fn visit_subscript(&mut self, subscript: Option<&Subscript>) {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -292,7 +292,7 @@ fn collect_base_prefix_spans_in_parameter_expansion(
             } => {
                 collect_base_prefix_spans_in_var_ref(reference, source, spans);
                 collect_base_prefix_spans_in_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     spans,
@@ -363,7 +363,7 @@ fn collect_base_prefix_spans_in_arithmetic_parameter_expansion(
             } => {
                 collect_base_prefix_spans_in_var_ref(reference, source, spans);
                 collect_base_prefix_spans_in_arithmetic_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     spans,
@@ -469,7 +469,7 @@ fn collect_base_prefix_spans_in_pattern(pattern: &Pattern, source: &str, spans: 
 }
 
 fn collect_base_prefix_spans_in_var_ref(reference: &VarRef, source: &str, spans: &mut Vec<Span>) {
-    collect_base_prefix_spans_in_subscript(reference.subscript.as_ref(), source, spans);
+    collect_base_prefix_spans_in_subscript(reference.subscript.as_deref(), source, spans);
 }
 
 fn collect_base_prefix_spans_in_subscript(
@@ -477,7 +477,7 @@ fn collect_base_prefix_spans_in_subscript(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    if let Some(expression) = subscript.and_then(|subscript| subscript.arithmetic_ast.as_ref()) {
+    if let Some(expression) = subscript.and_then(|subscript| subscript.arithmetic_ast.as_deref()) {
         collect_base_prefix_spans_in_arithmetic(expression, source, spans);
     }
 }
@@ -586,8 +586,8 @@ fn collect_base_prefix_spans_in_arithmetic_word_part(
         } => {
             collect_base_prefix_spans_in_var_ref(reference, source, spans);
             collect_base_prefix_spans_in_arithmetic_fragment(
-                operand_word_ast.as_ref(),
-                operand.as_ref(),
+                operand_word_ast.as_deref(),
+                operand.as_deref(),
                 source,
                 spans,
             );
@@ -1034,7 +1034,7 @@ fn collect_arithmetic_update_operator_spans_in_assignment_target(
 ) {
     if !var_ref_subscript_has_assoc_semantics(reference, semantic) {
         collect_arithmetic_update_operator_spans_in_subscript(
-            reference.subscript.as_ref(),
+            reference.subscript.as_deref(),
             source,
             spans,
         );
@@ -1045,7 +1045,7 @@ fn collect_arithmetic_update_operator_spans_in_assignment_target(
 }
 
 fn var_ref_subscript_has_assoc_semantics(reference: &VarRef, semantic: &SemanticModel) -> bool {
-    let Some(subscript) = reference.subscript.as_ref() else {
+    let Some(subscript) = reference.subscript.as_deref() else {
         return false;
     };
     if matches!(
@@ -1309,7 +1309,7 @@ fn collect_arithmetic_update_operator_spans_in_subscript(
     ) {
         return;
     }
-    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
+    if let Some(expression) = subscript.arithmetic_ast.as_deref() {
         collect_arithmetic_update_operator_spans(Some(expression), source, spans);
     }
 }

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -31,7 +31,7 @@ fn collect_use_replacement_expansion_spans(parts: &[WordPartNode], spans: &mut V
             | WordPart::IndirectExpansion {
                 operator: Some(operator),
                 ..
-            } if matches!(operator, ParameterOp::UseReplacement) => spans.push(part.span),
+            } if matches!(operator.as_ref(), ParameterOp::UseReplacement) => spans.push(part.span),
             WordPart::Parameter(_)
             | WordPart::ParameterExpansion { .. }
             | WordPart::IndirectExpansion { .. } => {}
@@ -267,4 +267,3 @@ fn compound_assignment_paren_span(assignment: &Assignment, source: &str) -> Opti
         .advanced_by(&text[..close + ')'.len_utf8()]);
     Some(Span::from_positions(start, end))
 }
-

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -252,7 +252,7 @@ fn anchored_assignment_command_span(
 }
 
 fn assignment_target_span(assignment: &Assignment) -> Span {
-    assignment.target.subscript.as_ref().map_or_else(
+    assignment.target.subscript.as_deref().map_or_else(
         || assignment.target.name_span,
         |subscript| {
             Span::from_positions(
@@ -650,7 +650,7 @@ fn visit_assignment_reference_spans_outside_nested_commands(
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     visit_subscript_reference_spans_outside_nested_commands(
-        assignment.target.subscript.as_ref(),
+        assignment.target.subscript.as_deref(),
         name,
         visit,
     )?;
@@ -834,7 +834,7 @@ fn visit_subscript_reference_spans_outside_nested_commands(
     if let Some(word) = subscript.word_ast() {
         visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
     }
-    if let Some(expr) = subscript.arithmetic_ast.as_ref() {
+    if let Some(expr) = subscript.arithmetic_ast.as_deref() {
         visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
     }
 
@@ -879,7 +879,7 @@ fn visit_word_part_reference_spans_outside_nested_commands(
             expression_word_ast,
             ..
         } => {
-            if let Some(expr) = expression_ast.as_ref() {
+            if let Some(expr) = expression_ast.as_deref() {
                 visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
             }
             visit_word_reference_spans_outside_nested_commands(expression_word_ast, name, visit)?;
@@ -897,7 +897,7 @@ fn visit_word_part_reference_spans_outside_nested_commands(
             visit_var_ref_reference_spans_outside_nested_commands(
                 reference, part.span, name, visit,
             )?;
-            if let Some(word) = operand_word_ast.as_ref() {
+            if let Some(word) = operand_word_ast.as_deref() {
                 visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
             }
         }
@@ -929,11 +929,11 @@ fn visit_word_part_reference_spans_outside_nested_commands(
             visit_var_ref_reference_spans_outside_nested_commands(
                 reference, part.span, name, visit,
             )?;
-            if let Some(expr) = offset_ast.as_ref() {
+            if let Some(expr) = offset_ast.as_deref() {
                 visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
             }
             visit_word_reference_spans_outside_nested_commands(offset_word_ast, name, visit)?;
-            if let Some(expr) = length_ast.as_ref() {
+            if let Some(expr) = length_ast.as_deref() {
                 visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
             }
             if let Some(word) = length_word_ast.as_ref() {
@@ -948,7 +948,7 @@ fn visit_word_part_reference_spans_outside_nested_commands(
             visit_var_ref_reference_spans_outside_nested_commands(
                 reference, part.span, name, visit,
             )?;
-            if let Some(word) = operand_word_ast.as_ref() {
+            if let Some(word) = operand_word_ast.as_deref() {
                 visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
             }
         }
@@ -986,7 +986,7 @@ fn visit_parameter_reference_spans_outside_nested_commands(
                 visit_var_ref_reference_spans_outside_nested_commands(
                     reference, span, name, visit,
                 )?;
-                if let Some(word) = operand_word_ast.as_ref() {
+                if let Some(word) = operand_word_ast.as_deref() {
                     visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
                 }
             }
@@ -999,10 +999,10 @@ fn visit_parameter_reference_spans_outside_nested_commands(
                 visit_var_ref_reference_spans_outside_nested_commands(
                     reference, span, name, visit,
                 )?;
-                if let Some(expr) = offset_ast.as_ref() {
+                if let Some(expr) = offset_ast.as_deref() {
                     visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
                 }
-                if let Some(expr) = length_ast.as_ref() {
+                if let Some(expr) = length_ast.as_deref() {
                     visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
                 }
             }
@@ -1054,7 +1054,7 @@ fn visit_var_ref_reference_spans_outside_nested_commands(
     }
 
     visit_subscript_reference_spans_outside_nested_commands(
-        reference.subscript.as_ref(),
+        reference.subscript.as_deref(),
         name,
         visit,
     )

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -1938,8 +1938,8 @@ fn collect_status_parameter_spans_in_word_part(
             }
             collect_status_parameter_spans_in_var_ref(reference, source, spans);
             collect_status_parameter_spans_in_fragment(
-                operand_word_ast.as_ref(),
-                operand.as_ref(),
+                operand_word_ast.as_deref(),
+                operand.as_deref(),
                 source,
                 spans,
             );
@@ -1981,7 +1981,7 @@ fn collect_status_parameter_spans_in_word_part(
             } else {
                 collect_status_parameter_spans_in_word(offset_word_ast, source, spans);
             }
-            match (length_ast.as_ref(), length_word_ast.as_ref()) {
+            match (length_ast.as_deref(), length_word_ast.as_ref()) {
                 (Some(length_ast), _) => {
                     visit_arithmetic_words(length_ast, &mut |word| {
                         collect_status_parameter_spans_in_word(word, source, spans);
@@ -2024,7 +2024,7 @@ fn collect_status_parameter_spans_in_parameter_expansion(
             } => {
                 collect_status_parameter_spans_in_var_ref(reference, source, spans);
                 collect_status_parameter_spans_in_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     spans,
@@ -2047,7 +2047,7 @@ fn collect_status_parameter_spans_in_parameter_expansion(
                     collect_status_parameter_spans_in_word(offset_word_ast, source, spans);
                 }
 
-                match (length_ast.as_ref(), length_word_ast.as_ref()) {
+                match (length_ast.as_deref(), length_word_ast.as_ref()) {
                     (Some(length_ast), _) => {
                         visit_arithmetic_words(length_ast, &mut |word| {
                             collect_status_parameter_spans_in_word(word, source, spans);
@@ -2103,7 +2103,7 @@ fn collect_status_parameter_spans_in_parameter_expansion(
                         );
                         collect_status_parameter_spans_in_fragment(
                             operation.length_word_ast(),
-                            length.as_ref(),
+                            length.as_deref(),
                             source,
                             spans,
                         );

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -401,7 +401,7 @@ fn collect_heredoc_body_substitution_occurrences<'a>(
     for part in parts {
         match &part.kind {
             shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
-                visit_arithmetic_words_in_expression(expression_ast.as_ref(), false, occurrences);
+                visit_arithmetic_words_in_expression(expression_ast.as_deref(), false, occurrences);
             }
             shuck_ast::HeredocBodyPart::CommandSubstitution { body, syntax } => {
                 occurrences.push(SubstitutionOccurrence {

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -351,7 +351,7 @@ fn collect_word_substitution_occurrences<'a>(
                 collect_word_substitution_occurrences(parts, true, occurrences);
             }
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
-                visit_arithmetic_words_in_expression(expression_ast.as_ref(), quoted, occurrences);
+                visit_arithmetic_words_in_expression(expression_ast.as_deref(), quoted, occurrences);
             }
             WordPart::CommandSubstitution { body, syntax } => {
                 occurrences.push(SubstitutionOccurrence {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -933,7 +933,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         .push(LegacyArithmeticFragmentFact { span: part.span });
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
-                        expression_ast.as_ref(),
+                        expression_ast.as_deref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
@@ -954,7 +954,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 } => {
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
-                        expression_ast.as_ref(),
+                        expression_ast.as_deref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -682,12 +682,12 @@ impl<'a> SurfaceFragmentSink<'a> {
                         .push(LegacyArithmeticFragmentFact { span: part.span });
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
-                        expression_ast.as_ref(),
+                        expression_ast.as_deref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
                     );
-                    if let Some(expression_ast) = expression_ast.as_ref() {
+                    if let Some(expression_ast) = expression_ast.as_deref() {
                         visit_arithmetic_words(expression_ast, &mut |word| {
                             self.collect_word(word, context);
                         });
@@ -703,7 +703,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 } => {
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
-                        expression_ast.as_ref(),
+                        expression_ast.as_deref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
@@ -764,7 +764,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         }
                     }
                     if matches!(
-                        operator,
+                        operator.as_ref(),
                         ParameterOp::UpperFirst
                             | ParameterOp::UpperAll
                             | ParameterOp::LowerFirst
@@ -773,7 +773,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         self.record_case_modification(part.span);
                     }
                     if matches!(
-                        operator,
+                        operator.as_ref(),
                         ParameterOp::ReplaceFirst { .. } | ParameterOp::ReplaceAll { .. }
                     ) {
                         self.record_replacement_expansion(part.span);
@@ -784,8 +784,8 @@ impl<'a> SurfaceFragmentSink<'a> {
                     self.record_var_ref_subscript(reference);
                     self.collect_parameter_operator_patterns(
                         operator,
-                        operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand.as_deref(),
+                        operand_word_ast.as_deref(),
                         context,
                     );
                 }
@@ -842,8 +842,8 @@ impl<'a> SurfaceFragmentSink<'a> {
                         });
                     self.collect_parameter_operator_patterns(
                         operator,
-                        operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand.as_deref(),
+                        operand_word_ast.as_deref(),
                         context,
                     );
                 }
@@ -1136,7 +1136,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     self.collect_parameter_operator_patterns(
                         operator,
                         operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand_word_ast.as_deref(),
                         context,
                     );
                 }
@@ -1261,7 +1261,7 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     pub(super) fn record_var_ref_subscript(&mut self, reference: &VarRef) {
-        self.record_subscript(reference.subscript.as_ref());
+        self.record_subscript(reference.subscript.as_deref());
     }
 
     pub(super) fn record_subscript(&mut self, subscript: Option<&Subscript>) {
@@ -2459,7 +2459,7 @@ fn push_cooked_unquoted_literal_inside_double_quotes(rendered: &mut String, text
 
 fn word_part_syntax(part: &WordPartNode, source: &str) -> String {
     Word {
-        parts: vec![part.clone()],
+        parts: vec![part.clone()].into(),
         span: part.span,
         brace_syntax: Vec::new(),
     }

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -115,7 +115,7 @@ fn visit_var_ref_subscript_words_with_source<'a>(
     _source: &'a str,
     visitor: &mut impl FnMut(&'a Word),
 ) {
-    visit_subscript_words(reference.subscript.as_ref(), _source, visitor);
+    visit_subscript_words(reference.subscript.as_deref(), _source, visitor);
 }
 
 fn visit_subscript_words<'a>(
@@ -129,7 +129,7 @@ fn visit_subscript_words<'a>(
     if subscript.selector().is_some() {
         return;
     }
-    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
+    if let Some(expression) = subscript.arithmetic_ast.as_deref() {
         visit_arithmetic_words_in_expr(expression, visitor);
         return;
     }
@@ -193,7 +193,7 @@ fn collect_var_ref_subscript_words<'a>(reference: &'a VarRef, words: &mut Vec<&'
         reference
             .subscript
             .as_ref()
-            .and_then(|subscript| subscript.arithmetic_ast.as_ref()),
+            .and_then(|subscript| subscript.arithmetic_ast.as_deref()),
         words,
     );
 }
@@ -613,7 +613,7 @@ fn collect_word_part_visits<'a, F>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, options, context, visitor);
-                if let Some(word) = operand_word_ast.as_ref() {
+                if let Some(word) = operand_word_ast.as_deref() {
                     collect_word_visits(word, options, context, visitor);
                 }
             }
@@ -641,7 +641,7 @@ fn collect_word_part_visits<'a, F>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, options, context, visitor);
-                if let Some(expression) = offset_ast.as_ref() {
+                if let Some(expression) = offset_ast.as_deref() {
                     let mut arithmetic_words = Vec::new();
                     collect_optional_arithmetic_words(Some(expression), &mut arithmetic_words);
                     for word in arithmetic_words {
@@ -650,7 +650,7 @@ fn collect_word_part_visits<'a, F>(
                 } else {
                     collect_word_visits(offset_word_ast, options, context, visitor);
                 }
-                if let Some(expression) = length_ast.as_ref() {
+                if let Some(expression) = length_ast.as_deref() {
                     let mut arithmetic_words = Vec::new();
                     collect_optional_arithmetic_words(Some(expression), &mut arithmetic_words);
                     for word in arithmetic_words {
@@ -709,7 +709,7 @@ fn collect_parameter_expansion_visits<'a, F>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, options, context, visitor);
-                if let Some(word) = operand_word_ast.as_ref() {
+                if let Some(word) = operand_word_ast.as_deref() {
                     collect_word_visits(word, options, context, visitor);
                 }
             }
@@ -720,7 +720,7 @@ fn collect_parameter_expansion_visits<'a, F>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, options, context, visitor);
-                if let Some(word) = operand_word_ast.as_ref() {
+                if let Some(word) = operand_word_ast.as_deref() {
                     collect_word_visits(word, options, context, visitor);
                 }
                 if let Some(word) = operator.replacement_word_ast() {
@@ -736,7 +736,7 @@ fn collect_parameter_expansion_visits<'a, F>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, options, context, visitor);
-                if let Some(expression) = offset_ast.as_ref() {
+                if let Some(expression) = offset_ast.as_deref() {
                     let mut arithmetic_words = Vec::new();
                     collect_optional_arithmetic_words(Some(expression), &mut arithmetic_words);
                     for word in arithmetic_words {
@@ -745,7 +745,7 @@ fn collect_parameter_expansion_visits<'a, F>(
                 } else {
                     collect_word_visits(offset_word_ast, options, context, visitor);
                 }
-                if let Some(expression) = length_ast.as_ref() {
+                if let Some(expression) = length_ast.as_deref() {
                     let mut arithmetic_words = Vec::new();
                     collect_optional_arithmetic_words(Some(expression), &mut arithmetic_words);
                     for word in arithmetic_words {

--- a/crates/shuck-linter/src/facts/word_spans.rs
+++ b/crates/shuck-linter/src/facts/word_spans.rs
@@ -2109,7 +2109,7 @@ fn collect_use_replacement_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) 
             | WordPart::IndirectExpansion {
                 operator: Some(operator),
                 ..
-            } if matches!(operator, ParameterOp::UseReplacement) => spans.push(part.span),
+            } if matches!(operator.as_ref(), ParameterOp::UseReplacement) => spans.push(part.span),
             WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
             | WordPart::Variable(_)
@@ -3588,7 +3588,7 @@ fn part_uses_assign_default_operator(part: &WordPart) -> bool {
         | WordPart::IndirectExpansion {
             operator: Some(operator),
             ..
-        } => matches!(operator, ParameterOp::AssignDefault),
+        } => matches!(operator.as_ref(), ParameterOp::AssignDefault),
         _ => false,
     }
 }

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -766,7 +766,7 @@ fn analyze_parameter_part(
                     ),
                     runtime_pattern: operator
                         .as_ref()
-                        .is_some_and(|operator| parameter_operator_uses_pattern(operator)),
+                        .is_some_and(parameter_operator_uses_pattern),
                     ..ExpansionHazards::default()
                 },
                 command_substitution: false,

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -692,7 +692,7 @@ fn analyze_part(
                 pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
                 runtime_pattern: operator
                     .as_ref()
-                    .is_some_and(parameter_operator_uses_pattern),
+                    .is_some_and(|operator| parameter_operator_uses_pattern(operator)),
                 ..ExpansionHazards::default()
             },
             command_substitution: false,
@@ -766,7 +766,7 @@ fn analyze_parameter_part(
                     ),
                     runtime_pattern: operator
                         .as_ref()
-                        .is_some_and(parameter_operator_uses_pattern),
+                        .is_some_and(|operator| parameter_operator_uses_pattern(operator)),
                     ..ExpansionHazards::default()
                 },
                 command_substitution: false,
@@ -1004,7 +1004,7 @@ fn array_part(
 
 fn parameter_operator_uses_pattern(operator: &shuck_ast::ParameterOp) -> bool {
     matches!(
-        operator,
+                        operator,
         shuck_ast::ParameterOp::RemovePrefixShort { .. }
             | shuck_ast::ParameterOp::RemovePrefixLong { .. }
             | shuck_ast::ParameterOp::RemoveSuffixShort { .. }
@@ -3735,7 +3735,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
                         Some(&reference.name),
                         Some(reference.name_span),
-                        reference.subscript.as_ref(),
+                        reference.subscript.as_deref(),
                     );
                     visit_var_ref_subscript_words_with_source(
                         reference,
@@ -3785,7 +3785,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
             Some(&assignment.target.name),
             Some(assignment.target.name_span),
-            assignment.target.subscript.as_ref(),
+            assignment.target.subscript.as_deref(),
         );
         visit_var_ref_subscript_words_with_source(
             &assignment.target,
@@ -4268,7 +4268,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     expression_word_ast,
                     ..
                 } => {
-                    if let Some(expression) = expression_ast.as_ref() {
+                    if let Some(expression) = expression_ast.as_deref() {
                         visit_arithmetic_words(expression, &mut |word| {
                             self.push_pending_arithmetic_word_occurrence(
                                 word,
@@ -4301,7 +4301,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     ..
                 } => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
                     operator,
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     enclosing_expansion_context,
                     host_kind,
                 ),
@@ -4344,7 +4344,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 },
             ) => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
                 operator,
-                operand_word_ast.as_ref(),
+                operand_word_ast.as_deref(),
                 enclosing_expansion_context,
                 host_kind,
             ),
@@ -4404,7 +4404,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         host_kind: WordFactHostKind,
     ) {
         if matches!(
-            operator,
+                        operator,
             ParameterOp::UseDefault
                 | ParameterOp::AssignDefault
                 | ParameterOp::UseReplacement
@@ -4818,7 +4818,7 @@ fn is_simple_arithmetic_reference_subscript(subscript: &Subscript, source: &str)
     subscript.selector().is_none()
         && !subscript.syntax_text(source).contains('$')
         && matches!(
-            subscript.arithmetic_ast.as_ref().map(|expr| &expr.kind),
+            subscript.arithmetic_ast.as_deref().map(|expr| &expr.kind),
             Some(ArithmeticExpr::Variable(_) | ArithmeticExpr::Number(_))
         )
 }
@@ -5918,7 +5918,7 @@ fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
 ) {
     if !var_ref_subscript_has_assoc_semantics(reference, semantic) {
         collect_arithmetic_update_operator_spans_in_subscript(
-            reference.subscript.as_ref(),
+            reference.subscript.as_deref(),
             source,
             spans,
         );
@@ -5988,7 +5988,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                         include_nested_commands,
                     );
                 }
-                if let Some(operand_word_ast) = operand_word_ast.as_ref() {
+                if let Some(operand_word_ast) = operand_word_ast.as_deref() {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
                         semantic,
@@ -6018,7 +6018,7 @@ fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     spans,
                     include_nested_commands,
                 );
-                if let Some(operand_word_ast) = operand_word_ast.as_ref() {
+                if let Some(operand_word_ast) = operand_word_ast.as_deref() {
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
                         semantic,
@@ -6196,7 +6196,7 @@ fn collect_arithmetic_spans_in_parameter_expansion(
                     command_substitution_spans,
                 );
                 collect_arithmetic_spans_in_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     collect_dollar_spans,
@@ -6219,7 +6219,7 @@ fn collect_arithmetic_spans_in_parameter_expansion(
                     command_substitution_spans,
                 );
                 collect_arithmetic_spans_in_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     collect_dollar_spans,

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -151,7 +151,7 @@ impl<'a> SafeValueIndex<'a> {
                         self.parameter_operator_is_safe(
                             &reference.name,
                             operator,
-                            operand.as_ref(),
+                            operand.as_deref(),
                             span,
                             query,
                         )
@@ -167,9 +167,13 @@ impl<'a> SafeValueIndex<'a> {
                 operator,
                 operand,
                 ..
-            } => {
-                self.parameter_expansion_is_safe(reference, operator, operand.as_ref(), span, query)
-            }
+            } => self.parameter_expansion_is_safe(
+                reference,
+                operator,
+                operand.as_deref(),
+                span,
+                query,
+            ),
         }
     }
 
@@ -215,7 +219,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn literal_part_is_safe(&self, part: &WordPart, span: Span, query: SafeValueQuery) -> bool {
         let word = Word {
-            parts: vec![WordPartNode::new(part.clone(), span)],
+            parts: vec![WordPartNode::new(part.clone(), span)].into(),
             span,
             brace_syntax: Vec::new(),
         };

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -702,7 +702,7 @@ fn collect_word_part_visits<'a>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, visits);
-                if let Some(word) = operand_word_ast.as_ref() {
+                if let Some(word) = operand_word_ast.as_deref() {
                     collect_word_visits(word, visits);
                 }
             }
@@ -730,14 +730,14 @@ fn collect_word_part_visits<'a>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, visits);
-                if let Some(expression) = offset_ast.as_ref() {
+                if let Some(expression) = offset_ast.as_deref() {
                     visit_arithmetic_words(expression, &mut |word| {
                         collect_word_visits(word, visits);
                     });
                 } else {
                     collect_word_visits(offset_word_ast, visits);
                 }
-                if let Some(expression) = length_ast.as_ref() {
+                if let Some(expression) = length_ast.as_deref() {
                     visit_arithmetic_words(expression, &mut |word| {
                         collect_word_visits(word, visits);
                     });
@@ -764,13 +764,13 @@ fn collect_var_ref_word_visits<'a>(
     reference: &'a VarRef,
     visits: &mut Vec<DirectiveCommandVisit<'a>>,
 ) {
-    let Some(subscript) = reference.subscript.as_ref() else {
+    let Some(subscript) = reference.subscript.as_deref() else {
         return;
     };
     if subscript.selector().is_some() {
         return;
     }
-    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
+    if let Some(expression) = subscript.arithmetic_ast.as_deref() {
         visit_arithmetic_words(expression, &mut |word| {
             collect_word_visits(word, visits);
         });
@@ -797,7 +797,7 @@ fn collect_parameter_expansion_visits<'a>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, visits);
-                if let Some(word) = operand_word_ast.as_ref() {
+                if let Some(word) = operand_word_ast.as_deref() {
                     collect_word_visits(word, visits);
                 }
             }
@@ -808,7 +808,7 @@ fn collect_parameter_expansion_visits<'a>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, visits);
-                if let Some(word) = operand_word_ast.as_ref() {
+                if let Some(word) = operand_word_ast.as_deref() {
                     collect_word_visits(word, visits);
                 }
                 if let Some(word) = operator.replacement_word_ast() {
@@ -824,14 +824,14 @@ fn collect_parameter_expansion_visits<'a>(
                 ..
             } => {
                 collect_var_ref_word_visits(reference, visits);
-                if let Some(expression) = offset_ast.as_ref() {
+                if let Some(expression) = offset_ast.as_deref() {
                     visit_arithmetic_words(expression, &mut |word| {
                         collect_word_visits(word, visits);
                     });
                 } else {
                     collect_word_visits(offset_word_ast, visits);
                 }
-                if let Some(expression) = length_ast.as_ref() {
+                if let Some(expression) = length_ast.as_deref() {
                     visit_arithmetic_words(expression, &mut |word| {
                         collect_word_visits(word, visits);
                     });

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -478,7 +478,7 @@ fn visit_var_ref_subscript_words<'a>(reference: &'a VarRef, visitor: &mut impl F
     if let Some(expression) = reference
         .subscript
         .as_ref()
-        .and_then(|subscript| subscript.arithmetic_ast.as_ref())
+        .and_then(|subscript| subscript.arithmetic_ast.as_deref())
     {
         visit_arithmetic_words(expression, visitor);
     }

--- a/crates/shuck-parser/src/parser/arithmetic.rs
+++ b/crates/shuck-parser/src/parser/arithmetic.rs
@@ -53,7 +53,7 @@ enum TokenKind {
     Tilde,
     Ident(Name),
     Number(SourceText),
-    ShellWord(Word),
+    ShellWord(Box<Word>),
 }
 
 #[derive(Debug, Clone)]
@@ -403,7 +403,7 @@ impl<'a> ArithmeticParser<'a> {
                 token.span,
             )),
             TokenKind::ShellWord(word) => Ok(ArithmeticExprNode::new(
-                ArithmeticExpr::ShellWord(Box::new(word)),
+                ArithmeticExpr::ShellWord(word),
                 token.span,
             )),
             TokenKind::End => {
@@ -731,7 +731,7 @@ impl<'a> ArithmeticParser<'a> {
         Parser::rebase_word(&mut word, self.position_at(start));
         self.index = end;
         Ok(Token {
-            kind: TokenKind::ShellWord(word),
+            kind: TokenKind::ShellWord(Box::new(word)),
             span: self.span_for(start, end),
         })
     }

--- a/crates/shuck-parser/src/parser/arithmetic.rs
+++ b/crates/shuck-parser/src/parser/arithmetic.rs
@@ -403,7 +403,7 @@ impl<'a> ArithmeticParser<'a> {
                 token.span,
             )),
             TokenKind::ShellWord(word) => Ok(ArithmeticExprNode::new(
-                ArithmeticExpr::ShellWord(word),
+                ArithmeticExpr::ShellWord(Box::new(word)),
                 token.span,
             )),
             TokenKind::End => {

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -3828,7 +3828,7 @@ impl<'a> Parser<'a> {
             _ => return Err(self.error("expected conditional operand")),
         };
 
-        Ok(self.word_with_parts(parts, Span::from_positions(start, end)))
+        Ok(self.word_with_parts(parts.into(), Span::from_positions(start, end)))
     }
 
     fn parse_arithmetic_command(&mut self) -> Result<CompoundCommand> {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -22,7 +22,7 @@ pub use lexer::{
     LexerErrorKind,
 };
 use memchr::{memchr, memchr2, memchr3};
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 
 use shuck_ast::{
     AlwaysCommand, AnonymousFunctionCommand, AnonymousFunctionSurface, ArithmeticCommand,
@@ -44,7 +44,7 @@ use shuck_ast::{
     SelectCommand, SimpleCommand as AstSimpleCommand, SourceText, Span, StaticCommandWrapperTarget,
     Stmt, StmtSeq, StmtTerminator, Subscript, SubscriptInterpretation, SubscriptKind,
     SubscriptSelector, TextSize, TimeCommand, TokenKind, UntilCommand, VarRef, WhileCommand, Word,
-    WordPart, WordPartNode, ZshDefaultingOp, ZshExpansionOperation, ZshExpansionTarget,
+    WordPart, WordPartNode, WordParts, ZshDefaultingOp, ZshExpansionOperation, ZshExpansionTarget,
     ZshGlobQualifier, ZshGlobQualifierGroup, ZshGlobQualifierKind, ZshGlobSegment,
     ZshInlineGlobControl, ZshModifier, ZshParameterExpansion, ZshPatternOp, ZshQualifiedGlob,
     ZshReplacementOp, ZshTrimOp, static_command_wrapper_target_index,
@@ -2142,7 +2142,7 @@ impl<'a> Parser<'a> {
         memchr3(b'$', b'`', b'\0', text.as_bytes()).is_some()
     }
 
-    fn word_with_parts(&self, parts: Vec<WordPartNode>, span: Span) -> Word {
+    fn word_with_parts(&self, parts: WordParts, span: Span) -> Word {
         let brace_syntax = self.brace_syntax_from_parts(&parts, span.start.offset);
         Word {
             parts,
@@ -2171,7 +2171,10 @@ impl<'a> Parser<'a> {
             WordPart::Literal(text) => HeredocBodyPart::Literal(text),
             WordPart::Variable(name) => HeredocBodyPart::Variable(name),
             WordPart::CommandSubstitution { body, syntax } => {
-                HeredocBodyPart::CommandSubstitution { body, syntax }
+                HeredocBodyPart::CommandSubstitution {
+                    body: *body,
+                    syntax,
+                }
             }
             WordPart::ArithmeticExpansion {
                 expression,
@@ -2180,11 +2183,11 @@ impl<'a> Parser<'a> {
                 syntax,
             } => HeredocBodyPart::ArithmeticExpansion {
                 expression,
-                expression_ast,
-                expression_word_ast,
+                expression_ast: expression_ast.map(|expression| *expression),
+                expression_word_ast: *expression_word_ast,
                 syntax,
             },
-            WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(Box::new(parameter)),
+            WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(parameter),
             other => panic!("unsupported heredoc body part: {other:?}"),
         };
 
@@ -3050,12 +3053,12 @@ impl<'a> Parser<'a> {
         }
 
         Some(self.word_with_parts(
-            vec![WordPartNode::new(
-                WordPart::ZshQualifiedGlob(ZshQualifiedGlob {
+            smallvec![WordPartNode::new(
+                WordPart::ZshQualifiedGlob(Box::new(ZshQualifiedGlob {
                     span,
                     segments,
                     qualifiers,
-                }),
+                })),
                 span,
             )],
             span,
@@ -3426,7 +3429,7 @@ impl<'a> Parser<'a> {
         {
             return Some(word);
         }
-        let mut parts = Vec::new();
+        let mut parts = WordParts::new();
 
         for segment in word.segments() {
             let source_backed = segment.span().is_some() && !token.flags.is_synthetic();
@@ -3601,7 +3604,7 @@ impl<'a> Parser<'a> {
 
             return match segment.kind() {
                 LexedWordSegmentKind::SingleQuoted => Some(self.word_with_parts(
-                    vec![self.single_quoted_part_from_text(
+                    smallvec![self.single_quoted_part_from_text(
                         text,
                         content_span,
                         wrapper_span,
@@ -3610,7 +3613,12 @@ impl<'a> Parser<'a> {
                     span,
                 )),
                 LexedWordSegmentKind::DollarSingleQuoted => Some(self.word_with_parts(
-                    vec![self.single_quoted_part_from_text(text, content_span, wrapper_span, true)],
+                    smallvec![self.single_quoted_part_from_text(
+                        text,
+                        content_span,
+                        wrapper_span,
+                        true,
+                    )],
                     span,
                 )),
                 LexedWordSegmentKind::Plain if Self::word_text_needs_parse(text) => Some(
@@ -3632,9 +3640,9 @@ impl<'a> Parser<'a> {
                         source_backed,
                     );
                     Some(self.word_with_parts(
-                        vec![WordPartNode::new(
+                        smallvec![WordPartNode::new(
                             WordPart::DoubleQuoted {
-                                parts: inner.parts,
+                                parts: inner.parts.into_vec(),
                                 dollar: matches!(
                                     segment.kind(),
                                     LexedWordSegmentKind::DollarDoubleQuoted
@@ -3646,11 +3654,11 @@ impl<'a> Parser<'a> {
                     ))
                 }
                 LexedWordSegmentKind::Plain => Some(self.word_with_parts(
-                    vec![self.literal_part_from_text(text, content_span, source_backed)],
+                    smallvec![self.literal_part_from_text(text, content_span, source_backed)],
                     span,
                 )),
                 LexedWordSegmentKind::DoubleQuoted => Some(self.word_with_parts(
-                    vec![self.double_quoted_literal_part_from_text(
+                    smallvec![self.double_quoted_literal_part_from_text(
                         text,
                         content_span,
                         wrapper_span,
@@ -3660,7 +3668,7 @@ impl<'a> Parser<'a> {
                     span,
                 )),
                 LexedWordSegmentKind::DollarDoubleQuoted => Some(self.word_with_parts(
-                    vec![self.double_quoted_literal_part_from_text(
+                    smallvec![self.double_quoted_literal_part_from_text(
                         text,
                         content_span,
                         wrapper_span,
@@ -3673,7 +3681,7 @@ impl<'a> Parser<'a> {
             };
         }
 
-        let mut parts = Vec::new();
+        let mut parts = WordParts::new();
         let mut cursor = span.start;
 
         for segment in word.segments() {
@@ -3738,7 +3746,7 @@ impl<'a> Parser<'a> {
                         );
                         parts.push(WordPartNode::new(
                             WordPart::DoubleQuoted {
-                                parts: inner.parts,
+                                parts: inner.parts.into_vec(),
                                 dollar: matches!(
                                     segment.kind(),
                                     LexedWordSegmentKind::DollarDoubleQuoted
@@ -5198,7 +5206,7 @@ impl<'a> Parser<'a> {
                 ..
             } => {
                 Self::rebase_var_ref(reference, base);
-                match operator {
+                match operator.as_mut() {
                     ParameterOp::RemovePrefixShort { pattern }
                     | ParameterOp::RemovePrefixLong { pattern }
                     | ParameterOp::RemoveSuffixShort { pattern }
@@ -5616,18 +5624,13 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn push_word_part(
-        parts: &mut Vec<WordPartNode>,
-        part: WordPart,
-        start: Position,
-        end: Position,
-    ) {
+    fn push_word_part(parts: &mut WordParts, part: WordPart, start: Position, end: Position) {
         parts.push(WordPartNode::new(part, Span::from_positions(start, end)));
     }
 
     fn flush_literal_part(
         &self,
-        parts: &mut Vec<WordPartNode>,
+        parts: &mut WordParts,
         current: &mut String,
         current_start: Position,
         end: Position,
@@ -5793,8 +5796,8 @@ impl<'a> Parser<'a> {
             raw,
             kind,
             interpretation,
-            word_ast,
-            arithmetic_ast,
+            word_ast: word_ast.map(Box::new),
+            arithmetic_ast: arithmetic_ast.map(Box::new),
         }
     }
 
@@ -5846,7 +5849,7 @@ impl<'a> Parser<'a> {
         VarRef {
             name: name.into(),
             name_span,
-            subscript,
+            subscript: subscript.map(Box::new),
             span,
         }
     }
@@ -5888,21 +5891,23 @@ impl<'a> Parser<'a> {
                 operand_word_ast,
                 colon_variant,
             } => Some(BourneParameterExpansion::Operation {
-                reference,
-                operator: self.enrich_parameter_operator(operator),
-                operand,
+                reference: *reference,
+                operator: self.enrich_parameter_operator(*operator),
+                operand: operand.map(|operand| *operand),
                 operand_word_ast,
                 colon_variant,
             }),
             WordPart::Length(reference) | WordPart::ArrayLength(reference) => {
-                Some(BourneParameterExpansion::Length { reference })
+                Some(BourneParameterExpansion::Length {
+                    reference: *reference,
+                })
             }
-            WordPart::ArrayAccess(reference) => {
-                Some(BourneParameterExpansion::Access { reference })
-            }
-            WordPart::ArrayIndices(reference) => {
-                Some(BourneParameterExpansion::Indices { reference })
-            }
+            WordPart::ArrayAccess(reference) => Some(BourneParameterExpansion::Access {
+                reference: *reference,
+            }),
+            WordPart::ArrayIndices(reference) => Some(BourneParameterExpansion::Indices {
+                reference: *reference,
+            }),
             WordPart::Substring {
                 reference,
                 offset,
@@ -5921,7 +5926,7 @@ impl<'a> Parser<'a> {
                 length_ast,
                 length_word_ast,
             } => Some(BourneParameterExpansion::Slice {
-                reference,
+                reference: *reference,
                 offset,
                 offset_ast,
                 offset_word_ast,
@@ -5936,9 +5941,9 @@ impl<'a> Parser<'a> {
                 operand_word_ast,
                 colon_variant,
             } => Some(BourneParameterExpansion::Indirect {
-                reference,
-                operator: operator.map(|operator| self.enrich_parameter_operator(operator)),
-                operand,
+                reference: *reference,
+                operator: operator.map(|operator| self.enrich_parameter_operator(*operator)),
+                operand: operand.map(|operand| *operand),
                 operand_word_ast,
                 colon_variant,
             }),
@@ -5949,7 +5954,7 @@ impl<'a> Parser<'a> {
                 reference,
                 operator,
             } => Some(BourneParameterExpansion::Transformation {
-                reference,
+                reference: *reference,
                 operator,
             }),
             WordPart::Variable(name) if raw_body_text == name.as_str() => {
@@ -5969,11 +5974,11 @@ impl<'a> Parser<'a> {
         let Some(syntax) = syntax else {
             unreachable!("matched Some above");
         };
-        WordPart::Parameter(ParameterExpansion {
+        WordPart::Parameter(Box::new(ParameterExpansion {
             syntax: ParameterExpansionSyntax::Bourne(syntax),
             span,
             raw_body,
-        })
+        }))
     }
 
     fn enrich_parameter_operator(&self, operator: ParameterOp) -> ParameterOp {
@@ -5984,7 +5989,7 @@ impl<'a> Parser<'a> {
                 ..
             } => ParameterOp::ReplaceFirst {
                 pattern,
-                replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                replacement_word_ast: Box::new(self.parse_source_text_as_word(&replacement)),
                 replacement,
             },
             ParameterOp::ReplaceAll {
@@ -5993,7 +5998,7 @@ impl<'a> Parser<'a> {
                 ..
             } => ParameterOp::ReplaceAll {
                 pattern,
-                replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                replacement_word_ast: Box::new(self.parse_source_text_as_word(&replacement)),
                 replacement,
             },
             ParameterOp::UseDefault
@@ -6046,11 +6051,11 @@ impl<'a> Parser<'a> {
         part_end: Position,
     ) -> WordPart {
         let syntax = self.parse_zsh_parameter_syntax(&raw_body, raw_body.span().start);
-        WordPart::Parameter(ParameterExpansion {
+        WordPart::Parameter(Box::new(ParameterExpansion {
             syntax: ParameterExpansionSyntax::Zsh(syntax),
             span: Span::from_positions(part_start, part_end),
             raw_body,
-        })
+        }))
     }
 
     fn parse_zsh_modifier_group(
@@ -6106,7 +6111,7 @@ impl<'a> Parser<'a> {
 
             let argument_word_ast = argument
                 .as_ref()
-                .map(|argument| self.parse_source_text_as_word(argument));
+                .map(|argument| Box::new(self.parse_source_text_as_word(argument)));
 
             modifiers.push(ZshModifier {
                 name,
@@ -6241,7 +6246,7 @@ impl<'a> Parser<'a> {
         {
             ZshExpansionTarget::Reference(reference)
         } else {
-            ZshExpansionTarget::Word(word)
+            ZshExpansionTarget::Word(Box::new(word))
         }
     }
 
@@ -6334,7 +6339,7 @@ impl<'a> Parser<'a> {
             return VarRef {
                 name: Name::from(name),
                 name_span: Span::new(),
-                subscript: Some(subscript),
+                subscript: Some(Box::new(subscript)),
                 span: Span::new(),
             };
         }
@@ -6519,7 +6524,7 @@ impl<'a> Parser<'a> {
             );
             return ZshExpansionOperation::PatternOperation {
                 kind: ZshPatternOp::Filter,
-                operand_word_ast: self.parse_source_text_as_word(&operand),
+                operand_word_ast: Box::new(self.parse_source_text_as_word(&operand)),
                 operand,
             };
         }
@@ -6547,7 +6552,7 @@ impl<'a> Parser<'a> {
             );
             return ZshExpansionOperation::Defaulting {
                 kind,
-                operand_word_ast: self.parse_source_text_as_word(&operand),
+                operand_word_ast: Box::new(self.parse_source_text_as_word(&operand)),
                 operand,
                 colon_variant: true,
             };
@@ -6565,7 +6570,7 @@ impl<'a> Parser<'a> {
             let operand = self.zsh_operation_source_text(text, base, prefix_len, text.len());
             return ZshExpansionOperation::TrimOperation {
                 kind,
-                operand_word_ast: self.parse_source_text_as_word(&operand),
+                operand_word_ast: Box::new(self.parse_source_text_as_word(&operand)),
                 operand,
             };
         }
@@ -6589,8 +6594,10 @@ impl<'a> Parser<'a> {
             });
             return ZshExpansionOperation::ReplacementOperation {
                 kind,
-                pattern_word_ast: self.parse_source_text_as_word(&pattern),
-                replacement_word_ast: self.parse_optional_source_text_as_word(replacement.as_ref()),
+                pattern_word_ast: Box::new(self.parse_source_text_as_word(&pattern)),
+                replacement_word_ast: self
+                    .parse_optional_source_text_as_word(replacement.as_ref())
+                    .map(Box::new),
                 pattern,
                 replacement,
             };
@@ -6600,7 +6607,7 @@ impl<'a> Parser<'a> {
             if Self::zsh_modifier_suffix_candidate(rest) {
                 let text = self.source_text(text.to_string(), base, base.advanced_by(text));
                 return ZshExpansionOperation::Unknown {
-                    word_ast: self.parse_source_text_as_word(&text),
+                    word_ast: Box::new(self.parse_source_text_as_word(&text)),
                     text,
                 };
             }
@@ -6613,17 +6620,19 @@ impl<'a> Parser<'a> {
                     self.zsh_operation_source_text(text, base, 1 + separator + 1, text.len())
                 });
                 return ZshExpansionOperation::Slice {
-                    offset_word_ast: self.parse_source_text_as_word(&offset),
-                    length_word_ast: self.parse_optional_source_text_as_word(length.as_ref()),
-                    offset,
-                    length,
+                    offset_word_ast: Box::new(self.parse_source_text_as_word(&offset)),
+                    length_word_ast: self
+                        .parse_optional_source_text_as_word(length.as_ref())
+                        .map(Box::new),
+                    offset: Box::new(offset),
+                    length: length.map(Box::new),
                 };
             }
         }
 
         let text = self.source_text(text.to_string(), base, base.advanced_by(text));
         ZshExpansionOperation::Unknown {
-            word_ast: self.parse_source_text_as_word(&text),
+            word_ast: Box::new(self.parse_source_text_as_word(&text)),
             text,
         }
     }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2171,10 +2171,7 @@ impl<'a> Parser<'a> {
             WordPart::Literal(text) => HeredocBodyPart::Literal(text),
             WordPart::Variable(name) => HeredocBodyPart::Variable(name),
             WordPart::CommandSubstitution { body, syntax } => {
-                HeredocBodyPart::CommandSubstitution {
-                    body: *body,
-                    syntax,
-                }
+                HeredocBodyPart::CommandSubstitution { body, syntax }
             }
             WordPart::ArithmeticExpansion {
                 expression,
@@ -2183,8 +2180,8 @@ impl<'a> Parser<'a> {
                 syntax,
             } => HeredocBodyPart::ArithmeticExpansion {
                 expression,
-                expression_ast: expression_ast.map(|expression| *expression),
-                expression_word_ast: *expression_word_ast,
+                expression_ast,
+                expression_word_ast,
                 syntax,
             },
             WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(parameter),

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -324,8 +324,8 @@ fn expect_substring_part(
     part: &WordPart,
 ) -> (
     &VarRef,
-    &Option<ArithmeticExprNode>,
-    &Option<ArithmeticExprNode>,
+    &Option<Box<ArithmeticExprNode>>,
+    &Option<Box<ArithmeticExprNode>>,
 ) {
     match part {
         WordPart::Substring {
@@ -351,8 +351,8 @@ fn expect_array_slice_part(
     part: &WordPart,
 ) -> (
     &VarRef,
-    &Option<ArithmeticExprNode>,
-    &Option<ArithmeticExprNode>,
+    &Option<Box<ArithmeticExprNode>>,
+    &Option<Box<ArithmeticExprNode>>,
 ) {
     match part {
         WordPart::ArraySlice {
@@ -383,7 +383,7 @@ fn expect_parameter_operation_part(
             operator,
             operand,
             ..
-        } => (reference, operator, operand.as_ref()),
+        } => (reference, operator, operand.as_deref()),
         WordPart::Parameter(parameter) => match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
                 reference,
@@ -423,8 +423,8 @@ fn expect_indirect_expansion_part(
             ..
         } => (
             reference,
-            operator.as_ref(),
-            operand.as_ref(),
+            operator.as_ref().map(|operator| operator.as_ref()),
+            operand.as_deref(),
             *colon_variant,
         ),
         WordPart::Parameter(parameter) => match &parameter.syntax {

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -945,31 +945,31 @@ fn test_parameter_forms_preserve_selector_kinds() {
 
     let reference = expect_array_access(&command.args[0]);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::At)
     );
 
     let reference = expect_array_access(&command.args[1]);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::Star)
     );
 
     let reference = expect_array_length_part(&command.args[2].parts[0].kind);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::At)
     );
 
     let reference = expect_array_indices_part(&command.args[3].parts[0].kind);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::Star)
     );
 
     let (reference, _, _) = expect_array_slice_part(&command.args[4].parts[0].kind);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::At)
     );
 }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1,6 +1,6 @@
 use super::*;
 use shuck_ast::ArrayValueWord;
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 #[derive(Debug, Clone, Copy)]
 struct PatternCursor {
     segment_index: usize,
@@ -130,11 +130,11 @@ impl<'a> PatternParser<'a> {
                 PatternSegment::Word(part) => {
                     self.flush_literal(&mut parts, &mut literal, &mut literal_start, literal_end);
                     parts.push(PatternPartNode::new(
-                        PatternPart::Word(Word {
-                            parts: vec![(*part).clone()],
+                        PatternPart::Word(Box::new(Word {
+                            parts: smallvec![(*part).clone()],
                             span: part.span,
                             brace_syntax: Vec::new(),
-                        }),
+                        })),
                         part.span,
                     ));
                     self.advance_to_next_segment(cursor);
@@ -547,7 +547,7 @@ impl<'a> Parser<'a> {
 
     pub(super) fn pattern_from_source_text(&mut self, text: &SourceText) -> Pattern {
         let span = text.span();
-        let mut parts = Vec::new();
+        let mut parts = WordParts::new();
         self.decode_word_parts_into_with_quote_fragments(
             text.slice(self.input),
             span.start,
@@ -1716,7 +1716,7 @@ impl<'a> Parser<'a> {
 
     pub(super) fn split_word_at(&self, word: Word, start: Position) -> Word {
         let value_span = Span::from_positions(start, word.span.end);
-        let mut parts = Vec::new();
+        let mut parts = WordParts::new();
 
         for part in word.parts {
             if let Some((kind, span)) = self.trim_word_part_prefix(part.kind, part.span, start) {
@@ -1773,7 +1773,7 @@ impl<'a> Parser<'a> {
                 } => {
                     reference.is_source_backed()
                         && self.parameter_operator_is_source_backed(operator)
-                        && operand.as_ref().is_none_or(SourceText::is_source_backed)
+                        && operand.as_deref().is_none_or(SourceText::is_source_backed)
                 }
                 WordPart::Length(reference)
                 | WordPart::ArrayAccess(reference)
@@ -1794,7 +1794,7 @@ impl<'a> Parser<'a> {
                 } => {
                     reference.is_source_backed()
                         && offset.is_source_backed()
-                        && length.as_ref().is_none_or(SourceText::is_source_backed)
+                        && length.as_deref().is_none_or(SourceText::is_source_backed)
                 }
                 WordPart::IndirectExpansion {
                     reference,
@@ -1804,7 +1804,7 @@ impl<'a> Parser<'a> {
                 } => {
                     reference.is_source_backed()
                         && operator.is_none()
-                        && operand.as_ref().is_none_or(SourceText::is_source_backed)
+                        && operand.as_deref().is_none_or(SourceText::is_source_backed)
                 }
             }
     }
@@ -1982,7 +1982,7 @@ impl<'a> Parser<'a> {
                 self.push_parameter_operator_syntax(
                     out,
                     operator,
-                    operand.as_ref(),
+                    operand.as_deref(),
                     *colon_variant,
                 );
                 out.push('}');
@@ -2042,7 +2042,7 @@ impl<'a> Parser<'a> {
                     self.push_parameter_operator_syntax(
                         out,
                         operator,
-                        operand.as_ref(),
+                        operand.as_deref(),
                         *colon_variant,
                     );
                 }
@@ -2904,8 +2904,11 @@ impl<'a> Parser<'a> {
                 let body = self.nested_stmt_seq_from_current_input(inner_start, close_span.start);
 
                 Ok(self.word_with_parts(
-                    vec![WordPartNode::new(
-                        WordPart::ProcessSubstitution { body, is_input },
+                    smallvec![WordPartNode::new(
+                        WordPart::ProcessSubstitution {
+                            body: Box::new(body),
+                            is_input,
+                        },
                         process_span.merge(close_span),
                     )],
                     process_span.merge(close_span),
@@ -2926,7 +2929,7 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
         preserve_escaped_expansion_literals: bool,
-        parts: &mut Vec<WordPartNode>,
+        parts: &mut WordParts,
     ) {
         self.decode_word_parts_into_with_quote_fragments(
             s,
@@ -2947,7 +2950,7 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
         options: DecodeWordPartsOptions,
-        parts: &mut Vec<WordPartNode>,
+        parts: &mut WordParts,
     ) {
         let mut chars = s.chars().peekable();
         let mut current = String::new();
@@ -3258,7 +3261,7 @@ impl<'a> Parser<'a> {
                 Self::push_word_part(
                     parts,
                     WordPart::DoubleQuoted {
-                        parts: inner.parts,
+                        parts: inner.parts.into_vec(),
                         dollar: false,
                     },
                     part_start,
@@ -3323,7 +3326,7 @@ impl<'a> Parser<'a> {
                 Self::push_word_part(
                     parts,
                     WordPart::CommandSubstitution {
-                        body,
+                        body: Box::new(body),
                         syntax: CommandSubstitutionSyntax::Backtick,
                     },
                     part_start,
@@ -3403,7 +3406,10 @@ impl<'a> Parser<'a> {
 
                 Self::push_word_part(
                     parts,
-                    WordPart::ProcessSubstitution { body, is_input },
+                    WordPart::ProcessSubstitution {
+                        body: Box::new(body),
+                        is_input,
+                    },
                     part_start,
                     cursor,
                 );
@@ -3542,7 +3548,7 @@ impl<'a> Parser<'a> {
                 Self::push_word_part(
                     parts,
                     WordPart::DoubleQuoted {
-                        parts: inner.parts,
+                        parts: inner.parts.into_vec(),
                         dollar: true,
                     },
                     part_start,
@@ -3702,7 +3708,7 @@ impl<'a> Parser<'a> {
                     Self::push_word_part(
                         parts,
                         WordPart::CommandSubstitution {
-                            body,
+                            body: Box::new(body),
                             syntax: CommandSubstitutionSyntax::DollarParen,
                         },
                         part_start,
@@ -3877,12 +3883,12 @@ impl<'a> Parser<'a> {
                         let part = if reference
                             .subscript
                             .as_ref()
-                            .and_then(Subscript::selector)
+                            .and_then(|subscript| subscript.selector())
                             .is_some()
                         {
-                            WordPart::ArrayLength(reference)
+                            WordPart::ArrayLength(Box::new(reference))
                         } else {
-                            WordPart::Length(reference)
+                            WordPart::Length(Box::new(reference))
                         };
                         let part = self.parameter_word_part_from_legacy(
                             part,
@@ -3894,9 +3900,9 @@ impl<'a> Parser<'a> {
                     } else {
                         Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                         let part = self.parameter_word_part_from_legacy(
-                            WordPart::Length(
+                            WordPart::Length(Box::new(
                                 self.parameter_var_ref(part_start, "${#", &var_name, None, cursor),
-                            ),
+                            )),
                             part_start,
                             cursor,
                             source_backed,
@@ -3967,10 +3973,10 @@ impl<'a> Parser<'a> {
                             if reference
                                 .subscript
                                 .as_ref()
-                                .and_then(Subscript::selector)
+                                .and_then(|subscript| subscript.selector())
                                 .is_some()
                             {
-                                WordPart::ArrayIndices(reference)
+                                WordPart::ArrayIndices(Box::new(reference))
                             } else {
                                 self.indirect_expansion_word_part(reference, None, None, false)
                             },
@@ -4137,15 +4143,17 @@ impl<'a> Parser<'a> {
                                 let operator = if replace_all {
                                     ParameterOp::ReplaceAll {
                                         pattern,
-                                        replacement_word_ast: self
-                                            .parse_source_text_as_word(&replacement),
+                                        replacement_word_ast: Box::new(
+                                            self.parse_source_text_as_word(&replacement),
+                                        ),
                                         replacement,
                                     }
                                 } else {
                                     ParameterOp::ReplaceFirst {
                                         pattern,
-                                        replacement_word_ast: self
-                                            .parse_source_text_as_word(&replacement),
+                                        replacement_word_ast: Box::new(
+                                            self.parse_source_text_as_word(&replacement),
+                                        ),
                                         replacement,
                                     }
                                 };
@@ -4405,15 +4413,17 @@ impl<'a> Parser<'a> {
                             let operator = if replace_all {
                                 ParameterOp::ReplaceAll {
                                     pattern,
-                                    replacement_word_ast: self
-                                        .parse_source_text_as_word(&replacement),
+                                    replacement_word_ast: Box::new(
+                                        self.parse_source_text_as_word(&replacement),
+                                    ),
                                     replacement,
                                 }
                             } else {
                                 ParameterOp::ReplaceFirst {
                                     pattern,
-                                    replacement_word_ast: self
-                                        .parse_source_text_as_word(&replacement),
+                                    replacement_word_ast: Box::new(
+                                        self.parse_source_text_as_word(&replacement),
+                                    ),
                                     replacement,
                                 }
                             };
@@ -4495,43 +4505,43 @@ impl<'a> Parser<'a> {
                                 let operator = Self::next_word_char_unwrap(&mut chars, &mut cursor);
                                 Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                                 WordPart::Transformation {
-                                    reference: self.parameter_var_ref(
+                                    reference: Box::new(self.parameter_var_ref(
                                         part_start,
                                         "${",
                                         &var_name,
                                         Some(subscript),
                                         cursor,
-                                    ),
+                                    )),
                                     operator,
                                 }
                             } else {
                                 Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                WordPart::ArrayAccess(self.parameter_var_ref(
+                                WordPart::ArrayAccess(Box::new(self.parameter_var_ref(
                                     part_start,
                                     "${",
                                     &var_name,
                                     Some(subscript),
                                     cursor,
-                                ))
+                                )))
                             }
                         } else {
                             Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                            WordPart::ArrayAccess(self.parameter_var_ref(
+                            WordPart::ArrayAccess(Box::new(self.parameter_var_ref(
                                 part_start,
                                 "${",
                                 &var_name,
                                 Some(subscript),
                                 cursor,
-                            ))
+                            )))
                         }
                     } else {
-                        WordPart::ArrayAccess(self.parameter_var_ref(
+                        WordPart::ArrayAccess(Box::new(self.parameter_var_ref(
                             part_start,
                             "${",
                             &var_name,
                             Some(subscript),
                             cursor,
-                        ))
+                        )))
                     };
 
                     let part = self.parameter_word_part_from_legacy(
@@ -4909,7 +4919,7 @@ impl<'a> Parser<'a> {
         source_backed: bool,
         preserve_escaped_expansion_literals: bool,
     ) -> Word {
-        let mut parts = Vec::new();
+        let mut parts = WordParts::new();
         self.decode_word_parts_into_with_escape_mode(
             s,
             base,
@@ -4928,7 +4938,7 @@ impl<'a> Parser<'a> {
         source_backed: bool,
         options: DecodeWordPartsOptions,
     ) -> Word {
-        let mut parts = Vec::new();
+        let mut parts = WordParts::new();
         self.decode_word_parts_into_with_quote_fragments(
             s,
             base,
@@ -4957,7 +4967,7 @@ impl<'a> Parser<'a> {
         source_backed: bool,
         preserve_escaped_expansion_literals: bool,
     ) -> Word {
-        let mut parts = Vec::new();
+        let mut parts = WordParts::new();
         self.decode_word_parts_into_with_quote_fragments(
             s,
             base,
@@ -5003,7 +5013,7 @@ impl<'a> Parser<'a> {
         span: Span,
         source_backed: bool,
     ) -> HeredocBody {
-        let mut parts = Vec::new();
+        let mut parts = WordParts::new();
         self.decode_word_parts_into_with_quote_fragments(
             s,
             span.start,
@@ -5044,8 +5054,11 @@ impl<'a> Parser<'a> {
         syntax: ArithmeticExpansionSyntax,
     ) -> WordPart {
         WordPart::ArithmeticExpansion {
-            expression_ast: self.parse_source_text_as_arithmetic(&expression).ok(),
-            expression_word_ast: self.parse_source_text_as_word(&expression),
+            expression_ast: self
+                .parse_source_text_as_arithmetic(&expression)
+                .ok()
+                .map(Box::new),
+            expression_word_ast: Box::new(self.parse_source_text_as_word(&expression)),
             expression,
             syntax,
         }
@@ -5058,11 +5071,13 @@ impl<'a> Parser<'a> {
         operand: Option<SourceText>,
         colon_variant: bool,
     ) -> WordPart {
-        let operand_word_ast = self.parse_optional_source_text_as_word(operand.as_ref());
+        let operand_word_ast = self
+            .parse_optional_source_text_as_word(operand.as_ref())
+            .map(Box::new);
         WordPart::ParameterExpansion {
-            reference,
-            operator,
-            operand,
+            reference: Box::new(reference),
+            operator: Box::new(operator),
+            operand: operand.map(Box::new),
             operand_word_ast,
             colon_variant,
         }
@@ -5075,11 +5090,13 @@ impl<'a> Parser<'a> {
         operand: Option<SourceText>,
         colon_variant: bool,
     ) -> WordPart {
-        let operand_word_ast = self.parse_optional_source_text_as_word(operand.as_ref());
+        let operand_word_ast = self
+            .parse_optional_source_text_as_word(operand.as_ref())
+            .map(Box::new);
         WordPart::IndirectExpansion {
-            reference,
-            operator,
-            operand,
+            reference: Box::new(reference),
+            operator: operator.map(Box::new),
+            operand: operand.map(Box::new),
             operand_word_ast,
             colon_variant,
         }
@@ -5091,18 +5108,23 @@ impl<'a> Parser<'a> {
         offset: SourceText,
         length: Option<SourceText>,
     ) -> WordPart {
-        let offset_ast = self.maybe_parse_source_text_as_arithmetic(&offset);
-        let offset_word_ast = self.parse_source_text_as_word(&offset);
+        let offset_ast = self
+            .maybe_parse_source_text_as_arithmetic(&offset)
+            .map(Box::new);
+        let offset_word_ast = Box::new(self.parse_source_text_as_word(&offset));
         let length_ast = length
             .as_ref()
-            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length));
-        let length_word_ast = self.parse_optional_source_text_as_word(length.as_ref());
+            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length))
+            .map(Box::new);
+        let length_word_ast = self
+            .parse_optional_source_text_as_word(length.as_ref())
+            .map(Box::new);
         WordPart::Substring {
-            reference,
-            offset,
+            reference: Box::new(reference),
+            offset: Box::new(offset),
             offset_ast,
             offset_word_ast,
-            length,
+            length: length.map(Box::new),
             length_ast,
             length_word_ast,
         }
@@ -5240,13 +5262,17 @@ impl<'a> Parser<'a> {
                     let operator = if replace_all {
                         ParameterOp::ReplaceAll {
                             pattern,
-                            replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                            replacement_word_ast: Box::new(
+                                self.parse_source_text_as_word(&replacement),
+                            ),
                             replacement,
                         }
                     } else {
                         ParameterOp::ReplaceFirst {
                             pattern,
-                            replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                            replacement_word_ast: Box::new(
+                                self.parse_source_text_as_word(&replacement),
+                            ),
                             replacement,
                         }
                     };
@@ -5301,8 +5327,9 @@ impl<'a> Parser<'a> {
                         let operator = Self::next_word_char_unwrap(chars, cursor);
                         Self::consume_word_char_if(chars, cursor, '}');
                         WordPart::Transformation {
-                            reference: self
-                                .parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                            reference: Box::new(
+                                self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                            ),
                             operator,
                         }
                     } else {
@@ -5335,18 +5362,23 @@ impl<'a> Parser<'a> {
         offset: SourceText,
         length: Option<SourceText>,
     ) -> WordPart {
-        let offset_ast = self.maybe_parse_source_text_as_arithmetic(&offset);
-        let offset_word_ast = self.parse_source_text_as_word(&offset);
+        let offset_ast = self
+            .maybe_parse_source_text_as_arithmetic(&offset)
+            .map(Box::new);
+        let offset_word_ast = Box::new(self.parse_source_text_as_word(&offset));
         let length_ast = length
             .as_ref()
-            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length));
-        let length_word_ast = self.parse_optional_source_text_as_word(length.as_ref());
+            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length))
+            .map(Box::new);
+        let length_word_ast = self
+            .parse_optional_source_text_as_word(length.as_ref())
+            .map(Box::new);
         WordPart::ArraySlice {
-            reference,
-            offset,
+            reference: Box::new(reference),
+            offset: Box::new(offset),
             offset_ast,
             offset_word_ast,
-            length,
+            length: length.map(Box::new),
             length_ast,
             length_word_ast,
         }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2267,10 +2267,10 @@ impl<'a> Parser<'a> {
         let value_word = self.split_word_at(word, value_start);
 
         let value = if value_word.parts.is_empty() {
-            AssignmentValue::Scalar(Word::literal_with_span(
+            AssignmentValue::Scalar(Box::new(Word::literal_with_span(
                 "",
                 Span::from_positions(value_start, assignment_span.end),
-            ))
+            )))
         } else if let Some((inner, inner_start)) = self
             .compound_array_inner_text(&value_word)
             .map(|(inner, inner_start)| (inner.into_owned(), inner_start))
@@ -2281,7 +2281,7 @@ impl<'a> Parser<'a> {
                 explicit_array_kind,
             ))
         } else {
-            AssignmentValue::Scalar(value_word)
+            AssignmentValue::Scalar(Box::new(value_word))
         };
 
         Some(Assignment {
@@ -2736,7 +2736,9 @@ impl<'a> Parser<'a> {
             return Some((
                 Assignment {
                     target,
-                    value: AssignmentValue::Scalar(Word::literal_with_span("", value_span)),
+                    value: AssignmentValue::Scalar(Box::new(Word::literal_with_span(
+                        "", value_span,
+                    ))),
                     append: is_append,
                     span: assignment_span,
                 },

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1653,7 +1653,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
             HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
                 self.visit_optional_arithmetic_expr_into(
-                    expression_ast.as_ref(),
+                    expression_ast.as_deref(),
                     flow,
                     nested_regions,
                 );

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -488,7 +488,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 DeclOperand::Name(name) => {
                     self.visit_var_ref_subscript_words(
                         Some(&name.name),
-                        name.subscript.as_ref(),
+                        name.subscript.as_deref(),
                         WordVisitKind::Expansion,
                         flow,
                         &mut nested_regions,
@@ -1021,7 +1021,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let reference_start = self.references.len();
         self.visit_var_ref_subscript_words(
             Some(&assignment.target.name),
-            assignment.target.subscript.as_ref(),
+            assignment.target.subscript.as_deref(),
             WordVisitKind::Expansion,
             flow,
             nested_regions,
@@ -1294,7 +1294,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let id = self.add_reference(&reference.name, reference_kind, span);
         self.visit_var_ref_subscript_words(
             Some(&reference.name),
-            reference.subscript.as_ref(),
+            reference.subscript.as_deref(),
             if matches!(reference_kind, ReferenceKind::ConditionalOperand) {
                 WordVisitKind::Conditional
             } else {
@@ -1410,7 +1410,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
                 self.visit_optional_arithmetic_expr_into(
-                    expression_ast.as_ref(),
+                    expression_ast.as_deref(),
                     flow,
                     nested_regions,
                 );
@@ -1433,7 +1433,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             } => {
                 let reference_id = self.visit_var_ref_reference(
                     reference,
-                    if matches!(operator, ParameterOp::Error) {
+                    if matches!(operator.as_ref(), ParameterOp::Error) {
                         ReferenceKind::RequiredRead
                     } else if matches!(kind, WordVisitKind::Conditional) {
                         ReferenceKind::ConditionalOperand
@@ -1447,13 +1447,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 if parameter_operator_guards_unset_reference(operator) {
                     self.guarded_parameter_refs.insert(reference_id);
                 }
-                if matches!(operator, ParameterOp::AssignDefault) {
+                if matches!(operator.as_ref(), ParameterOp::AssignDefault) {
                     self.add_parameter_default_binding(reference);
                 }
                 self.visit_parameter_operator_operand(
                     operator,
-                    operand.as_ref(),
-                    operand_word_ast.as_ref(),
+                    operand.as_deref(),
+                    operand_word_ast.as_deref(),
                     kind,
                     flow,
                     nested_regions,
@@ -1531,8 +1531,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 if let Some(operator) = operator {
                     self.visit_parameter_operator_operand(
                         operator,
-                        operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand.as_deref(),
+                        operand_word_ast.as_deref(),
                         kind,
                         flow,
                         nested_regions,
@@ -1556,8 +1556,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     nested_regions,
                     reference.span,
                 );
-                self.visit_optional_arithmetic_expr_into(offset_ast.as_ref(), flow, nested_regions);
-                self.visit_optional_arithmetic_expr_into(length_ast.as_ref(), flow, nested_regions);
+                self.visit_optional_arithmetic_expr_into(
+                    offset_ast.as_deref(),
+                    flow,
+                    nested_regions,
+                );
+                self.visit_optional_arithmetic_expr_into(
+                    length_ast.as_deref(),
+                    flow,
+                    nested_regions,
+                );
             }
             WordPart::ArraySlice {
                 reference,
@@ -1576,8 +1584,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     nested_regions,
                     reference.span,
                 );
-                self.visit_optional_arithmetic_expr_into(offset_ast.as_ref(), flow, nested_regions);
-                self.visit_optional_arithmetic_expr_into(length_ast.as_ref(), flow, nested_regions);
+                self.visit_optional_arithmetic_expr_into(
+                    offset_ast.as_deref(),
+                    flow,
+                    nested_regions,
+                );
+                self.visit_optional_arithmetic_expr_into(
+                    length_ast.as_deref(),
+                    flow,
+                    nested_regions,
+                );
             }
             WordPart::Transformation { reference, .. } => {
                 self.visit_var_ref_reference(
@@ -1720,7 +1736,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         self.visit_parameter_operator_operand(
                             operator,
                             operand.as_ref(),
-                            operand_word_ast.as_ref(),
+                            operand_word_ast.as_deref(),
                             kind,
                             flow,
                             nested_regions,
@@ -1756,12 +1772,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         span,
                     );
                     self.visit_optional_arithmetic_expr_into(
-                        offset_ast.as_ref(),
+                        offset_ast.as_deref(),
                         flow,
                         nested_regions,
                     );
                     self.visit_optional_arithmetic_expr_into(
-                        length_ast.as_ref(),
+                        length_ast.as_deref(),
                         flow,
                         nested_regions,
                     );
@@ -1795,7 +1811,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     self.visit_parameter_operator_operand(
                         operator,
                         operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand_word_ast.as_deref(),
                         kind,
                         flow,
                         nested_regions,
@@ -1903,7 +1919,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                             );
                             self.visit_fragment_word(
                                 operation.length_word_ast(),
-                                length.as_ref(),
+                                length.as_deref(),
                                 kind,
                                 flow,
                                 nested_regions,
@@ -4637,12 +4653,12 @@ mod tests {
         let word = word(vec![WordPart::DoubleQuoted {
             parts: vec![WordPartNode::new(
                 WordPart::CommandSubstitution {
-                    body: StmtSeq {
+                    body: Box::new(StmtSeq {
                         leading_comments: Vec::new(),
                         stmts: Vec::new(),
                         trailing_comments: Vec::new(),
                         span: Span::new(),
-                    },
+                    }),
                     syntax: shuck_ast::CommandSubstitutionSyntax::DollarParen,
                 },
                 Span::new(),
@@ -4655,7 +4671,7 @@ mod tests {
 
     #[test]
     fn inert_zsh_qualified_glob_short_circuits() {
-        let word = word(vec![WordPart::ZshQualifiedGlob(
+        let word = word(vec![WordPart::ZshQualifiedGlob(Box::new(
             shuck_ast::ZshQualifiedGlob {
                 span: Span::new(),
                 segments: vec![
@@ -4675,27 +4691,27 @@ mod tests {
                 ],
                 qualifiers: None,
             },
-        )]);
+        ))]);
 
         assert!(word_is_semantically_inert(&word));
     }
 
     #[test]
     fn pattern_with_expanding_word_is_not_inert() {
-        let pattern = pattern(vec![PatternPart::Word(word(vec![
+        let pattern = pattern(vec![PatternPart::Word(Box::new(word(vec![
             WordPart::ParameterExpansion {
-                reference: VarRef {
+                reference: Box::new(VarRef {
                     name: "name".into(),
                     name_span: Span::new(),
                     subscript: None,
                     span: Span::new(),
-                },
-                operator: ParameterOp::UseDefault,
-                operand: Some(SourceText::from("fallback")),
-                operand_word_ast: Some(Word::literal("fallback")),
+                }),
+                operator: Box::new(ParameterOp::UseDefault),
+                operand: Some(Box::new(SourceText::from("fallback"))),
+                operand_word_ast: Some(Box::new(Word::literal("fallback"))),
                 colon_variant: true,
             },
-        ]))]);
+        ])))]);
 
         assert!(!pattern_is_semantically_inert(&pattern));
     }


### PR DESCRIPTION
## Summary
- Change `Word.parts` to `WordParts = SmallVec<[WordPartNode; 2]>` for inline storage of common one- and two-part words.
- Add `smallvec` to `shuck-ast` and update parser/consumer construction paths for the new container.
- Box rare, bulky recursive expansion payloads so the inline word parts do not create excessive stack pressure.

## Notes
- `WordPart::DoubleQuoted { parts }` remains `Vec<WordPartNode>` because using `WordParts` there creates a recursive type layout cycle.
- The formatter benchmark-corpus stack test failed during iteration until bulky rare payloads were boxed; it now passes.

## Validation
- `cargo test -p shuck-ast`
- `cargo test -p shuck-parser`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-formatter`
- `make test`
- `cargo test --features http_client` was attempted but Cargo reported no selected package defines `http_client`.

## Benchmark
Shuck-only CLI macrobench, before `/Users/ewhauser/working/shuck` at `d5cfbecb`, after this branch:

| fixture | before | after | delta |
| --- | ---: | ---: | ---: |
| all | 71.21 ms | 65.63 ms | -7.83% |
| fzf-install | 8.66 ms | 11.32 ms | +30.75% |
| homebrew-install | 11.19 ms | 12.21 ms | +9.08% |
| nvm | 57.46 ms | 56.72 ms | -1.28% |
| pyenv-python-build | 30.78 ms | 30.60 ms | -0.58% |
| ruby-build | 18.89 ms | 18.73 ms | -0.84% |

The aggregate improves, but `fzf-install` and `homebrew-install` are above the rough 5% regression threshold; `fzf-install` also had high variance in the after run.
