### PR TITLE
perf(linter): reduce fact traversal overhead

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1,23 +1,3 @@
-fn build_base_prefix_arithmetic_spans(body: &StmtSeq, source: &str) -> Vec<Span> {
-    let mut spans = Vec::new();
-
-    for visit in iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
-        collect_base_prefix_spans_in_command(visit.command, source, &mut spans);
-        for redirect in visit.redirects {
-            if let Some(word) = redirect.word_target() {
-                collect_base_prefix_spans_in_word(word, source, &mut spans);
-            }
-        }
-    }
-
-    spans
-}
-
 fn collect_base_prefix_spans_in_command(command: &Command, source: &str, spans: &mut Vec<Span>) {
     match command {
         Command::Simple(command) => {
@@ -728,7 +708,6 @@ fn collect_base_prefix_spans_in_text(span: Span, source: &str, spans: &mut Vec<S
     }
 }
 
-
 fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
     commands
         .iter()
@@ -739,48 +718,6 @@ fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str)
             _ => None,
         })
         .collect()
-}
-
-fn build_arithmetic_update_operator_spans(
-    body: &StmtSeq,
-    semantic: &SemanticModel,
-    source: &str,
-) -> Vec<Span> {
-    let mut spans = Vec::new();
-
-    for visit in iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
-        collect_arithmetic_update_operator_spans_in_command(
-            visit.command,
-            semantic,
-            source,
-            &mut spans,
-        );
-        for redirect in visit.redirects {
-            if let Some(word) = redirect.word_target() {
-                collect_arithmetic_update_operator_spans_in_word(
-                    word, semantic, source, &mut spans,
-                );
-            } else if let Some(heredoc) = redirect.heredoc()
-                && heredoc.delimiter.expands_body
-            {
-                collect_arithmetic_update_operator_spans_in_heredoc_body(
-                    &heredoc.body.parts,
-                    semantic,
-                    source,
-                    &mut spans,
-                );
-            }
-        }
-    }
-
-    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
-    spans.dedup();
-    spans
 }
 
 fn collect_arithmetic_update_operator_spans_in_command(
@@ -796,7 +733,12 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     assignment, semantic, source, spans,
                 );
             }
-            collect_arithmetic_update_operator_spans_in_word(&command.name, semantic, source, spans);
+            collect_arithmetic_update_operator_spans_in_word(
+                &command.name,
+                semantic,
+                source,
+                spans,
+            );
             for word in &command.args {
                 collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
             }
@@ -809,14 +751,10 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     );
                 }
                 if let Some(word) = &command.depth {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
                 for word in &command.extra_args {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
             }
             BuiltinCommand::Continue(command) => {
@@ -826,14 +764,10 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     );
                 }
                 if let Some(word) = &command.depth {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
                 for word in &command.extra_args {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
             }
             BuiltinCommand::Return(command) => {
@@ -843,14 +777,10 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     );
                 }
                 if let Some(word) = &command.code {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
                 for word in &command.extra_args {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
             }
             BuiltinCommand::Exit(command) => {
@@ -860,14 +790,10 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     );
                 }
                 if let Some(word) = &command.code {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
                 for word in &command.extra_args {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
             }
         },
