### PR TITLE
fix(linter): add C006 parameter guard flow

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -3,9 +3,6 @@ reviewed_divergences:
     path_suffix: "acmesh-official__acme.sh__acme.sh"
     reason: "This acme.sh helper uses directive-heavy project-local plumbing that ShellCheck leaves alone in the corpus run, so we review this file narrowly instead of teaching C006 a special helper contract."
   - side: shuck-only
-    path_suffix: "acmesh-official__acme.sh__dnsapi__dns_dnsservices.sh"
-    reason: "This acme.sh helper uses directive-heavy project-local plumbing that ShellCheck leaves alone in the corpus run, so we review this file narrowly instead of teaching C006 a special helper contract."
-  - side: shuck-only
     path_suffix: "nvm-sh__nvm__test__fast__Unit tests__nvm_install_no_progress_bar"
     reason: "This nvm test harness reads helper-produced line bookkeeping that ShellCheck does not compare as live state in the corpus run."
   - side: shellcheck-only
@@ -23,23 +20,14 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__cli"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__docs"
-    reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__extras__rails"
     reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__build_config_system"
-    reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__cli"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__gemset"
-    reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__init"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__installer"
@@ -53,9 +41,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__base_install"
-    reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_install"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
@@ -104,14 +89,8 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__requirements__netbsd"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__rubygems"
-    reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__rubygems"
-    reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__rvmrc"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__rvmrc_set"
@@ -125,9 +104,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__selector"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__support"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__support"
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
@@ -137,9 +113,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__gemsets"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__help"
-    reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__info"
     reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
@@ -152,78 +125,18 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__list"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__maglev"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__maglev"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__migrate"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__notes"
     reason: "This RVM helper still surfaces a file-local unresolved helper read under Shuck's project-local analysis, and we keep it reviewed narrowly instead of hard-coding RVM-specific ambient variables."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__rvm"
-    reason: "This RVM helper still depends on project-local helper state that we are not modeling with a repo-specific ambient table, so the remaining ShellCheck-only hit stays reviewed for this file."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__tsocks__04_getpeername.patch"
-    reason: "This patch fixture contains generated configure-style placeholders that ShellCheck does not compare as live shell variables in the corpus run."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__scripts__config.guess"
-    reason: "This imported config.guess helper is directive-heavy, and ShellCheck stays quiet on this exact placeholder read in the corpus run."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__x11-packages__librewolf__build.sh"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__librewolf__build.sh"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__cmake.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__fetch.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__build-style__gem.sh"
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__gemspec.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__build-style__gemspec.sh"
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__go.sh"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__build-style__go.sh"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__haskell-stack.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__perl-module.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__python3-pep517.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__qmake.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__sip-build.sh"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__build-style__sip-build.sh"
-    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__texmf.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__build-style__void-cross.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__chroot-style__ethereal.sh"
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
@@ -234,59 +147,14 @@ reviewed_divergences:
     path_suffix: "void-linux__void-packages__common__environment__setup__sourcepkg.sh"
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__hooks__post-install__04-create-xbps-metadata-scripts.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__hooks__post-install__04-create-xbps-metadata-scripts.sh"
-    reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__hooks__post-install__15-qt-private-api.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__hooks__post-install__15-qt-private-api.sh"
-    reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__hooks__pre-pkg__04-generate-runtime-deps.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__hooks__pre-pkg__99-pkglint.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__xbps-src__libexec__build.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__build_dependencies.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__bulk.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__pkgtarget.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__show.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__common__xbps-src__shutils__update_check.sh"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__srcpkgs__xbps-triggers__files__pycompile"
-    reason: "This Void helper relies on framework variables supplied by the surrounding xbps-src flow, and ShellCheck still reports the remaining first-hit sites here. We review this file narrowly instead of adding a blanket shell-collapse exception."
-  - side: shellcheck-only
     path_suffix: "docker-library__official-images__test__config.sh"
     reason: "This generated test matrix is just a bundle of image-to-test mappings, so the ShellCheck-only C006 hits are the literal associative-array keys in those compound assignments rather than live variable reads."
-  - side: shellcheck-only
-    path_suffix: "moovweb__gvm__examples__native__configure"
-    reason: "This generated configure script threads Autoconf cleanup and reporting state through a trap block, and the remaining ShellCheck-only read is part of that template-driven control flow."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__depcomp"
     reason: "This generated dependency helper uses build-time placeholders such as `object` and `source` to rewrite depfiles, so the ShellCheck-only hits are expected template plumbing here."
   - side: shellcheck-only
     path_suffix: "moovweb__gvm__examples__native__install-sh"
     reason: "This generated install helper carries a trap around its temporary-directory probe, and the remaining ShellCheck-only read is part of that cleanup path."
