### PR TITLE
fix(linter): match C063 nested function reachability

### DIFF
--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -105,6 +105,7 @@ struct EffectivePerFileIgnore {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct EffectiveRuleOptions {
     c001_treat_indirect_expansion_targets_as_used: bool,
+    c063_report_unreached_nested_definitions: bool,
 }
 
 impl EffectiveCheckSettings {
@@ -169,6 +170,9 @@ impl EffectiveRuleOptions {
             c001_treat_indirect_expansion_targets_as_used: rule_options
                 .c001
                 .treat_indirect_expansion_targets_as_used,
+            c063_report_unreached_nested_definitions: rule_options
+                .c063
+                .report_unreached_nested_definitions,
         }
     }
 }
@@ -177,6 +181,8 @@ impl CacheKey for EffectiveRuleOptions {
     fn cache_key(&self, state: &mut CacheKeyHasher) {
         state.write_tag(b"effective-rule-options");
         self.c001_treat_indirect_expansion_targets_as_used
+            .cache_key(state);
+        self.c063_report_unreached_nested_definitions
             .cache_key(state);
     }
 }
@@ -880,6 +886,14 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::Linte
         .and_then(|c001| c001.treat_indirect_expansion_targets_as_used)
     {
         rule_options.c001.treat_indirect_expansion_targets_as_used = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.c063.as_ref())
+        .and_then(|c063| c063.report_unreached_nested_definitions)
+    {
+        rule_options.c063.report_unreached_nested_definitions = value;
     }
 
     rule_options
@@ -2941,6 +2955,46 @@ jobs:
         assert_eq!(second.cache_hits, 0);
         assert_eq!(second.cache_misses, 1);
         assert!(second.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn invalidates_cache_when_c063_rule_options_change() {
+        let tempdir = tempdir().unwrap();
+        let script = tempdir.path().join("script.sh");
+        fs::write(&script, "#!/bin/bash\nouter() {\n  inner() { :; }\n}\n").unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nselect = ['C063']\n",
+        )
+        .unwrap();
+
+        let first = run_check_with_cwd(
+            &check_args(false),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+        assert_eq!(first.cache_hits, 0);
+        assert_eq!(first.cache_misses, 1);
+        assert!(first.diagnostics.is_empty());
+
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nselect = ['C063']\n\n[lint.rule-options.c063]\nreport-unreached-nested-definitions = true\n",
+        )
+        .unwrap();
+
+        let second = run_check_with_cwd(
+            &check_args(false),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+        assert_eq!(second.cache_hits, 0);
+        assert_eq!(second.cache_misses, 1);
+        assert_eq!(second.diagnostics.len(), 1);
     }
 
     #[test]

--- a/crates/shuck-cli/src/config.rs
+++ b/crates/shuck-cli/src/config.rs
@@ -39,9 +39,10 @@ const CONFIG_OVERRIDE_LINT_KEYS: &[&str] = &[
     "extend-fixable",
     "rule-options",
 ];
-const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &["c001"];
+const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &["c001", "c063"];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
+const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
@@ -89,12 +90,16 @@ pub(crate) struct LintConfig {
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct LintRuleOptionsConfig {
     pub c001: Option<C001RuleOptionsConfig>,
+    pub c063: Option<C063RuleOptionsConfig>,
 }
 
 impl LintRuleOptionsConfig {
     fn apply_overrides(&mut self, overrides: Self) {
         if let Some(c001) = overrides.c001 {
             self.c001.get_or_insert_default().apply_overrides(c001);
+        }
+        if let Some(c063) = overrides.c063 {
+            self.c063.get_or_insert_default().apply_overrides(c063);
         }
     }
 }
@@ -110,6 +115,21 @@ impl C001RuleOptionsConfig {
         if overrides.treat_indirect_expansion_targets_as_used.is_some() {
             self.treat_indirect_expansion_targets_as_used =
                 overrides.treat_indirect_expansion_targets_as_used;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) struct C063RuleOptionsConfig {
+    pub report_unreached_nested_definitions: Option<bool>,
+}
+
+impl C063RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.report_unreached_nested_definitions.is_some() {
+            self.report_unreached_nested_definitions =
+                overrides.report_unreached_nested_definitions;
         }
     }
 }
@@ -471,6 +491,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(c001_value) = rule_options.get("c001") {
         validate_c001_rule_options_override(c001_value)?;
     }
+    if let Some(c063_value) = rule_options.get("c063") {
+        validate_c063_rule_options_override(c063_value)?;
+    }
 
     Ok(())
 }
