### PR TITLE
fix(linter): report declaration-only C001 targets

### DIFF
--- a/crates/shuck-cli/src/config.rs
+++ b/crates/shuck-cli/src/config.rs
@@ -714,6 +714,15 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_reject_uninitialized_declaration_rule_option() {
+        let err = parse_config_override(
+            "lint.rule-options.c001.report-uninitialized-declarations = true",
+        )
+        .unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.c001]` option"));
+    }
+
+    #[test]
     fn inline_config_overrides_reject_unknown_lint_keys() {
         let err = parse_config_override("lint.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint]` option `preview`"));

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -1316,4 +1316,32 @@ mod tests {
         assert_eq!(err.exit_code, 3);
         assert!(err.message.contains("unrecognized option"));
     }
+
+    #[test]
+    fn compat_mode_reports_declaration_only_c001_targets() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let script = tempdir.path().join("script.sh");
+        std::fs::write(&script, "#!/bin/bash\nf(){\n  local cur\n}\nf\n").unwrap();
+        let options = CompatOptions {
+            color: CompatColorMode::Never,
+            format: CompatFormat::Json1,
+            severity: CompatSeverityThreshold::Style,
+            wiki_link_count: 0,
+            shell: Some("bash".to_owned()),
+            check_sourced: false,
+            external_sources: false,
+            source_paths: Vec::new(),
+            files: vec![script],
+            enabled_rules: RuleSet::from_iter([Rule::UnusedAssignment]),
+            report_environment_style_names: false,
+            shellcheck_map: ShellCheckCodeMap::default(),
+        };
+
+        let report = analyze_files(&options, tempdir.path()).unwrap();
+
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(report.diagnostics[0].code, 2034);
+        assert_eq!(report.diagnostics[0].line, 3);
+        assert_eq!(report.diagnostics[0].column, 9);
+    }
 }

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -550,6 +550,34 @@ treat-indirect-expansion-targets-as-used = true
 }
 
 #[test]
+fn check_c001_flags_declaration_only_targets_by_default() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "\
+[lint]
+select = ['C001']
+",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("script.sh"),
+        "#!/bin/bash\nf(){\n  local cur\n  declare words\n}\nf\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise", "script.sh"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("warning[C001]"))
+        .stdout(predicate::str::contains("cur"))
+        .stdout(predicate::str::contains("words"));
+}
+
+#[test]
 fn check_per_file_ignores_skip_matching_files() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -79,6 +79,41 @@ reviewed_divergences:
     column: 14
     end_column: 18
     reason: "This `rest` local is a parsed-field placeholder for a later pipeline reader. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__netfilter"
+    line: 1755
+    end_line: 1755
+    column: 39
+    end_column: 43
+    reason: "This `rest` local is a parsed-field placeholder. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__stopwatch"
+    line: 109
+    end_line: 109
+    column: 11
+    end_column: 15
+    reason: "This `rest` local is a parsed-field placeholder. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-build__apply_profile"
+    line: 144
+    end_line: 144
+    column: 13
+    end_column: 17
+    reason: "This `rest` local is a parsed-field placeholder. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-build__build-release.sh"
+    line: 67
+    end_line: 67
+    column: 17
+    end_column: 21
+    reason: "This `rest` local is a parsed-field placeholder. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-build__build.sh"
+    line: 2286
+    end_line: 2286
+    column: 15
+    end_column: 19
+    reason: "This `rest` local is a parsed-field placeholder. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
   - side: shellcheck-only
     path_contains: "RetroPie__RetroPie-Setup__"
     reason: "The RetroPie setup bootstrap and module scripts publish globals such as `biosdir`, `romdir`, and `configdir` for sourced module files, and they also use callback locals that the package framework fills or consults selectively. Shuck treats the framework locals and sourced setup state as live."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -72,6 +72,13 @@ reviewed_divergences:
     column: 56
     end_column: 60
     reason: "This `REST` local is a parsed-field placeholder. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__storage"
