### PR TITLE
fix(linter): align C124 unreachable causes

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c124.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c124.yaml
@@ -1,85 +1,37 @@
 reviewed_divergences:
   - side: shuck-only
-    path_suffix: "Bash-it__bash-it__completion__available__gradle.completion.bash"
-    reason: "completion registration follows a helper function that returns before the file-level registration commands; the remaining gap is scoped to this callback-style completion fixture after removing the old repo-family allowlist"
-  - side: shellcheck-only
-    path_suffix: "acmesh-official__acme.sh__acme.sh"
-    reason: "this large helper script has a remaining subshell/source-control-flow C124 gap that Shuck does not model precisely enough yet; keep the review scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "aristocratos__bashtop__bashtop"
-    reason: "this is a semicolon-packed loop branch where Shuck reports the statement after a same-line break; keep the residual span difference scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "bin456789__reinstall__reinstall.sh"
-    reason: "this option parser has a remaining break/shift reachability difference in a loop dispatcher; keep the review scoped to the exact fixture"
-  - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__firmware"
-    reason: "this helper keeps disabled follow-up logic after an intentional early return; Shuck reports the local dead block while the oracle stays quiet, so the residual is reviewed at fixture scope"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this fixture still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__log"
-    reason: "this helper keeps disabled follow-up logic after an intentional early return; Shuck reports the local dead block while the oracle stays quiet, so the residual is reviewed at fixture scope"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this fixture still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
-    reason: "this helper keeps disabled follow-up logic after intentional early returns; Shuck reports the local dead blocks while the oracle stays quiet, so the residual is reviewed at fixture scope"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this fixture still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-build__build.sh"
-    reason: "this build script has a remaining guarded-return reachability difference in project-local control flow; keep the review scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-monitoring__crashlog_build_html.sh"
-    reason: "this monitoring helper keeps reporting fallback code after an early-return path; Shuck reports the local dead block while the oracle stays quiet, so the residual is reviewed at fixture scope"
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_netjson.sh"
-    reason: "this monitoring helper has large project-local early-return regions that Shuck marks as dead more aggressively than the oracle; keep the review scoped to the exact fixture"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this script still has guarded-return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__monitoring_standalone_generic.sh"
-    reason: "this monitoring helper keeps follow-up commands after an intentional early return; Shuck reports the local dead block while the oracle stays quiet, so the residual is reviewed at fixture scope"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this helper still has early-return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "gentoo__gentoo__eclass__tests__version-funcs.sh"
-    reason: "this test fixture has a remaining return-driven reachability difference in harness-style code; keep the review scoped to the exact fixture"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this test fixture still has return-driven harness flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
-    reason: "this menu script has remaining early-return dispatcher regions where Shuck reports dead follow-up commands more aggressively; keep the review scoped to the exact fixture"
-  - side: shellcheck-only
-    path_suffix: "leebaird__discover__dev-api-scanner.sh"
-    reason: "this generated scanner script exposes a C124 span-shape mismatch around nested loop code; keep the oracle-side residual scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "leebaird__discover__dev-api-scanner.sh"
-    reason: "this generated scanner script exposes a C124 span-shape mismatch around nested loop code; keep the Shuck-side residual scoped to the exact fixture"
-  - side: shellcheck-only
-    path_suffix: "megastep__makeself__makeself.sh"
-    reason: "this option parser differs only on same-line exit/usage anchors; keep the oracle-side residual scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "megastep__makeself__makeself.sh"
-    reason: "this option parser differs only on same-line exit/usage anchors; keep the Shuck-side residual scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "moovweb__gvm__examples__native__configure"
-    reason: "this generated configure script has remaining break-driven cleanup reachability differences; keep the review scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "moovweb__gvm__scripts__env__pkgset-use"
-    reason: "this dispatcher has nested case and early-exit regions that Shuck marks as dead more aggressively; keep the review scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
-    reason: "this large command dispatcher contains many intentional exit-heavy branches where Shuck's CFG currently reports broader dead regions than the oracle; keep the residual scoped to the exact fixture"
-  - side: shellcheck-only
-    path_suffix: "paulirish__dotfiles__.bash_prompt"
-    reason: "this prompt file has a small shell-guard reachability span mismatch; keep the oracle-side residual scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "paulirish__dotfiles__.bash_prompt"
-    reason: "this prompt file has a small shell-guard reachability span mismatch; keep the Shuck-side residual scoped to the exact fixture"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this menu script still has dispatcher-return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
-    reason: "this sourced RVM helper has a project-local early-return region that Shuck marks as dead more aggressively; keep the review scoped to the exact fixture"
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__scripts__bin__update-checksum"
-    reason: "this package helper has a remaining exit-driven dispatcher difference; keep the review scoped to the exact fixture"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this sourced helper still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "termux__termux-packages__scripts__lint-packages.sh"
-    reason: "this package linter has a remaining early-return region in helper-style control flow; keep the review scoped to the exact fixture"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this package linter still has early-return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "tj__git-extras__bin__git-scp"
-    reason: "this command-line parser has a same-line exit/usage reachability difference; keep the review scoped to the exact fixture"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this command-line helper still has exit-heavy usage flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "tteck__Proxmox__ct__fenrus.sh"
-    reason: "this installer script has a small exit-driven cleanup reachability difference; keep the review scoped to the exact fixture"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this installer script still has exit-driven setup flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "xwmx__nb__nb"
-    reason: "this large command dispatcher has a handful of intentional exit-heavy branches where Shuck reports broader dead regions; keep the residual scoped to the exact fixture"
+    reason: "Residual C124 mismatch outside the loop-control cause filter: this large dispatcher still has return-heavy helper flow that Shuck treats more aggressively than the comparison oracle."

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3903,6 +3903,51 @@ main() {
     }
 
     #[test]
