### PR TITLE
fix: recognize env -S shebangs

### DIFF
--- a/crates/shuck-cli/src/discover.rs
+++ b/crates/shuck-cli/src/discover.rs
@@ -632,16 +632,8 @@ fn read_shebang_prefix(path: &Path) -> Result<Vec<u8>> {
 
 fn infer_shebang_dialect(src: &[u8]) -> Option<&'static str> {
     let first_line = src.split(|byte| *byte == b'\n').next()?;
-    let line = std::str::from_utf8(first_line).ok()?.trim();
-    let line = line.strip_prefix("#!")?.trim();
-
-    let mut parts = line.split_whitespace();
-    let first = parts.next()?;
-    let interpreter = if Path::new(first).file_name()?.to_str()? == "env" {
-        parts.next()?
-    } else {
-        Path::new(first).file_name()?.to_str()?
-    };
+    let line = std::str::from_utf8(first_line).ok()?;
+    let interpreter = shuck_parser::shebang::interpreter_name(line)?;
 
     match interpreter.to_ascii_lowercase().as_str() {
         "bash" => Some("bash"),
@@ -720,6 +712,15 @@ mod tests {
         let tempdir = tempdir().unwrap();
         let script = tempdir.path().join("script");
         fs::write(&script, "#!/usr/bin/env zsh\nprint ok\n").unwrap();
+
+        assert!(is_shell_script(&script).unwrap());
+    }
+
+    #[test]
+    fn detects_env_split_bash_shebang() {
+        let tempdir = tempdir().unwrap();
+        let script = tempdir.path().join("script");
+        fs::write(&script, "#!/usr/bin/env -S bash -e\necho ok\n").unwrap();
 
         assert!(is_shell_script(&script).unwrap());
     }

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2336,14 +2336,7 @@ fn resolve_shell(path: &Path, src: &[u8]) -> String {
 }
 
 fn unsupported_large_corpus_shebang_shell(first_line: &str) -> Option<&str> {
-    let line = first_line.strip_prefix("#!")?.trim();
-    let mut parts = line.split_whitespace();
-    let first = parts.next()?;
-    let interpreter = if Path::new(first).file_name()?.to_str()? == "env" {
-        parts.find(|part| !part.starts_with('-'))?
-    } else {
-        Path::new(first).file_name()?.to_str()?
-    };
+    let interpreter = shuck_parser::shebang::interpreter_name(first_line)?;
 
     match interpreter.to_ascii_lowercase().as_str() {
         "fish" | "csh" | "tcsh" => Some(interpreter),
@@ -2856,6 +2849,14 @@ mod tests {
     }
 
     #[test]
+    fn resolve_shell_env_split_bash_shebang() {
+        assert_eq!(
+            resolve_shell(Path::new("script"), b"#!/usr/bin/env -S bash -e\n"),
+            "bash"
+        );
+    }
+
+    #[test]
     fn resolve_shell_dash_maps_to_sh() {
         assert_eq!(resolve_shell(Path::new("script"), b"#!/bin/dash\n"), "sh");
     }
@@ -2869,6 +2870,14 @@ mod tests {
     fn resolve_shell_fish_shebang_stays_unsupported() {
         assert_eq!(
             resolve_shell(Path::new("script"), b"#!/usr/bin/env fish\n"),
+            "fish"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_env_split_fish_shebang_stays_unsupported() {
+        assert_eq!(
+            resolve_shell(Path::new("script"), b"#!/usr/bin/env -S fish -e\n"),
             "fish"
         );
     }

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -1224,6 +1224,18 @@ mod tests {
             error,
             FormatError::Parse { message, .. } if message.contains("[[ ]] conditionals")
         ));
+
+        let split_error = format_source(
+            "#!/usr/bin/env -S sh -e\n[[ foo == bar ]]\n",
+            None,
+            &ShellFormatOptions::default(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            split_error,
+            FormatError::Parse { message, .. } if message.contains("[[ ]] conditionals")
+        ));
     }
 
     #[test]
@@ -1243,6 +1255,14 @@ mod tests {
         )
         .unwrap();
         assert_eq!(shebang_formatted, FormattedSource::Unchanged);
+
+        let split_shebang_formatted = format_source(
+            "#!/usr/bin/env -S zsh -f\nprint ${(m)foo}\n",
+            None,
+            &ShellFormatOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(split_shebang_formatted, FormattedSource::Unchanged);
     }
 
     #[test]

--- a/crates/shuck-formatter/src/options.rs
+++ b/crates/shuck-formatter/src/options.rs
@@ -296,20 +296,8 @@ impl FormatOptions for ResolvedShellFormatOptions {
 
 fn infer_dialect(source: &str, path: Option<&Path>) -> ParseDialect {
     if let Some(first_line) = source.lines().next()
-        && let Some(shebang) = first_line.strip_prefix("#!")
+        && let Some(interpreter) = shuck_parser::shebang::interpreter_name(first_line)
     {
-        let mut parts = shebang.split_whitespace();
-        let first = parts.next().unwrap_or_default();
-        let interpreter = if Path::new(first)
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name == "env")
-        {
-            parts.next().unwrap_or_default()
-        } else {
-            first
-        };
-        let interpreter = interpreter.rsplit('/').next().unwrap_or_default();
         return ParseDialect::from_name(interpreter);
     }
 

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -49,17 +49,7 @@ impl ShellDialect {
     }
 
     fn infer_from_shebang(source: &str) -> Option<Self> {
-        let first_line = source.lines().next()?.trim();
-        let line = first_line.strip_prefix("#!")?.trim();
-
-        let mut parts = line.split_whitespace();
-        let first = parts.next()?;
-        let interpreter = if Path::new(first).file_name()?.to_str()? == "env" {
-            parts.next()?
-        } else {
-            Path::new(first).file_name()?.to_str()?
-        };
-
+        let interpreter = shuck_parser::shebang::interpreter_name(source.lines().next()?)?;
         Some(Self::from_name(interpreter))
     }
 
@@ -95,6 +85,12 @@ mod tests {
     #[test]
     fn infers_from_shebang_before_extension() {
         let inferred = ShellDialect::infer("#!/usr/bin/env bash\nlocal foo=bar\n", None);
+        assert_eq!(inferred, ShellDialect::Bash);
+    }
+
+    #[test]
+    fn infers_from_env_split_shebang_before_extension() {
+        let inferred = ShellDialect::infer("#!/usr/bin/env -S bash -e\nlocal foo=bar\n", None);
         assert_eq!(inferred, ShellDialect::Bash);
     }
 

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -10,6 +10,8 @@ mod error;
 #[allow(missing_docs)]
 /// Parsing entrypoints, lexer types, and shell-profile configuration.
 pub mod parser;
+/// Shebang parsing helpers shared by Shuck crates.
+pub mod shebang;
 
 /// Error types returned by parser operations.
 pub use error::{Error, Result};

--- a/crates/shuck-parser/src/shebang.rs
+++ b/crates/shuck-parser/src/shebang.rs
@@ -1,0 +1,127 @@
+//! Helpers for reading interpreter names from shebang lines.
+
+use std::path::Path;
+
+/// Returns the interpreter command name from a shebang line.
+///
+/// For `/usr/bin/env` shebangs, this skips `env -S` and returns the first command
+/// in the split string, so `#!/usr/bin/env -S bash -e` reports `bash`.
+#[must_use]
+pub fn interpreter_name(line: &str) -> Option<&str> {
+    let line = line.trim();
+    let line = line.strip_prefix("#!")?.trim();
+
+    let mut parts = line.split_whitespace();
+    let first = parts.next()?;
+    let first_name = token_basename(first)?;
+    if first_name == "env" {
+        return env_interpreter_name(&mut parts);
+    }
+
+    Some(first_name)
+}
+
+fn env_interpreter_name<'a>(parts: &mut impl Iterator<Item = &'a str>) -> Option<&'a str> {
+    let mut skip_next = false;
+    while let Some(part) = parts.next() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+
+        if part == "-S" || part == "--split-string" {
+            return parts.next().and_then(token_basename);
+        }
+
+        if let Some(split_string) = part
+            .strip_prefix("-S")
+            .filter(|split_string| !split_string.is_empty())
+        {
+            return token_basename(split_string);
+        }
+
+        if let Some(split_string) = part.strip_prefix("--split-string=") {
+            return split_string
+                .split_whitespace()
+                .next()
+                .and_then(token_basename);
+        }
+
+        if looks_like_env_assignment(part) {
+            continue;
+        }
+
+        if env_option_consumes_value(part) {
+            skip_next = env_option_uses_separate_value(part);
+            continue;
+        }
+
+        if part.starts_with('-') {
+            continue;
+        }
+
+        return token_basename(part);
+    }
+
+    None
+}
+
+fn env_option_consumes_value(token: &str) -> bool {
+    matches!(token, "-u" | "-C" | "--unset" | "--chdir")
+        || token.starts_with("-u")
+        || token.starts_with("-C")
+        || token.starts_with("--unset=")
+        || token.starts_with("--chdir=")
+}
+
+fn env_option_uses_separate_value(token: &str) -> bool {
+    matches!(token, "-u" | "-C" | "--unset" | "--chdir")
+}
+
+fn looks_like_env_assignment(token: &str) -> bool {
+    let Some((name, _)) = token.split_once('=') else {
+        return false;
+    };
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn token_basename(token: &str) -> Option<&str> {
+    Path::new(token).file_name()?.to_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::interpreter_name;
+
+    #[test]
+    fn reads_direct_interpreter_name() {
+        assert_eq!(interpreter_name("#!/bin/dash"), Some("dash"));
+    }
+
+    #[test]
+    fn reads_env_interpreter_name() {
+        assert_eq!(interpreter_name("#!/usr/bin/env bash"), Some("bash"));
+    }
+
+    #[test]
+    fn skips_env_split_string_flag() {
+        assert_eq!(interpreter_name("#!/usr/bin/env -S bash -e"), Some("bash"));
+        assert_eq!(
+            interpreter_name("#!/usr/bin/env -S /bin/zsh -f"),
+            Some("zsh")
+        );
+    }
+
+    #[test]
+    fn skips_env_options_and_assignments() {
+        assert_eq!(
+            interpreter_name("#!/usr/bin/env -i FOO=1 -u BAR bash"),
+            Some("bash")
+        );
+    }
+}

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1828,19 +1828,8 @@ fn infer_parse_dialect_from_source(
     path: Option<&Path>,
 ) -> shuck_parser::ShellDialect {
     if let Some(line) = source.lines().next().map(str::trim)
-        && let Some(line) = line.strip_prefix("#!").map(str::trim)
+        && let Some(interpreter) = shuck_parser::shebang::interpreter_name(line)
     {
-        let mut parts = line.split_whitespace();
-        let first = parts.next();
-        let interpreter = first
-            .and_then(|first| {
-                if Path::new(first).file_name()?.to_str()? == "env" {
-                    parts.next()
-                } else {
-                    Path::new(first).file_name()?.to_str()
-                }
-            })
-            .unwrap_or_default();
         return match interpreter.to_ascii_lowercase().as_str() {
             "sh" | "dash" | "ksh" | "posix" => shuck_parser::ShellDialect::Posix,
             "mksh" => shuck_parser::ShellDialect::Mksh,
@@ -1869,17 +1858,7 @@ fn bash_runtime_vars_enabled(source: &str, path: Option<&Path>) -> bool {
 }
 
 fn infer_bash_from_shebang(source: &str) -> Option<bool> {
-    let first_line = source.lines().next()?.trim();
-    let line = first_line.strip_prefix("#!")?.trim();
-
-    let mut parts = line.split_whitespace();
-    let first = parts.next()?;
-    let interpreter = if Path::new(first).file_name()?.to_str()? == "env" {
-        parts.next()?
-    } else {
-        Path::new(first).file_name()?.to_str()?
-    };
-
+    let interpreter = shuck_parser::shebang::interpreter_name(source.lines().next()?)?;
     Some(interpreter.eq_ignore_ascii_case("bash"))
 }
 
@@ -6186,6 +6165,44 @@ printf '%s\\n' still_reachable
 
         assert_names_absent(&names, &unresolved);
         assert_names_absent(&names, &uninitialized);
+    }
+
+    #[test]
+    fn env_split_bash_shebang_enables_bash_runtime_vars() {
+        let source = bash_runtime_source("#!/usr/bin/env -S bash -e");
+        let model = model(&source);
+        let names = [
+            "LINENO",
+            "FUNCNAME",
+            "BASH_SOURCE",
+            "BASH_LINENO",
+            "RANDOM",
+            "BASH_REMATCH",
+            "READLINE_LINE",
+            "BASH_VERSION",
+            "BASH_VERSINFO",
+            "OSTYPE",
+            "HISTCONTROL",
+            "HISTSIZE",
+        ];
+
+        let unresolved = unresolved_names(&model);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_absent(&names, &unresolved);
+        assert_names_absent(&names, &uninitialized);
+    }
+
+    #[test]
+    fn inferred_profile_honors_env_split_shebang() {
+        assert_eq!(
+            infer_parse_dialect_from_source("#!/usr/bin/env -S sh -e\n:\n", None),
+            ShellDialect::Posix
+        );
+        assert_eq!(
+            infer_parse_dialect_from_source("#!/usr/bin/env -S zsh -f\nprint ok\n", None),
+            ShellDialect::Zsh
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix shebang interpreter inference for `/usr/bin/env -S ...` forms by adding a shared parser helper that extracts the real shell argument instead of treating `-S` as the interpreter.

## Details

- Added `shuck_parser::shebang::interpreter_name` for shared shebang parsing.
- Updated discovery, linter shell inference, formatter auto-dialect, semantic profile/runtime inference, and the large-corpus resolver to use the helper.
- Added regression coverage for extensionless discovery, linter inference, formatter dialect detection, semantic inference, and unsupported large-corpus shells.

## Root Cause

Each caller parsed `/usr/bin/env` shebangs by taking the token immediately after `env`. For split-string shebangs such as `#!/usr/bin/env -S bash -e`, that token is `-S`, so Shuck skipped extensionless shell scripts or inferred the wrong dialect.

## Validation

- `cargo test -p shuck-parser -p shuck-linter -p shuck-cli -p shuck-semantic env_split`
- `cargo test -p shuck-formatter auto_dialect_honors`
- `cargo test -p shuck-parser shebang`