@@ -484,6 +507,22 @@ fn validate_c001_rule_options_override(value: &toml::Value) -> std::result::Resu
             return Err(format!(
                 "unsupported `[lint.rule-options.c001]` option `{key}`; expected one of: {}",
                 CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_c063_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let c063 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.c063]` must be a TOML table".to_owned())?;
+    for key in c063.keys() {
+        if !CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.c063]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS.join(", ")
             ));
         }
     }
@@ -658,6 +697,23 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_c063_rule_option_keys() {
+        let config = parse_config_override(
+            "lint.rule-options.c063.report-unreached-nested-definitions = true",
+        )
+        .unwrap();
+        assert_eq!(
+            config
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c063.as_ref())
+                .and_then(|c063| c063.report_unreached_nested_definitions),
+            Some(true)
+        );
+    }
+
+    #[test]
     fn inline_config_overrides_reject_unknown_lint_keys() {
         let err = parse_config_override("lint.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint]` option `preview`"));
@@ -673,6 +729,12 @@ mod tests {
     fn inline_config_overrides_reject_unknown_c001_rule_option_keys() {
         let err = parse_config_override("lint.rule-options.c001.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint.rule-options.c001]` option `preview`"));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_c063_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.c063.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.c063]` option `preview`"));
     }
 
     #[test]
@@ -745,6 +807,40 @@ mod tests {
                 .as_ref()
                 .and_then(|options| options.c001.as_ref())
                 .and_then(|c001| c001.treat_indirect_expansion_targets_as_used),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn c063_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.c063.report-unreached-nested-definitions = true",
+                    )
+                    .unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.c063.report-unreached-nested-definitions = false",
+                    )
+                    .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c063.as_ref())
+                .and_then(|c063| c063.report_unreached_nested_definitions),
             Some(false)
         );
     }

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -955,6 +955,8 @@ fn lint_with_context(
         })?),
         source_paths: options.source_paths.clone(),
     };
+    let mut rule_options = shuck_linter::LinterRuleOptions::default();
+    rule_options.c063.report_unreached_nested_definitions = true;
     let settings = LinterSettings {
         rules: options.enabled_rules,
         severity_overrides: Default::default(),
@@ -963,7 +965,7 @@ fn lint_with_context(
         analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
         per_file_ignores: Default::default(),
         report_environment_style_names: options.report_environment_style_names,
-        rule_options: Default::default(),
+        rule_options,
     };
 
     let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result(

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2607,7 +2607,7 @@ fn build_large_corpus_linter_settings(
     selected_rules: Option<shuck_linter::RuleSet>,
     mapped_only: bool,
 ) -> shuck_linter::LinterSettings {
-    if let Some(rules) = selected_rules {
+    let settings = if let Some(rules) = selected_rules {
         shuck_linter::LinterSettings::for_rules(rules.iter())
     } else if mapped_only {
         let mapped_rules: HashSet<_> = shuck_linter::ShellCheckCodeMap::default()
@@ -2617,7 +2617,9 @@ fn build_large_corpus_linter_settings(
         shuck_linter::LinterSettings::for_rules(mapped_rules)
     } else {
         shuck_linter::LinterSettings::default()
-    }
+    };
+
+    settings.with_c063_report_unreached_nested_definitions(true)
 }
 
 fn large_corpus_source_resolver(

--- a/crates/shuck-cli/tests/shellcheck_compat.rs
+++ b/crates/shuck-cli/tests/shellcheck_compat.rs
@@ -317,6 +317,36 @@ fn compat_flags_indirect_only_sc2034_targets() {
 }
 
 #[test]
+fn compat_reports_unreached_nested_functions_as_sc2329() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("x.sh"),
+        "#!/bin/bash\nouter() {\n  inner() { :; }\n}\n",
+    )
+    .unwrap();
+
+    let output = run_compat(
+        [
+            "--norc",
+            "-s",
+            "bash",
+            "-f",
+            "json1",
+            "--include=SC2329",
+            "x.sh",
+        ]
+        .as_slice(),
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    let comment = comment_by_code(&comments, 2329);
+    assert_eq!(comment["line"].as_u64(), Some(3));
+    assert_eq!(comment["endLine"].as_u64(), Some(3));
+}
+
+#[test]
 fn compat_accepts_busybox_shell_alias() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("x.sh"), "echo hi\n").unwrap();

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c063.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c063.yaml
@@ -83,6 +83,34 @@ reviewed_divergences:
     line: 15
     reason: "git-extras intentionally swaps in its own commit helper for this command wrapper after sourcing the shared Git helper library."
   - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__helper__spec_helper.sh"
+    line: 113
+    reason: "ShellSpec's helper configuration creates nested mock output hooks for its DSL, and these are reached by framework indirection rather than plain direct calls."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__helper__spec_helper.sh"
+    line: 117
+    reason: "ShellSpec's helper configuration creates nested mock output hooks for its DSL, and these are reached by framework indirection rather than plain direct calls."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__helper__spec_helper.sh"
+    line: 121
+    reason: "ShellSpec's helper configuration creates nested mock output hooks for its DSL, and these are reached by framework indirection rather than plain direct calls."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__lib__core__evaluation.sh"
+    line: 238
+    reason: "ShellSpec installs a nested test wrapper as part of its interceptor machinery, so the remaining C063 hit is framework setup rather than a dead nested helper."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__lib__libexec__optparser__parser_definition.sh"
+    line: 301
+    reason: "ShellSpec's option-parser DSL creates extension-local helper names that are consumed through parser indirection rather than ordinary direct calls."
+  - side: shuck-only
+    path_suffix: "ko1nksm__shellspec__lib__libexec__optparser__parser_definition.sh"
+    line: 306
+    reason: "ShellSpec's option-parser DSL creates extension-local helper names that are consumed through parser indirection rather than ordinary direct calls."
+  - side: shuck-only
+    path_suffix: "xwmx__nb__nb"
+    line: 15574
+    reason: "nb's environment installer uses nested helper plumbing inside a dynamic command workflow, so this compat-only C063 hit is not a useful dead-function finding."
+  - side: shuck-only
     path_contains: "bitnami__containers__"
     reason: "Bitnami container libraries layer shared service wrappers and per-service overrides through sourced lib*.sh files, so the remaining Shuck-only C063 hits are framework hook replacements rather than dead definitions."
   - side: shellcheck-only

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -101,8 +101,8 @@ pub(crate) use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
 pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 /// Linter configuration and per-file ignore types.
 pub use settings::{
-    AmbientShellOptions, C001RuleOptions, CompiledPerFileIgnoreList, LinterRuleOptions,
-    LinterSettings, PerFileIgnore,
+    AmbientShellOptions, C001RuleOptions, C063RuleOptions, CompiledPerFileIgnoreList,
+    LinterRuleOptions, LinterSettings, PerFileIgnore,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -10,6 +10,7 @@ pub enum FunctionNotReachedReason {
     Overwritten,
     ScriptTerminates,
     UnreachableDefinition,
+    EnclosingFunctionUnreached,
 }
 
 pub struct OverwrittenFunction {
@@ -35,6 +36,10 @@ impl Violation for OverwrittenFunction {
                 "function `{}` cannot be reached by a direct call before the script terminates",
                 self.name
             ),
+            FunctionNotReachedReason::EnclosingFunctionUnreached => format!(
+                "function `{}` cannot be reached by a direct call before the enclosing function exits",
+                self.name
+            ),
         }
     }
 
@@ -47,13 +52,19 @@ impl Violation for OverwrittenFunction {
             | FunctionNotReachedReason::UnreachableDefinition => {
                 Some("delete the function definition that cannot be reached".to_owned())
             }
+            FunctionNotReachedReason::EnclosingFunctionUnreached => {
+                Some("delete the nested function definition that cannot be reached".to_owned())
+            }
         }
     }
 }
 
 pub fn overwritten_function(checker: &mut Checker) {
     let overwritten = checker.semantic_analysis().overwritten_functions().to_vec();
-    let unreached = checker.semantic_analysis().unreached_functions().to_vec();
+    let unreached = checker
+        .semantic_analysis()
+        .unreached_functions_with_options(checker.rule_options().c063.semantic_options())
+        .to_vec();
 
     for overwritten in overwritten {
         if overwritten.first_called {
@@ -81,6 +92,9 @@ pub fn overwritten_function(checker: &mut Checker) {
                 FunctionNotReachedReason::UnreachableDefinition
             }
             UnreachedFunctionReason::ScriptTerminates => FunctionNotReachedReason::ScriptTerminates,
+            UnreachedFunctionReason::EnclosingFunctionUnreached => {
+                FunctionNotReachedReason::EnclosingFunctionUnreached
+            }
         };
         report_function_definition(
             checker,
@@ -412,6 +426,49 @@ exit 0
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn nested_functions_at_plain_eof_do_not_report_by_default() {
+        let source = "\
+outer() {
+  inner() { echo hi; }
+}
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn c063_option_reports_unreached_nested_functions_at_plain_eof() {
+        let source = "\
+outer() {
+  inner() { echo hi; }
+}
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("delete the nested function definition that cannot be reached")
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use globset::{Glob, GlobMatcher};
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
-use shuck_semantic::UnusedAssignmentAnalysisOptions;
+use shuck_semantic::{UnreachedFunctionAnalysisOptions, UnusedAssignmentAnalysisOptions};
 
 use crate::{Category, Rule, RuleSelector, RuleSet, Severity, ShellDialect};
 
@@ -19,6 +19,8 @@ const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] = &[];
 pub struct LinterRuleOptions {
     /// Behavior overrides for `C001`.
     pub c001: C001RuleOptions,
+    /// Behavior overrides for `C063`.
+    pub c063: C063RuleOptions,
 }
 
 /// Behavior overrides for `C001` unused-assignment analysis.
@@ -34,6 +36,22 @@ impl C001RuleOptions {
     pub(crate) fn semantic_options(&self) -> UnusedAssignmentAnalysisOptions {
         UnusedAssignmentAnalysisOptions {
             treat_indirect_expansion_targets_as_used: self.treat_indirect_expansion_targets_as_used,
+        }
+    }
+}
+
+/// Behavior overrides for `C063` overwritten/unreached function analysis.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct C063RuleOptions {
+    /// Whether nested function definitions should be reported when no reachable direct call
+    /// reaches the enclosing function scope before that scope exits.
+    pub report_unreached_nested_definitions: bool,
+}
+
+impl C063RuleOptions {
+    pub(crate) fn semantic_options(&self) -> UnreachedFunctionAnalysisOptions {
+        UnreachedFunctionAnalysisOptions {
+            report_unreached_nested_definitions: self.report_unreached_nested_definitions,
         }
     }
 }
@@ -194,6 +212,11 @@ impl LinterSettings {
         self.rule_options
             .c001
             .treat_indirect_expansion_targets_as_used = value;
+        self
+    }
+
+    pub fn with_c063_report_unreached_nested_definitions(mut self, value: bool) -> Self {
+        self.rule_options.c063.report_unreached_nested_definitions = value;
         self
     }
 

--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -31,6 +31,7 @@ pub struct OverwrittenFunction {
 pub enum UnreachedFunctionReason {
     UnreachableDefinition,
     ScriptTerminates,
+    EnclosingFunctionUnreached,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -132,6 +132,14 @@ pub struct UnusedAssignmentAnalysisOptions {
     pub treat_indirect_expansion_targets_as_used: bool,
 }
 
+/// Behavior flags for unreached-function analysis.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UnreachedFunctionAnalysisOptions {
+    /// Whether nested function definitions should be reported when their enclosing function scope
+    /// is not reached by a direct call chain.
+    pub report_unreached_nested_definitions: bool,
+}
+
 #[allow(missing_docs)]
 impl SyntheticRead {
     pub fn scope(&self) -> ScopeId {
@@ -472,6 +480,7 @@ pub struct SemanticAnalysis<'model> {
     dead_code: OnceLock<Vec<DeadCode>>,
     overwritten_functions: OnceLock<Vec<OverwrittenFunction>>,
     unreached_functions: OnceLock<Vec<UnreachedFunction>>,
+    unreached_functions_shellcheck_compat: OnceLock<Vec<UnreachedFunction>>,
     scope_provided_binding_index: OnceLock<ScopeProvidedBindingIndex>,
 }
 
@@ -1226,6 +1235,7 @@ impl<'model> SemanticAnalysis<'model> {
             dead_code: OnceLock::new(),
             overwritten_functions: OnceLock::new(),
             unreached_functions: OnceLock::new(),
+            unreached_functions_shellcheck_compat: OnceLock::new(),
             scope_provided_binding_index: OnceLock::new(),
         }
     }
@@ -1440,7 +1450,20 @@ impl<'model> SemanticAnalysis<'model> {
 
     pub fn unreached_functions(&self) -> &[UnreachedFunction] {
         self.unreached_functions
-            .get_or_init(|| self.compute_unreached_functions())
+            .get_or_init(|| self.compute_unreached_functions_with_options(Default::default()))
+            .as_slice()
+    }
+
+    pub fn unreached_functions_with_options(
+        &self,
+        options: UnreachedFunctionAnalysisOptions,
+    ) -> &[UnreachedFunction] {
+        if options == UnreachedFunctionAnalysisOptions::default() {
+            return self.unreached_functions();
+        }
+
+        self.unreached_functions_shellcheck_compat
+            .get_or_init(|| self.compute_unreached_functions_with_options(options))
             .as_slice()
     }
 
@@ -1653,7 +1676,10 @@ impl<'model> SemanticAnalysis<'model> {
         executed
     }
 
-    fn compute_unreached_functions(&self) -> Vec<UnreachedFunction> {
+    fn compute_unreached_functions_with_options(
+        &self,
+        options: UnreachedFunctionAnalysisOptions,
+    ) -> Vec<UnreachedFunction> {
         if self.model.functions.is_empty() {
             return Vec::new();
         }
@@ -1676,7 +1702,8 @@ impl<'model> SemanticAnalysis<'model> {
             .iter()
             .copied()
             .collect::<FxHashSet<_>>();
-        if unreachable.is_empty() && script_terminators.is_empty() {
+        let has_termination_boundary = !unreachable.is_empty() || !script_terminators.is_empty();
+        if !has_termination_boundary && !options.report_unreached_nested_definitions {
             return Vec::new();
         }
 
@@ -1689,6 +1716,8 @@ impl<'model> SemanticAnalysis<'model> {
         let mut unreached = Vec::new();
         let mut empty_shadow_termination_cache = FxHashMap::default();
         let mut scope_execution_cache = FxHashMap::default();
+        let mut nested_scope_execution_cache = FxHashMap::default();
+        let mut reported_bindings = FxHashSet::default();
 
         for (name, bindings) in &self.model.functions {
             for &binding_id in bindings {
@@ -1699,69 +1728,97 @@ impl<'model> SemanticAnalysis<'model> {
 
                 let reachable_blocks =
                     reachable_binding_blocks(binding_id, &binding_blocks, &unreachable);
-                let Some(reachable_blocks) = reachable_blocks else {
-                    if !self.binding_execution_scope_can_run_before_termination(
-                        binding_id,
-                        cfg,
-                        &unreachable,
-                        &script_terminators,
-                        &mut scope_execution_cache,
-                    ) {
-                        continue;
+
+                if has_termination_boundary {
+                    match reachable_blocks.as_deref() {
+                        None => {
+                            if self.binding_execution_scope_can_run_before_termination(
+                                binding_id,
+                                cfg,
+                                &unreachable,
+                                &script_terminators,
+                                &mut scope_execution_cache,
+                            ) {
+                                reported_bindings.insert(binding_id);
+                                unreached.push(UnreachedFunction {
+                                    name: name.clone(),
+                                    binding: binding_id,
+                                    reason: UnreachedFunctionReason::UnreachableDefinition,
+                                });
+                            }
+                        }
+                        Some(reachable_blocks) => {
+                            if !skip_termination_reachability
+                                && self.binding_execution_scope_can_run_before_termination(
+                                    binding_id,
+                                    cfg,
+                                    &unreachable,
+                                    &script_terminators,
+                                    &mut scope_execution_cache,
+                                )
+                            {
+                                let shadow_blocks = self.shadow_function_blocks(
+                                    name,
+                                    binding_id,
+                                    &binding_blocks,
+                                    &unreachable,
+                                );
+                                let window = FunctionReachWindow {
+                                    binding: binding_id,
+                                    binding_blocks: reachable_blocks,
+                                    shadow_blocks: &shadow_blocks,
+                                    cfg,
+                                    unreachable: &unreachable,
+                                    script_terminators: &script_terminators,
+                                };
+                                let mut visiting_scopes = FxHashSet::default();
+                                let has_direct_call = self
+                                    .function_binding_has_direct_call_before_termination(
+                                        name,
+                                        &window,
+                                        &mut visiting_scopes,
+                                    );
+
+                                if !has_direct_call
+                                    && !script_terminators.is_empty()
+                                    && all_paths_terminate_before_natural_exit(
+                                        reachable_blocks,
+                                        cfg,
+                                        &script_terminators,
+                                        &natural_exits,
+                                        &unreachable,
+                                        &shadow_blocks,
+                                        &mut empty_shadow_termination_cache,
+                                    )
+                                {
+                                    reported_bindings.insert(binding_id);
+                                    unreached.push(UnreachedFunction {
+                                        name: name.clone(),
+                                        binding: binding_id,
+                                        reason: UnreachedFunctionReason::ScriptTerminates,
+                                    });
+                                }
+                            }
+                        }
                     }
-                    unreached.push(UnreachedFunction {
-                        name: name.clone(),
-                        binding: binding_id,
-                        reason: UnreachedFunctionReason::UnreachableDefinition,
-                    });
-                    continue;
-                };
-                if skip_termination_reachability
-                    || !self.binding_execution_scope_can_run_before_termination(
+                }
+
+                if options.report_unreached_nested_definitions
+                    && !reported_bindings.contains(&binding_id)
+                    && self.nested_function_definition_is_unreached(
+                        name,
                         binding_id,
                         cfg,
+                        &binding_blocks,
                         &unreachable,
-                        &script_terminators,
-                        &mut scope_execution_cache,
+                        &mut nested_scope_execution_cache,
                     )
                 {
-                    continue;
-                }
-
-                let shadow_blocks =
-                    self.shadow_function_blocks(name, binding_id, &binding_blocks, &unreachable);
-                let window = FunctionReachWindow {
-                    binding: binding_id,
-                    binding_blocks: &reachable_blocks,
-                    shadow_blocks: &shadow_blocks,
-                    cfg,
-                    unreachable: &unreachable,
-                    script_terminators: &script_terminators,
-                };
-                let mut visiting_scopes = FxHashSet::default();
-                if self.function_binding_has_direct_call_before_termination(
-                    name,
-                    &window,
-                    &mut visiting_scopes,
-                ) {
-                    continue;
-                }
-
-                if !script_terminators.is_empty()
-                    && all_paths_terminate_before_natural_exit(
-                        &reachable_blocks,
-                        cfg,
-                        &script_terminators,
-                        &natural_exits,
-                        &unreachable,
-                        &shadow_blocks,
-                        &mut empty_shadow_termination_cache,
-                    )
-                {
+                    reported_bindings.insert(binding_id);
                     unreached.push(UnreachedFunction {
                         name: name.clone(),
                         binding: binding_id,
-                        reason: UnreachedFunctionReason::ScriptTerminates,
+                        reason: UnreachedFunctionReason::EnclosingFunctionUnreached,
                     });
                 }
             }
@@ -1769,6 +1826,55 @@ impl<'model> SemanticAnalysis<'model> {
 
         unreached.sort_by_key(|unreached| self.model.binding(unreached.binding).span.start.offset);
         unreached
+    }
+
+    fn nested_function_definition_is_unreached(
+        &self,
+        name: &Name,
+        binding_id: BindingId,
+        cfg: &ControlFlowGraph,
+        binding_blocks: &[Vec<BlockId>],
+        unreachable: &FxHashSet<BlockId>,
+        scope_execution_cache: &mut FxHashMap<ScopeId, bool>,
+    ) -> bool {
+        let binding = self.model.binding(binding_id);
+        if self.enclosing_function_scope(binding.scope).is_none() {
+            return false;
+        }
+
+        let empty_terminators = FxHashSet::default();
+        if self.binding_execution_scope_can_run_before_termination(
+            binding_id,
+            cfg,
+            unreachable,
+            &empty_terminators,
+            scope_execution_cache,
+        ) {
+            return false;
+        }
+
+        let Some(reachable_blocks) =
+            reachable_binding_blocks(binding_id, binding_blocks, unreachable)
+        else {
+            return true;
+        };
+        let shadow_blocks =
+            self.shadow_function_blocks(name, binding_id, binding_blocks, unreachable);
+        let window = FunctionReachWindow {
+            binding: binding_id,
+            binding_blocks: &reachable_blocks,
+            shadow_blocks: &shadow_blocks,
+            cfg,
+            unreachable,
+            script_terminators: &empty_terminators,
+        };
+        let mut visiting_scopes = FxHashSet::default();
+
+        !self.function_binding_has_direct_call_before_termination(
+            name,
+            &window,
+            &mut visiting_scopes,
+        )
     }
 
     fn binding_execution_scope_can_run_before_termination(
@@ -1976,6 +2082,15 @@ impl<'model> SemanticAnalysis<'model> {
                 window.script_terminators,
             );
         };
+        if function_scope == binding.scope {
+            return blocks_have_path_avoiding_many(
+                window.cfg,
+                window.binding_blocks,
+                &site_blocks,
+                window.shadow_blocks,
+                window.script_terminators,
+            );
+        }
 
         let Some(scope_entry) = window.cfg.scope_entry(function_scope) else {
             return false;
@@ -3933,6 +4048,187 @@ factory_two
         let model = model(source);
 
         assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_report_nested_plain_eof_only_with_compat_option() {
+        let source = "\
+outer() {
+  inner() { :; }
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+
+        assert!(analysis.unreached_functions().is_empty());
+
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "inner");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::EnclosingFunctionUnreached
+        );
+    }
+
+    #[test]
+    fn unreached_functions_ignore_nested_definition_when_enclosing_function_is_called() {
+        let source = "\
+outer() {
+  inner() { :; }
+}
+outer
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert!(unreached.is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_do_not_count_indirect_enclosing_function_calls() {
+        let source = "\
+outer() {
+  inner() { :; }
+}
+name=outer
+$name
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "inner");
+    }
+
+    #[test]
+    fn unreached_functions_count_same_scope_nested_calls_before_enclosing_scope_exits() {
+        let source = "\
+outer() {
+  inner() { :; }
+  inner
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert!(unreached.is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_count_same_scope_command_substitution_calls() {
+        let source = "\
+outer() {
+  inner() { :; }
+  value=$(inner)
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert!(unreached.is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_count_transitive_nested_calls_before_enclosing_scope_exits() {
+        let source = "\
+outer() {
+  inner() { :; }
+  wrapper() {
+    inner
+  }
+  wrapper
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert!(unreached.is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_follow_nested_direct_call_chains() {
+        let source = "\
+outer() {
+  wrapper() {
+    inner() { :; }
+  }
+  wrapper
+}
+outer
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert!(unreached.is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_report_nested_definitions_when_intermediate_scope_is_not_called() {
+        let source = "\
+outer() {
+  wrapper() {
+    inner() { :; }
+  }
+}
+outer
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "inner");
+    }
+
+    #[test]
+    fn unreached_functions_do_not_count_calls_before_enclosing_definition() {
+        let source = "\
+outer
+outer() {
+  inner() { :; }
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "inner");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a compat-only C063 option for unreached nested function definitions
- wire the option through config, cache keys, ShellCheck compatibility mode, and the large-corpus harness
- add semantic, linter, CLI, compatibility, and corpus metadata coverage

## Tests
- cargo fmt
- cargo test -p shuck-semantic
- cargo test -p shuck-linter overwritten_function -- --nocapture
- cargo test -p shuck-cli c063 -- --nocapture
- cargo test -p shuck-cli --test shellcheck_compat -- --nocapture
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C063