### PR TITLE
chore(benchmark): add memory measurement tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ dependencies = [
  "criterion",
  "serde",
  "serde_json",
+ "shuck-ast",
  "shuck-cli",
  "shuck-formatter",
  "shuck-indexer",

--- a/crates/shuck-benchmark/AGENTS.md
+++ b/crates/shuck-benchmark/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+These instructions apply to `crates/shuck-benchmark`. Follow the repo-level
+`AGENTS.md` first, including the clean-room policy.
+
+## Memory and shape estimation tools
+
+Use these examples when estimating the payoff from arena allocation, AST layout
+changes, or fact/semantic storage changes. They are measurement tools, not
+Criterion timing benchmarks.
+
+```bash
+cargo run -q -p shuck-benchmark --example parser_memory -- --case all
+cargo run -q -p shuck-benchmark --example semantic_memory -- --case all
+cargo run -q -p shuck-benchmark --example linter_memory -- --case all
+cargo run -q -p shuck-benchmark --example formatter_memory -- --case all
+cargo run -q -p shuck-benchmark --example ast_shape -- --case all
+```
+
+Pass any benchmark case name after `--case`, such as `nvm`,
+`pyenv-python-build`, or `all`. The tools print JSON so results can be saved
+and diffed between branches.
+
+### Reading the reports
+
+- `allocation_count`, `reallocation_count`, `total_allocated_bytes`, and
+  `peak_live_bytes` are allocator-pressure signals. They are useful for sizing
+  possible wins, not for wall-clock timing.
+- `parser_memory` measures parsing and AST construction only.
+- `semantic_memory` measures parse + indexer + semantic model construction.
+- `linter_memory` reports both a full measured region and phase totals for
+  parse, index/suppression setup, and linting. Phase `final_live_bytes` can be
+  nonzero because later phases intentionally keep earlier outputs alive.
+- `formatter_memory` separates source formatting from AST-only formatting, which
+  helps distinguish parser/layout costs from formatter traversal/output costs.
+- `ast_shape` counts structural pressure in the parsed AST: recursive nodes,
+  non-empty `Vec` fields, `Box` edges, owned text fields, and an
+  `estimated_replaceable_heap_allocations` rough-order signal.
+
+Use the shape report together with allocator reports. For example, a large
+number of non-empty AST `Vec` fields means compact child-range storage may help;
+a large linter phase in `linter_memory` means AST arenas alone will not explain
+most end-to-end lint allocation.
+
+## Timing benchmarks
+
+Use Criterion for wall-clock estimates and comparisons:
+
+```bash
+cargo bench -p shuck-benchmark --bench parser -- --save-baseline before
+cargo bench -p shuck-benchmark --bench parser -- --baseline before
+cargo bench -p shuck-benchmark --bench semantic -- semantic/all
+cargo bench -p shuck-benchmark --bench linter -- linter/all
+cargo bench -p shuck-benchmark --bench formatter -- formatter_source/all
+```
+
+Parser operation counters are available behind the parser benchmarking feature:
+
+```bash
+cargo run -q -p shuck-benchmark --features parser-benchmarking --example parser_counts -- all
+```
+
+## Validation
+
+After changing benchmark helpers or examples, run:
+
+```bash
+cargo check -p shuck-benchmark --examples
+cargo test -p shuck-benchmark
+```

--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 parser-benchmarking = ["shuck-parser/benchmarking"]
 
 [dependencies]
+shuck-ast = { workspace = true }
 shuck-formatter = { workspace = true, features = ["benchmarking"] }
 shuck-indexer = { workspace = true }
 shuck-linter = { workspace = true, features = ["benchmarking"] }

--- a/crates/shuck-benchmark/examples/ast_shape.rs
+++ b/crates/shuck-benchmark/examples/ast_shape.rs
@@ -1,0 +1,948 @@
+use std::process;
+
+use serde::Serialize;
+use shuck_ast::*;
+use shuck_benchmark::{benchmark_cases, parse_fixture};
+use shuck_parser::parser::ParseStatus;
+
+#[derive(Debug, Default, Serialize)]
+struct AstShape {
+    stmt_sequences: u64,
+    statements: u64,
+    commands: u64,
+    words: u64,
+    word_parts: u64,
+    patterns: u64,
+    pattern_parts: u64,
+    arithmetic_exprs: u64,
+    conditional_exprs: u64,
+    redirects: u64,
+    heredocs: u64,
+    assignments: u64,
+    array_exprs: u64,
+    array_elems: u64,
+    var_refs: u64,
+    parameter_expansions: u64,
+    source_text_fields: u64,
+    non_source_text_fields: u64,
+    literal_text_fields: u64,
+    owned_literal_text_fields: u64,
+    string_fields: u64,
+    non_empty_string_fields: u64,
+    box_edges: u64,
+    vec_fields: u64,
+    non_empty_vec_fields: u64,
+    vec_elements: u64,
+    max_stmt_seq_depth: u64,
+    max_word_depth: u64,
+    max_arithmetic_depth: u64,
+    max_conditional_depth: u64,
+}
+
+impl AstShape {
+    fn estimated_replaceable_heap_allocations(&self) -> u64 {
+        self.box_edges
+            + self.non_empty_vec_fields
+            + self.non_source_text_fields
+            + self.owned_literal_text_fields
+            + self.non_empty_string_fields
+    }
+
+    fn record_vec<T>(&mut self, values: &[T]) {
+        self.vec_fields += 1;
+        self.vec_elements += values.len() as u64;
+        if !values.is_empty() {
+            self.non_empty_vec_fields += 1;
+        }
+    }
+
+    fn record_option_vec<T>(&mut self, values: &Option<Vec<T>>) {
+        self.vec_fields += 1;
+        if let Some(values) = values {
+            self.vec_elements += values.len() as u64;
+            if !values.is_empty() {
+                self.non_empty_vec_fields += 1;
+            }
+        }
+    }
+
+    fn record_box(&mut self) {
+        self.box_edges += 1;
+    }
+
+    fn record_source_text(&mut self, text: &SourceText) {
+        self.source_text_fields += 1;
+        if !text.is_source_backed() {
+            self.non_source_text_fields += 1;
+        }
+    }
+
+    fn record_literal_text(&mut self, text: &LiteralText) {
+        self.literal_text_fields += 1;
+        if !text.is_source_backed() {
+            self.owned_literal_text_fields += 1;
+        }
+    }
+
+    fn record_string(&mut self, value: &str) {
+        self.string_fields += 1;
+        if !value.is_empty() {
+            self.non_empty_string_fields += 1;
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CaseReport {
+    case: String,
+    files: usize,
+    recovered_files: usize,
+    command_count: usize,
+    estimated_replaceable_heap_allocations: u64,
+    shape: AstShape,
+}
+
+fn visit_file(file: &File, shape: &mut AstShape) {
+    visit_stmt_seq(&file.body, shape, 1);
+}
+
+fn visit_stmt_seq(seq: &StmtSeq, shape: &mut AstShape, depth: u64) {
+    shape.stmt_sequences += 1;
+    shape.max_stmt_seq_depth = shape.max_stmt_seq_depth.max(depth);
+    shape.record_vec(&seq.leading_comments);
+    shape.record_vec(&seq.stmts);
+    shape.record_vec(&seq.trailing_comments);
+    for stmt in &seq.stmts {
+        visit_stmt(stmt, shape, depth);
+    }
+}
+
+fn visit_stmt(stmt: &Stmt, shape: &mut AstShape, depth: u64) {
+    shape.statements += 1;
+    shape.record_vec(&stmt.leading_comments);
+    visit_command(&stmt.command, shape, depth);
+    shape.record_vec(&stmt.redirects);
+    for redirect in &stmt.redirects {
+        visit_redirect(redirect, shape);
+    }
+}
+
+fn visit_command(command: &Command, shape: &mut AstShape, depth: u64) {
+    shape.commands += 1;
+    match command {
+        Command::Simple(command) => {
+            visit_word(&command.name, shape, 1);
+            shape.record_vec(&command.args);
+            for arg in &command.args {
+                visit_word(arg, shape, 1);
+            }
+            shape.record_vec(&command.assignments);
+            for assignment in &command.assignments {
+                visit_assignment(assignment, shape);
+            }
+        }
+        Command::Builtin(command) => visit_builtin_command(command, shape),
+        Command::Decl(command) => {
+            shape.record_vec(&command.operands);
+            for operand in &command.operands {
+                visit_decl_operand(operand, shape);
+            }
+            shape.record_vec(&command.assignments);
+            for assignment in &command.assignments {
+                visit_assignment(assignment, shape);
+            }
+        }
+        Command::Binary(command) => {
+            shape.record_box();
+            visit_stmt(&command.left, shape, depth + 1);
+            shape.record_box();
+            visit_stmt(&command.right, shape, depth + 1);
+        }
+        Command::Compound(command) => visit_compound_command(command, shape, depth),
+        Command::Function(command) => {
+            visit_function_header(&command.header, shape);
+            shape.record_box();
+            visit_stmt(&command.body, shape, depth + 1);
+        }
+        Command::AnonymousFunction(command) => {
+            shape.record_box();
+            visit_stmt(&command.body, shape, depth + 1);
+            shape.record_vec(&command.args);
+            for arg in &command.args {
+                visit_word(arg, shape, 1);
+            }
+        }
+    }
+}
+
+fn visit_builtin_command(command: &BuiltinCommand, shape: &mut AstShape) {
+    match command {
+        BuiltinCommand::Break(command) => {
+            if let Some(depth) = &command.depth {
+                visit_word(depth, shape, 1);
+            }
+            shape.record_vec(&command.extra_args);
+            for arg in &command.extra_args {
+                visit_word(arg, shape, 1);
+            }
+            shape.record_vec(&command.assignments);
+            for assignment in &command.assignments {
+                visit_assignment(assignment, shape);
+            }
+        }
+        BuiltinCommand::Continue(command) => {
+            if let Some(depth) = &command.depth {
+                visit_word(depth, shape, 1);
+            }
+            shape.record_vec(&command.extra_args);
+            for arg in &command.extra_args {
+                visit_word(arg, shape, 1);
+            }
+            shape.record_vec(&command.assignments);
+            for assignment in &command.assignments {
+                visit_assignment(assignment, shape);
+            }
+        }
+        BuiltinCommand::Return(command) => {
+            if let Some(code) = &command.code {
+                visit_word(code, shape, 1);
+            }
+            shape.record_vec(&command.extra_args);
+            for arg in &command.extra_args {
+                visit_word(arg, shape, 1);
+            }
+            shape.record_vec(&command.assignments);
+            for assignment in &command.assignments {
+                visit_assignment(assignment, shape);
+            }
+        }
+        BuiltinCommand::Exit(command) => {
+            if let Some(code) = &command.code {
+                visit_word(code, shape, 1);
+            }
+            shape.record_vec(&command.extra_args);
+            for arg in &command.extra_args {
+                visit_word(arg, shape, 1);
+            }
+            shape.record_vec(&command.assignments);
+            for assignment in &command.assignments {
+                visit_assignment(assignment, shape);
+            }
+        }
+    }
+}
+
+fn visit_decl_operand(operand: &DeclOperand, shape: &mut AstShape) {
+    match operand {
+        DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => visit_word(word, shape, 1),
+        DeclOperand::Name(reference) => visit_var_ref(reference, shape),
+        DeclOperand::Assignment(assignment) => visit_assignment(assignment, shape),
+    }
+}
+
+fn visit_compound_command(command: &CompoundCommand, shape: &mut AstShape, depth: u64) {
+    match command {
+        CompoundCommand::If(command) => {
+            visit_stmt_seq(&command.condition, shape, depth + 1);
+            visit_stmt_seq(&command.then_branch, shape, depth + 1);
+            shape.record_vec(&command.elif_branches);
+            for (condition, branch) in &command.elif_branches {
+                visit_stmt_seq(condition, shape, depth + 1);
+                visit_stmt_seq(branch, shape, depth + 1);
+            }
+            if let Some(else_branch) = &command.else_branch {
+                visit_stmt_seq(else_branch, shape, depth + 1);
+            }
+        }
+        CompoundCommand::For(command) => {
+            shape.record_vec(&command.targets);
+            for target in &command.targets {
+                visit_word(&target.word, shape, 1);
+            }
+            shape.record_option_vec(&command.words);
+            if let Some(words) = &command.words {
+                for word in words {
+                    visit_word(word, shape, 1);
+                }
+            }
+            visit_stmt_seq(&command.body, shape, depth + 1);
+        }
+        CompoundCommand::Repeat(command) => {
+            visit_word(&command.count, shape, 1);
+            visit_stmt_seq(&command.body, shape, depth + 1);
+        }
+        CompoundCommand::Foreach(command) => {
+            shape.record_vec(&command.words);
+            for word in &command.words {
+                visit_word(word, shape, 1);
+            }
+            visit_stmt_seq(&command.body, shape, depth + 1);
+        }
+        CompoundCommand::ArithmeticFor(command) => {
+            shape.record_box();
+            if let Some(expr) = &command.init_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+            if let Some(expr) = &command.condition_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+            if let Some(expr) = &command.step_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+            visit_stmt_seq(&command.body, shape, depth + 1);
+        }
+        CompoundCommand::While(command) => {
+            visit_stmt_seq(&command.condition, shape, depth + 1);
+            visit_stmt_seq(&command.body, shape, depth + 1);
+        }
+        CompoundCommand::Until(command) => {
+            visit_stmt_seq(&command.condition, shape, depth + 1);
+            visit_stmt_seq(&command.body, shape, depth + 1);
+        }
+        CompoundCommand::Case(command) => {
+            visit_word(&command.word, shape, 1);
+            shape.record_vec(&command.cases);
+            for case in &command.cases {
+                shape.record_vec(&case.patterns);
+                for pattern in &case.patterns {
+                    visit_pattern(pattern, shape);
+                }
+                visit_stmt_seq(&case.body, shape, depth + 1);
+            }
+        }
+        CompoundCommand::Select(command) => {
+            shape.record_vec(&command.words);
+            for word in &command.words {
+                visit_word(word, shape, 1);
+            }
+            visit_stmt_seq(&command.body, shape, depth + 1);
+        }
+        CompoundCommand::Subshell(seq) | CompoundCommand::BraceGroup(seq) => {
+            visit_stmt_seq(seq, shape, depth + 1);
+        }
+        CompoundCommand::Arithmetic(command) => {
+            if let Some(expr) = &command.expr_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+        }
+        CompoundCommand::Time(command) => {
+            if let Some(command) = &command.command {
+                shape.record_box();
+                visit_stmt(command, shape, depth + 1);
+            }
+        }
+        CompoundCommand::Conditional(command) => {
+            visit_conditional_expr(&command.expression, shape, 1);
+        }
+        CompoundCommand::Coproc(command) => {
+            shape.record_box();
+            visit_stmt(&command.body, shape, depth + 1);
+        }
+        CompoundCommand::Always(command) => {
+            visit_stmt_seq(&command.body, shape, depth + 1);
+            visit_stmt_seq(&command.always_body, shape, depth + 1);
+        }
+    }
+}
+
+fn visit_function_header(header: &FunctionHeader, shape: &mut AstShape) {
+    shape.record_vec(&header.entries);
+    for entry in &header.entries {
+        visit_word(&entry.word, shape, 1);
+    }
+}
+
+fn visit_redirect(redirect: &Redirect, shape: &mut AstShape) {
+    shape.redirects += 1;
+    match &redirect.target {
+        RedirectTarget::Word(word) => visit_word(word, shape, 1),
+        RedirectTarget::Heredoc(heredoc) => visit_heredoc(heredoc, shape),
+    }
+}
+
+fn visit_heredoc(heredoc: &Heredoc, shape: &mut AstShape) {
+    shape.heredocs += 1;
+    visit_word(&heredoc.delimiter.raw, shape, 1);
+    shape.record_string(&heredoc.delimiter.cooked);
+    visit_heredoc_body(&heredoc.body, shape);
+}
+
+fn visit_heredoc_body(body: &HeredocBody, shape: &mut AstShape) {
+    shape.record_vec(&body.parts);
+    for part in &body.parts {
+        match &part.kind {
+            HeredocBodyPart::Literal(text) => shape.record_literal_text(text),
+            HeredocBodyPart::Variable(_) => {}
+            HeredocBodyPart::CommandSubstitution { body, .. } => visit_stmt_seq(body, shape, 1),
+            HeredocBodyPart::ArithmeticExpansion {
+                expression,
+                expression_ast,
+                expression_word_ast,
+                ..
+            } => {
+                shape.record_source_text(expression);
+                if let Some(expr) = expression_ast {
+                    visit_arithmetic_expr(expr, shape, 1);
+                }
+                visit_word(expression_word_ast, shape, 1);
+            }
+            HeredocBodyPart::Parameter(parameter) => {
+                shape.record_box();
+                visit_parameter_expansion(parameter, shape);
+            }
+        }
+    }
+}
+
+fn visit_assignment(assignment: &Assignment, shape: &mut AstShape) {
+    shape.assignments += 1;
+    visit_var_ref(&assignment.target, shape);
+    match &assignment.value {
+        AssignmentValue::Scalar(word) => visit_word(word, shape, 1),
+        AssignmentValue::Compound(array) => visit_array_expr(array, shape),
+    }
+}
+
+fn visit_array_expr(array: &ArrayExpr, shape: &mut AstShape) {
+    shape.array_exprs += 1;
+    shape.record_vec(&array.elements);
+    for element in &array.elements {
+        shape.array_elems += 1;
+        match element {
+            ArrayElem::Sequential(word) => visit_word(&word.word, shape, 1),
+            ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
+                visit_subscript(key, shape);
+                visit_word(&value.word, shape, 1);
+            }
+        }
+    }
+}
+
+fn visit_var_ref(reference: &VarRef, shape: &mut AstShape) {
+    shape.var_refs += 1;
+    if let Some(subscript) = &reference.subscript {
+        visit_subscript(subscript, shape);
+    }
+}
+
+fn visit_subscript(subscript: &Subscript, shape: &mut AstShape) {
+    shape.record_source_text(&subscript.text);
+    if let Some(raw) = &subscript.raw {
+        shape.record_source_text(raw);
+    }
+    if let Some(word) = &subscript.word_ast {
+        visit_word(word, shape, 1);
+    }
+    if let Some(expr) = &subscript.arithmetic_ast {
+        visit_arithmetic_expr(expr, shape, 1);
+    }
+}
+
+fn visit_word(word: &Word, shape: &mut AstShape, depth: u64) {
+    shape.words += 1;
+    shape.max_word_depth = shape.max_word_depth.max(depth);
+    shape.record_vec(&word.parts);
+    shape.record_vec(&word.brace_syntax);
+    for part in &word.parts {
+        shape.word_parts += 1;
+        visit_word_part(&part.kind, shape, depth);
+    }
+}
+
+fn visit_word_part(part: &WordPart, shape: &mut AstShape, depth: u64) {
+    match part {
+        WordPart::Literal(text) => shape.record_literal_text(text),
+        WordPart::ZshQualifiedGlob(glob) => visit_zsh_qualified_glob(glob, shape),
+        WordPart::SingleQuoted { value, .. } => shape.record_source_text(value),
+        WordPart::DoubleQuoted { parts, .. } => {
+            shape.record_vec(parts);
+            for part in parts {
+                shape.word_parts += 1;
+                visit_word_part(&part.kind, shape, depth + 1);
+            }
+        }
+        WordPart::Variable(_) => {}
+        WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
+            visit_stmt_seq(body, shape, 1)
+        }
+        WordPart::ArithmeticExpansion {
+            expression,
+            expression_ast,
+            expression_word_ast,
+            ..
+        } => {
+            shape.record_source_text(expression);
+            if let Some(expr) = expression_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+            visit_word(expression_word_ast, shape, depth + 1);
+        }
+        WordPart::Parameter(parameter) => visit_parameter_expansion(parameter, shape),
+        WordPart::ParameterExpansion {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            visit_var_ref(reference, shape);
+            visit_parameter_op(operator, shape);
+            if let Some(operand) = operand {
+                shape.record_source_text(operand);
+            }
+            if let Some(word) = operand_word_ast {
+                visit_word(word, shape, depth + 1);
+            }
+        }
+        WordPart::Length(reference)
+        | WordPart::ArrayAccess(reference)
+        | WordPart::ArrayLength(reference)
+        | WordPart::ArrayIndices(reference)
+        | WordPart::Transformation { reference, .. } => visit_var_ref(reference, shape),
+        WordPart::Substring {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+        }
+        | WordPart::ArraySlice {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+        } => {
+            visit_var_ref(reference, shape);
+            shape.record_source_text(offset);
+            if let Some(expr) = offset_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+            visit_word(offset_word_ast, shape, depth + 1);
+            if let Some(length) = length {
+                shape.record_source_text(length);
+            }
+            if let Some(expr) = length_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+            if let Some(word) = length_word_ast {
+                visit_word(word, shape, depth + 1);
+            }
+        }
+        WordPart::IndirectExpansion {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            visit_var_ref(reference, shape);
+            if let Some(operator) = operator {
+                visit_parameter_op(operator, shape);
+            }
+            if let Some(operand) = operand {
+                shape.record_source_text(operand);
+            }
+            if let Some(word) = operand_word_ast {
+                visit_word(word, shape, depth + 1);
+            }
+        }
+        WordPart::PrefixMatch { .. } => {}
+    }
+}
+
+fn visit_parameter_expansion(parameter: &ParameterExpansion, shape: &mut AstShape) {
+    shape.parameter_expansions += 1;
+    shape.record_source_text(&parameter.raw_body);
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(expansion) => visit_bourne_expansion(expansion, shape),
+        ParameterExpansionSyntax::Zsh(expansion) => visit_zsh_parameter_expansion(expansion, shape),
+    }
+}
+
+fn visit_bourne_expansion(expansion: &BourneParameterExpansion, shape: &mut AstShape) {
+    match expansion {
+        BourneParameterExpansion::Access { reference }
+        | BourneParameterExpansion::Length { reference }
+        | BourneParameterExpansion::Indices { reference }
+        | BourneParameterExpansion::Transformation { reference, .. } => {
+            visit_var_ref(reference, shape);
+        }
+        BourneParameterExpansion::Indirect {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            visit_var_ref(reference, shape);
+            if let Some(operator) = operator {
+                visit_parameter_op(operator, shape);
+            }
+            if let Some(operand) = operand {
+                shape.record_source_text(operand);
+            }
+            if let Some(word) = operand_word_ast {
+                visit_word(word, shape, 1);
+            }
+        }
+        BourneParameterExpansion::PrefixMatch { .. } => {}
+        BourneParameterExpansion::Slice {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+        } => {
+            visit_var_ref(reference, shape);
+            shape.record_source_text(offset);
+            if let Some(expr) = offset_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+            visit_word(offset_word_ast, shape, 1);
+            if let Some(length) = length {
+                shape.record_source_text(length);
+            }
+            if let Some(expr) = length_ast {
+                visit_arithmetic_expr(expr, shape, 1);
+            }
+            if let Some(word) = length_word_ast {
+                visit_word(word, shape, 1);
+            }
+        }
+        BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            visit_var_ref(reference, shape);
+            visit_parameter_op(operator, shape);
+            if let Some(operand) = operand {
+                shape.record_source_text(operand);
+            }
+            if let Some(word) = operand_word_ast {
+                visit_word(word, shape, 1);
+            }
+        }
+    }
+}
+
+fn visit_zsh_parameter_expansion(expansion: &ZshParameterExpansion, shape: &mut AstShape) {
+    visit_zsh_target(&expansion.target, shape);
+    shape.record_vec(&expansion.modifiers);
+    for modifier in &expansion.modifiers {
+        if let Some(argument) = &modifier.argument {
+            shape.record_source_text(argument);
+        }
+        if let Some(word) = &modifier.argument_word_ast {
+            visit_word(word, shape, 1);
+        }
+    }
+    if let Some(operation) = &expansion.operation {
+        visit_zsh_operation(operation, shape);
+    }
+}
+
+fn visit_zsh_target(target: &ZshExpansionTarget, shape: &mut AstShape) {
+    match target {
+        ZshExpansionTarget::Reference(reference) => visit_var_ref(reference, shape),
+        ZshExpansionTarget::Nested(parameter) => {
+            shape.record_box();
+            visit_parameter_expansion(parameter, shape);
+        }
+        ZshExpansionTarget::Word(word) => visit_word(word, shape, 1),
+        ZshExpansionTarget::Empty => {}
+    }
+}
+
+fn visit_zsh_operation(operation: &ZshExpansionOperation, shape: &mut AstShape) {
+    match operation {
+        ZshExpansionOperation::PatternOperation {
+            operand,
+            operand_word_ast,
+            ..
+        }
+        | ZshExpansionOperation::Defaulting {
+            operand,
+            operand_word_ast,
+            ..
+        }
+        | ZshExpansionOperation::TrimOperation {
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            shape.record_source_text(operand);
+            visit_word(operand_word_ast, shape, 1);
+        }
+        ZshExpansionOperation::ReplacementOperation {
+            pattern,
+            pattern_word_ast,
+            replacement,
+            replacement_word_ast,
+            ..
+        } => {
+            shape.record_source_text(pattern);
+            visit_word(pattern_word_ast, shape, 1);
+            if let Some(replacement) = replacement {
+                shape.record_source_text(replacement);
+            }
+            if let Some(word) = replacement_word_ast {
+                visit_word(word, shape, 1);
+            }
+        }
+        ZshExpansionOperation::Slice {
+            offset,
+            offset_word_ast,
+            length,
+            length_word_ast,
+        } => {
+            shape.record_source_text(offset);
+            visit_word(offset_word_ast, shape, 1);
+            if let Some(length) = length {
+                shape.record_source_text(length);
+            }
+            if let Some(word) = length_word_ast {
+                visit_word(word, shape, 1);
+            }
+        }
+        ZshExpansionOperation::Unknown { text, word_ast } => {
+            shape.record_source_text(text);
+            visit_word(word_ast, shape, 1);
+        }
+    }
+}
+
+fn visit_parameter_op(operator: &ParameterOp, shape: &mut AstShape) {
+    match operator {
+        ParameterOp::RemovePrefixShort { pattern }
+        | ParameterOp::RemovePrefixLong { pattern }
+        | ParameterOp::RemoveSuffixShort { pattern }
+        | ParameterOp::RemoveSuffixLong { pattern } => visit_pattern(pattern, shape),
+        ParameterOp::ReplaceFirst {
+            pattern,
+            replacement,
+            replacement_word_ast,
+        }
+        | ParameterOp::ReplaceAll {
+            pattern,
+            replacement,
+            replacement_word_ast,
+        } => {
+            visit_pattern(pattern, shape);
+            shape.record_source_text(replacement);
+            visit_word(replacement_word_ast, shape, 1);
+        }
+        ParameterOp::UseDefault
+        | ParameterOp::AssignDefault
+        | ParameterOp::UseReplacement
+        | ParameterOp::Error
+        | ParameterOp::UpperFirst
+        | ParameterOp::UpperAll
+        | ParameterOp::LowerFirst
+        | ParameterOp::LowerAll => {}
+    }
+}
+
+fn visit_zsh_qualified_glob(glob: &ZshQualifiedGlob, shape: &mut AstShape) {
+    shape.record_vec(&glob.segments);
+    for segment in &glob.segments {
+        match segment {
+            ZshGlobSegment::Pattern(pattern) => visit_pattern(pattern, shape),
+            ZshGlobSegment::InlineControl(_) => {}
+        }
+    }
+    if let Some(qualifiers) = &glob.qualifiers {
+        shape.record_vec(&qualifiers.fragments);
+        for qualifier in &qualifiers.fragments {
+            match qualifier {
+                ZshGlobQualifier::LetterSequence { text, .. } => shape.record_source_text(text),
+                ZshGlobQualifier::NumericArgument { start, end, .. } => {
+                    shape.record_source_text(start);
+                    if let Some(end) = end {
+                        shape.record_source_text(end);
+                    }
+                }
+                ZshGlobQualifier::Negation { .. } | ZshGlobQualifier::Flag { .. } => {}
+            }
+        }
+    }
+}
+
+fn visit_pattern(pattern: &Pattern, shape: &mut AstShape) {
+    shape.patterns += 1;
+    shape.record_vec(&pattern.parts);
+    for part in &pattern.parts {
+        shape.pattern_parts += 1;
+        match &part.kind {
+            PatternPart::Literal(text) => shape.record_literal_text(text),
+            PatternPart::AnyString | PatternPart::AnyChar => {}
+            PatternPart::CharClass(text) => shape.record_source_text(text),
+            PatternPart::Group { patterns, .. } => {
+                shape.record_vec(patterns);
+                for pattern in patterns {
+                    visit_pattern(pattern, shape);
+                }
+            }
+            PatternPart::Word(word) => visit_word(word, shape, 1),
+        }
+    }
+}
+
+fn visit_arithmetic_expr(expr: &ArithmeticExprNode, shape: &mut AstShape, depth: u64) {
+    shape.arithmetic_exprs += 1;
+    shape.max_arithmetic_depth = shape.max_arithmetic_depth.max(depth);
+    match &expr.kind {
+        ArithmeticExpr::Number(text) => shape.record_source_text(text),
+        ArithmeticExpr::Variable(_) => {}
+        ArithmeticExpr::Indexed { index, .. } => {
+            shape.record_box();
+            visit_arithmetic_expr(index, shape, depth + 1);
+        }
+        ArithmeticExpr::ShellWord(word) => visit_word(word, shape, 1),
+        ArithmeticExpr::Parenthesized { expression } => {
+            shape.record_box();
+            visit_arithmetic_expr(expression, shape, depth + 1);
+        }
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            shape.record_box();
+            visit_arithmetic_expr(expr, shape, depth + 1);
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            shape.record_box();
+            visit_arithmetic_expr(left, shape, depth + 1);
+            shape.record_box();
+            visit_arithmetic_expr(right, shape, depth + 1);
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            shape.record_box();
+            visit_arithmetic_expr(condition, shape, depth + 1);
+            shape.record_box();
+            visit_arithmetic_expr(then_expr, shape, depth + 1);
+            shape.record_box();
+            visit_arithmetic_expr(else_expr, shape, depth + 1);
+        }
+        ArithmeticExpr::Assignment { target, value, .. } => {
+            visit_arithmetic_lvalue(target, shape, depth + 1);
+            shape.record_box();
+            visit_arithmetic_expr(value, shape, depth + 1);
+        }
+    }
+}
+
+fn visit_arithmetic_lvalue(target: &ArithmeticLvalue, shape: &mut AstShape, depth: u64) {
+    match target {
+        ArithmeticLvalue::Variable(_) => {}
+        ArithmeticLvalue::Indexed { index, .. } => {
+            shape.record_box();
+            visit_arithmetic_expr(index, shape, depth + 1);
+        }
+    }
+}
+
+fn visit_conditional_expr(expr: &ConditionalExpr, shape: &mut AstShape, depth: u64) {
+    shape.conditional_exprs += 1;
+    shape.max_conditional_depth = shape.max_conditional_depth.max(depth);
+    match expr {
+        ConditionalExpr::Binary(expr) => {
+            shape.record_box();
+            visit_conditional_expr(&expr.left, shape, depth + 1);
+            shape.record_box();
+            visit_conditional_expr(&expr.right, shape, depth + 1);
+        }
+        ConditionalExpr::Unary(expr) => {
+            shape.record_box();
+            visit_conditional_expr(&expr.expr, shape, depth + 1);
+        }
+        ConditionalExpr::Parenthesized(expr) => {
+            shape.record_box();
+            visit_conditional_expr(&expr.expr, shape, depth + 1);
+        }
+        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => visit_word(word, shape, 1),
+        ConditionalExpr::Pattern(pattern) => visit_pattern(pattern, shape),
+        ConditionalExpr::VarRef(reference) => {
+            shape.record_box();
+            visit_var_ref(reference, shape);
+        }
+    }
+}
+
+fn single_case_report(case_name: &str) -> Option<CaseReport> {
+    let cases = benchmark_cases();
+    let case = cases.into_iter().find(|case| case.name == case_name)?;
+    let mut shape = AstShape::default();
+    let mut recovered_files = 0usize;
+    let mut command_count = 0usize;
+
+    for file in case.files {
+        let output = parse_fixture(file.source);
+        recovered_files += usize::from(output.status != ParseStatus::Clean);
+        command_count += output.file.body.len();
+        visit_file(&output.file, &mut shape);
+    }
+
+    Some(CaseReport {
+        case: case.name.to_string(),
+        files: case.files.len(),
+        recovered_files,
+        command_count,
+        estimated_replaceable_heap_allocations: shape.estimated_replaceable_heap_allocations(),
+        shape,
+    })
+}
+
+fn parse_case_arg() -> Option<String> {
+    let mut args = std::env::args().skip(1);
+    let arg = args.next()?;
+
+    match arg.as_str() {
+        "--case" => {
+            let value = args.next();
+            if let Some(extra) = args.next() {
+                eprintln!("unknown argument `{extra}`");
+                process::exit(2);
+            }
+            value
+        }
+        "--help" | "-h" => {
+            eprintln!("usage: cargo run -p shuck-benchmark --example ast_shape -- [--case NAME]");
+            process::exit(0);
+        }
+        _ => {
+            eprintln!("unknown argument `{arg}`");
+            process::exit(2);
+        }
+    }
+}
+
+fn main() -> serde_json::Result<()> {
+    let requested_case = parse_case_arg();
+    let reports = if let Some(case_name) = requested_case {
+        let Some(report) = single_case_report(&case_name) else {
+            eprintln!("unknown benchmark case `{case_name}`");
+            process::exit(2);
+        };
+        vec![report]
+    } else {
+        benchmark_cases()
+            .into_iter()
+            .filter_map(|case| single_case_report(case.name))
+            .collect::<Vec<_>>()
+    };
+
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports)?;
+    println!();
+    Ok(())
+}