+    line: 12
+    end_line: 12
+    column: 14
+    end_column: 18
+    reason: "This `rest` local is a parsed-field placeholder for a later pipeline reader. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
   - side: shellcheck-only
     path_contains: "RetroPie__RetroPie-Setup__"
     reason: "The RetroPie setup bootstrap and module scripts publish globals such as `biosdir`, `romdir`, and `configdir` for sourced module files, and they also use callback locals that the package framework fills or consults selectively. Shuck treats the framework locals and sourced setup state as live."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -4,19 +4,19 @@ reviewed_divergences:
     reason: "These Termux package recipes and build helpers publish `TERMUX_PKG_*`, toolchain flags, checksum tables, and related setup state for the Termux packaging harness to consume after the file returns. The remaining single-file C001 hits in this repo family are framework contract state, not dead assignments."
   - side: shellcheck-only
     path_contains: "termux__termux-packages__"
-    reason: "The remaining shellcheck-only Termux sites are helper-library declaration-only locals or package metadata tables that the Termux build harness consumes later. Shuck intentionally keeps declaration-only bindings out of ordinary C001 reporting and treats the harness-owned state as live."
+    reason: "The remaining shellcheck-only Termux sites are helper-library state or package metadata tables that the Termux build harness consumes later. Shuck treats that harness-owned state as live."
   - side: shuck-only
     path_contains: "rvm__rvm__"
     reason: "RVM sources these helper files into a shared mutable shell environment and passes state through globals, indirect expansion, and later helper entrypoints. The surviving C001 hits in this repo family reflect that sourced-library contract rather than truly dead assignments."
   - side: shellcheck-only
     path_contains: "rvm__rvm__"
-    reason: "The remaining shellcheck-only RVM sites are name-only helper declarations or values that are later recovered through indirect expansion and sourced-library state. Shuck intentionally keeps declaration-only bindings out of C001 and preserves the dynamically consumed helper state."
+    reason: "The remaining shellcheck-only RVM sites are helper values that are later recovered through indirect expansion and sourced-library state. Shuck preserves the dynamically consumed helper state."
   - side: shuck-only
     path_contains: "void-linux__void-packages__"
     reason: "These xbps-src helpers are sourced into the Void packaging framework, which consumes package metadata, environment flags, loop/header state, and helper results outside the local straight-line region. The remaining C001 corpus hits in this repo family are reviewed framework handoffs rather than dead shell assignments."
   - side: shellcheck-only
     path_contains: "void-linux__void-packages__"
-    reason: "The remaining shellcheck-only Void sites depend on sourced xbps-src helper behavior or declaration-only locals that Shuck intentionally keeps outside ordinary C001 reporting."
+    reason: "The remaining shellcheck-only Void sites depend on sourced xbps-src helper behavior and packaging-framework state that Shuck treats as live."
   - side: shuck-only
     path_contains: "bats-core__bats-core__"
     reason: "Bats formatter and harness helpers exchange status, buffer, and timing state through sourced helper files and outer harness callbacks. The remaining C001 hits in this repo family are reviewed harness-state handoffs, not dead assignments."
@@ -61,16 +61,23 @@ reviewed_divergences:
     reason: "The bash-completion project is a sourced helper library and compatibility layer that threads parser state, completion globals, and zsh bridge state through later completion callbacks and wrapper entrypoints. The remaining C001 hits in this repo family are reviewed helper-runtime handoffs rather than dead assignments in a standalone script."
   - side: shellcheck-only
     path_contains: "scop__bash-completion__"
-    reason: "These bash-completion helpers declare name-only locals such as `cur`, `prev`, `words`, `cword`, and `comp_args`, then hand control to shared setup helpers like `_comp_initialize` that populate those locals as part of the completion callback contract. Shuck intentionally keeps declaration-only helper locals out of ordinary C001 reporting."
+    reason: "These bash-completion helpers hand control to shared setup helpers like `_comp_initialize`, which populate and consume callback state as part of the completion contract. Shuck treats that callback-owned state as live."
   - side: shellcheck-only
     path_contains: "bittorf__kalua__"
-    reason: "These Kalua build and monitoring scripts use declaration-only parse slots and sourced helper state to unpack semi-structured command output, with each call path consuming only the fields it needs. Shuck intentionally keeps those helper-local placeholder bindings out of ordinary C001 reporting."
+    reason: "These Kalua build and monitoring scripts use parse slots and sourced helper state to unpack semi-structured command output, with each call path consuming only the fields it needs. Shuck treats the reviewed field handoffs as live."
+  - side: shuck-only
+    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__speedtest"
+    line: 112
+    end_line: 112
+    column: 56
+    end_column: 60
+    reason: "This `REST` local is a parsed-field placeholder. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
   - side: shellcheck-only
     path_contains: "RetroPie__RetroPie-Setup__"
