### PR TITLE
fix(linter): skip C124 short-circuit exit guards

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c124.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c124.yaml
@@ -3,9 +3,6 @@ reviewed_divergences:
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__firmware"
     reason: "Residual C124 mismatch outside the loop-control cause filter: this fixture still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__log"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this fixture still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
-  - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
     reason: "Residual C124 mismatch outside the loop-control cause filter: this fixture still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
@@ -14,9 +11,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__monitoring_standalone_generic.sh"
     reason: "Residual C124 mismatch outside the loop-control cause filter: this helper still has early-return flow that Shuck treats more aggressively than the comparison oracle."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__version-funcs.sh"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this test fixture still has return-driven harness flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
     reason: "Residual C124 mismatch outside the loop-control cause filter: this menu script still has dispatcher-return flow that Shuck treats more aggressively than the comparison oracle."
@@ -29,9 +23,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "tj__git-extras__bin__git-scp"
     reason: "Residual C124 mismatch outside the loop-control cause filter: this command-line helper still has exit-heavy usage flow that Shuck treats more aggressively than the comparison oracle."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__ct__fenrus.sh"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this installer script still has exit-driven setup flow that Shuck treats more aggressively than the comparison oracle."
   - side: shuck-only
     path_suffix: "xwmx__nb__nb"
     reason: "Residual C124 mismatch outside the loop-control cause filter: this large dispatcher still has return-heavy helper flow that Shuck treats more aggressively than the comparison oracle."

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -4311,6 +4311,22 @@ run && exit 0 || sleep 15
     }
 
     #[test]
+    fn unreachable_after_exit_skips_dead_short_circuit_exit_guards() {
+        let source = "\
+#!/bin/bash
+exit 0
+cleanup || exit 1
+echo after
+printf '%s\\n' later
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "echo after");
+        assert_eq!(diagnostics[1].span.slice(source), "printf '%s\\n' later");
+    }
+
+    #[test]
     fn unused_assignment_respects_disabled_rule() {
         let diagnostics = lint(
             "#!/bin/sh\nfoo=1\n",

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,5 +1,5 @@
-use crate::{Checker, Rule, Violation};
-use shuck_ast::Span;
+use crate::{Checker, CommandFact, ListFact, Rule, Violation};
+use shuck_ast::{BinaryOp, Span};
 use shuck_semantic::UnreachableCauseKind;
 
 pub struct UnreachableAfterExit;
@@ -16,6 +16,7 @@ impl Violation for UnreachableAfterExit {
 
 pub fn unreachable_after_exit(checker: &mut Checker) {
     let source = checker.source();
+    let short_circuit_guard_spans = short_circuit_exit_guard_spans(checker);
     let unreachable_spans = outermost_unreachable_spans(
         checker
             .semantic_analysis()
@@ -23,6 +24,7 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
             .iter()
             .filter(|dead_code| dead_code.cause_kind != UnreachableCauseKind::LoopControl)
             .flat_map(|dead_code| dead_code.unreachable.iter().copied())
+            .filter(|span| !short_circuit_guard_spans.contains(span))
             .collect::<Vec<_>>(),
     );
 
@@ -32,6 +34,39 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
     {
         checker.report(UnreachableAfterExit, span);
     }
+}
+
+fn short_circuit_exit_guard_spans(checker: &Checker) -> Vec<Span> {
+    let commands = checker.facts().commands();
+    checker
+        .facts()
+        .lists()
+        .iter()
+        .filter(|list| list_is_exit_guard(list, commands))
+        .map(ListFact::span)
+        .collect()
+}
+
+fn list_is_exit_guard(list: &ListFact<'_>, commands: &[CommandFact<'_>]) -> bool {
+    if list
+        .operators()
+        .last()
+        .is_none_or(|operator| operator.op() != BinaryOp::Or)
+    {
+        return false;
+    }
+
+    let Some(terminator_id) = list.segments().last().map(|segment| segment.command_id()) else {
+        return false;
+    };
+    let Some(terminator) = commands
+        .iter()
+        .find(|command| command.id() == terminator_id)
+    else {
+        return false;
+    };
+
+    matches!(terminator.static_utility_name(), Some("exit" | "return"))
 }
 
 fn outermost_unreachable_spans(mut spans: Vec<shuck_ast::Span>) -> Vec<shuck_ast::Span> {


### PR DESCRIPTION
## Summary
- skip C124 reports for unreachable short-circuit guard lists that end in `|| exit` or `|| return`
- keep reporting unreachable statements that follow those dead guards
- remove C124 corpus metadata entries for the three guard-list groups fixed by this change

## Root Cause
C124 flattened semantic dead-code groups and then selected outermost spans. When an unreachable statement was a short-circuit guard such as `cmd || exit`, that outer list span was reported even though the comparison oracle does not report the guard command itself after a terminator.

## Validation
- `cargo test -p shuck-linter unreachable_after_exit -- --nocapture`
- `cargo test -p shuck-linter rule_modules_avoid_direct_ast_traversal_tokens -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C124`
- before/after with C124 metadata cleared: 12 blocking fixture groups before, 9 after
- `make test`