### PR TITLE
perf(parser): avoid brace scan allocations

### DIFF
--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2758,6 +2758,10 @@ impl<'a> Parser<'a> {
         quote_context: BraceQuoteContext,
         out: &mut Vec<BraceSyntax>,
     ) {
+        if memchr(b'{', text.as_bytes()).is_none() {
+            return;
+        }
+
         #[derive(Clone, Copy)]
         struct ScanFrame<'a> {
             text: &'a str,
@@ -2765,11 +2769,12 @@ impl<'a> Parser<'a> {
             position: Position,
         }
 
-        let mut work = vec![ScanFrame {
+        let mut work = SmallVec::<[ScanFrame<'_>; 2]>::new();
+        work.push(ScanFrame {
             text,
             index: 0,
             position: base,
-        }];
+        });
 
         while let Some(mut frame) = work.pop() {
             let bytes = frame.text.as_bytes();


### PR DESCRIPTION
## Summary

- skip brace-syntax scanning immediately for literal text that cannot contain brace syntax
- keep the rare scan work stack inline with `SmallVec` instead of allocating a one-item `Vec`

## Profiling

Isolated interleaved `hyperfine` comparison against clean baseline:

- baseline: 82.3 ms ± 7.6
- parser-only patch: 80.2 ms ± 4.7

Dhat comparison against clean baseline:

- total allocations: 281,924,719 -> 280,973,512 bytes
- total allocation blocks: 1,092,879 -> 1,073,332
- `scan_brace_syntax_text`: 907,328 -> 8,288 bytes
- `scan_brace_syntax_text` blocks: 18,659 -> 37

The broader parser word bucket was effectively unchanged, so this is a narrow allocation reduction in the word/brace scan path rather than a full fix for the larger word-construction bucket.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-parser`
- `cargo clippy -p shuck-parser --all-targets -- -D warnings`
