### PR TITLE
docs: refresh architecture and rule guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ cargo test --features http_client
 
 # Run a single test
 cargo test -p shuck-cli -- test_name
-cargo test -p shuck-syntax -- test_name
+cargo test -p shuck-linter -- test_name
 cargo test -p shuck-parser -- test_name
 
 # Format and lint
@@ -102,25 +102,33 @@ nix --extra-experimental-features 'nix-command flakes' develop --command shellch
 
 ### Workspace crates
 
-- **`crates/shuck-cli`** — CLI binary. Discovers shell files, parses them via shuck-syntax, reports parse errors. Subcommands: `check` (lint files) and `clean` (remove caches). Project root is resolved by walking up to find `.shuck.toml` or `shuck.toml`.
-- **`crates/shuck-syntax`** — Linter-oriented syntax wrapper over shuck-parser's parser. Adds comment collection (including inside `$(...)` substitutions), suppression directive parsing (`# shuck: disable=SH-001` and `# shellcheck disable=SC2086`), a `SuppressionIndex` for line-level queries, and a dialect/profile parse-view layer. Today it supports native Bash `strict` and `strict-recovered` views plus Bash-backed `permissive` and `permissive-recovered` fallbacks for `sh`/`dash`/`ksh`/`mksh`.
+- **`crates/shuck-cli`** — CLI binary. Discovers files, resolves config, coordinates caching, parses shell sources, runs lint/format commands, applies fixes, and renders reports. Project roots are resolved by walking up to find `.shuck.toml` or `shuck.toml`.
+- **`crates/shuck-linter`** — Rule registry, checker dispatch, suppressions, generated rule metadata, fix application, and linter-owned facts built over parser, indexer, and semantic output.
+- **`crates/shuck-semantic`** — Semantic model for bindings, references, scopes, declarations, source closure, call graph, CFG, and dataflow.
+- **`crates/shuck-indexer`** — Positional and structural indexes over parsed scripts, including lines, comments, syntactic regions, heredocs, and continuation lines.
+- **`crates/shuck-extract`** — Embedded shell extraction for supported host files such as GitHub Actions workflows and composite actions.
 - **`crates/shuck-cache`** — File-level caching with SHA-256 keyed `PackageCache<T>`. Stores results in a shared cache root (from `--cache-dir`, `SHUCK_CACHE_DIR`, or the OS cache directory such as `~/Library/Caches/shuck` / `$XDG_CACHE_HOME/shuck`) using bincode serialization. Entries are keyed by file mtime+permissions and auto-pruned after 30 days.
-- **`crates/shuck-parser`** — The bash parser library. Provides `Lexer`, `Parser`, AST types, and the full execution runtime. Shuck only uses the parser/lexer portion.
+- **`crates/shuck-parser`** — The shell parser library. Provides source-backed lexing, dialect/profile-aware parsing, AST construction, recovery diagnostics, and syntax facts.
+- **`crates/shuck-ast`** — Shared AST node types, tokens, identifiers, and source span utilities.
+- **`crates/shuck-formatter`** and **`crates/shuck-format`** — Shell formatting plus reusable pretty-printer primitives.
 
 ### Data flow for `shuck check`
 
 1. **Discover** (`discover.rs`) — Walk input paths, detect shell scripts by extension (`.sh`, `.bash`, `.zsh`, `.ksh`) or shebang, skip ignored dirs (`.git`, `node_modules`, etc.)
 2. **Cache lookup** (`shuck-cache`) — Check if file has a valid cached result based on mtime/permissions
-3. **Parse** (`shuck-syntax::parse`) — Resolve a dialect profile into a concrete parse view, lex and collect comments, parse directives/suppressions, then parse AST via the selected backend grammar
-4. **Report** — Print `path:line:col: parse error message` format, cache results, exit 0 (success) or 1 (failures found)
+3. **Parse and index** (`shuck-parser`, `shuck-indexer`) — Infer the shell dialect, parse into an AST with recovery diagnostics, and build line/comment/region indexes
+4. **Suppressions and analysis** (`shuck-linter`) — Parse shuck and ShellCheck-style directives, build the semantic model and linter facts, dispatch enabled rules, and apply per-file ignores
+5. **Fix and report** — Optionally apply requested fixes, remap embedded diagnostics back to host files, render the selected output format, cache results, and return the appropriate exit status
 
 ### shuck-parser internals
 
 The parser (`crates/shuck-parser/src/parser/`) is a recursive descent parser with these modules:
 - `lexer.rs` — Tokenizer that handles shell quoting, expansions, heredocs
