### PR TITLE
perf(parser): stop over-reserving compound lists

### DIFF
--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -4285,7 +4285,7 @@ impl<'a> Parser<'a> {
 
     /// Parse commands until one of the terminating keywords
     fn parse_compound_list_until(&mut self, terminators: KeywordSet) -> Result<Vec<Stmt>> {
-        let mut stmts = Vec::with_capacity(4);
+        let mut stmts = Vec::new();
 
         loop {
             self.skip_command_separators()?;


### PR DESCRIPTION
## Summary
- avoid eagerly reserving space for four `Stmt`s in compound statement lists
- let small compound lists stay allocation-free until they actually receive entries

## Benchmark
Parser Criterion vs `main`:

```text
fzf-install           0.536 ms ->  0.605 ms   +12.77%
homebrew-install      1.316 ms ->  1.129 ms   -14.20%
ruby-build            2.313 ms ->  1.894 ms   -18.14%
pyenv-python-build    3.575 ms ->  3.502 ms    -2.05%
nvm                   7.152 ms ->  6.449 ms    -9.84%
all                  15.587 ms -> 13.717 ms   -12.00%
```

## Validation
- `cargo test -p shuck-parser`
- `cargo bench -p shuck-benchmark --bench parser -- --save-baseline=main --noplot` on `main`
- `cargo bench -p shuck-benchmark --bench parser -- --baseline=main --noplot` on this branch
