### PR TITLE
perf(linter): pack facts into indexed arenas

### DIFF
--- a/crates/shuck-ast/src/arena.rs
+++ b/crates/shuck-ast/src/arena.rs
@@ -1,0 +1,283 @@
+use std::marker::PhantomData;
+
+/// A compact typed index into an arena-backed store.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Idx<T> {
+    raw: u32,
+    marker: PhantomData<fn() -> T>,
+}
+
+impl<T> Idx<T> {
+    /// Creates an index from a `usize`, panicking when it does not fit in `u32`.
+    pub fn new(index: usize) -> Self {
+        let raw =
+            u32::try_from(index).unwrap_or_else(|err| panic!("arena index must fit in u32: {err}"));
+        Self::from_raw(raw)
+    }
+
+    /// Creates an index from its raw representation.
+    pub const fn from_raw(raw: u32) -> Self {
+        Self {
+            raw,
+            marker: PhantomData,
+        }
+    }
+
+    /// Returns this index as a `usize` for slice access.
+    pub const fn index(self) -> usize {
+        self.raw as usize
+    }
+
+    /// Returns this index as its packed raw value.
+    pub const fn raw(self) -> u32 {
+        self.raw
+    }
+}
+
+impl<T> Clone for Idx<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for Idx<T> {}
+
+/// A compact typed contiguous range into an arena-backed store.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct IdRange<T> {
+    start: u32,
+    len: u32,
+    marker: PhantomData<fn() -> T>,
+}
+
+impl<T> IdRange<T> {
+    /// Returns an empty range.
+    pub const fn empty() -> Self {
+        Self {
+            start: 0,
+            len: 0,
+            marker: PhantomData,
+        }
+    }
+
+    /// Creates a range from a typed start index and length.
+    pub fn new(start: Idx<T>, len: usize) -> Self {
+        Self::from_start_len(start.index(), len)
+    }
+
+    /// Creates a range from untyped start and length values.
+    pub fn from_start_len(start: usize, len: usize) -> Self {
+        let end = start
+            .checked_add(len)
+            .unwrap_or_else(|| panic!("arena range end must not overflow usize"));
+        if end > u32::MAX as usize {
+            panic!("arena range end must fit in u32");
+        }
+        let start = u32::try_from(start)
+            .unwrap_or_else(|err| panic!("arena range start must fit in u32: {err}"));
+        let len = u32::try_from(len)
+            .unwrap_or_else(|err| panic!("arena range length must fit in u32: {err}"));
+        Self {
+            start,
+            len,
+            marker: PhantomData,
+        }
+    }
+
+    /// Returns the first index in the range.
+    pub const fn start(self) -> Idx<T> {
+        Idx::from_raw(self.start)
+    }
+
+    /// Returns the start offset as a `usize`.
+    pub const fn start_index(self) -> usize {
+        self.start as usize
+    }
+
+    /// Returns the end offset as a `usize`.
+    pub const fn end_index(self) -> usize {
+        self.start as usize + self.len as usize
+    }
+
+    /// Returns the number of items in the range.
+    pub const fn len(self) -> usize {
+        self.len as usize
+    }
+
+    /// Returns `true` when the range contains no items.
+    pub const fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the slice covered by this range.
+    pub fn slice(self, store: &[T]) -> &[T] {
+        &store[self.start_index()..self.end_index()]
+    }
+
+    /// Returns the mutable slice covered by this range.
+    pub fn slice_mut(self, store: &mut [T]) -> &mut [T] {
+        &mut store[self.start_index()..self.end_index()]
+    }
+}
+
+impl<T> Clone for IdRange<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for IdRange<T> {}
+
+impl<T> Default for IdRange<T> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// A simple append-only store for variable-length typed child lists.
+#[derive(Debug, Clone, Default)]
+pub struct ListArena<T> {
+    items: Vec<T>,
+}
+
+impl<T> ListArena<T> {
+    /// Creates an empty list arena.
+    pub const fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    /// Creates an empty list arena with capacity for `capacity` items.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            items: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Appends one item and returns its typed index.
+    pub fn push(&mut self, item: T) -> Idx<T> {
+        let id = Idx::new(self.items.len());
+        self.items.push(item);
+        self.check_len();
+        id
+    }
+
+    /// Appends a variable-length list and returns the typed range for it.
+    pub fn push_many<I>(&mut self, items: I) -> IdRange<T>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let start = self.items.len();
+        self.items.extend(items);
+        self.check_len();
+        IdRange::from_start_len(start, self.items.len() - start)
+    }
+
+    /// Returns all arena items as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        &self.items
+    }
+
+    /// Returns all arena items as a mutable slice.
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        &mut self.items
+    }
+
+    /// Returns the slice covered by `range`.
+    pub fn get(&self, range: IdRange<T>) -> &[T] {
+        range.slice(&self.items)
+    }
+
+    /// Returns the mutable slice covered by `range`.
+    pub fn get_mut(&mut self, range: IdRange<T>) -> &mut [T] {
+        range.slice_mut(&mut self.items)
+    }
+
+    /// Returns the number of items in the arena.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns `true` when the arena is empty.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Consumes the arena and returns the packed items.
+    pub fn into_vec(self) -> Vec<T> {
+        self.items
+    }
+
+    /// Consumes the arena and returns the packed items as a boxed slice.
+    pub fn into_boxed_slice(self) -> Box<[T]> {
+        self.items.into_boxed_slice()
+    }
+
+    fn check_len(&self) {
+        if self.items.len() > u32::MAX as usize {
+            panic!("arena length must fit in u32");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IdRange, Idx, ListArena};
+
+    #[test]
+    fn typed_index_round_trips_raw_values() {
+        let id = Idx::<String>::new(42);
+        assert_eq!(id.index(), 42);
+        assert_eq!(id.raw(), 42);
+        assert_eq!(Idx::<String>::from_raw(7).index(), 7);
+    }
+
+    #[test]
+    #[should_panic(expected = "arena index must fit in u32")]
+    fn typed_index_panics_when_out_of_bounds() {
+        let _ = Idx::<()>::new(u32::MAX as usize + 1);
+    }
+
+    #[test]
+    fn typed_ranges_slice_storage() {
+        let values = [10, 20, 30, 40];
+        let range = IdRange::<i32>::from_start_len(1, 2);
+        assert_eq!(range.start().index(), 1);
+        assert_eq!(range.len(), 2);
+        assert_eq!(range.slice(&values), &[20, 30]);
+    }
+
+    #[test]
+    fn empty_ranges_are_zero_length() {
+        let range = IdRange::<i32>::empty();
+        let values = [10, 20];
+        assert!(range.is_empty());
+        assert_eq!(range.slice(&values), &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "arena range end must fit in u32")]
+    fn typed_range_panics_when_end_is_out_of_bounds() {
+        let _ = IdRange::<()>::from_start_len(u32::MAX as usize, 1);
+    }
+
+    #[test]
+    fn list_arena_packs_variable_length_lists() {
+        let mut arena = ListArena::new();
+        let first = arena.push_many([1, 2]);
+        let empty = arena.push_many([]);
+        let second = arena.push_many([3, 4, 5]);
+
+        assert_eq!(arena.get(first), &[1, 2]);
+        assert_eq!(arena.get(empty), &[]);
+        assert_eq!(arena.get(second), &[3, 4, 5]);
+        assert_eq!(arena.as_slice(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn list_arena_mutates_ranges_in_place() {
+        let mut arena = ListArena::new();
+        let range = arena.push_many([1, 2, 3]);
+        arena.get_mut(range)[1] = 9;
+        assert_eq!(arena.get(range), &[1, 9, 3]);
+    }
+}

--- a/crates/shuck-ast/src/lib.rs
+++ b/crates/shuck-ast/src/lib.rs
@@ -7,6 +7,8 @@
 //! `shuck-linter`, `shuck-semantic`, and `shuck-formatter` consume them.
 
 #[allow(missing_docs)]
+mod arena;
+#[allow(missing_docs)]
 mod ast;
 #[allow(missing_docs)]
 mod command_resolution;
@@ -17,6 +19,8 @@ mod span;
 #[allow(missing_docs)]
 mod tokens;
 
+/// Compact typed arena index and list storage utilities.
+pub use arena::{IdRange, Idx, ListArena};
 /// Parsed shell AST nodes and related syntax tree types.
 pub use ast::*;
 /// Static command-resolution helpers shared by semantic analysis and lint facts.

--- a/crates/shuck-cli/tests/zsh_option_state.rs
+++ b/crates/shuck-cli/tests/zsh_option_state.rs
@@ -348,11 +348,11 @@ fn parse_probe_output(stdout: &str) -> Result<ProbeRun> {
     Ok(run)
 }
 
-fn find_probe_command<'a>(
-    checker: &'a Checker<'_>,
+fn find_probe_command<'checker, 'ast>(
+    checker: &'checker Checker<'ast>,
     command_name: &str,
     probe_id: &str,
-) -> Result<&'a shuck_linter::CommandFact<'a>> {
+) -> Result<shuck_linter::CommandFactRef<'checker, 'ast>> {
     checker
         .facts()
         .structural_commands()

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2199,7 +2199,7 @@ fn build_declaration_assignment_probes<'a>(
     normalized: &NormalizedCommand<'a>,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
-) -> Box<[DeclarationAssignmentProbe]> {
+) -> Vec<DeclarationAssignmentProbe> {
     if let Some(declaration) = normalized.declaration.as_ref() {
         return declaration
             .assignment_operands
@@ -2222,8 +2222,7 @@ fn build_declaration_assignment_probes<'a>(
                     status_capture: word_is_standalone_status_capture(word),
                 })
             })
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+            .collect();
     }
 
     build_simple_command_declaration_assignment_probes(command, normalized, source, zsh_options)
@@ -2234,17 +2233,17 @@ fn build_simple_command_declaration_assignment_probes<'a>(
     normalized: &NormalizedCommand<'a>,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
-) -> Box<[DeclarationAssignmentProbe]> {
+) -> Vec<DeclarationAssignmentProbe> {
     let Command::Simple(_) = command else {
-        return Vec::new().into_boxed_slice();
+        return Vec::new();
     };
 
     if !normalized.wrappers.is_empty() {
-        return Vec::new().into_boxed_slice();
+        return Vec::new();
     }
 
     let Some(kind) = simple_command_declaration_kind(normalized.effective_or_literal_name()) else {
-        return Vec::new().into_boxed_slice();
+        return Vec::new();
     };
     let word_groups = contiguous_word_groups(normalized.body_args());
     let readonly_flag = matches!(
@@ -2277,8 +2276,7 @@ fn build_simple_command_declaration_assignment_probes<'a>(
                 status_capture: assignment_value_text_is_standalone_status_capture(value_text),
             })
         })
