### PR TITLE
fix(linter): broaden C063 function reachability

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c063.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c063.yaml
@@ -64,6 +64,14 @@ reviewed_divergences:
     line: 71
     reason: "RetroPie swaps in its own fatal-error helper for the package-management workflow after sourcing the shared setup library, so the overwrite is intentional."
   - side: shuck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
+    line: 883
+    reason: "RetroPie's optional user menu helper is reached through runtime menu-file discovery, so this termination-only C063 hit is framework dispatch rather than a dead definition."
+  - side: shuck-only
+    path_suffix: "SlackBuildsOrg__slackbuilds__network__openconnect__vpnc-script"
+    line: 210
+    reason: "The OpenConnect route helper is used by branch-selected route functions and command-substitution pipelines, so this termination-only C063 hit reflects dispatch shape rather than a dead definition."
+  - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__owncloud-vm.sh"
     line: 452
     reason: "This ProxmoxVE provisioning script replaces the sourced start helper in a later execution branch as part of its workflow setup."

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -2,10 +2,19 @@ use crate::context::FileContextTag;
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 use shuck_semantic::{
     BindingKind, BindingOrigin, OverwrittenFunction as SemanticOverwrittenFunction,
+    UnreachedFunction as SemanticUnreachedFunction, UnreachedFunctionReason,
 };
