### PR TITLE
perf(linter): trim fact graph allocations

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -561,6 +561,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 }),
         );
         let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
+        word_index.reserve(word_occurrences.len());
         let mut word_occurrence_ids_by_command =
             vec![SmallVec::<[WordOccurrenceId; 4]>::new(); commands.len()];
         for (index, fact) in word_occurrences.iter().enumerate() {

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -103,7 +103,7 @@ pub(super) struct CommandLookupEntry {
     id: CommandId,
 }
 
-type CommandLookupIndex = FxHashMap<FactSpan, Vec<CommandLookupEntry>>;
+type CommandLookupIndex = FxHashMap<FactSpan, SmallVec<[CommandLookupEntry; 1]>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SudoFamilyInvoker {


### PR DESCRIPTION
## Summary
- Store command lookup buckets in inline `SmallVec` storage for the common single-entry case.
- Reserve the word span index from the known word occurrence count before populating it.

## Profiling
Command: `shuck check --no-cache --output-format concise crates/shuck-benchmark/resources/files`

- CPU: 77.3 ms ± 3.3 ms before, 73.0 ms ± 1.6 ms after (-5.6%).
- Total dhat allocations: 281,924,510 bytes / 1,092,879 blocks before, 279,904,009 bytes / 1,063,836 blocks after.
- Linter fact/word bucket: 69,687,947 bytes / 38,309 blocks before, 68,618,535 bytes / 28,813 blocks after.
- Bucket delta: -1,069,412 bytes (-1.5%) and -9,496 blocks (-24.8%).
- Peak heap: 68,145,829 bytes before, 65,932,900 bytes after (-2,212,929 bytes, -3.2%).

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-cli`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`