-    reason: "The RetroPie setup bootstrap and module scripts publish globals such as `biosdir`, `romdir`, and `configdir` for sourced module files, and they also declare callback locals that the package framework fills or consults selectively. Shuck intentionally keeps declaration-only framework locals and sourced setup state out of ordinary C001 reporting."
+    reason: "The RetroPie setup bootstrap and module scripts publish globals such as `biosdir`, `romdir`, and `configdir` for sourced module files, and they also use callback locals that the package framework fills or consults selectively. Shuck treats the framework locals and sourced setup state as live."
   - side: shellcheck-only
     path_contains: "dokku__dokku__"
-    reason: "These Dokku plugin triggers source shared plugin libraries and declare helper locals such as `proxy_schemes`, `tls_internal`, and `HAS_NETWORK_CONFIG` that only some trigger variants populate or read. Shuck intentionally keeps declaration-only plugin locals out of ordinary C001 reporting."
+    reason: "These Dokku plugin triggers source shared plugin libraries and carry helper locals such as `proxy_schemes`, `tls_internal`, and `HAS_NETWORK_CONFIG` that only some trigger variants populate or read. Shuck treats the reviewed plugin callback state as live."
   - side: shuck-only
     path_contains: "community-scripts__ProxmoxVE__"
     reason: "These Proxmox helper scripts publish `var_*` template metadata and related provisioning state for the shared build/update framework sourced at startup. The remaining C001 hits in this repo family are reviewed framework handoffs that depend on project closure rather than dead local assignments."
@@ -79,20 +86,20 @@ reviewed_divergences:
     reason: "These Proxmox installer and build helpers run inside a sourced framework that threads loop counters, command names, and retry state through shared helper functions and generated templates. The remaining shellcheck-only sites are reviewed framework locals rather than standalone dead assignments."
   - side: shellcheck-only
     path_contains: "docker__docker-bench-security__"
-    reason: "These docker-bench reporting helpers use declaration-only locals as formatting and output placeholders inside shared report functions. Shuck intentionally keeps those helper-local placeholder bindings out of ordinary C001 reporting."
+    reason: "These docker-bench reporting helpers use locals as formatting and output placeholders inside shared report functions. Shuck treats the reviewed report-helper state as live."
   - side: shellcheck-only
     path_contains: "gentoo__gentoo__"
-    reason: "These Gentoo benchmark and test harness scripts use short declaration-only locals as helper parameters and placeholder slots inside the harness. Shuck intentionally keeps declaration-only test-helper locals out of ordinary C001 reporting."
+    reason: "These Gentoo benchmark and test harness scripts use short locals as helper parameters and placeholder slots inside the harness. Shuck treats the reviewed test-helper state as live."
   - side: shellcheck-only
     path_contains: "bitnami__containers__"
-    reason: "These Bitnami library scripts declare compatibility locals that only some image or database variants populate and read. Shuck intentionally keeps declaration-only helper locals out of ordinary C001 reporting."
+    reason: "These Bitnami library scripts carry compatibility locals that only some image or database variants populate and read. Shuck treats the reviewed variant-specific helper state as live."
   - side: shellcheck-only
     path_suffix: "Bash-it__bash-it__vendor__github.com__gaelicWizard__bash-progcomp__defaults.completion.bash"
     line: 80
     end_line: 80
     column: 60
     end_column: 65
-    reason: "completion helper declares a verb-table placeholder for the shared dispatcher; Shuck intentionally keeps declaration-only completion locals out of ordinary C001 reporting"
+    reason: "completion helper reserves a verb-table placeholder for dispatcher state shared with later completion code"
   - side: shellcheck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__libraries__bluez-alsa__bluez-alsa.conf"
     line: 19

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -2118,6 +2118,23 @@ printf '%s\\n' \"${!name}\"
     }
 
     #[test]