-- `ast.rs` — AST node types (`Script`, `Command`, `Pipeline`, etc.)
-- `tokens.rs` — Token enum
-- `span.rs` — Position/Span tracking
+- `commands.rs` — Command and statement parsing
+- `words.rs` — Word, expansion, pattern, and substitution parsing
+- `redirects.rs` — Redirection and heredoc delimiter parsing
+- `arithmetic.rs` — Arithmetic expression parsing
+- `heredocs.rs` — Heredoc body parsing
 
 ## Key conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,16 +216,17 @@ CLI fuzzer failures are minimized automatically and written under `fuzz/artifact
 
 | Crate | Purpose |
 |-------|---------|
-| `shuck-cli` | CLI binary `shuck` — file discovery, parsing, reporting |
-| `shuck-linter` | Lint rule registry, checker dispatch, violation types |
+| `shuck-cli` | CLI binary `shuck` — command orchestration, discovery, config, caching, fixes, and reporting |
+| `shuck-linter` | Lint rule registry, checker dispatch, facts, suppressions, fixes, and diagnostics |
 | `shuck-semantic` | Semantic model — bindings, scopes, CFG, dataflow |
 | `shuck-indexer` | Positional and structural indexes over parsed scripts |
 | `shuck-parser` | Recursive-descent Bash parser |
 | `shuck-ast` | AST node types, tokens, spans |
-| `shuck-syntax` | Dialect profiles, comment collection, suppression directives |
+| `shuck-extract` | Embedded shell extraction for supported host files such as GitHub Actions workflows |
 | `shuck-cache` | SHA-256 keyed file-level result caching |
 | `shuck-formatter` | Shell script formatter |
 | `shuck-format` | Low-level formatting document and printer primitives |
+| `shuck-benchmark` | Shared benchmark fixtures and benchmark harness helpers |
 
 ## Adding a Lint Rule
 