-  - side: shellcheck-only
-    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
-    reason: "This generated libtool script exports template/config symbols like `macro_version`, `lt_sysroot`, `finish_cmds`, and `hardcode_libdir_flag_spec`, so the remaining ShellCheck-only hits are part of the generated configuration surface rather than handwritten shell logic."
   - side: shellcheck-only
     path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__info_stats.sh"
     reason: "This stats module assembles an analytics payload from module-populated globals, so the ShellCheck-only reads are the expected framework contract rather than uncaught local assignments."
@@ -326,12 +194,6 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "leebaird__discover__dev-api-scanner.sh"
     reason: "This scanner builds an output filename from the current CORS origin, and the remaining ShellCheck-only anchor is the lower-case slug fragment inside that generated path. We review this one file narrowly instead of broadening C006 around the helper's filename templating."
-  - side: shellcheck-only
-    path_suffix: "gentoo__gentoo__sys-apps__memtest86+__files__39_memtest86+-r2"
-    reason: "This GRUB menu helper sources grub-mkconfig_lib and only uses grub_tab to indent generated submenu output, so the remaining ShellCheck-only hit is a sourced helper contract rather than a missing local assignment."
-  - side: shellcheck-only
-    path_suffix: "gentoo__gentoo__sys-apps__memtest86+__files__39_memtest86+-r3"
-    reason: "This GRUB menu helper sources grub-mkconfig_lib and only uses grub_tab to indent generated submenu output, so the remaining ShellCheck-only hit is a sourced helper contract rather than a missing local assignment."
   - side: shuck-only
     path_suffix: "233boy__v2ray__src__old.sh"
     reason: "This legacy V2Ray helper threads transport choice through sourced installer plumbing, so the remaining C006 read is a repo-local runtime handoff rather than a free-standing missing assignment."
@@ -343,9 +205,6 @@ reviewed_divergences:
     reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
     path_suffix: "Bash-it__bash-it__completion__available__git.completion.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__completion__available__gradle.completion.bash"
     reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
     path_suffix: "Bash-it__bash-it__completion__available__ng.completion.bash"
@@ -363,25 +222,10 @@ reviewed_divergences:
     path_suffix: "Bash-it__bash-it__scripts__reloader.bash"
     reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
-    path_suffix: "Bash-it__bash-it__themes__inretio__inretio.theme.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
     path_suffix: "Bash-it__bash-it__themes__liquidprompt__liquidprompt.theme.bash"
     reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
-    path_suffix: "Bash-it__bash-it__themes__nwinkler_random_colors__nwinkler_random_colors.theme.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__themes__wanelo__wanelo.theme.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__check_config.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
     path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_backup.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_debug.sh"
     reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
   - side: shuck-only
     path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_start.sh"
@@ -390,47 +234,11 @@ reviewed_divergences:
     path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_ts3_server_pass.sh"
     reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
   - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__info_messages.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
     path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__info_stats.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_fctr.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_jk2.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_mc.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_mcb.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_mta.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_pmc.sh"
     reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
   - side: shuck-only
     path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_steamcmd.sh"
     reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_ts3.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_ut99.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_vints.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__update_xnt.sh"
-    reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "HariSekhon__DevOps-Bash-tools__lib__aws.sh"
-    reason: "This Bash-tools fixture reads library-managed region, timestamp, or template state populated by sourced wrappers and sibling helpers, so the remaining C006 hits are reviewed library contracts rather than isolated undefined locals."
   - side: shuck-only
     path_suffix: "HariSekhon__DevOps-Bash-tools__terraform__terraform_resources.sh"
     reason: "This Bash-tools fixture reads library-managed region, timestamp, or template state populated by sourced wrappers and sibling helpers, so the remaining C006 hits are reviewed library contracts rather than isolated undefined locals."
@@ -528,22 +336,10 @@ reviewed_divergences:
     path_suffix: "leebaird__discover__misc__crack-wifi.sh"
     reason: "This interactive helper threads prompt-loop state through earlier control-flow branches, so the remaining C006 read is a reviewed loop-state handoff rather than an isolated undefined local."
   - side: shuck-only