@@ -913,9 +839,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             }
             CompoundCommand::Foreach(command) => {
                 for word in &command.words {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
             }
             CompoundCommand::Arithmetic(command) => {
@@ -955,9 +879,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             }
             CompoundCommand::Select(command) => {
                 for word in &command.words {
-                    collect_arithmetic_update_operator_spans_in_word(
-                        word, semantic, source, spans,
-                    );
+                    collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
                 }
             }
             CompoundCommand::If(_)
@@ -1117,7 +1039,9 @@ fn var_ref_name_has_visible_assoc_binding_from_named_callers(
                 continue;
             }
 
-            if let Some(caller_names) = named_function_scope_names(semantic, call_site.name_span.start.offset) {
+            if let Some(caller_names) =
+                named_function_scope_names(semantic, call_site.name_span.start.offset)
+            {
                 worklist.extend(caller_names.iter().cloned());
             }
         }
@@ -1182,10 +1106,7 @@ fn collect_arithmetic_update_operator_spans_in_conditional_expr(
     match expression {
         ConditionalExpr::Binary(expr) => {
             collect_arithmetic_update_operator_spans_in_conditional_expr(
-                &expr.left,
-                semantic,
-                source,
-                spans,
+                &expr.left, semantic, source, spans,
             );
             collect_arithmetic_update_operator_spans_in_conditional_expr(
                 &expr.right,
@@ -1196,32 +1117,22 @@ fn collect_arithmetic_update_operator_spans_in_conditional_expr(
         }
         ConditionalExpr::Unary(expr) => {
             collect_arithmetic_update_operator_spans_in_conditional_expr(
-                &expr.expr,
-                semantic,
-                source,
-                spans,
+                &expr.expr, semantic, source, spans,
             );
         }
         ConditionalExpr::Parenthesized(expr) => {
             collect_arithmetic_update_operator_spans_in_conditional_expr(
-                &expr.expr,
-                semantic,
-                source,
-                spans,
+                &expr.expr, semantic, source, spans,
             );
         }
         ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
             collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
         }
         ConditionalExpr::Pattern(pattern) => {
-            collect_arithmetic_update_operator_spans_in_pattern(
-                pattern, semantic, source, spans,
-            );
+            collect_arithmetic_update_operator_spans_in_pattern(pattern, semantic, source, spans);
         }
         ConditionalExpr::VarRef(reference) => {
-            collect_arithmetic_update_operator_spans_in_var_ref(
-                reference, semantic, source, spans,
-            );
+            collect_arithmetic_update_operator_spans_in_var_ref(reference, semantic, source, spans);
         }
     }
 }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -78,218 +78,269 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut getopts_cases = Vec::new();
         let mut condition_status_capture_spans = Vec::new();
         let mut command_substitution_command_spans = Vec::new();
+        let mut arithmetic_update_operator_spans = Vec::new();
+        let mut base_prefix_arithmetic_spans = Vec::new();
 
-        for traversed in iter_commands_with_context(
+        walk_commands(
             &self.file.body,
             CommandWalkOptions {
                 descend_nested_word_commands: true,
             },
-        ) {
-            let visit = traversed.visit;
-            let context = traversed.context;
-            let key = FactSpan::new(command_span(visit.command));
-            let id = CommandId::new(commands.len());
-            let lookup_kind = command_lookup_kind(visit.command);
-            let entries = command_ids_by_span.entry(key).or_default();
-            let previous = entries.iter().find(|entry| entry.kind == lookup_kind);
-            debug_assert!(previous.is_none(), "duplicate command lookup key");
-            entries.push(CommandLookupEntry {
-                kind: lookup_kind,
-                id,
-            });
+            &mut |visit, context| {
+                let key = FactSpan::new(command_span(visit.command));
+                let id = CommandId::new(commands.len());
+                let lookup_kind = command_lookup_kind(visit.command);
+                let entries = command_ids_by_span.entry(key).or_default();
+                let previous = entries.iter().find(|entry| entry.kind == lookup_kind);
+                debug_assert!(previous.is_none(), "duplicate command lookup key");
+                entries.push(CommandLookupEntry {
+                    kind: lookup_kind,
+                    id,
+                });
 
-            if context.in_if_condition {
-                if_condition_command_ids.insert(id);
-            }
-            if context.in_elif_condition {
-                elif_condition_command_ids.insert(id);
-            }
-
-            collect_binding_values(visit.command, self.semantic, self.source, &mut binding_values);
-            collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
-            collect_command_substitution_command_span(
-                visit.command,
-                self.source,
-                &mut command_substitution_command_spans,
-            );
-            collect_comma_array_assignment_spans(
-                visit.command,
-                self.source,
-                &mut comma_array_assignment_spans,
-            );
-            collect_ifs_literal_backslash_assignment_value_spans(
-                visit.command,
-                self.source,
-                &mut ifs_literal_backslash_assignment_value_spans,
-            );
-            let normalized = command::normalize_command(visit.command, self.source);
-            let command_zsh_options = effective_command_zsh_options(
-                self.semantic,
-                command_span(visit.command).start.offset,
-                &normalized,
-            );
-            let nested_word_command = context.nested_word_command;
-            if !nested_word_command {
-                structural_command_ids.push(id);
-            }
-            build_word_facts_for_command(
-                visit,
-                self.source,
-                self.semantic,
-                WordFactCommandContext {
-                    command_id: id,
-                    nested_word_command,
-                },
-                &normalized,
-                command_zsh_options.clone(),
-                WordFactOutputs {
-                    word_nodes: &mut word_nodes,
-                    word_node_ids_by_span: &mut word_node_ids_by_span,
-                    word_occurrences: &mut word_occurrences,
-                    pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
-                    compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
-                    array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
-                    assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
-                    case_pattern_expansions: &mut case_pattern_expansions,
-                    pattern_literal_spans: &mut pattern_literal_spans,
-                    arithmetic: &mut arithmetic_summary,
-                    surface: &mut surface_fragments,
-                },
-            );
-            let redirect_facts = build_redirect_facts(
-                visit.redirects,
-                Some(self.semantic),
-                self.source,
-                command_zsh_options.as_ref(),
-            );
-            let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
-            let declaration_assignment_probes = build_declaration_assignment_probes(
-                visit.command,
-                &normalized,
-                self.source,
-                command_zsh_options.as_ref(),
-            );
-            let glued_closing_bracket_operand_span =
-                build_glued_closing_bracket_operand_span(visit.command, self.source);
-            let glued_closing_bracket_insert_offset =
-                build_glued_closing_bracket_insert_offset(visit.command, self.source);
-            let simple_test =
-                build_simple_test_fact(visit.command, self.source, self._file_context);
-            let conditional = build_conditional_fact(visit.command, self.source);
-            commands.push(CommandFact {
-                id,
-                key,
-                visit,
-                nested_word_command,
-                normalized,
-                zsh_options: command_zsh_options,
-                redirect_facts,
-                substitution_facts: Vec::new().into_boxed_slice(),
-                options,
-                scope_read_source_words: Vec::new().into_boxed_slice(),
-                scope_name_read_uses: Vec::new().into_boxed_slice(),
-                scope_heredoc_name_read_uses: Vec::new().into_boxed_slice(),
-                scope_name_write_uses: Vec::new().into_boxed_slice(),
-                declaration_assignment_probes,
-                glued_closing_bracket_operand_span,
-                glued_closing_bracket_insert_offset,
-                linebreak_in_test_anchor_span: None,
-                linebreak_in_test_insert_offset: None,
-                simple_test,
-                conditional,
-            });
-
-            if let Command::Function(function) = visit.command {
-                functions.push(function);
-                if let Some(span) = function_body_without_braces_span(function) {
-                    function_body_without_braces_spans.push(span);
+                if context.in_if_condition {
+                    if_condition_command_ids.insert(id);
                 }
-            }
+                if context.in_elif_condition {
+                    elif_condition_command_ids.insert(id);
+                }
 
-            if !nested_word_command {
-                match visit.command {
-                    Command::Compound(CompoundCommand::If(command)) => {
-                        collect_condition_status_capture_from_body(
-                            &command.condition,
-                            &command.then_branch,
+                collect_binding_values(
+                    visit.command,
+                    self.semantic,
+                    self.source,
+                    &mut binding_values,
+                );
+                collect_broken_assoc_key_spans(
+                    visit.command,
+                    self.source,
+                    &mut broken_assoc_key_spans,
+                );
+                collect_command_substitution_command_span(
+                    visit.command,
+                    self.source,
+                    &mut command_substitution_command_spans,
+                );
+                collect_comma_array_assignment_spans(
+                    visit.command,
+                    self.source,
+                    &mut comma_array_assignment_spans,
+                );
+                collect_ifs_literal_backslash_assignment_value_spans(
+                    visit.command,
+                    self.source,
+                    &mut ifs_literal_backslash_assignment_value_spans,
+                );
+                let normalized = command::normalize_command(visit.command, self.source);
+                let command_zsh_options = effective_command_zsh_options(
+                    self.semantic,
+                    command_span(visit.command).start.offset,
+                    &normalized,
+                );
+                let nested_word_command = context.nested_word_command;
+                if !nested_word_command {
+                    structural_command_ids.push(id);
+                }
+                build_word_facts_for_command(
+                    visit,
+                    self.source,
+                    self.semantic,
+                    WordFactCommandContext {
+                        command_id: id,
+                        nested_word_command,
+                    },
+                    &normalized,
+                    command_zsh_options.clone(),
+                    WordFactOutputs {
+                        word_nodes: &mut word_nodes,
+                        word_node_ids_by_span: &mut word_node_ids_by_span,
+                        word_occurrences: &mut word_occurrences,
+                        pending_arithmetic_word_occurrences:
+                            &mut pending_arithmetic_word_occurrences,
+                        compound_assignment_value_word_spans:
+                            &mut compound_assignment_value_word_spans,
+                        array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
+                        assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
+                        case_pattern_expansions: &mut case_pattern_expansions,
+                        pattern_literal_spans: &mut pattern_literal_spans,
+                        arithmetic: &mut arithmetic_summary,
+                        surface: &mut surface_fragments,
+                    },
+                );
+                collect_base_prefix_spans_in_command(
+                    visit.command,
+                    self.source,
+                    &mut base_prefix_arithmetic_spans,
+                );
+                collect_arithmetic_update_operator_spans_in_command(
+                    visit.command,
+                    self.semantic,
+                    self.source,
+                    &mut arithmetic_update_operator_spans,
+                );
+                for redirect in visit.redirects {
+                    if let Some(word) = redirect.word_target() {
+                        collect_base_prefix_spans_in_word(
+                            word,
                             self.source,
-                            &mut condition_status_capture_spans,
+                            &mut base_prefix_arithmetic_spans,
                         );
+                        collect_arithmetic_update_operator_spans_in_word(
+                            word,
+                            self.semantic,
+                            self.source,
+                            &mut arithmetic_update_operator_spans,
+                        );
+                    } else if let Some(heredoc) = redirect.heredoc()
+                        && heredoc.delimiter.expands_body
+                    {
+                        collect_arithmetic_update_operator_spans_in_heredoc_body(
+                            &heredoc.body.parts,
+                            self.semantic,
+                            self.source,
+                            &mut arithmetic_update_operator_spans,
+                        );
+                    }
+                }
+                let redirect_facts = build_redirect_facts(
+                    visit.redirects,
+                    Some(self.semantic),
+                    self.source,
+                    command_zsh_options.as_ref(),
+                );
+                let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
+                let declaration_assignment_probes = build_declaration_assignment_probes(
+                    visit.command,
+                    &normalized,
+                    self.source,
+                    command_zsh_options.as_ref(),
+                );
+                let glued_closing_bracket_operand_span =
+                    build_glued_closing_bracket_operand_span(visit.command, self.source);
+                let glued_closing_bracket_insert_offset =
+                    build_glued_closing_bracket_insert_offset(visit.command, self.source);
+                let simple_test =
+                    build_simple_test_fact(visit.command, self.source, self._file_context);
+                let conditional = build_conditional_fact(visit.command, self.source);
+                commands.push(CommandFact {
+                    id,
+                    key,
+                    visit,
+                    nested_word_command,
+                    normalized,
+                    zsh_options: command_zsh_options,
+                    redirect_facts,
+                    substitution_facts: Vec::new().into_boxed_slice(),
+                    options,
+                    scope_read_source_words: Vec::new().into_boxed_slice(),
+                    scope_name_read_uses: Vec::new().into_boxed_slice(),
+                    scope_heredoc_name_read_uses: Vec::new().into_boxed_slice(),
+                    scope_name_write_uses: Vec::new().into_boxed_slice(),
+                    declaration_assignment_probes,
+                    glued_closing_bracket_operand_span,
+                    glued_closing_bracket_insert_offset,
+                    linebreak_in_test_anchor_span: None,
+                    linebreak_in_test_insert_offset: None,
+                    simple_test,
+                    conditional,
+                });
 
-                        let mut previous_condition = &command.condition;
-                        for (index, (condition, branch)) in command.elif_branches.iter().enumerate()
-                        {
-                            if index > 0
-                                || !stmt_seq_contains_nested_control_flow(&command.then_branch)
+                if let Command::Function(function) = visit.command {
+                    functions.push(function);
+                    if let Some(span) = function_body_without_braces_span(function) {
+                        function_body_without_braces_spans.push(span);
+                    }
+                }
+
+                if !nested_word_command {
+                    match visit.command {
+                        Command::Compound(CompoundCommand::If(command)) => {
+                            collect_condition_status_capture_from_body(
+                                &command.condition,
+                                &command.then_branch,
+                                self.source,
+                                &mut condition_status_capture_spans,
+                            );
+
+                            let mut previous_condition = &command.condition;
+                            for (index, (condition, branch)) in
+                                command.elif_branches.iter().enumerate()
                             {
+                                if index > 0
+                                    || !stmt_seq_contains_nested_control_flow(&command.then_branch)
+                                {
+                                    collect_condition_status_capture_from_body(
+                                        previous_condition,
+                                        condition,
+                                        self.source,
+                                        &mut condition_status_capture_spans,
+                                    );
+                                }
+                                collect_condition_status_capture_from_body(
+                                    condition,
+                                    branch,
+                                    self.source,
+                                    &mut condition_status_capture_spans,
+                                );
+                                previous_condition = condition;
+                            }
+
+                            if let Some(else_branch) = &command.else_branch {
                                 collect_condition_status_capture_from_body(
                                     previous_condition,
-                                    condition,
+                                    else_branch,
                                     self.source,
                                     &mut condition_status_capture_spans,
                                 );
                             }
+                        }
+                        Command::Compound(CompoundCommand::While(command)) => {
                             collect_condition_status_capture_from_body(
-                                condition,
-                                branch,
+                                &command.condition,
+                                &command.body,
                                 self.source,
                                 &mut condition_status_capture_spans,
                             );
-                            previous_condition = condition;
+                            if let Some(case) =
+                                build_getopts_case_fact_for_while(command, self.source)
+                            {
+                                getopts_cases.push(case);
+                            }
                         }
-
-                        if let Some(else_branch) = &command.else_branch {
+                        Command::Compound(CompoundCommand::Until(command)) => {
                             collect_condition_status_capture_from_body(
-                                previous_condition,
-                                else_branch,
+                                &command.condition,
+                                &command.body,
                                 self.source,
                                 &mut condition_status_capture_spans,
                             );
                         }
-                    }
-                    Command::Compound(CompoundCommand::While(command)) => {
-                        collect_condition_status_capture_from_body(
-                            &command.condition,
-                            &command.body,
-                            self.source,
-                            &mut condition_status_capture_spans,
-                        );
-                        if let Some(case) = build_getopts_case_fact_for_while(command, self.source)
+                        Command::Binary(command)
+                            if matches!(command.op, BinaryOp::And | BinaryOp::Or) =>
                         {
-                            getopts_cases.push(case);
+                            if stmt_terminals_are_test_commands(&command.left, self.source) {
+                                collect_status_parameter_spans_in_stmt(
+                                    &command.right,
+                                    self.source,
+                                    &mut condition_status_capture_spans,
+                                );
+                            }
                         }
+                        Command::Simple(_)
+                        | Command::Builtin(_)
+                        | Command::Decl(_)
+                        | Command::Binary(_)
+                        | Command::Compound(_)
+                        | Command::Function(_)
+                        | Command::AnonymousFunction(_) => {}
                     }
-                    Command::Compound(CompoundCommand::Until(command)) => {
-                        collect_condition_status_capture_from_body(
-                            &command.condition,
-                            &command.body,
-                            self.source,
-                            &mut condition_status_capture_spans,
-                        );
-                    }
-                    Command::Binary(command)
-                        if matches!(command.op, BinaryOp::And | BinaryOp::Or) =>
-                    {
-                        if stmt_terminals_are_test_commands(&command.left, self.source) {
-                            collect_status_parameter_spans_in_stmt(
-                                &command.right,
-                                self.source,
-                                &mut condition_status_capture_spans,
-                            );
-                        }
-                    }
-                    Command::Simple(_)
-                    | Command::Builtin(_)
-                    | Command::Decl(_)
-                    | Command::Binary(_)
-                    | Command::Compound(_)
-                    | Command::Function(_)
-                    | Command::AnonymousFunction(_) => {}
                 }
-            }
+            },
+        );
 
-        }
-
+        arithmetic_update_operator_spans
+            .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+        arithmetic_update_operator_spans.dedup();
         populate_linebreak_in_test_facts(&mut commands, self.source);
         let substitution_facts =
             build_substitution_facts(&commands, &command_ids_by_span, self.source);
@@ -448,10 +499,6 @@ impl<'a> LinterFactsBuilder<'a> {
             &positional_parameters,
         );
         let double_paren_grouping_spans = build_double_paren_grouping_spans(&commands, self.source);
-        let arithmetic_update_operator_spans =
-            build_arithmetic_update_operator_spans(&self.file.body, self.semantic, self.source);
-        let base_prefix_arithmetic_spans =
-            build_base_prefix_arithmetic_spans(&self.file.body, self.source);
         let suppressed_subscript_reference_spans = build_suppressed_subscript_reference_spans(
             self.semantic,
             &suppressed_subscript_spans,
@@ -498,19 +545,21 @@ impl<'a> LinterFactsBuilder<'a> {
             assignment_scope_spans: env_prefix_assignment_scope_spans,
             expansion_scope_spans: env_prefix_expansion_scope_spans,
         } = build_env_prefix_scope_spans(self.source, &commands);
-        word_occurrences.extend(pending_arithmetic_word_occurrences.into_iter().map(
-            |pending| WordOccurrence {
-                node_id: pending.node_id,
-                command_id: pending.command_id,
-                nested_word_command: pending.nested_word_command,
-                context: WordFactContext::ArithmeticCommand,
-                host_kind: pending.host_kind,
-                runtime_literal: RuntimeLiteralAnalysis::default(),
-                operand_class: None,
-                enclosing_expansion_context: Some(pending.enclosing_expansion_context),
-                array_assignment_split_scalar_expansion_spans: OnceCell::new(),
-            },
-        ));
+        word_occurrences.extend(
+            pending_arithmetic_word_occurrences
+                .into_iter()
+                .map(|pending| WordOccurrence {
+                    node_id: pending.node_id,
+                    command_id: pending.command_id,
+                    nested_word_command: pending.nested_word_command,
+                    context: WordFactContext::ArithmeticCommand,
+                    host_kind: pending.host_kind,
+                    runtime_literal: RuntimeLiteralAnalysis::default(),
+                    operand_class: None,
+                    enclosing_expansion_context: Some(pending.enclosing_expansion_context),
+                    array_assignment_split_scalar_expansion_spans: OnceCell::new(),
+                }),
+        );
         let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
         let mut word_occurrence_ids_by_command =
             vec![SmallVec::<[WordOccurrenceId; 4]>::new(); commands.len()];
@@ -714,9 +763,9 @@ fn stmt_contains_nested_control_flow(stmt: &Stmt) -> bool {
             | CompoundCommand::Case(_)
             | CompoundCommand::Always(_),
         ) => true,
-        Command::Compound(
-            CompoundCommand::BraceGroup(body) | CompoundCommand::Subshell(body),
-        ) => body.iter().any(stmt_contains_nested_control_flow),
+        Command::Compound(CompoundCommand::BraceGroup(body) | CompoundCommand::Subshell(body)) => {
+            body.iter().any(stmt_contains_nested_control_flow)
+        }
         Command::Compound(CompoundCommand::Time(command)) => command
             .command
             .as_ref()

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -101,21 +101,22 @@ include!("words.rs");
 
 #[cfg(feature = "benchmarking")]
 pub(crate) fn benchmark_normalize_commands(file: &File, source: &str) -> usize {
-    iter_commands_with_context(
+    let mut total = 0;
+    walk_commands(
         &file.body,
         CommandWalkOptions {
             descend_nested_word_commands: true,
         },
-    )
-    .map(|traversed| {
-        let normalized = normalize_command(traversed.visit.command, source);
-        normalized.wrappers.len()
-            + normalized.body_words.len()
-            + usize::from(normalized.literal_name.is_some())
-            + usize::from(normalized.effective_name.is_some())
-            + usize::from(normalized.declaration.is_some())
-    })
-    .sum()
+        &mut |visit, _| {
+            let normalized = normalize_command(visit.command, source);
+            total += normalized.wrappers.len()
+                + normalized.body_words.len()
+                + usize::from(normalized.literal_name.is_some())
+                + usize::from(normalized.effective_name.is_some())
+                + usize::from(normalized.declaration.is_some());
+        },
+    );
+    total
 }
 
 #[allow(unused_imports)]

--- a/crates/shuck-linter/src/facts/statements.rs
+++ b/crates/shuck-linter/src/facts/statements.rs
@@ -250,4 +250,3 @@ fn collect_statement_sequence_facts_in_stmt<'a>(
     );
 }
 
-

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -33,17 +33,8 @@ struct CommandVisit<'a> {
     redirects: &'a [Redirect],
 }
 
-#[derive(Debug, Clone, Copy)]
-struct TraversedCommandVisit<'a> {
-    visit: CommandVisit<'a>,
-    context: CommandTraversalContext,
-}
-
-fn walk_commands<'a, F>(
-    commands: &'a StmtSeq,
-    options: CommandWalkOptions,
-    visitor: &mut F,
-) where
+fn walk_commands<'a, F>(commands: &'a StmtSeq, options: CommandWalkOptions, visitor: &mut F)
+where
     F: FnMut(CommandVisit<'a>, CommandTraversalContext),
 {
     collect_command_visits(
@@ -54,22 +45,15 @@ fn walk_commands<'a, F>(
     );
 }
 
-fn iter_commands_with_context<'a>(
-    commands: &'a StmtSeq,
-    options: CommandWalkOptions,
-) -> impl Iterator<Item = TraversedCommandVisit<'a>> {
-    let mut visits = Vec::new();
-    walk_commands(commands, options, &mut |visit, context| {
-        visits.push(TraversedCommandVisit { visit, context });
-    });
-    visits.into_iter()
-}
-
 fn iter_commands<'a>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
 ) -> impl Iterator<Item = CommandVisit<'a>> {
-    iter_commands_with_context(commands, options).map(|visit| visit.visit)
+    let mut visits = Vec::new();
+    walk_commands(commands, options, &mut |visit, _| {
+        visits.push(visit);
+    });
+    visits.into_iter()
 }
 
 fn zsh_glob_patterns(glob: &shuck_ast::ZshQualifiedGlob) -> impl Iterator<Item = &Pattern> + '_ {
