### PR TITLE
fix(semantic): infer sourced helper parse profiles

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1164,6 +1164,34 @@ helper_value=ready
     }
 
     #[test]
+    fn sourced_env_split_bash_helper_normalizes_shebang_path() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("helper.sh");
+        fs::write(
+            &main,
+            "\
+#!/bin/sh
+. ./helper.sh
+printf '%s\\n' \"$helper_value\"
+",
+        )
+        .unwrap();
+        fs::write(
+            &helper,
+            "\
+#!/usr/bin/env -S /bin/bash -e
+for ((i=0; i<1; i++)); do :; done
+helper_value=ready
+",
+        )
+        .unwrap();
+
+        let diagnostics = lint_path_for_rule(&main, Rule::UndefinedVariable);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn sourced_helper_reads_keep_c150_live_for_subshell_assignments() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1136,6 +1136,34 @@ helper_value=ready
     }
 
     #[test]
+    fn sourced_env_split_bash_helper_prefers_shebang_over_sh_extension() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("helper.sh");
+        fs::write(
+            &main,
+            "\
+#!/bin/sh
+. ./helper.sh
+printf '%s\\n' \"$helper_value\"
+",
+        )
+        .unwrap();
+        fs::write(
+            &helper,
+            "\
+#!/usr/bin/env -S bash -e
+for ((i=0; i<1; i++)); do :; done
+helper_value=ready
+",
+        )
+        .unwrap();
+
+        let diagnostics = lint_path_for_rule(&main, Rule::UndefinedVariable);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn sourced_helper_reads_keep_c150_live_for_subshell_assignments() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1192,6 +1192,34 @@ helper_value=ready
     }
 
     #[test]
+    fn sourced_env_split_bash_helper_skips_env_assignments() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("helper.sh");
+        fs::write(
+            &main,
+            "\
+#!/bin/sh
+. ./helper.sh
+printf '%s\\n' \"$helper_value\"
+",
+        )
+        .unwrap();
+        fs::write(
+            &helper,
+            "\
+#!/usr/bin/env -S FOO=1 bash -e
+for ((i=0; i<1; i++)); do :; done
+helper_value=ready
+",
+        )
+        .unwrap();
+
+        let diagnostics = lint_path_for_rule(&main, Rule::UndefinedVariable);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn sourced_helper_reads_keep_c150_live_for_subshell_assignments() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1108,6 +1108,34 @@ set_flag() {
     }
 
     #[test]
+    fn sourced_zsh_helper_imports_bindings_after_zsh_only_syntax() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.zsh");
+        let helper = temp.path().join("helper.zsh");
+        fs::write(
+            &main,
+            "\
+#!/bin/zsh
+. ./helper.zsh
+print \"$helper_value\"
+",
+        )
+        .unwrap();
+        fs::write(
+            &helper,
+            "\
+#!/bin/zsh
+repeat 1; do print loaded; done
+helper_value=ready
+",
+        )
+        .unwrap();
+
+        let diagnostics = lint_path_for_rule(&main, Rule::UndefinedVariable);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn sourced_helper_reads_keep_c150_live_for_subshell_assignments() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-parser/src/shebang.rs
+++ b/crates/shuck-parser/src/shebang.rs
@@ -30,21 +30,18 @@ fn env_interpreter_name<'a>(parts: &mut impl Iterator<Item = &'a str>) -> Option
         }
 
         if part == "-S" || part == "--split-string" {
-            return parts.next().and_then(token_basename);
+            return env_interpreter_name(parts);
         }
 
         if let Some(split_string) = part
             .strip_prefix("-S")
             .filter(|split_string| !split_string.is_empty())
         {
-            return token_basename(split_string);
+            return split_string_interpreter_name(split_string);
         }
 
         if let Some(split_string) = part.strip_prefix("--split-string=") {
-            return split_string
-                .split_whitespace()
-                .next()
-                .and_then(token_basename);
+            return split_string_interpreter_name(split_string);
         }
 
         if looks_like_env_assignment(part) {
@@ -64,6 +61,10 @@ fn env_interpreter_name<'a>(parts: &mut impl Iterator<Item = &'a str>) -> Option
     }
 
     None