--- a/crates/shuck-benchmark/examples/formatter_memory.rs
+++ b/crates/shuck-benchmark/examples/formatter_memory.rs
@@ -1,0 +1,176 @@
+use std::path::Path;
+use std::process;
+
+use serde::Serialize;
+use shuck_benchmark::memory::{CountingAllocator, Frame, measure};
+use shuck_benchmark::{benchmark_cases, parse_fixture};
+use shuck_formatter::{FormattedSource, ShellFormatOptions, format_file_ast, format_source};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator<std::alloc::System> = CountingAllocator(std::alloc::System);
+
+#[derive(Debug, Serialize)]
+struct MemoryMetrics {
+    allocation_count: u64,
+    reallocation_count: u64,
+    total_allocated_bytes: u64,
+    total_reallocated_bytes: u64,
+    peak_live_bytes: u64,
+    final_live_bytes: u64,
+}
+
+impl From<Frame> for MemoryMetrics {
+    fn from(frame: Frame) -> Self {
+        Self {
+            allocation_count: frame.allocation_count,
+            reallocation_count: frame.reallocation_count,
+            total_allocated_bytes: frame.total_allocated_bytes,
+            total_reallocated_bytes: frame.total_reallocated_bytes,
+            peak_live_bytes: frame.peak_live_bytes,
+            final_live_bytes: frame.current_live_bytes.max(0) as u64,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct FormatterMetrics {
+    output_bytes: usize,
+    changed_files: usize,
+    metrics: MemoryMetrics,
+}
+
+#[derive(Debug, Serialize)]
+struct CaseReport {
+    case: String,
+    files: usize,
+    source: FormatterMetrics,
+    ast_only: FormatterMetrics,
+}
+
+fn output_bytes(source: &str, formatted: FormattedSource) -> (usize, bool) {
+    match formatted {
+        FormattedSource::Unchanged => (source.len(), false),
+        FormattedSource::Formatted(formatted) => (formatted.len(), true),
+    }
+}
+
+fn format_source_case(
+    files: &[shuck_benchmark::TestFile],
+    options: &ShellFormatOptions,
+) -> FormatterMetrics {
+    let (frame, (output_bytes, changed_files)) = measure(|| {
+        let mut total_output_bytes = 0usize;
+        let mut changed_files = 0usize;
+
+        for file in files {
+            let formatted = match format_source(file.source, None::<&Path>, options) {
+                Ok(formatted) => formatted,
+                Err(err) => panic!("formatter benchmark input should format: {err}"),
+            };
+            let (bytes, changed) = output_bytes(file.source, formatted);
+            total_output_bytes += bytes;
+            changed_files += usize::from(changed);
+        }
+
+        (total_output_bytes, changed_files)
+    });
+
+    FormatterMetrics {
+        output_bytes,
+        changed_files,
+        metrics: frame.into(),
+    }
+}
+
+fn format_ast_case(
+    files: &[shuck_benchmark::TestFile],
+    options: &ShellFormatOptions,
+) -> FormatterMetrics {
+    let parsed_files = files
+        .iter()
+        .map(|file| parse_fixture(file.source))
+        .collect::<Vec<_>>();
+
+    let (frame, (output_bytes, changed_files)) = measure(|| {
+        let mut total_output_bytes = 0usize;
+        let mut changed_files = 0usize;
+
+        for (file, parsed) in files.iter().zip(parsed_files) {
+            let formatted = match format_file_ast(file.source, parsed.file, None::<&Path>, options)
+            {
+                Ok(formatted) => formatted,
+                Err(err) => panic!("formatter AST benchmark input should format: {err}"),
+            };
+            let (bytes, changed) = output_bytes(file.source, formatted);
+            total_output_bytes += bytes;
+            changed_files += usize::from(changed);
+        }
+
+        (total_output_bytes, changed_files)
+    });
+
+    FormatterMetrics {
+        output_bytes,
+        changed_files,
+        metrics: frame.into(),
+    }
+}
+
+fn single_case_report(case_name: &str) -> Option<CaseReport> {
+    let cases = benchmark_cases();
+    let case = cases.into_iter().find(|case| case.name == case_name)?;
+    let options = ShellFormatOptions::default();
+
+    Some(CaseReport {
+        case: case.name.to_string(),
+        files: case.files.len(),
+        source: format_source_case(case.files, &options),
+        ast_only: format_ast_case(case.files, &options),
+    })
+}
+
+fn parse_case_arg() -> Option<String> {
+    let mut args = std::env::args().skip(1);
+    let arg = args.next()?;
+
+    match arg.as_str() {
+        "--case" => {
+            let value = args.next();
+            if let Some(extra) = args.next() {
+                eprintln!("unknown argument `{extra}`");
+                process::exit(2);
+            }
+            value
+        }
+        "--help" | "-h" => {
+            eprintln!(
+                "usage: cargo run -p shuck-benchmark --example formatter_memory -- [--case NAME]"
+            );
+            process::exit(0);
+        }
+        _ => {
+            eprintln!("unknown argument `{arg}`");
+            process::exit(2);
+        }
+    }
+}
+
+fn main() -> serde_json::Result<()> {
+    let requested_case = parse_case_arg();
+    let reports = if let Some(case_name) = requested_case {
+        let Some(report) = single_case_report(&case_name) else {
+            eprintln!("unknown benchmark case `{case_name}`");
+            process::exit(2);
+        };
+        vec![report]
+    } else {
+        benchmark_cases()
+            .into_iter()
+            .filter_map(|case| single_case_report(case.name))
+            .collect::<Vec<_>>()
+    };
+
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports)?;
+    println!();
+    Ok(())
+}

--- a/crates/shuck-benchmark/examples/linter_memory.rs
+++ b/crates/shuck-benchmark/examples/linter_memory.rs
@@ -1,0 +1,214 @@
+use std::process;
+
+use serde::Serialize;
+use shuck_benchmark::benchmark_cases;
+use shuck_benchmark::memory::{CountingAllocator, Frame, measure};
+use shuck_indexer::Indexer;
+use shuck_linter::{
+    LinterSettings, ShellCheckCodeMap, SuppressionIndex, first_statement_line, lint_file,
+    parse_directives,
+};
+use shuck_parser::parser::{ParseStatus, Parser};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator<std::alloc::System> = CountingAllocator(std::alloc::System);
+
+#[derive(Debug, Default, Serialize)]
+struct MemoryMetrics {
+    allocation_count: u64,
+    reallocation_count: u64,
+    total_allocated_bytes: u64,
+    total_reallocated_bytes: u64,
+    peak_live_bytes: u64,
+    final_live_bytes: u64,
+}
+
+impl From<Frame> for MemoryMetrics {
+    fn from(frame: Frame) -> Self {
+        Self {
+            allocation_count: frame.allocation_count,
+            reallocation_count: frame.reallocation_count,
+            total_allocated_bytes: frame.total_allocated_bytes,
+            total_reallocated_bytes: frame.total_reallocated_bytes,
+            peak_live_bytes: frame.peak_live_bytes,
+            final_live_bytes: frame.current_live_bytes.max(0) as u64,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CaseReport {
+    case: String,
+    files: usize,
+    recovered_files: usize,
+    command_count: usize,
+    diagnostic_count: usize,
+    full: MemoryMetrics,
+    phases: PhaseMetrics,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct PhaseMetrics {
+    parse: MemoryMetrics,
+    index_and_suppressions: MemoryMetrics,
+    lint: MemoryMetrics,
+}
+
+impl PhaseMetrics {
+    fn add_parse(&mut self, frame: Frame) {
+        add_metrics(&mut self.parse, frame);
+    }
+
+    fn add_index_and_suppressions(&mut self, frame: Frame) {
+        add_metrics(&mut self.index_and_suppressions, frame);
+    }
+
+    fn add_lint(&mut self, frame: Frame) {
+        add_metrics(&mut self.lint, frame);
+    }
+}
+
+fn add_metrics(metrics: &mut MemoryMetrics, frame: Frame) {
+    metrics.allocation_count += frame.allocation_count;
+    metrics.reallocation_count += frame.reallocation_count;
+    metrics.total_allocated_bytes += frame.total_allocated_bytes;
+    metrics.total_reallocated_bytes += frame.total_reallocated_bytes;
+    metrics.peak_live_bytes = metrics.peak_live_bytes.max(frame.peak_live_bytes);
+    metrics.final_live_bytes += frame.current_live_bytes.max(0) as u64;
+}
+
+struct FileLintReport {
+    command_count: usize,
+    diagnostic_count: usize,
+    recovered: bool,
+    parse_frame: Frame,
+    index_and_suppressions_frame: Frame,
+    lint_frame: Frame,
+}
+
+fn lint_source_with_phases(
+    source: &str,
+    settings: &LinterSettings,
+    shellcheck_map: &ShellCheckCodeMap,
+) -> FileLintReport {
+    let (parse_frame, output) = measure(|| Parser::new(source).parse());
+    let (index_and_suppressions_frame, (indexer, suppression_index)) = measure(|| {
+        let indexer = Indexer::new(source, &output);
+        let directives = parse_directives(
+            source,
+            &output.file,
+            indexer.comment_index(),
+            shellcheck_map,
+        );
+        let suppression_index = (!directives.is_empty()).then(|| {
+            SuppressionIndex::new(
+                &directives,
+                &output.file,
+                first_statement_line(&output.file).unwrap_or(u32::MAX),
+            )
+        });
+
+        (indexer, suppression_index)
+    });
+    let (lint_frame, diagnostics) = measure(|| {
+        lint_file(
+            &output,
+            source,
+            &indexer,
+            settings,
+            suppression_index.as_ref(),
+            None,
+        )
+    });
+
+    FileLintReport {
+        command_count: output.file.body.len(),
+        diagnostic_count: diagnostics.len(),
+        recovered: output.status != ParseStatus::Clean,
+        parse_frame,
+        index_and_suppressions_frame,
+        lint_frame,
+    }
+}
+
+fn single_case_report(case_name: &str) -> Option<CaseReport> {
+    let cases = benchmark_cases();
+    let case = cases.into_iter().find(|case| case.name == case_name)?;
+    let settings = LinterSettings::default();
+    let shellcheck_map = ShellCheckCodeMap::default();
+
+    let (frame, (recovered_files, command_count, diagnostic_count, phases)) = measure(|| {
+        let mut recovered_files = 0usize;
+        let mut command_count = 0usize;
+        let mut diagnostic_count = 0usize;
+        let mut phases = PhaseMetrics::default();
+
+        for file in case.files {
+            let report = lint_source_with_phases(file.source, &settings, &shellcheck_map);
+            command_count += report.command_count;
+            diagnostic_count += report.diagnostic_count;
+            recovered_files += usize::from(report.recovered);
+            phases.add_parse(report.parse_frame);
+            phases.add_index_and_suppressions(report.index_and_suppressions_frame);
+            phases.add_lint(report.lint_frame);
+        }
+
+        (recovered_files, command_count, diagnostic_count, phases)
+    });
+
+    Some(CaseReport {
+        case: case.name.to_string(),
+        files: case.files.len(),
+        recovered_files,
+        command_count,
+        diagnostic_count,
+        full: frame.into(),
+        phases,
+    })
+}
+
+fn parse_case_arg() -> Option<String> {
+    let mut args = std::env::args().skip(1);
+    let arg = args.next()?;
+
+    match arg.as_str() {
+        "--case" => {
+            let value = args.next();
+            if let Some(extra) = args.next() {
+                eprintln!("unknown argument `{extra}`");
+                process::exit(2);
+            }
+            value
+        }
+        "--help" | "-h" => {
+            eprintln!(
+                "usage: cargo run -p shuck-benchmark --example linter_memory -- [--case NAME]"
+            );
+            process::exit(0);
+        }
+        _ => {
+            eprintln!("unknown argument `{arg}`");
+            process::exit(2);
+        }
+    }
+}
+
+fn main() -> serde_json::Result<()> {
+    let requested_case = parse_case_arg();
+    let reports = if let Some(case_name) = requested_case {
+        let Some(report) = single_case_report(&case_name) else {
+            eprintln!("unknown benchmark case `{case_name}`");
+            process::exit(2);
+        };
+        vec![report]
+    } else {
+        benchmark_cases()
+            .into_iter()
+            .filter_map(|case| single_case_report(case.name))
+            .collect::<Vec<_>>()
+    };
+
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports)?;
+    println!();
+    Ok(())
+}

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -6,6 +6,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+/// Allocation measurement helpers used by benchmark examples.
+pub mod memory;
+
 use shuck_parser::parser::{ParseResult, Parser};
 #[cfg(feature = "parser-benchmarking")]
 use shuck_parser::parser::{ParseStatus, ParserBenchmarkCounters};

--- a/crates/shuck-benchmark/src/memory.rs
+++ b/crates/shuck-benchmark/src/memory.rs
@@ -1,0 +1,149 @@
+//! Lightweight allocation counters for benchmark examples.
+
+use std::cell::RefCell;
+
+/// Maximum nested measurement depth supported by [`measure`].
+const MAX_MEASURE_DEPTH: usize = 8;
+
+/// Allocation counters collected for one measured region.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Frame {
+    /// Number of successful allocation calls.
+    pub allocation_count: u64,
+    /// Number of successful reallocation calls.
+    pub reallocation_count: u64,
+    /// Sum of requested allocation sizes.
+    pub total_allocated_bytes: u64,
+    /// Sum of requested new reallocation sizes.
+    pub total_reallocated_bytes: u64,
+    /// Bytes still live at the end of the measured region.
+    pub current_live_bytes: i64,
+    /// Highest live byte count observed during the measured region.
+    pub peak_live_bytes: u64,
+}
+
+impl Frame {
+    fn on_alloc(&mut self, size: usize) {
+        self.allocation_count += 1;
+        self.total_allocated_bytes += size as u64;
+        self.current_live_bytes += size as i64;
+        self.peak_live_bytes = self
+            .peak_live_bytes
+            .max(self.current_live_bytes.max(0) as u64);
+    }
+
+    fn on_dealloc(&mut self, size: usize) {
+        self.current_live_bytes -= size as i64;
+    }
+
+    fn on_realloc(&mut self, old_size: usize, new_size: usize) {
+        self.reallocation_count += 1;
+        self.total_reallocated_bytes += new_size as u64;
+        self.current_live_bytes += new_size as i64 - old_size as i64;
+        self.peak_live_bytes = self
+            .peak_live_bytes
+            .max(self.current_live_bytes.max(0) as u64);
+    }
+}
+
+#[derive(Debug, Default)]
+struct CounterState {
+    depth: usize,
+    frames: [Frame; MAX_MEASURE_DEPTH],
+}
+
+thread_local! {
+    static COUNTER_STATE: RefCell<CounterState> = RefCell::new(CounterState::default());
+}
+
+/// Global allocator wrapper that records allocations made inside [`measure`].
+pub struct CountingAllocator<A>(pub A);
+
+unsafe impl<A: std::alloc::GlobalAlloc> std::alloc::GlobalAlloc for CountingAllocator<A> {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        let ptr = unsafe { self.0.alloc(layout) };
+        if !ptr.is_null() {
+            record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        record_dealloc(layout.size());
+        unsafe { self.0.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { self.0.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            record_realloc(layout.size(), new_size);
+        }
+        new_ptr
+    }
+}
+
+fn record_alloc(size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_alloc(size);
+        }
+    });
+}
+
+fn record_dealloc(size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_dealloc(size);
+        }
+    });
+}
+
+fn record_realloc(old_size: usize, new_size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_realloc(old_size, new_size);
+        }
+    });
+}
+
+/// Measure allocations made while running `f`.
+pub fn measure<T>(f: impl FnOnce() -> T) -> (Frame, T) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        assert!(
+            state.depth + 1 < MAX_MEASURE_DEPTH,
+            "measurement nesting too deep"
+        );
+        state.depth += 1;
+        let depth = state.depth;
+        state.frames[depth] = Frame::default();
+    });
+
+    let result = f();
+
+    let frame = COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        let frame = state.frames[depth];
+        state.frames[depth] = Frame::default();
+        state.depth -= 1;
+        frame
+    });
+
+    (frame, result)
+}


### PR DESCRIPTION
## Summary

- Add shared allocation measurement helpers for benchmark examples.
- Add JSON-reporting examples for linter memory, formatter memory, and AST shape pressure.
- Document how to run and interpret the memory and shape tools in `crates/shuck-benchmark/AGENTS.md`.

## Motivation

We want a repeatable way to estimate arena-allocation payoff before rewriting AST or fact storage. These tools separate allocator pressure from wall-clock Criterion timings and make it easier to compare parser, semantic, linter, formatter, and AST-shape costs across branches.

## Validation

- `cargo check -p shuck-benchmark --examples`
- `cargo test -p shuck-benchmark`