### PR TITLE
fix(linter): preserve C006 reports after subscript reads

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c006.yaml
@@ -1826,3 +1826,38 @@ reviewed_divergences:
     column: 49
     end_column: 56
     reason: "This Void helper still produces a Shuck-side unresolved read from collapsed framework context in this one file, so it stays reviewed narrowly rather than relaxing C006 across the wider shell-collapse family."
+  - side: shuck-only
+    path_suffix: "233boy__v2ray__src__old.sh"
+    line: 50
+    end_line: 50
+    column: 6
+    end_column: 22
+    reason: "This legacy V2Ray helper threads transport choice through sourced installer plumbing, so the remaining C006 read is a repo-local runtime handoff rather than a free-standing missing assignment."
+  - side: shuck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__helpers.sh"
+    line: 472
+    end_line: 472
+    column: 20
+    end_column: 26
+    reason: "This RetroPie fixture exchanges menu ids, config roots, or launching-image options through the surrounding setup framework, so the remaining C006 hits are reviewed framework state rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__helpers.sh"
+    line: 472
+    end_line: 472
+    column: 27
+    end_column: 35
+    reason: "This RetroPie fixture exchanges menu ids, config roots, or launching-image options through the surrounding setup framework, so the remaining C006 hits are reviewed framework state rather than missing local assignments."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__info"
+    line: 189
+    end_line: 189
+    column: 6
+    end_column: 20
+    reason: "This file only differs on the exact C006 anchor in the corpus run, so both sides stay reviewed narrowly instead of widening the core span logic again."
+  - side: shuck-only
+    path_suffix: "rvm__rvm__scripts__repair"
+    line: 152
+    end_line: 152
+    column: 6
+    end_column: 20
+    reason: "This RVM script helper is sourced into a shared mutable environment and passes state through globals, helper side effects, and indirect expansion, so the remaining C006 hits are reviewed library/runtime contracts rather than standalone missing assignments."

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -440,7 +440,6 @@ impl<'a> LinterFactsBuilder<'a> {
             replacement_expansions,
             positional_parameter_trims,
             suppressed_subscript_spans,
-            name_suppressing_subscript_spans,
             arithmetic_only_suppressed_subscript_spans,
         } = surface_fragments.finish();
         let function_positional_parameter_facts = build_function_positional_parameter_facts(
@@ -458,11 +457,6 @@ impl<'a> LinterFactsBuilder<'a> {
             &suppressed_subscript_spans,
             &arithmetic_only_suppressed_subscript_spans,
         );
-        let name_suppressing_subscript_reference_spans =
-            build_name_suppressing_subscript_reference_spans(
-                self.semantic,
-                &name_suppressing_subscript_spans,
-            );
         pattern_exactly_one_extglob_spans.extend(surface_pattern_exactly_one_extglob_spans);
         pattern_charclass_spans.extend(surface_pattern_charclass_spans);
         let escape_scan_matches = build_escape_scan_matches(
@@ -596,7 +590,6 @@ impl<'a> LinterFactsBuilder<'a> {
             presence_test_references_by_name: presence_tested_names.references_by_name,
             presence_test_names_by_name: presence_tested_names.names_by_name,
             suppressed_subscript_reference_spans,
-            name_suppressing_subscript_reference_spans,
             compound_assignment_value_word_spans,
             word_nodes,
             word_occurrences,

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -30,8 +30,8 @@ use self::{
         ParameterPatternSpecialTargetFragmentFact, PositionalParameterTrimFragmentFact,
         ReplacementExpansionFragmentFact, SubstringExpansionFragmentFact, SurfaceFragmentFacts,
         SurfaceFragmentSink, SurfaceScanContext, SuspectClosingQuoteFragmentFact,
-        ZshParameterIndexFlagFragmentFact, build_name_suppressing_subscript_reference_spans,
-        build_suppressed_subscript_reference_spans, rewrite_pattern_as_single_double_quoted_string,
+        ZshParameterIndexFlagFragmentFact, build_suppressed_subscript_reference_spans,
+        rewrite_pattern_as_single_double_quoted_string,
         rewrite_word_as_single_double_quoted_string,
     },
 };

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -21,7 +21,6 @@ pub struct LinterFacts<'a> {
     presence_test_references_by_name: FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
     presence_test_names_by_name: FxHashMap<Name, Vec<PresenceTestNameFact>>,
     suppressed_subscript_reference_spans: FxHashSet<FactSpan>,
-    name_suppressing_subscript_reference_spans: FxHashSet<FactSpan>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
     word_nodes: Vec<WordNode<'a>>,
     word_occurrences: Vec<WordOccurrence>,
@@ -358,11 +357,6 @@ impl<'a> LinterFacts<'a> {
 
     pub fn is_suppressed_subscript_reference(&self, span: Span) -> bool {
         self.suppressed_subscript_reference_spans
-            .contains(&FactSpan::new(span))
-    }
-
-    pub fn is_name_suppressing_subscript_reference(&self, span: Span) -> bool {
-        self.name_suppressing_subscript_reference_spans
             .contains(&FactSpan::new(span))
     }
 

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -300,7 +300,6 @@ pub(super) struct SurfaceFragmentFacts {
     pub(super) replacement_expansions: Vec<ReplacementExpansionFragmentFact>,
     pub(super) positional_parameter_trims: Vec<PositionalParameterTrimFragmentFact>,
     pub(super) suppressed_subscript_spans: Vec<Span>,
-    pub(super) name_suppressing_subscript_spans: Vec<Span>,
     pub(super) arithmetic_only_suppressed_subscript_spans: Vec<Span>,
 }
 
@@ -1270,9 +1269,6 @@ impl<'a> SurfaceFragmentSink<'a> {
             return;
         }
         self.facts.suppressed_subscript_spans.push(subscript.span());
-        self.facts
-            .name_suppressing_subscript_spans
-            .push(subscript.span());
     }
 
     pub(super) fn record_arithmetic_only_suppressed_subscript(
@@ -2253,17 +2249,6 @@ pub(super) fn build_suppressed_subscript_reference_spans(
         |reference| matches!(reference.kind, ReferenceKind::ArithmeticRead),
     ));
     spans
-}
-
-pub(super) fn build_name_suppressing_subscript_reference_spans(
-    semantic: &SemanticModel,
-    name_suppressing_subscript_spans: &[Span],
-) -> FxHashSet<FactSpan> {
-    build_subscript_reference_spans_with_filter(
-        semantic.references(),
-        name_suppressing_subscript_spans,
-        |_| true,
-    )
 }
 
 fn build_subscript_reference_spans_with_filter(

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -879,12 +879,6 @@ write_target
     assert!(!facts.is_suppressed_subscript_reference(reference_span("assoc_target_id")));
     assert!(!facts.is_suppressed_subscript_reference(reference_span("assoc_dynamic_key")));
     assert!(!facts.is_suppressed_subscript_reference(reference_span("free")));
-
-    assert!(facts.is_name_suppressing_subscript_reference(reference_span("read_idx")));
-    assert!(facts.is_name_suppressing_subscript_reference(reference_span("assoc_read_idx")));
-    assert!(!facts.is_name_suppressing_subscript_reference(reference_span("bare_check")));
-    assert!(!facts.is_name_suppressing_subscript_reference(reference_span("assoc_target_bare")));
-    assert!(!facts.is_name_suppressing_subscript_reference(reference_span("assoc_bare_key")));
 }
 
 #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -3599,7 +3599,7 @@ printf '%s %s\\n' \"${map[swift-cmark]}\" \"${map[$dynamic_key]}\"
     }
 
     #[test]