-    path_suffix: "moovweb__gvm__examples__native__configure"
-    reason: "This GVM fixture mixes generated Autotools scripts or wrapper state sourced from the surrounding toolchain environment, so the remaining C006 hits are reviewed template or wrapper contracts rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
-    reason: "This GVM fixture mixes generated Autotools scripts or wrapper state sourced from the surrounding toolchain environment, so the remaining C006 hits are reviewed template or wrapper contracts rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "moovweb__gvm__scripts__env__pkgset-use"
-    reason: "This GVM fixture mixes generated Autotools scripts or wrapper state sourced from the surrounding toolchain environment, so the remaining C006 hits are reviewed template or wrapper contracts rather than missing local assignments."
-  - side: shuck-only
     path_suffix: "openrc__openrc__sh__rc-cgroup.sh"
     reason: "This OpenRC helper expects daemon options or service-command lists to arrive from the wider service runtime, so the remaining C006 hits are reviewed service-framework reads rather than standalone assignment bugs."
   - side: shuck-only
     path_suffix: "openrc__openrc__sh__s6.sh"
-    reason: "This OpenRC helper expects daemon options or service-command lists to arrive from the wider service runtime, so the remaining C006 hits are reviewed service-framework reads rather than standalone assignment bugs."
-  - side: shuck-only
-    path_suffix: "openrc__openrc__sh__start-stop-daemon.sh"
     reason: "This OpenRC helper expects daemon options or service-command lists to arrive from the wider service runtime, so the remaining C006 hits are reviewed service-framework reads rather than standalone assignment bugs."
   - side: shuck-only
     path_suffix: "openrc__openrc__sh__supervise-daemon.sh"
@@ -551,13 +347,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
     reason: "This Easy-RSA front-end carries shell-mode and temporary-file bookkeeping through long helper-driven control flow, so the remaining C006 reads are reviewed runtime handoffs rather than missing local assignments."
-  - side: shellcheck-only
-    path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
-    line: 3780
-    end_line: 3780
-    column: 38
-    end_column: 52
-    reason: "This exact Easy-RSA read sits in a region Shuck classifies as unreachable through an exit-helper path, so the remaining oracle-side C006 gap stays reviewed narrowly instead of widening undefined-variable reporting in unreachable code."
   - side: shuck-only
     path_suffix: "rupa__z__z.sh"
     reason: "This directory-ranking helper builds matcher state through branch-local accumulators, so the remaining C006 read is a reviewed control-flow handoff rather than an isolated undefined local."
@@ -655,17 +444,5 @@ reviewed_divergences:
     path_suffix: "rvm__rvm__scripts__tools"
     reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."
   - side: shuck-only
-    path_suffix: "scop__bash-completion__completions-core__tar.bash"
-    reason: "This bash-completion fixture threads parser indices or subcommand tables through sourced completion callbacks, so the remaining C006 hits are reviewed completion-runtime state rather than missing local assignments."
-  - side: shuck-only
-    path_suffix: "scop__bash-completion__completions-core__tmux.bash"
-    reason: "This bash-completion fixture threads parser indices or subcommand tables through sourced completion callbacks, so the remaining C006 hits are reviewed completion-runtime state rather than missing local assignments."
-  - side: shuck-only
     path_suffix: "tj__git-extras__bin__git-brv"
     reason: "This formatter computes column widths across earlier display branches, so the remaining C006 reads are reviewed layout-state handoffs rather than isolated undefined locals."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__scripts__lint-conflicts"
-    reason: "This xbps-src helper fills pair state while walking conflict groups, so the remaining C006 read is a reviewed packaging-framework handoff rather than a standalone missing assignment."
-  - side: shuck-only
-    path_suffix: "xwmx__nb__nb"
-    reason: "This note-search helper builds query fragments through recursive filter assembly, so the remaining C006 read is a reviewed builder-state handoff rather than an isolated undefined local."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -194,6 +194,12 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "leebaird__discover__dev-api-scanner.sh"
     reason: "This scanner builds an output filename from the current CORS origin, and the remaining ShellCheck-only anchor is the lower-case slug fragment inside that generated path. We review this one file narrowly instead of broadening C006 around the helper's filename templating."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__sys-apps__memtest86+__files__39_memtest86+-r2"
+    reason: "This GRUB menu helper sources grub-mkconfig_lib and only uses grub_tab to indent generated submenu output, so the remaining ShellCheck-only hit is a sourced helper contract rather than a missing local assignment."
+  - side: shellcheck-only
+    path_suffix: "gentoo__gentoo__sys-apps__memtest86+__files__39_memtest86+-r3"
+    reason: "This GRUB menu helper sources grub-mkconfig_lib and only uses grub_tab to indent generated submenu output, so the remaining ShellCheck-only hit is a sourced helper contract rather than a missing local assignment."
   - side: shuck-only
     path_suffix: "233boy__v2ray__src__old.sh"
     reason: "This legacy V2Ray helper threads transport choice through sourced installer plumbing, so the remaining C006 read is a repo-local runtime handoff rather than a free-standing missing assignment."

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3240,7 +3240,7 @@ printf '%s\\n' \"$fallback_name\" \"$seed_name\" \"$replacement_name\" \"$hint_n
 ";
         let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
 
