### PR TITLE
fix(linter): align compat source closure policy

### DIFF
--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -270,6 +270,7 @@ fn prepare_word_facts_input(
             file_entry_contract: None,
             analyzed_paths: None,
             shell_profile: Some(shell_profile_for_large_corpus_shell(&fixture.shell)),
+            resolve_source_closure: true,
         },
     );
 

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -965,6 +965,7 @@ fn lint_with_context(
         analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
         per_file_ignores: Default::default(),
         report_environment_style_names: options.report_environment_style_names,
+        resolve_source_closure: options.external_sources,
         rule_options,
     };
 

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -982,15 +982,12 @@ fn large_corpus_conforms_with_shellcheck() {
         build_shellcheck_filter_codes(cfg.selected_rules, cfg.mapped_only);
     let shellcheck_cache = ShellCheckCache::new(&cfg.cache_dir, &shellcheck);
     shellcheck_cache.prepare(&fixtures, &discover_worktree_roots());
-    let linter_settings = build_large_corpus_linter_settings(cfg.selected_rules, cfg.mapped_only);
+    let linter_settings =
+        build_large_corpus_compat_linter_settings(cfg.selected_rules, cfg.mapped_only);
     let supported_fixtures =
         select_supported_large_corpus_fixtures(&fixtures, Some(&supported_shells));
     let skipped_unsupported_shells = fixtures.len().saturating_sub(supported_fixtures.len());
-    let shuck_path_resolver = large_corpus_source_resolver(
-        cfg.selected_rules.as_ref(),
-        shellcheck_filter_codes.as_ref(),
-        &supported_fixtures,
-    );
+    let shuck_path_resolver = None;
 
     let failure_collection =
         collect_fixture_failures(&supported_fixtures, cfg.keep_going, |fixture| {
@@ -2622,19 +2619,12 @@ fn build_large_corpus_linter_settings(
     settings.with_c063_report_unreached_nested_definitions(true)
 }
 
-fn large_corpus_source_resolver(
-    selected_rules: Option<&shuck_linter::RuleSet>,
-    shellcheck_filter_codes: Option<&HashSet<u32>>,
-    supported_fixtures: &[&LargeCorpusFixture],
-) -> Option<Arc<LargeCorpusPathResolver>> {
-    if large_corpus_uses_single_file_c001_oracle(selected_rules, shellcheck_filter_codes) {
-        // C001 follows ShellCheck's single-file oracle here. Resolving sourced
-        // files changes assignment liveness and turns project-closure context
-        // into unrelated rule deltas.
-        return None;
-    }
-
-    Some(Arc::new(LargeCorpusPathResolver::new(supported_fixtures)))
+fn build_large_corpus_compat_linter_settings(
+    selected_rules: Option<shuck_linter::RuleSet>,
+    mapped_only: bool,
+) -> shuck_linter::LinterSettings {
+    build_large_corpus_linter_settings(selected_rules, mapped_only)
+        .with_resolve_source_closure(false)
 }
 
 fn large_corpus_uses_single_file_c001_oracle(
@@ -3651,7 +3641,7 @@ mod tests {
     }
 
     #[test]
-    fn mixed_rule_large_corpus_filter_keeps_source_resolver_even_with_c001_only_codes() {
+    fn mixed_rule_large_corpus_filter_is_not_c001_only_even_with_c001_only_codes() {
         let selected_rules = shuck_linter::RuleSet::from_iter([
             shuck_linter::Rule::UnusedAssignment,
             shuck_linter::Rule::MixedAndOrInCondition,
@@ -3663,6 +3653,42 @@ mod tests {
             Some(&selected_rules),
             Some(&shellcheck_codes)
         ));
+    }
+
+    #[test]
+    fn default_large_corpus_comparison_disables_source_closure() {
+        let settings = build_large_corpus_compat_linter_settings(None, false);
+
+        assert!(!settings.resolve_source_closure);
+    }
+
+    #[test]
+    fn mixed_c001_c006_large_corpus_comparison_disables_source_closure() {
+        let selected_rules = shuck_linter::RuleSet::from_iter([
+            shuck_linter::Rule::UnusedAssignment,
+            shuck_linter::Rule::UndefinedVariable,
+        ]);
+
+        let settings = build_large_corpus_compat_linter_settings(Some(selected_rules), false);
+
+        assert!(!settings.resolve_source_closure);
+        assert!(
+            settings
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+        assert!(
+            settings
+                .rules
+                .contains(shuck_linter::Rule::UndefinedVariable)
+        );
+    }
+
+    #[test]
+    fn large_corpus_timing_settings_keep_source_closure_enabled() {
+        let settings = build_large_corpus_linter_settings(None, false);
+
+        assert!(settings.resolve_source_closure);
     }
 
     #[test]

--- a/crates/shuck-cli/tests/shellcheck_compat.rs
+++ b/crates/shuck-cli/tests/shellcheck_compat.rs
@@ -31,6 +31,12 @@ fn comment_by_code(comments: &[Value], code: u64) -> &Value {
         .unwrap()
 }
 
+fn has_comment(comments: &[Value], file: &str, code: u64) -> bool {
+    comments.iter().any(|comment| {
+        comment["file"].as_str() == Some(file) && comment["code"].as_u64() == Some(code)
+    })
+}
+
 #[test]
 fn env_activation_uses_shellcheck_surface() {
     let mut cmd = compat_cmd();
@@ -380,6 +386,83 @@ fn compat_check_sourced_reports_resolved_source_diagnostics() {
         .code(1)
         .stdout(predicate::str::contains("\"file\":\"lib.sh\""))
         .stdout(predicate::str::contains("\"code\":2086"));
+}
+
+#[test]
+fn compat_external_sources_controls_c001_source_closure() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("main.sh"),
+        "#!/bin/sh\nfoo=1\n. ./lib.sh\n",
+    )
+    .unwrap();
+    fs::write(tempdir.path().join("lib.sh"), "printf '%s\\n' \"$foo\"\n").unwrap();
+
+    let output = run_compat(
+        &["--norc", "--include=SC2034", "-f", "json1", "main.sh"],
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let comments = json1_comments(&output);
+    assert!(has_comment(&comments, "main.sh", 2034));
+
+    let output = run_compat(
+        &["--norc", "-x", "--include=SC2034", "-f", "json1", "main.sh"],
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert!(json1_comments(&output).is_empty());
+}
+
+#[test]
+fn compat_external_sources_controls_c006_source_closure() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("main.sh"),
+        "#!/bin/sh\n. ./lib.sh\nprintf '%s\\n' \"$foo\"\n",
+    )
+    .unwrap();
+    fs::write(tempdir.path().join("lib.sh"), "foo=1\n").unwrap();
+
+    let output = run_compat(
+        &["--norc", "--include=SC2154", "-f", "json1", "main.sh"],
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let comments = json1_comments(&output);
+    assert!(has_comment(&comments, "main.sh", 2154));
+
+    let output = run_compat(
+        &["--norc", "-x", "--include=SC2154", "-f", "json1", "main.sh"],
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert!(json1_comments(&output).is_empty());
+}
+
+#[test]
+fn compat_check_sourced_does_not_imply_source_closure() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("main.sh"),
+        "#!/bin/sh\nfoo=1\n. ./lib.sh\n",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("lib.sh"),
+        "#!/bin/sh\nprintf '%s\\n' \"$foo\"\nbar=1\n",
+    )
+    .unwrap();
+
+    let output = run_compat(
+        &["--norc", "-a", "--include=SC2034", "-f", "json1", "main.sh"],
+        tempdir.path(),
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let comments = json1_comments(&output);
+    assert!(has_comment(&comments, "main.sh", 2034));
+    assert!(has_comment(&comments, "lib.sh", 2034));
 }
 
 #[test]

--- a/crates/shuck-cli/tests/shellcheck_compat.rs
+++ b/crates/shuck-cli/tests/shellcheck_compat.rs
@@ -159,6 +159,29 @@ fn compat_json1_uses_metadata_info_level_for_sc1091() {
 }
 
 #[test]
+fn compat_no_external_sources_keeps_explicit_sourced_files_available_for_sc1091() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("main.sh"), "#!/bin/sh\n. ./lib.sh\n").unwrap();
+    fs::write(tempdir.path().join("lib.sh"), "#!/bin/sh\necho ok\n").unwrap();
+
+    let output = run_compat(
+        [
+            "--norc",
+            "--include=SC1091",
+            "-f",
+            "json1",
+            "main.sh",
+            "lib.sh",
+        ]
+        .as_slice(),
+        tempdir.path(),
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(json1_comments(&output), Vec::<Value>::new());
+}
+
+#[test]
 fn compat_severity_filter_respects_metadata_info_level_for_sc1091() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("x.sh"), "#!/bin/sh\n. ./lib.sh\n").unwrap();

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c001.yaml
@@ -1,7 +1,4 @@
 reviewed_divergences:
-  - side: shuck-only
-    path_contains: "termux__termux-packages__"
-    reason: "These Termux package recipes and build helpers publish `TERMUX_PKG_*`, toolchain flags, checksum tables, and related setup state for the Termux packaging harness to consume after the file returns. The remaining single-file C001 hits in this repo family are framework contract state, not dead assignments."
   - side: shellcheck-only
     path_contains: "termux__termux-packages__"
     reason: "The remaining shellcheck-only Termux sites are helper-library state or package metadata tables that the Termux build harness consumes later. Shuck treats that harness-owned state as live."
@@ -12,59 +9,14 @@ reviewed_divergences:
     path_contains: "rvm__rvm__"
     reason: "The remaining shellcheck-only RVM sites are helper values that are later recovered through indirect expansion and sourced-library state. Shuck preserves the dynamically consumed helper state."
   - side: shuck-only
-    path_contains: "void-linux__void-packages__"
-    reason: "These xbps-src helpers are sourced into the Void packaging framework, which consumes package metadata, environment flags, loop/header state, and helper results outside the local straight-line region. The remaining C001 corpus hits in this repo family are reviewed framework handoffs rather than dead shell assignments."
-  - side: shellcheck-only
-    path_contains: "void-linux__void-packages__"
-    reason: "The remaining shellcheck-only Void sites depend on sourced xbps-src helper behavior and packaging-framework state that Shuck treats as live."
-  - side: shuck-only
-    path_contains: "bats-core__bats-core__"
-    reason: "Bats formatter and harness helpers exchange status, buffer, and timing state through sourced helper files and outer harness callbacks. The remaining C001 hits in this repo family are reviewed harness-state handoffs, not dead assignments."
-  - side: shellcheck-only
-    path_contains: "bats-core__bats-core__"
-    reason: "The remaining shellcheck-only Bats sites depend on the outer harness contract and sourced helper plumbing that Shuck does not treat as ordinary dead assignments."
-  - side: shuck-only
     path_suffix: "dylanaraps__neofetch__neofetch"
     reason: "This Neofetch script builds a generated config surface and then interprets those option variables and helper names through later config-driven entrypoints. The remaining C001 hits are reviewed config-template state rather than dead assignments."
-  - side: shuck-only
-    path_contains: "megastep__makeself__"
-    reason: "Makeself threads header flags and archive settings through generated stub output and later extraction-time behavior. The remaining C001 hits are reviewed archive-metadata handoffs rather than dead assignments in the local file."
-  - side: shuck-only
-    path_suffix: "dehydrated-io__dehydrated__docs__examples__hook.sh"
-    reason: "This example hook documents the callback contract by binding positional parameters that are described in comments and intended for user customization. The remaining C001 hits are reviewed example-hook parameters, not accidental dead assignments."
-  - side: shuck-only
-    path_contains: "nvm-sh__nvm__"
-    reason: "These NVM helpers and test fixtures thread state through sourced shell setup, test harness callbacks, and shell-collapsed compatibility paths. The surviving C001 hits in this repo family are reviewed harness or shell-collapse divergences rather than ordinary dead assignments."
-  - side: shuck-only
-    path_contains: "acmesh-official__acme.sh__"
-    reason: "acme.sh helper modules exchange state through sourced helper functions, hook callbacks, and module-level globals. The remaining C001 hits in this repo family are reviewed helper-state handoffs rather than dead assignments."
-  - side: shuck-only
-    path_contains: "asdf-vm__asdf__"
-    reason: "asdf helper scripts pass state through sourced command libraries and later helper entrypoints. The remaining C001 hits in this repo family are reviewed library-state handoffs rather than dead assignments."
-  - side: shuck-only
-    path_contains: "pi-hole__pi-hole__"
-    reason: "These Pi-hole maintenance scripts thread installer and runtime state through sourced helpers and later callback-style entrypoints. The remaining C001 hits in this repo family are reviewed helper-state handoffs rather than dead assignments."
   - side: shuck-only
     path_contains: "romkatv__powerlevel10k__"
     reason: "Powerlevel10k setup helpers pass transient state through generated shell code and later prompt initialization paths. The remaining C001 hits in this repo family are reviewed prompt-state handoffs rather than dead assignments."
   - side: shuck-only
-    path_contains: "sstephenson__bats__"
-    reason: "These legacy Bats harness helpers exchange state through sourced callbacks and outer harness control flow. The remaining C001 hits in this repo family are reviewed harness-state handoffs rather than dead assignments."
-  - side: shuck-only
-    path_contains: "pyenv__pyenv__"
-    reason: "These pyenv rehash and python-build helpers exchange state through sourced helper libraries, plugin hooks, and later tool entrypoints. The remaining C001 hits in this repo family are reviewed library-state handoffs rather than dead assignments."
-  - side: shuck-only
-    path_contains: "tj__n__"
-    reason: "These `n` installer helpers and tests pass transient state through helper functions and outer test harness calls. The remaining C001 hits in this repo family are reviewed harness-state handoffs rather than dead assignments."
-  - side: shuck-only
     path_contains: "scop__bash-completion__"
     reason: "The bash-completion project is a sourced helper library and compatibility layer that threads parser state, completion globals, and zsh bridge state through later completion callbacks and wrapper entrypoints. The remaining C001 hits in this repo family are reviewed helper-runtime handoffs rather than dead assignments in a standalone script."
-  - side: shellcheck-only
-    path_contains: "scop__bash-completion__"
-    reason: "These bash-completion helpers hand control to shared setup helpers like `_comp_initialize`, which populate and consume callback state as part of the completion contract. Shuck treats that callback-owned state as live."
-  - side: shellcheck-only
-    path_contains: "bittorf__kalua__"
-    reason: "These Kalua build and monitoring scripts use parse slots and sourced helper state to unpack semi-structured command output, with each call path consuming only the fields it needs. Shuck treats the reviewed field handoffs as live."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__speedtest"
     line: 112
@@ -114,167 +66,9 @@ reviewed_divergences:
     column: 15
     end_column: 19
     reason: "This `rest` local is a parsed-field placeholder. Shuck reports declaration-only locals as ordinary C001 targets, while the comparison oracle suppresses rest-style placeholder names more broadly."
-  - side: shellcheck-only
-    path_contains: "RetroPie__RetroPie-Setup__"
-    reason: "The RetroPie setup bootstrap and module scripts publish globals such as `biosdir`, `romdir`, and `configdir` for sourced module files, and they also use callback locals that the package framework fills or consults selectively. Shuck treats the framework locals and sourced setup state as live."
-  - side: shellcheck-only
-    path_contains: "dokku__dokku__"
-    reason: "These Dokku plugin triggers source shared plugin libraries and carry helper locals such as `proxy_schemes`, `tls_internal`, and `HAS_NETWORK_CONFIG` that only some trigger variants populate or read. Shuck treats the reviewed plugin callback state as live."
   - side: shuck-only
     path_contains: "community-scripts__ProxmoxVE__"
     reason: "These Proxmox helper scripts publish `var_*` template metadata and related provisioning state for the shared build/update framework sourced at startup. The remaining C001 hits in this repo family are reviewed framework handoffs that depend on project closure rather than dead local assignments."
-  - side: shellcheck-only
-    path_contains: "community-scripts__ProxmoxVE__"
-    reason: "These Proxmox installer and build helpers run inside a sourced framework that threads loop counters, command names, and retry state through shared helper functions and generated templates. The remaining shellcheck-only sites are reviewed framework locals rather than standalone dead assignments."
-  - side: shellcheck-only
-    path_contains: "docker__docker-bench-security__"
-    reason: "These docker-bench reporting helpers use locals as formatting and output placeholders inside shared report functions. Shuck treats the reviewed report-helper state as live."
-  - side: shellcheck-only
-    path_contains: "gentoo__gentoo__"
-    reason: "These Gentoo benchmark and test harness scripts use short locals as helper parameters and placeholder slots inside the harness. Shuck treats the reviewed test-helper state as live."
-  - side: shellcheck-only
-    path_contains: "bitnami__containers__"
-    reason: "These Bitnami library scripts carry compatibility locals that only some image or database variants populate and read. Shuck treats the reviewed variant-specific helper state as live."
-  - side: shellcheck-only
-    path_suffix: "Bash-it__bash-it__vendor__github.com__gaelicWizard__bash-progcomp__defaults.completion.bash"
-    line: 80
-    end_line: 80
-    column: 60
-    end_column: 65
-    reason: "completion helper reserves a verb-table placeholder for dispatcher state shared with later completion code"
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__libraries__bluez-alsa__bluez-alsa.conf"
-    line: 19
-    end_line: 19
-    column: 1
-    end_column: 14
-    reason: "config value is consumed by rc.bluez-alsa after sourcing the file"
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__misc__g15daemon__rc.g15daemon.conf"
-    line: 8
-    end_line: 8
-    column: 1
-    end_column: 11
-    reason: "plugin table entry is consumed by rc.g15daemon after sourcing the config"
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__misc__g15daemon__rc.g15daemon.conf"
-    line: 9
-    end_line: 9
-    column: 1
-    end_column: 17
-    reason: "plugin parameter table entry is consumed by rc.g15daemon after sourcing the config"
-  - side: shellcheck-only
-    path_suffix: "233boy__v2ray__install.sh"
-    line: 424
-    end_line: 424
-    column: 5
-    end_column: 19
-    reason: "install mode flag is consumed by the dynamically sourced core.sh helper"
-  - side: shellcheck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_details.sh"
-    line: 19
-    end_line: 19
-    column: 2
-    end_column: 5
-    reason: "loop variable is consumed by the sibling query_gamedig.sh helper invoked in the loop"
-  - side: shellcheck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_postdetails.sh"
-    line: 35
-    end_line: 35
-    column: 2
-    end_column: 5
-    reason: "loop variable is consumed by the sibling query_gamedig.sh helper invoked in the loop"
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__ham__rtl-sdr__rtl-sdr.SlackBuild"
-    line: 119
-    end_line: 119
-    column: 3
-    end_column: 6
-    reason: "reviewed one-off loop-header compatibility gap for the unused packaging loop counter in this fixture"
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__network__nagios__nagios.SlackBuild"
-    line: 46
-    end_line: 46
-    column: 1
-    end_column: 4
-    reason: "reviewed one-off loop-header compatibility gap for the relative-path builder counter in this fixture"
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__network__openconnect__vpnc-script"
-    line: 589
-    end_line: 589
-    column: 5
-    end_column: 8
-    reason: "reviewed one-off loop-header compatibility gap for the tun-device retry counter in this fixture"
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__PrintNode__rc.PrintNode"
-    line: 46
-    end_line: 46
-    column: 9
-    end_column: 12
-    reason: "reviewed one-off loop-header compatibility gap for the shutdown wait counter in this fixture"
-  - side: shellcheck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__efi-sync__file__rc.efi-sync.new"
-    line: 33
-    end_line: 33
-    column: 3
-    end_column: 6
-    reason: "reviewed one-off loop-header compatibility gap for the shutdown polling counter in this fixture"
-  - side: shellcheck-only
-    path_suffix: "alpinelinux__aports__.githooks__pre-commit"
-    line: 70
-    end_line: 70
-    column: 34
-    end_column: 41
-    reason: "checksum helper reserves a parsed content slot alongside checksum and filename, but this path only consumes the other fields"
-  - side: shellcheck-only
-    path_suffix: "alpinelinux__aports__community__tea__bash_autocomplete"
-    line: 7
-    end_line: 7
-    column: 20
-    end_column: 24
-    reason: "completion helper keeps a declaration-only placeholder alongside the shared bash-completion locals"
-  - side: shellcheck-only
-    path_suffix: "dockur__windows__src__install.sh"
-    line: 382
-    end_line: 382
-    column: 27
-    end_column: 33
-    reason: "bootdisk extractor reserves alternate total-size slots for image layouts that this path does not consume"
-  - side: shellcheck-only
-    path_suffix: "dockur__windows__src__install.sh"
-    line: 383
-    end_line: 383
-    column: 33
-    end_column: 39
-    reason: "bootdisk extractor reserves alternate hard-link slots for image layouts that this path does not consume"
-  - side: shellcheck-only
-    path_suffix: "dockur__windows__src__install.sh"
-    line: 383
-    end_line: 383
-    column: 47
-    end_column: 53
-    reason: "bootdisk extractor reserves alternate hard-link slots for image layouts that this path does not consume"
-  - side: shellcheck-only
-    path_suffix: "google__oss-fuzz__infra__base-images__base-clang__checkout_build_install_llvm.sh"
-    line: 83
-    end_line: 83
-    column: 3
-    end_column: 6
-    reason: "reviewed one-off loop-header compatibility gap for the clone retry counter in this fixture"
-  - side: shellcheck-only
-    path_suffix: "google__oss-fuzz__infra__base-images__base-clang__checkout_build_install_llvm_ubuntu_20_04.sh"
-    line: 83
-    end_line: 83
-    column: 3
-    end_column: 6
-    reason: "reviewed one-off loop-header compatibility gap for the clone retry counter in this fixture"
-  - side: shellcheck-only
-    path_suffix: "google__oss-fuzz__infra__base-images__base-clang__checkout_build_install_llvm_ubuntu_24_04.sh"
-    line: 82
-    end_line: 82
-    column: 3
-    end_column: 6
-    reason: "reviewed one-off loop-header compatibility gap for the clone retry counter in this fixture"
   - side: shellcheck-only
     path_suffix: "leebaird__discover__dev-api-scanner.sh"
     line: 561
@@ -283,44 +77,9 @@ reviewed_divergences:
     end_column: 51
     reason: "documentation endpoint extraction stages a lowercase helper name that this path never reads before handing off to the later uppercase endpoint queue"
   - side: shellcheck-only
-    path_suffix: "moovweb__gvm__examples__native__ltmain.sh"
-    line: 1249
-    end_line: 1249
-    column: 2
-    end_column: 5
-    reason: "reviewed one-off loop-header compatibility gap for the fixed-count libtool probe counter in this fixture"
-  - side: shuck-only
-    path_suffix: "moovweb__gvm__examples__native__configure"
-    line: 747
-    end_line: 747
-    column: 1
-    end_column: 15
-    reason: "generated configure script reads this substitution list in a later reporting block that the current parser recovery path does not surface to C001"
-  - side: shellcheck-only
-    path_suffix: "moovweb__gvm__scripts__completion"
-    line: 6
-    end_line: 6
-    column: 12
-    end_column: 16
-    reason: "completion helper keeps a declaration-only placeholder alongside the shared bash-completion locals"
-  - side: shellcheck-only
     path_suffix: "nvie__gitflow__git-flow"
     line: 85
     end_line: 85
     column: 18
     end_column: 31
     reason: "shFlags owns this generated flag binding after DEFINE_boolean wires the parser state"
-  - side: shellcheck-only
-    path_suffix: "openrc__openrc__sh__rc-cgroup.sh"
-    line: 176
-    end_line: 176
-    column: 22
-    end_column: 28
-    reason: "cgroup event parser carries an extra declaration-only scratch slot in this helper path"
-  - side: shellcheck-only
-    path_suffix: "swoodford__aws__ec2-ami-encrypted-ebs-boot-volume.sh"
-    line: 280
-    end_line: 280
-    column: 3
-    end_column: 6
-    reason: "reviewed one-off loop-header compatibility gap for the AMI availability polling counter in this fixture"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -143,9 +143,6 @@ reviewed_divergences:
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__environment__setup__replace-interpreter.sh"
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__environment__setup__sourcepkg.sh"
-    reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
   - side: shellcheck-only
     path_suffix: "docker-library__official-images__test__config.sh"
     reason: "This generated test matrix is just a bundle of image-to-test mappings, so the ShellCheck-only C006 hits are the literal associative-array keys in those compound assignments rather than live variable reads."
@@ -174,9 +171,6 @@ reviewed_divergences:
     path_suffix: "juewuy__ShellCrash__scripts__libs__logger.sh"
     reason: "This logger helper pushes to multiple notification backends using values injected by the broader ShellCrash runtime, so the remaining ShellCheck-only reads are framework-managed settings rather than script-local variables."
   - side: shellcheck-only
-    path_suffix: "HariSekhon__DevOps-Bash-tools__bigdata__cloudera_navigator_audit_logs.sh"
-    reason: "This audit-log helper relies on a date source and timestamp value supplied by the wider Bash-tools library, so the ShellCheck-only read is the expected library contract around time formatting."
-  - side: shellcheck-only
     path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__configedit.sh"
     reason: "This RetroPie menu helper filters config paths from the shared configuration root, so the ShellCheck-only read is the surrounding module's directory context rather than an uninitialized local."
   - side: shellcheck-only
@@ -194,42 +188,9 @@ reviewed_divergences:
   - side: shellcheck-only
     path_suffix: "leebaird__discover__dev-api-scanner.sh"
     reason: "This scanner builds an output filename from the current CORS origin, and the remaining ShellCheck-only anchor is the lower-case slug fragment inside that generated path. We review this one file narrowly instead of broadening C006 around the helper's filename templating."
-  - side: shellcheck-only
-    path_suffix: "gentoo__gentoo__sys-apps__memtest86+__files__39_memtest86+-r2"
-    reason: "This GRUB menu helper sources grub-mkconfig_lib and only uses grub_tab to indent generated submenu output, so the remaining ShellCheck-only hit is a sourced helper contract rather than a missing local assignment."
-  - side: shellcheck-only
-    path_suffix: "gentoo__gentoo__sys-apps__memtest86+__files__39_memtest86+-r3"
-    reason: "This GRUB menu helper sources grub-mkconfig_lib and only uses grub_tab to indent generated submenu output, so the remaining ShellCheck-only hit is a sourced helper contract rather than a missing local assignment."
   - side: shuck-only
     path_suffix: "233boy__v2ray__src__old.sh"
     reason: "This legacy V2Ray helper threads transport choice through sourced installer plumbing, so the remaining C006 read is a repo-local runtime handoff rather than a free-standing missing assignment."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__bash_it.sh"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__completion__available__docker.completion.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__completion__available__git.completion.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__completion__available__ng.completion.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__completion__available__svn.completion.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__completion__available__travis.completion.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__plugins__available__latex.plugin.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__scripts__reloader.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
-  - side: shuck-only
-    path_suffix: "Bash-it__bash-it__themes__liquidprompt__liquidprompt.theme.bash"
-    reason: "This Bash-it fixture bootstraps completions, plugins, or themes by sourcing helpers that publish function names and palette globals into a shared interactive session, so the remaining C006 hits are reviewed framework-owned helper/runtime names rather than standalone-script misses."
   - side: shuck-only
     path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__command_backup.sh"
     reason: "This LinuxGSM fixture runs inside a sourced manager runtime that prepopulates lock paths, passwords, stats fields, and config locations, so the remaining C006 hits are reviewed module contracts with that runtime rather than missing local assignments."

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -253,6 +253,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
             file_entry_contract,
             analyzed_paths,
             shell_profile: Some(shell_profile),
+            resolve_source_closure: settings.resolve_source_closure,
         },
     );
     let checker = Checker::new(
@@ -3937,6 +3938,52 @@ flag=1
         let diagnostics = lint_path_for_rule(&main, Rule::UnusedAssignment);
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn disabled_source_closure_reports_assignment_only_read_by_sourced_helper() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("lib.sh");
+        let source = "\
+#!/bin/sh
+foo=1
+. ./lib.sh
+";
+        fs::write(&main, source).unwrap();
+        fs::write(&helper, "printf '%s\\n' \"$foo\"\n").unwrap();
+
+        let diagnostics = lint_path(
+            &main,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_resolve_source_closure(false),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UnusedAssignment);
+        assert_eq!(diagnostics[0].span.slice(source), "foo");
+    }
+
+    #[test]
+    fn disabled_source_closure_reports_read_only_assigned_by_sourced_helper() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("lib.sh");
+        let source = "\
+#!/bin/sh
+. ./lib.sh
+printf '%s\\n' \"$foo\"
+";
+        fs::write(&main, source).unwrap();
+        fs::write(&helper, "foo=1\n").unwrap();
+
+        let diagnostics = lint_path(
+            &main,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_resolve_source_closure(false),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
+        assert_eq!(diagnostics[0].span.slice(source), "$foo");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
+++ b/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
@@ -93,6 +93,25 @@ mod tests {
     }
 
     #[test]
+    fn ignores_explicit_literal_source_when_source_closure_is_disabled() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.sh");
+        let helper = temp.path().join("helper.sh");
+        let source = "#!/bin/sh\n. ./helper.sh\n";
+        fs::write(&helper, "echo ok\n").unwrap();
+
+        let diagnostics = test_snippet_at_path(
+            &main,
+            source,
+            &LinterSettings::for_rule(Rule::UntrackedSourceFile)
+                .with_analyzed_paths([main.clone(), helper.clone()])
+                .with_resolve_source_closure(false),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_resolved_literal_source_when_helper_is_not_an_input() {
         let temp = tempdir().unwrap();
         let main = temp.path().join("main.sh");

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -64,6 +64,7 @@ pub struct LinterSettings {
     pub analyzed_paths: Option<Arc<FxHashSet<PathBuf>>>,
     pub per_file_ignores: Arc<CompiledPerFileIgnoreList>,
     pub report_environment_style_names: bool,
+    pub resolve_source_closure: bool,
     pub rule_options: LinterRuleOptions,
 }
 
@@ -83,6 +84,7 @@ impl Default for LinterSettings {
             analyzed_paths: None,
             per_file_ignores: Arc::new(CompiledPerFileIgnoreList::default()),
             report_environment_style_names: false,
+            resolve_source_closure: true,
             rule_options: LinterRuleOptions::default(),
         }
     }
@@ -220,6 +222,11 @@ impl LinterSettings {
         self.rule_options
             .c001
             .treat_indirect_expansion_targets_as_used = value;
+        self
+    }
+
+    pub fn with_resolve_source_closure(mut self, value: bool) -> Self {
+        self.resolve_source_closure = value;
         self
     }
 

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -274,11 +274,25 @@ impl FileContract {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct SemanticBuildOptions<'a> {
     pub source_path: Option<&'a Path>,
     pub source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
     pub file_entry_contract: Option<FileContract>,
     pub analyzed_paths: Option<&'a rustc_hash::FxHashSet<PathBuf>>,
     pub shell_profile: Option<ShellProfile>,
+    pub resolve_source_closure: bool,
+}
+
+impl Default for SemanticBuildOptions<'_> {
+    fn default() -> Self {
+        Self {
+            source_path: None,
+            source_path_resolver: None,
+            file_entry_contract: None,
+            analyzed_paths: None,
+            shell_profile: None,
+            resolve_source_closure: true,
+        }
+    }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2410,6 +2410,7 @@ pub fn build_with_observer_at_path_with_resolver(
             file_entry_contract: None,
             analyzed_paths: None,
             shell_profile: None,
+            resolve_source_closure: true,
         },
     )
 }
@@ -2432,7 +2433,9 @@ fn build_semantic_model(
     if let Some(contract) = options.file_entry_contract {
         model.apply_file_entry_contract(contract, file);
     }
-    if let Some(source_path) = options.source_path {
+    if options.resolve_source_closure
+        && let Some(source_path) = options.source_path
+    {
         let (
             synthetic_reads,
             imported_bindings,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2433,23 +2433,38 @@ fn build_semantic_model(
     if let Some(contract) = options.file_entry_contract {
         model.apply_file_entry_contract(contract, file);
     }
-    if options.resolve_source_closure
-        && let Some(source_path) = options.source_path
-    {
+    if let Some(source_path) = options.source_path {
         let (
             synthetic_reads,
             imported_bindings,
             source_ref_resolutions,
             source_ref_explicitness,
             source_ref_diagnostic_classes,
-        ) = source_closure::collect_source_closure_contracts(
-            &model,
-            file,
-            source,
-            source_path,
-            options.source_path_resolver,
-            options.analyzed_paths,
-        );
+        ) = if options.resolve_source_closure {
+            source_closure::collect_source_closure_contracts(
+                &model,
+                file,
+                source,
+                source_path,
+                options.source_path_resolver,
+                options.analyzed_paths,
+            )
+        } else {
+            let (source_ref_resolutions, source_ref_explicitness, source_ref_diagnostic_classes) =
+                source_closure::collect_source_ref_metadata(
+                    &model,
+                    source_path,
+                    options.source_path_resolver,
+                    options.analyzed_paths,
+                );
+            (
+                Vec::new(),
+                Vec::new(),
+                source_ref_resolutions,
+                source_ref_explicitness,
+                source_ref_diagnostic_classes,
+            )
+        };
         model.apply_source_contracts(
             synthetic_reads,
             imported_bindings,

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -36,6 +36,12 @@ type SourceClosureContractResult = (
     Vec<SourceRefDiagnosticClass>,
 );
 
+type SourceRefMetadataResult = (
+    Vec<SourceRefResolution>,
+    Vec<bool>,
+    Vec<SourceRefDiagnosticClass>,
+);
+
 #[derive(Clone)]
 struct SourceClosureLookupContext<'a> {
     source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
@@ -111,6 +117,48 @@ pub(crate) fn collect_source_closure_contracts(
         contracts.source_ref_resolutions,
         contracts.source_ref_explicitness,
         contracts.source_ref_diagnostic_classes,
+    )
+}
+
+pub(crate) fn collect_source_ref_metadata(
+    model: &SemanticModel,
+    source_path: &Path,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+    analyzed_paths: Option<&FxHashSet<PathBuf>>,
+) -> SourceRefMetadataResult {
+    let facts = collect_ast_facts(model);
+    let call_args_by_scope = resolve_literal_call_args_by_scope(model, &facts.calls);
+    let context = SourceClosureLookupContext {
+        source_path_resolver,
+        analyzed_paths,
+        shell_profile: model.shell_profile().clone(),
+    };
+    let mut source_ref_resolutions = Vec::new();
+    let mut source_ref_explicitness = Vec::new();
+    let mut source_ref_diagnostic_classes = Vec::new();
+
+    for source_ref in model.source_refs() {
+        let scope = model.scope_at(source_ref.span.start.offset);
+        let template = facts.source_templates.get(&SpanKey::new(source_ref.span));
+        let candidates = source_candidates(
+            &source_ref.kind,
+            template,
+            call_args_by_scope.get(&scope).map(Vec::as_slice),
+            source_path,
+        );
+        let (resolved, explicit) =
+            source_ref_metadata_for_candidates(source_path, candidates, &context);
+
+        source_ref_resolutions.push(classify_source_ref_resolution(&source_ref.kind, resolved));
+        source_ref_explicitness.push(explicit);
+        source_ref_diagnostic_classes
+            .push(classify_source_ref_diagnostic_class(source_ref, template));
+    }
+
+    (
+        source_ref_resolutions,
+        source_ref_explicitness,
+        source_ref_diagnostic_classes,
     )
 }
 
@@ -243,12 +291,9 @@ fn merge_contracts_for_candidates(
         let resolved_paths =
             resolve_helper_paths(source_path, &candidate, context.source_path_resolver);
         resolved |= !resolved_paths.is_empty();
-        explicit |= resolved_paths.iter().any(|path| {
-            context.analyzed_paths.is_some_and(|paths| {
-                paths.contains(path)
-                    || paths.contains(&fs::canonicalize(path).unwrap_or_else(|_| path.clone()))
-            })
-        });
+        explicit |= resolved_paths
+            .iter()
+            .any(|path| path_is_explicitly_analyzed(path, context.analyzed_paths));
         for resolved_path in resolved_paths {
             contracts.push(summarize_helper(&resolved_path, summaries, active, context));
         }
@@ -258,6 +303,32 @@ fn merge_contracts_for_candidates(
         resolved,
         explicit,
     )
+}
+
+fn source_ref_metadata_for_candidates(
+    source_path: &Path,
+    candidates: impl IntoIterator<Item = String>,
+    context: &SourceClosureLookupContext<'_>,
+) -> (bool, bool) {
+    let mut resolved = false;
+    let mut explicit = false;
+    for candidate in candidates {
+        let resolved_paths =
+            resolve_helper_paths(source_path, &candidate, context.source_path_resolver);
+        resolved |= !resolved_paths.is_empty();
+        explicit |= resolved_paths
+            .iter()
+            .any(|path| path_is_explicitly_analyzed(path, context.analyzed_paths));
+    }
+
+    (resolved, explicit)
+}
+
+fn path_is_explicitly_analyzed(path: &Path, analyzed_paths: Option<&FxHashSet<PathBuf>>) -> bool {
+    analyzed_paths.is_some_and(|paths| {
+        paths.contains(path)
+            || paths.contains(&fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
+    })
 }
 
 fn classify_source_ref_resolution(kind: &SourceRefKind, resolved: bool) -> SourceRefResolution {


### PR DESCRIPTION
## Summary

- Add an explicit `resolve_source_closure` switch to semantic and linter settings, defaulting on for normal Shuck analysis.
- Match ShellCheck-compatible behavior by enabling cross-file source closure only for `-x` / `--external-sources`; `-a` still discovers and checks sourced files without implying cross-file dataflow.
- Disable source closure in large-corpus compatibility runs, while leaving timing runs on the normal Shuck policy.
- Prune stale C001/C006 reviewed-divergence metadata now that the compatibility comparison uses ShellCheck's single-file source-closure policy.

## Validation

- `cargo test -p shuck-linter disabled_source_closure`
- `cargo test -p shuck-cli --test shellcheck_compat`
- `cargo test -p shuck-cli --test large_corpus`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001,C006`
- `cargo fmt --check`
- `git diff --check`
