### PR TITLE
docs(website): add shellcheck repo conformance table

### DIFF
--- a/website/app/components/docs/ShellcheckCompatRepoTable.tsx
+++ b/website/app/components/docs/ShellcheckCompatRepoTable.tsx
@@ -1,0 +1,102 @@
+import { shellcheckCompatRepos } from "@/app/lib/shellcheck-compat-data";
+import type {
+  ShellcheckCompatRepoData,
+  ShellcheckCompatRepoStatus,
+} from "@/app/lib/shellcheck-compat-types";
+
+const statusLabels: Record<ShellcheckCompatRepoStatus, string> = {
+  passes: "Passes checked-in corpus conformance",
+  known_issues: "Known reviewed divergences or ShellCheck unsupported",
+};
+
+const statusColors: Record<ShellcheckCompatRepoStatus, string> = {
+  passes: "bg-green-400",
+  known_issues: "bg-yellow-300",
+};
+
+function issueCountLabel(issueCount: number) {
+  return `${issueCount} known issue${issueCount === 1 ? "" : "s"}`;
+}
+
+function statusLabel(repo: ShellcheckCompatRepoData) {
+  if (repo.status === "known_issues") {
+    return issueCountLabel(repo.issueCount);
+  }
+
+  return statusLabels[repo.status];
+}
+
+function StatusDot({ repo }: { repo: ShellcheckCompatRepoData }) {
+  const label = statusLabel(repo);
+
+  return (
+    <span className="group relative inline-flex items-center justify-center">
+      <span
+        tabIndex={0}
+        className={`inline-block h-2.5 w-2.5 rounded-full outline-none ${statusColors[repo.status]} focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg-card`}
+        aria-label={label}
+      />
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md border border-fg-dim/30 bg-bg-card px-2 py-1 text-xs text-fg-primary opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        {label}
+      </span>
+    </span>
+  );
+}
+
+export default function ShellcheckCompatRepoTable() {
+  return (
+    <div className="my-6">
+      <div className="mb-3 flex flex-wrap gap-4 text-sm text-fg-secondary">
+        <span className="inline-flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-green-400" aria-hidden="true" />
+          Passes checked-in corpus conformance
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-yellow-300" aria-hidden="true" />
+          Known reviewed divergences or ShellCheck unsupported
+        </span>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-fg-dim/20">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-fg-dim/20 bg-bg-card/50">
+              <th className="px-3 py-2 text-left font-medium text-fg-secondary">
+                Repository
+              </th>
+              <th className="w-20 px-3 py-2 text-center font-medium text-fg-secondary">
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {shellcheckCompatRepos.map((repo) => (
+              <tr
+                key={repo.repo}
+                className="border-b border-fg-dim/10 last:border-b-0 hover:bg-bg-card/30 transition-colors"
+              >
+                <td className="px-3 py-2">
+                  <a
+                    href={repo.url}
+                    className="text-fg-primary hover:text-accent hover:underline"
+                  >
+                    {repo.repo}
+                  </a>
+                </td>
+                <td className="px-3 py-2 text-center">
+                  <span className="inline-flex items-center justify-center">
+                    <StatusDot repo={repo} />
+                    <span className="sr-only">{statusLabel(repo)}</span>
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/website/app/lib/shellcheck-compat-data.generated.json
+++ b/website/app/lib/shellcheck-compat-data.generated.json
@@ -1,0 +1,632 @@
+[
+  {
+    "repo": "233boy/v2ray",
+    "repoKey": "233boy__v2ray",
+    "url": "https://github.com/233boy/v2ray",
+    "status": "known_issues",
+    "issueCount": 5
+  },
+  {
+    "repo": "89luca89/distrobox",
+    "repoKey": "89luca89__distrobox",
+    "url": "https://github.com/89luca89/distrobox",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "acmesh-official/acme.sh",
+    "repoKey": "acmesh-official__acme.sh",
+    "url": "https://github.com/acmesh-official/acme.sh",
+    "status": "known_issues",
+    "issueCount": 5
+  },
+  {
+    "repo": "alexanderepstein/Bash-Snippets",
+    "repoKey": "alexanderepstein__Bash-Snippets",
+    "url": "https://github.com/alexanderepstein/Bash-Snippets",
+    "status": "known_issues",
+    "issueCount": 13
+  },
+  {
+    "repo": "alpinelinux/aports",
+    "repoKey": "alpinelinux__aports",
+    "url": "https://github.com/alpinelinux/aports",
+    "status": "known_issues",
+    "issueCount": 6
+  },
+  {
+    "repo": "angristan/openvpn-install",
+    "repoKey": "angristan__openvpn-install",
+    "url": "https://github.com/angristan/openvpn-install",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "aristocratos/bashtop",
+    "repoKey": "aristocratos__bashtop",
+    "url": "https://github.com/aristocratos/bashtop",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "asdf-vm/asdf",
+    "repoKey": "asdf-vm__asdf",
+    "url": "https://github.com/asdf-vm/asdf",
+    "status": "known_issues",
+    "issueCount": 2
+  },
+  {
+    "repo": "awslabs/git-secrets",
+    "repoKey": "awslabs__git-secrets",
+    "url": "https://github.com/awslabs/git-secrets",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "basecamp/omarchy",
+    "repoKey": "basecamp__omarchy",
+    "url": "https://github.com/basecamp/omarchy",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "Bash-it/bash-it",
+    "repoKey": "Bash-it__bash-it",
+    "url": "https://github.com/Bash-it/bash-it",
+    "status": "known_issues",
+    "issueCount": 10
+  },
+  {
+    "repo": "bats-core/bats-core",
+    "repoKey": "bats-core__bats-core",
+    "url": "https://github.com/bats-core/bats-core",
+    "status": "known_issues",
+    "issueCount": 5
+  },
+  {
+    "repo": "bin456789/reinstall",
+    "repoKey": "bin456789__reinstall",
+    "url": "https://github.com/bin456789/reinstall",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "bitnami/containers",
+    "repoKey": "bitnami__containers",
+    "url": "https://github.com/bitnami/containers",
+    "status": "known_issues",
+    "issueCount": 3
+  },
+  {
+    "repo": "bittorf/kalua",
+    "repoKey": "bittorf__kalua",
+    "url": "https://github.com/bittorf/kalua",
+    "status": "known_issues",
+    "issueCount": 56
+  },
+  {
+    "repo": "CISOfy/lynis",
+    "repoKey": "CISOfy__lynis",
+    "url": "https://github.com/CISOfy/lynis",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "client9/shlib",
+    "repoKey": "client9__shlib",
+    "url": "https://github.com/client9/shlib",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "community-scripts/ProxmoxVE",
+    "repoKey": "community-scripts__ProxmoxVE",
+    "url": "https://github.com/community-scripts/ProxmoxVE",
+    "status": "known_issues",
+    "issueCount": 30
+  },
+  {
+    "repo": "dehydrated-io/dehydrated",
+    "repoKey": "dehydrated-io__dehydrated",
+    "url": "https://github.com/dehydrated-io/dehydrated",
+    "status": "known_issues",
+    "issueCount": 3
+  },
+  {
+    "repo": "docker-library/official-images",
+    "repoKey": "docker-library__official-images",
+    "url": "https://github.com/docker-library/official-images",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "docker-mailserver/docker-mailserver",
+    "repoKey": "docker-mailserver__docker-mailserver",
+    "url": "https://github.com/docker-mailserver/docker-mailserver",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "docker/docker-bench-security",
+    "repoKey": "docker__docker-bench-security",
+    "url": "https://github.com/docker/docker-bench-security",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "dockur/windows",
+    "repoKey": "dockur__windows",
+    "url": "https://github.com/dockur/windows",
+    "status": "known_issues",
+    "issueCount": 3
+  },
+  {
+    "repo": "dokku/dokku",
+    "repoKey": "dokku__dokku",
+    "url": "https://github.com/dokku/dokku",
+    "status": "known_issues",
+    "issueCount": 18
+  },
+  {
+    "repo": "dylanaraps/neofetch",
+    "repoKey": "dylanaraps__neofetch",
+    "url": "https://github.com/dylanaraps/neofetch",
+    "status": "known_issues",
+    "issueCount": 6
+  },
+  {
+    "repo": "dylanaraps/pure-bash-bible",
+    "repoKey": "dylanaraps__pure-bash-bible",
+    "url": "https://github.com/dylanaraps/pure-bash-bible",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "dylanaraps/pure-sh-bible",
+    "repoKey": "dylanaraps__pure-sh-bible",
+    "url": "https://github.com/dylanaraps/pure-sh-bible",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "fideloper/Vaprobash",
+    "repoKey": "fideloper__Vaprobash",
+    "url": "https://github.com/fideloper/Vaprobash",
+    "status": "known_issues",
+    "issueCount": 2
+  },
+  {
+    "repo": "GameServerManagers/LinuxGSM",
+    "repoKey": "GameServerManagers__LinuxGSM",
+    "url": "https://github.com/GameServerManagers/LinuxGSM",
+    "status": "known_issues",
+    "issueCount": 13
+  },
+  {
+    "repo": "gentoo/gentoo",
+    "repoKey": "gentoo__gentoo",
+    "url": "https://github.com/gentoo/gentoo",
+    "status": "known_issues",
+    "issueCount": 27
+  },
+  {
+    "repo": "google/oss-fuzz",
+    "repoKey": "google__oss-fuzz",
+    "url": "https://github.com/google/oss-fuzz",
+    "status": "known_issues",
+    "issueCount": 14
+  },
+  {
+    "repo": "HariSekhon/DevOps-Bash-tools",
+    "repoKey": "HariSekhon__DevOps-Bash-tools",
+    "url": "https://github.com/HariSekhon/DevOps-Bash-tools",
+    "status": "known_issues",
+    "issueCount": 7
+  },
+  {
+    "repo": "helmuthdu/aui",
+    "repoKey": "helmuthdu__aui",
+    "url": "https://github.com/helmuthdu/aui",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "holman/dotfiles",
+    "repoKey": "holman__dotfiles",
+    "url": "https://github.com/holman/dotfiles",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "hwdsl2/setup-ipsec-vpn",
+    "repoKey": "hwdsl2__setup-ipsec-vpn",
+    "url": "https://github.com/hwdsl2/setup-ipsec-vpn",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "itzg/docker-minecraft-server",
+    "repoKey": "itzg__docker-minecraft-server",
+    "url": "https://github.com/itzg/docker-minecraft-server",
+    "status": "known_issues",
+    "issueCount": 2
+  },
+  {
+    "repo": "jessfraz/dotfiles",
+    "repoKey": "jessfraz__dotfiles",
+    "url": "https://github.com/jessfraz/dotfiles",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "jorgebucaran/fisher",
+    "repoKey": "jorgebucaran__fisher",
+    "url": "https://github.com/jorgebucaran/fisher",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "juewuy/ShellCrash",
+    "repoKey": "juewuy__ShellCrash",
+    "url": "https://github.com/juewuy/ShellCrash",
+    "status": "known_issues",
+    "issueCount": 14
+  },
+  {
+    "repo": "ko1nksm/shellspec",
+    "repoKey": "ko1nksm__shellspec",
+    "url": "https://github.com/ko1nksm/shellspec",
+    "status": "known_issues",
+    "issueCount": 11
+  },
+  {
+    "repo": "kward/shunit2",
+    "repoKey": "kward__shunit2",
+    "url": "https://github.com/kward/shunit2",
+    "status": "known_issues",
+    "issueCount": 2
+  },
+  {
+    "repo": "leebaird/discover",
+    "repoKey": "leebaird__discover",
+    "url": "https://github.com/leebaird/discover",
+    "status": "known_issues",
+    "issueCount": 3
+  },
+  {
+    "repo": "lmc999/RegionRestrictionCheck",
+    "repoKey": "lmc999__RegionRestrictionCheck",
+    "url": "https://github.com/lmc999/RegionRestrictionCheck",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "LukeSmithxyz/LARBS",
+    "repoKey": "LukeSmithxyz__LARBS",
+    "url": "https://github.com/LukeSmithxyz/LARBS",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "masonr/yet-another-bench-script",
+    "repoKey": "masonr__yet-another-bench-script",
+    "url": "https://github.com/masonr/yet-another-bench-script",
+    "status": "known_issues",
+    "issueCount": 3
+  },
+  {
+    "repo": "mathiasbynens/dotfiles",
+    "repoKey": "mathiasbynens__dotfiles",
+    "url": "https://github.com/mathiasbynens/dotfiles",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "megastep/makeself",
+    "repoKey": "megastep__makeself",
+    "url": "https://github.com/megastep/makeself",
+    "status": "known_issues",
+    "issueCount": 4
+  },
+  {
+    "repo": "moovweb/gvm",
+    "repoKey": "moovweb__gvm",
+    "url": "https://github.com/moovweb/gvm",
+    "status": "known_issues",
+    "issueCount": 10
+  },
+  {
+    "repo": "nextcloud/docker",
+    "repoKey": "nextcloud__docker",
+    "url": "https://github.com/nextcloud/docker",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "nvie/gitflow",
+    "repoKey": "nvie__gitflow",
+    "url": "https://github.com/nvie/gitflow",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "nvm-sh/nvm",
+    "repoKey": "nvm-sh__nvm",
+    "url": "https://github.com/nvm-sh/nvm",
+    "status": "known_issues",
+    "issueCount": 11
+  },
+  {
+    "repo": "Nyr/openvpn-install",
+    "repoKey": "Nyr__openvpn-install",
+    "url": "https://github.com/Nyr/openvpn-install",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "oh-my-fish/oh-my-fish",
+    "repoKey": "oh-my-fish__oh-my-fish",
+    "url": "https://github.com/oh-my-fish/oh-my-fish",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "ohmyzsh/ohmyzsh",
+    "repoKey": "ohmyzsh__ohmyzsh",
+    "url": "https://github.com/ohmyzsh/ohmyzsh",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "openrc/openrc",
+    "repoKey": "openrc__openrc",
+    "url": "https://github.com/openrc/openrc",
+    "status": "known_issues",
+    "issueCount": 5
+  },
+  {
+    "repo": "openvpn/easy-rsa",
+    "repoKey": "openvpn__easy-rsa",
+    "url": "https://github.com/openvpn/easy-rsa",
+    "status": "known_issues",
+    "issueCount": 3
+  },
+  {
+    "repo": "p8952/bocker",
+    "repoKey": "p8952__bocker",
+    "url": "https://github.com/p8952/bocker",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "paulirish/dotfiles",
+    "repoKey": "paulirish__dotfiles",
+    "url": "https://github.com/paulirish/dotfiles",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "pi-hole/pi-hole",
+    "repoKey": "pi-hole__pi-hole",
+    "url": "https://github.com/pi-hole/pi-hole",
+    "status": "known_issues",
+    "issueCount": 5
+  },
+  {
+    "repo": "pyenv/pyenv",
+    "repoKey": "pyenv__pyenv",
+    "url": "https://github.com/pyenv/pyenv",
+    "status": "known_issues",
+    "issueCount": 2
+  },
+  {
+    "repo": "pystardust/ani-cli",
+    "repoKey": "pystardust__ani-cli",
+    "url": "https://github.com/pystardust/ani-cli",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "quickemu-project/quickemu",
+    "repoKey": "quickemu-project__quickemu",
+    "url": "https://github.com/quickemu-project/quickemu",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "rbenv/rbenv",
+    "repoKey": "rbenv__rbenv",
+    "url": "https://github.com/rbenv/rbenv",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "RetroPie/RetroPie-Setup",
+    "repoKey": "RetroPie__RetroPie-Setup",
+    "url": "https://github.com/RetroPie/RetroPie-Setup",
+    "status": "known_issues",
+    "issueCount": 11
+  },
+  {
+    "repo": "romkatv/powerlevel10k",
+    "repoKey": "romkatv__powerlevel10k",
+    "url": "https://github.com/romkatv/powerlevel10k",
+    "status": "known_issues",
+    "issueCount": 5
+  },
+  {
+    "repo": "rupa/z",
+    "repoKey": "rupa__z",
+    "url": "https://github.com/rupa/z",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "rvm/rvm",
+    "repoKey": "rvm__rvm",
+    "url": "https://github.com/rvm/rvm",
+    "status": "known_issues",
+    "issueCount": 94
+  },
+  {
+    "repo": "scop/bash-completion",
+    "repoKey": "scop__bash-completion",
+    "url": "https://github.com/scop/bash-completion",
+    "status": "known_issues",
+    "issueCount": 8
+  },
+  {
+    "repo": "sickcodes/Docker-OSX",
+    "repoKey": "sickcodes__Docker-OSX",
+    "url": "https://github.com/sickcodes/Docker-OSX",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "SlackBuildsOrg/slackbuilds",
+    "repoKey": "SlackBuildsOrg__slackbuilds",
+    "url": "https://github.com/SlackBuildsOrg/slackbuilds",
+    "status": "known_issues",
+    "issueCount": 25
+  },
+  {
+    "repo": "sorin-ionescu/prezto",
+    "repoKey": "sorin-ionescu__prezto",
+    "url": "https://github.com/sorin-ionescu/prezto",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "spiritLHLS/one-click-installation-script",
+    "repoKey": "spiritLHLS__one-click-installation-script",
+    "url": "https://github.com/spiritLHLS/one-click-installation-script",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "sstephenson/bats",
+    "repoKey": "sstephenson__bats",
+    "url": "https://github.com/sstephenson/bats",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "super-linter/super-linter",
+    "repoKey": "super-linter__super-linter",
+    "url": "https://github.com/super-linter/super-linter",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "swoodford/aws",
+    "repoKey": "swoodford__aws",
+    "url": "https://github.com/swoodford/aws",
+    "status": "known_issues",
+    "issueCount": 5
+  },
+  {
+    "repo": "termux/termux-packages",
+    "repoKey": "termux__termux-packages",
+    "url": "https://github.com/termux/termux-packages",
+    "status": "known_issues",
+    "issueCount": 22
+  },
+  {
+    "repo": "thoughtbot/dotfiles",
+    "repoKey": "thoughtbot__dotfiles",
+    "url": "https://github.com/thoughtbot/dotfiles",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "tj/git-extras",
+    "repoKey": "tj__git-extras",
+    "url": "https://github.com/tj/git-extras",
+    "status": "known_issues",
+    "issueCount": 4
+  },
+  {
+    "repo": "tj/n",
+    "repoKey": "tj__n",
+    "url": "https://github.com/tj/n",
+    "status": "known_issues",
+    "issueCount": 1
+  },
+  {
+    "repo": "tmux-plugins/tmux-resurrect",
+    "repoKey": "tmux-plugins__tmux-resurrect",
+    "url": "https://github.com/tmux-plugins/tmux-resurrect",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "tmux-plugins/tpm",
+    "repoKey": "tmux-plugins__tpm",
+    "url": "https://github.com/tmux-plugins/tpm",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "tteck/Proxmox",
+    "repoKey": "tteck__Proxmox",
+    "url": "https://github.com/tteck/Proxmox",
+    "status": "known_issues",
+    "issueCount": 22
+  },
+  {
+    "repo": "v1s1t0r1sh3r3/airgeddon",
+    "repoKey": "v1s1t0r1sh3r3__airgeddon",
+    "url": "https://github.com/v1s1t0r1sh3r3/airgeddon",
+    "status": "known_issues",
+    "issueCount": 2
+  },
+  {
+    "repo": "v2fly/fhs-install-v2ray",
+    "repoKey": "v2fly__fhs-install-v2ray",
+    "url": "https://github.com/v2fly/fhs-install-v2ray",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "void-linux/void-packages",
+    "repoKey": "void-linux__void-packages",
+    "url": "https://github.com/void-linux/void-packages",
+    "status": "known_issues",
+    "issueCount": 15
+  },
+  {
+    "repo": "xwmx/nb",
+    "repoKey": "xwmx__nb",
+    "url": "https://github.com/xwmx/nb",
+    "status": "known_issues",
+    "issueCount": 7
+  },
+  {
+    "repo": "zdharma-continuum/zinit",
+    "repoKey": "zdharma-continuum__zinit",
+    "url": "https://github.com/zdharma-continuum/zinit",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "zsh-users/zsh-autosuggestions",
+    "repoKey": "zsh-users__zsh-autosuggestions",
+    "url": "https://github.com/zsh-users/zsh-autosuggestions",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "zsh-users/zsh-completions",
+    "repoKey": "zsh-users__zsh-completions",
+    "url": "https://github.com/zsh-users/zsh-completions",
+    "status": "passes",
+    "issueCount": 0
+  },
+  {
+    "repo": "zsh-users/zsh-syntax-highlighting",
+    "repoKey": "zsh-users__zsh-syntax-highlighting",
+    "url": "https://github.com/zsh-users/zsh-syntax-highlighting",
+    "status": "passes",
+    "issueCount": 0
+  }
+]

--- a/website/app/lib/shellcheck-compat-data.ts
+++ b/website/app/lib/shellcheck-compat-data.ts
@@ -1,0 +1,5 @@
+import shellcheckCompatRepoJson from "./shellcheck-compat-data.generated.json";
+import type { ShellcheckCompatRepoData } from "./shellcheck-compat-types";
+
+export const shellcheckCompatRepos =
+  shellcheckCompatRepoJson as ShellcheckCompatRepoData[];

--- a/website/app/lib/shellcheck-compat-types.ts
+++ b/website/app/lib/shellcheck-compat-types.ts
@@ -1,0 +1,9 @@
+export type ShellcheckCompatRepoStatus = "passes" | "known_issues";
+
+export interface ShellcheckCompatRepoData {
+  repo: string;
+  repoKey: string;
+  url: string;
+  status: ShellcheckCompatRepoStatus;
+  issueCount: number;
+}

--- a/website/content/shellcheck-compat/index.mdx
+++ b/website/content/shellcheck-compat/index.mdx
@@ -1,3 +1,5 @@
+import ShellcheckCompatRepoTable from "@/app/components/docs/ShellcheckCompatRepoTable";
+
 # ShellCheck Compatibility
 
 Shuck can expose a ShellCheck-shaped CLI for teams that want to migrate existing editor integrations, CI jobs, or local workflows without changing every call site at once.
@@ -157,3 +159,9 @@ That keeps your existing `rules_lint` entry point, target names, and `.shellchec
 - Diagnostic codes, suppressions, and filters use `SCxxxx` identifiers, so existing `# shellcheck disable=...` comments continue to work.
 - `--list-optional` is available, but not every named optional check is implemented yet. Treat that catalog as a compatibility target rather than a guarantee that every check can already be enabled.
 - If you want Shuck-only features such as the native multi-dialect workflow or automatic fixes, use the regular [`shuck check` docs](/docs/getting-started) instead of the compatibility surface.
+
+## Repository conformance
+
+This table tracks the curated large-corpus repositories that Shuck uses for ShellCheck compatibility work. Green means the checked-in corpus metadata has no known reviewed repo issues. Yellow means the repo currently has known reviewed divergences or is skipped because ShellCheck does not support it in the corpus harness.
+
+<ShellcheckCompatRepoTable />

--- a/website/package.json
+++ b/website/package.json
@@ -5,8 +5,10 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "generate:rules": "tsx scripts/generate-rules.ts",
-    "prebuild": "pnpm generate:rules",
-    "dev": "pnpm generate:rules && next dev",
+    "generate:shellcheck-compat": "tsx scripts/generate-shellcheck-compat.ts",
+    "generate:data": "pnpm generate:rules && pnpm generate:shellcheck-compat",
+    "prebuild": "pnpm generate:data",
+    "dev": "pnpm generate:data && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/website/scripts/generate-shellcheck-compat.ts
+++ b/website/scripts/generate-shellcheck-compat.ts
@@ -1,0 +1,13 @@
+import {
+  shellcheckCompatDataOutputPath,
+  writeShellcheckCompatRepoData,
+} from "./shellcheck-compat-data";
+
+const repoData = writeShellcheckCompatRepoData();
+const knownIssueCount = repoData.filter(
+  (repo) => repo.status === "known_issues",
+).length;
+
+console.log(
+  `Generated ${repoData.length} repository conformance rows (${knownIssueCount} with known issues) -> ${shellcheckCompatDataOutputPath}`,
+);

--- a/website/scripts/shellcheck-compat-data.test.ts
+++ b/website/scripts/shellcheck-compat-data.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildShellcheckCompatRepoData,
+  collectKnownIssueRepoCounts,
+  extractRepoKeyFromMetadataPath,
+  generateShellcheckCompatRepoData,
+  parseCuratedRepoList,
+  parseUnsupportedRepoKeys,
+} from "./shellcheck-compat-data";
+
+test("parseCuratedRepoList dedupes repositories while preserving order", () => {
+  const repos = parseCuratedRepoList(`REPOS="
+foo/bar
+baz/qux
+foo/bar
+"`);
+
+  assert.deepEqual(repos, ["foo/bar", "baz/qux"]);
+});
+
+test("extractRepoKeyFromMetadataPath handles direct and prefixed corpus paths", () => {
+  assert.equal(
+    extractRepoKeyFromMetadataPath("termux__termux-packages__packages__dart__build.sh"),
+    "termux__termux-packages",
+  );
+  assert.equal(
+    extractRepoKeyFromMetadataPath("scripts/rvm__rvm__bin__rvmsudo"),
+    "rvm__rvm",
+  );
+  assert.equal(
+    extractRepoKeyFromMetadataPath("corpus/scripts/xwmx__nb__nb"),
+    "xwmx__nb",
+  );
+});
+
+test("collectKnownIssueRepoCounts maps path_contains and path_suffix entries back to repos", () => {
+  const repoCounts = collectKnownIssueRepoCounts([
+    {
+      reviewed_divergences: [
+        { path_contains: "scripts/rvm__rvm__" },
+        {
+          path_suffix:
+            "corpus/scripts/termux__termux-packages__packages__dart__build.sh",
+        },
+      ],
+    },
+  ]);
+
+  assert.equal(repoCounts.get("rvm__rvm"), 1);
+  assert.equal(repoCounts.get("termux__termux-packages"), 1);
+});
+
+test("parseUnsupportedRepoKeys trims repo prefixes from the harness constant", () => {
+  const repoKeys = parseUnsupportedRepoKeys(`
+const LARGE_CORPUS_SHELLCHECK_UNSUPPORTED_REPO_PREFIXES: &[&str] = &[
+    "ohmyzsh__ohmyzsh__",
+    "foo__bar__",
+];
+`);
+
+  assert.deepEqual(repoKeys, ["ohmyzsh__ohmyzsh", "foo__bar"]);
+});
+
+test("buildShellcheckCompatRepoData marks known-issue and unsupported repos yellow", () => {
+  const repoData = buildShellcheckCompatRepoData({
+    curatedRepos: ["ohmyzsh/ohmyzsh", "rbenv/rbenv", "rvm/rvm"],
+    knownIssueRepoCounts: new Map([["rvm__rvm", 3]]),
+    unsupportedRepoKeys: new Set(["ohmyzsh__ohmyzsh"]),
+  });
+
+  assert.equal(
+    repoData.find((repo) => repo.repo === "ohmyzsh/ohmyzsh")?.status,
+    "known_issues",
+  );
+  assert.equal(
+    repoData.find((repo) => repo.repo === "ohmyzsh/ohmyzsh")?.issueCount,
+    1,
+  );
+  assert.equal(
+    repoData.find((repo) => repo.repo === "rvm/rvm")?.status,
+    "known_issues",
+  );
+  assert.equal(
+    repoData.find((repo) => repo.repo === "rvm/rvm")?.issueCount,
+    3,
+  );
+  assert.equal(
+    repoData.find((repo) => repo.repo === "rbenv/rbenv")?.status,
+    "passes",
+  );
+  assert.equal(
+    repoData.find((repo) => repo.repo === "rbenv/rbenv")?.issueCount,
+    0,
+  );
+  assert.deepEqual(repoData.map((repo) => repo.repo), [
+    "ohmyzsh/ohmyzsh",
+    "rbenv/rbenv",
+    "rvm/rvm",
+  ]);
+});
+
+test("generateShellcheckCompatRepoData reflects the checked-in corpus sources", () => {
+  const repoData = generateShellcheckCompatRepoData();
+
+  assert.equal(
+    repoData.find((repo) => repo.repo === "rvm/rvm")?.status,
+    "known_issues",
+  );
+  assert.equal(
+    repoData.find((repo) => repo.repo === "ohmyzsh/ohmyzsh")?.status,
+    "known_issues",
+  );
+  assert.equal(
+    repoData.find((repo) => repo.repo === "rbenv/rbenv")?.status,
+    "passes",
+  );
+  assert.equal(
+    repoData.filter((repo) => repo.repo === "xwmx/nb").length,
+    1,
+  );
+  assert.ok(
+    (repoData.find((repo) => repo.repo === "rvm/rvm")?.issueCount ?? 0) > 0,
+  );
+  assert.equal(
+    repoData.find((repo) => repo.repo === "rbenv/rbenv")?.issueCount,
+    0,
+  );
+});

--- a/website/scripts/shellcheck-compat-data.ts
+++ b/website/scripts/shellcheck-compat-data.ts
@@ -1,0 +1,208 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import type {
+  ShellcheckCompatRepoData,
+  ShellcheckCompatRepoStatus,
+} from "../app/lib/shellcheck-compat-types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface ReviewedDivergenceRecord {
+  path_contains?: string;
+  path_suffix?: string;
+}
+
+export interface CorpusMetadataDocument {
+  review_all_divergences?: boolean;
+  reviewed_divergences?: ReviewedDivergenceRecord[];
+}
+
+const repoRootDir = resolve(__dirname, "../..");
+const corpusDownloadPath = join(repoRootDir, "scripts/corpus-download.sh");
+const corpusMetadataDir = join(
+  repoRootDir,
+  "crates/shuck-cli/tests/testdata/corpus-metadata",
+);
+const largeCorpusPath = join(
+  repoRootDir,
+  "crates/shuck-cli/tests/large_corpus.rs",
+);
+
+export const shellcheckCompatDataOutputPath = join(
+  repoRootDir,
+  "website/app/lib/shellcheck-compat-data.generated.json",
+);
+
+export function parseCuratedRepoList(source: string): string[] {
+  const reposMatch = source.match(/REPOS="\n?([\s\S]*?)"/u);
+  if (!reposMatch) {
+    return [];
+  }
+
+  const repos: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of reposMatch[1].split(/\r?\n/u)) {
+    const repo = line.trim();
+    if (!repo || seen.has(repo)) {
+      continue;
+    }
+
+    seen.add(repo);
+    repos.push(repo);
+  }
+
+  return repos;
+}
+
+export function repoKeyFromRepo(repo: string): string {
+  return repo.replace("/", "__");
+}
+
+export function normalizeMetadataPath(pathValue: string): string {
+  return pathValue.replace(/^(?:corpus\/)?scripts\//u, "");
+}
+
+export function extractRepoKeyFromMetadataPath(
+  pathValue: string,
+): string | null {
+  const normalized = normalizeMetadataPath(pathValue);
+  const [owner, name] = normalized.split("__");
+
+  if (!owner || !name) {
+    return null;
+  }
+
+  return `${owner}__${name}`;
+}
+
+export function collectKnownIssueRepoKeys(
+  metadataDocuments: CorpusMetadataDocument[],
+): Set<string> {
+  return new Set(collectKnownIssueRepoCounts(metadataDocuments).keys());
+}
+
+export function collectKnownIssueRepoCounts(
+  metadataDocuments: CorpusMetadataDocument[],
+): Map<string, number> {
+  const repoCounts = new Map<string, number>();
+
+  for (const document of metadataDocuments) {
+    for (const divergence of document.reviewed_divergences ?? []) {
+      for (const pathValue of [
+        divergence.path_contains,
+        divergence.path_suffix,
+      ]) {
+        if (typeof pathValue !== "string") {
+          continue;
+        }
+
+        const repoKey = extractRepoKeyFromMetadataPath(pathValue);
+        if (repoKey) {
+          repoCounts.set(repoKey, (repoCounts.get(repoKey) ?? 0) + 1);
+          break;
+        }
+      }
+    }
+  }
+
+  return repoCounts;
+}
+
+export function parseUnsupportedRepoKeys(source: string): string[] {
+  const match = source.match(
+    /const LARGE_CORPUS_SHELLCHECK_UNSUPPORTED_REPO_PREFIXES: &\[&str\] = &\[([\s\S]*?)\];/u,
+  );
+  const body = match?.[1] ?? "";
+  const repoKeys: string[] = [];
+  const seen = new Set<string>();
+
+  for (const literal of body.matchAll(/"([^"]+)"/gu)) {
+    const repoKey = literal[1].replace(/__+$/u, "");
+    if (!repoKey || seen.has(repoKey)) {
+      continue;
+    }
+
+    seen.add(repoKey);
+    repoKeys.push(repoKey);
+  }
+
+  return repoKeys;
+}
+
+export function buildShellcheckCompatRepoData(input: {
+  curatedRepos: string[];
+  knownIssueRepoCounts: Map<string, number>;
+  unsupportedRepoKeys: Set<string>;
+}): ShellcheckCompatRepoData[] {
+  return input.curatedRepos
+    .map((repo) => {
+      const repoKey = repoKeyFromRepo(repo);
+      const issueCount =
+        (input.knownIssueRepoCounts.get(repoKey) ?? 0) +
+        (input.unsupportedRepoKeys.has(repoKey) ? 1 : 0);
+      const status: ShellcheckCompatRepoStatus = issueCount > 0
+        ? "known_issues"
+        : "passes";
+
+      return {
+        repo,
+        repoKey,
+        url: `https://github.com/${repo}`,
+        status,
+        issueCount,
+      };
+    })
+    .sort((left, right) => left.repo.localeCompare(right.repo));
+}
+
+function loadCorpusMetadataDocuments(
+  metadataDirPath: string = corpusMetadataDir,
+): CorpusMetadataDocument[] {
+  return readdirSync(metadataDirPath)
+    .filter((file) => file.endsWith(".yaml"))
+    .map((file) => {
+      const content = readFileSync(join(metadataDirPath, file), "utf-8");
+      return (parseYaml(content) as CorpusMetadataDocument | null) ?? {};
+    });
+}
+
+export function generateShellcheckCompatRepoData(
+  rootDir: string = repoRootDir,
+): ShellcheckCompatRepoData[] {
+  const curatedRepos = parseCuratedRepoList(
+    readFileSync(join(rootDir, "scripts/corpus-download.sh"), "utf-8"),
+  );
+  const knownIssueRepoCounts = collectKnownIssueRepoCounts(
+    loadCorpusMetadataDocuments(
+      join(rootDir, "crates/shuck-cli/tests/testdata/corpus-metadata"),
+    ),
+  );
+  const unsupportedRepoKeys = new Set(
+    parseUnsupportedRepoKeys(
+      readFileSync(join(rootDir, "crates/shuck-cli/tests/large_corpus.rs"), "utf-8"),
+    ),
+  );
+
+  return buildShellcheckCompatRepoData({
+    curatedRepos,
+    knownIssueRepoCounts,
+    unsupportedRepoKeys,
+  });
+}
+
+export function writeShellcheckCompatRepoData(
+  outputPath: string = shellcheckCompatDataOutputPath,
+): ShellcheckCompatRepoData[] {
+  const repoData = generateShellcheckCompatRepoData();
+  writeFileSync(outputPath, JSON.stringify(repoData, null, 2) + "\n");
+  return repoData;
+}
+
+export const shellcheckCompatSourcePaths = {
+  corpusDownloadPath,
+  corpusMetadataDir,
+  largeCorpusPath,
+};


### PR DESCRIPTION
## Summary
Add a repository conformance table to the ShellCheck compatibility docs page and generate its data from the curated large-corpus sources already in the repo.

## What Changed
- add a generated website dataset for ShellCheck compatibility repository status
- derive repo rows from `scripts/corpus-download.sh`, corpus metadata, and unsupported-repo prefixes in the large-corpus harness
- render the docs table with green/yellow indicators, inline hover/focus tooltips, and alphabetical ordering
- move the repository conformance section to the bottom of the compatibility page
- add focused generator tests for repo parsing, metadata mapping, unsupported repos, ordering, and issue counts

## Why
This makes the compatibility page more concrete by showing which upstream repositories are covered by the checked-in corpus and which ones still have known reviewed issues.

## Validation
- `pnpm exec tsx --test app/lib/benchmarks.test.ts scripts/shellcheck-compat-data.test.ts`
- `pnpm build`
- verified the live page locally at `http://localhost:3000/docs/shellcheck-compat`