-        assert_eq!(diagnostics.len(), 4);
+        assert_eq!(diagnostics.len(), 5);
         assert!(
             diagnostics
                 .iter()
@@ -3251,7 +3251,7 @@ printf '%s\\n' \"$fallback_name\" \"$seed_name\" \"$replacement_name\" \"$hint_n
                 .iter()
                 .any(|d| d.message.contains("fallback_name"))
         );
-        assert!(diagnostics.iter().all(|d| !d.message.contains("seed_name")));
+        assert!(diagnostics.iter().any(|d| d.message.contains("seed_name")));
         assert!(
             diagnostics
                 .iter()

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3111,19 +3111,33 @@ printf '%s %s\\n' \"$missing\" \"$also_missing\"
     }
 
     #[test]
-    fn undefined_variable_uses_first_plain_read_after_ignored_occurrences() {
+    fn undefined_variable_parameter_guard_flow_respects_same_command_order() {
         let source = "\
 #!/bin/sh
-printf '%s\\n' \"${guarded:-fallback}\"
-printf '%s\\n' \"$guarded\"
-printf '%s\\n' \"$guarded\"
+printf '%s\\n' \"$before_default\" \"${before_default:-fallback}\"
+printf '%s\\n' \"${guarded:-fallback}\" \"$guarded\"
+printf '%s\\n' \"$plain_missing\"
 ";
         let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
-        assert!(diagnostics[0].message.contains("guarded"));
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics.len(), 2);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("before_default")
+                    && diagnostic.span.start.line == 2)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("plain_missing")
+                    && diagnostic.span.start.line == 4)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("guarded"))
+        );
     }
 
     #[test]
@@ -3226,7 +3240,7 @@ printf '%s\\n' \"$fallback_name\" \"$seed_name\" \"$replacement_name\" \"$hint_n
 ";
         let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
 
-        assert_eq!(diagnostics.len(), 5);
+        assert_eq!(diagnostics.len(), 4);
         assert!(
             diagnostics
                 .iter()
@@ -3237,7 +3251,7 @@ printf '%s\\n' \"$fallback_name\" \"$seed_name\" \"$replacement_name\" \"$hint_n
                 .iter()
                 .any(|d| d.message.contains("fallback_name"))
         );
-        assert!(diagnostics.iter().any(|d| d.message.contains("seed_name")));
+        assert!(diagnostics.iter().all(|d| !d.message.contains("seed_name")));
         assert!(
             diagnostics
                 .iter()

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -140,4 +140,22 @@ printf '%s\\n' \"$before_default\" \"${before_default:-fallback}\" \"$plain_miss
             vec!["$before_default", "$plain_missing"]
         );
     }
+
+    #[test]
+    fn parameter_guard_flow_does_not_escape_conditional_operands() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' \"${outer:+${nested_default:-fallback}}\" \"$outer\" \"$nested_default\"
+printf '%s\\n' \"${other:+${nested_replacement:+alt}}\" \"$other\" \"$nested_replacement\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UndefinedVariable));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$nested_default", "$nested_replacement"]
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -119,4 +119,25 @@ printf '%s\\n' \"$seed_name\" \"$hint_name\"
                 .all(|diagnostic| diagnostic.span.start.line == 3)
         );
     }