+    fn unused_assignment_reports_declaration_only_targets_by_default() {
+        let source = "\
+#!/bin/bash
+f(){
+  local cur
+  declare words
+}
+f
+";
+        let diagnostics = lint(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "cur");
+        assert_eq!(diagnostics[1].span.slice(source), "words");
+    }
+
+    #[test]
     fn unused_assignment_keeps_dynamic_target_arrays_live() {
         let diagnostics = lint(
             "\
@@ -3767,9 +3784,8 @@ printf '%s\\n' \"$([ -n \"$missing\" ] && printf '%s' \"$missing\")\"
     }
 
     #[test]
-    fn unread_name_only_declarations_are_not_flagged() {
-        let diagnostics = lint(
-            "\
+    fn unread_name_only_declarations_are_flagged() {
+        let source = "\
 #!/bin/bash
 f() {
   local foo
@@ -3777,11 +3793,13 @@ f() {
   typeset baz
 }
 f
-",
-            &LinterSettings::for_rule(Rule::UnusedAssignment),
-        );
+";
+        let diagnostics = lint(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
+        assert_eq!(diagnostics[1].span.slice(source), "bar");
+        assert_eq!(diagnostics[2].span.slice(source), "baz");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use shuck_semantic::{
-    Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin, ReferenceKind,
+    Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin, ReferenceKind, ScopeId,
 };
 
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
@@ -43,9 +43,17 @@ pub fn unused_assignment(checker: &mut Checker) {
     let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();
     let mut last_unused_binding_by_family = HashMap::new();
     let mut family_keys = HashMap::with_capacity(semantic.bindings().len());
+    let mut intentional_placeholder_sites_by_family =
+        HashMap::<BindingFamilyKey, Vec<(usize, ScopeId)>>::new();
 
     for binding in semantic.bindings() {
         if is_intentionally_unused_binding(binding) {
+            if is_intentionally_unused_read_placeholder(binding) {
+                intentional_placeholder_sites_by_family
+                    .entry(binding.name.to_string())
+                    .or_default()
+                    .push((binding.span.start.offset, binding.scope));
+            }
             continue;
         }
 
@@ -64,7 +72,6 @@ pub fn unused_assignment(checker: &mut Checker) {
 
     for binding in semantic.bindings() {
         if is_intentionally_unused_binding(binding) {
-            families_with_used_bindings.insert(binding.name.to_string());
             continue;
         }
 
@@ -98,6 +105,13 @@ pub fn unused_assignment(checker: &mut Checker) {
         }
 
         if !is_reportable_unused_assignment(binding.kind, binding.attributes) {
+            continue;
+        }
+
+        if uninitialized_declaration_precedes_intentional_placeholder(
+            binding,
+            &intentional_placeholder_sites_by_family,
+        ) {
             continue;
         }
 
@@ -207,9 +221,29 @@ fn all_reportable_assignment_spans_suppressed(
 }
 
 fn is_intentionally_unused_binding(binding: &Binding) -> bool {
-    is_underscore_name(binding.name.as_str())
-        || (matches!(binding.kind, BindingKind::ReadTarget)
-            && matches!(binding.name.as_str(), "rest" | "REST"))
+    is_underscore_name(binding.name.as_str()) || is_intentionally_unused_read_placeholder(binding)
+}
+
+fn is_intentionally_unused_read_placeholder(binding: &Binding) -> bool {
+    matches!(binding.kind, BindingKind::ReadTarget)
+        && matches!(binding.name.as_str(), "rest" | "REST")
+}
+
+fn uninitialized_declaration_precedes_intentional_placeholder(
+    binding: &Binding,
+    placeholder_sites_by_family: &HashMap<BindingFamilyKey, Vec<(usize, ScopeId)>>,
+) -> bool {
+    matches!(binding.kind, BindingKind::Declaration(_))
+        && !binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED)
+        && placeholder_sites_by_family
+            .get(binding.name.as_str())
+            .is_some_and(|sites| {
+                sites.iter().any(|(offset, scope)| {
+                    *scope == binding.scope && *offset > binding.span.start.offset
+                })
+            })
 }
 
 fn is_underscore_name(name: &str) -> bool {
@@ -527,6 +561,21 @@ eval \"$(declare -f cd)\"
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "rest");
         assert_eq!(diagnostics[1].span.slice(source), "REST");
+    }
+
+    #[test]
+    fn read_rest_placeholders_do_not_hide_real_dead_assignments() {
+        let source = "\
+#!/bin/bash
+rest=1
+read -r field rest
+printf '%s\\n' \"$field\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "rest");
+        assert_eq!(diagnostics[0].span.start.line, 2);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use shuck_semantic::{
-    Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin, ReferenceKind, ScopeId,
+    Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin, ReferenceKind,
 };
 
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
@@ -43,17 +43,9 @@ pub fn unused_assignment(checker: &mut Checker) {
     let mut unused_bindings_by_family = HashMap::<BindingFamilyKey, Vec<_>>::new();
     let mut last_unused_binding_by_family = HashMap::new();
     let mut family_keys = HashMap::with_capacity(semantic.bindings().len());
-    let mut intentional_placeholder_sites_by_family =
-        HashMap::<BindingFamilyKey, Vec<(usize, ScopeId)>>::new();
 
     for binding in semantic.bindings() {
         if is_intentionally_unused_binding(binding) {
-            if is_intentionally_unused_read_placeholder(binding) {
-                intentional_placeholder_sites_by_family
-                    .entry(binding.name.to_string())
-                    .or_default()
-                    .push((binding.span.start.offset, binding.scope));
-            }
             continue;
         }
 
@@ -105,13 +97,6 @@ pub fn unused_assignment(checker: &mut Checker) {
         }
 
         if !is_reportable_unused_assignment(binding.kind, binding.attributes) {
-            continue;
-        }
-
-        if uninitialized_declaration_precedes_intentional_placeholder(
-            binding,
-            &intentional_placeholder_sites_by_family,
-        ) {
             continue;
         }
 
@@ -227,23 +212,6 @@ fn is_intentionally_unused_binding(binding: &Binding) -> bool {
 fn is_intentionally_unused_read_placeholder(binding: &Binding) -> bool {
     matches!(binding.kind, BindingKind::ReadTarget)
         && matches!(binding.name.as_str(), "rest" | "REST")
-}
-
-fn uninitialized_declaration_precedes_intentional_placeholder(
-    binding: &Binding,
-    placeholder_sites_by_family: &HashMap<BindingFamilyKey, Vec<(usize, ScopeId)>>,
-) -> bool {
-    matches!(binding.kind, BindingKind::Declaration(_))
-        && !binding
-            .attributes
-            .contains(BindingAttributes::DECLARATION_INITIALIZED)
-        && placeholder_sites_by_family
-            .get(binding.name.as_str())
-            .is_some_and(|sites| {
-                sites.iter().any(|(offset, scope)| {
-                    *scope == binding.scope && *offset > binding.span.start.offset
-                })
-            })
 }
 
 fn is_underscore_name(name: &str) -> bool {
@@ -528,12 +496,7 @@ done
 
     #[test]
     fn read_rest_names_are_treated_as_intentional_placeholders() {
-        let source = "\
-#!/bin/bash
-local rest
-read -r cron_id rest
-printf '%s\\n' \"$cron_id\"
-";
+        let source = "#!/bin/bash\nread -r cron_id rest\nprintf '%s\\n' \"$cron_id\"\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert!(diagnostics.is_empty());
@@ -576,6 +539,26 @@ printf '%s\\n' \"$field\"
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "rest");
         assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn read_rest_placeholders_do_not_hide_branch_declarations() {
+        let source = "\
+#!/bin/bash
+f(){
+  if cond; then
+    local rest
+  else
+    read -r _ rest
+  fi
+}
+f
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "rest");
+        assert_eq!(diagnostics[0].span.start.line, 4);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -64,6 +64,7 @@ pub fn unused_assignment(checker: &mut Checker) {
 
     for binding in semantic.bindings() {
         if is_intentionally_unused_binding(binding) {
+            families_with_used_bindings.insert(binding.name.to_string());
             continue;
         }
 
@@ -215,7 +216,7 @@ fn is_underscore_name(name: &str) -> bool {
     name.starts_with('_')
 }
 
-fn is_reportable_unused_assignment(kind: BindingKind, attributes: BindingAttributes) -> bool {
+fn is_reportable_unused_assignment(kind: BindingKind, _attributes: BindingAttributes) -> bool {
     match kind {
         BindingKind::Assignment
         | BindingKind::ArrayAssignment
@@ -226,25 +227,29 @@ fn is_reportable_unused_assignment(kind: BindingKind, attributes: BindingAttribu
         | BindingKind::GetoptsTarget
         | BindingKind::ArithmeticAssignment => true,
         BindingKind::AppendAssignment | BindingKind::ParameterDefaultAssignment => false,
-        BindingKind::Declaration(_) => {
-            attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
-        }
+        BindingKind::Declaration(_) => true,
         BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref => false,
     }
 }
 
 fn participates_in_unused_assignment_family(
     kind: BindingKind,
-    attributes: BindingAttributes,
+    _attributes: BindingAttributes,
 ) -> bool {
-    is_reportable_unused_assignment(kind, attributes)
-        || matches!(
-            kind,
-            BindingKind::LoopVariable
-                | BindingKind::AppendAssignment
-                | BindingKind::ParameterDefaultAssignment
-                | BindingKind::Declaration(_)
-        )
+    matches!(
+        kind,
+        BindingKind::Assignment
+            | BindingKind::ArrayAssignment
+            | BindingKind::LoopVariable
+            | BindingKind::ReadTarget
+            | BindingKind::MapfileTarget
+            | BindingKind::PrintfTarget
+            | BindingKind::GetoptsTarget
+            | BindingKind::ArithmeticAssignment
+            | BindingKind::AppendAssignment
+            | BindingKind::ParameterDefaultAssignment
+            | BindingKind::Declaration(_)
+    )
 }
 
 fn binding_counts_as_used_family_member(
@@ -489,7 +494,26 @@ done
 
     #[test]
     fn read_rest_names_are_treated_as_intentional_placeholders() {
-        let source = "#!/bin/bash\nread -r cron_id rest\nprintf '%s\\n' \"$cron_id\"\n";
+        let source = "\
+#!/bin/bash
+local rest
+read -r cron_id rest
+printf '%s\\n' \"$cron_id\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn function_declaration_queries_do_not_create_unused_variable_targets() {
+        let source = "\
+#!/bin/bash
+if ! declare -f -F config_unset >/dev/null; then
+  :
+fi
+eval \"$(declare -f cd)\"
+";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert!(diagnostics.is_empty());
@@ -768,13 +792,14 @@ foo=1
     }
 
     #[test]
-    fn unused_uninitialized_local_branches_do_not_hide_dead_assignments() {
+    fn unused_uninitialized_local_branches_report_the_last_dead_binding() {
         let source =
             "#!/bin/bash\nf(){\n  if a; then\n    foo=1\n  else\n    local foo\n  fi\n}\nf\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line, 6);
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
     }
 
     #[test]
@@ -792,6 +817,23 @@ foo=1
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 5);
+    }
+
+    #[test]
+    fn reports_declaration_only_bindings_by_default() {
+        let source = "\
+#!/bin/bash
+f(){
+  local cur
+  declare words
+}
+f
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "cur");
+        assert_eq!(diagnostics[1].span.slice(source), "words");
     }
 
     #[test]

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -484,17 +484,24 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let flags = declaration_flags(&command.operands, self.source);
         let global_flag_enabled =
             declaration_flag_is_enabled(&command.operands, self.source, 'g').unwrap_or(false);
-        let name_operands_are_function_names =
-            declaration_name_operands_are_function_names(&command.operands, self.source);
         self.declarations.push(Declaration {
             builtin,
             span: command.span,
             operands: declaration_operands(&command.operands, self.source),
         });
 
+        let mut name_operands_are_function_names = false;
         for operand in &command.operands {
             match operand {
-                DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
+                DeclOperand::Flag(word) => {
+                    update_declaration_function_name_mode(
+                        word,
+                        self.source,
+                        &mut name_operands_are_function_names,
+                    );
+                    self.visit_word_into(word, WordVisitKind::Expansion, flow, &mut nested_regions);
+                }
+                DeclOperand::Dynamic(word) => {
                     self.visit_word_into(word, WordVisitKind::Expansion, flow, &mut nested_regions);
                 }
                 DeclOperand::Name(name) => {
@@ -3282,11 +3289,6 @@ fn declaration_flags(operands: &[DeclOperand], source: &str) -> FxHashSet<char> 
     flags
 }
 
-fn declaration_name_operands_are_function_names(operands: &[DeclOperand], source: &str) -> bool {
-    declaration_flag_is_enabled(operands, source, 'f').unwrap_or(false)
-        || declaration_flag_is_enabled(operands, source, 'F').unwrap_or(false)
-}
-
 fn declaration_flag_is_enabled(
     operands: &[DeclOperand],
     source: &str,
@@ -3314,6 +3316,26 @@ fn declaration_flag_is_enabled(
         }
     }
     enabled
+}
+
+fn update_declaration_function_name_mode(word: &Word, source: &str, function_name_mode: &mut bool) {
+    let Some(text) = static_word_text(word, source) else {
+        return;
+    };
+    let mut chars = text.chars();
+    let Some(polarity) = chars.next() else {
+        return;
+    };
+    let enabled_for_operand = match polarity {
+        '-' => true,
+        '+' => false,
+        _ => return,
+    };
+    for flag in chars {
+        if matches!(flag, 'f' | 'F') {
+            *function_name_mode = enabled_for_operand;
+        }
+    }
 }
 
 fn declaration_operands(operands: &[DeclOperand], source: &str) -> Vec<DeclarationOperand> {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -484,6 +484,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let flags = declaration_flags(&command.operands, self.source);
         let global_flag_enabled =
             declaration_flag_is_enabled(&command.operands, self.source, 'g').unwrap_or(false);
+        let name_operands_are_function_names = declaration_name_operands_are_function_names(&flags);
         self.declarations.push(Declaration {
             builtin,
             span: command.span,
@@ -503,13 +504,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         flow,
                         &mut nested_regions,
                     );
-                    self.visit_name_only_declaration_operand(
-                        builtin,
-                        &flags,
-                        global_flag_enabled,
-                        &name.name,
-                        name.span,
-                    );
+                    if !name_operands_are_function_names {
+                        self.visit_name_only_declaration_operand(
+                            builtin,
+                            &flags,
+                            global_flag_enabled,
+                            &name.name,
+                            name.span,
+                        );
+                    }
                 }
                 DeclOperand::Assignment(assignment) => {
                     let (scope, mut attributes) =
@@ -3276,6 +3279,10 @@ fn declaration_flags(operands: &[DeclOperand], source: &str) -> FxHashSet<char> 
         }
     }
     flags
+}
+
+fn declaration_name_operands_are_function_names(flags: &FxHashSet<char>) -> bool {
+    flags.contains(&'f') || flags.contains(&'F')
 }
 
 fn declaration_flag_is_enabled(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -484,7 +484,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let flags = declaration_flags(&command.operands, self.source);
         let global_flag_enabled =
             declaration_flag_is_enabled(&command.operands, self.source, 'g').unwrap_or(false);
-        let name_operands_are_function_names = declaration_name_operands_are_function_names(&flags);
+        let name_operands_are_function_names =
+            declaration_name_operands_are_function_names(&command.operands, self.source);
         self.declarations.push(Declaration {
             builtin,
             span: command.span,
@@ -3281,8 +3282,9 @@ fn declaration_flags(operands: &[DeclOperand], source: &str) -> FxHashSet<char> 
     flags
 }
 
-fn declaration_name_operands_are_function_names(flags: &FxHashSet<char>) -> bool {
-    flags.contains(&'f') || flags.contains(&'F')
+fn declaration_name_operands_are_function_names(operands: &[DeclOperand], source: &str) -> bool {
+    declaration_flag_is_enabled(operands, source, 'f').unwrap_or(false)
+        || declaration_flag_is_enabled(operands, source, 'F').unwrap_or(false)
 }
 
 fn declaration_flag_is_enabled(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5525,6 +5525,31 @@ check_status
     }
 
     #[test]
+    fn declaration_function_name_operands_do_not_create_variable_bindings() {
+        let source = "\
+declare -f -F config_unset >/dev/null
+export -f helper
+readonly -f locked
+typeset -f typed
+";
+        let model = model(source);
+        let function_operand_names = ["config_unset", "helper", "locked", "typed"];
+
+        for name in function_operand_names {
+            assert!(
+                model.bindings().iter().all(|binding| binding.name != name),
+                "{name} should be treated as a function name, not a variable binding"
+            );
+            assert!(
+                model.references().iter().all(|reference| {
+                    reference.name != name || reference.kind != ReferenceKind::DeclarationName
+                }),
+                "{name} should not create a declaration-name variable reference"
+            );
+        }
+    }
+
+    #[test]
     fn repeated_name_only_local_reuses_existing_same_scope_binding() {
         let source = "f() { local foo=1; local foo; echo \"$foo\"; }\n";
         let model = model(source);

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5550,6 +5550,31 @@ typeset -f typed
     }
 
     #[test]
+    fn declaration_plus_function_flags_keep_name_operands_as_variables() {
+        let source = "\
+declare +f config_unset
+declare +F config_maybe
+declare -f +f config_after_toggle
+typeset +f typed
+";
+        let model = model(source);
+        let variable_operand_names = [
+            "config_unset",
+            "config_maybe",
+            "config_after_toggle",
+            "typed",
+        ];
+
+        for name in variable_operand_names {
+            assert!(
+                model.bindings().iter().any(|binding| binding.name == name
+                    && matches!(binding.kind, BindingKind::Declaration(_))),
+                "{name} should be treated as a variable declaration"
+            );
+        }
+    }
+
+    #[test]
     fn repeated_name_only_local_reuses_existing_same_scope_binding() {
         let source = "f() { local foo=1; local foo; echo \"$foo\"; }\n";
         let model = model(source);

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5555,6 +5555,8 @@ typeset -f typed
 declare +f config_unset
 declare +F config_maybe
 declare -f +f config_after_toggle
+declare +f config_before -f helper_function
+declare -f hidden_function +f config_after
 typeset +f typed
 ";
         let model = model(source);
@@ -5562,6 +5564,8 @@ typeset +f typed
             "config_unset",
             "config_maybe",
             "config_after_toggle",
+            "config_before",
+            "config_after",
             "typed",
         ];
 
@@ -5570,6 +5574,20 @@ typeset +f typed
                 model.bindings().iter().any(|binding| binding.name == name
                     && matches!(binding.kind, BindingKind::Declaration(_))),
                 "{name} should be treated as a variable declaration"
+            );
+        }
+
+        let function_operand_names = ["helper_function", "hidden_function"];
+        for name in function_operand_names {
+            assert!(
+                model.bindings().iter().all(|binding| binding.name != name),
+                "{name} should be treated as a function name, not a variable binding"
+            );
+            assert!(
+                model.references().iter().all(|reference| {
+                    reference.name != name || reference.kind != ReferenceKind::DeclarationName
+                }),
+                "{name} should not create a declaration-name variable reference"
             );
         }
     }

--- a/docs/rules/C001.yaml
+++ b/docs/rules/C001.yaml
@@ -11,7 +11,7 @@ shells:
   - dash
   - ksh
 description: A variable is assigned but never read later, so the statement has no effect on the script's behavior.
-rationale: Remove dead assignments, or export the value if a child process needs it. C001 follows ShellCheck for resolved indirect-expansion targets such as `${!name}`; set `[lint.rule-options.c001].treat-indirect-expansion-targets-as-used = true` only if those targets should count as live reads in your project.
+rationale: Remove dead assignments, or export the value if a child process needs it. C001 reports declaration-only bindings such as `local name` and `declare name`, since an unused local slot can be just as stale as an initialized assignment. C001 follows ShellCheck for resolved indirect-expansion targets such as `${!name}`; set `[lint.rule-options.c001].treat-indirect-expansion-targets-as-used = true` only if those targets should count as live reads in your project.
 safe_fix: false
 fix_description: "Rename the reported unused assignment target to `_`."
 source:


### PR DESCRIPTION
## Summary

- Report declaration-only C001 bindings such as `local name` and `declare name` by default in normal and shellcheck-compat modes.
- Remove the proposed configurability surface and reject the old experimental config key.
- Fix semantic modeling for `declare -f/-F` so function-name operands are not treated as variable bindings.
- Refresh C001 corpus metadata for the new policy and keep one narrow reviewed `REST` placeholder divergence documented.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic`
- `make test`
- `cargo clippy --all-targets -- -D warnings`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001` (`blocking=0`, `reviewed_divergences=33`)
