### PR TITLE
fix(linter): broaden ambient runtime contracts

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -484,9 +484,13 @@ fn line_invokes_completion_initializer_command(line: &str) -> bool {
             continue;
         }
 
-        if ch == '#' && previous.is_none_or(char::is_whitespace) {
+        if ch == '#' && shell_comment_can_start_after(previous) {
             if let Some(start) = token_start.take()
-                && completion_initializer_token(&line[start..index], &mut command_position)
+                && completion_initializer_token(
+                    &line[start..index],
+                    &line[index..],
+                    &mut command_position,
+                )
             {
                 return true;
             }
@@ -500,7 +504,11 @@ fn line_invokes_completion_initializer_command(line: &str) -> bool {
         }
 
         if let Some(start) = token_start.take()
-            && completion_initializer_token(&line[start..index], &mut command_position)
+            && completion_initializer_token(
+                &line[start..index],
+                &line[index..],
+                &mut command_position,
+            )
         {
             return true;
         }
@@ -515,12 +523,16 @@ fn line_invokes_completion_initializer_command(line: &str) -> bool {
         previous = Some(ch);
     }
 
-    token_start
-        .is_some_and(|start| completion_initializer_token(&line[start..], &mut command_position))
+    token_start.is_some_and(|start| {
+        completion_initializer_token(&line[start..], "", &mut command_position)
+    })
 }
 
-fn completion_initializer_token(token: &str, command_position: &mut bool) -> bool {
-    if *command_position && is_completion_initializer_command(token) {
+fn completion_initializer_token(token: &str, following: &str, command_position: &mut bool) -> bool {
+    if *command_position
+        && is_completion_initializer_command(token)
+        && !starts_function_definition_suffix(following)
+    {
         return true;
     }
 
@@ -530,6 +542,14 @@ fn completion_initializer_token(token: &str, command_position: &mut bool) -> boo
 
     *command_position = shell_control_token_keeps_command_position(token);
     false
+}
+
+fn shell_comment_can_start_after(previous: Option<char>) -> bool {
+    previous.is_none_or(|ch| ch.is_whitespace() || matches!(ch, ';' | '&' | '|' | '(' | '{'))
+}
+
+fn starts_function_definition_suffix(following: &str) -> bool {
+    following.trim_start().starts_with("()")
 }
 
 fn is_completion_initializer_command(token: &str) -> bool {
@@ -893,6 +913,42 @@ _example() {
         let source = "\
 _example() {
   my_init_completion_wrapper || return
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_initializer_definition_do_not_initialize_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+_init_completion() {
+  :
+}
+_example() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_separator_comment_do_not_initialize_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+noop;# _init_completion later
+_example() {
   printf '%s\\n' \"$cur\" \"$cword\"
 }
 ";

--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, VecDeque};
 use std::path::Path;
 
 use shuck_ast::Name;
@@ -446,9 +446,195 @@ fn completion_runtime_path_shape(lower: &str) -> bool {
 }
 
 fn completion_runtime_source_shape(source: &str) -> bool {
-    source
-        .lines()
-        .any(line_invokes_completion_initializer_command)
+    let mut pending_heredocs = VecDeque::new();
+
+    for line in source.lines() {
+        if skip_heredoc_body_line(line, &mut pending_heredocs) {
+            continue;
+        }
+
+        if line_invokes_completion_initializer_command(line) {
+            return true;
+        }
+
+        pending_heredocs.extend(heredoc_delimiters_in_code_line(line));
+    }
+
+    false
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingHeredocDelimiter {
+    text: String,
+    strip_tabs: bool,
+}
+
+fn skip_heredoc_body_line(
+    line: &str,
+    pending_heredocs: &mut VecDeque<PendingHeredocDelimiter>,
+) -> bool {
+    let Some(delimiter) = pending_heredocs.front() else {
+        return false;
+    };
+
+    if heredoc_line_matches_delimiter(line, delimiter) {
+        pending_heredocs.pop_front();
+    }
+    true
+}
+
+fn heredoc_line_matches_delimiter(line: &str, delimiter: &PendingHeredocDelimiter) -> bool {
+    let candidate = if delimiter.strip_tabs {
+        line.trim_start_matches('\t')
+    } else {
+        line
+    };
+    candidate == delimiter.text
+}
+
+fn heredoc_delimiters_in_code_line(line: &str) -> Vec<PendingHeredocDelimiter> {
+    let mut delimiters = Vec::new();
+    let mut index = 0;
+    let mut escaped = false;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut previous = None;
+
+    while index < line.len() {
+        let ch = line[index..].chars().next().expect("index is in bounds");
+        let next_index = index + ch.len_utf8();
+
+        if in_single_quote {
+            in_single_quote = ch != '\'';
+            previous = Some(ch);
+            index = next_index;
+            continue;
+        }
+
+        if in_double_quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_double_quote = false;
+            }
+            previous = Some(ch);
+            index = next_index;
+            continue;
+        }
+
+        if escaped {
+            escaped = false;
+            previous = Some(ch);
+            index = next_index;
+            continue;
+        }
+
+        if ch == '#' && shell_comment_can_start_after(previous) {
+            break;
+        }
+
+        if ch == '<' && line[index..].starts_with("<<") && !line[index..].starts_with("<<<") {
+            let strip_tabs = line[index..].starts_with("<<-");
+            let delimiter_start = index + if strip_tabs { 3 } else { 2 };
+            if let Some((delimiter, delimiter_end)) =
+                parse_heredoc_delimiter(line, delimiter_start, strip_tabs)
+            {
+                delimiters.push(delimiter);
+                previous = None;
+                index = delimiter_end;
+                continue;
+            }
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '\'' => in_single_quote = true,
+            '"' => in_double_quote = true,
+            _ => {}
+        }
+
+        previous = Some(ch);
+        index = next_index;
+    }
+
+    delimiters
+}
+
+fn parse_heredoc_delimiter(
+    line: &str,
+    mut index: usize,
+    strip_tabs: bool,
+) -> Option<(PendingHeredocDelimiter, usize)> {
+    let mut skipped_spacing = false;
+    while index < line.len() {
+        let ch = line[index..].chars().next().expect("index is in bounds");
+        if !matches!(ch, ' ' | '\t') {
+            break;
+        }
+        skipped_spacing = true;
+        index += ch.len_utf8();
+    }
+
+    if skipped_spacing && line[index..].starts_with('#') {
+        return None;
+    }
+
+    let mut text = String::new();
+    let mut escaped = false;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+
+    while index < line.len() {
+        let ch = line[index..].chars().next().expect("index is in bounds");
+        let next_index = index + ch.len_utf8();
+
+        if escaped {
+            text.push(ch);
+            escaped = false;
+            index = next_index;
+            continue;
+        }
+
+        if in_single_quote {
+            if ch == '\'' {
+                in_single_quote = false;
+            } else {
+                text.push(ch);
+            }
+            index = next_index;
+            continue;
+        }
+
+        if in_double_quote {
+            if ch == '"' {
+                in_double_quote = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else {
+                text.push(ch);
+            }
+            index = next_index;
+            continue;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '\'' => in_single_quote = true,
+            '"' => in_double_quote = true,
+            _ if heredoc_delimiter_terminator(ch) => break,
+            _ => text.push(ch),
+        }
+
+        index = next_index;
+    }
+
+    (!text.is_empty()).then_some((PendingHeredocDelimiter { text, strip_tabs }, index))
+}
+
+fn heredoc_delimiter_terminator(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, ';' | '&' | '|' | '<' | '>' | '(' | ')' | '{' | '}')
 }
 
 fn line_invokes_completion_initializer_command(line: &str) -> bool {
@@ -948,6 +1134,25 @@ _example() {
         let path = Path::new("/tmp/bash-completion/completions/example.bash");
         let source = "\
 noop;# _init_completion later
+_example() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_initializer_in_heredoc_do_not_initialize_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+cat <<EOF
+_init_completion
+EOF
 _example() {
   printf '%s\\n' \"$cur\" \"$cword\"
 }

--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -421,28 +421,37 @@ fn bash_it_theme_runtime_shape(source: &str, lower: &str) -> bool {
 }
 
 fn completion_runtime_shape(source: &str, lower: &str) -> bool {
+    completion_runtime_path_shape(lower) && completion_runtime_source_shape(source)
+}
+
+fn completion_runtime_path_shape(lower: &str) -> bool {
     path_matches_any(
         lower,
         &[
-            "/completion/",
-            "/completions/",
-            ".completion.",
+            "/bash-completion/",
+            "/bash_completion/",
+            "bash-completion__",
+            "bash_completion__",
+            "__bash-completion__",
+            "__bash_completion__",
+            "/bash-it/completion/",
+            "/bash-it/completions/",
+            "__bash-it__completion__",
+            "__bash-it__completions__",
+            "/bash-progcomp/",
+            "__bash-progcomp__",
             "bash_autocomplete",
-            "__completion__",
-            "__completions-",
-            "__completions__",
         ],
-    ) && source_contains_any(
+    )
+}
+
+fn completion_runtime_source_shape(source: &str) -> bool {
+    source_contains_any(
         source,
         &[
-            "COMPREPLY",
-            "COMP_WORDS",
-            "COMP_CWORD",
             "_init_completion",
             "_get_comp_words_by_ref",
-            "compgen ",
-            "compgen\t",
-            "complete -F",
+            "_comp_initialize",
             "about-completion",
         ],
     )
@@ -695,6 +704,58 @@ helper() {
 
         assert!(!has_initialized_binding(&contract, "cur"));
         assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn generic_completion_paths_with_compreply_do_not_initialize_completion_contracts() {
+        let path = Path::new("/tmp/project/completions/example.sh");
+        let source = "\
+helper() {
+  COMPREPLY=()
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_without_initializer_do_not_initialize_completion_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+_example() {
+  COMPREPLY=()
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_initializer_get_completion_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+_example() {
+  _init_completion || return
+  printf '%s\\n' \"$cur\" \"$cword\" \"$comp_args\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(has_initialized_binding(&contract, "cur"));
+        assert!(has_initialized_binding(&contract, "cword"));
+        assert!(has_initialized_binding(&contract, "comp_args"));
         assert!(!contract.externally_consumed_bindings);
     }
 

--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -271,7 +271,7 @@ fn matches_sourced_runtime_contract(
 }
 
 fn build_sourced_runtime_contract(
-    _source: &str,
+    source: &str,
     path: &Path,
     _shell: ShellDialect,
     _file_context: &FileContext,
@@ -279,7 +279,7 @@ fn build_sourced_runtime_contract(
     let lower = lower_path(path);
     let mut names = BTreeSet::new();
 
-    for name in runtime_names_for_path(&lower) {
+    for name in runtime_names_for_source_path(source, &lower) {
         names.insert((*name).to_owned());
     }
 
@@ -349,8 +349,8 @@ fn sourced_runtime_source_shape(
         || (lower_path.contains("termux-packages") && source.contains("TERMUX_"))
 }
 
-fn runtime_names_for_path(lower: &str) -> &'static [&'static str] {
-    if path_matches_any(lower, &["/themes/", ".theme.", "__themes__"]) {
+fn runtime_names_for_source_path(source: &str, lower: &str) -> &'static [&'static str] {
+    if bash_it_theme_runtime_shape(source, lower) {
         return &[
             "black",
             "red",
@@ -375,7 +375,53 @@ fn runtime_names_for_path(lower: &str) -> &'static [&'static str] {
         ];
     }
 
-    if path_matches_any(
+    if completion_runtime_shape(source, lower) {
+        return &["cur", "prev", "words", "cword", "comp_args", "split"];
+    }
+
+    &[]
+}
+
+fn bash_it_theme_runtime_shape(source: &str, lower: &str) -> bool {
+    path_matches_any(
+        lower,
+        &[
+            "/bash-it/themes/",
+            "/bash-it/theme/",
+            "__bash-it__themes__",
+            "__bash-it__theme__",
+        ],
+    ) && (source.contains("PROMPT_COMMAND")
+        || source.contains("SCM_THEME_PROMPT")
+        || source_mentions_any(
+            source,
+            &[
+                "black",
+                "red",
+                "green",
+                "yellow",
+                "blue",
+                "purple",
+                "cyan",
+                "white",
+                "normal",
+                "default",
+                "reset_color",
+                "bold_black",
+                "bold_red",
+                "bold_green",
+                "bold_yellow",
+                "bold_blue",
+                "bold_purple",
+                "bold_cyan",
+                "bold_white",
+                "italic",
+            ],
+        ))
+}
+
+fn completion_runtime_shape(source: &str, lower: &str) -> bool {
+    path_matches_any(
         lower,
         &[
             "/completion/",
@@ -386,11 +432,20 @@ fn runtime_names_for_path(lower: &str) -> &'static [&'static str] {
             "__completions-",
             "__completions__",
         ],
-    ) {
-        return &["cur", "prev", "words", "cword", "comp_args", "split"];
-    }
-
-    &[]
+    ) && source_contains_any(
+        source,
+        &[
+            "COMPREPLY",
+            "COMP_WORDS",
+            "COMP_CWORD",
+            "_init_completion",
+            "_get_comp_words_by_ref",
+            "compgen ",
+            "compgen\t",
+            "complete -F",
+            "about-completion",
+        ],
+    )
 }
 
 fn lower_path(path: &Path) -> String {
@@ -399,6 +454,10 @@ fn lower_path(path: &Path) -> String {
 
 fn path_matches_any(lower_path: &str, patterns: &[&str]) -> bool {
     patterns.iter().any(|pattern| lower_path.contains(pattern))
+}
+
+fn source_contains_any(source: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| source.contains(needle))
 }
 
 fn has_probable_function_definition(source: &str) -> bool {
@@ -591,7 +650,7 @@ esac
     }
 
     #[test]
-    fn sourced_runtime_theme_paths_get_generic_initialized_contracts() {
+    fn bash_it_theme_paths_get_palette_initialized_contracts() {
         let path = Path::new("/tmp/Bash-it/themes/example/example.theme.bash");
         let source = "\
 prompt_command() {
@@ -604,6 +663,38 @@ PROMPT_COMMAND=prompt_command
 
         assert!(has_initialized_binding(&contract, "green"));
         assert!(has_initialized_binding(&contract, "reset_color"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn generic_theme_paths_do_not_initialize_palette_contracts() {
+        let path = Path::new("/tmp/project/themes/example.theme.bash");
+        let source = "\
+helper() {
+  printf '%s\\n' \"$green\" \"$reset_color\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "green"));
+        assert!(!has_initialized_binding(&contract, "reset_color"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn generic_completion_paths_do_not_initialize_completion_contracts() {
+        let path = Path::new("/tmp/project/completions/example.sh");
+        let source = "\
+helper() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
         assert!(!contract.externally_consumed_bindings);
     }
 

--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -446,15 +446,130 @@ fn completion_runtime_path_shape(lower: &str) -> bool {
 }
 
 fn completion_runtime_source_shape(source: &str) -> bool {
-    source_contains_any(
-        source,
-        &[
-            "_init_completion",
-            "_get_comp_words_by_ref",
-            "_comp_initialize",
-            "about-completion",
-        ],
+    source
+        .lines()
+        .any(line_invokes_completion_initializer_command)
+}
+
+fn line_invokes_completion_initializer_command(line: &str) -> bool {
+    let mut command_position = true;
+    let mut escaped = false;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut previous = None;
+    let mut token_start = None;
+
+    for (index, ch) in line.char_indices() {
+        if in_single_quote {
+            in_single_quote = ch != '\'';
+            previous = Some(ch);
+            continue;
+        }
+
+        if in_double_quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_double_quote = false;
+            }
+            previous = Some(ch);
+            continue;
+        }
+
+        if escaped {
+            escaped = false;
+            previous = Some(ch);
+            continue;
+        }
+
+        if ch == '#' && previous.is_none_or(char::is_whitespace) {
+            if let Some(start) = token_start.take()
+                && completion_initializer_token(&line[start..index], &mut command_position)
+            {
+                return true;
+            }
+            break;
+        }
+
+        if is_completion_runtime_token_char(ch) {
+            token_start.get_or_insert(index);
+            previous = Some(ch);
+            continue;
+        }
+
+        if let Some(start) = token_start.take()
+            && completion_initializer_token(&line[start..index], &mut command_position)
+        {
+            return true;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '\'' => in_single_quote = true,
+            '"' => in_double_quote = true,
+            ';' | '&' | '|' | '(' | '{' | '!' => command_position = true,
+            _ => {}
+        }
+        previous = Some(ch);
+    }
+
+    token_start
+        .is_some_and(|start| completion_initializer_token(&line[start..], &mut command_position))
+}
+
+fn completion_initializer_token(token: &str, command_position: &mut bool) -> bool {
+    if *command_position && is_completion_initializer_command(token) {
+        return true;
+    }
+
+    if shell_assignment_token(token) {
+        return false;
+    }
+
+    *command_position = shell_control_token_keeps_command_position(token);
+    false
+}
+
+fn is_completion_initializer_command(token: &str) -> bool {
+    matches!(
+        token,
+        "_init_completion" | "_get_comp_words_by_ref" | "_comp_initialize" | "about-completion"
     )
+}
+
+fn shell_assignment_token(token: &str) -> bool {
+    let Some((name, _value)) = token.split_once('=') else {
+        return false;
+    };
+
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn shell_control_token_keeps_command_position(token: &str) -> bool {
+    matches!(
+        token,
+        "if" | "then"
+            | "do"
+            | "else"
+            | "elif"
+            | "while"
+            | "until"
+            | "time"
+            | "command"
+            | "builtin"
+            | "env"
+    )
+}
+
+fn is_completion_runtime_token_char(ch: char) -> bool {
+    ch == '_' || ch == '-' || ch == '=' || ch.is_ascii_alphanumeric()
 }
 
 fn lower_path(path: &Path) -> String {
@@ -463,10 +578,6 @@ fn lower_path(path: &Path) -> String {
 
 fn path_matches_any(lower_path: &str, patterns: &[&str]) -> bool {
     patterns.iter().any(|pattern| lower_path.contains(pattern))
-}
-
-fn source_contains_any(source: &str, needles: &[&str]) -> bool {
-    needles.iter().any(|needle| source.contains(needle))
 }
 
 fn has_probable_function_definition(source: &str) -> bool {
@@ -756,6 +867,40 @@ _example() {
         assert!(has_initialized_binding(&contract, "cur"));
         assert!(has_initialized_binding(&contract, "cword"));
         assert!(has_initialized_binding(&contract, "comp_args"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_commented_initializer_do_not_initialize_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+# TODO: call _init_completion later
+_example() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_wrapper_identifier_do_not_initialize_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+_example() {
+  my_init_completion_wrapper || return
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
         assert!(!contract.externally_consumed_bindings);
     }
 

--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -1,13 +1,19 @@
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use shuck_ast::Name;
 use shuck_semantic::{ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind};
 
-use crate::{FileContext, ShellDialect};
+use crate::{FileContext, FileContextTag, ShellDialect};
 
 struct AmbientContractProvider {
     matches: fn(source: &str, path: &Path, shell: ShellDialect, file_context: &FileContext) -> bool,
-    build: fn() -> FileContract,
+    build: fn(
+        source: &str,
+        path: &Path,
+        shell: ShellDialect,
+        file_context: &FileContext,
+    ) -> FileContract,
 }
 
 pub(crate) fn file_entry_contract(
@@ -23,7 +29,10 @@ pub(crate) fn file_entry_contract(
     for provider in providers() {
         if (provider.matches)(source, path, shell, file_context) {
             matched = true;
-            merge_contract(&mut merged, (provider.build)());
+            merge_contract(
+                &mut merged,
+                (provider.build)(source, path, shell, file_context),
+            );
         }
     }
 
@@ -48,10 +57,15 @@ fn providers() -> &'static [AmbientContractProvider] {
             matches: matches_void_packages_pycompile_trigger_contract,
             build: build_void_packages_pycompile_trigger_contract,
         },
+        AmbientContractProvider {
+            matches: matches_sourced_runtime_contract,
+            build: build_sourced_runtime_contract,
+        },
     ]
 }
 
 fn merge_contract(merged: &mut FileContract, contract: FileContract) {
+    merged.externally_consumed_bindings |= contract.externally_consumed_bindings;
     for name in contract.required_reads {
         merged.add_required_read(name);
     }
@@ -142,15 +156,22 @@ fn matches_void_packages_pycompile_trigger_contract(
             || source.contains("case \"$ACTION\""))
 }
 
-fn build_void_packages_build_style_contract() -> FileContract {
-    variable_contract(&[
+fn build_void_packages_build_style_contract(
+    _source: &str,
+    _path: &Path,
+    _shell: ShellDialect,
+    _file_context: &FileContext,
+) -> FileContract {
+    runtime_variable_contract(&[
         "build_style",
         "distfiles",
         "metapackage",
         "pkgname",
         "pkgver",
+        "version",
         "pycompile_version",
         "XBPS_SRCPKGDIR",
+        "XBPS_SRCDISTDIR",
         "XBPS_TARGET_WORDSIZE",
         "configure_args",
         "makejobs",
@@ -163,8 +184,13 @@ fn build_void_packages_build_style_contract() -> FileContract {
     ])
 }
 
-fn build_void_packages_pre_pkg_hook_contract() -> FileContract {
-    variable_contract(&[
+fn build_void_packages_pre_pkg_hook_contract(
+    _source: &str,
+    _path: &Path,
+    _shell: ShellDialect,
+    _file_context: &FileContext,
+) -> FileContract {
+    runtime_variable_contract(&[
         "PKGDESTDIR",
         "pkgname",
         "pkgver",
@@ -179,10 +205,16 @@ fn build_void_packages_pre_pkg_hook_contract() -> FileContract {
     ])
 }
 
-fn build_void_packages_xbps_src_framework_contract() -> FileContract {
-    variable_contract(&[
+fn build_void_packages_xbps_src_framework_contract(
+    _source: &str,
+    _path: &Path,
+    _shell: ShellDialect,
+    _file_context: &FileContext,
+) -> FileContract {
+    runtime_variable_contract(&[
         "XBPS_COMMONDIR",
         "XBPS_SRCPKGDIR",
+        "XBPS_SRCDISTDIR",
         "XBPS_BUILDSTYLEDIR",
         "XBPS_LIBEXECDIR",
         "XBPS_STATEDIR",
@@ -196,6 +228,8 @@ fn build_void_packages_xbps_src_framework_contract() -> FileContract {
         "build_style",
         "sourcepkg",
         "subpackages",
+        "wrksrc",
+        "build_option_",
         "NOCOLORS",
         "XBPS_CFLAGS",
         "XBPS_CPPFLAGS",
@@ -205,11 +239,16 @@ fn build_void_packages_xbps_src_framework_contract() -> FileContract {
     ])
 }
 
-fn build_void_packages_pycompile_trigger_contract() -> FileContract {
-    variable_contract(&["pycompile_dirs", "pycompile_module", "pycompile_version"])
+fn build_void_packages_pycompile_trigger_contract(
+    _source: &str,
+    _path: &Path,
+    _shell: ShellDialect,
+    _file_context: &FileContext,
+) -> FileContract {
+    runtime_variable_contract(&["pycompile_dirs", "pycompile_module", "pycompile_version"])
 }
 
-fn variable_contract(names: &[&str]) -> FileContract {
+fn runtime_variable_contract(names: &[&str]) -> FileContract {
     let mut contract = FileContract::default();
     for name in names {
         contract.add_provided_binding(ProvidedBinding::new(
@@ -219,6 +258,139 @@ fn variable_contract(names: &[&str]) -> FileContract {
         ));
     }
     contract
+}
+
+fn matches_sourced_runtime_contract(
+    source: &str,
+    path: &Path,
+    _shell: ShellDialect,
+    file_context: &FileContext,
+) -> bool {
+    let lower = lower_path(path);
+    sourced_runtime_path_shape(&lower) && sourced_runtime_source_shape(source, file_context, &lower)
+}
+
+fn build_sourced_runtime_contract(
+    _source: &str,
+    path: &Path,
+    _shell: ShellDialect,
+    _file_context: &FileContext,
+) -> FileContract {
+    let lower = lower_path(path);
+    let mut names = BTreeSet::new();
+
+    for name in runtime_names_for_path(&lower) {
+        names.insert((*name).to_owned());
+    }
+
+    let mut contract = FileContract {
+        ..FileContract::default()
+    };
+    for name in names {
+        contract.add_provided_binding(ProvidedBinding::new_file_entry_initialized(
+            Name::from(name.as_str()),
+            ProvidedBindingKind::Variable,
+            ContractCertainty::Definite,
+        ));
+    }
+    contract
+}
+
+fn sourced_runtime_path_shape(lower: &str) -> bool {
+    path_matches_any(
+        lower,
+        &[
+            "/completion/",
+            "/completions/",
+            ".completion.",
+            "bash_autocomplete",
+            "__completion__",
+            "__completions-",
+            "__completions__",
+            "/themes/",
+            ".theme.",
+            "__themes__",
+            "/plugins/",
+            "/plugin/",
+            "__plugins__",
+            "/modules/",
+            "__modules__",
+            "/scriptmodules/",
+            "__scriptmodules__",
+            "/scripts/functions/",
+            "__scripts__functions__",
+            "/rvm/scripts/",
+            "__rvm__scripts__",
+            "/lgsm/modules/",
+            "__lgsm__modules__",
+            "/common/environment/setup/",
+            "__common__environment__setup__",
+            "/common/chroot-style/",
+            "__common__chroot-style__",
+            "/common/hooks/",
+            "__common__hooks__",
+            "termux-packages/packages/",
+            "termux-packages__packages__",
+        ],
+    )
+}
+
+fn sourced_runtime_source_shape(
+    source: &str,
+    file_context: &FileContext,
+    lower_path: &str,
+) -> bool {
+    file_context.has_tag(FileContextTag::HelperLibrary)
+        || has_probable_function_definition(source)
+        || has_source_command(source)
+        || source.contains("PROMPT_COMMAND")
+        || source.contains("COMPREPLY")
+        || source.contains("about-completion")
+        || (lower_path.contains("termux-packages") && source.contains("TERMUX_"))
+}
+
+fn runtime_names_for_path(lower: &str) -> &'static [&'static str] {
+    if path_matches_any(lower, &["/themes/", ".theme.", "__themes__"]) {
+        return &[
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "purple",
+            "cyan",
+            "white",
+            "normal",
+            "default",
+            "reset_color",
+            "bold_black",
+            "bold_red",
+            "bold_green",
+            "bold_yellow",
+            "bold_blue",
+            "bold_purple",
+            "bold_cyan",
+            "bold_white",
+            "italic",
+        ];
+    }
+
+    if path_matches_any(
+        lower,
+        &[
+            "/completion/",
+            "/completions/",
+            ".completion.",
+            "bash_autocomplete",
+            "__completion__",
+            "__completions-",
+            "__completions__",
+        ],
+    ) {
+        return &["cur", "prev", "words", "cword", "comp_args", "split"];
+    }
+
+    &[]
 }
 
 fn lower_path(path: &Path) -> String {
@@ -241,6 +413,15 @@ fn has_named_function_definition(source: &str, name: &str) -> bool {
         .lines()
         .map(str::trim)
         .any(|trimmed| named_function_definition(trimmed, name))
+}
+
+fn has_source_command(source: &str) -> bool {
+    source.lines().map(str::trim).any(|trimmed| {
+        trimmed.starts_with("source ")
+            || trimmed.starts_with(". ")
+            || trimmed.starts_with("\\source ")
+            || trimmed.starts_with("\\. ")
+    })
 }
 
 fn xbps_src_framework_has_shell_shape(source: &str, libexec_path: bool) -> bool {
@@ -305,6 +486,14 @@ mod tests {
             .any(|binding| binding.name == name)
     }
 
+    fn has_initialized_binding(contract: &FileContract, name: &str) -> bool {
+        contract.provided_bindings.iter().any(|binding| {
+            binding.name == name
+                && binding.file_entry_initialization
+                    == shuck_semantic::FileEntryBindingInitialization::Initialized
+        })
+    }
+
     #[test]
     fn void_packages_build_style_paths_get_an_explicit_contract() {
         let path = Path::new("/tmp/void-packages/common/build-style/void-cross.sh");
@@ -320,6 +509,8 @@ printf '%s\\n' \"$pkgname\" \"$pkgver\" \"$XBPS_SRCPKGDIR\" \"$configure_args\"
         assert!(has_binding(&contract, "wrksrc"));
         assert!(has_binding(&contract, "XBPS_SRCPKGDIR"));
         assert!(has_binding(&contract, "configure_args"));
+        assert!(!has_initialized_binding(&contract, "wrksrc"));
+        assert!(!contract.externally_consumed_bindings);
     }
 
     #[test]
@@ -336,6 +527,8 @@ printf '%s\\n' \"$pkgname\" \"$pkgver\" \"$XBPS_COMMONDIR\"
         assert!(has_binding(&contract, "pkgname"));
         assert!(has_binding(&contract, "pkgver"));
         assert!(has_binding(&contract, "XBPS_COMMONDIR"));
+        assert!(!has_initialized_binding(&contract, "pkgname"));
+        assert!(!contract.externally_consumed_bindings);
     }
 
     #[test]
@@ -352,6 +545,8 @@ printf '%s\\n' \"$XBPS_SRCPKGDIR\" \"$XBPS_STATEDIR\" \"$pkgname\" \"$build_styl
         assert!(has_binding(&contract, "XBPS_SRCPKGDIR"));
         assert!(has_binding(&contract, "XBPS_STATEDIR"));
         assert!(has_binding(&contract, "build_style"));
+        assert!(!has_initialized_binding(&contract, "build_style"));
+        assert!(!contract.externally_consumed_bindings);
     }
 
     #[test]
@@ -371,6 +566,8 @@ done
         assert!(has_binding(&contract, "subpackages"));
         assert!(has_binding(&contract, "XBPS_LIBEXECDIR"));
         assert!(has_binding(&contract, "XBPS_CROSS_BUILD"));
+        assert!(!has_initialized_binding(&contract, "sourcepkg"));
+        assert!(!contract.externally_consumed_bindings);
     }
 
     #[test]
@@ -389,6 +586,42 @@ esac
         assert!(has_binding(&contract, "pycompile_dirs"));
         assert!(has_binding(&contract, "pycompile_module"));
         assert!(has_binding(&contract, "pycompile_version"));
+        assert!(!has_initialized_binding(&contract, "pycompile_version"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn sourced_runtime_theme_paths_get_generic_initialized_contracts() {
+        let path = Path::new("/tmp/Bash-it/themes/example/example.theme.bash");
+        let source = "\
+prompt_command() {
+  PS1=\"${green?} ${green} ${reset_color?}\"
+}
+PROMPT_COMMAND=prompt_command
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(has_initialized_binding(&contract, "green"));
+        assert!(has_initialized_binding(&contract, "reset_color"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn sourced_runtime_module_paths_do_not_initialize_arbitrary_reads() {
+        let path = Path::new("/tmp/LinuxGSM/lgsm/modules/command_backup.sh");
+        let source = "\
+commandname=\"BACKUP\"
+backup_run() {
+  printf '%s\\n' \"$lockdir\" \"$commandname\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_initialized_binding(&contract, "lockdir"));
+        assert!(!has_initialized_binding(&contract, "commandname"));
+        assert!(!contract.externally_consumed_bindings);
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1174,6 +1174,56 @@ complete_example() {
     }
 
     #[test]
+    fn bash_completion_directory_with_commented_initializer_does_not_suppress_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/bash-completion/completions/example.bash"),
+            "\
+# TODO: call _init_completion later
+complete_example() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+    }
+
+    #[test]
+    fn bash_completion_directory_with_wrapper_identifier_does_not_suppress_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/bash-completion/completions/example.bash"),
+            "\
+complete_example() {
+  my_init_completion_wrapper || return
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+    }
+
+    #[test]
     fn sourced_runtime_contract_does_not_mark_arbitrary_assignments_used() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/rvm/scripts/cleanup"),

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1224,6 +1224,58 @@ complete_example() {
     }
 
     #[test]
+    fn bash_completion_directory_with_initializer_definition_does_not_suppress_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/bash-completion/completions/example.bash"),
+            "\
+_init_completion() {
+  :
+}
+complete_example() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+    }
+
+    #[test]
+    fn bash_completion_directory_with_separator_comment_does_not_suppress_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/bash-completion/completions/example.bash"),
+            "\
+noop;# _init_completion later
+complete_example() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+    }
+
+    #[test]
     fn sourced_runtime_contract_does_not_mark_arbitrary_assignments_used() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/rvm/scripts/cleanup"),

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1044,6 +1044,65 @@ esac
     }
 
     #[test]
+    fn sourced_theme_contract_suppresses_runtime_color_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/bash-it/themes/minimal/minimal.theme.bash"),
+            "\
+prompt_command() {
+  PS1=\"${green?} ${green} ${reset_color?}\"
+}
+PROMPT_COMMAND=prompt_command
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn sourced_runtime_contract_does_not_mark_arbitrary_assignments_used() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/rvm/scripts/cleanup"),
+            "\
+rvm_base_except=\"selector\"
+cleanup() { :; }
+",
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UnusedAssignment);
+    }
+
+    #[test]
+    fn sourced_module_contract_does_not_suppress_arbitrary_runtime_state_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/LinuxGSM/lgsm/modules/command_backup.sh"),
+            "\
+commandname=\"BACKUP\"
+backup_run() {
+  printf '%s\\n' \"$lockdir\" \"$commandname\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
+    }
+
+    #[test]
+    fn prefix_name_expansions_do_not_trigger_c006() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/project/plain.sh"),
+            "unset \"${!completion_prefix@}\"\n",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn project_closure_context_without_a_provider_still_reports_c006() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/project/scripts/helper.sh"),

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1108,6 +1108,72 @@ complete_example() {
     }
 
     #[test]
+    fn generic_completion_directory_with_compreply_does_not_suppress_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/project/completions/example.sh"),
+            "\
+complete_example() {
+  COMPREPLY=()
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+    }
+
+    #[test]
+    fn bash_completion_directory_without_initializer_does_not_suppress_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/bash-completion/completions/example.bash"),
+            "\
+complete_example() {
+  COMPREPLY=()
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+    }
+
+    #[test]
+    fn bash_completion_directory_with_initializer_suppresses_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/bash-completion/completions/example.bash"),
+            "\
+complete_example() {
+  _init_completion || return
+  printf '%s\\n' \"$cur\" \"$cword\" \"$comp_args\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn sourced_runtime_contract_does_not_mark_arbitrary_assignments_used() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/rvm/scripts/cleanup"),

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1060,6 +1060,54 @@ PROMPT_COMMAND=prompt_command
     }
 
     #[test]
+    fn generic_theme_directory_does_not_suppress_palette_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/project/themes/minimal.theme.bash"),
+            "\
+render_prompt() {
+  printf '%s\\n' \"$green\" \"$reset_color\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("green"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("reset_color"))
+        );
+    }
+
+    #[test]
+    fn generic_completion_directory_does_not_suppress_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/project/completions/example.sh"),
+            "\
+complete_example() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+    }
+
+    #[test]
     fn sourced_runtime_contract_does_not_mark_arbitrary_assignments_used() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/rvm/scripts/cleanup"),

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1276,6 +1276,33 @@ complete_example() {
     }
 
     #[test]
+    fn bash_completion_directory_with_heredoc_initializer_does_not_suppress_helper_reads() {
+        let diagnostics = lint_named_source(
+            Path::new("/tmp/bash-completion/completions/example.bash"),
+            "\
+cat <<EOF
+_init_completion
+EOF
+complete_example() {
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+",
+            &LinterSettings::for_rule(Rule::UndefinedVariable),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+    }
+
+    #[test]
     fn sourced_runtime_contract_does_not_mark_arbitrary_assignments_used() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/rvm/scripts/cleanup"),

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -4258,6 +4258,7 @@ printf '%s\\n' $pkgname
                         ContractCertainty::Definite,
                     )],
                     provided_functions: Vec::new(),
+                    externally_consumed_bindings: false,
                 }),
                 ..SemanticBuildOptions::default()
             },

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -117,7 +117,7 @@ pub(crate) fn is_array_like_binding(binding: &Binding) -> bool {
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct BindingAttributes: u16 {
+    pub struct BindingAttributes: u32 {
         const EXPORTED               = 0b0000_0001;
         const READONLY               = 0b0000_0010;
         const LOCAL                  = 0b0000_0100;
@@ -133,5 +133,7 @@ bitflags! {
         const EMPTY_INITIALIZER      = 0b0001_0000_0000_0000;
         const IMPORTED_FILE_ENTRY    = 0b0010_0000_0000_0000;
         const SELF_REFERENTIAL_READ  = 0b0100_0000_0000_0000;
+        const IMPORTED_FILE_ENTRY_INITIALIZED = 0b1000_0000_0000_0000;
+        const EXTERNALLY_CONSUMED    = 0b0001_0000_0000_0000_0000;
     }
 }

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1502,17 +1502,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     reference.span,
                 );
             }
-            WordPart::PrefixMatch { prefix, .. } => {
-                self.add_reference(
-                    prefix,
-                    if matches!(kind, WordVisitKind::Conditional) {
-                        ReferenceKind::ConditionalOperand
-                    } else {
-                        ReferenceKind::IndirectExpansion
-                    },
-                    span,
-                );
-            }
+            WordPart::PrefixMatch { .. } => {}
             WordPart::IndirectExpansion {
                 reference,
                 operator,
@@ -1731,17 +1721,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         );
                     }
                 }
-                BourneParameterExpansion::PrefixMatch { prefix, .. } => {
-                    self.add_reference(
-                        prefix,
-                        if matches!(kind, WordVisitKind::Conditional) {
-                            ReferenceKind::ConditionalOperand
-                        } else {
-                            ReferenceKind::IndirectExpansion
-                        },
-                        span,
-                    );
-                }
+                BourneParameterExpansion::PrefixMatch { .. } => {}
                 BourneParameterExpansion::Slice {
                     reference,
                     offset_ast,

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -26,11 +26,28 @@ pub enum ProvidedBindingKind {
     Function,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum FileEntryBindingInitialization {
+    #[default]
+    AmbientOnly,
+    Initialized,
+}
+
+impl FileEntryBindingInitialization {
+    fn merge_same_site(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Initialized, _) | (_, Self::Initialized) => Self::Initialized,
+            (Self::AmbientOnly, Self::AmbientOnly) => Self::AmbientOnly,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ProvidedBinding {
     pub name: Name,
     pub kind: ProvidedBindingKind,
     pub certainty: ContractCertainty,
+    pub file_entry_initialization: FileEntryBindingInitialization,
 }
 
 impl ProvidedBinding {
@@ -39,6 +56,20 @@ impl ProvidedBinding {
             name,
             kind,
             certainty,
+            file_entry_initialization: FileEntryBindingInitialization::AmbientOnly,
+        }
+    }
+
+    pub fn new_file_entry_initialized(
+        name: Name,
+        kind: ProvidedBindingKind,
+        certainty: ContractCertainty,
+    ) -> Self {
+        Self {
+            name,
+            kind,
+            certainty,
+            file_entry_initialization: FileEntryBindingInitialization::Initialized,
         }
     }
 }
@@ -72,6 +103,9 @@ impl FunctionContract {
         for existing in &mut self.provided_bindings {
             if existing.name == binding.name && existing.kind == binding.kind {
                 existing.certainty = existing.certainty.merge_same_site(binding.certainty);
+                existing.file_entry_initialization = existing
+                    .file_entry_initialization
+                    .merge_same_site(binding.file_entry_initialization);
                 merged = true;
                 break;
             }
@@ -92,8 +126,10 @@ impl FunctionContract {
         let first = contracts.first()?;
         let mut merged = Self::new(first.name.clone());
         let total = contracts.len();
-        let mut provided_counts: FxHashMap<(Name, ProvidedBindingKind), (usize, bool)> =
-            FxHashMap::default();
+        let mut provided_counts: FxHashMap<
+            (Name, ProvidedBindingKind),
+            (usize, bool, FileEntryBindingInitialization),
+        > = FxHashMap::default();
 
         for contract in contracts {
             for name in &contract.required_reads {
@@ -102,22 +138,25 @@ impl FunctionContract {
             for binding in &contract.provided_bindings {
                 let entry = provided_counts
                     .entry((binding.name.clone(), binding.kind))
-                    .or_insert((0, true));
+                    .or_insert((0, true, FileEntryBindingInitialization::AmbientOnly));
                 entry.0 += 1;
                 entry.1 &= binding.certainty == ContractCertainty::Definite;
+                entry.2 = entry.2.merge_same_site(binding.file_entry_initialization);
             }
             for path in &contract.origin_paths {
                 merged.add_origin_path(path.clone());
             }
         }
 
-        for ((name, kind), (present_count, all_definite)) in provided_counts {
+        for ((name, kind), (present_count, all_definite, initialization)) in provided_counts {
             let certainty = if present_count == total && all_definite {
                 ContractCertainty::Definite
             } else {
                 ContractCertainty::Possible
             };
-            merged.add_provided_binding(ProvidedBinding::new(name, kind, certainty));
+            let mut binding = ProvidedBinding::new(name, kind, certainty);
+            binding.file_entry_initialization = initialization;
+            merged.add_provided_binding(binding);
         }
 
         Some(merged)
@@ -129,6 +168,7 @@ pub struct FileContract {
     pub required_reads: Vec<Name>,
     pub provided_bindings: Vec<ProvidedBinding>,
     pub provided_functions: Vec<FunctionContract>,
+    pub externally_consumed_bindings: bool,
 }
 
 impl FileContract {
@@ -143,6 +183,9 @@ impl FileContract {
         for existing in &mut self.provided_bindings {
             if existing.name == binding.name && existing.kind == binding.kind {
                 existing.certainty = existing.certainty.merge_same_site(binding.certainty);
+                existing.file_entry_initialization = existing
+                    .file_entry_initialization
+                    .merge_same_site(binding.file_entry_initialization);
                 merged = true;
                 break;
             }
@@ -179,21 +222,25 @@ impl FileContract {
     pub(crate) fn merge_candidate_contracts(contracts: &[Self]) -> Self {
         let mut merged = Self::default();
         let total = contracts.len();
-        let mut provided_counts: FxHashMap<(Name, ProvidedBindingKind), (usize, bool)> =
-            FxHashMap::default();
+        let mut provided_counts: FxHashMap<
+            (Name, ProvidedBindingKind),
+            (usize, bool, FileEntryBindingInitialization),
+        > = FxHashMap::default();
         let mut function_contracts_by_name: FxHashMap<Name, Vec<FunctionContract>> =
             FxHashMap::default();
 
         for contract in contracts {
+            merged.externally_consumed_bindings |= contract.externally_consumed_bindings;
             for name in &contract.required_reads {
                 merged.add_required_read(name.clone());
             }
             for binding in &contract.provided_bindings {
                 let entry = provided_counts
                     .entry((binding.name.clone(), binding.kind))
-                    .or_insert((0, true));
+                    .or_insert((0, true, FileEntryBindingInitialization::AmbientOnly));
                 entry.0 += 1;
                 entry.1 &= binding.certainty == ContractCertainty::Definite;
+                entry.2 = entry.2.merge_same_site(binding.file_entry_initialization);
             }
             for function in &contract.provided_functions {
                 function_contracts_by_name
@@ -203,13 +250,15 @@ impl FileContract {
             }
         }
 
-        for ((name, kind), (present_count, all_definite)) in provided_counts {
+        for ((name, kind), (present_count, all_definite, initialization)) in provided_counts {
             let certainty = if present_count == total && all_definite {
                 ContractCertainty::Definite
             } else {
                 ContractCertainty::Possible
             };
-            merged.add_provided_binding(ProvidedBinding::new(name, kind, certainty));
+            let mut binding = ProvidedBinding::new(name, kind, certainty);
+            binding.file_entry_initialization = initialization;
+            merged.add_provided_binding(binding);
         }
 
         for functions in function_contracts_by_name.into_values() {

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -337,6 +337,9 @@ fn reference_resolves_to_file_entry_contract_variable(
         && binding
             .attributes
             .contains(BindingAttributes::IMPORTED_FILE_ENTRY)
+        && !binding
+            .attributes
+            .contains(BindingAttributes::IMPORTED_FILE_ENTRY_INITIALIZED)
 }
 
 fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
@@ -469,6 +472,9 @@ fn analyze_unused_assignments_exact(
             || binding
                 .attributes
                 .contains(BindingAttributes::SELF_REFERENTIAL_READ)
+            || binding
+                .attributes
+                .contains(BindingAttributes::EXTERNALLY_CONSUMED)
             || context.runtime.is_always_used_binding(&binding.name)
         {
             used_bindings.insert(binding.id.index());

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -45,8 +45,8 @@ pub use call_graph::{
 pub use cfg::{BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext, UnreachableCauseKind};
 /// Contract and build-option types used when constructing semantic models.
 pub use contract::{
-    ContractCertainty, FileContract, FunctionContract, ProvidedBinding, ProvidedBindingKind,
-    SemanticBuildOptions,
+    ContractCertainty, FileContract, FileEntryBindingInitialization, FunctionContract,
+    ProvidedBinding, ProvidedBindingKind, SemanticBuildOptions,
 };
 /// Dataflow results surfaced by the semantic analysis layer.
 pub use dataflow::{
@@ -933,6 +933,9 @@ impl SemanticModel {
         }
         if file_entry_contract {
             attributes |= BindingAttributes::IMPORTED_FILE_ENTRY;
+            if provided.file_entry_initialization == FileEntryBindingInitialization::Initialized {
+                attributes |= BindingAttributes::IMPORTED_FILE_ENTRY_INITIALIZED;
+            }
         }
 
         let id = BindingId(self.bindings.len() as u32);
@@ -984,8 +987,13 @@ impl SemanticModel {
         if contract.required_reads.is_empty()
             && contract.provided_bindings.is_empty()
             && contract.provided_functions.is_empty()
+            && !contract.externally_consumed_bindings
         {
             return;
+        }
+
+        if contract.externally_consumed_bindings {
+            self.mark_file_entry_consumed_bindings();
         }
 
         let mut synthetic_reads = self.synthetic_reads.clone();
@@ -1041,6 +1049,19 @@ impl SemanticModel {
             &self.functions,
             &self.call_sites,
         );
+    }
+
+    fn mark_file_entry_consumed_bindings(&mut self) {
+        for binding in &mut self.bindings {
+            if file_entry_contract_can_consume_binding(binding) {
+                binding.attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
+            }
+        }
+        self.heuristic_unused_assignments.retain(|binding_id| {
+            !self.bindings[binding_id.index()]
+                .attributes
+                .contains(BindingAttributes::EXTERNALLY_CONSUMED)
+        });
     }
 
     pub(crate) fn apply_source_contracts(
@@ -1207,6 +1228,27 @@ impl SemanticModel {
             entry_bindings: &self.entry_bindings,
         }
     }
+}
+
+fn file_entry_contract_can_consume_binding(binding: &Binding) -> bool {
+    if binding.attributes.contains(BindingAttributes::LOCAL) {
+        return false;
+    }
+
+    matches!(
+        binding.kind,
+        BindingKind::Assignment
+            | BindingKind::ArrayAssignment
+            | BindingKind::AppendAssignment
+            | BindingKind::ParameterDefaultAssignment
+            | BindingKind::LoopVariable
+            | BindingKind::ReadTarget
+            | BindingKind::MapfileTarget
+            | BindingKind::PrintfTarget
+            | BindingKind::GetoptsTarget
+            | BindingKind::ArithmeticAssignment
+            | BindingKind::Declaration(_)
+    )
 }
 
 #[allow(missing_docs)]
@@ -3366,6 +3408,7 @@ printf '%s\\n' \"$pkgname\"
                         ContractCertainty::Definite,
                     )],
                     provided_functions: Vec::new(),
+                    externally_consumed_bindings: false,
                 }),
                 ..SemanticBuildOptions::default()
             },
@@ -4490,6 +4533,7 @@ echo $value
                         ContractCertainty::Definite,
                     )],
                     provided_functions: Vec::new(),
+                    externally_consumed_bindings: false,
                 }),
                 ..SemanticBuildOptions::default()
             },
@@ -6388,6 +6432,16 @@ f
 ";
         let model = model(source);
         assert!(uninitialized_names(&model).is_empty());
+    }
+
+    #[test]
+    fn prefix_name_expansions_do_not_read_the_prefix_as_a_variable() {
+        let source = "unset \"${!completion_prefix@}\"\nprintf '%s\\n' \"$ordinary_missing\"\n";
+        let model = model(source);
+        let uninitialized = uninitialized_names(&model);
+
+        assert_names_absent(&["completion_prefix"], &uninitialized);
+        assert_names_present(&["ordinary_missing"], &uninitialized);
     }
 
     #[test]
@@ -8527,6 +8581,7 @@ printf '%s\\n' \"$flag\"
                         ),
                     ],
                     provided_functions: Vec::new(),
+                    externally_consumed_bindings: false,
                 }),
                 ..SemanticBuildOptions::default()
             },
@@ -8591,6 +8646,7 @@ build() {
                         ),
                     ],
                     provided_functions: Vec::new(),
+                    externally_consumed_bindings: false,
                 }),
                 ..SemanticBuildOptions::default()
             },
@@ -8668,6 +8724,7 @@ hook() {
                         ),
                     ],
                     provided_functions: Vec::new(),
+                    externally_consumed_bindings: false,
                 }),
                 ..SemanticBuildOptions::default()
             },
@@ -8703,6 +8760,73 @@ hook() {
                 ("pkgver".to_owned(), UninitializedCertainty::Definite),
             ]
         );
+    }
+
+    #[test]
+    fn initialized_file_entry_bindings_suppress_uninitialized_reads() {
+        let source = "printf '%s\\n' \"$theme_color\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build_with_options(
+            &output.file,
+            source,
+            &indexer,
+            SemanticBuildOptions {
+                file_entry_contract: Some(FileContract {
+                    required_reads: Vec::new(),
+                    provided_bindings: vec![ProvidedBinding::new_file_entry_initialized(
+                        Name::from("theme_color"),
+                        ProvidedBindingKind::Variable,
+                        ContractCertainty::Definite,
+                    )],
+                    provided_functions: Vec::new(),
+                    externally_consumed_bindings: false,
+                }),
+                ..SemanticBuildOptions::default()
+            },
+        );
+
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.name == "theme_color")
+            .unwrap();
+        let binding = model.resolved_binding(reference.id).unwrap();
+        assert!(
+            binding
+                .attributes
+                .contains(BindingAttributes::IMPORTED_FILE_ENTRY_INITIALIZED)
+        );
+        assert!(uninitialized_names(&model).is_empty());
+    }
+
+    #[test]
+    fn file_entry_contracts_can_mark_assignments_as_caller_consumed() {
+        let source = "published=1\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build_with_options(
+            &output.file,
+            source,
+            &indexer,
+            SemanticBuildOptions {
+                file_entry_contract: Some(FileContract {
+                    required_reads: Vec::new(),
+                    provided_bindings: Vec::new(),
+                    provided_functions: Vec::new(),
+                    externally_consumed_bindings: true,
+                }),
+                ..SemanticBuildOptions::default()
+            },
+        );
+
+        let binding = binding_for_name(&model, "published");
+        assert!(
+            binding
+                .attributes
+                .contains(BindingAttributes::EXTERNALLY_CONSUMED)
+        );
+        assert!(model.analysis().unused_assignments().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add initialized file-entry contract plumbing so selected ambient runtime bindings can suppress C006 without weakening ordinary imported file-entry bindings.
- Add generic sourced runtime contracts for completion/theme/plugin/module-shaped files, with narrow path-known bindings for Bash-it themes and completions.
- Stop prefix-name expansions like `${!prefix@}` and `${!prefix*}` from being treated as reads of `prefix`.

## Impact

This removes reviewed C001/C006 corpus divergences for Bash-it completion/theme runtime globals and a Void prefix-name expansion case without adding new reviewed metadata or broadening ordinary script behavior.

## Validation

- `cargo clippy --all-targets -- -D warnings`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001,C006`

Large corpus result for C001/C006: `blocking=0`, `implementation_diffs=0`, `reviewed_divergences=692` (down from the baseline `705`).