+    fn unreachable_after_exit_reports_condition_body_after_terminating_condition() {
+        let source = "\
+#!/bin/bash
+if exit 0; then
+  printf '%s\\n' never
+fi
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "printf '%s\\n' never");
+    }
+
+    #[test]
+    fn unreachable_after_exit_includes_redirects_but_not_statement_terminators() {
+        let source = "\
+#!/bin/bash
+exit 0
+while read -r item; do
+  printf '%s\\n' \"$item\"
+done < input.txt;
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "while read -r item; do\n  printf '%s\\n' \"$item\"\ndone < input.txt"
+        );
+    }
+
+    #[test]
+    fn unreachable_after_exit_ignores_loop_control_only_dead_code() {
+        let source = "\
+#!/bin/bash
+while true; do
+  break; printf '%s\\n' after_break
+done
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn unreachable_after_exit_reports_after_brace_group_defined_exit_helpers() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3948,6 +3948,24 @@ done
     }
 
     #[test]
+    fn unreachable_after_exit_ignores_loop_control_if_branches_and_following_code() {
+        let source = "\
+#!/bin/bash
+while true; do
+  if break; then
+    printf '%s\\n' after_true
+  else
+    printf '%s\\n' after_false
+  fi
+  printf '%s\\n' after_if
+done
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn unreachable_after_exit_reports_after_brace_group_defined_exit_helpers() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/continue_outside_loop_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/continue_outside_loop_in_function.rs
@@ -61,6 +61,24 @@ f() {
     }
 
     #[test]
+    fn ignores_continue_inside_function_loop_brace_group() {
+        let source = "\
+#!/bin/bash
+f() {
+  for gpu in \"${gpus[@]}\"; do
+    [[ \"$gpu\" == Intel ]] && { unset -v gpu; continue; }
+  done
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ContinueOutsideLoopInFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_continue_inside_function_subshells() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
@@ -122,6 +122,24 @@ done
     }
 
     #[test]
+    fn ignores_loop_control_inside_function_loop_brace_group() {
+        let source = "\
+#!/bin/bash
+f() {
+  for op in a; do
+    if [[ \"$op\" == a ]]; then { echo ok; break; }; fi
+  done
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LoopControlOutsideLoop),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn ignores_continue_inside_functions() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
@@ -129,6 +129,21 @@ cd /tmp && pwd
     }
 
     #[test]
+    fn ignores_directory_change_inside_checked_subshell_group() {
+        let source = "\
+make_tar() {
+  (cd \"$DIST_ROOT/unix/\"; tar -czf \"../out.tgz\" out) || die
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UncheckedDirectoryChange),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_cd_in_following_list_position() {
         let source = "echo start && cd /tmp\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,5 +1,6 @@
 use crate::{Checker, Rule, Violation};
 use shuck_ast::Span;
+use shuck_semantic::UnreachableCauseKind;
 
 pub struct UnreachableAfterExit;
 
@@ -20,13 +21,14 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
             .semantic_analysis()
             .dead_code()
             .iter()
+            .filter(|dead_code| dead_code.cause_kind != UnreachableCauseKind::LoopControl)
             .flat_map(|dead_code| dead_code.unreachable.iter().copied())
             .collect::<Vec<_>>(),
     );
 
     for span in unreachable_spans
         .into_iter()
-        .map(|span| trim_trailing_whitespace(span, source))
+        .map(|span| trim_trailing_terminator(span, source))
     {
         checker.report(UnreachableAfterExit, span);
     }
@@ -60,7 +62,11 @@ fn span_contained_by(inner: shuck_ast::Span, outer: shuck_ast::Span) -> bool {
     outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
 
-fn trim_trailing_whitespace(span: Span, source: &str) -> Span {
-    let trimmed = span.slice(source).trim_end_matches(char::is_whitespace);
+fn trim_trailing_terminator(span: Span, source: &str) -> Span {
+    let trimmed = span
+        .slice(source)
+        .trim_end_matches(char::is_whitespace)
+        .trim_end_matches(';')
+        .trim_end_matches(char::is_whitespace);
     Span::from_positions(span.start, span.start.advanced_by(trimmed))
 }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -102,6 +102,21 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     defaulting_parameter_operand_depth: u32,
 }
 
+fn semantic_statement_span(stmt: &Stmt) -> Span {
+    let mut end = stmt
+        .terminator_span
+        .filter(|terminator| terminator.end.offset == stmt.span.end.offset)
+        .map_or(stmt.span.end, |terminator| terminator.start);
+
+    for redirect in stmt.redirects.iter() {
+        if redirect.span.end.offset > end.offset {
+            end = redirect.span.end;
+        }
+    }
+
+    Span::from_positions(stmt.span.start, end)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct FlowState {
     in_function: bool,
@@ -276,7 +291,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     }
 
     fn visit_stmt(&mut self, stmt: &'a Stmt, flow: FlowState) -> RecordedCommandId {
-        let span = stmt.span;
+        let span = semantic_statement_span(stmt);
         let scope = self.current_scope();
         let context = Self::flow_context(flow);
         self.flow_contexts.push((span, context.clone()));

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -1644,11 +1644,15 @@ impl<'a> GraphBuilder<'a> {
         let condition_seq = self.build_sequence(ranges.condition, loops);
         let entry = condition_seq.entry.or_else(|| Some(self.empty_block()));
         let mut false_exits = condition_seq.exits.clone();
+        let mut false_cause = false_exits
+            .is_empty()
+            .then_some(condition_seq.terminal_cause)
+            .flatten();
 
         let then_start = self.blocks.len();
         let then_seq = self.build_sequence(ranges.then_branch, loops);
-        if condition_seq.exits.is_empty()
-            && let Some(cause) = condition_seq.terminal_cause
+        if false_exits.is_empty()
+            && let Some(cause) = false_cause
         {
             self.mark_unreachable_blocks_since(then_start, cause);
         }
@@ -1658,17 +1662,24 @@ impl<'a> GraphBuilder<'a> {
             }
         }
 
-        let mut branch_exits = then_seq.exits;
-        let mut branch_cause = branch_exits
-            .is_empty()
-            .then_some(then_seq.terminal_cause)
-            .flatten();
+        let then_reachable = !condition_seq.exits.is_empty();
+        let mut branch_exits = if then_reachable {
+            then_seq.exits
+        } else {
+            Vec::new()
+        };
+        let mut branch_cause = if then_reachable && branch_exits.is_empty() {
+            then_seq.terminal_cause
+        } else {
+            None
+        };
 
         for elif_branch in self.program.elif_branches(ranges.elif_branches) {
+            let elif_reachable = !false_exits.is_empty();
             let elif_start = self.blocks.len();
             let elif_cond = self.build_sequence(elif_branch.condition, loops);
             if false_exits.is_empty()
-                && let Some(cause) = branch_cause
+                && let Some(cause) = false_cause
             {
                 self.mark_unreachable_blocks_since(elif_start, cause);
             }
@@ -1680,9 +1691,18 @@ impl<'a> GraphBuilder<'a> {
 
             let elif_body_start = self.blocks.len();
             let elif_body_seq = self.build_sequence(elif_branch.body, loops);
-            if elif_cond.exits.is_empty()
-                && let Some(cause) = elif_cond.terminal_cause
-            {
+            let elif_body_reachable = elif_reachable && !elif_cond.exits.is_empty();
+            let elif_cond_cause = elif_cond
+                .exits
+                .is_empty()
+                .then_some(elif_cond.terminal_cause)
+                .flatten();
+            let elif_body_unreachable_cause = if elif_reachable {
+                elif_cond_cause
+            } else {
+                false_cause
+            };
+            if !elif_body_reachable && let Some(cause) = elif_body_unreachable_cause {
                 self.mark_unreachable_blocks_since(elif_body_start, cause);
             }
             if let Some(body_entry) = elif_body_seq.entry {
@@ -1691,28 +1711,43 @@ impl<'a> GraphBuilder<'a> {
                 }
             }
 
-            let previous_false_cause = false_exits.is_empty().then_some(branch_cause).flatten();
-            false_exits = elif_cond.exits;
+            false_exits = if elif_reachable {
+                elif_cond.exits
+            } else {
+                Vec::new()
+            };
+            false_cause = if false_exits.is_empty() {
+                if elif_reachable {
+                    elif_cond_cause
+                } else {
+                    false_cause
+                }
+            } else {
+                None
+            };
             let elif_body_cause = elif_body_seq
                 .exits
                 .is_empty()
                 .then_some(elif_body_seq.terminal_cause)
                 .flatten();
-            append_unique_block_ids(&mut branch_exits, &elif_body_seq.exits);
-            branch_cause = if branch_exits.is_empty() {
-                merge_terminal_causes(
-                    self.program.command(command).span,
-                    [branch_cause, previous_false_cause, elif_body_cause],
-                )
-            } else {
-                None
-            };
+            if elif_body_reachable {
+                append_unique_block_ids(&mut branch_exits, &elif_body_seq.exits);
+                branch_cause = if branch_exits.is_empty() {
+                    merge_terminal_causes(
+                        self.program.command(command).span,
+                        [branch_cause, elif_body_cause],
+                    )
+                } else {
+                    None
+                };
+            }
         }
 
+        let else_reachable = !false_exits.is_empty();
         let else_start = self.blocks.len();
         let else_seq = self.build_sequence(ranges.else_branch, loops);
         if false_exits.is_empty()
-            && let Some(cause) = branch_cause
+            && let Some(cause) = false_cause
         {
             self.mark_unreachable_blocks_since(else_start, cause);
         }
@@ -1720,23 +1755,37 @@ impl<'a> GraphBuilder<'a> {
             for exit in &false_exits {
                 self.add_edge(*exit, else_entry, EdgeKind::ConditionalFalse);
             }
-            let else_cause = else_seq
-                .exits
-                .is_empty()
-                .then_some(else_seq.terminal_cause)
-                .flatten();
-            branch_exits.extend(else_seq.exits);
-            branch_cause = if branch_exits.is_empty() {
-                merge_terminal_causes(
+            if else_reachable {
+                let else_cause = else_seq
+                    .exits
+                    .is_empty()
+                    .then_some(else_seq.terminal_cause)
+                    .flatten();
+                append_unique_block_ids(&mut branch_exits, &else_seq.exits);
+                branch_cause = if branch_exits.is_empty() {
+                    merge_terminal_causes(
+                        self.program.command(command).span,
+                        [branch_cause, else_cause],
+                    )
+                } else {
+                    None
+                };
+            } else if branch_exits.is_empty() {
+                branch_cause = merge_terminal_causes(
                     self.program.command(command).span,
-                    [branch_cause, else_cause],
-                )
+                    [branch_cause, false_cause],
+                );
             } else {
-                None
-            };
+                branch_cause = None;
+            }
         } else {
             branch_exits.extend(false_exits);
-            if !branch_exits.is_empty() {
+            if branch_exits.is_empty() {
+                branch_cause = merge_terminal_causes(
+                    self.program.command(command).span,
+                    [branch_cause, false_cause],
+                );
+            } else {
                 branch_cause = None;
             }
         }

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -56,7 +56,7 @@ pub struct ControlFlowGraph {
     pub(crate) scope_entries: FxHashMap<ScopeId, BlockId>,
     pub(crate) scope_exits: FxHashMap<ScopeId, Vec<BlockId>>,
     pub(crate) command_blocks: FxHashMap<SpanKey, Vec<BlockId>>,
-    pub(crate) unreachable_causes: FxHashMap<BlockId, Span>,
+    pub(crate) unreachable_causes: FxHashMap<BlockId, UnreachableCause>,
 }
 
 impl ControlFlowGraph {
@@ -103,8 +103,36 @@ impl ControlFlowGraph {
             .unwrap_or(&[])
     }
 
-    pub(crate) fn unreachable_cause(&self, id: BlockId) -> Option<Span> {
+    pub(crate) fn unreachable_cause(&self, id: BlockId) -> Option<UnreachableCause> {
         self.unreachable_causes.get(&id).copied()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnreachableCauseKind {
+    ShellTerminator,
+    LoopControl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct UnreachableCause {
+    pub(crate) span: Span,
+    pub(crate) kind: UnreachableCauseKind,
+}
+
+impl UnreachableCause {
+    fn shell_terminator(span: Span) -> Self {
+        Self {
+            span,
+            kind: UnreachableCauseKind::ShellTerminator,
+        }
+    }
+
+    fn loop_control(span: Span) -> Self {
+        Self {
+            span,
+            kind: UnreachableCauseKind::LoopControl,
+        }
     }
 }
 
@@ -798,14 +826,21 @@ fn command_exit_effect(
         RecordedCommandKind::BraceGroup { body } => {
             sequence_exit_effect(program, body, terminating_call_spans)
         }
-        RecordedCommandKind::While { .. }
-        | RecordedCommandKind::Until { .. }
-        | RecordedCommandKind::For { .. }
-        | RecordedCommandKind::Select { .. }
-        | RecordedCommandKind::ArithmeticFor { .. }
-        | RecordedCommandKind::Case { .. }
-        | RecordedCommandKind::Subshell { .. }
-        | RecordedCommandKind::Pipeline { .. } => ExitEffect::continuing(),
+        RecordedCommandKind::While { condition, body }
+        | RecordedCommandKind::Until { condition, body } => {
+            loop_exit_effect(program, condition, body, terminating_call_spans)
+        }
+        RecordedCommandKind::For { body }
+        | RecordedCommandKind::Select { body }
+        | RecordedCommandKind::ArithmeticFor { body } => {
+            counted_loop_exit_effect(program, body, terminating_call_spans)
+        }
+        RecordedCommandKind::Case { arms } => {
+            case_exit_effect(program, arms, terminating_call_spans)
+        }
+        RecordedCommandKind::Subshell { .. } | RecordedCommandKind::Pipeline { .. } => {
+            ExitEffect::continuing()
+        }
     }
 }
 
@@ -902,6 +937,55 @@ fn elif_chain_exit_effect(
     }
 
     false_path
+}
+
+fn loop_exit_effect(
+    program: &RecordedProgram,
+    condition: RecordedCommandRange,
+    body: RecordedCommandRange,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let mut effect = ExitEffect::continuing();
+    let condition_effect = sequence_exit_effect(program, condition, terminating_call_spans);
+    let body_effect = sequence_exit_effect(program, body, terminating_call_spans);
+    effect.may_return |= condition_effect.may_return || body_effect.may_return;
+    effect.may_exit |= condition_effect.may_exit || body_effect.may_exit;
+    effect
+}
+
+fn counted_loop_exit_effect(
+    program: &RecordedProgram,
+    body: RecordedCommandRange,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let mut effect = ExitEffect::continuing();
+    let body_effect = sequence_exit_effect(program, body, terminating_call_spans);
+    effect.may_return |= body_effect.may_return;
+    effect.may_exit |= body_effect.may_exit;
+    effect
+}
+
+fn case_exit_effect(
+    program: &RecordedProgram,
+    arms: RecordedCaseArmRange,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let arms = program.case_arms(arms);
+    let mut effect = if arms.iter().any(|arm| arm.matches_anything) {
+        ExitEffect::default()
+    } else {
+        ExitEffect::continuing()
+    };
+
+    for arm in arms {
+        effect.combine_alternative(sequence_exit_effect(
+            program,
+            arm.commands,
+            terminating_call_spans,
+        ));
+    }
+
+    effect
 }
 
 impl FunctionCallResolver<'_> {
@@ -1087,6 +1171,27 @@ fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = Sco
 struct SequenceResult {
     entry: Option<BlockId>,
     exits: Vec<BlockId>,
+    terminal_cause: Option<UnreachableCause>,
+}
+
+fn merge_terminal_causes<const N: usize>(
+    fallback_span: Span,
+    causes: [Option<UnreachableCause>; N],
+) -> Option<UnreachableCause> {
+    let mut merged: Option<UnreachableCause> = None;
+    for cause in causes.into_iter().flatten() {
+        merged = Some(match merged {
+            None => cause,
+            Some(existing)
+                if existing.kind == UnreachableCauseKind::LoopControl
+                    && cause.kind == UnreachableCauseKind::LoopControl =>
+            {
+                existing
+            }
+            Some(_) => UnreachableCause::shell_terminator(fallback_span),
+        });
+    }
+    merged
 }
 
 #[derive(Clone, Copy)]
@@ -1111,7 +1216,7 @@ struct GraphBuilder<'a> {
     blocks: Vec<BasicBlock>,
     successors: FxHashMap<BlockId, Vec<(BlockId, EdgeKind)>>,
     command_blocks: FxHashMap<SpanKey, Vec<BlockId>>,
-    unreachable_causes: FxHashMap<BlockId, Span>,
+    unreachable_causes: FxHashMap<BlockId, UnreachableCause>,
     scope_entries: FxHashMap<ScopeId, BlockId>,
 }
 
@@ -1217,15 +1322,26 @@ impl<'a> GraphBuilder<'a> {
 
             if sequence.exits.is_empty() {
                 pending.clear();
-                unreachable_cause.get_or_insert(command.span);
+                unreachable_cause.get_or_insert_with(|| {
+                    sequence
+                        .terminal_cause
+                        .unwrap_or_else(|| UnreachableCause::shell_terminator(command.span))
+                });
             } else {
                 pending = sequence.exits;
             }
         }
 
+        let terminal_cause = if pending.is_empty() {
+            unreachable_cause
+        } else {
+            None
+        };
+
         SequenceResult {
             entry,
             exits: pending,
+            terminal_cause,
         }
     }
 
@@ -1251,6 +1367,14 @@ impl<'a> GraphBuilder<'a> {
                 SequenceResult {
                     entry: Some(block),
                     exits,
+                    terminal_cause: if self
+                        .script_terminating_calls
+                        .contains(&SpanKey::new(command.span))
+                    {
+                        Some(UnreachableCause::shell_terminator(command.span))
+                    } else {
+                        None
+                    },
                 }
             }
             RecordedCommandKind::Break { depth } => {
@@ -1261,6 +1385,7 @@ impl<'a> GraphBuilder<'a> {
                 SequenceResult {
                     entry: Some(block),
                     exits: Vec::new(),
+                    terminal_cause: Some(UnreachableCause::loop_control(command.span)),
                 }
             }
             RecordedCommandKind::Continue { depth } => {
@@ -1271,6 +1396,7 @@ impl<'a> GraphBuilder<'a> {
                 SequenceResult {
                     entry: Some(block),
                     exits: Vec::new(),
+                    terminal_cause: Some(UnreachableCause::loop_control(command.span)),
                 }
             }
             RecordedCommandKind::Return | RecordedCommandKind::Exit => {
@@ -1278,6 +1404,7 @@ impl<'a> GraphBuilder<'a> {
                 SequenceResult {
                     entry: Some(block),
                     exits: Vec::new(),
+                    terminal_cause: Some(UnreachableCause::shell_terminator(command.span)),
                 }
             }
             RecordedCommandKind::List { first, rest } => {
@@ -1340,6 +1467,7 @@ impl<'a> GraphBuilder<'a> {
                 SequenceResult {
                     entry: Some(block),
                     exits: vec![block],
+                    terminal_cause: None,
                 }
             }
             RecordedCommandKind::Pipeline { segments } => {
@@ -1357,6 +1485,7 @@ impl<'a> GraphBuilder<'a> {
                 SequenceResult {
                     entry: Some(block),
                     exits: vec![block],
+                    terminal_cause: None,
                 }
             }
         }
@@ -1380,6 +1509,7 @@ impl<'a> GraphBuilder<'a> {
             self.add_edge(header, entry, EdgeKind::Sequential);
         } else {
             sequence.exits = vec![header];
+            sequence.terminal_cause = None;
         }
         sequence.entry = Some(header);
         sequence
@@ -1396,48 +1526,112 @@ impl<'a> GraphBuilder<'a> {
         let current = self.build_command(first, loops, false);
         let entry = current.entry;
         let mut success_exits = current.exits.clone();
-        let mut failure_exits = current.exits;
+        let mut failure_exits = current.exits.clone();
+        let mut success_cause = current
+            .exits
+            .is_empty()
+            .then_some(current.terminal_cause)
+            .flatten();
+        let mut failure_cause = success_cause;
 
         for item in self.program.list_items(rest) {
+            let next_start = self.blocks.len();
             let next = self.build_command(item.command, loops, false);
-            let (triggering_exits, edge_kind) = match item.operator {
-                RecordedListOperator::And => (&success_exits, EdgeKind::ConditionalTrue),
-                RecordedListOperator::Or => (&failure_exits, EdgeKind::ConditionalFalse),
+            let (triggering_exits, triggering_cause, edge_kind) = match item.operator {
+                RecordedListOperator::And => {
+                    (&success_exits, success_cause, EdgeKind::ConditionalTrue)
+                }
+                RecordedListOperator::Or => {
+                    (&failure_exits, failure_cause, EdgeKind::ConditionalFalse)
+                }
             };
 
             if let Some(next_entry) = next.entry {
-                for exit in triggering_exits {
-                    self.add_edge(*exit, next_entry, edge_kind);
+                if triggering_exits.is_empty() {
+                    if let Some(cause) = triggering_cause {
+                        self.mark_unreachable_blocks_since(next_start, cause);
+                    }
+                } else {
+                    for exit in triggering_exits {
+                        self.add_edge(*exit, next_entry, edge_kind);
+                    }
                 }
             }
 
             let next_reachable = next.entry.is_some() && !triggering_exits.is_empty();
-            let (next_success_exits, mut next_failure_exits) = if next_reachable {
-                (next.exits.clone(), next.exits)
-            } else {
-                (Vec::new(), Vec::new())
-            };
+            let (next_success_exits, mut next_failure_exits, next_terminal_cause) =
+                if next_reachable {
+                    (next.exits.clone(), next.exits, next.terminal_cause)
+                } else {
+                    (Vec::new(), Vec::new(), triggering_cause)
+                };
+            let next_success_cause = next_success_exits
+                .is_empty()
+                .then_some(next_terminal_cause)
+                .flatten();
+            let next_failure_cause = next_failure_exits
+                .is_empty()
+                .then_some(next_terminal_cause)
+                .flatten();
 
             match item.operator {
                 RecordedListOperator::And => {
+                    let existing_failure_cause = failure_exits.is_empty().then_some(failure_cause);
                     append_unique_block_ids(&mut failure_exits, &next_failure_exits);
+                    failure_cause = if failure_exits.is_empty() {
+                        merge_terminal_causes(
+                            self.program.command(command).span,
+                            [existing_failure_cause.flatten(), next_failure_cause],
+                        )
+                    } else {
+                        None
+                    };
                     success_exits = next_success_exits;
+                    success_cause = next_success_cause;
                 }
                 RecordedListOperator::Or => {
+                    let existing_success_cause = success_exits.is_empty().then_some(success_cause);
                     append_unique_block_ids(&mut success_exits, &next_success_exits);
+                    success_cause = if success_exits.is_empty() {
+                        merge_terminal_causes(
+                            self.program.command(command).span,
+                            [existing_success_cause.flatten(), next_success_cause],
+                        )
+                    } else {
+                        None
+                    };
                     failure_exits = std::mem::take(&mut next_failure_exits);
+                    failure_cause = next_failure_cause;
                 }
             }
         }
 
         let mut exits = success_exits;
         append_unique_block_ids(&mut exits, &failure_exits);
+        let terminal_cause = if exits.is_empty() {
+            merge_terminal_causes(
+                self.program.command(command).span,
+                [success_cause, failure_cause],
+            )
+        } else {
+            None
+        };
         self.wrap_sequence_with_command_header(
             command,
-            SequenceResult { entry, exits },
+            SequenceResult {
+                entry,
+                exits,
+                terminal_cause,
+            },
             loops,
             force_command_header,
         )
+    }
+
+    fn mark_unreachable_blocks_since(&mut self, start: usize, cause: UnreachableCause) {
+        for block in &self.blocks[start..] {
+            self.unreachable_causes.insert(block.id, cause);
+        }
     }
 
     fn build_if(
@@ -1451,45 +1645,100 @@ impl<'a> GraphBuilder<'a> {
         let entry = condition_seq.entry.or_else(|| Some(self.empty_block()));
         let mut false_exits = condition_seq.exits.clone();
 
+        let then_start = self.blocks.len();
         let then_seq = self.build_sequence(ranges.then_branch, loops);
-        if let (Some(cond_entry), Some(then_entry)) = (entry, then_seq.entry) {
+        if condition_seq.exits.is_empty()
+            && let Some(cause) = condition_seq.terminal_cause
+        {
+            self.mark_unreachable_blocks_since(then_start, cause);
+        }
+        if let (Some(_cond_entry), Some(then_entry)) = (entry, then_seq.entry) {
             for exit in &condition_seq.exits {
                 self.add_edge(*exit, then_entry, EdgeKind::ConditionalTrue);
-            }
-            if condition_seq.exits.is_empty() {
-                self.add_edge(cond_entry, then_entry, EdgeKind::ConditionalTrue);
             }
         }
 
         let mut branch_exits = then_seq.exits;
+        let mut branch_cause = branch_exits
+            .is_empty()
+            .then_some(then_seq.terminal_cause)
+            .flatten();
 
         for elif_branch in self.program.elif_branches(ranges.elif_branches) {
+            let elif_start = self.blocks.len();
             let elif_cond = self.build_sequence(elif_branch.condition, loops);
+            if false_exits.is_empty()
+                && let Some(cause) = branch_cause
+            {
+                self.mark_unreachable_blocks_since(elif_start, cause);
+            }
             if let Some(elif_entry) = elif_cond.entry {
                 for exit in &false_exits {
                     self.add_edge(*exit, elif_entry, EdgeKind::ConditionalFalse);
                 }
             }
 
+            let elif_body_start = self.blocks.len();
             let elif_body_seq = self.build_sequence(elif_branch.body, loops);
+            if elif_cond.exits.is_empty()
+                && let Some(cause) = elif_cond.terminal_cause
+            {
+                self.mark_unreachable_blocks_since(elif_body_start, cause);
+            }
             if let Some(body_entry) = elif_body_seq.entry {
                 for exit in &elif_cond.exits {
                     self.add_edge(*exit, body_entry, EdgeKind::ConditionalTrue);
                 }
             }
 
+            let previous_false_cause = false_exits.is_empty().then_some(branch_cause).flatten();
             false_exits = elif_cond.exits;
-            branch_exits.extend(elif_body_seq.exits);
+            let elif_body_cause = elif_body_seq
+                .exits
+                .is_empty()
+                .then_some(elif_body_seq.terminal_cause)
+                .flatten();
+            append_unique_block_ids(&mut branch_exits, &elif_body_seq.exits);
+            branch_cause = if branch_exits.is_empty() {
+                merge_terminal_causes(
+                    self.program.command(command).span,
+                    [branch_cause, previous_false_cause, elif_body_cause],
+                )
+            } else {
+                None
+            };
         }
 
+        let else_start = self.blocks.len();
         let else_seq = self.build_sequence(ranges.else_branch, loops);
+        if false_exits.is_empty()
+            && let Some(cause) = branch_cause
+        {
+            self.mark_unreachable_blocks_since(else_start, cause);
+        }
         if let Some(else_entry) = else_seq.entry {
             for exit in &false_exits {
                 self.add_edge(*exit, else_entry, EdgeKind::ConditionalFalse);
             }
+            let else_cause = else_seq
+                .exits
+                .is_empty()
+                .then_some(else_seq.terminal_cause)
+                .flatten();
             branch_exits.extend(else_seq.exits);
+            branch_cause = if branch_exits.is_empty() {
+                merge_terminal_causes(
+                    self.program.command(command).span,
+                    [branch_cause, else_cause],
+                )
+            } else {
+                None
+            };
         } else {
             branch_exits.extend(false_exits);
+            if !branch_exits.is_empty() {
+                branch_cause = None;
+            }
         }
 
         self.wrap_sequence_with_command_header(
@@ -1497,6 +1746,7 @@ impl<'a> GraphBuilder<'a> {
             SequenceResult {
                 entry,
                 exits: branch_exits,
+                terminal_cause: branch_cause,
             },
             loops,
             force_command_header,
@@ -1558,6 +1808,7 @@ impl<'a> GraphBuilder<'a> {
             SequenceResult {
                 entry,
                 exits: vec![exit_block],
+                terminal_cause: None,
             },
             loops,
             force_command_header,
@@ -1592,6 +1843,7 @@ impl<'a> GraphBuilder<'a> {
         SequenceResult {
             entry: Some(header),
             exits: vec![exit_block],
+            terminal_cause: None,
         }
     }
 
@@ -1687,6 +1939,7 @@ impl<'a> GraphBuilder<'a> {
         SequenceResult {
             entry: Some(head),
             exits: vec![exit_block],
+            terminal_cause: None,
         }
     }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -8,7 +8,7 @@ use crate::{
     Binding, BindingAttributes, BindingId, BindingKind, BlockId, CallSite, ContractCertainty,
     ControlFlowGraph, EdgeKind, FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, Reference,
     ReferenceId, ReferenceKind, Scope, ScopeId, ScopeKind, SpanKey, SyntheticRead,
-    UnusedAssignmentAnalysisOptions,
+    UnreachableCauseKind, UnusedAssignmentAnalysisOptions,
 };
 use std::sync::OnceLock;
 
@@ -46,6 +46,7 @@ pub enum UninitializedCertainty {
 pub struct DeadCode {
     pub unreachable: Vec<Span>,
     pub cause: Span,
+    pub cause_kind: UnreachableCauseKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -339,17 +340,23 @@ fn reference_resolves_to_file_entry_contract_variable(
 }
 
 fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
-    let mut dead_code_by_cause: FxHashMap<(usize, usize), (Span, Vec<Span>)> = FxHashMap::default();
+    let mut dead_code_by_cause: FxHashMap<
+        (usize, usize, UnreachableCauseKind),
+        (crate::cfg::UnreachableCause, Vec<Span>),
+    > = FxHashMap::default();
     for block_id in cfg.unreachable() {
         let block = cfg.block(*block_id);
         if block.commands.is_empty() {
             continue;
         }
-        let cause = cfg
-            .unreachable_cause(*block_id)
-            .unwrap_or_else(|| block.commands[0]);
+        let cause =
+            cfg.unreachable_cause(*block_id)
+                .unwrap_or_else(|| crate::cfg::UnreachableCause {
+                    span: block.commands[0],
+                    kind: UnreachableCauseKind::ShellTerminator,
+                });
         dead_code_by_cause
-            .entry((cause.start.offset, cause.end.offset))
+            .entry((cause.span.start.offset, cause.span.end.offset, cause.kind))
             .or_insert_with(|| (cause, Vec::new()))
             .1
             .extend(block.commands.iter().copied());
@@ -358,7 +365,8 @@ fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
         .into_iter()
         .map(|(_, (cause, unreachable))| DeadCode {
             unreachable: outermost_unreachable_spans(unreachable),
-            cause,
+            cause: cause.span,
+            cause_kind: cause.kind,
         })
         .collect::<Vec<_>>();
     dead_code.sort_by_key(|dead| (dead.cause.start.offset, dead.cause.end.offset));

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -40,7 +40,7 @@ pub use binding::{
 /// Call-graph structures derived from the analyzed script.
 pub use call_graph::{CallGraph, CallSite, OverwrittenFunction};
 /// Control-flow graph types and flow-context annotations.
-pub use cfg::{BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext};
+pub use cfg::{BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext, UnreachableCauseKind};
 /// Contract and build-option types used when constructing semantic models.
 pub use contract::{
     ContractCertainty, FileContract, FunctionContract, ProvidedBinding, ProvidedBindingKind,
@@ -5836,6 +5836,82 @@ main() {
             .collect::<Vec<_>>();
 
         assert!(unreachable.contains(&"printf '%s\\n' never".to_owned()));
+    }
+
+    #[test]
+    fn condition_body_after_script_terminating_condition_is_dead() {
+        let source = "\
+if exit 0; then
+  printf '%s\\n' never
+fi
+";
+        let model = model(source);
+        let unreachable = model
+            .analysis()
+            .dead_code()
+            .iter()
+            .flat_map(|entry| entry.unreachable.iter())
+            .map(|span| span.slice(source).trim_end().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(
+            unreachable.contains(&"printf '%s\\n' never".to_owned()),
+            "unreachable spans: {unreachable:?}"
+        );
+    }
+
+    #[test]
+    fn case_return_paths_keep_helper_from_being_script_terminating() {
+        let source = "\
+die() {
+  exit 1
+}
+helper() {
+  case \"$1\" in
+    ok)
+      return
+      ;;
+  esac
+  die
+}
+main() {
+  helper ok
+  printf '%s\\n' still_reachable
+}
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
+    }
+
+    #[test]
+    fn loop_return_paths_keep_helper_from_being_script_terminating() {
+        let source = "\
+die() {
+  exit 1
+}
+helper() {
+  for item in 1; do
+    return
+  done
+  die
+}
+main() {
+  helper
+  printf '%s\\n' still_reachable
+}
+";
+        let model = model(source);
+
+        assert!(
+            model.analysis().dead_code().is_empty(),
+            "dead code: {:?}",
+            model.analysis().dead_code()
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -889,12 +889,22 @@ impl SemanticModel {
     pub fn flow_context_at(&self, span: &Span) -> Option<&FlowContext> {
         self.flow_contexts
             .iter()
-            .find_map(|(candidate, context)| (candidate == span).then_some(context))
+            .rfind(|(candidate, _)| candidate == span)
+            .map(|(_, context)| context)
             .or_else(|| {
-                self.flow_contexts.iter().find_map(|(candidate, context)| {
-                    (contains_span(*candidate, *span) || contains_span(*span, *candidate))
-                        .then_some(context)
-                })
+                self.flow_contexts
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, (candidate, _))| {
+                        contains_span(*candidate, *span) || contains_span(*span, *candidate)
+                    })
+                    .min_by_key(|(index, (candidate, _))| {
+                        (
+                            candidate.end.offset.saturating_sub(candidate.start.offset),
+                            std::cmp::Reverse(*index),
+                        )
+                    })
+                    .map(|(_, (_, context))| context)
             })
     }
 
@@ -5790,6 +5800,38 @@ DESCRIPTION=\"${DESCRIPTION:-Deployment metadata updated}\"
             "echo dead"
         );
         assert_eq!(dead_code[0].cause.slice(source).trim_end(), "exit 0");
+    }
+
+    #[test]
+    fn loop_control_condition_keeps_unreachable_if_tree_causes() {
+        let source = "\
+while true; do
+  if break; then
+    printf '%s\\n' after_true
+  else
+    printf '%s\\n' after_false
+  fi
+  printf '%s\\n' after_if
+done
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let dead_code = analysis.dead_code();
+        let unreachable = dead_code
+            .iter()
+            .flat_map(|entry| entry.unreachable.iter())
+            .map(|span| span.slice(source).trim_end().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(unreachable.contains(&"printf '%s\\n' after_true".to_owned()));
+        assert!(unreachable.contains(&"printf '%s\\n' after_false".to_owned()));
+        assert!(unreachable.contains(&"printf '%s\\n' after_if".to_owned()));
+        assert!(
+            dead_code
+                .iter()
+                .all(|entry| entry.cause_kind == UnreachableCauseKind::LoopControl),
+            "dead code: {dead_code:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add CFG/dataflow cause metadata for dead-code regions
- make C124 ignore break/continue-caused unreachable spans to match the ShellCheck oracle
- tighten C124 span handling and narrow residual corpus metadata to non-loop-control mismatches

## Validation
- cargo test -p shuck-semantic dead_code --lib
- cargo test -p shuck-linter unreachable_after_exit --lib
- make test
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C124 (implementation_diffs=0; still blocked only by two unrelated parser harness failures)
