### PR TITLE
perf(parser): reduce word construction allocations

### DIFF
--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -52,6 +52,8 @@ use shuck_ast::{
 
 use crate::error::{Error, Result};
 
+type WordPartBuffer = SmallVec<[WordPartNode; 2]>;
+
 /// Default maximum AST depth (matches ExecutionLimits default)
 const DEFAULT_MAX_AST_DEPTH: usize = 100;
 
@@ -2151,6 +2153,28 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn word_with_part_buffer(&self, parts: WordPartBuffer, span: Span) -> Word {
+        let brace_syntax = self.brace_syntax_from_parts(&parts, span.start.offset);
+        let parts = if parts.spilled() {
+            parts.into_vec()
+        } else {
+            let mut vec = Vec::with_capacity(parts.len());
+            vec.extend(parts);
+            vec
+        };
+        Word {
+            parts,
+            span,
+            brace_syntax,
+        }
+    }
+
+    fn word_with_single_part(&self, part: WordPartNode, span: Span) -> Word {
+        let mut parts = WordPartBuffer::new();
+        parts.push(part);
+        self.word_with_part_buffer(parts, span)
+    }
+
     fn heredoc_body_with_parts(
         &self,
         parts: Vec<HeredocBodyPartNode>,
@@ -3426,7 +3450,7 @@ impl<'a> Parser<'a> {
         {
             return Some(word);
         }
-        let mut parts = Vec::new();
+        let mut parts = Self::word_part_buffer_with_capacity(word.segments().size_hint().0);
 
         for segment in word.segments() {
             let source_backed = segment.span().is_some() && !token.flags.is_synthetic();
@@ -3493,7 +3517,7 @@ impl<'a> Parser<'a> {
             parts.push(part);
         }
 
-        Some(self.word_with_parts(parts, span))
+        Some(self.word_with_part_buffer(parts, span))
     }
 
     fn segment_content_span(segment: &LexedWordSegment<'_>, fallback: Span) -> Span {
@@ -3600,17 +3624,12 @@ impl<'a> Parser<'a> {
                 source_backed && self.source_matches(content_span, decode_text);
 
             return match segment.kind() {
-                LexedWordSegmentKind::SingleQuoted => Some(self.word_with_parts(
-                    vec![self.single_quoted_part_from_text(
-                        text,
-                        content_span,
-                        wrapper_span,
-                        false,
-                    )],
+                LexedWordSegmentKind::SingleQuoted => Some(self.word_with_single_part(
+                    self.single_quoted_part_from_text(text, content_span, wrapper_span, false),
                     span,
                 )),
-                LexedWordSegmentKind::DollarSingleQuoted => Some(self.word_with_parts(
-                    vec![self.single_quoted_part_from_text(text, content_span, wrapper_span, true)],
+                LexedWordSegmentKind::DollarSingleQuoted => Some(self.word_with_single_part(
+                    self.single_quoted_part_from_text(text, content_span, wrapper_span, true),
                     span,
                 )),
                 LexedWordSegmentKind::Plain if Self::word_text_needs_parse(text) => Some(
@@ -3631,8 +3650,8 @@ impl<'a> Parser<'a> {
                         content_span.start,
                         source_backed,
                     );
-                    Some(self.word_with_parts(
-                        vec![WordPartNode::new(
+                    Some(self.word_with_single_part(
+                        WordPartNode::new(
                             WordPart::DoubleQuoted {
                                 parts: inner.parts,
                                 dollar: matches!(
@@ -3641,39 +3660,39 @@ impl<'a> Parser<'a> {
                                 ),
                             },
                             wrapper_span,
-                        )],
+                        ),
                         span,
                     ))
                 }
-                LexedWordSegmentKind::Plain => Some(self.word_with_parts(
-                    vec![self.literal_part_from_text(text, content_span, source_backed)],
+                LexedWordSegmentKind::Plain => Some(self.word_with_single_part(
+                    self.literal_part_from_text(text, content_span, source_backed),
                     span,
                 )),
-                LexedWordSegmentKind::DoubleQuoted => Some(self.word_with_parts(
-                    vec![self.double_quoted_literal_part_from_text(
+                LexedWordSegmentKind::DoubleQuoted => Some(self.word_with_single_part(
+                    self.double_quoted_literal_part_from_text(
                         text,
                         content_span,
                         wrapper_span,
                         source_backed,
                         false,
-                    )],
+                    ),
                     span,
                 )),
-                LexedWordSegmentKind::DollarDoubleQuoted => Some(self.word_with_parts(
-                    vec![self.double_quoted_literal_part_from_text(
+                LexedWordSegmentKind::DollarDoubleQuoted => Some(self.word_with_single_part(
+                    self.double_quoted_literal_part_from_text(
                         text,
                         content_span,
                         wrapper_span,
                         source_backed,
                         true,
-                    )],
+                    ),
                     span,
                 )),
                 LexedWordSegmentKind::Composite => None,
             };
         }
 
-        let mut parts = Vec::new();
+        let mut parts = Self::word_part_buffer_with_capacity(word.segments().size_hint().0);
         let mut cursor = span.start;
 
         for segment in word.segments() {
@@ -3760,7 +3779,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Some(self.word_with_parts(parts, span))
+        Some(self.word_with_part_buffer(parts, span))
     }
 
     fn current_word_ref(&mut self) -> Option<&Word> {
@@ -5616,18 +5635,13 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn push_word_part(
-        parts: &mut Vec<WordPartNode>,
-        part: WordPart,
-        start: Position,
-        end: Position,
-    ) {
+    fn push_word_part(parts: &mut WordPartBuffer, part: WordPart, start: Position, end: Position) {
         parts.push(WordPartNode::new(part, Span::from_positions(start, end)));
     }
 
     fn flush_literal_part(
         &self,
-        parts: &mut Vec<WordPartNode>,
+        parts: &mut WordPartBuffer,
         current: &mut String,
         current_start: Position,
         end: Position,
@@ -5645,6 +5659,14 @@ impl<'a> Parser<'a> {
                 current_start,
                 end,
             );
+        }
+    }
+
+    fn word_part_buffer_with_capacity(capacity: usize) -> WordPartBuffer {
+        if capacity <= 2 {
+            WordPartBuffer::new()
+        } else {
+            WordPartBuffer::with_capacity(capacity)
         }
     }
 

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -547,7 +547,7 @@ impl<'a> Parser<'a> {
 
     pub(super) fn pattern_from_source_text(&mut self, text: &SourceText) -> Pattern {
         let span = text.span();
-        let mut parts = Vec::new();
+        let mut parts = WordPartBuffer::new();
         self.decode_word_parts_into_with_quote_fragments(
             text.slice(self.input),
             span.start,
@@ -1716,7 +1716,7 @@ impl<'a> Parser<'a> {
 
     pub(super) fn split_word_at(&self, word: Word, start: Position) -> Word {
         let value_span = Span::from_positions(start, word.span.end);
-        let mut parts = Vec::new();
+        let mut parts = WordPartBuffer::new();
 
         for part in word.parts {
             if let Some((kind, span)) = self.trim_word_part_prefix(part.kind, part.span, start) {
@@ -1724,7 +1724,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        self.word_with_parts(parts, value_span)
+        self.word_with_part_buffer(parts, value_span)
     }
 
     pub(super) fn word_syntax_is_source_backed(&self, word: &Word) -> bool {
@@ -2926,7 +2926,7 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
         preserve_escaped_expansion_literals: bool,
-        parts: &mut Vec<WordPartNode>,
+        parts: &mut WordPartBuffer,
     ) {
         self.decode_word_parts_into_with_quote_fragments(
             s,
@@ -2947,7 +2947,7 @@ impl<'a> Parser<'a> {
         base: Position,
         source_backed: bool,
         options: DecodeWordPartsOptions,
-        parts: &mut Vec<WordPartNode>,
+        parts: &mut WordPartBuffer,
     ) {
         let mut chars = s.chars().peekable();
         let mut current = String::new();
@@ -4909,7 +4909,7 @@ impl<'a> Parser<'a> {
         source_backed: bool,
         preserve_escaped_expansion_literals: bool,
     ) -> Word {
-        let mut parts = Vec::new();
+        let mut parts = WordPartBuffer::new();
         self.decode_word_parts_into_with_escape_mode(
             s,
             base,
@@ -4917,7 +4917,7 @@ impl<'a> Parser<'a> {
             preserve_escaped_expansion_literals,
             &mut parts,
         );
-        self.word_with_parts(parts, span)
+        self.word_with_part_buffer(parts, span)
     }
 
     fn decode_word_text_with_options(
@@ -4928,7 +4928,7 @@ impl<'a> Parser<'a> {
         source_backed: bool,
         options: DecodeWordPartsOptions,
     ) -> Word {
-        let mut parts = Vec::new();
+        let mut parts = WordPartBuffer::new();
         self.decode_word_parts_into_with_quote_fragments(
             s,
             base,
@@ -4936,7 +4936,7 @@ impl<'a> Parser<'a> {
             options,
             &mut parts,
         );
-        self.word_with_parts(parts, span)
+        self.word_with_part_buffer(parts, span)
     }
 
     pub(super) fn decode_fragment_word_text(
@@ -4957,7 +4957,7 @@ impl<'a> Parser<'a> {
         source_backed: bool,
         preserve_escaped_expansion_literals: bool,
     ) -> Word {
-        let mut parts = Vec::new();
+        let mut parts = WordPartBuffer::new();
         self.decode_word_parts_into_with_quote_fragments(
             s,
             base,
@@ -4970,7 +4970,7 @@ impl<'a> Parser<'a> {
             },
             &mut parts,
         );
-        self.word_with_parts(parts, span)
+        self.word_with_part_buffer(parts, span)
     }
 
     pub(super) fn decode_quoted_segment_text(
@@ -5003,7 +5003,7 @@ impl<'a> Parser<'a> {
         span: Span,
         source_backed: bool,
     ) -> HeredocBody {
-        let mut parts = Vec::new();
+        let mut parts = WordPartBuffer::new();
         self.decode_word_parts_into_with_quote_fragments(
             s,
             span.start,


### PR DESCRIPTION
## Summary

- Use a parser-local `SmallVec` buffer for transient word-part construction while keeping the public AST `Word.parts` representation as `Vec<WordPartNode>`.
- Route simple single-part word construction and decoded word-part paths through the buffer boundary to avoid intermediate first-push growth on common one/two-part words.
- Keep behavior unchanged; this is a parser allocation-only change.

## Profiling

Fixture command:

```bash
shuck check --no-cache --output-format concise crates/shuck-benchmark/resources/files
```

CPU, release build, hyperfine 30 runs:

- Before: `70.9 ms +/- 1.0 ms`
- After: `71.4 ms +/- 2.2 ms`

Allocation profile via `dhat` harness:

- Total: `257,038,789` -> `250,670,244` bytes (`-2.5%`)
- Requested parser-word bucket script: `51,157,667` -> `11,209,307` bytes (`-78.1%`)
- Helper-inclusive view, counting the new final AST materialization helper: `51,157,667` -> `44,733,787` bytes (`-12.6%`)
- Peak memory footprint from `/usr/bin/time -l`: `129,335,872` -> `129,860,160` bytes (effectively flat on this busy machine)

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-parser`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-cli`
- `cargo clippy -p shuck-parser --all-targets -- -D warnings`