+
+#[derive(Clone, Copy)]
+pub enum FunctionNotReachedReason {
+    Overwritten,
+    ScriptTerminates,
+    UnreachableDefinition,
+}
 
 pub struct OverwrittenFunction {
     pub name: String,
+    pub reason: FunctionNotReachedReason,
 }
 
 impl Violation for OverwrittenFunction {
@@ -16,19 +25,35 @@ impl Violation for OverwrittenFunction {
     }
 
     fn message(&self) -> String {
-        format!(
-            "function `{}` is overwritten before any direct call can reach it",
-            self.name
-        )
+        match self.reason {
+            FunctionNotReachedReason::Overwritten => format!(
+                "function `{}` is overwritten before any direct call can reach it",
+                self.name
+            ),
+            FunctionNotReachedReason::ScriptTerminates
+            | FunctionNotReachedReason::UnreachableDefinition => format!(
+                "function `{}` cannot be reached by a direct call before the script terminates",
+                self.name
+            ),
+        }
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("delete the earlier overwritten function definition".to_owned())
+        match self.reason {
+            FunctionNotReachedReason::Overwritten => {
+                Some("delete the earlier overwritten function definition".to_owned())
+            }
+            FunctionNotReachedReason::ScriptTerminates
+            | FunctionNotReachedReason::UnreachableDefinition => {
+                Some("delete the function definition that cannot be reached".to_owned())
+            }
+        }
     }
 }
 
 pub fn overwritten_function(checker: &mut Checker) {
     let overwritten = checker.semantic_analysis().overwritten_functions().to_vec();
+    let unreached = checker.semantic_analysis().unreached_functions().to_vec();
 
     for overwritten in overwritten {
         if overwritten.first_called {
@@ -38,22 +63,56 @@ pub fn overwritten_function(checker: &mut Checker) {
             continue;
         }
 
-        let binding = checker.semantic().binding(overwritten.first);
-        let definition_span = match &binding.origin {
-            BindingOrigin::FunctionDefinition { definition_span } => *definition_span,
-            _ => binding.span,
-        };
-
-        checker.report_diagnostic_dedup(
-            Diagnostic::new(
-                OverwrittenFunction {
-                    name: overwritten.name.to_string(),
-                },
-                definition_span,
-            )
-            .with_fix(Fix::unsafe_edit(Edit::deletion(definition_span))),
+        report_function_definition(
+            checker,
+            overwritten.first,
+            overwritten.name.to_string(),
+            FunctionNotReachedReason::Overwritten,
         );
     }
+
+    for unreached in unreached {
+        if should_suppress_unreached(checker, &unreached) {
+            continue;
+        }
+
+        let reason = match unreached.reason {
+            UnreachedFunctionReason::UnreachableDefinition => {
+                FunctionNotReachedReason::UnreachableDefinition
+            }
+            UnreachedFunctionReason::ScriptTerminates => FunctionNotReachedReason::ScriptTerminates,
+        };
+        report_function_definition(
+            checker,
+            unreached.binding,
+            unreached.name.to_string(),
+            reason,
+        );
+    }
+}
+
+fn report_function_definition(
+    checker: &mut Checker<'_>,
+    binding_id: shuck_semantic::BindingId,
+    name: String,
+    reason: FunctionNotReachedReason,
+) {
+    let binding = checker.semantic().binding(binding_id);
+    let definition_span = match &binding.origin {
+        BindingOrigin::FunctionDefinition { definition_span } => *definition_span,
+        _ => binding.span,
+    };
+    let diagnostic_span = trim_trailing_whitespace(definition_span, checker.source());
+
+    checker.report_diagnostic_dedup(
+        Diagnostic::new(OverwrittenFunction { name, reason }, diagnostic_span)
+            .with_fix(Fix::unsafe_edit(Edit::deletion(definition_span))),
+    );
+}
+
+fn trim_trailing_whitespace(span: shuck_ast::Span, source: &str) -> shuck_ast::Span {
+    let trimmed = span.slice(source).trim_end_matches(char::is_whitespace);
+    shuck_ast::Span::from_positions(span.start, span.start.advanced_by(trimmed))
 }
 
 fn should_suppress_overwrite(
@@ -101,6 +160,13 @@ fn should_suppress_overwrite(
                     first.span.end.offset,
                     second.span.start.offset,
                 )))
+}
+
+fn should_suppress_unreached(checker: &Checker<'_>, unreached: &SemanticUnreachedFunction) -> bool {
+    let binding = checker.semantic().binding(unreached.binding);
+
+    matches!(binding.kind, BindingKind::Imported)
+        || checker.file_context().has_tag(FileContextTag::ShellSpec)
 }
 
 fn unset_function_between(
@@ -317,6 +383,88 @@ myfunc
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn functions_before_script_termination_report() {
+        let source = "\
+myfunc() { echo hi; }
+exit 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+    }
+
+    #[test]
+    fn functions_at_plain_eof_do_not_report() {
+        let source = "myfunc() { echo hi; }\n";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn direct_calls_before_script_termination_do_not_report() {
+        let source = "\
+myfunc() { echo hi; }
+myfunc
+exit 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unreachable_function_definitions_report() {
+        let source = "\
+exit 0
+myfunc() { echo hi; }
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn unreachable_function_definitions_report_alongside_unreachable_code() {
+        let source = "\
+exit 0
+myfunc() { echo hi; }
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rules([Rule::OverwrittenFunction, Rule::UnreachableAfterExit]),
+        );
+        let rules = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.rule)
+            .collect::<Vec<_>>();
+
+        assert!(rules.contains(&Rule::OverwrittenFunction));
+        assert!(rules.contains(&Rule::UnreachableAfterExit));
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -4546,8 +4546,8 @@ impl<'a> Parser<'a> {
                 }
                 // Inside brace groups, a bare `}` can still be a literal
                 // argument like `echo }`, but only when it's separated from the
-                // preceding token by whitespace and isn't introducing an outer
-                // redirect on the brace group itself.
+                // preceding token by whitespace. Closers are handled in command
+                // position by the enclosing brace parser.
                 Some(TokenKind::RightBrace) if right_brace_is_literal_argument => {
                     words.push(Word::literal_with_span("}", self.current_span));
                     self.advance();

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -386,6 +386,81 @@ fn test_posix_function_allows_if_body() {
 }
 
 #[test]
+fn test_posix_function_parses_negated_bracket_if_body() {
+    let input = "\
+recent_file(){
+    if ! [ -f \"$file\" ]; then
+        return 1
+    elif find \"$file\" -mtime -\"$days\" -print | grep -q .; then
+        return 0
+    else
+        local days_ago_in_seconds
+        days_ago_in_seconds=\"$(date -d \"$days days ago\" '+%s')\"
+        if is_mac; then
+            if [ \"$(stat -f '%m' \"$file\")\" -ge \"$days_ago_in_seconds\" ]; then
+                return 0
+            else
+                return 1
+            fi
+        elif [ \"$(stat -c '%Y' \"$file\")\" -ge \"$days_ago_in_seconds\" ]; then
+            return 0
+        else
+            return 1
+        fi
+    fi
+}
+";
+    let parsed = Parser::new(input).parse().unwrap();
+
+    assert!(matches!(
+        expect_function(&parsed.file.body[0]).body.command,
+        AstCommand::Compound(..)
+    ));
+}
+
+#[test]
+fn test_posix_function_allows_single_quoted_zsh_glob_control_text_in_body() {
+    let input = "\
+parse_hint(){
+    printf '%s\\n' 'literal (# marker)' \"$@\"
+}
+";
+    let parsed = Parser::new(input).parse().unwrap();
+
+    assert_eq!(parsed.file.body.len(), 1);
+}
+
+#[test]
+fn test_simple_command_allows_nft_brace_literals_inside_and_block() {
+    let input = "\
+start_nftables() {
+    [ \"$tun_statu\" = true ] && {
+        nft add chain inet fw4 forward { type filter hook forward priority filter \\; } 2>/dev/null
+        nft add chain inet fw4 input { type filter hook input priority filter \\; } 2>/dev/null
+    }
+}
+";
+    let parsed = Parser::new(input).parse().unwrap();
+
+    assert_eq!(parsed.file.body.len(), 1);
+    let function = expect_function(&parsed.file.body[0]);
+    assert!(matches!(function.body.command, AstCommand::Compound(..)));
+}
+
+#[test]
+fn test_function_keyword_allows_plus_name_in_bash() {
+    let input = "function run++ () {\n  ((run_count+=1))\n}\nrun++\n";
+    let parsed = Parser::new(input).parse().unwrap();
+
+    assert_eq!(parsed.file.body.len(), 2);
+    let function = expect_function(&parsed.file.body[0]);
+    assert_eq!(
+        function.static_names().next().map(|name| name.as_str()),
+        Some("run++")
+    );
+}
+
+#[test]
 fn test_function_body_rejects_simple_command() {
     let parser = Parser::new("f() echo hi\n");
     assert!(

--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -26,3 +26,16 @@ pub struct OverwrittenFunction {
     pub second: BindingId,
     pub first_called: bool,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnreachedFunctionReason {
+    UnreachableDefinition,
+    ScriptTerminates,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnreachedFunction {
+    pub name: Name,
+    pub binding: BindingId,
+    pub reason: UnreachedFunctionReason,
+}

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -52,6 +52,8 @@ pub struct ControlFlowGraph {
     predecessors: FxHashMap<BlockId, Vec<BlockId>>,
     entry: BlockId,
     exits: Vec<BlockId>,
+    natural_exits: Vec<BlockId>,
+    script_terminators: Vec<BlockId>,
     unreachable: Vec<BlockId>,
     pub(crate) scope_entries: FxHashMap<ScopeId, BlockId>,
     pub(crate) scope_exits: FxHashMap<ScopeId, Vec<BlockId>>,
@@ -82,6 +84,14 @@ impl ControlFlowGraph {
 
     pub fn exits(&self) -> &[BlockId] {
         &self.exits
+    }
+
+    pub fn natural_exits(&self) -> &[BlockId] {
+        &self.natural_exits
+    }
+
+    pub fn script_terminators(&self) -> &[BlockId] {
+        &self.script_terminators
     }
 
     pub fn scope_entry(&self, scope: ScopeId) -> Option<BlockId> {
@@ -1218,6 +1228,7 @@ struct GraphBuilder<'a> {
     command_blocks: FxHashMap<SpanKey, Vec<BlockId>>,
     unreachable_causes: FxHashMap<BlockId, UnreachableCause>,
     scope_entries: FxHashMap<ScopeId, BlockId>,
+    script_terminators: Vec<BlockId>,
 }
 
 pub(crate) fn build_control_flow_graph(
@@ -1245,11 +1256,17 @@ pub(crate) fn build_control_flow_graph(
         command_blocks: FxHashMap::default(),
         unreachable_causes: FxHashMap::default(),
         scope_entries: FxHashMap::default(),
+        script_terminators: Vec::new(),
     };
 
     let file = builder.build_sequence(program.file_commands(), &[]);
     let entry = file.entry.unwrap_or_else(|| builder.empty_block());
     builder.scope_entries.insert(ScopeId(0), entry);
+    let mut natural_exits = if file.entry.is_none() {
+        vec![entry]
+    } else {
+        file.exits.clone()
+    };
     let file_exits = if file.exits.is_empty() {
         vec![entry]
     } else {
@@ -1264,6 +1281,11 @@ pub(crate) fn build_control_flow_graph(
         let function = builder.build_sequence(*commands, &[]);
         let function_entry = function.entry.unwrap_or_else(|| builder.empty_block());
         builder.scope_entries.insert(*scope, function_entry);
+        if function.entry.is_none() {
+            natural_exits.push(function_entry);
+        } else {
+            natural_exits.extend(function.exits.iter().copied());
+        }
         let function_exits = if function.exits.is_empty() {
             vec![function_entry]
         } else {
@@ -1283,6 +1305,8 @@ pub(crate) fn build_control_flow_graph(
         predecessors,
         entry,
         exits,
+        natural_exits,
+        script_terminators: builder.script_terminators,
         unreachable,
         scope_entries: builder.scope_entries,
         scope_exits,
@@ -1360,6 +1384,7 @@ impl<'a> GraphBuilder<'a> {
                     .script_terminating_calls
                     .contains(&SpanKey::new(command.span))
                 {
+                    self.script_terminators.push(block);
                     Vec::new()
                 } else {
                     vec![block]
@@ -1401,6 +1426,9 @@ impl<'a> GraphBuilder<'a> {
             }
             RecordedCommandKind::Return | RecordedCommandKind::Exit => {
                 let block = self.command_block(command.span);
+                if matches!(command.kind, RecordedCommandKind::Exit) {
+                    self.script_terminators.push(block);
+                }
                 SequenceResult {
                     entry: Some(block),
                     exits: Vec::new(),

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -79,6 +79,7 @@ use crate::source_closure::ImportedBindingContractSite;
 use crate::zsh_options::ZshOptionAnalysis;
 
 const MAX_FUNCTIONS_FOR_TERMINATION_REACHABILITY: usize = 200;
+const MAX_TERMINATION_REACHABILITY_WORK: usize = 20_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct SpanKey {
@@ -1660,10 +1661,12 @@ impl<'model> SemanticAnalysis<'model> {
             .values()
             .map(|bindings| bindings.len())
             .sum::<usize>();
-        let skip_termination_reachability =
-            function_count > MAX_FUNCTIONS_FOR_TERMINATION_REACHABILITY;
 
         let cfg = self.cfg();
+        let skip_termination_reachability = function_count
+            > MAX_FUNCTIONS_FOR_TERMINATION_REACHABILITY
+            || function_count.saturating_mul(cfg.blocks().len())
+                > MAX_TERMINATION_REACHABILITY_WORK;
         let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
         let script_terminators = cfg
             .script_terminators()
@@ -2532,53 +2535,58 @@ fn all_paths_terminate_before_natural_exit(
 ) -> bool {
     let mut saw_termination = false;
     let cacheable = shadow_blocks.is_empty();
+    let mut context = TerminationPathContext {
+        cfg,
+        script_terminators,
+        natural_exits,
+        unreachable,
+        shadow_blocks,
+        empty_shadow_cache,
+        cacheable,
+        saw_termination: &mut saw_termination,
+    };
     starts.iter().copied().all(|start| {
-        path_terminates_before_natural_exit(
-            start,
-            cfg,
-            script_terminators,
-            natural_exits,
-            unreachable,
-            shadow_blocks,
-            &mut FxHashSet::default(),
-            &mut saw_termination,
-            empty_shadow_cache,
-            cacheable,
-        )
-    }) && saw_termination
+        path_terminates_before_natural_exit(start, &mut FxHashSet::default(), &mut context)
+    }) && *context.saw_termination
+}
+
+struct TerminationPathContext<'a, 'cache, 'seen> {
+    cfg: &'a ControlFlowGraph,
+    script_terminators: &'a FxHashSet<BlockId>,
+    natural_exits: &'a FxHashSet<BlockId>,
+    unreachable: &'a FxHashSet<BlockId>,
+    shadow_blocks: &'a FxHashSet<BlockId>,
+    empty_shadow_cache: &'cache mut FxHashMap<BlockId, bool>,
+    cacheable: bool,
+    saw_termination: &'seen mut bool,
 }
 
 fn path_terminates_before_natural_exit(
     block: BlockId,
-    cfg: &ControlFlowGraph,
-    script_terminators: &FxHashSet<BlockId>,
-    natural_exits: &FxHashSet<BlockId>,
-    unreachable: &FxHashSet<BlockId>,
-    shadow_blocks: &FxHashSet<BlockId>,
     visiting: &mut FxHashSet<BlockId>,
-    saw_termination: &mut bool,
-    empty_shadow_cache: &mut FxHashMap<BlockId, bool>,
-    cacheable: bool,
+    context: &mut TerminationPathContext<'_, '_, '_>,
 ) -> bool {
-    if cacheable && let Some(cached) = empty_shadow_cache.get(&block) {
+    if context.cacheable
+        && let Some(cached) = context.empty_shadow_cache.get(&block)
+    {
         if *cached {
-            *saw_termination = true;
+            *context.saw_termination = true;
         }
         return *cached;
     }
-    if unreachable.contains(&block) || shadow_blocks.contains(&block) {
+    if context.unreachable.contains(&block) || context.shadow_blocks.contains(&block) {
         return false;
     }
-    if script_terminators.contains(&block) {
-        *saw_termination = true;
-        if cacheable {
-            empty_shadow_cache.insert(block, true);
+    if context.script_terminators.contains(&block) {
+        *context.saw_termination = true;
+        if context.cacheable {
+            context.empty_shadow_cache.insert(block, true);
         }
         return true;
     }
-    if natural_exits.contains(&block) {
-        if cacheable {
-            empty_shadow_cache.insert(block, false);
+    if context.natural_exits.contains(&block) {
+        if context.cacheable {
+            context.empty_shadow_cache.insert(block, false);
         }
         return false;
     }
@@ -2586,26 +2594,15 @@ fn path_terminates_before_natural_exit(
         return false;
     }
 
-    let successors = cfg.successors(block);
+    let successors = context.cfg.successors(block);
     let terminates = !successors.is_empty()
         && successors.iter().all(|(successor, _)| {
-            path_terminates_before_natural_exit(
-                *successor,
-                cfg,
-                script_terminators,
-                natural_exits,
-                unreachable,
-                shadow_blocks,
-                visiting,
-                saw_termination,
-                empty_shadow_cache,
-                cacheable,
-            )
+            path_terminates_before_natural_exit(*successor, visiting, context)
         });
 
     visiting.remove(&block);
-    if cacheable {
-        empty_shadow_cache.insert(block, terminates);
+    if context.cacheable {
+        context.empty_shadow_cache.insert(block, terminates);
     }
     terminates
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -38,7 +38,9 @@ pub use binding::{
     BuiltinBindingTargetKind, LoopValueOrigin,
 };
 /// Call-graph structures derived from the analyzed script.
-pub use call_graph::{CallGraph, CallSite, OverwrittenFunction};
+pub use call_graph::{
+    CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,
+};
 /// Control-flow graph types and flow-context annotations.
 pub use cfg::{BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext, UnreachableCauseKind};
 /// Contract and build-option types used when constructing semantic models.
@@ -75,6 +77,8 @@ use crate::dataflow::{DataflowContext, DataflowResult, ExactVariableDataflow};
 use crate::runtime::RuntimePrelude;
 use crate::source_closure::ImportedBindingContractSite;
 use crate::zsh_options::ZshOptionAnalysis;
+
+const MAX_FUNCTIONS_FOR_TERMINATION_REACHABILITY: usize = 200;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct SpanKey {
@@ -465,6 +469,7 @@ pub struct SemanticAnalysis<'model> {
     uninitialized_references: OnceLock<Vec<UninitializedReference>>,
     dead_code: OnceLock<Vec<DeadCode>>,
     overwritten_functions: OnceLock<Vec<OverwrittenFunction>>,
+    unreached_functions: OnceLock<Vec<UnreachedFunction>>,
     scope_provided_binding_index: OnceLock<ScopeProvidedBindingIndex>,
 }
 
@@ -474,6 +479,15 @@ struct OverwriteWindow<'a> {
     second_blocks: &'a [BlockId],
     cfg: &'a ControlFlowGraph,
     unreachable: &'a FxHashSet<BlockId>,
+}
+
+struct FunctionReachWindow<'a> {
+    binding: BindingId,
+    binding_blocks: &'a [BlockId],
+    shadow_blocks: &'a FxHashSet<BlockId>,
+    cfg: &'a ControlFlowGraph,
+    unreachable: &'a FxHashSet<BlockId>,
+    script_terminators: &'a FxHashSet<BlockId>,
 }
 
 #[allow(missing_docs)]
@@ -1207,6 +1221,7 @@ impl<'model> SemanticAnalysis<'model> {
             uninitialized_references: OnceLock::new(),
             dead_code: OnceLock::new(),
             overwritten_functions: OnceLock::new(),
+            unreached_functions: OnceLock::new(),
             scope_provided_binding_index: OnceLock::new(),
         }
     }
@@ -1419,6 +1434,12 @@ impl<'model> SemanticAnalysis<'model> {
             .as_slice()
     }
 
+    pub fn unreached_functions(&self) -> &[UnreachedFunction] {
+        self.unreached_functions
+            .get_or_init(|| self.compute_unreached_functions())
+            .as_slice()
+    }
+
     #[doc(hidden)]
     pub fn scope_provided_bindings(&self, scope: ScopeId) -> &[ProvidedBinding] {
         self.scope_provided_binding_index()
@@ -1525,12 +1546,26 @@ impl<'model> SemanticAnalysis<'model> {
         window: &OverwriteWindow<'_>,
         site: &CallSite,
     ) -> Vec<BlockId> {
-        window
-            .cfg
-            .block_ids_for_span(site.span)
+        self.reachable_call_site_blocks_in_cfg(window.cfg, site, window.unreachable)
+    }
+
+    fn reachable_call_site_blocks_in_cfg(
+        &self,
+        cfg: &ControlFlowGraph,
+        site: &CallSite,
+        unreachable: &FxHashSet<BlockId>,
+    ) -> Vec<BlockId> {
+        let command_span = self
+            .model
+            .recorded_program
+            .call_command_spans
+            .get(&SpanKey::new(site.span))
+            .copied()
+            .unwrap_or(site.span);
+        cfg.block_ids_for_span(command_span)
             .iter()
             .copied()
-            .filter(|block| !window.unreachable.contains(block))
+            .filter(|block| !unreachable.contains(block))
             .collect()
     }
 
@@ -1612,6 +1647,421 @@ impl<'model> SemanticAnalysis<'model> {
 
         visiting_scopes.remove(&site.scope);
         executed
+    }
+
+    fn compute_unreached_functions(&self) -> Vec<UnreachedFunction> {
+        if self.model.functions.is_empty() {
+            return Vec::new();
+        }
+
+        let function_count = self
+            .model
+            .functions
+            .values()
+            .map(|bindings| bindings.len())
+            .sum::<usize>();
+        let skip_termination_reachability =
+            function_count > MAX_FUNCTIONS_FOR_TERMINATION_REACHABILITY;
+
+        let cfg = self.cfg();
+        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let script_terminators = cfg
+            .script_terminators()
+            .iter()
+            .copied()
+            .collect::<FxHashSet<_>>();
+        if unreachable.is_empty() && script_terminators.is_empty() {
+            return Vec::new();
+        }
+
+        let binding_blocks = build_binding_block_index(cfg.blocks(), self.model.bindings.len());
+        let natural_exits = cfg
+            .natural_exits()
+            .iter()
+            .copied()
+            .collect::<FxHashSet<_>>();
+        let mut unreached = Vec::new();
+        let mut empty_shadow_termination_cache = FxHashMap::default();
+        let mut scope_execution_cache = FxHashMap::default();
+
+        for (name, bindings) in &self.model.functions {
+            for &binding_id in bindings {
+                let binding = self.model.binding(binding_id);
+                if !matches!(binding.kind, BindingKind::FunctionDefinition) {
+                    continue;
+                }
+
+                let reachable_blocks =
+                    reachable_binding_blocks(binding_id, &binding_blocks, &unreachable);
+                let Some(reachable_blocks) = reachable_blocks else {
+                    if !self.binding_execution_scope_can_run_before_termination(
+                        binding_id,
+                        cfg,
+                        &unreachable,
+                        &script_terminators,
+                        &mut scope_execution_cache,
+                    ) {
+                        continue;
+                    }
+                    unreached.push(UnreachedFunction {
+                        name: name.clone(),
+                        binding: binding_id,
+                        reason: UnreachedFunctionReason::UnreachableDefinition,
+                    });
+                    continue;
+                };
+                if skip_termination_reachability
+                    || !self.binding_execution_scope_can_run_before_termination(
+                        binding_id,
+                        cfg,
+                        &unreachable,
+                        &script_terminators,
+                        &mut scope_execution_cache,
+                    )
+                {
+                    continue;
+                }
+
+                let shadow_blocks =
+                    self.shadow_function_blocks(name, binding_id, &binding_blocks, &unreachable);
+                let window = FunctionReachWindow {
+                    binding: binding_id,
+                    binding_blocks: &reachable_blocks,
+                    shadow_blocks: &shadow_blocks,
+                    cfg,
+                    unreachable: &unreachable,
+                    script_terminators: &script_terminators,
+                };
+                let mut visiting_scopes = FxHashSet::default();
+                if self.function_binding_has_direct_call_before_termination(
+                    name,
+                    &window,
+                    &mut visiting_scopes,
+                ) {
+                    continue;
+                }
+
+                if !script_terminators.is_empty()
+                    && all_paths_terminate_before_natural_exit(
+                        &reachable_blocks,
+                        cfg,
+                        &script_terminators,
+                        &natural_exits,
+                        &unreachable,
+                        &shadow_blocks,
+                        &mut empty_shadow_termination_cache,
+                    )
+                {
+                    unreached.push(UnreachedFunction {
+                        name: name.clone(),
+                        binding: binding_id,
+                        reason: UnreachedFunctionReason::ScriptTerminates,
+                    });
+                }
+            }
+        }
+
+        unreached.sort_by_key(|unreached| self.model.binding(unreached.binding).span.start.offset);
+        unreached
+    }
+
+    fn binding_execution_scope_can_run_before_termination(
+        &self,
+        binding_id: BindingId,
+        cfg: &ControlFlowGraph,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+        scope_execution_cache: &mut FxHashMap<ScopeId, bool>,
+    ) -> bool {
+        let binding = self.model.binding(binding_id);
+        let Some(function_scope) = self.enclosing_function_scope(binding.scope) else {
+            return true;
+        };
+
+        let mut visiting_scopes = FxHashSet::default();
+        self.function_scope_can_run_before_termination(
+            function_scope,
+            cfg,
+            unreachable,
+            script_terminators,
+            &mut visiting_scopes,
+            scope_execution_cache,
+        )
+    }
+
+    fn function_scope_can_run_before_termination(
+        &self,
+        function_scope: ScopeId,
+        cfg: &ControlFlowGraph,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+        scope_execution_cache: &mut FxHashMap<ScopeId, bool>,
+    ) -> bool {
+        if !visiting_scopes.contains(&function_scope)
+            && let Some(cached) = scope_execution_cache.get(&function_scope)
+        {
+            return *cached;
+        }
+        if !visiting_scopes.insert(function_scope) {
+            return false;
+        }
+
+        let can_run = self
+            .model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(binding, body_scope)| (*body_scope == function_scope).then_some(*binding))
+            .any(|function_binding| {
+                let function = self.model.binding(function_binding);
+                self.model
+                    .call_sites_for(&function.name)
+                    .iter()
+                    .any(|site| {
+                        self.overwrite_call_site_resolves_to_binding(
+                            &function.name,
+                            site,
+                            function_binding,
+                        ) && self.call_site_context_can_run_before_termination(
+                            site,
+                            cfg,
+                            unreachable,
+                            script_terminators,
+                            visiting_scopes,
+                            scope_execution_cache,
+                        )
+                    })
+            });
+
+        visiting_scopes.remove(&function_scope);
+        scope_execution_cache.insert(function_scope, can_run);
+        can_run
+    }
+
+    fn call_site_context_can_run_before_termination(
+        &self,
+        site: &CallSite,
+        cfg: &ControlFlowGraph,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+        scope_execution_cache: &mut FxHashMap<ScopeId, bool>,
+    ) -> bool {
+        let site_blocks = self.reachable_call_site_blocks_in_cfg(cfg, site, unreachable);
+        if site_blocks.is_empty() {
+            return false;
+        }
+
+        let Some(function_scope) = self.enclosing_function_scope(site.scope) else {
+            return blocks_have_path_avoiding(
+                cfg,
+                &[cfg.entry()],
+                &site_blocks,
+                script_terminators,
+            );
+        };
+        let Some(scope_entry) = cfg.scope_entry(function_scope) else {
+            return false;
+        };
+        if !blocks_have_path_avoiding(cfg, &[scope_entry], &site_blocks, script_terminators) {
+            return false;
+        }
+
+        self.function_scope_can_run_before_termination(
+            function_scope,
+            cfg,
+            unreachable,
+            script_terminators,
+            visiting_scopes,
+            scope_execution_cache,
+        )
+    }
+
+    fn function_binding_has_direct_call_before_termination(
+        &self,
+        name: &Name,
+        window: &FunctionReachWindow<'_>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        self.model.call_sites_for(name).iter().any(|site| {
+            self.call_site_can_resolve_to_binding_on_reachable_path(name, site, window)
+                && self.call_site_executes_before_termination(site, window, visiting_scopes)
+        })
+    }
+
+    fn call_site_can_resolve_to_binding_on_reachable_path(
+        &self,
+        name: &Name,
+        site: &CallSite,
+        window: &FunctionReachWindow<'_>,
+    ) -> bool {
+        let binding = self.model.binding(window.binding);
+        if site.scope == binding.scope {
+            let site_blocks =
+                self.reachable_call_site_blocks_in_cfg(window.cfg, site, window.unreachable);
+            return !site_blocks.is_empty()
+                && blocks_have_path_avoiding_many(
+                    window.cfg,
+                    window.binding_blocks,
+                    &site_blocks,
+                    window.shadow_blocks,
+                    window.script_terminators,
+                );
+        }
+
+        if self.overwrite_call_site_resolves_to_binding(name, site, window.binding) {
+            return true;
+        }
+
+        if !self
+            .model
+            .ancestor_scopes(site.scope)
+            .any(|scope| scope == binding.scope)
+        {
+            return false;
+        }
+        let Some(function_scope) = self.enclosing_function_scope(site.scope) else {
+            return false;
+        };
+
+        self.model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(function_binding, body_scope)| {
+                (*body_scope == function_scope).then_some(*function_binding)
+            })
+            .map(|function_binding| {
+                reachable_blocks_for_binding(window.cfg, function_binding, window.unreachable)
+            })
+            .any(|function_blocks| {
+                !function_blocks.is_empty()
+                    && blocks_have_path_avoiding_many(
+                        window.cfg,
+                        window.binding_blocks,
+                        &function_blocks,
+                        window.shadow_blocks,
+                        window.script_terminators,
+                    )
+            })
+    }
+
+    fn call_site_executes_before_termination(
+        &self,
+        site: &CallSite,
+        window: &FunctionReachWindow<'_>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let site_blocks =
+            self.reachable_call_site_blocks_in_cfg(window.cfg, site, window.unreachable);
+        if site_blocks.is_empty() {
+            return false;
+        }
+
+        let binding = self.model.binding(window.binding);
+        if site.scope == binding.scope {
+            return blocks_have_path_avoiding_many(
+                window.cfg,
+                window.binding_blocks,
+                &site_blocks,
+                window.shadow_blocks,
+                window.script_terminators,
+            );
+        }
+
+        let Some(function_scope) = self.enclosing_function_scope(site.scope) else {
+            return blocks_have_path_avoiding_many(
+                window.cfg,
+                window.binding_blocks,
+                &site_blocks,
+                window.shadow_blocks,
+                window.script_terminators,
+            );
+        };
+
+        let Some(scope_entry) = window.cfg.scope_entry(function_scope) else {
+            return false;
+        };
+        if !blocks_have_path_avoiding(
+            window.cfg,
+            &[scope_entry],
+            &site_blocks,
+            window.script_terminators,
+        ) {
+            return false;
+        }
+
+        if !visiting_scopes.insert(function_scope) {
+            return false;
+        }
+
+        let executed = self
+            .model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(binding_id, body_scope)| {
+                (*body_scope == function_scope).then_some(*binding_id)
+            })
+            .any(|function_binding| {
+                let function_name = self.model.binding(function_binding).name.clone();
+                self.model
+                    .call_sites_for(&function_name)
+                    .iter()
+                    .any(|caller| {
+                        self.overwrite_call_site_resolves_to_binding(
+                            &function_name,
+                            caller,
+                            function_binding,
+                        ) && self.call_site_executes_before_termination(
+                            caller,
+                            window,
+                            visiting_scopes,
+                        )
+                    })
+            });
+
+        visiting_scopes.remove(&function_scope);
+        executed
+    }
+
+    fn shadow_function_blocks(
+        &self,
+        name: &Name,
+        binding_id: BindingId,
+        binding_blocks: &[Vec<BlockId>],
+        unreachable: &FxHashSet<BlockId>,
+    ) -> FxHashSet<BlockId> {
+        let binding = self.model.binding(binding_id);
+        self.model
+            .function_definitions(name)
+            .iter()
+            .copied()
+            .filter(|other| *other != binding_id)
+            .filter(|other| {
+                let other_binding = self.model.binding(*other);
+                other_binding.scope == binding.scope
+                    && other_binding.span.start.offset > binding.span.start.offset
+            })
+            .flat_map(|other| {
+                binding_blocks
+                    .get(other.index())
+                    .into_iter()
+                    .flat_map(|blocks| blocks.iter())
+                    .copied()
+                    .filter(|block| !unreachable.contains(block))
+            })
+            .collect()
+    }
+
+    fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
+        self.model.ancestor_scopes(scope).find(|scope_id| {
+            matches!(
+                self.model.scope_kind(*scope_id),
+                ScopeKind::Function(function) if !function.is_anonymous()
+            )
+        })
     }
 
     fn compute_overwritten_functions(&self) -> Vec<OverwrittenFunction> {
@@ -1993,6 +2443,171 @@ fn blocks_have_path(
             .copied()
             .any(|end| reachability.reaches(start, end))
     })
+}
+
+fn reachable_blocks_for_binding(
+    cfg: &ControlFlowGraph,
+    binding: BindingId,
+    unreachable: &FxHashSet<BlockId>,
+) -> Vec<BlockId> {
+    cfg.blocks()
+        .iter()
+        .filter(|block| block.bindings.contains(&binding) && !unreachable.contains(&block.id))
+        .map(|block| block.id)
+        .collect()
+}
+
+fn blocks_have_path_avoiding(
+    cfg: &ControlFlowGraph,
+    starts: &[BlockId],
+    ends: &[BlockId],
+    avoid: &FxHashSet<BlockId>,
+) -> bool {
+    starts.iter().copied().any(|start| {
+        ends.iter()
+            .copied()
+            .any(|end| block_reaches_avoiding(cfg, start, end, avoid))
+    })
+}
+
+fn blocks_have_path_avoiding_many(
+    cfg: &ControlFlowGraph,
+    starts: &[BlockId],
+    ends: &[BlockId],
+    first_avoid: &FxHashSet<BlockId>,
+    second_avoid: &FxHashSet<BlockId>,
+) -> bool {
+    starts.iter().copied().any(|start| {
+        ends.iter()
+            .copied()
+            .any(|end| block_reaches_avoiding_many(cfg, start, end, first_avoid, second_avoid))
+    })
+}
+
+fn block_reaches_avoiding(
+    cfg: &ControlFlowGraph,
+    start: BlockId,
+    end: BlockId,
+    avoid: &FxHashSet<BlockId>,
+) -> bool {
+    let empty = FxHashSet::default();
+    block_reaches_avoiding_many(cfg, start, end, avoid, &empty)
+}
+
+fn block_reaches_avoiding_many(
+    cfg: &ControlFlowGraph,
+    start: BlockId,
+    end: BlockId,
+    first_avoid: &FxHashSet<BlockId>,
+    second_avoid: &FxHashSet<BlockId>,
+) -> bool {
+    let mut visited = FxHashSet::default();
+    let mut stack = vec![start];
+    while let Some(block) = stack.pop() {
+        if !visited.insert(block) {
+            continue;
+        }
+        if block == end {
+            return true;
+        }
+        if first_avoid.contains(&block) || second_avoid.contains(&block) {
+            continue;
+        }
+        for (successor, _) in cfg.successors(block) {
+            stack.push(*successor);
+        }
+    }
+
+    false
+}
+
+fn all_paths_terminate_before_natural_exit(
+    starts: &[BlockId],
+    cfg: &ControlFlowGraph,
+    script_terminators: &FxHashSet<BlockId>,
+    natural_exits: &FxHashSet<BlockId>,
+    unreachable: &FxHashSet<BlockId>,
+    shadow_blocks: &FxHashSet<BlockId>,
+    empty_shadow_cache: &mut FxHashMap<BlockId, bool>,
+) -> bool {
+    let mut saw_termination = false;
+    let cacheable = shadow_blocks.is_empty();
+    starts.iter().copied().all(|start| {
+        path_terminates_before_natural_exit(
+            start,
+            cfg,
+            script_terminators,
+            natural_exits,
+            unreachable,
+            shadow_blocks,
+            &mut FxHashSet::default(),
+            &mut saw_termination,
+            empty_shadow_cache,
+            cacheable,
+        )
+    }) && saw_termination
+}
+
+fn path_terminates_before_natural_exit(
+    block: BlockId,
+    cfg: &ControlFlowGraph,
+    script_terminators: &FxHashSet<BlockId>,
+    natural_exits: &FxHashSet<BlockId>,
+    unreachable: &FxHashSet<BlockId>,
+    shadow_blocks: &FxHashSet<BlockId>,
+    visiting: &mut FxHashSet<BlockId>,
+    saw_termination: &mut bool,
+    empty_shadow_cache: &mut FxHashMap<BlockId, bool>,
+    cacheable: bool,
+) -> bool {
+    if cacheable && let Some(cached) = empty_shadow_cache.get(&block) {
+        if *cached {
+            *saw_termination = true;
+        }
+        return *cached;
+    }
+    if unreachable.contains(&block) || shadow_blocks.contains(&block) {
+        return false;
+    }
+    if script_terminators.contains(&block) {
+        *saw_termination = true;
+        if cacheable {
+            empty_shadow_cache.insert(block, true);
+        }
+        return true;
+    }
+    if natural_exits.contains(&block) {
+        if cacheable {
+            empty_shadow_cache.insert(block, false);
+        }
+        return false;
+    }
+    if !visiting.insert(block) {
+        return false;
+    }
+
+    let successors = cfg.successors(block);
+    let terminates = !successors.is_empty()
+        && successors.iter().all(|(successor, _)| {
+            path_terminates_before_natural_exit(
+                *successor,
+                cfg,
+                script_terminators,
+                natural_exits,
+                unreachable,
+                shadow_blocks,
+                visiting,
+                saw_termination,
+                empty_shadow_cache,
+                cacheable,
+            )
+        });
+
+    visiting.remove(&block);
+    if cacheable {
+        empty_shadow_cache.insert(block, terminates);
+    }
+    terminates
 }
 
 fn block_reaches_without(
@@ -3280,6 +3895,141 @@ factory_two
         let model = model(source);
 
         assert!(model.analysis().overwritten_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_report_definitions_before_script_termination() {
+        let source = "f() { echo hi; }\nexit 0\n";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached = analysis.unreached_functions();
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "f");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::ScriptTerminates
+        );
+    }
+
+    #[test]
+    fn unreached_functions_ignore_definitions_at_plain_eof() {
+        let source = "f() { echo hi; }\n";
+        let model = model(source);
+
+        assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_ignore_direct_calls_before_termination() {
+        let source = "f() { echo hi; }\nf\nexit 0\n";
+        let model = model(source);
+
+        assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_count_direct_calls_that_terminate() {
+        let source = "f() { exit 1; }\nf\n";
+        let model = model(source);
+
+        assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_report_unreachable_definitions() {
+        let source = "exit 0\nf() { echo hi; }\n";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached = analysis.unreached_functions();
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "f");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::UnreachableDefinition
+        );
+    }
+
+    #[test]
+    fn unreached_functions_ignore_non_guaranteed_termination() {
+        let source = "f() { echo hi; }\nif cond; then exit 0; fi\n";
+        let model = model(source);
+
+        assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_count_transitive_direct_calls_before_termination() {
+        let source = "\
+run_case() {
+  helper
+}
+helper() { echo hi; }
+run_case
+exit 0
+";
+        let model = model(source);
+
+        assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_count_nested_substitution_calls_before_termination() {
+        let source = "\
+run_case() {
+  output=\"$(echo value | helper)\"
+}
+helper() { echo hi; }
+run_case
+exit 0
+";
+        let model = model(source);
+
+        assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_count_negated_condition_calls_before_termination() {
+        let source = "\
+die() { exit 1; }
+check() { :; }
+validate() {
+  if ! check \"$value\"; then
+    die
+  fi
+}
+validate
+exit 0
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached_names = analysis
+            .unreached_functions()
+            .iter()
+            .map(|unreached| unreached.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(!unreached_names.contains(&"check"));
+    }
+
+    #[test]
+    fn unreached_functions_count_calls_to_branch_selected_definitions() {
+        let source = "\
+if use_first; then
+  helper() { echo first; }
+else
+  helper() { echo second; }
+fi
+run_case() {
+  helper
+}
+run_case
+exit 0
+";
+        let model = model(source);
+
+        assert!(model.analysis().unreached_functions().is_empty());
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1935,18 +1935,9 @@ impl<'model> SemanticAnalysis<'model> {
             .filter_map(|(function_binding, body_scope)| {
                 (*body_scope == function_scope).then_some(*function_binding)
             })
-            .map(|function_binding| {
-                reachable_blocks_for_binding(window.cfg, function_binding, window.unreachable)
-            })
-            .any(|function_blocks| {
-                !function_blocks.is_empty()
-                    && blocks_have_path_avoiding_many(
-                        window.cfg,
-                        window.binding_blocks,
-                        &function_blocks,
-                        window.shadow_blocks,
-                        window.script_terminators,
-                    )
+            .any(|function_binding| {
+                !reachable_blocks_for_binding(window.cfg, function_binding, window.unreachable)
+                    .is_empty()
             })
     }
 
@@ -4027,6 +4018,28 @@ exit 0
         let model = model(source);
 
         assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_count_late_bound_wrapper_calls_newer_definition() {
+        let source = "\
+helper() { echo old; }
+run_case() {
+  helper
+}
+helper() { echo new; }
+run_case
+exit 0
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached_names = analysis
+            .unreached_functions()
+            .iter()
+            .map(|unreached| unreached.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(!unreached_names.contains(&"helper"));
     }
 
     #[test]

--- a/docs/rules/C063.yaml
+++ b/docs/rules/C063.yaml
@@ -10,10 +10,10 @@ shells:
   - bash
   - dash
   - ksh
-description: A local function definition is overwritten before any reachable direct call can resolve to it.
-rationale: Remove the dead definition, rename one version, or call it before the later local definition replaces it.
+description: A local function definition is overwritten or cut off by script termination before any reachable direct call can resolve to it.
+rationale: Remove the dead definition, rename one version, or call it before the later local definition or terminating command makes it unreachable.
 safe_fix: false
-fix_description: "Delete the earlier function definition that is overwritten before any direct call reaches it."
+fix_description: "Delete the function definition that no reachable direct call can use."
 source:
   shell_checks_rule: rules/SH-171.yaml
   shell_checks_example: examples/171.sh
@@ -25,3 +25,8 @@ examples:
       myfunc() { return 1; }
       myfunc() { return 0; }
       myfunc
+  - kind: invalid
+    code: |
+      #!/bin/sh
+      myfunc() { echo hi; }
+      exit 0


### PR DESCRIPTION
## Summary

- broaden C063 beyond overwritten definitions to also flag functions that cannot be directly reached before guaranteed script termination
- report C063 on unreachable function definitions alongside C124
- extend semantic CFG/call-graph analysis, rule tests, docs, and reviewed corpus metadata for the new behavior

## Root Cause

C063 only consumed the overwritten-function analysis, so definitions that remained in scope but were cut off by `exit` or were themselves in unreachable regions were missed.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic unreached_functions --lib`
- `cargo test -p shuck-linter overwritten_function --lib`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C063` reported `implementation_diffs=0`; it still exits nonzero because two unrelated parser harness fixtures fail to parse in Shuck while ShellCheck parses them.