-    fn undefined_variable_suppresses_later_subscript_writes_after_read_subscripts() {
+    fn undefined_variable_reports_later_subscript_writes_after_read_subscripts() {
         let source = "\
 #!/bin/bash
 declare -a args
@@ -3612,11 +3612,17 @@ tools[$target]=ok
 ";
         let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$__array_start", "$target"]
+        );
     }
 
     #[test]
-    fn undefined_variable_suppresses_later_plain_uses_after_subscript_only_uses() {
+    fn undefined_variable_reports_later_plain_uses_after_subscript_only_uses() {
         let source = "\
 #!/bin/bash
 declare -a args
@@ -3626,7 +3632,13 @@ printf '%s %s\\n' \"$idx\" \"$target\"
 ";
         let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
 
-        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$idx", "$target"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -55,12 +55,6 @@ pub fn undefined_variable(checker: &mut Checker) {
             .facts()
             .is_suppressed_subscript_reference(reference.span)
         {
-            if checker
-                .facts()
-                .is_name_suppressing_subscript_reference(reference.span)
-            {
-                suppressed_names.insert(reference.name.clone());
-            }
             continue;
         }
         if !is_reportable_variable_reference(
@@ -215,12 +209,13 @@ map+=([assoc_bare_key]=value)
     }
 
     #[test]
-    fn non_read_subscript_suppression_does_not_hide_later_plain_uses() {
+    fn subscript_suppression_does_not_hide_later_plain_uses() {
         let source = "\
 #!/bin/bash
+printf '%s\\n' \"${arr[$read_idx]}\"
 [[ -v arr[bare_check] ]]
 unset arr[$unset_idx]
-printf '%s\\n' \"$bare_check\" \"$unset_idx\"
+printf '%s\\n' \"$read_idx\" \"$bare_check\" \"$unset_idx\"
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UndefinedVariable));
 
@@ -229,7 +224,7 @@ printf '%s\\n' \"$bare_check\" \"$unset_idx\"
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["$bare_check", "$unset_idx"]
+            vec!["$read_idx", "$bare_check", "$unset_idx"]
         );
     }
 


### PR DESCRIPTION
## Summary
- stop treating suppressed subscript-only C006 references as name-wide suppressions
- keep later plain and write-context references reportable after read-style subscript use
- restore exact reviewed C006 corpus metadata for the remaining intentional divergences

PR #553 merged with the main indexed-subscript arithmetic fix before this review-cleanup patch could land, so this is the follow-up for that automated review feedback.

## Verification
- cargo fmt --check
- cargo test -p shuck-linter
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006