### PR TITLE
perf(linter): reuse analyzed path set

### DIFF
--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1141,13 +1141,17 @@ fn run_check_with_cwd(
     }
 
     for mut run in runs {
-        let analyzed_paths = run
-            .files
-            .iter()
-            .filter(|file| file.kind == FileKind::Shell)
-            .map(|file| file.absolute_path.clone())
-            .collect::<Vec<_>>();
         let project_settings = run.settings.clone();
+        let analyzed_paths = LinterSettings::analyzed_path_set(
+            run.files
+                .iter()
+                .filter(|file| file.kind == FileKind::Shell)
+                .map(|file| file.absolute_path.clone()),
+        );
+        let linter_settings = project_settings
+            .linter_settings
+            .clone()
+            .with_analyzed_path_set(analyzed_paths);
         let pending = run.take_pending_files(|file, cached| {
             report.cache_hits += 1;
             let source = (include_source && !cached.diagnostics.is_empty())
@@ -1169,10 +1173,7 @@ fn run_check_with_cwd(
             .map(|pending| {
                 analyze_file(
                     pending,
-                    &project_settings
-                        .linter_settings
-                        .clone()
-                        .with_analyzed_paths(analyzed_paths.clone()),
+                    &linter_settings,
                     &shellcheck_map,
                     include_source,
                     fix_applicability,

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -193,14 +193,22 @@ impl LinterSettings {
         self
     }
 
-    pub fn with_analyzed_paths(mut self, paths: impl IntoIterator<Item = PathBuf>) -> Self {
-        self.analyzed_paths = Some(Arc::new(
+    pub fn analyzed_path_set(paths: impl IntoIterator<Item = PathBuf>) -> Arc<FxHashSet<PathBuf>> {
+        Arc::new(
             paths
                 .into_iter()
                 .map(|path| std::fs::canonicalize(&path).unwrap_or(path))
                 .collect(),
-        ));
+        )
+    }
+
+    pub fn with_analyzed_path_set(mut self, paths: Arc<FxHashSet<PathBuf>>) -> Self {
+        self.analyzed_paths = Some(paths);
         self
+    }
+
+    pub fn with_analyzed_paths(self, paths: impl IntoIterator<Item = PathBuf>) -> Self {
+        self.with_analyzed_path_set(Self::analyzed_path_set(paths))
     }
 
     pub fn with_per_file_ignores(mut self, per_file_ignores: CompiledPerFileIgnoreList) -> Self {
@@ -361,6 +369,21 @@ mod tests {
                 "{rule:?} must stay in the non-style default-disabled set"
             );
         }
+    }
+
+    #[test]
+    fn with_analyzed_path_set_reuses_shared_set() {
+        let tempdir = tempdir().unwrap();
+        let script_path = tempdir.path().join("script.sh");
+        std::fs::write(&script_path, "echo hi\n").unwrap();
+
+        let analyzed_paths = LinterSettings::analyzed_path_set([script_path.clone()]);
+        let settings =
+            LinterSettings::default().with_analyzed_path_set(Arc::clone(&analyzed_paths));
+
+        let stored = settings.analyzed_paths.as_ref().unwrap();
+        assert!(Arc::ptr_eq(stored, &analyzed_paths));
+        assert!(stored.contains(&std::fs::canonicalize(script_path).unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Build the canonicalized analyzed-path set once per project check run instead of once per pending file.
- Add `LinterSettings::analyzed_path_set` and `with_analyzed_path_set` so callers can share the `Arc` directly while preserving the existing `with_analyzed_paths` helper.
- Add a unit test that verifies the shared set is reused.

## Why
The parallel check path cloned the project file list and canonicalized every shell file for each file being analyzed. On large projects that turns setup into O(N^2) path allocation and filesystem canonicalization work before linting starts.

## Validation
- `cargo test -p shuck-linter -p shuck-cli`
- `cargo clippy -p shuck-linter -p shuck-cli --all-targets -- -D warnings`