+}
+
+fn split_string_interpreter_name(split_string: &str) -> Option<&str> {
+    env_interpreter_name(&mut split_string.split_whitespace())
 }
 
 fn env_option_consumes_value(token: &str) -> bool {
@@ -121,6 +122,10 @@ mod tests {
     fn skips_env_options_and_assignments() {
         assert_eq!(
             interpreter_name("#!/usr/bin/env -i FOO=1 -u BAR bash"),
+            Some("bash")
+        );
+        assert_eq!(
+            interpreter_name("#!/usr/bin/env -S FOO=1 bash -e"),
             Some("bash")
         );
     }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1885,8 +1885,7 @@ fn bash_runtime_vars_enabled(source: &str, path: Option<&Path>) -> bool {
 }
 
 fn infer_bash_from_shebang(source: &str) -> Option<bool> {
-    let interpreter = shuck_parser::shebang::interpreter_name(source.lines().next()?)?;
-    Some(interpreter.eq_ignore_ascii_case("bash"))
+    shebang_interpreter(source).map(|interpreter| interpreter.eq_ignore_ascii_case("bash"))
 }
 
 fn contains_offset(span: Span, offset: usize) -> bool {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1829,26 +1829,51 @@ fn infer_parse_dialect_from_source(
     source: &str,
     path: Option<&Path>,
 ) -> shuck_parser::ShellDialect {
-    if let Some(line) = source.lines().next().map(str::trim)
-        && let Some(interpreter) = shuck_parser::shebang::interpreter_name(line)
-    {
-        return match interpreter.to_ascii_lowercase().as_str() {
-            "sh" | "dash" | "ksh" | "posix" => shuck_parser::ShellDialect::Posix,
-            "mksh" => shuck_parser::ShellDialect::Mksh,
-            "zsh" => shuck_parser::ShellDialect::Zsh,
-            _ => shuck_parser::ShellDialect::Bash,
-        };
+    if let Some(interpreter) = shebang_interpreter(source) {
+        return parse_dialect_from_name(&interpreter).unwrap_or(shuck_parser::ShellDialect::Bash);
     }
 
+    infer_parse_dialect_from_path(path).unwrap_or(shuck_parser::ShellDialect::Bash)
+}
+
+pub(crate) fn infer_explicit_parse_dialect_from_source(
+    source: &str,
+    path: Option<&Path>,
+) -> Option<shuck_parser::ShellDialect> {
+    if let Some(interpreter) = shebang_interpreter(source)
+        && let Some(dialect) = parse_dialect_from_name(&interpreter)
+    {
+        return Some(dialect);
+    }
+
+    infer_parse_dialect_from_path(path)
+}
+
+fn shebang_interpreter(source: &str) -> Option<&str> {
+    shuck_parser::shebang::interpreter_name(source.lines().next()?)
+}
+
+fn infer_parse_dialect_from_path(path: Option<&Path>) -> Option<shuck_parser::ShellDialect> {
     match path
         .and_then(|path| path.extension().and_then(|ext| ext.to_str()))
         .map(|ext| ext.to_ascii_lowercase())
         .as_deref()
     {
-        Some("sh" | "dash" | "ksh") => shuck_parser::ShellDialect::Posix,
-        Some("mksh") => shuck_parser::ShellDialect::Mksh,
-        Some("zsh") => shuck_parser::ShellDialect::Zsh,
-        _ => shuck_parser::ShellDialect::Bash,
+        Some("sh" | "dash" | "ksh") => Some(shuck_parser::ShellDialect::Posix),
+        Some("mksh") => Some(shuck_parser::ShellDialect::Mksh),
+        Some("bash") => Some(shuck_parser::ShellDialect::Bash),
+        Some("zsh") => Some(shuck_parser::ShellDialect::Zsh),
+        _ => None,
+    }
+}
+
+fn parse_dialect_from_name(name: &str) -> Option<shuck_parser::ShellDialect> {
+    match name.to_ascii_lowercase().as_str() {
+        "sh" | "dash" | "ksh" | "posix" => Some(shuck_parser::ShellDialect::Posix),
+        "mksh" => Some(shuck_parser::ShellDialect::Mksh),
+        "bash" => Some(shuck_parser::ShellDialect::Bash),
+        "zsh" => Some(shuck_parser::ShellDialect::Zsh),
+        _ => None,
     }
 }
 

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1830,7 +1830,7 @@ fn infer_parse_dialect_from_source(
     path: Option<&Path>,
 ) -> shuck_parser::ShellDialect {
     if let Some(interpreter) = shebang_interpreter(source) {
-        return parse_dialect_from_name(&interpreter).unwrap_or(shuck_parser::ShellDialect::Bash);
+        return parse_dialect_from_name(interpreter).unwrap_or(shuck_parser::ShellDialect::Bash);
     }
 
     infer_parse_dialect_from_path(path).unwrap_or(shuck_parser::ShellDialect::Bash)
@@ -1841,7 +1841,7 @@ pub(crate) fn infer_explicit_parse_dialect_from_source(
     path: Option<&Path>,
 ) -> Option<shuck_parser::ShellDialect> {
     if let Some(interpreter) = shebang_interpreter(source)
-        && let Some(dialect) = parse_dialect_from_name(&interpreter)
+        && let Some(dialect) = parse_dialect_from_name(interpreter)
     {
         return Some(dialect);
     }

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -9,12 +9,13 @@ use shuck_ast::{
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
+use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile, ZshOptionState};
 
 use crate::{
     Binding, BindingId, BindingKind, ContractCertainty, FileContract, FunctionContract,
     FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel,
     SourcePathResolver, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution, SpanKey,
-    SyntheticRead, build_semantic_model_base,
+    SyntheticRead, build_semantic_model_base, infer_explicit_parse_dialect_from_source,
 };
 
 #[derive(Debug, Clone)]
@@ -35,10 +36,32 @@ type SourceClosureContractResult = (
     Vec<SourceRefDiagnosticClass>,
 );
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct SourceClosureLookupContext<'a> {
     source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
     analyzed_paths: Option<&'a FxHashSet<PathBuf>>,
+    shell_profile: ShellProfile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct HelperSummaryKey {
+    path: PathBuf,
+    shell_profile: ShellProfileKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ShellProfileKey {
+    dialect: ParseShellDialect,
+    options: Option<ZshOptionState>,
+}
+
+impl ShellProfileKey {
+    fn from_profile(profile: &ShellProfile) -> Self {
+        Self {
+            dialect: profile.dialect,
+            options: profile.options.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -71,6 +94,7 @@ pub(crate) fn collect_source_closure_contracts(
     let context = SourceClosureLookupContext {
         source_path_resolver,
         analyzed_paths,
+        shell_profile: model.shell_profile().clone(),
     };
     let contracts = collect_source_closure_contracts_with_cache(
         model,
@@ -79,7 +103,7 @@ pub(crate) fn collect_source_closure_contracts(
         source_path,
         &mut summaries,
         &mut active,
-        context,
+        &context,
     );
     (
         contracts.synthetic_reads,
@@ -95,9 +119,9 @@ fn collect_source_closure_contracts_with_cache(
     _file: &File,
     _source: &str,
     source_path: &Path,
-    summaries: &mut FxHashMap<PathBuf, FileContract>,
-    active: &mut FxHashSet<PathBuf>,
-    context: SourceClosureLookupContext<'_>,
+    summaries: &mut FxHashMap<HelperSummaryKey, FileContract>,
+    active: &mut FxHashSet<HelperSummaryKey>,
+    context: &SourceClosureLookupContext<'_>,
 ) -> SourceClosureContracts {
     let facts = collect_ast_facts(model);
     let call_args_by_scope = resolve_literal_call_args_by_scope(model, &facts.calls);
@@ -208,9 +232,9 @@ fn collect_source_closure_contracts_with_cache(
 fn merge_contracts_for_candidates(
     source_path: &Path,
     candidates: impl IntoIterator<Item = String>,
-    summaries: &mut FxHashMap<PathBuf, FileContract>,
-    active: &mut FxHashSet<PathBuf>,
-    context: SourceClosureLookupContext<'_>,
+    summaries: &mut FxHashMap<HelperSummaryKey, FileContract>,
+    active: &mut FxHashSet<HelperSummaryKey>,
+    context: &SourceClosureLookupContext<'_>,
 ) -> (FileContract, bool, bool) {
     let mut contracts = Vec::new();
     let mut resolved = false;
@@ -226,12 +250,7 @@ fn merge_contracts_for_candidates(
             })
         });
         for resolved_path in resolved_paths {
-            contracts.push(summarize_helper(
-                &resolved_path,
-                summaries,
-                active,
-                context.source_path_resolver,
-            ));
+            contracts.push(summarize_helper(&resolved_path, summaries, active, context));
         }
     }
     (
@@ -1086,11 +1105,19 @@ fn candidate_path_variants(candidate: &str) -> Vec<PathBuf> {
 
 fn summarize_helper(
     path: &Path,
-    summaries: &mut FxHashMap<PathBuf, FileContract>,
-    active: &mut FxHashSet<PathBuf>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+    summaries: &mut FxHashMap<HelperSummaryKey, FileContract>,
+    active: &mut FxHashSet<HelperSummaryKey>,
+    context: &SourceClosureLookupContext<'_>,
 ) -> FileContract {
-    let key = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let canonical_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let Ok(source) = fs::read_to_string(&canonical_path) else {
+        return FileContract::default();
+    };
+    let shell_profile = helper_shell_profile(&source, &canonical_path, &context.shell_profile);
+    let key = HelperSummaryKey {
+        path: canonical_path.clone(),
+        shell_profile: ShellProfileKey::from_profile(&shell_profile),
+    };
     if let Some(summary) = summaries.get(&key) {
         return summary.clone();
     }
@@ -1098,7 +1125,14 @@ fn summarize_helper(
         return FileContract::default();
     }
 
-    let summary = summarize_helper_uncached(&key, summaries, active, source_path_resolver);
+    let summary = summarize_helper_uncached(
+        &canonical_path,
+        &source,
+        shell_profile,
+        summaries,
+        active,
+        context.source_path_resolver,
+    );
     active.remove(&key);
     summaries.insert(key, summary.clone());
     summary
@@ -1106,37 +1140,37 @@ fn summarize_helper(
 
 fn summarize_helper_uncached(
     path: &Path,
-    summaries: &mut FxHashMap<PathBuf, FileContract>,
-    active: &mut FxHashSet<PathBuf>,
+    source: &str,
+    shell_profile: ShellProfile,
+    summaries: &mut FxHashMap<HelperSummaryKey, FileContract>,
+    active: &mut FxHashSet<HelperSummaryKey>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> FileContract {
-    let Ok(source) = fs::read_to_string(path) else {
-        return FileContract::default();
-    };
-    let output = Parser::new(&source).parse();
+    let output = Parser::with_profile(source, shell_profile.clone()).parse();
     if output.is_err() {
         return FileContract::default();
     }
-    let indexer = Indexer::new(&source, &output);
+    let indexer = Indexer::new(source, &output);
     let mut observer = crate::NoopTraversalObserver;
     let mut semantic = build_semantic_model_base(
         &output.file,
-        &source,
+        source,
         &indexer,
         &mut observer,
         Some(path),
-        None,
+        Some(shell_profile.clone()),
     );
     let collected = collect_source_closure_contracts_with_cache(
         &semantic,
         &output.file,
-        &source,
+        source,
         path,
         summaries,
         active,
-        SourceClosureLookupContext {
+        &SourceClosureLookupContext {
             source_path_resolver,
             analyzed_paths: None,
+            shell_profile,
         },
     );
     semantic.apply_source_contracts(
@@ -1166,6 +1200,12 @@ fn summarize_helper_uncached(
         contract.add_provided_function(function);
     }
     contract
+}
+
+fn helper_shell_profile(source: &str, path: &Path, inherited: &ShellProfile) -> ShellProfile {
+    infer_explicit_parse_dialect_from_source(source, Some(path))
+        .map(ShellProfile::native)
+        .unwrap_or_else(|| inherited.clone())
 }
 
 fn summarize_scope_body_contract(

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1110,6 +1110,14 @@ fn summarize_helper(
     context: &SourceClosureLookupContext<'_>,
 ) -> FileContract {
     let canonical_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let requested_key = HelperSummaryKey {
+        path: canonical_path.clone(),
+        shell_profile: ShellProfileKey::from_profile(&context.shell_profile),
+    };
+    if let Some(summary) = summaries.get(&requested_key) {
+        return summary.clone();
+    }
+
     let Ok(source) = fs::read_to_string(&canonical_path) else {
         return FileContract::default();
     };
@@ -1119,7 +1127,9 @@ fn summarize_helper(
         shell_profile: ShellProfileKey::from_profile(&shell_profile),
     };
     if let Some(summary) = summaries.get(&key) {
-        return summary.clone();
+        let summary = summary.clone();
+        summaries.insert(requested_key, summary.clone());
+        return summary;
     }
     if !active.insert(key.clone()) {
         return FileContract::default();
@@ -1135,6 +1145,7 @@ fn summarize_helper(
     );
     active.remove(&key);
     summaries.insert(key, summary.clone());
+    summaries.insert(requested_key, summary.clone());
     summary
 }
 
@@ -1327,7 +1338,6 @@ mod tests {
     use shuck_parser::parser::ShellDialect;
     #[cfg(windows)]
     use std::fs;
-    #[cfg(windows)]
     use tempfile::tempdir;
 
     #[test]
@@ -1371,6 +1381,34 @@ coproc loader { . \"$2\"; }
 
         assert_eq!(source_call_count, 2);
         assert_eq!(facts.source_templates.len(), 2);
+    }
+
+    #[test]
+    fn summarize_helper_reuses_request_profile_cache_hit_before_reading() {
+        let temp = tempdir().unwrap();
+        let helper = temp.path().join("helper");
+        std::fs::write(&helper, "#!/bin/zsh\nloaded_value=ok\n").unwrap();
+        let canonical_helper = std::fs::canonicalize(&helper).unwrap();
+
+        let context = SourceClosureLookupContext {
+            source_path_resolver: None,
+            analyzed_paths: None,
+            shell_profile: ShellProfile::native(ParseShellDialect::Bash),
+        };
+        let mut summaries = FxHashMap::default();
+        let mut active = FxHashSet::default();
+
+        let first = summarize_helper(&canonical_helper, &mut summaries, &mut active, &context);
+        assert!(first.provided_bindings.iter().any(|binding| {
+            binding.name.as_str() == "loaded_value"
+                && binding.kind == ProvidedBindingKind::Variable
+                && binding.certainty == ContractCertainty::Definite
+        }));
+
+        std::fs::remove_file(&helper).unwrap();
+
+        let second = summarize_helper(&canonical_helper, &mut summaries, &mut active, &context);
+        assert_eq!(second, first);
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary
- Parse sourced helper summaries with a profile derived from the helper shebang or file extension, falling back to the caller profile when the helper has no explicit identity.
- Key helper summary recursion/cache entries by both canonical path and shell profile so contracts do not leak across dialects.
- Add a regression for a zsh main file sourcing a zsh helper with zsh-only syntax before exporting a binding.

## Root Cause
`summarize_helper_uncached` used `Parser::new`, which always parses as Bash. That made zsh helpers with zsh-only syntax fail summary import, so bindings exported by the helper could still be reported as undefined in the sourcing file.

## Validation
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
- `git diff --check`