-        .collect::<Vec<_>>()
-        .into_boxed_slice()
+        .collect()
 }
 
 fn assignment_value_text_is_standalone_status_capture(text: &str) -> bool {

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1343,14 +1343,6 @@ fn build_nonpersistent_assignment_spans(
 
     let innermost_command_ids_by_offset =
         build_innermost_command_ids_by_offset(commands, command_id_query_offsets);
-    let commands_by_id = commands
-        .iter()
-        .map(|command| (command.id(), command))
-        .collect::<FxHashMap<_, _>>();
-    let command_end_offsets = commands
-        .iter()
-        .map(|command| (command.id(), command.span().end.offset))
-        .collect::<FxHashMap<_, _>>();
     let persistent_reset_offsets_by_name: FxHashMap<Name, Vec<PersistentReset>> =
         persistent_reset_offsets_by_name
             .into_iter()
@@ -1363,7 +1355,9 @@ fn build_nonpersistent_assignment_spans(
                             offset,
                         );
                         let command_end_offset = command_id
-                            .and_then(|id| command_end_offsets.get(&id).copied())
+                            .and_then(|id| commands.get(id.index()))
+                            .map(CommandFact::span)
+                            .map(|span| span.end.offset)
                             .unwrap_or(offset);
 
                         PersistentReset {
@@ -1434,12 +1428,14 @@ fn build_nonpersistent_assignment_spans(
             synthetic_read.span().start.offset,
         );
         let same_command_prefix_reset = synthetic_command_id
-            .and_then(|id| commands_by_id.get(&id).copied())
+            .and_then(|id| commands.get(id.index()))
             .is_some_and(|command| {
                 command_prefix_assignments_reset_name(command.command(), synthetic_read.name())
             });
         let synthetic_command_end_offset = synthetic_command_id
-            .and_then(|id| command_end_offsets.get(&id).copied())
+            .and_then(|id| commands.get(id.index()))
+            .map(CommandFact::span)
+            .map(|span| span.end.offset)
             .unwrap_or(synthetic_read.span().start.offset);
         let synthetic_function_scope =
             enclosing_function_scope_for_scope(semantic, synthetic_read.scope());
@@ -1885,7 +1881,8 @@ fn build_innermost_command_ids_by_offset(
         command_spans.sort_unstable_by(|left, right| compare_command_offset_entries(*left, *right));
     }
 
-    let mut command_ids_by_offset = FxHashMap::default();
+    let mut command_ids_by_offset =
+        FxHashMap::with_capacity_and_hasher(offsets.len(), Default::default());
     let mut active_commands = Vec::new();
     let mut next_command = 0;
     for offset in offsets {

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -1,7 +1,7 @@
 fn build_literal_brace_spans(
     nodes: &[WordNode<'_>],
     occurrences: &[WordOccurrence],
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     source: &str,
     heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {
@@ -204,7 +204,7 @@ fn span_is_active_brace_expansion_edge_in_source(span: Span, source: &str) -> bo
 }
 
 fn is_find_exec_placeholder_word(
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     source: &str,
@@ -216,7 +216,7 @@ fn is_find_exec_placeholder_word(
         return false;
     }
 
-    let command = &commands[fact.command_id.index()];
+    let command = command_fact_ref(commands, fact.command_id);
     if command.has_wrapper(WrapperKind::FindExec) || command.has_wrapper(WrapperKind::FindExecDir) {
         return true;
     }
@@ -228,7 +228,7 @@ fn is_find_exec_placeholder_word(
     }) || line_has_find_exec_placeholder_context(source, occurrence_span(nodes, fact))
 }
 
-fn is_find_exec_command(command: &CommandFact<'_>, source: &str) -> bool {
+fn is_find_exec_command(command: CommandFactRef<'_, '_>, source: &str) -> bool {
     let is_find = command.static_utility_name_is("find")
         || command.body_name_word().is_some_and(|name_word| {
             name_word
@@ -293,7 +293,7 @@ fn line_has_find_exec_placeholder_context(source: &str, brace_span: Span) -> boo
 }
 
 fn is_xargs_replacement_word(
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     source: &str,
@@ -302,7 +302,7 @@ fn is_xargs_replacement_word(
         return false;
     }
 
-    let command = &commands[fact.command_id.index()];
+    let command = command_fact_ref(commands, fact.command_id);
     if !command.effective_name_is("xargs") {
         return false;
     }
@@ -621,7 +621,7 @@ fn unclassified_literal_brace_spans(word: &Word, source: &str) -> Vec<Span> {
 }
 
 fn uncovered_command_brace_spans(
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     source: &str,
     heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {
@@ -1007,7 +1007,7 @@ fn closing_brace_ends_shell_group(text: &str, index: usize) -> bool {
 }
 
 fn unmatched_command_substitution_brace_spans(
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     source: &str,
     heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -6,70 +6,27 @@ fn build_literal_brace_spans(
     heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {
     let mut spans = Vec::new();
+    let mut processed_word_nodes = vec![false; nodes.len()];
 
     for fact in occurrences {
         if fact.context == WordFactContext::Expansion(ExpansionContext::RegexOperand) {
             continue;
         }
 
-        let word = occurrence_word(nodes, fact);
         let is_find_exec_placeholder_word =
             is_find_exec_placeholder_word(commands, nodes, fact, source);
         let is_xargs_replacement_word = is_xargs_replacement_word(commands, nodes, fact, source);
-        spans.extend(
-            word.brace_syntax()
-                .iter()
-                .copied()
-                .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
-                .filter(|brace| !literal_brace_syntax_looks_like_active_expansion(*brace, source))
-                .filter(|brace| {
-                    matches!(
-                        brace.kind,
-                        BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
-                    ) || brace_syntax_with_whitespace_is_literal(*brace, source)
-                })
-                .filter(|brace| {
-                    brace.span.slice(source) != "{}"
-                        && !brace_span_has_escaped_dollar_prefix(brace.span, source)
-                        && !is_find_exec_placeholder_word
-                        && !is_xargs_replacement_word
-                })
-                .flat_map(|brace| brace_character_spans(brace.span, source))
-                .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
-                .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-                .filter(|span| {
-                    !word_span_is_inside_command_substitution(nodes, fact, *span, source)
-                }),
-        );
-
-        if !is_find_exec_placeholder_word && !is_xargs_replacement_word {
-            spans.extend(
-                unclassified_literal_brace_spans(word, source)
-                    .into_iter()
-                    .filter(|span| {
-                        !span_inside_nested_escaped_parameter_template(word, *span, source)
-                    })
-                    .filter(|span| {
-                        !brace_span_is_plain_parameter_expansion_edge(word, *span, source)
-                    })
-                    .filter(|span| {
-                        !word_span_is_inside_command_substitution(nodes, fact, *span, source)
-                    }),
-            );
-            spans.extend(
-                escaped_parameter_expansion_brace_edge_spans(word, source)
-                    .into_iter()
-                    .filter(|span| {
-                        !span_inside_nested_escaped_parameter_template(word, *span, source)
-                    })
-                    .filter(|span| {
-                        !brace_span_is_plain_parameter_expansion_edge(word, *span, source)
-                    })
-                    .filter(|span| {
-                        !word_span_is_inside_command_substitution(nodes, fact, *span, source)
-                    }),
-            );
+        if is_find_exec_placeholder_word || is_xargs_replacement_word {
+            continue;
         }
+
+        let node_index = fact.node_id.index();
+        if processed_word_nodes[node_index] {
+            continue;
+        }
+        processed_word_nodes[node_index] = true;
+
+        collect_literal_brace_spans_for_word(nodes, fact, source, &mut spans);
     }
 
     spans.extend(uncovered_command_brace_spans(
@@ -87,6 +44,61 @@ fn build_literal_brace_spans(
     spans.sort_by_key(|span| (span.start.offset, span.end.offset));
     spans.dedup_by_key(|span| (span.start.offset, span.end.offset));
     spans
+}
+
+fn collect_literal_brace_spans_for_word(
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let word = occurrence_word(nodes, fact);
+    let mut dynamic_exclusions = Vec::new();
+    collect_dynamic_brace_exclusions(
+        &word.parts,
+        word.span.start.offset,
+        word.span.end.offset,
+        source,
+        &mut dynamic_exclusions,
+    );
+    dynamic_exclusions.sort_by_key(|span| (span.start_offset, span.end_offset));
+
+    spans.extend(
+        word.brace_syntax()
+            .iter()
+            .copied()
+            .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
+            .filter(|brace| !literal_brace_syntax_looks_like_active_expansion(*brace, source))
+            .filter(|brace| {
+                matches!(
+                    brace.kind,
+                    BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
+                ) || brace_syntax_with_whitespace_is_literal(*brace, source)
+            })
+            .filter(|brace| {
+                brace.span.slice(source) != "{}"
+                    && !brace_span_has_escaped_dollar_prefix(brace.span, source)
+            })
+            .flat_map(|brace| brace_character_spans(brace.span, source))
+            .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
+            .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
+            .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source)),
+    );
+
+    spans.extend(
+        escaped_parameter_expansion_brace_edge_spans(word, source, &dynamic_exclusions)
+            .into_iter()
+            .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
+            .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
+            .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source)),
+    );
+    spans.extend(
+        unclassified_literal_brace_spans(word, source, &mut dynamic_exclusions)
+            .into_iter()
+            .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
+            .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
+            .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source)),
+    );
 }
 
 fn word_span_is_inside_command_substitution(
@@ -536,17 +548,13 @@ fn word_is_empty_brace_pair_variant(word: &Word, source: &str) -> bool {
     matches!(word.span.slice(source), "{}" | "\\{\\}")
 }
 
-fn unclassified_literal_brace_spans(word: &Word, source: &str) -> Vec<Span> {
+fn unclassified_literal_brace_spans(
+    word: &Word,
+    source: &str,
+    excluded: &mut Vec<DynamicBraceExcludedSpan>,
+) -> Vec<Span> {
     let span = word.span;
     let text = span.slice(source);
-    let mut excluded = Vec::new();
-    collect_dynamic_brace_exclusions(
-        &word.parts,
-        span.start.offset,
-        span.end.offset,
-        source,
-        &mut excluded,
-    );
     excluded.extend(
         word.brace_syntax()
             .iter()
@@ -1079,20 +1087,15 @@ struct DynamicBraceExcludedSpan {
     kind: DynamicBraceExcludedSpanKind,
 }
 
-fn escaped_parameter_expansion_brace_edge_spans(word: &Word, source: &str) -> Vec<Span> {
+fn escaped_parameter_expansion_brace_edge_spans(
+    word: &Word,
+    source: &str,
+    excluded: &[DynamicBraceExcludedSpan],
+) -> Vec<Span> {
     let span = word.span;
     let text = span.slice(source);
     let mut spans = Vec::new();
     let mut literal_stack: Vec<LiteralBraceCandidate> = Vec::new();
-    let mut excluded = Vec::new();
-    collect_dynamic_brace_exclusions(
-        &word.parts,
-        span.start.offset,
-        span.end.offset,
-        source,
-        &mut excluded,
-    );
-    excluded.sort_by_key(|span| (span.start_offset, span.end_offset));
     let mut excluded_index = 0usize;
     let mut index = 0usize;
     let mut previous_char = None;

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -9,6 +9,13 @@ struct LinterFactsBuilder<'a> {
 }
 
 #[derive(Debug, Default)]
+struct FactBuildCapacity {
+    commands: usize,
+    structural_commands: usize,
+    functions: usize,
+}
+
+#[derive(Debug, Default)]
 struct ArithmeticFactSummary {
     array_index_arithmetic_spans: Vec<Span>,
     arithmetic_score_line_spans: Vec<Span>,
@@ -29,6 +36,26 @@ struct HeredocFactSummary {
 
 fn total_child_len<T>(lists: &[Vec<T>]) -> usize {
     lists.iter().map(Vec::len).sum()
+}
+
+fn estimate_fact_build_capacity(file: &File) -> FactBuildCapacity {
+    let mut capacity = FactBuildCapacity::default();
+    walk_commands(
+        &file.body,
+        CommandWalkOptions {
+            descend_nested_word_commands: true,
+        },
+        &mut |visit, context| {
+            capacity.commands += 1;
+            if !context.nested_word_command {
+                capacity.structural_commands += 1;
+            }
+            if matches!(visit.command, Command::Function(_)) {
+                capacity.functions += 1;
+            }
+        },
+    );
+    capacity
 }
 
 impl<'a> LinterFactsBuilder<'a> {
@@ -54,23 +81,33 @@ impl<'a> LinterFactsBuilder<'a> {
 
     fn build(self) -> LinterFacts<'a> {
         let source = self.source;
-        let mut commands = Vec::new();
+        let capacity = estimate_fact_build_capacity(self.file);
+        let estimated_word_nodes = capacity.commands.saturating_mul(2);
+        let estimated_word_occurrences = capacity.commands.saturating_mul(3);
+
+        let mut commands = Vec::with_capacity(capacity.commands);
         let mut redirect_fact_store = ListArena::new();
         let mut declaration_assignment_probe_store = ListArena::new();
-        let mut structural_command_ids = Vec::new();
-        let mut command_ids_by_span = CommandLookupIndex::default();
-        let mut if_condition_command_ids = FxHashSet::default();
-        let mut elif_condition_command_ids = FxHashSet::default();
+        let mut structural_command_ids = Vec::with_capacity(capacity.structural_commands);
+        let mut command_ids_by_span =
+            CommandLookupIndex::with_capacity_and_hasher(capacity.commands, Default::default());
+        let mut if_condition_command_ids =
+            FxHashSet::with_capacity_and_hasher(capacity.commands / 4, Default::default());
+        let mut elif_condition_command_ids =
+            FxHashSet::with_capacity_and_hasher(capacity.commands / 8, Default::default());
         let mut binding_values = FxHashMap::default();
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
         let mut ifs_literal_backslash_assignment_value_spans = Vec::new();
-        let mut word_nodes = Vec::new();
-        let mut word_node_ids_by_span = FxHashMap::default();
-        let mut word_occurrences = Vec::new();
-        let mut pending_arithmetic_word_occurrences = Vec::new();
+        let mut word_nodes = Vec::with_capacity(estimated_word_nodes);
+        let mut word_node_ids_by_span =
+            FxHashMap::with_capacity_and_hasher(estimated_word_nodes, Default::default());
+        let mut word_occurrences = Vec::with_capacity(estimated_word_occurrences);
+        let mut pending_arithmetic_word_occurrences =
+            Vec::with_capacity(capacity.commands.saturating_div(4));
         let mut compound_assignment_value_word_spans = FxHashSet::default();
-        let mut array_assignment_split_word_ids = Vec::new();
+        let mut array_assignment_split_word_ids =
+            Vec::with_capacity(capacity.commands.saturating_div(8));
         let mut assoc_binding_visibility_memo = FxHashMap::default();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut case_pattern_expansions = Vec::new();
@@ -78,8 +115,8 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut pattern_charclass_spans = Vec::new();
         let mut arithmetic_summary = ArithmeticFactSummary::default();
         let mut surface_fragments = SurfaceFragmentSink::new(self.source);
-        let mut functions = Vec::new();
-        let mut function_body_without_braces_spans = Vec::new();
+        let mut functions = Vec::with_capacity(capacity.functions);
+        let mut function_body_without_braces_spans = Vec::with_capacity(capacity.functions);
         let redundant_return_status_spans = Vec::new();
         let mut getopts_cases = Vec::new();
         let mut condition_status_capture_spans = Vec::new();

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -637,22 +637,19 @@ impl<'a> LinterFactsBuilder<'a> {
         );
         let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
         word_index.reserve(word_occurrences.len());
-        let mut word_occurrence_counts_by_command = vec![0usize; commands.len()];
+        let mut word_occurrence_offsets_by_command = vec![0usize; commands.len()];
         for fact in &word_occurrences {
-            word_occurrence_counts_by_command[fact.command_id.index()] += 1;
+            word_occurrence_offsets_by_command[fact.command_id.index()] += 1;
         }
         let mut next_word_occurrence_offset = 0usize;
-        let word_occurrence_ids_by_command = word_occurrence_counts_by_command
-            .iter()
+        let word_occurrence_ids_by_command = word_occurrence_offsets_by_command
+            .iter_mut()
             .map(|count| {
                 let range = IdRange::from_start_len(next_word_occurrence_offset, *count);
-                next_word_occurrence_offset += *count;
+                *count = next_word_occurrence_offset;
+                next_word_occurrence_offset = range.end_index();
                 range
             })
-            .collect::<Vec<_>>();
-        let mut next_word_occurrence_offsets = word_occurrence_ids_by_command
-            .iter()
-            .map(|range| range.start_index())
             .collect::<Vec<_>>();
         let mut word_occurrence_ids =
             vec![WordOccurrenceId::new(0); next_word_occurrence_offset];
@@ -663,9 +660,9 @@ impl<'a> LinterFactsBuilder<'a> {
                 .or_default()
                 .push(id);
             let command_index = fact.command_id.index();
-            let offset = next_word_occurrence_offsets[command_index];
+            let offset = word_occurrence_offsets_by_command[command_index];
             word_occurrence_ids[offset] = id;
-            next_word_occurrence_offsets[command_index] += 1;
+            word_occurrence_offsets_by_command[command_index] += 1;
         }
         fact_store.word_occurrence_ids = word_occurrence_ids;
         fact_store.word_occurrence_ids_by_command = word_occurrence_ids_by_command;

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -27,6 +27,10 @@ struct HeredocFactSummary {
     spaced_tabstrip_close_spans: Vec<Span>,
 }
 
+fn total_child_len<T>(lists: &[Vec<T>]) -> usize {
+    lists.iter().map(Vec::len).sum()
+}
+
 impl<'a> LinterFactsBuilder<'a> {
     fn new(
         file: &'a File,
@@ -51,6 +55,8 @@ impl<'a> LinterFactsBuilder<'a> {
     fn build(self) -> LinterFacts<'a> {
         let source = self.source;
         let mut commands = Vec::new();
+        let mut redirect_fact_store = ListArena::new();
+        let mut declaration_assignment_probe_store = ListArena::new();
         let mut structural_command_ids = Vec::new();
         let mut command_ids_by_span = CommandLookupIndex::default();
         let mut if_condition_command_ids = FxHashSet::default();
@@ -104,7 +110,6 @@ impl<'a> LinterFactsBuilder<'a> {
                 if context.in_elif_condition {
                     elif_condition_command_ids.insert(id);
                 }
-
                 collect_binding_values(
                     visit.command,
                     self.semantic,
@@ -208,6 +213,7 @@ impl<'a> LinterFactsBuilder<'a> {
                     self.source,
                     command_zsh_options.as_ref(),
                 );
+                let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
                 let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
@@ -215,6 +221,8 @@ impl<'a> LinterFactsBuilder<'a> {
                     self.source,
                     command_zsh_options.as_ref(),
                 );
+                let declaration_assignment_probe_range =
+                    declaration_assignment_probe_store.push_many(declaration_assignment_probes);
                 let glued_closing_bracket_operand_span =
                     build_glued_closing_bracket_operand_span(visit.command, self.source);
                 let glued_closing_bracket_insert_offset =
@@ -229,14 +237,14 @@ impl<'a> LinterFactsBuilder<'a> {
                     nested_word_command,
                     normalized,
                     zsh_options: command_zsh_options,
-                    redirect_facts,
-                    substitution_facts: Vec::new().into_boxed_slice(),
+                    redirect_facts: redirect_fact_range,
+                    substitution_facts: IdRange::empty(),
                     options,
-                    scope_read_source_words: Vec::new().into_boxed_slice(),
-                    scope_name_read_uses: Vec::new().into_boxed_slice(),
-                    scope_heredoc_name_read_uses: Vec::new().into_boxed_slice(),
-                    scope_name_write_uses: Vec::new().into_boxed_slice(),
-                    declaration_assignment_probes,
+                    scope_read_source_words: IdRange::empty(),
+                    scope_name_read_uses: IdRange::empty(),
+                    scope_heredoc_name_read_uses: IdRange::empty(),
+                    scope_name_write_uses: IdRange::empty(),
+                    declaration_assignment_probes: declaration_assignment_probe_range,
                     glued_closing_bracket_operand_span,
                     glued_closing_bracket_insert_offset,
                     linebreak_in_test_anchor_span: None,
@@ -341,12 +349,24 @@ impl<'a> LinterFactsBuilder<'a> {
         arithmetic_update_operator_spans
             .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
         arithmetic_update_operator_spans.dedup();
+
+        let mut fact_store = FactStore::empty();
+        fact_store.redirect_facts = redirect_fact_store.into_vec();
+        fact_store.declaration_assignment_probes = declaration_assignment_probe_store.into_vec();
+
         populate_linebreak_in_test_facts(&mut commands, self.source);
-        let substitution_facts =
-            build_substitution_facts(&commands, &command_ids_by_span, self.source);
+        let substitution_facts = build_substitution_facts(
+            CommandFacts::new(&commands, &fact_store),
+            &command_ids_by_span,
+            self.source,
+        );
+        let mut substitution_fact_store = ListArena::with_capacity(total_child_len(
+            &substitution_facts,
+        ));
         for (fact, substitutions) in commands.iter_mut().zip(substitution_facts) {
-            fact.substitution_facts = substitutions;
+            fact.substitution_facts = substitution_fact_store.push_many(substitutions);
         }
+        fact_store.substitution_facts = substitution_fact_store.into_vec();
 
         let presence_tested_names =
             build_presence_tested_names(&commands, self.source, self.semantic);
@@ -392,10 +412,23 @@ impl<'a> LinterFactsBuilder<'a> {
         let case_pattern_impossible_spans =
             build_case_pattern_impossible_spans(&commands, self.source);
         let pipelines = build_pipeline_facts(&commands, &command_ids_by_span);
-        let scope_read_source_words =
-            build_scope_read_source_words(&commands, &pipelines, &if_condition_command_ids, source);
+        let command_facts = CommandFacts::new(&commands, &fact_store);
+        let scope_read_source_words = build_scope_read_source_words(
+            command_facts,
+            &pipelines,
+            &if_condition_command_ids,
+            source,
+        );
         let (scope_name_read_uses, scope_heredoc_name_read_uses, scope_name_write_uses) =
-            build_scope_name_uses(&commands, &pipelines, source);
+            build_scope_name_uses(command_facts, &pipelines, source);
+        let mut scope_read_source_word_store =
+            ListArena::with_capacity(total_child_len(&scope_read_source_words));
+        let mut scope_name_read_use_store =
+            ListArena::with_capacity(total_child_len(&scope_name_read_uses));
+        let mut scope_heredoc_name_read_use_store =
+            ListArena::with_capacity(total_child_len(&scope_heredoc_name_read_uses));
+        let mut scope_name_write_use_store =
+            ListArena::with_capacity(total_child_len(&scope_name_write_uses));
         for ((((fact, words), name_reads), heredoc_name_reads), name_writes) in commands
             .iter_mut()
             .zip(scope_read_source_words)
@@ -403,11 +436,16 @@ impl<'a> LinterFactsBuilder<'a> {
             .zip(scope_heredoc_name_read_uses)
             .zip(scope_name_write_uses)
         {
-            fact.scope_read_source_words = words;
-            fact.scope_name_read_uses = name_reads;
-            fact.scope_heredoc_name_read_uses = heredoc_name_reads;
-            fact.scope_name_write_uses = name_writes;
+            fact.scope_read_source_words = scope_read_source_word_store.push_many(words);
+            fact.scope_name_read_uses = scope_name_read_use_store.push_many(name_reads);
+            fact.scope_heredoc_name_read_uses =
+                scope_heredoc_name_read_use_store.push_many(heredoc_name_reads);
+            fact.scope_name_write_uses = scope_name_write_use_store.push_many(name_writes);
         }
+        fact_store.scope_read_source_words = scope_read_source_word_store.into_vec();
+        fact_store.scope_name_read_uses = scope_name_read_use_store.into_vec();
+        fact_store.scope_heredoc_name_read_uses = scope_heredoc_name_read_use_store.into_vec();
+        fact_store.scope_name_write_uses = scope_name_write_use_store.into_vec();
         let lists = build_list_facts(&commands, &command_ids_by_span, self.source);
         let completion_registered_function_command_flags =
             build_completion_registered_function_command_flags(
@@ -462,7 +500,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let literal_brace_spans = build_literal_brace_spans(
             &word_nodes,
             &word_occurrences,
-            &commands,
+            CommandFacts::new(&commands, &fact_store),
             source,
             self._indexer.region_index().heredoc_ranges(),
         );
@@ -562,18 +600,40 @@ impl<'a> LinterFactsBuilder<'a> {
         );
         let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
         word_index.reserve(word_occurrences.len());
-        let mut word_occurrence_ids_by_command =
-            vec![SmallVec::<[WordOccurrenceId; 4]>::new(); commands.len()];
+        let mut word_occurrence_counts_by_command = vec![0usize; commands.len()];
+        for fact in &word_occurrences {
+            word_occurrence_counts_by_command[fact.command_id.index()] += 1;
+        }
+        let mut next_word_occurrence_offset = 0usize;
+        let word_occurrence_ids_by_command = word_occurrence_counts_by_command
+            .iter()
+            .map(|count| {
+                let range = IdRange::from_start_len(next_word_occurrence_offset, *count);
+                next_word_occurrence_offset += *count;
+                range
+            })
+            .collect::<Vec<_>>();
+        let mut next_word_occurrence_offsets = word_occurrence_ids_by_command
+            .iter()
+            .map(|range| range.start_index())
+            .collect::<Vec<_>>();
+        let mut word_occurrence_ids =
+            vec![WordOccurrenceId::new(0); next_word_occurrence_offset];
         for (index, fact) in word_occurrences.iter().enumerate() {
             let id = WordOccurrenceId::new(index);
             word_index
                 .entry(occurrence_key(&word_nodes, fact))
                 .or_default()
                 .push(id);
-            word_occurrence_ids_by_command[fact.command_id.index()].push(id);
+            let command_index = fact.command_id.index();
+            let offset = next_word_occurrence_offsets[command_index];
+            word_occurrence_ids[offset] = id;
+            next_word_occurrence_offsets[command_index] += 1;
         }
+        fact_store.word_occurrence_ids = word_occurrence_ids;
+        fact_store.word_occurrence_ids_by_command = word_occurrence_ids_by_command;
         let echo_to_sed_substitution_spans = build_echo_to_sed_substitution_spans(
-            &commands,
+            CommandFacts::new(&commands, &fact_store),
             &pipelines,
             &backticks,
             &word_nodes,
@@ -644,7 +704,7 @@ impl<'a> LinterFactsBuilder<'a> {
             word_nodes,
             word_occurrences,
             word_index,
-            word_occurrence_ids_by_command,
+            fact_store,
             unquoted_command_argument_use_offsets,
             array_assignment_split_word_ids,
             brace_variable_before_bracket_spans,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -6,14 +6,14 @@ pub struct CommandFact<'a> {
     nested_word_command: bool,
     normalized: NormalizedCommand<'a>,
     zsh_options: Option<ZshOptionState>,
-    redirect_facts: Box<[RedirectFact<'a>]>,
-    substitution_facts: Box<[SubstitutionFact]>,
+    redirect_facts: IdRange<RedirectFact<'a>>,
+    substitution_facts: IdRange<SubstitutionFact>,
     options: CommandOptionFacts<'a>,
-    scope_read_source_words: Box<[PathWordFact<'a>]>,
-    scope_name_read_uses: Box<[ComparableNameUse]>,
-    scope_heredoc_name_read_uses: Box<[ComparableNameUse]>,
-    scope_name_write_uses: Box<[ComparableNameUse]>,
-    declaration_assignment_probes: Box<[DeclarationAssignmentProbe]>,
+    scope_read_source_words: IdRange<PathWordFact<'a>>,
+    scope_name_read_uses: IdRange<ComparableNameUse>,
+    scope_heredoc_name_read_uses: IdRange<ComparableNameUse>,
+    scope_name_write_uses: IdRange<ComparableNameUse>,
+    declaration_assignment_probes: IdRange<DeclarationAssignmentProbe>,
     glued_closing_bracket_operand_span: Option<Span>,
     glued_closing_bracket_insert_offset: Option<usize>,
     linebreak_in_test_anchor_span: Option<Span>,
@@ -59,40 +59,12 @@ impl<'a> CommandFact<'a> {
         self.zsh_options.as_ref()
     }
 
-    pub fn redirect_facts(&self) -> &[RedirectFact<'a>] {
-        &self.redirect_facts
-    }
-
-    pub fn substitution_facts(&self) -> &[SubstitutionFact] {
-        &self.substitution_facts
-    }
-
     pub fn normalized(&self) -> &NormalizedCommand<'a> {
         &self.normalized
     }
 
     pub fn options(&self) -> &CommandOptionFacts<'a> {
         &self.options
-    }
-
-    pub fn scope_read_source_words(&self) -> &[PathWordFact<'a>] {
-        &self.scope_read_source_words
-    }
-
-    pub(crate) fn scope_name_read_uses(&self) -> &[ComparableNameUse] {
-        &self.scope_name_read_uses
-    }
-
-    pub(crate) fn scope_heredoc_name_read_uses(&self) -> &[ComparableNameUse] {
-        &self.scope_heredoc_name_read_uses
-    }
-
-    pub(crate) fn scope_name_write_uses(&self) -> &[ComparableNameUse] {
-        &self.scope_name_write_uses
-    }
-
-    pub fn declaration_assignment_probes(&self) -> &[DeclarationAssignmentProbe] {
-        &self.declaration_assignment_probes
     }
 
     pub fn glued_closing_bracket_operand_span(&self) -> Option<Span> {
@@ -213,14 +185,194 @@ impl<'a> CommandFact<'a> {
         self.options.file_operand_words()
     }
 
-    pub fn shellcheck_command_span(&self, source: &str) -> Option<Span> {
+}
+
+impl<'facts, 'a> CommandFactRef<'facts, 'a> {
+    pub fn id(self) -> CommandId {
+        self.fact.id()
+    }
+
+    pub fn key(self) -> FactSpan {
+        self.fact.key()
+    }
+
+    pub fn is_nested_word_command(self) -> bool {
+        self.fact.is_nested_word_command()
+    }
+
+    pub fn stmt(self) -> &'a Stmt {
+        self.fact.stmt()
+    }
+
+    pub fn command(self) -> &'a Command {
+        self.fact.command()
+    }
+
+    pub fn span(self) -> Span {
+        self.fact.span()
+    }
+
+    pub fn span_in_source(self, source: &str) -> Span {
+        self.fact.span_in_source(source)
+    }
+
+    pub fn redirects(self) -> &'a [Redirect] {
+        self.fact.redirects()
+    }
+
+    pub fn zsh_options(self) -> Option<&'facts ZshOptionState> {
+        self.fact.zsh_options.as_ref()
+    }
+
+    pub fn redirect_facts(self) -> &'facts [RedirectFact<'a>] {
+        self.store.redirect_facts(self.fact.redirect_facts)
+    }
+
+    pub fn substitution_facts(self) -> &'facts [SubstitutionFact] {
+        self.store.substitution_facts(self.fact.substitution_facts)
+    }
+
+    pub fn scope_read_source_words(self) -> &'facts [PathWordFact<'a>] {
+        self.store
+            .scope_read_source_words(self.fact.scope_read_source_words)
+    }
+
+    pub(crate) fn scope_name_read_uses(self) -> &'facts [ComparableNameUse] {
+        self.store.scope_name_read_uses(self.fact.scope_name_read_uses)
+    }
+
+    pub(crate) fn scope_heredoc_name_read_uses(self) -> &'facts [ComparableNameUse] {
+        self.store
+            .scope_heredoc_name_read_uses(self.fact.scope_heredoc_name_read_uses)
+    }
+
+    pub(crate) fn scope_name_write_uses(self) -> &'facts [ComparableNameUse] {
+        self.store
+            .scope_name_write_uses(self.fact.scope_name_write_uses)
+    }
+
+    pub fn declaration_assignment_probes(self) -> &'facts [DeclarationAssignmentProbe] {
+        self.store
+            .declaration_assignment_probes(self.fact.declaration_assignment_probes)
+    }
+
+    pub fn normalized(self) -> &'facts NormalizedCommand<'a> {
+        &self.fact.normalized
+    }
+
+    pub fn options(self) -> &'facts CommandOptionFacts<'a> {
+        &self.fact.options
+    }
+
+    pub fn glued_closing_bracket_operand_span(self) -> Option<Span> {
+        self.fact.glued_closing_bracket_operand_span()
+    }
+
+    pub fn glued_closing_bracket_insert_offset(self) -> Option<usize> {
+        self.fact.glued_closing_bracket_insert_offset()
+    }
+
+    pub fn linebreak_in_test_anchor_span(self) -> Option<Span> {
+        self.fact.linebreak_in_test_anchor_span()
+    }
+
+    pub fn linebreak_in_test_insert_offset(self) -> Option<usize> {
+        self.fact.linebreak_in_test_insert_offset()
+    }
+
+    pub fn simple_test(self) -> Option<&'facts SimpleTestFact<'a>> {
+        self.fact.simple_test.as_ref()
+    }
+
+    pub fn conditional(self) -> Option<&'facts ConditionalFact<'a>> {
+        self.fact.conditional.as_ref()
+    }
+
+    pub fn literal_name(self) -> Option<&'facts str> {
+        self.fact.normalized.literal_name.as_deref()
+    }
+
+    pub fn effective_name(self) -> Option<&'facts str> {
+        self.fact.normalized.effective_name.as_deref()
+    }
+
+    pub fn effective_or_literal_name(self) -> Option<&'facts str> {
+        self.fact.normalized.effective_or_literal_name()
+    }
+
+    pub fn effective_name_is(self, name: &str) -> bool {
+        self.fact.effective_name_is(name)
+    }
+
+    pub fn static_utility_name(self) -> Option<&'facts str> {
+        self.effective_or_literal_name()
+    }
+
+    pub fn static_utility_name_is(self, name: &str) -> bool {
+        self.static_utility_name() == Some(name)
+    }
+
+    pub fn wrappers(self) -> &'facts [WrapperKind] {
+        &self.fact.normalized.wrappers
+    }
+
+    pub fn has_wrapper(self, wrapper: WrapperKind) -> bool {
+        self.fact.has_wrapper(wrapper)
+    }
+
+    pub fn declaration(self) -> Option<&'facts NormalizedDeclaration<'a>> {
+        self.fact.normalized.declaration.as_ref()
+    }
+
+    pub fn body_span(self) -> Span {
+        self.fact.body_span()
+    }
+
+    pub fn body_name_word(self) -> Option<&'a Word> {
+        self.fact.body_name_word()
+    }
+
+    pub fn body_word_span(self) -> Option<Span> {
+        self.fact.body_word_span()
+    }
+
+    pub fn body_word_contains_template_placeholder(self, source: &str) -> bool {
+        self.fact.body_word_contains_template_placeholder(source)
+    }
+
+    pub fn body_word_has_suspicious_quoted_command_trailer(
+        self,
+        source: &str,
+        trailing_literal_char: Option<char>,
+    ) -> bool {
+        self.fact
+            .body_word_has_suspicious_quoted_command_trailer(source, trailing_literal_char)
+    }
+
+    pub fn body_word_has_hash_suffix(self, source: &str) -> bool {
+        self.fact.body_word_has_hash_suffix(source)
+    }
+
+    pub fn bracket_command_name_needs_separator(self, source: &str) -> bool {
+        self.fact.bracket_command_name_needs_separator(source)
+    }
+
+    pub fn body_args(self) -> &'facts [&'a Word] {
+        self.fact.normalized.body_args()
+    }
+
+    pub fn file_operand_words(self) -> &'facts [&'a Word] {
+        self.fact.options.file_operand_words()
+    }
+
+    pub fn shellcheck_command_span(self, source: &str) -> Option<Span> {
         command_span_with_redirects_and_shellcheck_tail(self, source)
             .map(|span| trim_trailing_whitespace_span(span, source))
     }
 }
 
 fn pipeline_span_with_shellcheck_tail(
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     pipeline: &PipelineFact<'_>,
     source: &str,
 ) -> Span {
@@ -230,8 +382,8 @@ fn pipeline_span_with_shellcheck_tail(
     let Some(last_segment) = pipeline.last_segment() else {
         unreachable!("pipeline has segments");
     };
-    let first = command_fact(commands, first_segment.command_id());
-    let last = command_fact(commands, last_segment.command_id());
+    let first = command_fact_ref(commands, first_segment.command_id());
+    let last = command_fact_ref(commands, last_segment.command_id());
     let last_end = last.span_in_source(source).end;
     let end = extend_over_shellcheck_trailing_inline_space(last_end, source);
 
@@ -242,7 +394,7 @@ fn pipeline_span_with_shellcheck_tail(
 }
 
 fn command_span_with_redirects_and_shellcheck_tail(
-    command: &CommandFact<'_>,
+    command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<Span> {
     let body_name = command.body_name_word()?;
@@ -505,11 +657,11 @@ fn background_semicolon_span(
 }
 
 fn build_scope_read_source_words<'a>(
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
-) -> Vec<Box<[PathWordFact<'a>]>> {
+) -> Vec<Vec<PathWordFact<'a>>> {
     let mut words_by_command = vec![Vec::new(); commands.len()];
 
     for command in commands {
@@ -555,12 +707,9 @@ fn build_scope_read_source_words<'a>(
     }
 
     words_by_command
-        .into_iter()
-        .map(Vec::into_boxed_slice)
-        .collect()
 }
 
-type ScopeNameUseBuckets = Vec<Box<[ComparableNameUse]>>;
+type ScopeNameUseBuckets = Vec<Vec<ComparableNameUse>>;
 type ScopeNameUseSets = (
     ScopeNameUseBuckets,
     ScopeNameUseBuckets,
@@ -568,7 +717,7 @@ type ScopeNameUseSets = (
 );
 
 fn build_scope_name_uses<'a>(
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
     source: &str,
 ) -> ScopeNameUseSets {
@@ -639,23 +788,14 @@ fn build_scope_name_uses<'a>(
     }
 
     (
-        reads_by_command
-            .into_iter()
-            .map(Vec::into_boxed_slice)
-            .collect(),
-        heredoc_reads_by_command
-            .into_iter()
-            .map(Vec::into_boxed_slice)
-            .collect(),
-        writes_by_command
-            .into_iter()
-            .map(Vec::into_boxed_slice)
-            .collect(),
+        reads_by_command,
+        heredoc_reads_by_command,
+        writes_by_command,
     )
 }
 
 fn own_scope_read_source_words<'a>(
-    command: &CommandFact<'a>,
+    command: CommandFactRef<'_, 'a>,
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
 ) -> Vec<PathWordFact<'a>> {
@@ -678,7 +818,7 @@ fn own_scope_read_source_words<'a>(
     words
 }
 
-fn own_scope_name_read_uses(command: &CommandFact<'_>, _source: &str) -> Vec<ComparableNameUse> {
+fn own_scope_name_read_uses(command: CommandFactRef<'_, '_>, _source: &str) -> Vec<ComparableNameUse> {
     let mut uses = Vec::new();
 
     for redirect in command.redirect_facts() {
@@ -702,7 +842,7 @@ fn own_scope_name_read_uses(command: &CommandFact<'_>, _source: &str) -> Vec<Com
 }
 
 fn own_scope_heredoc_name_read_uses(
-    command: &CommandFact<'_>,
+    command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Vec<ComparableNameUse> {
     let mut uses = Vec::new();
@@ -724,7 +864,7 @@ fn own_scope_heredoc_name_read_uses(
     uses
 }
 
-fn own_scope_name_write_uses(command: &CommandFact<'_>, _source: &str) -> Vec<ComparableNameUse> {
+fn own_scope_name_write_uses(command: CommandFactRef<'_, '_>, _source: &str) -> Vec<ComparableNameUse> {
     let mut uses = Vec::new();
 
     if let Some(read) = command.options().read() {
@@ -735,8 +875,8 @@ fn own_scope_name_write_uses(command: &CommandFact<'_>, _source: &str) -> Vec<Co
 }
 
 fn nested_scope_read_source_words<'a>(
-    commands: &[CommandFact<'a>],
-    command: &CommandFact<'a>,
+    commands: CommandFacts<'_, 'a>,
+    command: CommandFactRef<'_, 'a>,
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
 ) -> Vec<PathWordFact<'a>> {
@@ -748,8 +888,8 @@ fn nested_scope_read_source_words<'a>(
 }
 
 fn nested_scope_name_read_uses(
-    commands: &[CommandFact<'_>],
-    command: &CommandFact<'_>,
+    commands: CommandFacts<'_, '_>,
+    command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Vec<ComparableNameUse> {
     commands
@@ -760,8 +900,8 @@ fn nested_scope_name_read_uses(
 }
 
 fn nested_scope_heredoc_name_read_uses(
-    commands: &[CommandFact<'_>],
-    command: &CommandFact<'_>,
+    commands: CommandFacts<'_, '_>,
+    command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Vec<ComparableNameUse> {
     commands
@@ -772,8 +912,8 @@ fn nested_scope_heredoc_name_read_uses(
 }
 
 fn nested_scope_name_write_uses(
-    commands: &[CommandFact<'_>],
-    command: &CommandFact<'_>,
+    commands: CommandFacts<'_, '_>,
+    command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Vec<ComparableNameUse> {
     commands
@@ -793,7 +933,7 @@ fn dedup_name_uses(uses: &mut Vec<ComparableNameUse>) {
     uses.retain(|name_use| seen.insert((name_use.key().clone(), FactSpan::new(name_use.span()))));
 }
 
-fn command_has_file_output_redirect(command: &CommandFact<'_>) -> bool {
+fn command_has_file_output_redirect(command: CommandFactRef<'_, '_>) -> bool {
     command.redirect_facts().iter().any(|redirect| {
         matches!(
             redirect.redirect().kind,
@@ -807,7 +947,7 @@ fn command_has_file_output_redirect(command: &CommandFact<'_>) -> bool {
     })
 }
 
-fn command_has_file_input_redirect(command: &CommandFact<'_>) -> bool {
+fn command_has_file_input_redirect(command: CommandFactRef<'_, '_>) -> bool {
     command.redirect_facts().iter().any(|redirect| {
         matches!(
             redirect.redirect().kind,
@@ -818,12 +958,12 @@ fn command_has_file_input_redirect(command: &CommandFact<'_>) -> bool {
     })
 }
 
-fn command_file_operand_words<'a>(command: &CommandFact<'a>) -> Vec<&'a Word> {
+fn command_file_operand_words<'a>(command: CommandFactRef<'_, 'a>) -> Vec<&'a Word> {
     command.file_operand_words().to_vec()
 }
 
 fn command_redirect_read_source_words<'a>(
-    command: &CommandFact<'a>,
+    command: CommandFactRef<'_, 'a>,
     source: &str,
 ) -> Vec<PathWordFact<'a>> {
     command
@@ -853,7 +993,7 @@ fn command_redirect_read_source_words<'a>(
 }
 
 fn command_simple_test_path_words<'a>(
-    command: &CommandFact<'a>,
+    command: CommandFactRef<'_, 'a>,
     source: &str,
 ) -> Vec<PathWordFact<'a>> {
     let Some(simple_test) = command.simple_test() else {
@@ -875,7 +1015,7 @@ fn command_simple_test_path_words<'a>(
 }
 
 fn command_conditional_path_words<'a>(
-    command: &CommandFact<'a>,
+    command: CommandFactRef<'_, 'a>,
     source: &str,
 ) -> Vec<PathWordFact<'a>> {
     let mut words = Vec::new();
@@ -1018,6 +1158,15 @@ fn command_fact<'a>(commands: &'a [CommandFact<'a>], id: CommandId) -> &'a Comma
     &commands[id.index()]
 }
 
+fn command_fact_ref<'facts, 'a>(
+    commands: CommandFacts<'facts, 'a>,
+    id: CommandId,
+) -> CommandFactRef<'facts, 'a> {
+    commands
+        .get(id.index())
+        .unwrap_or_else(|| panic!("command id {} must exist", id.index()))
+}
+
 fn build_command_parent_ids(commands: &[CommandFact<'_>]) -> Vec<Option<CommandId>> {
     let mut command_spans = commands
         .iter()
@@ -1103,6 +1252,14 @@ fn command_fact_for_stmt<'a>(
     command_ids_by_span: &CommandLookupIndex,
 ) -> Option<&'a CommandFact<'a>> {
     command_fact_for_command(&stmt.command, commands, command_ids_by_span)
+}
+
+fn command_fact_ref_for_stmt<'facts, 'a>(
+    stmt: &Stmt,
+    commands: CommandFacts<'facts, 'a>,
+    command_ids_by_span: &CommandLookupIndex,
+) -> Option<CommandFactRef<'facts, 'a>> {
+    command_id_for_command(&stmt.command, command_ids_by_span).map(|id| command_fact_ref(commands, id))
 }
 
 fn builtin_span(command: &BuiltinCommand) -> Span {

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -665,17 +665,18 @@ fn build_scope_read_source_words<'a>(
     let mut words_by_command = vec![Vec::new(); commands.len()];
 
     for command in commands {
-        let mut scope_words = own_scope_read_source_words(command, if_condition_command_ids, source);
+        let scope_words = &mut words_by_command[command.id().index()];
+        collect_own_scope_read_source_words(command, if_condition_command_ids, source, scope_words);
         if command_has_file_output_redirect(command) {
-            scope_words.extend(nested_scope_read_source_words(
+            collect_nested_scope_read_source_words(
                 commands,
                 command,
                 if_condition_command_ids,
                 source,
-            ));
+                scope_words,
+            );
         }
-        dedup_path_words(&mut scope_words);
-        words_by_command[command.id().index()] = scope_words;
+        dedup_path_words(scope_words);
     }
 
     for pipeline in pipelines {
@@ -688,7 +689,7 @@ fn build_scope_read_source_words<'a>(
                     .get(id.index())
                     .is_some_and(command_has_file_output_redirect)
             })
-            .collect::<Vec<_>>();
+            .collect::<SmallVec<[_; 4]>>();
         if writer_ids.is_empty() {
             continue;
         }
@@ -726,28 +727,29 @@ fn build_scope_name_uses<'a>(
     let mut writes_by_command = vec![Vec::new(); commands.len()];
 
     for command in commands {
-        let mut read_uses = own_scope_name_read_uses(command, source);
+        let read_uses = &mut reads_by_command[command.id().index()];
+        collect_own_scope_name_read_uses(command, source, read_uses);
         if command_has_file_output_redirect(command) {
-            read_uses.extend(nested_scope_name_read_uses(commands, command, source));
+            collect_nested_scope_name_read_uses(commands, command, source, read_uses);
         }
-        dedup_name_uses(&mut read_uses);
-        reads_by_command[command.id().index()] = read_uses;
+        dedup_name_uses(read_uses);
 
-        let mut heredoc_read_uses = own_scope_heredoc_name_read_uses(command, source);
+        let heredoc_read_uses = &mut heredoc_reads_by_command[command.id().index()];
+        collect_own_scope_heredoc_name_read_uses(command, source, heredoc_read_uses);
         if command_has_file_output_redirect(command) || command_has_file_input_redirect(command) {
-            heredoc_read_uses.extend(nested_scope_heredoc_name_read_uses(
+            collect_nested_scope_heredoc_name_read_uses(
                 commands, command, source,
-            ));
+                heredoc_read_uses,
+            );
         }
-        dedup_name_uses(&mut heredoc_read_uses);
-        heredoc_reads_by_command[command.id().index()] = heredoc_read_uses;
+        dedup_name_uses(heredoc_read_uses);
 
-        let mut write_uses = own_scope_name_write_uses(command, source);
+        let write_uses = &mut writes_by_command[command.id().index()];
+        collect_own_scope_name_write_uses(command, source, write_uses);
         if command_has_file_input_redirect(command) {
-            write_uses.extend(nested_scope_name_write_uses(commands, command, source));
+            collect_nested_scope_name_write_uses(commands, command, source, write_uses);
         }
-        dedup_name_uses(&mut write_uses);
-        writes_by_command[command.id().index()] = write_uses;
+        dedup_name_uses(write_uses);
     }
 
     for pipeline in pipelines {
@@ -760,7 +762,7 @@ fn build_scope_name_uses<'a>(
                     .get(id.index())
                     .is_some_and(command_has_file_output_redirect)
             })
-            .collect::<Vec<_>>();
+            .collect::<SmallVec<[_; 4]>>();
         if writer_ids.is_empty() {
             continue;
         }
@@ -799,8 +801,21 @@ fn own_scope_read_source_words<'a>(
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
 ) -> Vec<PathWordFact<'a>> {
-    let mut words = command_file_operand_words(command)
-        .into_iter()
+    let mut words = Vec::new();
+    collect_own_scope_read_source_words(command, if_condition_command_ids, source, &mut words);
+    words
+}
+
+fn collect_own_scope_read_source_words<'a>(
+    command: CommandFactRef<'_, 'a>,
+    if_condition_command_ids: &FxHashSet<CommandId>,
+    source: &str,
+    words: &mut Vec<PathWordFact<'a>>,
+) {
+    words.extend(command
+        .file_operand_words()
+        .iter()
+        .copied()
         .map(|word| {
             PathWordFact::new(
                 word,
@@ -809,18 +824,25 @@ fn own_scope_read_source_words<'a>(
                 command.zsh_options(),
             )
         })
-        .collect::<Vec<_>>();
+    );
     words.extend(command_redirect_read_source_words(command, source));
     words.extend(command_simple_test_path_words(command, source));
     if !if_condition_command_ids.contains(&command.id()) {
         words.extend(command_conditional_path_words(command, source));
     }
-    words
 }
 
 fn own_scope_name_read_uses(command: CommandFactRef<'_, '_>, _source: &str) -> Vec<ComparableNameUse> {
     let mut uses = Vec::new();
+    collect_own_scope_name_read_uses(command, _source, &mut uses);
+    uses
+}
 
+fn collect_own_scope_name_read_uses(
+    command: CommandFactRef<'_, '_>,
+    _source: &str,
+    uses: &mut Vec<ComparableNameUse>,
+) {
     for redirect in command.redirect_facts() {
         match redirect.redirect().kind {
             RedirectKind::Input => {
@@ -837,8 +859,6 @@ fn own_scope_name_read_uses(command: CommandFactRef<'_, '_>, _source: &str) -> V
             | RedirectKind::OutputBoth => {}
         }
     }
-
-    uses
 }
 
 fn own_scope_heredoc_name_read_uses(
@@ -846,7 +866,15 @@ fn own_scope_heredoc_name_read_uses(
     source: &str,
 ) -> Vec<ComparableNameUse> {
     let mut uses = Vec::new();
+    collect_own_scope_heredoc_name_read_uses(command, source, &mut uses);
+    uses
+}
 
+fn collect_own_scope_heredoc_name_read_uses(
+    command: CommandFactRef<'_, '_>,
+    source: &str,
+    uses: &mut Vec<ComparableNameUse>,
+) {
     for redirect in command.redirect_facts() {
         if !matches!(
             redirect.redirect().kind,
@@ -860,67 +888,73 @@ fn own_scope_heredoc_name_read_uses(
             uses.extend(comparable_heredoc_name_uses(&heredoc.body, source));
         }
     }
-
-    uses
 }
 
-fn own_scope_name_write_uses(command: CommandFactRef<'_, '_>, _source: &str) -> Vec<ComparableNameUse> {
-    let mut uses = Vec::new();
-
+fn collect_own_scope_name_write_uses(
+    command: CommandFactRef<'_, '_>,
+    _source: &str,
+    uses: &mut Vec<ComparableNameUse>,
+) {
     if let Some(read) = command.options().read() {
         uses.extend(read.target_name_uses().iter().cloned());
     }
-
-    uses
 }
 
-fn nested_scope_read_source_words<'a>(
+fn collect_nested_scope_read_source_words<'a>(
     commands: CommandFacts<'_, 'a>,
     command: CommandFactRef<'_, 'a>,
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
-) -> Vec<PathWordFact<'a>> {
-    commands
+    words: &mut Vec<PathWordFact<'a>>,
+) {
+    for other in commands
         .iter()
         .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
-        .flat_map(|other| own_scope_read_source_words(other, if_condition_command_ids, source))
-        .collect()
+    {
+        collect_own_scope_read_source_words(other, if_condition_command_ids, source, words);
+    }
 }
 
-fn nested_scope_name_read_uses(
+fn collect_nested_scope_name_read_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
-) -> Vec<ComparableNameUse> {
-    commands
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    for other in commands
         .iter()
         .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
-        .flat_map(|other| own_scope_name_read_uses(other, source))
-        .collect()
+    {
+        collect_own_scope_name_read_uses(other, source, uses);
+    }
 }
 
-fn nested_scope_heredoc_name_read_uses(
+fn collect_nested_scope_heredoc_name_read_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
-) -> Vec<ComparableNameUse> {
-    commands
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    for other in commands
         .iter()
         .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
-        .flat_map(|other| own_scope_heredoc_name_read_uses(other, source))
-        .collect()
+    {
+        collect_own_scope_heredoc_name_read_uses(other, source, uses);
+    }
 }
 
-fn nested_scope_name_write_uses(
+fn collect_nested_scope_name_write_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
-) -> Vec<ComparableNameUse> {
-    commands
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    for other in commands
         .iter()
         .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
-        .flat_map(|other| own_scope_name_write_uses(other, source))
-        .collect()
+    {
+        collect_own_scope_name_write_uses(other, source, uses);
+    }
 }
 
 fn dedup_path_words(words: &mut Vec<PathWordFact<'_>>) {
@@ -956,10 +990,6 @@ fn command_has_file_input_redirect(command: CommandFactRef<'_, '_>) -> bool {
             .analysis()
             .is_some_and(|analysis| analysis.is_file_target())
     })
-}
-
-fn command_file_operand_words<'a>(command: CommandFactRef<'_, 'a>) -> Vec<&'a Word> {
-    command.file_operand_words().to_vec()
 }
 
 fn command_redirect_read_source_words<'a>(

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -20,15 +20,15 @@ impl From<Span> for FactSpan {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct CommandId(usize);
+pub struct CommandId(u32);
 
 impl CommandId {
     fn new(index: usize) -> Self {
-        Self(index)
+        Self(fact_id_index_to_u32(index, "command fact id"))
     }
 
     fn index(self) -> usize {
-        self.0
+        self.0 as usize
     }
 }
 
@@ -37,7 +37,7 @@ pub struct WordNodeId(u32);
 
 impl WordNodeId {
     fn new(index: usize) -> Self {
-        Self(index as u32)
+        Self(fact_id_index_to_u32(index, "word node id"))
     }
 
     fn index(self) -> usize {
@@ -50,12 +50,26 @@ pub struct WordOccurrenceId(u32);
 
 impl WordOccurrenceId {
     fn new(index: usize) -> Self {
-        Self(index as u32)
+        Self(fact_id_index_to_u32(index, "word occurrence id"))
     }
 
     fn index(self) -> usize {
         self.0 as usize
     }
+}
+
+#[inline]
+fn fact_id_index_to_u32(index: usize, kind: &'static str) -> u32 {
+    if index > u32::MAX as usize {
+        fact_id_index_overflow(kind);
+    }
+    index as u32
+}
+
+#[cold]
+#[inline(never)]
+fn fact_id_index_overflow(kind: &'static str) -> ! {
+    panic!("{kind} must fit in u32");
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -104,6 +118,198 @@ pub(super) struct CommandLookupEntry {
 }
 
 type CommandLookupIndex = FxHashMap<FactSpan, SmallVec<[CommandLookupEntry; 1]>>;
+
+#[derive(Debug, Clone)]
+struct FactStore<'a> {
+    redirect_facts: Vec<RedirectFact<'a>>,
+    substitution_facts: Vec<SubstitutionFact>,
+    scope_read_source_words: Vec<PathWordFact<'a>>,
+    scope_name_read_uses: Vec<ComparableNameUse>,
+    scope_heredoc_name_read_uses: Vec<ComparableNameUse>,
+    scope_name_write_uses: Vec<ComparableNameUse>,
+    declaration_assignment_probes: Vec<DeclarationAssignmentProbe>,
+    word_occurrence_ids: Vec<WordOccurrenceId>,
+    word_occurrence_ids_by_command: Vec<IdRange<WordOccurrenceId>>,
+}
+
+impl<'a> FactStore<'a> {
+    fn empty() -> Self {
+        Self {
+            redirect_facts: Vec::new(),
+            substitution_facts: Vec::new(),
+            scope_read_source_words: Vec::new(),
+            scope_name_read_uses: Vec::new(),
+            scope_heredoc_name_read_uses: Vec::new(),
+            scope_name_write_uses: Vec::new(),
+            declaration_assignment_probes: Vec::new(),
+            word_occurrence_ids: Vec::new(),
+            word_occurrence_ids_by_command: Vec::new(),
+        }
+    }
+
+    fn redirect_facts(&self, range: IdRange<RedirectFact<'a>>) -> &[RedirectFact<'a>] {
+        range.slice(&self.redirect_facts)
+    }
+
+    fn substitution_facts(&self, range: IdRange<SubstitutionFact>) -> &[SubstitutionFact] {
+        range.slice(&self.substitution_facts)
+    }
+
+    fn scope_read_source_words(&self, range: IdRange<PathWordFact<'a>>) -> &[PathWordFact<'a>] {
+        range.slice(&self.scope_read_source_words)
+    }
+
+    fn scope_name_read_uses(&self, range: IdRange<ComparableNameUse>) -> &[ComparableNameUse] {
+        range.slice(&self.scope_name_read_uses)
+    }
+
+    fn scope_heredoc_name_read_uses(
+        &self,
+        range: IdRange<ComparableNameUse>,
+    ) -> &[ComparableNameUse] {
+        range.slice(&self.scope_heredoc_name_read_uses)
+    }
+
+    fn scope_name_write_uses(&self, range: IdRange<ComparableNameUse>) -> &[ComparableNameUse] {
+        range.slice(&self.scope_name_write_uses)
+    }
+
+    fn declaration_assignment_probes(
+        &self,
+        range: IdRange<DeclarationAssignmentProbe>,
+    ) -> &[DeclarationAssignmentProbe] {
+        range.slice(&self.declaration_assignment_probes)
+    }
+
+    fn word_occurrence_ids_for_command(&self, id: CommandId) -> &[WordOccurrenceId] {
+        self.word_occurrence_ids_by_command
+            .get(id.index())
+            .copied()
+            .map_or(&[], |range| range.slice(&self.word_occurrence_ids))
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct CommandFactRef<'facts, 'a> {
+    fact: &'facts CommandFact<'a>,
+    store: &'facts FactStore<'a>,
+}
+
+impl<'facts, 'a> CommandFactRef<'facts, 'a> {
+    fn new(fact: &'facts CommandFact<'a>, store: &'facts FactStore<'a>) -> Self {
+        Self { fact, store }
+    }
+}
+
+impl<'facts, 'a> std::fmt::Debug for CommandFactRef<'facts, 'a> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.fact.fmt(formatter)
+    }
+}
+
+impl<'facts, 'a> std::ops::Deref for CommandFactRef<'facts, 'a> {
+    type Target = CommandFact<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        self.fact
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct CommandFacts<'facts, 'a> {
+    commands: &'facts [CommandFact<'a>],
+    store: &'facts FactStore<'a>,
+}
+
+impl<'facts, 'a> CommandFacts<'facts, 'a> {
+    fn new(commands: &'facts [CommandFact<'a>], store: &'facts FactStore<'a>) -> Self {
+        Self { commands, store }
+    }
+
+    pub fn len(self) -> usize {
+        self.commands.len()
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.commands.is_empty()
+    }
+
+    pub fn iter(self) -> CommandFactIter<'facts, 'a> {
+        CommandFactIter {
+            inner: self.commands.iter(),
+            store: self.store,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw(self) -> &'facts [CommandFact<'a>] {
+        self.commands
+    }
+
+    pub fn get(self, index: usize) -> Option<CommandFactRef<'facts, 'a>> {
+        self.commands
+            .get(index)
+            .map(|fact| CommandFactRef::new(fact, self.store))
+    }
+
+    pub fn first(self) -> Option<CommandFactRef<'facts, 'a>> {
+        self.get(0)
+    }
+
+    pub fn last(self) -> Option<CommandFactRef<'facts, 'a>> {
+        self.commands
+            .last()
+            .map(|fact| CommandFactRef::new(fact, self.store))
+    }
+}
+
+impl<'facts, 'a> IntoIterator for CommandFacts<'facts, 'a> {
+    type Item = CommandFactRef<'facts, 'a>;
+    type IntoIter = CommandFactIter<'facts, 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'facts, 'a> IntoIterator for &CommandFacts<'facts, 'a> {
+    type Item = CommandFactRef<'facts, 'a>;
+    type IntoIter = CommandFactIter<'facts, 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (*self).iter()
+    }
+}
+
+#[derive(Clone)]
+pub struct CommandFactIter<'facts, 'a> {
+    inner: std::slice::Iter<'facts, CommandFact<'a>>,
+    store: &'facts FactStore<'a>,
+}
+
+impl<'facts, 'a> Iterator for CommandFactIter<'facts, 'a> {
+    type Item = CommandFactRef<'facts, 'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|fact| CommandFactRef::new(fact, self.store))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<'facts, 'a> DoubleEndedIterator for CommandFactIter<'facts, 'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|fact| CommandFactRef::new(fact, self.store))
+    }
+}
+
+impl<'facts, 'a> ExactSizeIterator for CommandFactIter<'facts, 'a> {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SudoFamilyInvoker {

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -96,6 +96,7 @@ pub(super) fn build_escape_scan_matches(
     }
 
     let mut matches = Vec::new();
+    let mut span_buffer = Vec::new();
 
     for fact in occurrences
         .iter()
@@ -117,10 +118,13 @@ pub(super) fn build_escape_scan_matches(
             inputs.single_quoted_fragments,
         );
 
-        for span in word_spans::word_literal_part_spans_excluding_parameter_operator_tails(
+        span_buffer.clear();
+        word_spans::collect_word_literal_part_spans_excluding_parameter_operator_tails(
             word,
             context.source,
-        ) {
+            &mut span_buffer,
+        );
+        for span in span_buffer.drain(..) {
             append_escape_scan_matches(
                 &mut matches,
                 span,
@@ -183,10 +187,13 @@ pub(super) fn build_escape_scan_matches(
             inputs.single_quoted_fragments,
         );
 
-        for span in word_spans::word_literal_scan_segments_excluding_expansions(
+        span_buffer.clear();
+        word_spans::collect_word_literal_scan_segments_excluding_expansions(
             occurrence_word(nodes, fact),
             context.source,
-        ) {
+            &mut span_buffer,
+        );
+        for span in span_buffer.drain(..) {
             append_escape_scan_matches(
                 &mut matches,
                 span,

--- a/crates/shuck-linter/src/facts/lists.rs
+++ b/crates/shuck-linter/src/facts/lists.rs
@@ -358,4 +358,3 @@ fn matches_assignment_ternary(
         && then_branch.assignment_target().is_some()
         && then_branch.assignment_target() == else_branch.assignment_target()
 }
-

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -46,13 +46,13 @@ use shuck_ast::{
     BraceSyntaxKind, BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command,
     CommandSubstitutionSyntax, CompoundCommand, ConditionalBinaryOp, ConditionalExpr,
     ConditionalUnaryOp, DeclClause, DeclOperand, File, ForCommand, FunctionDef,
-    HeredocBodyPartNode, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
-    PatternPart, Position, PrefixMatchKind, Redirect, RedirectKind, SelectCommand, SimpleCommand,
-    SourceText, Span, StaticCommandWrapperTarget, Stmt, StmtSeq, StmtTerminator, Subscript,
-    SubscriptSelector, TextRange, TextSize, VarRef, WhileCommand, Word, WordPart, WordPartNode,
-    ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob,
-    is_shell_variable_name, static_command_name_text, static_command_wrapper_target_index,
-    static_word_text, word_is_standalone_status_capture,
+    HeredocBodyPartNode, IdRange, ListArena, Name, ParameterExpansion, ParameterExpansionSyntax,
+    ParameterOp, Pattern, PatternPart, Position, PrefixMatchKind, Redirect, RedirectKind,
+    SelectCommand, SimpleCommand, SourceText, Span, StaticCommandWrapperTarget, Stmt, StmtSeq,
+    StmtTerminator, Subscript, SubscriptSelector, TextRange, TextSize, VarRef, WhileCommand, Word,
+    WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
+    ZshQualifiedGlob, is_shell_variable_name, static_command_name_text,
+    static_command_wrapper_target_index, static_word_text, word_is_standalone_status_capture,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
@@ -121,7 +121,10 @@ pub(crate) fn benchmark_normalize_commands(file: &File, source: &str) -> usize {
 
 #[allow(unused_imports)]
 pub(crate) mod core {
-    pub use super::{CommandId, FactSpan, SudoFamilyInvoker, WordNodeId, WordOccurrenceId};
+    pub use super::{
+        CommandFactRef, CommandFacts, CommandId, FactSpan, SudoFamilyInvoker, WordNodeId,
+        WordOccurrenceId,
+    };
 }
 
 #[allow(unused_imports)]
@@ -185,7 +188,7 @@ pub(crate) mod command_options {
 
 #[allow(unused_imports)]
 pub(crate) mod commands {
-    pub use super::CommandFact;
+    pub use super::{CommandFact, CommandFactRef};
 }
 
 #[allow(unused_imports)]

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -372,27 +372,11 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter {
-            inner: Box::new(
-                self.word_occurrences
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, occurrence)| occurrence.context != WordFactContext::ArithmeticCommand)
-                    .map(|(index, _)| self.word_occurrence_ref(WordOccurrenceId::new(index))),
-            ),
-        }
+        WordOccurrenceIter::all(self, WordOccurrenceFilter::NonArithmetic)
     }
 
     pub fn arithmetic_command_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter {
-            inner: Box::new(
-                self.word_occurrences
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, occurrence)| occurrence.context == WordFactContext::ArithmeticCommand)
-                    .map(|(index, _)| self.word_occurrence_ref(WordOccurrenceId::new(index))),
-            ),
-        }
+        WordOccurrenceIter::all(self, WordOccurrenceFilter::ArithmeticCommand)
     }
 
     pub fn is_compound_assignment_value_word(&self, fact: WordOccurrenceRef<'_, '_>) -> bool {
@@ -401,18 +385,11 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn expansion_word_facts(&self, context: ExpansionContext) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter {
-            inner: Box::new(
-                self.word_facts()
-                    .filter(move |fact| fact.expansion_context() == Some(context)),
-            ),
-        }
+        WordOccurrenceIter::all(self, WordOccurrenceFilter::Expansion(context))
     }
 
     pub fn case_subject_facts(&self) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter {
-            inner: Box::new(self.word_facts().filter(|fact| fact.is_case_subject())),
-        }
+        WordOccurrenceIter::all(self, WordOccurrenceFilter::CaseSubject)
     }
 
     pub fn word_fact(
@@ -449,14 +426,11 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn array_assignment_split_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter {
-            inner: Box::new(
-                self.array_assignment_split_word_ids
-                    .iter()
-                    .copied()
-                    .map(|id| self.word_occurrence_ref(id)),
-            ),
-        }
+        WordOccurrenceIter::ids(
+            self,
+            &self.array_assignment_split_word_ids,
+            WordOccurrenceFilter::Any,
+        )
     }
 
     fn word_occurrence_ref(&self, id: WordOccurrenceId) -> WordOccurrenceRef<'_, 'a> {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -25,7 +25,7 @@ pub struct LinterFacts<'a> {
     word_nodes: Vec<WordNode<'a>>,
     word_occurrences: Vec<WordOccurrence>,
     word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
-    word_occurrence_ids_by_command: Vec<SmallVec<[WordOccurrenceId; 4]>>,
+    fact_store: FactStore<'a>,
     unquoted_command_argument_use_offsets: FxHashMap<Name, Vec<usize>>,
     array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     brace_variable_before_bracket_spans: Vec<Span>,
@@ -178,8 +178,8 @@ impl<'a> LinterFacts<'a> {
         .build()
     }
 
-    pub fn commands(&self) -> &[CommandFact<'a>] {
-        &self.commands
+    pub fn commands(&self) -> CommandFacts<'_, 'a> {
+        CommandFacts::new(&self.commands, &self.fact_store)
     }
 
     pub fn malformed_bracket_test_spans(&self, source: &str) -> Vec<Span> {
@@ -234,18 +234,18 @@ impl<'a> LinterFacts<'a> {
             .unwrap_or_default()
     }
 
-    pub fn structural_commands(&self) -> impl Iterator<Item = &CommandFact<'a>> + '_ {
+    pub fn structural_commands(&self) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
         self.structural_command_ids
             .iter()
             .copied()
             .map(|id| self.command(id))
     }
 
-    pub fn command(&self, id: CommandId) -> &CommandFact<'a> {
-        &self.commands[id.index()]
+    pub fn command(&self, id: CommandId) -> CommandFactRef<'_, 'a> {
+        CommandFactRef::new(&self.commands[id.index()], &self.fact_store)
     }
 
-    pub fn innermost_command_at(&self, offset: usize) -> Option<&CommandFact<'a>> {
+    pub fn innermost_command_at(&self, offset: usize) -> Option<CommandFactRef<'_, 'a>> {
         self.innermost_command_id_at(offset)
             .map(|id| self.command(id))
     }
@@ -258,7 +258,7 @@ impl<'a> LinterFacts<'a> {
         self.command_parent_ids.get(id.index()).copied().flatten()
     }
 
-    pub fn command_parent(&self, id: CommandId) -> Option<&CommandFact<'a>> {
+    pub fn command_parent(&self, id: CommandId) -> Option<CommandFactRef<'_, 'a>> {
         self.command_parent_id(id)
             .map(|parent_id| self.command(parent_id))
     }
@@ -468,9 +468,7 @@ impl<'a> LinterFacts<'a> {
     }
 
     fn word_occurrence_ids_for_command(&self, id: CommandId) -> &[WordOccurrenceId] {
-        self.word_occurrence_ids_by_command
-            .get(id.index())
-            .map_or(&[], SmallVec::as_slice)
+        self.fact_store.word_occurrence_ids_for_command(id)
     }
 
     fn word_node(&self, id: WordNodeId) -> &WordNode<'a> {

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -655,7 +655,7 @@ fn build_redirect_facts<'a>(
     semantic: Option<&SemanticModel>,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
-) -> Box<[RedirectFact<'a>]> {
+) -> Vec<RedirectFact<'a>> {
     redirects
         .iter()
         .map(|redirect| RedirectFact {
@@ -702,8 +702,7 @@ fn build_redirect_facts<'a>(
                 })
                 .into_boxed_slice(),
         })
-        .collect::<Vec<_>>()
-        .into_boxed_slice()
+        .collect()
 }
 
 fn brace_fd_redirection_span(redirect: &Redirect, source: &str) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -1239,24 +1239,24 @@ fn substitution_body_is_line_oriented<'a>(
 
 fn substitution_body_is_pgrep_lookup<'a>(
     body: &'a StmtSeq,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
     matches!(
         body.as_slice(),
         [stmt]
-            if stmt_effective_or_literal_basename_is(stmt, "pgrep", commands, command_ids_by_span)
+            if stmt_effective_or_literal_basename_is_ref(stmt, "pgrep", commands, command_ids_by_span)
     )
 }
 
 fn substitution_body_is_seq_utility<'a>(
     body: &'a StmtSeq,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
     matches!(
         body.as_slice(),
-        [stmt] if stmt_effective_or_literal_basename_is(stmt, "seq", commands, command_ids_by_span)
+        [stmt] if stmt_effective_or_literal_basename_is_ref(stmt, "seq", commands, command_ids_by_span)
     )
 }
 
@@ -1367,14 +1367,14 @@ fn stmt_literal_name_is<'a>(
         == Some(name)
 }
 
-fn stmt_effective_or_literal_basename_is<'a>(
+fn stmt_effective_or_literal_basename_is_ref<'a>(
     stmt: &'a Stmt,
     name: &str,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
-    command_fact_for_stmt(stmt, commands, command_ids_by_span)
-        .and_then(CommandFact::effective_or_literal_name)
+    command_fact_ref_for_stmt(stmt, commands, command_ids_by_span)
+        .and_then(CommandFactRef::effective_or_literal_name)
         .is_some_and(|command_name| {
             command_name == name || command_name.rsplit('/').next() == Some(name)
         })

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -149,10 +149,10 @@ impl SubstitutionFact {
 }
 
 pub(super) fn build_substitution_facts<'a>(
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
-) -> Vec<Box<[SubstitutionFact]>> {
+) -> Vec<Vec<SubstitutionFact>> {
     commands
         .iter()
         .map(|fact| build_command_substitution_facts(fact, commands, command_ids_by_span, source))
@@ -160,11 +160,11 @@ pub(super) fn build_substitution_facts<'a>(
 }
 
 fn build_command_substitution_facts<'a>(
-    fact: &CommandFact<'a>,
-    commands: &[CommandFact<'a>],
+    fact: CommandFactRef<'_, 'a>,
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
-) -> Box<[SubstitutionFact]> {
+) -> Vec<SubstitutionFact> {
     let mut substitutions = Vec::new();
     let mut substitution_index = FxHashMap::default();
     let context = SubstitutionFactBuildContext {
@@ -233,7 +233,7 @@ fn build_command_substitution_facts<'a>(
         );
     });
 
-    substitutions.into_boxed_slice()
+    substitutions
 }
 
 fn collect_or_update_word_substitution_facts<'a>(
@@ -276,7 +276,7 @@ fn collect_or_update_heredoc_body_substitution_facts<'a>(
 
 #[derive(Clone, Copy)]
 struct SubstitutionFactBuildContext<'a, 'b> {
-    commands: &'b [CommandFact<'a>],
+    commands: CommandFacts<'b, 'a>,
     command_ids_by_span: &'b CommandLookupIndex,
     source: &'b str,
 }
@@ -513,7 +513,7 @@ struct RedirectSummary {
 
 fn classify_substitution_body<'a>(
     body: &'a StmtSeq,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> SubstitutionBodyFacts {
@@ -560,7 +560,7 @@ fn classify_substitution_body<'a>(
 
 fn summarize_stmt_seq_redirects<'a>(
     body: &'a StmtSeq,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> RedirectSummary {
@@ -584,7 +584,7 @@ fn summarize_stmt_seq_redirects<'a>(
 
 fn summarize_stmt_redirects<'a>(
     stmt: &'a Stmt,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> RedirectSummary {
@@ -630,12 +630,12 @@ fn summarize_stmt_redirects<'a>(
 fn summarize_command_redirects<'a>(
     command: &Command,
     redirects: &[Redirect],
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> RedirectSummary {
     if let Some(id) = command_id_for_command(command, command_ids_by_span) {
-        summarize_redirect_facts(command_fact(commands, id).redirect_facts(), source)
+        summarize_redirect_facts(command_fact_ref(commands, id).redirect_facts(), source)
     } else {
         let redirect_facts = build_redirect_facts(redirects, None, source, None);
         summarize_redirect_facts(&redirect_facts, source)
@@ -1001,7 +1001,7 @@ fn leading_dynamic_dash_literal_in_parts(
 
 fn substitution_body_contains_ls<'a>(
     body: &'a StmtSeq,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
     body.stmts
@@ -1011,7 +1011,7 @@ fn substitution_body_contains_ls<'a>(
 
 fn substitution_body_processed_ls_pipeline_spans<'a>(
     body: &'a StmtSeq,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> Vec<Span> {
@@ -1035,7 +1035,7 @@ fn substitution_body_processed_ls_pipeline_spans<'a>(
 
 fn collect_processed_ls_pipeline_spans_in_stmt<'a>(
     stmt: &'a Stmt,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1103,11 +1103,11 @@ fn collect_pipeline_parts<'a>(
 
 fn stmt_is_raw_ls<'a>(
     stmt: &'a Stmt,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> bool {
-    if let Some(fact) = command_fact_for_stmt(stmt, commands, command_ids_by_span) {
+    if let Some(fact) = command_fact_ref_for_stmt(stmt, commands, command_ids_by_span) {
         return fact.literal_name() == Some("ls") && fact.wrappers().is_empty();
     }
 
@@ -1117,12 +1117,12 @@ fn stmt_is_raw_ls<'a>(
 
 fn stmt_static_utility_name_is<'a>(
     stmt: &'a Stmt,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
     name: &str,
 ) -> bool {
-    if let Some(fact) = command_fact_for_stmt(stmt, commands, command_ids_by_span) {
+    if let Some(fact) = command_fact_ref_for_stmt(stmt, commands, command_ids_by_span) {
         return fact.static_utility_name() == Some(name);
     }
 
@@ -1132,11 +1132,11 @@ fn stmt_static_utility_name_is<'a>(
 fn ls_command_span_before_pipe<'a>(
     stmt: &'a Stmt,
     operator_span: Span,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
 ) -> Span {
-    let start = command_fact_for_stmt(stmt, commands, command_ids_by_span)
+    let start = command_fact_ref_for_stmt(stmt, commands, command_ids_by_span)
         .and_then(|fact| fact.shellcheck_command_span(source))
         .unwrap_or_else(|| command::normalize_command(&stmt.command, source).body_span)
         .start;
@@ -1161,10 +1161,10 @@ fn substitution_body_contains_grep(body: &StmtSeq, source: &str) -> bool {
 
 fn stmt_contains_raw_ls<'a>(
     stmt: &'a Stmt,
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
-    command_fact_for_stmt(stmt, commands, command_ids_by_span)
+    command_fact_ref_for_stmt(stmt, commands, command_ids_by_span)
         .is_some_and(|fact| fact.literal_name() == Some("ls") && fact.wrappers().is_empty())
         || match &stmt.command {
             Command::Binary(binary) => {

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -202,7 +202,7 @@ fn precomputes_innermost_command_ids_for_nested_offsets() {
         .expect("expected nested uname command");
 
     let command_ids_by_offset = super::build_innermost_command_ids_by_offset(
-        facts.commands(),
+        facts.commands().raw(),
         vec![
             source.find("echo").expect("expected echo offset"),
             source.find("printf").expect("expected printf offset"),

--- a/crates/shuck-linter/src/facts/word_spans.rs
+++ b/crates/shuck-linter/src/facts/word_spans.rs
@@ -286,18 +286,29 @@ pub fn word_literal_part_spans_excluding_parameter_operator_tails(
     word: &Word,
     source: &str,
 ) -> Vec<Span> {
-    word.parts
-        .iter()
-        .enumerate()
-        .filter_map(|(index, part)| match &part.kind {
-            WordPart::Literal(_)
-                if !literal_part_is_parameter_operator_tail(&word.parts, index, source) =>
-            {
-                Some(part.span)
-            }
-            _ => None,
-        })
-        .collect()
+    let mut spans = Vec::new();
+    collect_word_literal_part_spans_excluding_parameter_operator_tails(word, source, &mut spans);
+    spans
+}
+
+pub fn collect_word_literal_part_spans_excluding_parameter_operator_tails(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    spans.extend(
+        word.parts
+            .iter()
+            .enumerate()
+            .filter_map(|(index, part)| match &part.kind {
+                WordPart::Literal(_)
+                    if !literal_part_is_parameter_operator_tail(&word.parts, index, source) =>
+                {
+                    Some(part.span)
+                }
+                _ => None,
+            }),
+    );
 }
 
 pub fn word_has_single_literal_part(word: &Word) -> bool {
@@ -310,7 +321,19 @@ pub fn word_has_single_literal_part(word: &Word) -> bool {
 pub fn word_literal_scan_segments_excluding_expansions(word: &Word, source: &str) -> Vec<Span> {
     let mut excluded = Vec::new();
     collect_literal_scan_exclusions(&word.parts, &mut excluded);
-    scan_span_excluding(word.span, &excluded, source)
+    let mut spans = Vec::new();
+    collect_scan_span_excluding(word.span, &excluded, source, &mut spans);
+    spans
+}
+
+pub fn collect_word_literal_scan_segments_excluding_expansions(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let mut excluded = Vec::new();
+    collect_literal_scan_exclusions(&word.parts, &mut excluded);
+    collect_scan_span_excluding(word.span, &excluded, source, spans);
 }
 
 pub fn word_unquoted_glob_pattern_spans(word: &Word, source: &str) -> Vec<Span> {
@@ -3242,11 +3265,17 @@ fn span_within_literal(span: Span, source: &str, start: usize, end: usize) -> Sp
 }
 
 fn scan_span_excluding(span: Span, excluded: &[Span], source: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_scan_span_excluding(span, excluded, source, &mut spans);
+    spans
+}
+
+fn collect_scan_span_excluding(span: Span, excluded: &[Span], source: &str, spans: &mut Vec<Span>) {
     if excluded.is_empty() {
-        return vec![span];
+        spans.push(span);
+        return;
     }
 
-    let mut spans = Vec::new();
     let mut cursor = span.start.offset;
     for excluded_span in excluded.iter().copied().filter(|excluded_span| {
         excluded_span.end.offset > span.start.offset && excluded_span.start.offset < span.end.offset
@@ -3261,8 +3290,6 @@ fn scan_span_excluding(span: Span, excluded: &[Span], source: &str) -> Vec<Span>
     if cursor < span.end.offset {
         spans.push(scan_span_segment(span, cursor, span.end.offset, source));
     }
-
-    spans
 }
 
 fn merge_adjacent_spans(spans: Vec<Span>, source: &str) -> Vec<Span> {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1103,12 +1103,65 @@ pub struct WordOccurrenceRef<'facts, 'a> {
 }
 
 pub struct WordOccurrenceIter<'facts, 'a> {
-    inner: Box<dyn Iterator<Item = WordOccurrenceRef<'facts, 'a>> + 'facts>,
+    facts: &'facts LinterFacts<'a>,
+    source: WordOccurrenceIterSource<'facts>,
+    filter: WordOccurrenceFilter,
+}
+
+enum WordOccurrenceIterSource<'facts> {
+    All { next: usize },
+    Ids(std::slice::Iter<'facts, WordOccurrenceId>),
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum WordOccurrenceFilter {
+    Any,
+    NonArithmetic,
+    ArithmeticCommand,
+    Expansion(ExpansionContext),
+    CaseSubject,
 }
 
 impl<'facts, 'a> WordOccurrenceIter<'facts, 'a> {
+    pub(crate) fn all(facts: &'facts LinterFacts<'a>, filter: WordOccurrenceFilter) -> Self {
+        Self {
+            facts,
+            source: WordOccurrenceIterSource::All { next: 0 },
+            filter,
+        }
+    }
+
+    pub(crate) fn ids(
+        facts: &'facts LinterFacts<'a>,
+        ids: &'facts [WordOccurrenceId],
+        filter: WordOccurrenceFilter,
+    ) -> Self {
+        Self {
+            facts,
+            source: WordOccurrenceIterSource::Ids(ids.iter()),
+            filter,
+        }
+    }
+
     pub fn iter(self) -> Self {
         self
+    }
+
+    fn accepts(&self, id: WordOccurrenceId) -> bool {
+        let occurrence = self.facts.word_occurrence(id);
+        match self.filter {
+            WordOccurrenceFilter::Any => true,
+            WordOccurrenceFilter::NonArithmetic => {
+                occurrence.context != WordFactContext::ArithmeticCommand
+            }
+            WordOccurrenceFilter::ArithmeticCommand => {
+                occurrence.context == WordFactContext::ArithmeticCommand
+            }
+            WordOccurrenceFilter::Expansion(context) => {
+                occurrence.context == WordFactContext::Expansion(context)
+            }
+            WordOccurrenceFilter::CaseSubject => self.facts.word_occurrence_ref(id).is_case_subject(),
+        }
     }
 }
 
@@ -1116,7 +1169,20 @@ impl<'facts, 'a> Iterator for WordOccurrenceIter<'facts, 'a> {
     type Item = WordOccurrenceRef<'facts, 'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
+        loop {
+            let id = match &mut self.source {
+                WordOccurrenceIterSource::All { next } => {
+                    let id = WordOccurrenceId::new(*next);
+                    *next += 1;
+                    (id.index() < self.facts.word_occurrences.len()).then_some(id)
+                }
+                WordOccurrenceIterSource::Ids(ids) => ids.next().copied(),
+            }?;
+
+            if self.accepts(id) {
+                return Some(self.facts.word_occurrence_ref(id));
+            }
+        }
     }
 }
 

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2002,7 +2002,7 @@ fn text_contains_echo_backslash_escape(text: &str, is_sensitive: fn(u8) -> bool)
 }
 
 fn build_echo_to_sed_substitution_spans<'a>(
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
     backticks: &[BacktickFragmentFact],
     nodes: &[WordNode<'a>],
@@ -2041,7 +2041,7 @@ fn build_echo_to_sed_substitution_spans<'a>(
 }
 
 fn sc2001_like_pipeline_span<'a>(
-    commands: &[CommandFact<'a>],
+    commands: CommandFacts<'_, 'a>,
     pipeline: &PipelineFact<'a>,
     backticks: &[BacktickFragmentFact],
     nodes: &[WordNode<'a>],
@@ -2053,8 +2053,8 @@ fn sc2001_like_pipeline_span<'a>(
         return None;
     };
 
-    let left = command_fact(commands, left_segment.command_id());
-    let right = command_fact(commands, right_segment.command_id());
+    let left = command_fact_ref(commands, left_segment.command_id());
+    let right = command_fact_ref(commands, right_segment.command_id());
 
     if !command_is_plain_named(left, "echo") || !command_is_plain_named(right, "sed") {
         return None;
@@ -2115,7 +2115,7 @@ fn sc2001_like_pipeline_span<'a>(
 }
 
 fn sc2001_like_here_string_span(
-    command: &CommandFact<'_>,
+    command: CommandFactRef<'_, '_>,
     backticks: &[BacktickFragmentFact],
     source: &str,
 ) -> Option<Span> {
@@ -2143,24 +2143,27 @@ fn sc2001_like_here_string_span(
     command_span_with_redirects_and_shellcheck_tail(command, source)
 }
 
-fn command_is_plain_named(command: &CommandFact<'_>, name: &str) -> bool {
+fn command_is_plain_named(command: CommandFactRef<'_, '_>, name: &str) -> bool {
     command.effective_name_is(name) && command.wrappers().is_empty()
 }
 
 fn sc2001_like_backtick_pipeline_span(
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     pipeline: &PipelineFact<'_>,
-    sed_command: &CommandFact<'_>,
+    sed_command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<Span> {
     let first_segment = pipeline.first_segment()?;
-    let first = command_fact(commands, first_segment.command_id());
+    let first = command_fact_ref(commands, first_segment.command_id());
     let start = first.body_name_word()?.span.start;
     let end = sc2001_like_backtick_sed_script_end(sed_command.body_args(), source)?;
     Some(Span::from_positions(start, end))
 }
 
-fn sc2001_like_backtick_command_span(command: &CommandFact<'_>, source: &str) -> Option<Span> {
+fn sc2001_like_backtick_command_span(
+    command: CommandFactRef<'_, '_>,
+    source: &str,
+) -> Option<Span> {
     let start = command.body_name_word()?.span.start;
     let end = sc2001_like_backtick_sed_script_end(command.body_args(), source)?;
     Some(Span::from_positions(start, end))
@@ -2280,7 +2283,7 @@ fn rewind_offset_by_chars(source: &str, mut offset: usize, count: usize) -> Opti
 }
 
 fn command_has_sc2001_like_sed_script(
-    command: &CommandFact<'_>,
+    command: CommandFactRef<'_, '_>,
     backticks: &[BacktickFragmentFact],
     source: &str,
 ) -> bool {
@@ -2297,7 +2300,7 @@ fn command_has_sc2001_like_sed_script(
 }
 
 fn command_is_inside_backtick_fragment(
-    command: &CommandFact<'_>,
+    command: CommandFactRef<'_, '_>,
     backticks: &[BacktickFragmentFact],
 ) -> bool {
     let span = command.span();

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -58,11 +58,11 @@ pub use diagnostic::{Diagnostic, Severity};
 pub use facts::CommandSubstitutionKind;
 /// Extracted structural facts available to rules and callers.
 pub use facts::{
-    BacktickFragmentFact, CommandFact, CommandOptionFacts, ConditionalBareWordFact,
-    ConditionalBinaryFact, ConditionalFact, ConditionalMixedLogicalOperatorFact,
-    ConditionalNodeFact, ConditionalOperandFact, ConditionalOperatorFamily,
-    ConditionalPortabilityFacts, ConditionalUnaryFact, ExitCommandFacts, ExpansionAnalysis,
-    ExpansionContext, ExpansionHazards, ExpansionValueShape, FindCommandFacts,
+    BacktickFragmentFact, CommandFact, CommandFactRef, CommandFacts, CommandOptionFacts,
+    ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact,
+    ConditionalMixedLogicalOperatorFact, ConditionalNodeFact, ConditionalOperandFact,
+    ConditionalOperatorFamily, ConditionalPortabilityFacts, ConditionalUnaryFact, ExitCommandFacts,
+    ExpansionAnalysis, ExpansionContext, ExpansionHazards, ExpansionValueShape, FindCommandFacts,
     FindExecCommandFacts, FindExecShellCommandFacts, ForHeaderFact, FunctionCallArityFacts,
     FunctionHeaderFact, GrepPatternSourceKind, LegacyArithmeticFragmentFact, ListFact,
     ListOperatorFact, LoopHeaderWordFact, PathWordFact, PipelineFact, PipelineOperatorFact,

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -539,7 +539,7 @@ impl<'a> SafeValueIndex<'a> {
     fn function_definition_command(
         &self,
         function: &FunctionDef,
-    ) -> Option<&crate::facts::CommandFact<'a>> {
+    ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
         self.facts.commands().iter().find(|command| {
             matches!(
                 command.command(),
@@ -593,7 +593,10 @@ impl<'a> SafeValueIndex<'a> {
         command.span_in_source(self.source).end.offset <= call_span.start.offset
     }
 
-    fn command_for_name_word_span(&self, span: Span) -> Option<&crate::facts::CommandFact<'a>> {
+    fn command_for_name_word_span(
+        &self,
+        span: Span,
+    ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
         self.facts.commands().iter().find(|command| {
             command
                 .body_name_word()
@@ -861,7 +864,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn command_blocks_cover_all_paths_to_reference(
         &self,
-        command: &crate::facts::CommandFact<'a>,
+        command: crate::facts::CommandFactRef<'_, 'a>,
         name: &Name,
         at: Span,
     ) -> bool {
@@ -2276,7 +2279,7 @@ fn build_case_cli_reachable_function_scopes(
                 && semantic
                     .ancestor_scopes(semantic.scope_at(command.span().start.offset))
                     .all(|scope| !matches!(semantic.scope(scope).kind, ScopeKind::Function(_)))
-                && command_fact_is_standalone_exit(command)
+                && command_fact_is_standalone_exit(*command)
         })
         .map(|command| command.span().start.offset)
         .min();
@@ -2300,7 +2303,7 @@ fn build_case_cli_reachable_function_scopes(
         .collect()
 }
 
-fn command_fact_is_standalone_exit(command: &crate::facts::CommandFact<'_>) -> bool {
+fn command_fact_is_standalone_exit(command: crate::facts::CommandFactRef<'_, '_>) -> bool {
     if command.stmt().negated
         || matches!(
             command.stmt().terminator,

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -72,6 +72,11 @@ pub struct SafeValueIndex<'a> {
     case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
     definite_uninitialized_refs: FxHashSet<FactSpan>,
     maybe_uninitialized_refs: FxHashSet<FactSpan>,
+    function_commands_by_span: FxHashMap<FactSpan, crate::facts::CommandId>,
+    commands_by_name_word_span: FxHashMap<FactSpan, crate::facts::CommandId>,
+    reference_ids_by_name_span: FxHashMap<(Name, FactSpan), ReferenceId>,
+    block_by_reference: FxHashMap<ReferenceId, BlockId>,
+    block_by_binding: FxHashMap<BindingId, BlockId>,
     memo: FxHashMap<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>), bool>,
     visiting: FxHashSet<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>)>,
     binding_value_stack: Vec<BindingId>,
@@ -100,6 +105,42 @@ impl<'a> SafeValueIndex<'a> {
             .collect();
         let case_cli_reachable_function_scopes =
             build_case_cli_reachable_function_scopes(semantic, facts);
+        let mut function_commands_by_span = FxHashMap::default();
+        let mut commands_by_name_word_span = FxHashMap::default();
+        for command in facts.commands() {
+            if let Command::Function(function) = command.command() {
+                function_commands_by_span.insert(FactSpan::new(function.span), command.id());
+            }
+            if let Some(name_word) = command.body_name_word() {
+                commands_by_name_word_span.insert(FactSpan::new(name_word.span), command.id());
+            }
+        }
+        let reference_ids_by_name_span = semantic
+            .references()
+            .iter()
+            .filter(|reference| {
+                !matches!(
+                    reference.kind,
+                    ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
+                )
+            })
+            .map(|reference| {
+                (
+                    (reference.name.clone(), FactSpan::new(reference.span)),
+                    reference.id,
+                )
+            })
+            .collect();
+        let mut block_by_reference = FxHashMap::default();
+        let mut block_by_binding = FxHashMap::default();
+        for block in analysis.cfg().blocks() {
+            for reference_id in &block.references {
+                block_by_reference.insert(*reference_id, block.id);
+            }
+            for binding_id in &block.bindings {
+                block_by_binding.insert(*binding_id, block.id);
+            }
+        }
 
         Self {
             semantic,
@@ -109,6 +150,11 @@ impl<'a> SafeValueIndex<'a> {
             case_cli_reachable_function_scopes,
             definite_uninitialized_refs,
             maybe_uninitialized_refs,
+            function_commands_by_span,
+            commands_by_name_word_span,
+            reference_ids_by_name_span,
+            block_by_reference,
+            block_by_binding,
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
             binding_value_stack: Vec::new(),
@@ -540,12 +586,10 @@ impl<'a> SafeValueIndex<'a> {
         &self,
         function: &FunctionDef,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
-        self.facts.commands().iter().find(|command| {
-            matches!(
-                command.command(),
-                Command::Function(candidate) if candidate.span == function.span
-            )
-        })
+        self.function_commands_by_span
+            .get(&FactSpan::new(function.span))
+            .copied()
+            .map(|id| self.facts.command(id))
     }
 
     fn definition_command_is_visible_at_call(
@@ -597,11 +641,10 @@ impl<'a> SafeValueIndex<'a> {
         &self,
         span: Span,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
-        self.facts.commands().iter().find(|command| {
-            command
-                .body_name_word()
-                .is_some_and(|name_word| name_word.span == span)
-        })
+        self.commands_by_name_word_span
+            .get(&FactSpan::new(span))
+            .copied()
+            .map(|id| self.facts.command(id))
     }
 
     fn command_runs_in_unconditional_flow(
@@ -1976,18 +2019,9 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn reference_id_for_name_at(&self, name: &Name, at: Span) -> Option<ReferenceId> {
-        self.semantic
-            .references()
-            .iter()
-            .find(|reference| {
-                reference.span == at
-                    && &reference.name == name
-                    && !matches!(
-                        reference.kind,
-                        ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
-                    )
-            })
-            .map(|reference| reference.id)
+        self.reference_ids_by_name_span
+            .get(&(name.clone(), FactSpan::new(at)))
+            .copied()
     }
 
     fn block_for_name_reference_or_virtual_offset(&self, name: &Name, at: Span) -> Option<BlockId> {
@@ -2026,21 +2060,11 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn block_for_binding(&self, binding_id: BindingId) -> Option<BlockId> {
-        self.analysis
-            .cfg()
-            .blocks()
-            .iter()
-            .find(|block| block.bindings.contains(&binding_id))
-            .map(|block| block.id)
+        self.block_by_binding.get(&binding_id).copied()
     }
 
     fn block_for_reference(&self, reference_id: ReferenceId) -> Option<BlockId> {
-        self.analysis
-            .cfg()
-            .blocks()
-            .iter()
-            .find(|block| block.references.contains(&reference_id))
-            .map(|block| block.id)
+        self.block_by_reference.get(&reference_id).copied()
     }
 
     fn transformation_is_safe(

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -108,7 +108,7 @@ fn builtin_array_history_events(checker: &Checker<'_>) -> Vec<ArrayHistoryEvent>
 
 fn command_array_history_events(
     checker: &Checker<'_>,
-    command: &crate::facts::commands::CommandFact<'_>,
+    command: crate::facts::commands::CommandFactRef<'_, '_>,
 ) -> Vec<ArrayHistoryEvent> {
     if matches!(checker.shell(), ShellDialect::Bash) && command.effective_name_is("read") {
         return command
@@ -371,7 +371,7 @@ fn read_target_is_array_like(checker: &Checker<'_>, binding: &Binding) -> bool {
 
     binding_command(checker, binding)
         .filter(|command| command.effective_name_is("read"))
-        .filter(|command| !command_is_shadowed_function(checker, command))
+        .filter(|command| !command_is_shadowed_function(checker, *command))
         .and_then(|command| command.options().read())
         .is_some_and(|read| {
             read.array_target_name_uses()
@@ -401,10 +401,10 @@ fn mapfile_target_is_array_like(checker: &Checker<'_>, binding: &Binding) -> boo
         })
 }
 
-fn binding_command<'a>(
-    checker: &'a Checker<'_>,
+fn binding_command<'checker, 'ast>(
+    checker: &'checker Checker<'ast>,
     binding: &Binding,
-) -> Option<&'a crate::facts::commands::CommandFact<'a>> {
+) -> Option<crate::facts::commands::CommandFactRef<'checker, 'ast>> {
     checker
         .facts()
         .innermost_command_at(binding.span.start.offset)
@@ -420,7 +420,7 @@ fn binding_command<'a>(
 
 fn command_is_shadowed_function(
     checker: &Checker<'_>,
-    command: &crate::facts::commands::CommandFact<'_>,
+    command: crate::facts::commands::CommandFactRef<'_, '_>,
 ) -> bool {
     let Some(name_span) = command.body_word_span() else {
         return false;
@@ -469,7 +469,9 @@ fn command_name_has_visible_function_binding(
         })
 }
 
-fn command_forces_builtin_resolution(command: &crate::facts::commands::CommandFact<'_>) -> bool {
+fn command_forces_builtin_resolution(
+    command: crate::facts::commands::CommandFactRef<'_, '_>,
+) -> bool {
     let mut saw_forcing_wrapper = false;
 
     for wrapper in command.wrappers() {
@@ -484,7 +486,7 @@ fn command_forces_builtin_resolution(command: &crate::facts::commands::CommandFa
 
 fn command_wrapper_is_shadowed_function(
     checker: &Checker<'_>,
-    command: &crate::facts::commands::CommandFact<'_>,
+    command: crate::facts::commands::CommandFactRef<'_, '_>,
     at: shuck_ast::Span,
 ) -> bool {
     let mut lookup_bypasses_functions = false;

--- a/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
@@ -26,7 +26,7 @@ pub fn assignment_to_numeric_variable(checker: &mut Checker) {
     checker.report_all_dedup(spans, || AssignmentToNumericVariable);
 }
 
-fn command_assignment_spans(fact: &crate::facts::CommandFact<'_>, source: &str) -> Vec<Span> {
+fn command_assignment_spans(fact: crate::facts::CommandFactRef<'_, '_>, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
 
     if let Some(span) = command_numeric_assignment_span(fact, source) {
@@ -53,7 +53,7 @@ fn command_assignment_spans(fact: &crate::facts::CommandFact<'_>, source: &str) 
 }
 
 fn command_numeric_assignment_span(
-    fact: &crate::facts::CommandFact<'_>,
+    fact: crate::facts::CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<Span> {
     let text = fact.span().slice(source);

--- a/crates/shuck-linter/src/rules/correctness/c_prototype_fragment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_prototype_fragment.rs
@@ -38,7 +38,7 @@ pub fn c_prototype_fragment(checker: &mut Checker) {
 }
 
 fn attached_background_ampersand_span(
-    command: &crate::CommandFact<'_>,
+    command: crate::CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<Span> {
     if command.stmt().terminator != Some(StmtTerminator::Background(BackgroundOperator::Plain)) {

--- a/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
@@ -26,7 +26,9 @@ pub fn c_style_comment(checker: &mut Checker) {
 
     for index in 0..checker.facts().commands().len() {
         let diagnostic = {
-            let command = &checker.facts().commands()[index];
+            let Some(command) = checker.facts().commands().get(index) else {
+                continue;
+            };
             let Some(name) = command.body_name_word() else {
                 continue;
             };

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -1,7 +1,7 @@
 use shuck_ast::{Command, Span};
 
 use crate::{
-    Checker, CommandFact, Edit, Fix, FixAvailability, PipelineFact, PipelineSegmentFact, Rule,
+    Checker, CommandFactRef, Edit, Fix, FixAvailability, PipelineFact, PipelineSegmentFact, Rule,
     Violation,
 };
 
@@ -76,7 +76,7 @@ fn unsafe_find_to_xargs_diagnostics(
         .collect()
 }
 
-fn find_output_to_xargs_fix(left: &CommandFact<'_>, right: &CommandFact<'_>) -> Fix {
+fn find_output_to_xargs_fix(left: CommandFactRef<'_, '_>, right: CommandFactRef<'_, '_>) -> Fix {
     let mut edits = Vec::new();
 
     if !left.options().find().is_some_and(|find| find.has_print0) {
@@ -104,7 +104,7 @@ fn find_output_to_xargs_fix(left: &CommandFact<'_>, right: &CommandFact<'_>) -> 
     Fix::unsafe_edits(edits)
 }
 
-fn find_print0_insertion_offset(command: &CommandFact<'_>) -> usize {
+fn find_print0_insertion_offset(command: CommandFactRef<'_, '_>) -> usize {
     command
         .redirect_facts()
         .first()
@@ -114,14 +114,14 @@ fn find_print0_insertion_offset(command: &CommandFact<'_>) -> usize {
         .expect("find command diagnostics should have a body insertion point")
 }
 
-fn xargs_null_input_insertion_offset(command: &CommandFact<'_>) -> usize {
+fn xargs_null_input_insertion_offset(command: CommandFactRef<'_, '_>) -> usize {
     command
         .body_name_word()
         .map(|word| word.span.end.offset)
         .expect("xargs command diagnostics should have a body name word")
 }
 
-fn find_command_span(segment: &PipelineSegmentFact<'_>, fact: &CommandFact<'_>) -> Span {
+fn find_command_span(segment: &PipelineSegmentFact<'_>, fact: CommandFactRef<'_, '_>) -> Span {
     match &segment.command() {
         Command::Simple(simple) => {
             let end = segment

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -2,8 +2,8 @@ use shuck_ast::{ConditionalBinaryOp, RedirectKind, Span, static_word_text};
 use shuck_semantic::{BindingAttributes, BindingId};
 
 use crate::{
-    Checker, CommandFact, ConditionalBinaryFact, ConditionalNodeFact, ConditionalOperandFact, Edit,
-    Fix, FixAvailability, RedirectFact, Rule, SimpleTestSyntax, Violation, WordOccurrenceRef,
+    Checker, CommandFactRef, ConditionalBinaryFact, ConditionalNodeFact, ConditionalOperandFact,
+    Edit, Fix, FixAvailability, RedirectFact, Rule, SimpleTestSyntax, Violation, WordOccurrenceRef,
 };
 
 pub struct GreaterThanInTest;
@@ -41,7 +41,7 @@ pub fn greater_than_in_test(checker: &mut Checker) {
 }
 
 fn comparison_operator_diagnostics(
-    command: &CommandFact<'_>,
+    command: CommandFactRef<'_, '_>,
     checker: &Checker<'_>,
     source: &str,
 ) -> Vec<crate::Diagnostic> {
@@ -53,7 +53,7 @@ fn comparison_operator_diagnostics(
 }
 
 fn bracket_comparison_redirect_diagnostics(
-    command: &CommandFact<'_>,
+    command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Vec<crate::Diagnostic> {
     let Some(simple_test) = command.simple_test() else {
@@ -182,7 +182,7 @@ fn has_trailing_token_boundary(text: &str) -> bool {
 }
 
 fn double_bracket_numeric_comparison_diagnostics(
-    command: &CommandFact<'_>,
+    command: CommandFactRef<'_, '_>,
     checker: &Checker<'_>,
     source: &str,
 ) -> Vec<crate::Diagnostic> {

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -80,7 +80,7 @@ fn command_exempts_glob_warning(command: Option<&str>) -> bool {
 }
 
 fn command_has_separator_before(
-    command: &crate::facts::CommandFact<'_>,
+    command: crate::facts::CommandFactRef<'_, '_>,
     target_span: Span,
     source: &str,
 ) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
+++ b/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
@@ -29,7 +29,7 @@ pub fn local_cross_reference(checker: &mut Checker) {
 
 fn declaration_cross_reference_spans(
     checker: &Checker<'_>,
-    fact: &crate::CommandFact<'_>,
+    fact: crate::CommandFactRef<'_, '_>,
 ) -> Vec<Span> {
     let Some(declaration) = fact.declaration() else {
         return Vec::new();

--- a/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
@@ -31,7 +31,7 @@ pub fn non_shell_syntax_in_script(checker: &mut Checker) {
 }
 
 fn non_shell_syntax_span(
-    command: &crate::CommandFact<'_>,
+    command: crate::CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<shuck_ast::Span> {
     if command.stmt().terminator != Some(StmtTerminator::Semicolon) {

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -499,7 +499,7 @@ struct OpenCommand {
 }
 
 fn build_innermost_command_ids_by_offset(
-    commands: &[crate::facts::CommandFact<'_>],
+    commands: crate::facts::CommandFacts<'_, '_>,
     mut offsets: Vec<usize>,
 ) -> FxHashMap<usize, Option<CommandId>> {
     if offsets.is_empty() {

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -28,7 +28,7 @@ pub fn redirect_clobbers_input(checker: &mut Checker) {
     checker.report_all_dedup(spans, || RedirectClobbersInput);
 }
 
-fn clobber_spans_for_command(fact: &crate::CommandFact<'_>) -> Vec<Span> {
+fn clobber_spans_for_command(fact: crate::CommandFactRef<'_, '_>) -> Vec<Span> {
     if fact.effective_name_is("echo") || fact.effective_name_is("printf") {
         return Vec::new();
     }

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
@@ -59,7 +59,7 @@ pub(crate) fn unchecked_directory_change_spans(checker: &mut Checker) -> Vec<(&'
         .collect::<Vec<_>>()
 }
 
-pub(crate) fn report_span(fact: &crate::facts::CommandFact<'_>, source: &str) -> Span {
+pub(crate) fn report_span(fact: crate::facts::CommandFactRef<'_, '_>, source: &str) -> Span {
     match fact.command() {
         Command::Simple(command) => {
             let mut start = command.name.span.start;

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, CommandFact, ListFact, Rule, Violation, WrapperKind};
+use crate::{Checker, CommandFact, CommandFacts, ListFact, Rule, Violation, WrapperKind};
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Command as AstCommand, Name, Span};
 use shuck_semantic::{
@@ -246,7 +246,7 @@ fn span_is_inside_unreached_function(span: Span, function_spans: &[Span]) -> boo
 fn span_matches_short_circuit_skip(
     span: Span,
     short_circuit_lists: &[ListFact<'_>],
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     semantic_analysis: &SemanticAnalysis<'_>,
 ) -> bool {
     short_circuit_lists.iter().any(|list| {
@@ -271,7 +271,7 @@ fn span_matches_short_circuit_skip(
 
 fn list_starts_with_condition(
     list: &ListFact<'_>,
-    commands: &[CommandFact<'_>],
+    commands: CommandFacts<'_, '_>,
     semantic_analysis: &SemanticAnalysis<'_>,
 ) -> bool {
     let Some(first_segment) = list.segments().first() else {
@@ -291,7 +291,7 @@ fn list_starts_with_condition(
             Some("[" | "test" | "true" | "false")
         );
 
-    starts_like_condition && !command_name_resolves_to_function(command, semantic_analysis)
+    starts_like_condition && !command_name_resolves_to_function(&command, semantic_analysis)
 }
 
 fn command_name_resolves_to_function(

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -1,6 +1,6 @@
 use shuck_ast::{Span, static_word_text};
 
-use crate::{Checker, CommandFact, PipelineFact, Rule, Violation};
+use crate::{Checker, CommandFactRef, PipelineFact, Rule, Violation};
 
 pub struct GrepCountPipeline;
 
@@ -59,7 +59,7 @@ fn unsafe_grep_count_pipeline_spans(
         .collect()
 }
 
-fn command_body_span(fact: &CommandFact<'_>) -> Option<Span> {
+fn command_body_span(fact: CommandFactRef<'_, '_>) -> Option<Span> {
     let body_name = fact.body_name_word()?;
     let mut end = body_name.span.end;
 
@@ -79,11 +79,11 @@ fn command_body_span(fact: &CommandFact<'_>) -> Option<Span> {
     Some(Span::from_positions(body_name.span.start, end))
 }
 
-fn is_raw_utility_named(fact: &CommandFact<'_>, name: &str) -> bool {
+fn is_raw_utility_named(fact: CommandFactRef<'_, '_>, name: &str) -> bool {
     fact.literal_name() == Some(name) && fact.wrappers().is_empty()
 }
 
-fn wc_uses_line_count(fact: &CommandFact<'_>, source: &str) -> bool {
+fn wc_uses_line_count(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
     fact.body_args().iter().any(|word| {
         static_word_text(word, source).is_some_and(|text| {
             text == "-l" || text == "--lines" || (text.starts_with('-') && text[1..].contains('l'))

--- a/crates/shuck-linter/src/rules/portability/array_assignment.rs
+++ b/crates/shuck-linter/src/rules/portability/array_assignment.rs
@@ -29,7 +29,10 @@ pub fn array_assignment(checker: &mut Checker) {
     checker.report_all_dedup(spans, || ArrayAssignment);
 }
 
-fn command_array_assignment_spans(command: &crate::CommandFact<'_>, source: &str) -> Vec<Span> {
+fn command_array_assignment_spans(
+    command: crate::CommandFactRef<'_, '_>,
+    source: &str,
+) -> Vec<Span> {
     match command.command() {
         Command::Simple(command) => command
             .assignments

--- a/crates/shuck-linter/src/rules/portability/declare_command.rs
+++ b/crates/shuck-linter/src/rules/portability/declare_command.rs
@@ -49,7 +49,7 @@ pub fn declare_command(checker: &mut Checker) {
     }
 }
 
-fn portability_builtin_name(fact: &crate::CommandFact<'_>) -> Option<&'static str> {
+fn portability_builtin_name(fact: crate::CommandFactRef<'_, '_>) -> Option<&'static str> {
     match fact.effective_or_literal_name()? {
         "declare" => Some("declare"),
         "typeset" => Some("typeset"),
@@ -68,7 +68,7 @@ fn portability_builtin_name(fact: &crate::CommandFact<'_>) -> Option<&'static st
     }
 }
 
-fn declaration_command_anchor_span(fact: &crate::CommandFact<'_>, source: &str) -> Span {
+fn declaration_command_anchor_span(fact: crate::CommandFactRef<'_, '_>, source: &str) -> Span {
     let start = declaration_command_anchor_start(fact, source);
 
     if let Some(declaration) = fact.declaration() {
@@ -81,7 +81,7 @@ fn declaration_command_anchor_span(fact: &crate::CommandFact<'_>, source: &str) 
 }
 
 fn declaration_command_anchor_start(
-    fact: &crate::CommandFact<'_>,
+    fact: crate::CommandFactRef<'_, '_>,
     source: &str,
 ) -> shuck_ast::Position {
     if !fact.wrappers().is_empty() {
@@ -101,7 +101,7 @@ fn declaration_command_anchor_start(
         .unwrap_or_else(|| fact.span().start)
 }
 
-fn effective_name_span(fact: &crate::CommandFact<'_>, source: &str) -> Option<Span> {
+fn effective_name_span(fact: crate::CommandFactRef<'_, '_>, source: &str) -> Option<Span> {
     let word = fact.body_name_word()?;
     let name = fact.effective_or_literal_name()?;
     let text = word.span.slice(source);
@@ -114,7 +114,7 @@ fn effective_name_span(fact: &crate::CommandFact<'_>, source: &str) -> Option<Sp
 }
 
 fn declaration_anchor_end(
-    fact: &crate::CommandFact<'_>,
+    fact: crate::CommandFactRef<'_, '_>,
     mut end: shuck_ast::Position,
     source: &str,
 ) -> shuck_ast::Position {
@@ -127,7 +127,7 @@ fn declaration_anchor_end(
     clip_terminator(fact, end, source)
 }
 
-fn command_anchor_end(fact: &crate::CommandFact<'_>, source: &str) -> shuck_ast::Position {
+fn command_anchor_end(fact: crate::CommandFactRef<'_, '_>, source: &str) -> shuck_ast::Position {
     let end = fact
         .shellcheck_command_span(source)
         .map(|span| span.end)
@@ -136,7 +136,7 @@ fn command_anchor_end(fact: &crate::CommandFact<'_>, source: &str) -> shuck_ast:
 }
 
 fn clip_terminator(
-    fact: &crate::CommandFact<'_>,
+    fact: crate::CommandFactRef<'_, '_>,
     mut end: shuck_ast::Position,
     _source: &str,
 ) -> shuck_ast::Position {

--- a/crates/shuck-linter/src/rules/portability/source_common.rs
+++ b/crates/shuck-linter/src/rules/portability/source_common.rs
@@ -1,6 +1,6 @@
 use shuck_ast::{Command, Redirect, SimpleCommand, Span};
 
-use crate::{Checker, CommandFact, ShellDialect};
+use crate::{Checker, CommandFactRef, ShellDialect};
 
 pub(super) fn source_command_spans_in_sh(checker: &Checker<'_>) -> Vec<Span> {
     if !matches!(checker.shell(), ShellDialect::Sh | ShellDialect::Dash) {
@@ -17,7 +17,10 @@ pub(super) fn source_command_spans_in_sh(checker: &Checker<'_>) -> Vec<Span> {
         .collect()
 }
 
-pub(super) fn source_anchor_span_for_command_fact(fact: &CommandFact<'_>, source: &str) -> Span {
+pub(super) fn source_anchor_span_for_command_fact(
+    fact: CommandFactRef<'_, '_>,
+    source: &str,
+) -> Span {
     source_anchor_span(fact.command(), fact.redirects(), fact.span(), source)
 }
 

--- a/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
@@ -1,7 +1,7 @@
 use shuck_ast::Span;
 use shuck_semantic::{ScopeKind, SourceRef, SourceRefKind};
 
-use crate::{Checker, CommandFact, Rule, ShellDialect, Violation};
+use crate::{Checker, CommandFactRef, Rule, ShellDialect, Violation};
 
 use super::source_common::source_anchor_span_for_command_fact;
 
@@ -39,10 +39,10 @@ pub fn source_inside_function_in_sh(checker: &mut Checker) {
     checker.report_all(spans, || SourceInsideFunctionInSh);
 }
 
-fn source_command_for_ref<'a>(
-    checker: &'a Checker<'_>,
+fn source_command_for_ref<'checker, 'ast>(
+    checker: &'checker Checker<'ast>,
     source_ref: &SourceRef,
-) -> Option<&'a CommandFact<'a>> {
+) -> Option<CommandFactRef<'checker, 'ast>> {
     checker
         .facts()
         .commands()

--- a/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
+++ b/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
@@ -30,7 +30,7 @@ pub fn avoid_let_builtin(checker: &mut Checker) {
     checker.report_all(spans, || AvoidLetBuiltin);
 }
 
-fn let_command_span(source: &str, fact: &crate::facts::CommandFact<'_>) -> Option<Span> {
+fn let_command_span(source: &str, fact: crate::facts::CommandFactRef<'_, '_>) -> Option<Span> {
     let name = fact.body_name_word()?;
     let mut end = fact
         .body_args()

--- a/crates/shuck-linter/src/rules/style/combine_appends.rs
+++ b/crates/shuck-linter/src/rules/style/combine_appends.rs
@@ -154,10 +154,10 @@ fn append_target_for_statement(
     }
 }
 
-fn commands_for_statement<'a>(
-    checker: &'a Checker<'_>,
+fn commands_for_statement<'checker, 'ast>(
+    checker: &'checker Checker<'ast>,
     statement: &StatementFact,
-) -> Vec<&'a crate::CommandFact<'a>> {
+) -> Vec<crate::CommandFactRef<'checker, 'ast>> {
     let command = checker.facts().command(statement.command_id());
     let mut command_ids = FxHashSet::default();
     let mut commands = Vec::new();

--- a/crates/shuck-linter/src/rules/style/local_declare_combined.rs
+++ b/crates/shuck-linter/src/rules/style/local_declare_combined.rs
@@ -32,7 +32,7 @@ pub fn local_declare_combined(checker: &mut Checker) {
     checker.report_all_dedup(spans, || LocalDeclareCombined);
 }
 
-fn declaration_combination_span(fact: &crate::CommandFact<'_>) -> Option<shuck_ast::Span> {
+fn declaration_combination_span(fact: crate::CommandFactRef<'_, '_>) -> Option<shuck_ast::Span> {
     let declaration = fact.declaration()?;
     let expected = match declaration.kind {
         DeclarationKind::Local => "declare",

--- a/crates/shuck-linter/src/rules/style/ls_grep_pipeline.rs
+++ b/crates/shuck-linter/src/rules/style/ls_grep_pipeline.rs
@@ -34,7 +34,7 @@ pub fn ls_grep_pipeline(checker: &mut Checker) {
     checker.report_all_dedup(spans, || LsGrepPipeline);
 }
 
-fn is_raw_utility_named(fact: &crate::CommandFact<'_>, name: &str) -> bool {
+fn is_raw_utility_named(fact: crate::CommandFactRef<'_, '_>, name: &str) -> bool {
     fact.literal_name() == Some(name) && fact.wrappers().is_empty()
 }
 

--- a/crates/shuck-linter/src/rules/style/ls_piped_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/style/ls_piped_to_xargs.rs
@@ -34,7 +34,7 @@ pub fn ls_piped_to_xargs(checker: &mut Checker) {
     checker.report_all_dedup(spans, || LsPipedToXargs);
 }
 
-fn is_raw_command_named(fact: &crate::CommandFact<'_>, name: &str) -> bool {
+fn is_raw_command_named(fact: crate::CommandFactRef<'_, '_>, name: &str) -> bool {
     fact.literal_name() == Some(name) && fact.wrappers().is_empty()
 }
 

--- a/crates/shuck-linter/src/rules/style/ps_grep_pipeline.rs
+++ b/crates/shuck-linter/src/rules/style/ps_grep_pipeline.rs
@@ -1,6 +1,6 @@
 use shuck_ast::Span;
 
-use crate::{Checker, CommandFact, PipelineFact, Rule, Violation};
+use crate::{Checker, CommandFactRef, PipelineFact, Rule, Violation};
 
 pub struct PsGrepPipeline;
 
@@ -46,7 +46,7 @@ fn unsafe_ps_grep_pipeline_spans(checker: &Checker<'_>, pipeline: &PipelineFact<
         .collect()
 }
 
-fn command_body_span(fact: &CommandFact<'_>) -> Option<Span> {
+fn command_body_span(fact: CommandFactRef<'_, '_>) -> Option<Span> {
     let body_name = fact.body_name_word()?;
     let mut end = body_name.span.end;
 
@@ -66,7 +66,7 @@ fn command_body_span(fact: &CommandFact<'_>) -> Option<Span> {
     Some(Span::from_positions(body_name.span.start, end))
 }
 
-fn is_raw_utility_named(fact: &CommandFact<'_>, name: &str) -> bool {
+fn is_raw_utility_named(fact: CommandFactRef<'_, '_>, name: &str) -> bool {
     fact.literal_name() == Some(name) && fact.wrappers().is_empty()
 }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
@@ -1,6 +1,6 @@
 use shuck_ast::static_word_text;
 
-use crate::{Checker, CommandFact, ExpansionContext, Rule, Violation, WordFactContext};
+use crate::{Checker, CommandFactRef, ExpansionContext, Rule, Violation, WordFactContext};
 
 pub struct UnquotedPathInMkdir;
 
@@ -35,7 +35,7 @@ pub fn unquoted_path_in_mkdir(checker: &mut Checker) {
     checker.report_all_dedup(spans, || UnquotedPathInMkdir);
 }
 
-fn mkdir_path_operand_spans(command: &CommandFact<'_>, source: &str) -> Vec<shuck_ast::Span> {
+fn mkdir_path_operand_spans(command: CommandFactRef<'_, '_>, source: &str) -> Vec<shuck_ast::Span> {
     let mut spans = Vec::new();
     let mut options_open = true;
     let mut expects_mode_operand = false;

--- a/specs/015-indexed-arenas.md
+++ b/specs/015-indexed-arenas.md
@@ -1,0 +1,91 @@
+# 015: Indexed Arenas
+
+## Status
+
+Proposed
+
+## Summary
+
+Move Shuck toward compact indexed storage for both parsed syntax and derived facts, with two separate arenas: an AST arena owned by parsed files and a fact arena owned by analysis. The first implementation milestone packs linter fact child lists behind compatibility accessors while leaving the recursive AST intact. A later milestone migrates `shuck-ast::File` to an ID-backed `AstStore`.
+
+## Motivation
+
+The current AST is easy to consume but allocation-heavy: statements, commands, words, patterns, redirects, and several expression forms carry nested `Vec` and `Box` fields. Linter facts compound that cost by storing many per-command child lists as individual boxed slices. Large-corpus profiling has shown the linter phase can allocate heavily, so the fastest visible win is to pack fact lists first.
+
+The migration must preserve source-backed text and avoid spreading arena lifetimes through the public APIs. Diagnostics, formatter mutation, cache keys, and semantic analysis all benefit from stable IDs and spans, but they should not depend on one global bump arena of borrowed AST nodes.
+
+## Design
+
+### Shared Arena Primitives
+
+`shuck-ast` provides reusable typed arena helpers:
+
+```rust
+pub struct Idx<T>(u32);
+pub struct IdRange<T> { start: u32, len: u32 }
+pub struct ListArena<T> { items: Vec<T> }
+```
+
+These types are intentionally small and dependency-free. They panic if an index or range cannot fit in `u32`, which keeps stored IDs compact and makes overflow failures explicit during construction. `ListArena<T>` is append-only and returns `IdRange<T>` values for variable-length child lists.
+
+### Fact Arena First
+
+`LinterFacts` keeps the existing rule-facing surface while packing high-churn child lists:
+
+- `CommandFact::redirect_facts()`
+- `CommandFact::substitution_facts()`
+- `CommandFact::scope_read_source_words()`
+- command-local comparable name-use buckets
+- `CommandFact::declaration_assignment_probes()`
+- word-occurrence IDs by command
+
+Each parent fact stores a typed range. The backing storage is a contiguous side array. During the compatibility phase, `CommandFact` exposes the same slice-returning methods by holding packed slice handles, so rules do not need broad edits.
+
+Facts continue to reference AST nodes through existing borrowed AST views and spans for now. The AST migration will replace those references with AST IDs once `AstStore` exists.
+
+### AST Arena Later
+
+The later AST milestone introduces:
+
+```rust
+pub struct ParsedFile {
+    pub source: Arc<str>,
+    pub ast: AstStore,
+    pub root: StmtSeqId,
+    pub syntax_facts: SyntaxFacts,
+}
+```
+
+`AstStore` owns typed node arrays for statements, commands, words, word parts, patterns, arithmetic expressions, redirects, comments, and syntax extras. Variable-length children use `IdRange<T>` rather than per-node vectors. Text remains source-backed through spans and existing source-text wrappers; owned strings remain reserved for cooked or synthetic text.
+
+### Boundary Between Layers
+
+The AST and fact arenas stay separate. Facts should eventually store AST IDs, not references to AST nodes. That keeps derived facts compact, avoids lifetime coupling, and gives diagnostics and formatter analysis a stable source-node identity.
+
+## Alternatives Considered
+
+### One Global Bump Arena
+
+A single bump-allocated world of `&'arena` AST and fact references would reduce allocation overhead, but it would spread lifetimes through parser, semantic, linter, formatter, cache, and diagnostic APIs. It also makes formatter mutation awkward. This design rejects the global arena in favor of owned stores and typed IDs.
+
+### Convert AST First
+
+Converting the AST first attacks parser allocations directly, but it has a large blast radius across parser tests, semantic traversal, formatter logic, and rule internals. Packing facts first gives an incremental performance win while establishing the ID/range vocabulary the AST migration will reuse.
+
+### Change Rule APIs Immediately
+
+Rules could switch directly from `&CommandFact` slices to explicit fact views over `FactStore`. That is the end-state shape, but doing it in the first patch would mix storage migration with rule rewrites. Compatibility accessors keep the first milestone behavior-preserving.
+
+## Verification
+
+- `cargo test -p shuck-ast`
+- `cargo test -p shuck-linter`
+- `cargo test -p shuck-semantic`
+- `cargo test -p shuck-parser`
+- `cargo test -p shuck-formatter`
+- `make test`
+- `cargo bench -p shuck-benchmark --bench large_corpus_hotspots`
+- `cargo bench -p shuck-benchmark --bench check_command`
+- `make bench-memory-compare`
+
+For the fact-packing milestone, rule snapshots should not change. Benchmark runs should show no throughput regression before continuing to the AST migration.


### PR DESCRIPTION
## Summary

- Add shared typed arena primitives in `shuck-ast` plus the indexed-arenas design spec.
- Pack linter fact child lists into a `Vec`-backed `FactStore` with typed ranges.
- Preserve rule-facing APIs through `CommandFactRef` / `CommandFacts` compatibility views.

## Validation

- `make test`
- `git diff --check`

## Benchmark Notes

Earlier local runs against the matching base showed `linter_facts/all` improving by roughly 30%, `linter/all` statistically neutral, parser memory unchanged, and large-corpus word facts improved. The `check_command` aggregate remained noisy, so this PR keeps the AST migration out of scope until the facts API settles.