### PR TITLE
fix(linter): align C087 with SC2072

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c087.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c087.yaml
@@ -1,5 +1,0 @@
-reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__ct__immich.sh"
-    line: 114
-    reason: "This Proxmox update helper compares a saved semver-style string from `$(cat ~/.immich)` against `2.5.1` with lexical `[[ ... > ... ]]`. C087 intentionally keeps this warning because multi-segment dotted versions are still ordered as plain strings here, while the pinned SC2072 oracle only flags decimal-style comparisons and stays silent on `2.5.1`-style operands, so this semver-policy divergence is reviewed."

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C087.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C087.sh
@@ -6,7 +6,7 @@
 # Invalid: the same issue applies when the dotted version is on the left.
 [[ 1.2 < $ver ]]
 
-# Invalid: comparing two dotted numeric literals still uses lexical ordering.
+# Invalid: comparing a dotted decimal literal to another dotted value still uses lexical ordering.
 [[ 1.2.3 < 2.0 ]]
 
 # Invalid: lexical `>` still compares version-like values as strings.
@@ -18,6 +18,7 @@
 # Valid: integer-only comparisons belong to the generic numeric/string rule family.
 [[ $count < 10 ]]
 
-# Valid: plain string ordering is outside this version-specific rule.
+# Valid: plain string ordering and multi-segment versions are outside the SC2072-shaped rule.
 [[ foo < bar ]]
 [[ $tag < v1.2 ]]
+[[ $ver < 2.5.1 ]]

--- a/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_comparison_for_version.rs
@@ -68,32 +68,19 @@ fn version_operand_span(binary: &ConditionalBinaryFact<'_>, source: &str) -> Opt
     }
 }
 
-// Treat any all-digit dotted literal (for example `1.27` or `2.5.1`) as
-// version-like here, since lexical `[[ ... < ... ]]` / `[[ ... > ... ]]`
-// comparisons are not version-aware for either shape.
+// Match the SC2072 oracle's decimal-like shape: one dot with digits on both
+// sides. Multi-segment versions are intentionally outside C087 unless the
+// other operand has this decimal form.
 fn is_dotted_numeric_version_like(text: &str) -> bool {
-    let mut saw_dot = false;
-    let mut saw_digit = false;
-    let mut segment_has_digit = false;
+    let Some((left, right)) = text.split_once('.') else {
+        return false;
+    };
 
-    for ch in text.chars() {
-        match ch {
-            '0'..='9' => {
-                saw_digit = true;
-                segment_has_digit = true;
-            }
-            '.' => {
-                if !segment_has_digit {
-                    return false;
-                }
-                saw_dot = true;
-                segment_has_digit = false;
-            }
-            _ => return false,
-        }
-    }
-
-    saw_digit && saw_dot && segment_has_digit
+    !left.is_empty()
+        && !right.is_empty()
+        && !right.contains('.')
+        && left.bytes().all(|byte| byte.is_ascii_digit())
+        && right.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 #[cfg(test)]
@@ -132,7 +119,7 @@ mod tests {
 #!/bin/bash
 [[ \"$actual\" > \"0.8\" ]]
 [[ \"1.2\" < $ver ]]
-[[ $(cat version.txt) < 2.5.1 ]]
+[[ $(cat version.txt) < 2.5 ]]
 ";
         let diagnostics = test_snippet(
             source,
@@ -144,7 +131,7 @@ mod tests {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["\"0.8\"", "\"1.2\"", "2.5.1"]
+            vec!["\"0.8\"", "\"1.2\"", "2.5"]
         );
     }
 
@@ -170,6 +157,9 @@ mod tests {
 [[ $count < 10 ]]
 [[ foo < bar ]]
 [[ $tag < v1.2 ]]
+[[ 1.2.3 < $ver ]]
+[[ $ver < 1.2.3 ]]
+[[ 1.2.3 < 2.3.4 ]]
 [ \"$ver\" \\< 1.27 ]
 ";
         let diagnostics = test_snippet(

--- a/docs/rules/C087.yaml
+++ b/docs/rules/C087.yaml
@@ -9,8 +9,8 @@ shells:
   - sh
   - bash
   - dash
-description: "A `<` or `>` operator inside `[[ ]]` compares dotted numeric values lexicographically, so version-like strings such as `2.5.1` are not ordered by version semantics."
-rationale: "Use `-lt` or `-gt` for integer comparisons, or a version-aware tool for dotted version strings."
+description: "A `<` or `>` operator inside `[[ ]]` compares decimal-like values lexicographically, so strings such as `1.27` are not ordered numerically."
+rationale: "Use `-lt` or `-gt` for integer comparisons, or a version-aware tool when comparing release strings."
 safe_fix: false
 fix_description: null
 source:
@@ -28,11 +28,4 @@ examples:
       #!/bin/bash
       if [[ "$actual" > "0.8" ]]; then
         echo new
-      fi
-  - kind: invalid
-    code: |
-      #!/bin/bash
-      current=$(cat ~/.immich)
-      if [[ $current > 2.5.1 ]]; then
-        echo upgrade
       fi


### PR DESCRIPTION
## Summary
- narrow C087 to the SC2072 decimal-like operand shape
- stop reporting lone multi-segment versions such as 2.5.1
- remove the reviewed divergence metadata for the Proxmox corpus fixture

## Validation
- cargo fmt
- cargo test -p shuck-linter string_comparison_for_version
- cargo test -p shuck-linter rules::correctness::tests::rules::rule_stringcomparisonforversion_path_new_c087_sh_expects
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C087 (C087 implementation_diffs=0 and reviewed_divergences=0; exits nonzero due to 3 unrelated harness failures)