### PR TITLE
fix(linter): reduce C124 corpus divergences

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c124.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c124.yaml
@@ -1,28 +1,41 @@
 reviewed_divergences:
   - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__firmware"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this fixture still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this fixture still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-build__build.sh"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this script still has guarded-return flow that Shuck treats more aggressively than the comparison oracle."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-monitoring__monitoring_standalone_generic.sh"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this helper still has early-return flow that Shuck treats more aggressively than the comparison oracle."
+    path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
+    line: 180
+    column: 13
+    reason: "The called update helper always reaches its final exit, so the success-message statement after that call is genuinely dead; the comparison oracle misses this helper-propagated termination in the sourced menu module."
   - side: shuck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this menu script still has dispatcher-return flow that Shuck treats more aggressively than the comparison oracle."
+    line: 181
+    column: 13
+    reason: "The called update helper always reaches its final exit, so the formatting statement after that call is genuinely dead; the comparison oracle misses this helper-propagated termination in the sourced menu module."
   - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this sourced helper still has function-local return flow that Shuck treats more aggressively than the comparison oracle."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__scripts__lint-packages.sh"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this package linter still has early-return flow that Shuck treats more aggressively than the comparison oracle."
-  - side: shuck-only
-    path_suffix: "tj__git-extras__bin__git-scp"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this command-line helper still has exit-heavy usage flow that Shuck treats more aggressively than the comparison oracle."
+    path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
+    line: 182
+    column: 13
+    reason: "The called update helper already exits the shell, so this explicit exit cannot run; the comparison oracle misses this helper-propagated termination in the sourced menu module."
   - side: shuck-only
     path_suffix: "xwmx__nb__nb"
-    reason: "Residual C124 mismatch outside the loop-control cause filter: this large dispatcher still has return-heavy helper flow that Shuck treats more aggressively than the comparison oracle."
+    line: 12716
+    column: 5
+    reason: "Both branches immediately above return from the function, so the option-reset statement cannot execute when that outer branch is taken; the comparison oracle misses this branch-local dead statement in the large dispatcher."
+  - side: shuck-only
+    path_suffix: "xwmx__nb__nb"
+    line: 22569
+    column: 5
+    reason: "The preceding conditional handles both alternatives with returns, so the fallback response call cannot execute; the comparison oracle reports the surrounding function reachability but misses this internal dead branch."
+  - side: shuck-only
+    path_suffix: "xwmx__nb__nb"
+    line: 22571
+    column: 5
+    reason: "The preceding conditional handles both alternatives with returns, so the fallback return cannot execute; the comparison oracle reports the surrounding function reachability but misses this internal dead branch."
+  - side: shuck-only
+    path_suffix: "xwmx__nb__nb"
+    line: 25796
+    column: 5
+    reason: "The case statement has a catch-all arm and every arm leaves the function, so the loop shift after the case cannot execute; the comparison oracle misses this internal dead statement in the large dispatcher."
+  - side: shuck-only
+    path_suffix: "xwmx__nb__nb"
+    line: 27243
+    column: 39
+    reason: "The helper called earlier in this case arm always exits the shell, so the following return cannot execute; the comparison oracle reports the surrounding function reachability but misses this helper-propagated termination."

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -4686,6 +4686,24 @@ check() {
     }
 
     #[test]