@@ -282,20 +283,21 @@ declare_rules! {
 
 If the rule has a legacy `SH-NNN` code, add an alias in the `code_to_rule()` function in the same file.
 
-### Step 3: Add ShellCheck mapping
+### Step 3: Populate generated metadata
 
-If the rule maps to a ShellCheck code, add the mapping in `crates/shuck-linter/src/suppression/shellcheck_map.rs`:
-
-```rust
-(2034, Rule::YourRuleName),  // SC2034
-```
-
-Then populate the matching ShellCheck log level in the rule metadata:
+If the rule maps to a ShellCheck code, set `shellcheck_code` in `docs/rules/{CODE}.yaml` and populate the matching ShellCheck log level:
 
 ```bash
 nix --extra-experimental-features 'nix-command flakes' develop --command \
   python3 scripts/update_shellcheck_levels.py --rules C042
 ```
+
+`crates/shuck-linter/build.rs` generates the runtime rule metadata and ordinary
+ShellCheck-code mappings from `docs/rules/*.yaml`. Do not hand-edit
+`crates/shuck-linter/src/suppression/shellcheck_map.rs` for normal rule
+mappings; only update `SUPPRESSION_ALIAS_CODES` there when an old ShellCheck
+code should suppress a rule without being the rule's canonical compatibility
+code.
 
 ### Step 4: Implement the rule
 
@@ -319,7 +321,7 @@ impl Violation for YourRuleName {
 }
 
 pub fn your_rule_name(checker: &mut Checker) {
-    // Query the semantic model, facts, or AST
+    // Query the semantic model or precomputed linter facts.
     // Report violations with checker.report(violation, span)
 }
 ```
@@ -327,11 +329,15 @@ pub fn your_rule_name(checker: &mut Checker) {
 Key APIs available on `Checker`:
 - `checker.semantic()` — bindings, references, scopes, call graph
 - `checker.facts()` — normalized commands, pipelines, conditionals
-- `checker.ast()` — raw AST
 - `checker.source()` — source text
 - `checker.shell()` — detected shell dialect
 - `checker.report(violation, span)` — emit a diagnostic
 - `checker.report_dedup(violation, span)` — emit with deduplication
+
+New rule files should be cheap filters over `checker.facts()` or
+`checker.semantic()`. Do not directly walk the AST or rescan source text to
+rediscover shell structure; if a rule needs structural data that facts do not
+expose yet, add that data to `crates/shuck-linter/src/facts/` first.
 
 Look at existing rules for patterns:
 - Simple semantic rule: `rules/correctness/unused_assignment.rs`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shuck parses and analyzes shell scripts to catch common bugs, style issues, and 
 ## Features
 
 - High performance — ~20x faster than ShellCheck
-- Linting with rules across correctness and style categories
+- Linting with rules across correctness, security, performance, portability, and style categories
 - Safe and unsafe fix support for selected diagnostics
 - Multi-dialect support: bash, sh/POSIX, mksh, zsh
 - Automatic file discovery via extensions and shebang detection
@@ -108,7 +108,7 @@ deploy.sh:45:3: warning[S005] legacy backtick command substitution
 
 ## Rules
 
-Shuck ships with rules organized into four categories:
+Shuck ships with rules organized into five categories:
 
 | Category | Prefix | Description |
 |----------|--------|-------------|
@@ -116,6 +116,7 @@ Shuck ships with rules organized into four categories:
 | Style | S | Code quality and best-practice suggestions. |
 | Performance | P | Inefficient patterns that have simpler or faster alternatives. |
 | Portability | X | Bash-isms and shell-specific constructs that break under POSIX or other shells. |
+| Security | K | Potentially dangerous shell patterns such as risky deletion, unsafe evaluation, or local expansion. |
 
 Each rule has a short code (e.g., `C006`, `S001`) that appears in diagnostics and can be used in suppression directives. Diagnostics are classified as error, warning, or hint depending on severity.
 

--- a/specs/001-parser.md
+++ b/specs/001-parser.md
@@ -525,7 +525,7 @@ pub enum Error {
 **Recovery Mode** (`parse_recovered() -> RecoveredParse`):
 - Collects parse diagnostics and continues
 - Returns partial script + list of errors
-- Used by shuck-syntax for IDE-style error reporting
+- Used by shuck-linter, the CLI, and downstream tools for parse-aware diagnostics
 
 ```rust
 pub struct RecoveredParse {

--- a/specs/003-indexer.md
+++ b/specs/003-indexer.md
@@ -270,9 +270,13 @@ The `Indexer` is constructed once per file and shared immutably across all rules
 
 ## Alternatives Considered
 
-### Embed indexing in shuck-syntax
+### Embed indexing in a syntax facade
 
-shuck-syntax (referenced in CLAUDE.md but not yet created as a crate) is described as a "linter-oriented syntax wrapper." We could build the indexer directly into that crate. Rejected because: shuck-syntax's role is dialect/profile management and parse-view selection. The indexer is a distinct concern — positional metadata over a parsed AST — and separating it keeps both crates focused. The indexer has no opinion about dialects or parse modes; it works on any `ParseOutput`.
+A linter-oriented syntax facade could own dialect/profile management, parse-view
+selection, and positional indexing. Rejected because the indexer is a distinct
+concern — positional metadata over a parsed AST — and separating it keeps both
+crates focused. The indexer has no opinion about dialects or parse modes; it
+works on any parser output.
 
 ### Build indexes lazily on first query
 

--- a/specs/007-benchmarks.md
+++ b/specs/007-benchmarks.md
@@ -82,7 +82,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-shuck-syntax = { path = "../shuck-syntax" }
+shuck-parser = { path = "../shuck-parser" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }


### PR DESCRIPTION
## Summary

- Update README rule-category docs to include Security (`K`) rules.
- Refresh contributor architecture guidance to match the current workspace crates and generated rule metadata flow.
- Remove stale `shuck-syntax` references from repo guidance and older specs.

## Why

The documentation still described an older architecture in a few places, including a removed `shuck-syntax` crate and manual ShellCheck mapping edits. That could send contributors down the wrong path when adding rules or reading the project layout.

## Impact

This is documentation-only. It should make contributor onboarding and rule authoring guidance line up with the current codebase.

## Validation

- `rg` for stale phrases: `shuck-syntax`, `four categories`, and the old rule implementation wording
- `git diff --cached --check`