+
+    #[test]
+    fn parameter_guard_flow_suppresses_later_reads_of_the_guarded_name() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' \"${defaulted:-fallback}\" \"$defaulted\"
+printf '%s\\n' \"${assigned:=fallback}\" \"$assigned\"
+printf '%s\\n' \"${required:?missing}\" \"$required\"
+printf '%s\\n' \"${replacement:+alt}\" \"$replacement\"
+printf '%s\\n' \"$before_default\" \"${before_default:-fallback}\" \"$plain_missing\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UndefinedVariable));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$before_default", "$plain_missing"]
+        );
+    }
 }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -49,6 +49,7 @@ pub(crate) struct BuildOutput {
     pub(crate) reference_index: FxHashMap<Name, SmallVec<[ReferenceId; 2]>>,
     pub(crate) predefined_runtime_refs: FxHashSet<ReferenceId>,
     pub(crate) guarded_parameter_refs: FxHashSet<ReferenceId>,
+    pub(crate) parameter_guard_flow_refs: FxHashSet<ReferenceId>,
     pub(crate) defaulting_parameter_operand_refs: FxHashSet<ReferenceId>,
     pub(crate) binding_index: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     pub(crate) resolved: FxHashMap<ReferenceId, BindingId>,
@@ -78,6 +79,7 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     reference_index: FxHashMap<Name, SmallVec<[ReferenceId; 2]>>,
     predefined_runtime_refs: FxHashSet<ReferenceId>,
     guarded_parameter_refs: FxHashSet<ReferenceId>,
+    parameter_guard_flow_refs: FxHashSet<ReferenceId>,
     defaulting_parameter_operand_refs: FxHashSet<ReferenceId>,
     binding_index: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     resolved: FxHashMap<ReferenceId, BindingId>,
@@ -176,6 +178,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             reference_index: FxHashMap::default(),
             predefined_runtime_refs: FxHashSet::default(),
             guarded_parameter_refs: FxHashSet::default(),
+            parameter_guard_flow_refs: FxHashSet::default(),
             defaulting_parameter_operand_refs: FxHashSet::default(),
             binding_index: FxHashMap::default(),
             resolved: FxHashMap::default(),
@@ -216,6 +219,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             reference_index: builder.reference_index,
             predefined_runtime_refs: builder.predefined_runtime_refs,
             guarded_parameter_refs: builder.guarded_parameter_refs,
+            parameter_guard_flow_refs: builder.parameter_guard_flow_refs,
             defaulting_parameter_operand_refs: builder.defaulting_parameter_operand_refs,
             binding_index: builder.binding_index,
             resolved: builder.resolved,
@@ -1450,6 +1454,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 );
                 if parameter_operator_guards_unset_reference(operator) {
                     self.guarded_parameter_refs.insert(reference_id);
+                    self.parameter_guard_flow_refs.insert(reference_id);
                 }
                 if matches!(operator, ParameterOp::AssignDefault) {
                     self.add_parameter_default_binding(reference);
@@ -1792,6 +1797,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     );
                     if parameter_operator_guards_unset_reference(operator) {
                         self.guarded_parameter_refs.insert(reference_id);
+                        self.parameter_guard_flow_refs.insert(reference_id);
                     }
                     if matches!(operator, ParameterOp::AssignDefault) {
                         self.add_parameter_default_binding(reference);

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -5,8 +5,8 @@ use shuck_ast::{
     AnonymousFunctionCommand, ArithmeticAssignOp, ArithmeticExpr, ArithmeticExprNode,
     ArithmeticLvalue, ArithmeticUnaryOp, ArrayElem, ArrayExpr, ArrayKind, Assignment,
     AssignmentValue, BinaryCommand, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command,
-    CompoundCommand, ConditionalExpr, ConditionalUnaryOp, DeclOperand, File, FunctionDef,
-    HeredocBody, HeredocBodyPart, HeredocBodyPartNode, Name, ParameterExpansion,
+    CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclOperand, File,
+    FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, Name, ParameterExpansion,
     ParameterExpansionSyntax, ParameterOp, Pattern, PatternGroupKind, PatternPart, PatternPartNode,
     Span, StaticCommandWrapperTarget, Stmt, StmtSeq, Subscript, VarRef, Word, WordPart,
     WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
@@ -103,6 +103,7 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     command_stack: Vec<Span>,
     guarded_parameter_operand_depth: u32,
     defaulting_parameter_operand_depth: u32,
+    short_circuit_condition_depth: u32,
 }
 
 fn semantic_statement_span(stmt: &Stmt) -> Span {
@@ -202,6 +203,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             command_stack: Vec::new(),
             guarded_parameter_operand_depth: 0,
             defaulting_parameter_operand_depth: 0,
+            short_circuit_condition_depth: 0,
         };
         let file_commands = builder.visit_stmt_seq(&file.body, FlowState::default());
         builder.recorded_program.set_file_commands(file_commands);
@@ -2004,7 +2006,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn record_guarded_parameter_reference(&mut self, reference_id: ReferenceId) {
         self.guarded_parameter_refs.insert(reference_id);
-        if self.defaulting_parameter_operand_depth == 0 {
+        if self.defaulting_parameter_operand_depth == 0 && self.short_circuit_condition_depth == 0 {
             self.parameter_guard_flow_refs.insert(reference_id);
         }
     }
@@ -2051,7 +2053,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         match expression {
             ConditionalExpr::Binary(expr) => {
                 self.visit_conditional_expr_into(&expr.left, flow, nested_regions);
-                self.visit_conditional_expr_into(&expr.right, flow, nested_regions);
+                if matches!(expr.op, ConditionalBinaryOp::And | ConditionalBinaryOp::Or) {
+                    self.short_circuit_condition_depth += 1;
+                    self.visit_conditional_expr_into(&expr.right, flow, nested_regions);
+                    self.short_circuit_condition_depth -= 1;
+                } else {
+                    self.visit_conditional_expr_into(&expr.right, flow, nested_regions);
+                }
             }
             ConditionalExpr::Unary(expr) => {
                 if expr.op == ConditionalUnaryOp::VariableSet

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1453,8 +1453,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     reference.span,
                 );
                 if parameter_operator_guards_unset_reference(operator) {
-                    self.guarded_parameter_refs.insert(reference_id);
-                    self.parameter_guard_flow_refs.insert(reference_id);
+                    self.record_guarded_parameter_reference(reference_id);
                 }
                 if matches!(operator, ParameterOp::AssignDefault) {
                     self.add_parameter_default_binding(reference);
@@ -1796,8 +1795,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         span,
                     );
                     if parameter_operator_guards_unset_reference(operator) {
-                        self.guarded_parameter_refs.insert(reference_id);
-                        self.parameter_guard_flow_refs.insert(reference_id);
+                        self.record_guarded_parameter_reference(reference_id);
                     }
                     if matches!(operator, ParameterOp::AssignDefault) {
                         self.add_parameter_default_binding(reference);
@@ -2001,6 +1999,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             | ParameterOp::UpperAll
             | ParameterOp::LowerFirst
             | ParameterOp::LowerAll => {}
+        }
+    }
+
+    fn record_guarded_parameter_reference(&mut self, reference_id: ReferenceId) {
+        self.guarded_parameter_refs.insert(reference_id);
+        if self.defaulting_parameter_operand_depth == 0 {
+            self.parameter_guard_flow_refs.insert(reference_id);
         }
     }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -73,6 +73,7 @@ pub(crate) struct DataflowContext<'a> {
     pub(crate) references: &'a [Reference],
     pub(crate) predefined_runtime_refs: &'a FxHashSet<ReferenceId>,
     pub(crate) guarded_parameter_refs: &'a FxHashSet<ReferenceId>,
+    pub(crate) parameter_guard_flow_refs: &'a FxHashSet<ReferenceId>,
     pub(crate) resolved: &'a FxHashMap<ReferenceId, BindingId>,
     pub(crate) call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     pub(crate) indirect_targets_by_reference: &'a FxHashMap<ReferenceId, Vec<BindingId>>,
@@ -90,6 +91,7 @@ pub(crate) struct ExactVariableDataflow {
     unreachable_blocks: DenseBitSet,
     reaching_definitions: OnceLock<DenseReachingDefinitions>,
     initialized_name_states: OnceLock<DenseInitializedNameStates>,
+    c006_initialized_name_states: OnceLock<DenseInitializedNameStates>,
     scope_components: OnceLock<Vec<ExactScopeComponent>>,
 }
 
@@ -118,6 +120,32 @@ impl ExactVariableDataflow {
                 context.bindings,
                 &self.binding_data,
                 context.entry_bindings,
+            )
+        })
+    }
+
+    fn c006_initialized_name_states<'a>(
+        &'a self,
+        context: &DataflowContext<'_>,
+    ) -> &'a DenseInitializedNameStates {
+        self.c006_initialized_name_states.get_or_init(|| {
+            let extra_initialized_names = context
+                .parameter_guard_flow_refs
+                .iter()
+                .copied()
+                .filter_map(|reference_id| {
+                    let reference = &context.references[reference_id.index()];
+                    let block = self.reference_blocks[reference_id.index()]?;
+                    let name = self.names.get(&reference.name)?;
+                    Some((block, name))
+                })
+                .collect::<Vec<_>>();
+            compute_initialized_name_states_dense_with_extra_name_gens(
+                context.cfg,
+                context.bindings,
+                &self.binding_data,
+                context.entry_bindings,
+                &extra_initialized_names,
             )
         })
     }