+    fn unreachable_after_exit_reports_shadowed_condition_names_in_short_circuit_lists() {
+        let source = "\
+#!/bin/bash
+true() {
+  exit 0
+}
+check() {
+  true && echo a && echo b
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "echo a");
+        assert_eq!(diagnostics[1].span.slice(source), "echo b");
+    }
+
+    #[test]
     fn unreachable_after_exit_keeps_dead_two_segment_short_circuit_tail() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -4705,7 +4705,7 @@ check() {
 
     #[test]
     fn unreachable_after_exit_reports_shadowed_condition_wrapper_names() {
-        for wrapper in ["command", "builtin"] {
+        for wrapper in ["command", "builtin", "sudo", "doas", "run0"] {
             let source = format!(
                 "\
 #!/bin/bash

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -4704,6 +4704,25 @@ check() {
     }
 
     #[test]
+    fn unreachable_after_exit_ignores_conditionally_defined_condition_names() {
+        let source = "\
+#!/bin/bash
+die() {
+  exit 1
+}
+check() {
+  if maybe; then
+    true() { exit 0; }
+  fi
+  true && die && exit 1
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn unreachable_after_exit_keeps_dead_two_segment_short_circuit_tail() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -4627,6 +4627,20 @@ run && exit 0 || sleep 15
     }
 
     #[test]
+    fn unreachable_after_exit_skips_dead_short_circuit_lists() {
+        let source = "\
+#!/bin/bash
+exit 0
+echo one && echo two
+echo after
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "echo after");
+    }
+
+    #[test]
     fn unreachable_after_exit_skips_dead_short_circuit_exit_guards() {
         let source = "\
 #!/bin/bash
@@ -4640,6 +4654,36 @@ printf '%s\\n' later
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "echo after");
         assert_eq!(diagnostics[1].span.slice(source), "printf '%s\\n' later");
+    }
+
+    #[test]
+    fn unreachable_after_exit_skips_dead_short_circuit_segments() {
+        let source = "\
+#!/bin/bash
+usage() { exit 0; }
+error() {
+  [ $# -eq 0 ] && usage && exit 0
+  echo after
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn unreachable_after_exit_keeps_dead_two_segment_short_circuit_tail() {
+        let source = "\
+#!/bin/bash
+finish() { exit \"$1\"; }
+terminal() {
+  finish 34 && return 34
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "return 34");
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -4704,6 +4704,28 @@ check() {
     }
 
     #[test]
+    fn unreachable_after_exit_reports_shadowed_condition_wrapper_names() {
+        for wrapper in ["command", "builtin"] {
+            let source = format!(
+                "\
+#!/bin/bash
+{wrapper}() {{
+  exit 0
+}}
+check() {{
+  {wrapper} true && echo a && echo b
+}}
+"
+            );
+            let diagnostics = lint_for_rule(&source, Rule::UnreachableAfterExit);
+
+            assert_eq!(diagnostics.len(), 2, "{wrapper}: {diagnostics:?}");
+            assert_eq!(diagnostics[0].span.slice(&source), "echo a", "{wrapper}");
+            assert_eq!(diagnostics[1].span.slice(&source), "echo b", "{wrapper}");
+        }
+    }
+
+    #[test]
     fn unreachable_after_exit_ignores_conditionally_defined_condition_names() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -4672,6 +4672,20 @@ error() {
     }
 
     #[test]
+    fn unreachable_after_exit_reports_nested_dead_code_in_skipped_short_circuit_segments() {
+        let source = "\
+#!/bin/bash
+check() {
+  [ \"$1\" = stop ] && { return 0; echo inner; } && echo tail
+}
+";
+        let diagnostics = lint_for_rule(source, Rule::UnreachableAfterExit);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "echo inner");
+    }
+
+    #[test]
     fn unreachable_after_exit_keeps_dead_two_segment_short_circuit_tail() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -85,16 +85,14 @@ fn list_starts_with_condition(
         return false;
     };
 
-    if command_name_resolves_to_function(command, semantic_analysis) {
-        return false;
-    }
-
-    command.simple_test().is_some()
+    let starts_like_condition = command.simple_test().is_some()
         || command.conditional().is_some()
         || matches!(
             command.effective_or_literal_name(),
             Some("[" | "test" | "true" | "false")
-        )
+        );
+
+    starts_like_condition && !command_name_resolves_to_function(command, semantic_analysis)
 }
 
 fn command_name_resolves_to_function(

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -55,12 +55,10 @@ fn span_matches_short_circuit_skip(
             return false;
         }
 
-        let span_index = list
-            .segments()
+        list.segments()
             .iter()
-            .position(|segment| span_starts_in(span, segment.span()));
-
-        span_index.is_some_and(|index| index > 0)
+            .enumerate()
+            .any(|(index, segment)| index > 0 && span.start == segment.span().start)
     })
 }
 
@@ -81,10 +79,6 @@ fn list_starts_with_condition(list: &ListFact<'_>, commands: &[CommandFact<'_>])
             command.effective_or_literal_name(),
             Some("[" | "test" | "true" | "false")
         )
-}
-
-fn span_starts_in(inner: Span, outer: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.start.offset < outer.end.offset
 }
 
 fn outermost_unreachable_spans(mut spans: Vec<shuck_ast::Span>) -> Vec<shuck_ast::Span> {

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -124,13 +124,11 @@ fn wrapper_name_resolves_to_function(
     command: &CommandFact<'_>,
     semantic_analysis: &SemanticAnalysis<'_>,
 ) -> bool {
-    let Some(wrapper) = command.wrappers().first() else {
+    if command.wrappers().is_empty() {
         return false;
-    };
-    let name = match wrapper {
-        WrapperKind::Command => "command",
-        WrapperKind::Builtin => "builtin",
-        _ => return false,
+    }
+    let Some(name) = command.literal_name() else {
+        return false;
     };
     let AstCommand::Simple(simple) = command.command() else {
         return false;

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,6 +1,6 @@
 use crate::{Checker, CommandFact, ListFact, Rule, Violation, WrapperKind};
 use shuck_ast::{Name, Span};
-use shuck_semantic::{SemanticModel, UnreachableCauseKind};
+use shuck_semantic::{SemanticAnalysis, UnreachableCauseKind};
 
 pub struct UnreachableAfterExit;
 
@@ -18,16 +18,20 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
     let source = checker.source();
     let short_circuit_lists = checker.facts().lists();
     let commands = checker.facts().commands();
-    let semantic = checker.semantic();
+    let semantic_analysis = checker.semantic_analysis();
     let unreachable_spans = outermost_unreachable_spans(
-        checker
-            .semantic_analysis()
+        semantic_analysis
             .dead_code()
             .iter()
             .filter(|dead_code| dead_code.cause_kind != UnreachableCauseKind::LoopControl)
             .flat_map(|dead_code| dead_code.unreachable.iter().copied())
             .filter(|span| {
-                !span_matches_short_circuit_skip(*span, short_circuit_lists, commands, semantic)
+                !span_matches_short_circuit_skip(
+                    *span,
+                    short_circuit_lists,
+                    commands,
+                    semantic_analysis,
+                )
             })
             .collect::<Vec<_>>(),
     );
@@ -44,7 +48,7 @@ fn span_matches_short_circuit_skip(
     span: Span,
     short_circuit_lists: &[ListFact<'_>],
     commands: &[CommandFact<'_>],
-    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
 ) -> bool {
     short_circuit_lists.iter().any(|list| {
         if span == list.span() {
@@ -55,7 +59,7 @@ fn span_matches_short_circuit_skip(
             return false;
         }
 
-        if !list_starts_with_condition(list, commands, semantic) {
+        if !list_starts_with_condition(list, commands, semantic_analysis) {
             return false;
         }
 
@@ -69,7 +73,7 @@ fn span_matches_short_circuit_skip(
 fn list_starts_with_condition(
     list: &ListFact<'_>,
     commands: &[CommandFact<'_>],
-    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
 ) -> bool {
     let Some(first_segment) = list.segments().first() else {
         return false;
@@ -81,7 +85,7 @@ fn list_starts_with_condition(
         return false;
     };
 
-    if command_name_resolves_to_function(command, semantic) {
+    if command_name_resolves_to_function(command, semantic_analysis) {
         return false;
     }
 
@@ -93,7 +97,10 @@ fn list_starts_with_condition(
         )
 }
 
-fn command_name_resolves_to_function(command: &CommandFact<'_>, semantic: &SemanticModel) -> bool {
+fn command_name_resolves_to_function(
+    command: &CommandFact<'_>,
+    semantic_analysis: &SemanticAnalysis<'_>,
+) -> bool {
     if command.has_wrapper(WrapperKind::Command) || command.has_wrapper(WrapperKind::Builtin) {
         return false;
     }
@@ -106,11 +113,9 @@ fn command_name_resolves_to_function(command: &CommandFact<'_>, semantic: &Seman
     };
     let name = Name::from(name);
 
-    semantic
-        .function_definitions(&name)
-        .iter()
-        .copied()
-        .any(|binding_id| semantic.binding_visible_at(binding_id, name_span))
+    semantic_analysis
+        .visible_function_binding_at_call(&name, name_span)
+        .is_some()
 }
 
 fn outermost_unreachable_spans(mut spans: Vec<shuck_ast::Span>) -> Vec<shuck_ast::Span> {

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,5 +1,5 @@
 use crate::{Checker, CommandFact, ListFact, Rule, Violation};
-use shuck_ast::{BinaryOp, Span};
+use shuck_ast::Span;
 use shuck_semantic::UnreachableCauseKind;
 
 pub struct UnreachableAfterExit;
@@ -16,7 +16,8 @@ impl Violation for UnreachableAfterExit {
 
 pub fn unreachable_after_exit(checker: &mut Checker) {
     let source = checker.source();
-    let short_circuit_guard_spans = short_circuit_exit_guard_spans(checker);
+    let short_circuit_lists = checker.facts().lists();
+    let commands = checker.facts().commands();
     let unreachable_spans = outermost_unreachable_spans(
         checker
             .semantic_analysis()
@@ -24,7 +25,7 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
             .iter()
             .filter(|dead_code| dead_code.cause_kind != UnreachableCauseKind::LoopControl)
             .flat_map(|dead_code| dead_code.unreachable.iter().copied())
-            .filter(|span| !short_circuit_guard_spans.contains(span))
+            .filter(|span| !span_matches_short_circuit_skip(*span, short_circuit_lists, commands))
             .collect::<Vec<_>>(),
     );
 
@@ -36,37 +37,54 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
     }
 }
 
-fn short_circuit_exit_guard_spans(checker: &Checker) -> Vec<Span> {
-    let commands = checker.facts().commands();
-    checker
-        .facts()
-        .lists()
-        .iter()
-        .filter(|list| list_is_exit_guard(list, commands))
-        .map(ListFact::span)
-        .collect()
+fn span_matches_short_circuit_skip(
+    span: Span,
+    short_circuit_lists: &[ListFact<'_>],
+    commands: &[CommandFact<'_>],
+) -> bool {
+    short_circuit_lists.iter().any(|list| {
+        if span == list.span() {
+            return true;
+        }
+
+        if list.segments().len() < 3 || !span_contained_by(span, list.span()) {
+            return false;
+        }
+
+        if !list_starts_with_condition(list, commands) {
+            return false;
+        }
+
+        let span_index = list
+            .segments()
+            .iter()
+            .position(|segment| span_starts_in(span, segment.span()));
+
+        span_index.is_some_and(|index| index > 0)
+    })
 }
 
-fn list_is_exit_guard(list: &ListFact<'_>, commands: &[CommandFact<'_>]) -> bool {
-    if list
-        .operators()
-        .last()
-        .is_none_or(|operator| operator.op() != BinaryOp::Or)
-    {
-        return false;
-    }
-
-    let Some(terminator_id) = list.segments().last().map(|segment| segment.command_id()) else {
+fn list_starts_with_condition(list: &ListFact<'_>, commands: &[CommandFact<'_>]) -> bool {
+    let Some(first_segment) = list.segments().first() else {
         return false;
     };
-    let Some(terminator) = commands
+    let Some(command) = commands
         .iter()
-        .find(|command| command.id() == terminator_id)
+        .find(|command| command.id() == first_segment.command_id())
     else {
         return false;
     };
 
-    matches!(terminator.static_utility_name(), Some("exit" | "return"))
+    command.simple_test().is_some()
+        || command.conditional().is_some()
+        || matches!(
+            command.effective_or_literal_name(),
+            Some("[" | "test" | "true" | "false")
+        )
+}
+
+fn span_starts_in(inner: Span, outer: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.start.offset < outer.end.offset
 }
 
 fn outermost_unreachable_spans(mut spans: Vec<shuck_ast::Span>) -> Vec<shuck_ast::Span> {

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,5 +1,5 @@
 use crate::{Checker, CommandFact, ListFact, Rule, Violation, WrapperKind};
-use shuck_ast::{Name, Span};
+use shuck_ast::{Command as AstCommand, Name, Span};
 use shuck_semantic::{SemanticAnalysis, UnreachableCauseKind};
 
 pub struct UnreachableAfterExit;
@@ -101,6 +101,10 @@ fn command_name_resolves_to_function(
     command: &CommandFact<'_>,
     semantic_analysis: &SemanticAnalysis<'_>,
 ) -> bool {
+    if wrapper_name_resolves_to_function(command, semantic_analysis) {
+        return true;
+    }
+
     if command.has_wrapper(WrapperKind::Command) || command.has_wrapper(WrapperKind::Builtin) {
         return false;
     }
@@ -115,6 +119,27 @@ fn command_name_resolves_to_function(
 
     semantic_analysis
         .visible_function_binding_at_call(&name, name_span)
+        .is_some()
+}
+
+fn wrapper_name_resolves_to_function(
+    command: &CommandFact<'_>,
+    semantic_analysis: &SemanticAnalysis<'_>,
+) -> bool {
+    let Some(wrapper) = command.wrappers().first() else {
+        return false;
+    };
+    let name = match wrapper {
+        WrapperKind::Command => "command",
+        WrapperKind::Builtin => "builtin",
+        _ => return false,
+    };
+    let AstCommand::Simple(simple) = command.command() else {
+        return false;
+    };
+
+    semantic_analysis
+        .visible_function_binding_at_call(&Name::from(name), simple.name.span)
         .is_some()
 }
 

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,6 +1,6 @@
-use crate::{Checker, CommandFact, ListFact, Rule, Violation};
-use shuck_ast::Span;
-use shuck_semantic::UnreachableCauseKind;
+use crate::{Checker, CommandFact, ListFact, Rule, Violation, WrapperKind};
+use shuck_ast::{Name, Span};
+use shuck_semantic::{SemanticModel, UnreachableCauseKind};
 
 pub struct UnreachableAfterExit;
 
@@ -18,6 +18,7 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
     let source = checker.source();
     let short_circuit_lists = checker.facts().lists();
     let commands = checker.facts().commands();
+    let semantic = checker.semantic();
     let unreachable_spans = outermost_unreachable_spans(
         checker
             .semantic_analysis()
@@ -25,7 +26,9 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
             .iter()
             .filter(|dead_code| dead_code.cause_kind != UnreachableCauseKind::LoopControl)
             .flat_map(|dead_code| dead_code.unreachable.iter().copied())
-            .filter(|span| !span_matches_short_circuit_skip(*span, short_circuit_lists, commands))
+            .filter(|span| {
+                !span_matches_short_circuit_skip(*span, short_circuit_lists, commands, semantic)
+            })
             .collect::<Vec<_>>(),
     );
 
@@ -41,6 +44,7 @@ fn span_matches_short_circuit_skip(
     span: Span,
     short_circuit_lists: &[ListFact<'_>],
     commands: &[CommandFact<'_>],
+    semantic: &SemanticModel,
 ) -> bool {
     short_circuit_lists.iter().any(|list| {
         if span == list.span() {
@@ -51,7 +55,7 @@ fn span_matches_short_circuit_skip(
             return false;
         }
 
-        if !list_starts_with_condition(list, commands) {
+        if !list_starts_with_condition(list, commands, semantic) {
             return false;
         }
 
@@ -62,7 +66,11 @@ fn span_matches_short_circuit_skip(
     })
 }
 
-fn list_starts_with_condition(list: &ListFact<'_>, commands: &[CommandFact<'_>]) -> bool {
+fn list_starts_with_condition(
+    list: &ListFact<'_>,
+    commands: &[CommandFact<'_>],
+    semantic: &SemanticModel,
+) -> bool {
     let Some(first_segment) = list.segments().first() else {
         return false;
     };
@@ -73,12 +81,36 @@ fn list_starts_with_condition(list: &ListFact<'_>, commands: &[CommandFact<'_>])
         return false;
     };
 
+    if command_name_resolves_to_function(command, semantic) {
+        return false;
+    }
+
     command.simple_test().is_some()
         || command.conditional().is_some()
         || matches!(
             command.effective_or_literal_name(),
             Some("[" | "test" | "true" | "false")
         )
+}
+
+fn command_name_resolves_to_function(command: &CommandFact<'_>, semantic: &SemanticModel) -> bool {
+    if command.has_wrapper(WrapperKind::Command) || command.has_wrapper(WrapperKind::Builtin) {
+        return false;
+    }
+
+    let Some(name) = command.effective_or_literal_name() else {
+        return false;
+    };
+    let Some(name_span) = command.body_word_span() else {
+        return false;
+    };
+    let name = Name::from(name);
+
+    semantic
+        .function_definitions(&name)
+        .iter()
+        .copied()
+        .any(|binding_id| semantic.binding_visible_at(binding_id, name_span))
 }
 
 fn outermost_unreachable_spans(mut spans: Vec<shuck_ast::Span>) -> Vec<shuck_ast::Span> {
@@ -110,8 +142,12 @@ fn span_contained_by(inner: shuck_ast::Span, outer: shuck_ast::Span) -> bool {
 }
 
 fn trim_trailing_terminator(span: Span, source: &str) -> Span {
-    let trimmed = span
-        .slice(source)
+    let trimmed = span.slice(source).trim_end_matches(char::is_whitespace);
+    let trimmed = trimmed
+        .strip_suffix("&&")
+        .or_else(|| trimmed.strip_suffix("||"))
+        .unwrap_or(trimmed);
+    let trimmed = trimmed
         .trim_end_matches(char::is_whitespace)
         .trim_end_matches(';')
         .trim_end_matches(char::is_whitespace);

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -609,11 +609,7 @@ pub(crate) struct FunctionBindingLookup<'a> {
 }
 
 impl FunctionBindingLookup<'_> {
-    pub(crate) fn visible_function_binding_at_call(
-        &self,
-        name: &Name,
-        site: &CallSite,
-    ) -> Option<BindingId> {
+    pub(crate) fn visible_function_call_bindings(&self) -> FxHashMap<SpanKey, BindingId> {
         let mut resolver = FunctionCallResolver {
             program: self.program,
             scopes: self.scopes,
@@ -623,8 +619,20 @@ impl FunctionBindingLookup<'_> {
             function_bindings_by_scope: self.function_bindings_by_scope,
             entry_before_offset_cache: FxHashMap::default(),
         };
+        let mut call_bindings = FxHashMap::default();
 
-        resolver.visible_function_binding(name, site.scope, site.span.start.offset)
+        for (name, sites) in self.call_sites {
+            for site in sites {
+                let Some(binding) =
+                    resolver.visible_function_binding(name, site.scope, site.span.start.offset)
+                else {
+                    continue;
+                };
+                call_bindings.insert(SpanKey::new(site.name_span), binding);
+            }
+        }
+
+        call_bindings
     }
 }
 

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -599,32 +599,36 @@ fn resolve_script_terminating_call_spans(
     changed
 }
 
-pub(crate) fn visible_function_binding_at_call(
-    program: &RecordedProgram,
-    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
-    scopes: &[Scope],
-    bindings: &[Binding],
-    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
-    name: &Name,
-    site: &CallSite,
-) -> Option<BindingId> {
-    let unconditional_function_bindings =
-        collect_unconditional_function_bindings(program, command_bindings, bindings);
-    let scope_function_bindings = function_bindings_by_scope(program);
-    let mut resolver = FunctionCallResolver {
-        program,
-        scopes,
-        bindings,
-        call_sites,
-        unconditional_function_bindings: &unconditional_function_bindings,
-        function_bindings_by_scope: &scope_function_bindings,
-        entry_before_offset_cache: FxHashMap::default(),
-    };
-
-    resolver.visible_function_binding(name, site.scope, site.span.start.offset)
+pub(crate) struct FunctionBindingLookup<'a> {
+    pub(crate) program: &'a RecordedProgram,
+    pub(crate) scopes: &'a [Scope],
+    pub(crate) bindings: &'a [Binding],
+    pub(crate) call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    pub(crate) unconditional_function_bindings: &'a FxHashSet<BindingId>,
+    pub(crate) function_bindings_by_scope: &'a FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>,
 }
 
-fn function_bindings_by_scope(
+impl FunctionBindingLookup<'_> {
+    pub(crate) fn visible_function_binding_at_call(
+        &self,
+        name: &Name,
+        site: &CallSite,
+    ) -> Option<BindingId> {
+        let mut resolver = FunctionCallResolver {
+            program: self.program,
+            scopes: self.scopes,
+            bindings: self.bindings,
+            call_sites: self.call_sites,
+            unconditional_function_bindings: self.unconditional_function_bindings,
+            function_bindings_by_scope: self.function_bindings_by_scope,
+            entry_before_offset_cache: FxHashMap::default(),
+        };
+
+        resolver.visible_function_binding(name, site.scope, site.span.start.offset)
+    }
+}
+
+pub(crate) fn function_bindings_by_scope(
     program: &RecordedProgram,
 ) -> FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {
     let mut bindings_by_scope: FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> = FxHashMap::default();
@@ -682,7 +686,7 @@ fn recorded_command_span_for_call_site(program: &RecordedProgram, site: &CallSit
         .unwrap_or(site.span)
 }
 
-fn collect_unconditional_function_bindings(
+pub(crate) fn collect_unconditional_function_bindings(
     program: &RecordedProgram,
     command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
     bindings: &[Binding],

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -599,6 +599,31 @@ fn resolve_script_terminating_call_spans(
     changed
 }
 
+pub(crate) fn visible_function_binding_at_call(
+    program: &RecordedProgram,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    scopes: &[Scope],
+    bindings: &[Binding],
+    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    name: &Name,
+    site: &CallSite,
+) -> Option<BindingId> {
+    let unconditional_function_bindings =
+        collect_unconditional_function_bindings(program, command_bindings, bindings);
+    let scope_function_bindings = function_bindings_by_scope(program);
+    let mut resolver = FunctionCallResolver {
+        program,
+        scopes,
+        bindings,
+        call_sites,
+        unconditional_function_bindings: &unconditional_function_bindings,
+        function_bindings_by_scope: &scope_function_bindings,
+        entry_before_offset_cache: FxHashMap::default(),
+    };
+
+    resolver.visible_function_binding(name, site.scope, site.span.start.offset)
+}
+
 fn function_bindings_by_scope(
     program: &RecordedProgram,
 ) -> FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -473,6 +473,8 @@ pub struct SemanticAnalysis<'model> {
     overwritten_functions: OnceLock<Vec<OverwrittenFunction>>,
     unreached_functions: OnceLock<Vec<UnreachedFunction>>,
     scope_provided_binding_index: OnceLock<ScopeProvidedBindingIndex>,
+    unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
+    function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
 }
 
 struct OverwriteWindow<'a> {
@@ -1269,6 +1271,8 @@ impl<'model> SemanticAnalysis<'model> {
             overwritten_functions: OnceLock::new(),
             unreached_functions: OnceLock::new(),
             scope_provided_binding_index: OnceLock::new(),
+            unconditional_function_bindings: OnceLock::new(),
+            function_bindings_by_scope: OnceLock::new(),
         }
     }
 
@@ -1296,15 +1300,31 @@ impl<'model> SemanticAnalysis<'model> {
             .iter()
             .find(|site| site.name_span == name_span)?;
 
-        cfg::visible_function_binding_at_call(
-            &self.model.recorded_program,
-            &self.model.command_bindings,
-            &self.model.scopes,
-            &self.model.bindings,
-            &self.model.call_sites,
-            name,
-            site,
-        )
+        let lookup = cfg::FunctionBindingLookup {
+            program: &self.model.recorded_program,
+            scopes: &self.model.scopes,
+            bindings: &self.model.bindings,
+            call_sites: &self.model.call_sites,
+            unconditional_function_bindings: self.unconditional_function_bindings(),
+            function_bindings_by_scope: self.function_bindings_by_scope(),
+        };
+
+        lookup.visible_function_binding_at_call(name, site)
+    }
+
+    fn unconditional_function_bindings(&self) -> &FxHashSet<BindingId> {
+        self.unconditional_function_bindings.get_or_init(|| {
+            cfg::collect_unconditional_function_bindings(
+                &self.model.recorded_program,
+                &self.model.command_bindings,
+                &self.model.bindings,
+            )
+        })
+    }
+
+    fn function_bindings_by_scope(&self) -> &FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {
+        self.function_bindings_by_scope
+            .get_or_init(|| cfg::function_bindings_by_scope(&self.model.recorded_program))
     }
 
     #[doc(hidden)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -475,6 +475,7 @@ pub struct SemanticAnalysis<'model> {
     scope_provided_binding_index: OnceLock<ScopeProvidedBindingIndex>,
     unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
     function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
+    visible_function_call_bindings: OnceLock<FxHashMap<SpanKey, BindingId>>,
 }
 
 struct OverwriteWindow<'a> {
@@ -1273,6 +1274,7 @@ impl<'model> SemanticAnalysis<'model> {
             scope_provided_binding_index: OnceLock::new(),
             unconditional_function_bindings: OnceLock::new(),
             function_bindings_by_scope: OnceLock::new(),
+            visible_function_call_bindings: OnceLock::new(),
         }
     }
 
@@ -1294,22 +1296,32 @@ impl<'model> SemanticAnalysis<'model> {
         name: &Name,
         name_span: Span,
     ) -> Option<BindingId> {
-        let site = self
-            .model
+        self.model
             .call_sites_for(name)
             .iter()
             .find(|site| site.name_span == name_span)?;
 
-        let lookup = cfg::FunctionBindingLookup {
+        self.visible_function_call_bindings()
+            .get(&SpanKey::new(name_span))
+            .copied()
+    }
+
+    fn function_binding_lookup(&self) -> cfg::FunctionBindingLookup<'_> {
+        cfg::FunctionBindingLookup {
             program: &self.model.recorded_program,
             scopes: &self.model.scopes,
             bindings: &self.model.bindings,
             call_sites: &self.model.call_sites,
             unconditional_function_bindings: self.unconditional_function_bindings(),
             function_bindings_by_scope: self.function_bindings_by_scope(),
-        };
+        }
+    }
 
-        lookup.visible_function_binding_at_call(name, site)
+    fn visible_function_call_bindings(&self) -> &FxHashMap<SpanKey, BindingId> {
+        self.visible_function_call_bindings.get_or_init(|| {
+            self.function_binding_lookup()
+                .visible_function_call_bindings()
+        })
     }
 
     fn unconditional_function_bindings(&self) -> &FxHashSet<BindingId> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1285,6 +1285,28 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    pub fn visible_function_binding_at_call(
+        &self,
+        name: &Name,
+        name_span: Span,
+    ) -> Option<BindingId> {
+        let site = self
+            .model
+            .call_sites_for(name)
+            .iter()
+            .find(|site| site.name_span == name_span)?;
+
+        cfg::visible_function_binding_at_call(
+            &self.model.recorded_program,
+            &self.model.command_bindings,
+            &self.model.scopes,
+            &self.model.bindings,
+            &self.model.call_sites,
+            name,
+            site,
+        )
+    }
+
     #[doc(hidden)]
     pub fn block_ids_for_span(&self, span: Span) -> &[BlockId] {
         self.cfg().block_ids_for_span(span)


### PR DESCRIPTION
## Summary

- Align C124 dead-code reporting with the comparison oracle for dead short-circuit lists and condition-led short-circuit chains.
- Add regression coverage for skipped short-circuit list/segment cases and preserved two-segment helper tails.
- Narrow C124 corpus metadata from broad fixture-level entries to line-specific reviewed oracle misses.

## Root Cause

C124 still reported some short-circuit list shapes that the ShellCheck comparison target does not report, leaving broad metadata to suppress fixture-level differences. The remaining differences are helper-propagated or branch-local dead-code cases where Shuck is intentionally more precise.

## Validation

- `cargo test -p shuck-linter unreachable_after_exit --lib`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C124`
- `make test`
- `git diff --check`