@@ -947,8 +931,8 @@ mod traversal_tests {
     use shuck_parser::parser::Parser;
 
     use super::{
-        CommandWalkOptions, ConditionKind, iter_commands, visit_var_ref_subscript_words_with_source,
-        walk_commands,
+        CommandWalkOptions, ConditionKind, iter_commands,
+        visit_var_ref_subscript_words_with_source, walk_commands,
     };
 
     fn parse_commands(source: &str) -> StmtSeq {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1215,7 +1215,10 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 
     pub fn has_suspicious_quoted_command_trailer(self, source: &str) -> bool {
-        quoted_command_name_has_suspicious_ending(self.span().slice(source), self.trailing_literal_char())
+        quoted_command_name_has_suspicious_ending(
+            self.span().slice(source),
+            self.trailing_literal_char(),
+        )
     }
 
     pub fn has_hash_suffix(self, source: &str) -> bool {
@@ -1745,8 +1748,8 @@ fn contains_positional_parameter_reference(value: &str) -> bool {
 
     while let Some(byte) = bytes.get(index).copied() {
         match byte {
-            b'\'' if !in_double_quotes
-                && (in_single_quotes || !is_escaped_dollar(value, index)) =>
+            b'\''
+                if !in_double_quotes && (in_single_quotes || !is_escaped_dollar(value, index)) =>
             {
                 in_single_quotes = !in_single_quotes;
                 index += 1;
@@ -2106,7 +2109,9 @@ fn sc2001_like_pipeline_span<'a>(
         return sc2001_like_backtick_pipeline_span(commands, pipeline, right, source);
     }
 
-    Some(pipeline_span_with_shellcheck_tail(commands, pipeline, source))
+    Some(pipeline_span_with_shellcheck_tail(
+        commands, pipeline, source,
+    ))
 }
 
 fn sc2001_like_here_string_span(
@@ -2168,7 +2173,10 @@ fn sc2001_like_backtick_sed_script_end(args: &[&Word], source: &str) -> Option<P
     };
 
     let raw_script_end = match script_words {
-        [script] => backtick_sed_script_content_end_offset(script.span.slice(source), script.span.end.offset)?,
+        [script] => backtick_sed_script_content_end_offset(
+            script.span.slice(source),
+            script.span.end.offset,
+        )?,
         [first, .., last]
             if first.span.slice(source).starts_with("\\\"")
                 && last.span.slice(source).ends_with("\\\"") =>
@@ -2250,7 +2258,8 @@ fn backtick_sed_script_uses_escaped_double_quotes(script_words: &[&Word], source
             text.len() >= 4 && text.starts_with("\\\"") && text.ends_with("\\\"")
         }
         [first, .., last] => {
-            first.span.slice(source).starts_with("\\\"") && last.span.slice(source).ends_with("\\\"")
+            first.span.slice(source).starts_with("\\\"")
+                && last.span.slice(source).ends_with("\\\"")
         }
         _ => false,
     }
@@ -2456,7 +2465,10 @@ fn mixed_quote_literal_is_warnable_between_double_quotes(text: &str) -> bool {
     }
 
     if text.chars().any(|ch| ch.is_ascii_alphanumeric()) {
-        if text.chars().any(|ch| matches!(ch, '*' | '?' | '[' | '{' | '}')) {
+        if text
+            .chars()
+            .any(|ch| matches!(ch, '*' | '?' | '[' | '{' | '}'))
+        {
             return false;
         }
 
@@ -2532,9 +2544,7 @@ fn mixed_quote_shell_fragment_balance_delta_for_part(
 
 #[derive(Clone, Copy)]
 enum MixedQuoteShellParenFrame {
-    Command {
-        opened_in_double_quotes: bool,
-    },
+    Command { opened_in_double_quotes: bool },
     Group,
 }
 
@@ -2980,11 +2990,7 @@ fn mixed_quote_text_ends_with_unescaped_double_quote(text: &str) -> bool {
         return false;
     };
 
-    let backslash_count = prefix
-        .chars()
-        .rev()
-        .take_while(|ch| *ch == '\\')
-        .count();
+    let backslash_count = prefix.chars().rev().take_while(|ch| *ch == '\\').count();
     backslash_count % 2 == 0
 }
 
@@ -3131,46 +3137,46 @@ pub(crate) fn benchmark_collect_word_facts(
     let mut arithmetic_summary = ArithmeticFactSummary::default();
     let mut surface_fragments = SurfaceFragmentSink::new(source);
 
-    for (next_command_id, traversed) in iter_commands_with_context(
+    let mut next_command_id = 0;
+    walk_commands(
         &file.body,
         CommandWalkOptions {
             descend_nested_word_commands: true,
         },
-    )
-    .enumerate()
-    {
-        let visit = traversed.visit;
-        let normalized = command::normalize_command(visit.command, source);
-        let command_zsh_options = effective_command_zsh_options(
-            semantic,
-            command_span(visit.command).start.offset,
-            &normalized,
-        );
-        build_word_facts_for_command(
-            visit,
-            source,
-            semantic,
-            WordFactCommandContext {
-                command_id: CommandId::new(next_command_id),
-                nested_word_command: traversed.context.nested_word_command,
-            },
-            &normalized,
-            command_zsh_options,
-            WordFactOutputs {
-                word_nodes: &mut word_nodes,
-                word_node_ids_by_span: &mut word_node_ids_by_span,
-                word_occurrences: &mut word_occurrences,
-                pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
-                compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
-                array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
-                assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
-                case_pattern_expansions: &mut case_pattern_expansions,
-                pattern_literal_spans: &mut pattern_literal_spans,
-                arithmetic: &mut arithmetic_summary,
-                surface: &mut surface_fragments,
-            },
-        );
-    }
+        &mut |visit, context| {
+            let normalized = command::normalize_command(visit.command, source);
+            let command_zsh_options = effective_command_zsh_options(
+                semantic,
+                command_span(visit.command).start.offset,
+                &normalized,
+            );
+            build_word_facts_for_command(
+                visit,
+                source,
+                semantic,
+                WordFactCommandContext {
+                    command_id: CommandId::new(next_command_id),
+                    nested_word_command: context.nested_word_command,
+                },
+                &normalized,
+                command_zsh_options,
+                WordFactOutputs {
+                    word_nodes: &mut word_nodes,
+                    word_node_ids_by_span: &mut word_node_ids_by_span,
+                    word_occurrences: &mut word_occurrences,
+                    pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
+                    compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
+                    array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
+                    assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
+                    case_pattern_expansions: &mut case_pattern_expansions,
+                    pattern_literal_spans: &mut pattern_literal_spans,
+                    arithmetic: &mut arithmetic_summary,
+                    surface: &mut surface_fragments,
+                },
+            );
+            next_command_id += 1;
+        },
+    );
 
     let surface_fragments = surface_fragments.finish();
 
@@ -3232,26 +3238,32 @@ fn derive_word_fact_data(word: &Word, source: &str) -> WordNodeDerived {
         contains_shell_quoting_literals: word_contains_shell_quoting_literals(word, source),
         active_expansion_spans: word_spans::active_expansion_spans_in_source(word, source)
             .into_boxed_slice(),
-        scalar_expansion_spans:
-            word_spans::scalar_expansion_part_spans(word, source).into_boxed_slice(),
-        unquoted_scalar_expansion_spans:
-            word_spans::unquoted_scalar_expansion_part_spans(word, source).into_boxed_slice(),
-        array_expansion_spans:
-            word_spans::array_expansion_part_spans(word, source).into_boxed_slice(),
+        scalar_expansion_spans: word_spans::scalar_expansion_part_spans(word, source)
+            .into_boxed_slice(),
+        unquoted_scalar_expansion_spans: word_spans::unquoted_scalar_expansion_part_spans(
+            word, source,
+        )
+        .into_boxed_slice(),
+        array_expansion_spans: word_spans::array_expansion_part_spans(word, source)
+            .into_boxed_slice(),
         all_elements_array_expansion_spans: word_spans::all_elements_array_expansion_part_spans(
             word, source,
         )
         .into_boxed_slice(),
         direct_all_elements_array_expansion_spans:
             word_spans::direct_all_elements_array_expansion_part_spans(word, source)
-            .into_boxed_slice(),
+                .into_boxed_slice(),
         unquoted_all_elements_array_expansion_spans:
             word_spans::unquoted_all_elements_array_expansion_part_spans(word, source)
                 .into_boxed_slice(),
-        unquoted_array_expansion_spans: word_spans::unquoted_array_expansion_part_spans(word, source)
-            .into_boxed_slice(),
-        command_substitution_spans: word_spans::command_substitution_part_spans_in_source(word, source)
-            .into_boxed_slice(),
+        unquoted_array_expansion_spans: word_spans::unquoted_array_expansion_part_spans(
+            word, source,
+        )
+        .into_boxed_slice(),
+        command_substitution_spans: word_spans::command_substitution_part_spans_in_source(
+            word, source,
+        )
+        .into_boxed_slice(),
         unquoted_command_substitution_spans:
             word_spans::unquoted_command_substitution_part_spans_in_source(word, source)
                 .into_boxed_slice(),
@@ -3542,7 +3554,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         let surface_context = self.surface_context();
         match command {
             Command::Simple(command) => {
-                if let Some(target_index) = simple_command_wrapper_target_index(command, self.source)
+                if let Some(target_index) =
+                    simple_command_wrapper_target_index(command, self.source)
                 {
                     let target_word = simple_command_word_at(command, target_index);
                     self.push_word_with_surface(
@@ -3774,10 +3787,9 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         reference.subscript.as_ref(),
                     );
                     if !indexed_semantics {
-                        self.surface
-                            .record_arithmetic_only_suppressed_subscript(
-                                reference.subscript.as_ref(),
-                            );
+                        self.surface.record_arithmetic_only_suppressed_subscript(
+                            reference.subscript.as_ref(),
+                        );
                     }
                     visit_var_ref_subscript_words_with_source(
                         reference,
@@ -3832,27 +3844,23 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             self.surface
                 .record_arithmetic_only_suppressed_subscript(assignment.target.subscript.as_ref());
         }
-        visit_var_ref_subscript_words_with_source(
-            &assignment.target,
-            self.source,
-            &mut |word| {
-                collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
-                    &word.parts,
-                    self.source,
-                    &mut self.arithmetic.dollar_in_arithmetic_spans,
-                );
-                if indexed_semantics {
-                    self.collect_array_index_arithmetic_spans(word);
-                    self.collect_dollar_prefixed_indexed_subscript_spans(word);
-                }
-                self.push_word_with_surface(
-                    word,
-                    context,
-                    WordFactHostKind::AssignmentTargetSubscript,
-                    surface_context,
-                );
-            },
-        );
+        visit_var_ref_subscript_words_with_source(&assignment.target, self.source, &mut |word| {
+            collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+                &word.parts,
+                self.source,
+                &mut self.arithmetic.dollar_in_arithmetic_spans,
+            );
+            if indexed_semantics {
+                self.collect_array_index_arithmetic_spans(word);
+                self.collect_dollar_prefixed_indexed_subscript_spans(word);
+            }
+            self.push_word_with_surface(
+                word,
+                context,
+                WordFactHostKind::AssignmentTargetSubscript,
+                surface_context,
+            );
+        });
 
         match &assignment.value {
             AssignmentValue::Scalar(word) => {
@@ -4083,20 +4091,14 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             ConditionalExpr::VarRef(reference) => {
                 self.surface
                     .record_arithmetic_only_suppressed_subscript(reference.subscript.as_ref());
-                visit_var_ref_subscript_words_with_source(
-                    reference,
-                    self.source,
-                    &mut |word| {
-                        self.push_word_with_surface(
-                            word,
-                            WordFactContext::Expansion(
-                                ExpansionContext::ConditionalVarRefSubscript,
-                            ),
-                            WordFactHostKind::ConditionalVarRefSubscript,
-                            surface_context,
-                        );
-                    },
-                );
+                visit_var_ref_subscript_words_with_source(reference, self.source, &mut |word| {
+                    self.push_word_with_surface(
+                        word,
+                        WordFactContext::Expansion(ExpansionContext::ConditionalVarRefSubscript),
+                        WordFactHostKind::ConditionalVarRefSubscript,
+                        surface_context,
+                    );
+                });
             }
         }
     }
@@ -4414,11 +4416,12 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                             enclosing_expansion_context,
                             host_kind,
                         ),
-                    ZshExpansionTarget::Word(word) => self.collect_pending_arithmetic_word_occurrences(
-                        word,
-                        enclosing_expansion_context,
-                        host_kind,
-                    ),
+                    ZshExpansionTarget::Word(word) => self
+                        .collect_pending_arithmetic_word_occurrences(
+                            word,
+                            enclosing_expansion_context,
+                            host_kind,
+                        ),
                     ZshExpansionTarget::Reference(_) | ZshExpansionTarget::Empty => {}
                 }
 
@@ -4519,9 +4522,9 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     | WordFactContext::Expansion(ExpansionContext::DeclarationAssignmentValue)
             )
         {
-            self.arithmetic
-                .arithmetic_score_line_spans
-                .extend(word_spans::parenthesized_arithmetic_expansion_part_spans(word));
+            self.arithmetic.arithmetic_score_line_spans.extend(
+                word_spans::parenthesized_arithmetic_expansion_part_spans(word),
+            );
         }
 
         collect_arithmetic_expansion_spans_from_parts(
@@ -5104,7 +5107,9 @@ fn collect_wrapped_arithmetic_spans_in_word(
     let mut index = 0usize;
 
     while index + 2 < bytes.len() {
-        if !is_unescaped_dollar(bytes, index) || bytes[index + 1] != b'(' || bytes[index + 2] != b'('
+        if !is_unescaped_dollar(bytes, index)
+            || bytes[index + 1] != b'('
+            || bytes[index + 2] != b'('
         {
             index += 1;
             continue;
@@ -5801,9 +5806,7 @@ fn collect_arithmetic_update_operator_spans_from_parts(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_arithmetic_update_operator_spans_from_parts_impl(
-        parts, semantic, source, spans, false,
-    );
+    collect_arithmetic_update_operator_spans_from_parts_impl(parts, semantic, source, spans, false);
 }
 
 fn collect_arithmetic_update_operator_spans_from_parts_impl(
@@ -6746,12 +6749,14 @@ fn xargs_suppresses_default_inline_replace_diagnostic(args: &[&Word], source: &s
         return false;
     };
 
-    if matches!(command_name.as_ref(), "sh" | "bash" | "dash" | "ksh" | "zsh")
-        && args
-            .get(1)
-            .and_then(|word| static_word_text(word, source))
-            .as_deref()
-            == Some("-c")
+    if matches!(
+        command_name.as_ref(),
+        "sh" | "bash" | "dash" | "ksh" | "zsh"
+    ) && args
+        .get(1)
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("-c")
     {
         return true;
     }
@@ -6773,7 +6778,9 @@ fn xargs_suppresses_default_inline_replace_diagnostic(args: &[&Word], source: &s
 }
 
 fn is_echo_option_text(text: &str) -> bool {
-    text != "-" && text.starts_with('-') && text[1..].chars().all(|ch| matches!(ch, 'n' | 'e' | 'E'))
+    text != "-"
+        && text.starts_with('-')
+        && text[1..].chars().all(|ch| matches!(ch, 'n' | 'e' | 'E'))
 }
 
 fn xargs_long_option_argument(
@@ -7107,8 +7114,8 @@ ${@:2} ${arr[0]} ${arr[@]} ${!name} ${name:-fallback} \"$@$@\" \"prefix$name\"\n
         assert_eq!(
             plain,
             vec![
-                true, true, true, true, true, true, true, true, false, false, false, false,
-                false, false, false
+                true, true, true, true, true, true, true, true, false, false, false, false, false,
+                false, false
             ]
         );
     }


### PR DESCRIPTION
## Summary

- avoid materializing an intermediate command-visit vector in the linter fact builder
- collect arithmetic update and base-prefix arithmetic spans during the existing command fact walk instead of doing separate `file.body` traversals
- switch benchmark-only normalization and word-fact collection helpers to callback traversal

I also tried merging the sequence-sensitive collectors into one shared walk, but Criterion showed that regressed `linter_facts/all`, so this PR keeps those specialized passes in place.

## Validation

- `cargo check -p shuck-linter`
- `cargo test -p shuck-linter`
- `cargo check -p shuck-benchmark`
- `cargo bench -p shuck-benchmark --bench linter -- --baseline=main --noplot`

## Benchmark Results

Focused Criterion run against `main`:

| benchmark | main | current | delta |
|---|---:|---:|---:|
| `linter/all` | 110.393 ms | 82.393 ms | -25.36% |
| `linter_facts/all` | 44.493 ms | 36.971 ms | -16.91% |
| `linter_word_facts/all` | 11.286 ms | 8.841 ms | -21.66% |
| `linter_normalization/all` | 4.382 ms | 4.773 ms | +8.92% |