@@ -227,6 +255,7 @@ pub(crate) fn build_exact_variable_dataflow(
         unreachable_blocks,
         reaching_definitions: OnceLock::new(),
         initialized_name_states: OnceLock::new(),
+        c006_initialized_name_states: OnceLock::new(),
         scope_components: OnceLock::new(),
     }
 }
@@ -261,7 +290,7 @@ fn analyze_uninitialized_references_exact(
     context: &DataflowContext<'_>,
     exact: &ExactVariableDataflow,
 ) -> Vec<UninitializedReference> {
-    let initialized_name_states = exact.initialized_name_states(context);
+    let initialized_name_states = exact.c006_initialized_name_states(context);
     let maybe_defined = &initialized_name_states.maybe_in;
     let definitely_defined = &initialized_name_states.definite_in;
 
@@ -303,8 +332,12 @@ fn analyze_uninitialized_references_exact(
         let Some(name_id) = exact.names.get(&reference.name) else {
             continue;
         };
-        let maybe = maybe_defined[block_id.index()].contains(name_id.index());
-        let definite = definitely_defined[block_id.index()].contains(name_id.index());
+        let same_block_guard = parameter_guard_flow_precedes_reference_in_same_block(
+            context, exact, reference, block_id,
+        );
+        let maybe = maybe_defined[block_id.index()].contains(name_id.index()) || same_block_guard;
+        let definite =
+            definitely_defined[block_id.index()].contains(name_id.index()) || same_block_guard;
 
         if !maybe {
             uninitialized_references.push(UninitializedReference {
@@ -320,6 +353,27 @@ fn analyze_uninitialized_references_exact(
     }
 
     uninitialized_references
+}
+
+fn parameter_guard_flow_precedes_reference_in_same_block(
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
+    reference: &Reference,
+    block_id: BlockId,
+) -> bool {
+    context
+        .parameter_guard_flow_refs
+        .iter()
+        .copied()
+        .any(|guard_id| {
+            guard_id != reference.id
+                && exact.reference_blocks[guard_id.index()] == Some(block_id)
+                && {
+                    let guard = &context.references[guard_id.index()];
+                    guard.name == reference.name
+                        && guard.span.start.offset < reference.span.start.offset
+                }
+        })
 }
 
 fn reference_resolves_to_file_entry_contract_variable(
@@ -1375,6 +1429,22 @@ fn compute_initialized_name_states_dense(
     binding_data: &DenseBindingData,
     entry_bindings: &[BindingId],
 ) -> DenseInitializedNameStates {
+    compute_initialized_name_states_dense_with_extra_name_gens(
+        cfg,
+        bindings,
+        binding_data,
+        entry_bindings,
+        &[],
+    )
+}
+
+fn compute_initialized_name_states_dense_with_extra_name_gens(
+    cfg: &ControlFlowGraph,
+    bindings: &[Binding],
+    binding_data: &DenseBindingData,
+    entry_bindings: &[BindingId],
+    extra_initialized_names: &[(BlockId, NameId)],
+) -> DenseInitializedNameStates {
     let entry_blocks = entry_binding_root_blocks(cfg);
     let block_count = cfg.blocks().len();
     let name_count = binding_data.bindings_for_name.len();
@@ -1398,6 +1468,11 @@ fn compute_initialized_name_states_dense(
                 None => {}
             }
         }
+    }
+
+    for (block, name) in extra_initialized_names {
+        maybe_gen[block.index()].insert(name.index());
+        definite_gen[block.index()].insert(name.index());
     }
 
     let mut entry_maybe = DenseBitSet::new(name_count);

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -432,6 +432,7 @@ pub struct SemanticModel {
     reference_index: FxHashMap<Name, SmallVec<[ReferenceId; 2]>>,
     predefined_runtime_refs: FxHashSet<ReferenceId>,
     guarded_parameter_refs: FxHashSet<ReferenceId>,
+    parameter_guard_flow_refs: FxHashSet<ReferenceId>,
     defaulting_parameter_operand_refs: FxHashSet<ReferenceId>,
     binding_index: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     resolved: FxHashMap<ReferenceId, BindingId>,
@@ -544,6 +545,7 @@ impl SemanticModel {
             reference_index,
             predefined_runtime_refs: built.predefined_runtime_refs,
             guarded_parameter_refs: built.guarded_parameter_refs,
+            parameter_guard_flow_refs: built.parameter_guard_flow_refs,
             defaulting_parameter_operand_refs: built.defaulting_parameter_operand_refs,
             binding_index: built.binding_index,
             resolved: built.resolved,
@@ -1199,6 +1201,7 @@ impl SemanticModel {
             references: &self.references,
             predefined_runtime_refs: &self.predefined_runtime_refs,
             guarded_parameter_refs: &self.guarded_parameter_refs,
+            parameter_guard_flow_refs: &self.parameter_guard_flow_refs,
             resolved: &self.resolved,
             call_sites: &self.call_sites,
             indirect_targets_by_reference: &self.indirect_targets_by_reference,
@@ -6514,6 +6517,68 @@ printf '%s\\n' \"$config_path\" \"$still_missing\"
             })
             .unwrap();
         assert_eq!(binding.span.slice(source), "${config_path:=/tmp/default}");
+    }
+
+    #[test]
+    fn parameter_guard_flow_initializes_later_c006_reads() {
+        let source = "\
+printf '%s\\n' \"${defaulted:-fallback}\"
+printf '%s\\n' \"${assigned:=fallback}\"
+printf '%s\\n' \"${required:?missing}\"
+printf '%s\\n' \"${replacement:+alt}\"
+printf '%s\\n' \"$defaulted\" \"$assigned\" \"$required\" \"$replacement\" \"$still_missing\"
+";
+        let model = model(source);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_absent(
+            &["defaulted", "assigned", "required", "replacement"],
+            &uninitialized,
+        );
+        assert_names_present(&["still_missing"], &uninitialized);
+    }
+
+    #[test]
+    fn parameter_guard_flow_respects_same_command_order() {
+        let source = "\
+printf '%s\\n' \
+  \"${same_default:-fallback}\" \"$same_default\" \
+  \"${same_assigned:=fallback}\" \"$same_assigned\" \
+  \"${same_required:?missing}\" \"$same_required\" \
+  \"${same_replacement:+alt}\" \"$same_replacement\" \
+  \"$before_default\" \"${before_default:-fallback}\" \
+  \"$still_missing\"
+";
+        let model = model(source);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_absent(
+            &[
+                "same_default",
+                "same_assigned",
+                "same_required",
+                "same_replacement",
+            ],
+            &uninitialized,
+        );
+        assert_names_present(&["before_default", "still_missing"], &uninitialized);
+    }
+
+    #[test]
+    fn non_assigning_parameter_guard_flow_does_not_create_bindings() {
+        let source = "\
+: \"${defaulted:-fallback}\" \"${replacement:+alt}\"
+";
+        let model = model(source);
+
+        assert!(model.bindings_for(&Name::from("defaulted")).is_empty());
+        assert!(model.bindings_for(&Name::from("replacement")).is_empty());
+        assert!(
+            model
+                .analysis()
+                .summarize_scope_provided_bindings(ScopeId(0))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -6565,6 +6565,19 @@ printf '%s\\n' \
     }
 
     #[test]
+    fn parameter_guard_flow_does_not_escape_conditional_operands() {
+        let source = "\
+printf '%s\\n' \"${outer:+${nested_default:-fallback}}\" \"$outer\" \"$nested_default\"
+printf '%s\\n' \"${other:+${nested_replacement:+alt}}\" \"$other\" \"$nested_replacement\"
+";
+        let model = model(source);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_absent(&["outer", "other"], &uninitialized);
+        assert_names_present(&["nested_default", "nested_replacement"], &uninitialized);
+    }
+
+    #[test]
     fn non_assigning_parameter_guard_flow_does_not_create_bindings() {
         let source = "\
 : \"${defaulted:-fallback}\" \"${replacement:+alt}\"

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -6578,6 +6578,25 @@ printf '%s\\n' \"${other:+${nested_replacement:+alt}}\" \"$other\" \"$nested_rep
     }
 
     #[test]
+    fn parameter_guard_flow_does_not_escape_short_circuit_conditionals() {
+        let source = "\
+flag=
+[[ ${left_guard:-fallback} && $flag ]]
+printf '%s\\n' \"$left_guard\"
+[[ $flag && ${right_and:-fallback} ]]
+printf '%s\\n' \"$right_and\"
+flag=1
+[[ $flag || ${right_or:+alt} ]]
+printf '%s\\n' \"$right_or\"
+";
+        let model = model(source);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_absent(&["left_guard"], &uninitialized);
+        assert_names_present(&["right_and", "right_or"], &uninitialized);
+    }
+
+    #[test]
     fn non_assigning_parameter_guard_flow_does_not_create_bindings() {
         let source = "\
 : \"${defaulted:-fallback}\" \"${replacement:+alt}\"


### PR DESCRIPTION
## Summary
- Add semantic C006 parameter guard/default flow for guarded carrier references (`:-`, `:=`, `:?`, `:+`), including same-command ordering.
- Keep non-assigning guard/default expansions out of real binding and provided-binding summaries.
- Prune obsolete C006 corpus metadata after the engine fix.

## Tests
- `cargo test -p shuck-semantic parameter`
- `cargo test -p shuck-linter undefined_variable`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006`
