### PR TITLE
perf(linter): reduce scratch allocation churn

### DIFF
--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -16,46 +16,59 @@ fn build_literal_brace_spans(
         let is_find_exec_placeholder_word =
             is_find_exec_placeholder_word(commands, nodes, fact, source);
         let is_xargs_replacement_word = is_xargs_replacement_word(commands, nodes, fact, source);
-        let direct_spans = word
-            .brace_syntax()
-            .iter()
-            .copied()
-            .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
-            .filter(|brace| !literal_brace_syntax_looks_like_active_expansion(*brace, source))
-            .filter(|brace| {
-                matches!(
-                    brace.kind,
-                    BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
-                ) || brace_syntax_with_whitespace_is_literal(*brace, source)
-            })
-            .filter(|brace| {
-                brace.span.slice(source) != "{}"
-                    && !brace_span_has_escaped_dollar_prefix(brace.span, source)
-                    && !is_find_exec_placeholder_word
-                    && !is_xargs_replacement_word
-            })
-            .flat_map(|brace| brace_character_spans(brace.span, source))
-            .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
-            .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-            .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source))
-            .collect::<Vec<_>>();
-        spans.extend(direct_spans);
+        spans.extend(
+            word.brace_syntax()
+                .iter()
+                .copied()
+                .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
+                .filter(|brace| !literal_brace_syntax_looks_like_active_expansion(*brace, source))
+                .filter(|brace| {
+                    matches!(
+                        brace.kind,
+                        BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
+                    ) || brace_syntax_with_whitespace_is_literal(*brace, source)
+                })
+                .filter(|brace| {
+                    brace.span.slice(source) != "{}"
+                        && !brace_span_has_escaped_dollar_prefix(brace.span, source)
+                        && !is_find_exec_placeholder_word
+                        && !is_xargs_replacement_word
+                })
+                .flat_map(|brace| brace_character_spans(brace.span, source))
+                .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
+                .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
+                .filter(|span| {
+                    !word_span_is_inside_command_substitution(nodes, fact, *span, source)
+                }),
+        );
 
         if !is_find_exec_placeholder_word && !is_xargs_replacement_word {
-            let unclassified = unclassified_literal_brace_spans(word, source)
-                .into_iter()
-                .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
-                .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-                .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source))
-                .collect::<Vec<_>>();
-            spans.extend(unclassified);
-            let escaped = escaped_parameter_expansion_brace_edge_spans(word, source)
-                .into_iter()
-                .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
-                .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-                .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source))
-                .collect::<Vec<_>>();
-            spans.extend(escaped);
+            spans.extend(
+                unclassified_literal_brace_spans(word, source)
+                    .into_iter()
+                    .filter(|span| {
+                        !span_inside_nested_escaped_parameter_template(word, *span, source)
+                    })
+                    .filter(|span| {
+                        !brace_span_is_plain_parameter_expansion_edge(word, *span, source)
+                    })
+                    .filter(|span| {
+                        !word_span_is_inside_command_substitution(nodes, fact, *span, source)
+                    }),
+            );
+            spans.extend(
+                escaped_parameter_expansion_brace_edge_spans(word, source)
+                    .into_iter()
+                    .filter(|span| {
+                        !span_inside_nested_escaped_parameter_template(word, *span, source)
+                    })
+                    .filter(|span| {
+                        !brace_span_is_plain_parameter_expansion_edge(word, *span, source)
+                    })
+                    .filter(|span| {
+                        !word_span_is_inside_command_substitution(nodes, fact, *span, source)
+                    }),
+            );
         }
     }
 

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -467,16 +467,18 @@ fn case_pattern_epsilon_closure(
     tokens: &[CasePatternToken],
     seeds: impl IntoIterator<Item = usize>,
 ) -> CasePatternStates {
+    let mut seen = SmallVec::<[bool; 16]>::new();
+    seen.resize(tokens.len() + 1, false);
     let mut states = CasePatternStates::new();
     let mut stack = CasePatternStates::new();
 
     for state in seeds {
-        push_case_pattern_state(tokens.len(), &mut states, &mut stack, state);
+        push_case_pattern_state(&mut seen, &mut states, &mut stack, state);
     }
 
     while let Some(state) = stack.pop() {
         if matches!(tokens.get(state), Some(CasePatternToken::AnyString)) {
-            push_case_pattern_state(tokens.len(), &mut states, &mut stack, state + 1);
+            push_case_pattern_state(&mut seen, &mut states, &mut stack, state + 1);
         }
     }
 
@@ -489,12 +491,15 @@ fn case_pattern_states_from_slice(states: &[usize]) -> CasePatternStates {
 }
 
 fn push_case_pattern_state(
-    token_len: usize,
+    seen: &mut [bool],
     states: &mut CasePatternStates,
     stack: &mut CasePatternStates,
     state: usize,
 ) {
-    if state <= token_len && !states.contains(&state) {
+    if let Some(present) = seen.get_mut(state)
+        && !*present
+    {
+        *present = true;
         states.push(state);
         stack.push(state);
     }

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -386,6 +386,10 @@ impl StaticCasePatternMatcher {
             }
         }
 
+        if next.is_empty() {
+            return CasePatternStates::new();
+        }
+
         self.epsilon_closure(next)
     }
 

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -204,6 +204,8 @@ enum CasePatternSymbol {
     Other,
 }
 
+type CasePatternStates = SmallVec<[usize; 8]>;
+
 #[derive(Debug, Clone)]
 struct ReachableCasePattern {
     span: Span,
@@ -272,7 +274,10 @@ impl StaticCasePatternMatcher {
             other.literal_symbols.as_ref(),
         );
 
-        let start = (self.start_states.to_vec(), other.start_states.to_vec());
+        let start = (
+            case_pattern_states_from_slice(self.start_states.as_ref()),
+            case_pattern_states_from_slice(other.start_states.as_ref()),
+        );
         let mut seen = FxHashSet::default();
         let mut worklist = vec![start.clone()];
         seen.insert(start);
@@ -304,7 +309,10 @@ impl StaticCasePatternMatcher {
             other.literal_symbols.as_ref(),
         );
 
-        let start = (self.start_states.to_vec(), other.start_states.to_vec());
+        let start = (
+            case_pattern_states_from_slice(self.start_states.as_ref()),
+            case_pattern_states_from_slice(other.start_states.as_ref()),
+        );
         let mut seen = FxHashSet::default();
         let mut worklist = vec![start.clone()];
         seen.insert(start);
@@ -359,8 +367,8 @@ impl StaticCasePatternMatcher {
         true
     }
 
-    fn advance(&self, states: &[usize], symbol: CasePatternSymbol) -> Vec<usize> {
-        let mut next = Vec::new();
+    fn advance(&self, states: &[usize], symbol: CasePatternSymbol) -> CasePatternStates {
+        let mut next = CasePatternStates::new();
 
         for &state in states {
             let Some(token) = self.tokens.get(state) else {
@@ -378,14 +386,10 @@ impl StaticCasePatternMatcher {
             }
         }
 
-        if next.is_empty() {
-            return Vec::new();
-        }
-
         self.epsilon_closure(next)
     }
 
-    fn epsilon_closure(&self, seeds: impl IntoIterator<Item = usize>) -> Vec<usize> {
+    fn epsilon_closure(&self, seeds: impl IntoIterator<Item = usize>) -> CasePatternStates {
         case_pattern_epsilon_closure(&self.tokens, seeds)
     }
 
@@ -462,31 +466,38 @@ fn summarize_static_case_pattern_tokens(tokens: &[CasePatternToken]) -> StaticCa
 fn case_pattern_epsilon_closure(
     tokens: &[CasePatternToken],
     seeds: impl IntoIterator<Item = usize>,
-) -> Vec<usize> {
-    let mut seen = vec![false; tokens.len() + 1];
-    let mut stack = Vec::new();
+) -> CasePatternStates {
+    let mut states = CasePatternStates::new();
+    let mut stack = CasePatternStates::new();
 
     for state in seeds {
-        if state <= tokens.len() && !seen[state] {
-            seen[state] = true;
-            stack.push(state);
-        }
+        push_case_pattern_state(tokens.len(), &mut states, &mut stack, state);
     }
 
     while let Some(state) = stack.pop() {
         if matches!(tokens.get(state), Some(CasePatternToken::AnyString)) {
-            let next = state + 1;
-            if !seen[next] {
-                seen[next] = true;
-                stack.push(next);
-            }
+            push_case_pattern_state(tokens.len(), &mut states, &mut stack, state + 1);
         }
     }
 
-    seen.into_iter()
-        .enumerate()
-        .filter_map(|(index, present)| present.then_some(index))
-        .collect()
+    states.sort_unstable();
+    states
+}
+
+fn case_pattern_states_from_slice(states: &[usize]) -> CasePatternStates {
+    states.iter().copied().collect()
+}
+
+fn push_case_pattern_state(
+    token_len: usize,
+    states: &mut CasePatternStates,
+    stack: &mut CasePatternStates,
+    state: usize,
+) {
+    if state <= token_len && !states.contains(&state) {
+        states.push(state);
+        stack.push(state);
+    }
 }
 
 fn merged_case_pattern_symbols(left: &[char], right: &[char]) -> Vec<CasePatternSymbol> {

--- a/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
@@ -24,23 +24,23 @@ pub fn c_style_comment(checker: &mut Checker) {
         return;
     }
 
-    let diagnostics = checker
-        .facts()
-        .commands()
-        .iter()
-        .filter_map(|command| {
-            let name = command.body_name_word()?;
+    for index in 0..checker.facts().commands().len() {
+        let diagnostic = {
+            let command = &checker.facts().commands()[index];
+            let Some(name) = command.body_name_word() else {
+                continue;
+            };
             name.span
                 .slice(checker.source())
                 .starts_with("/*")
                 .then_some(crate::Diagnostic::new(CStyleComment, name.span).with_fix(
                     Fix::unsafe_edit(Edit::insertion(name.span.start.offset, "# ")),
                 ))
-        })
-        .collect::<Vec<_>>();
+        };
 
-    for diagnostic in diagnostics {
-        checker.report_diagnostic(diagnostic);
+        if let Some(diagnostic) = diagnostic {
+            checker.report_diagnostic(diagnostic);
+        }
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use shuck_ast::{Name, Position, Span};
+use smallvec::SmallVec;
 
 use crate::facts::ComparableNameUseKind;
 use crate::{Checker, Rule, Violation};
@@ -482,9 +483,12 @@ fn canonical_uppercase_name(name: &str) -> String {
 }
 
 fn candidate_match_rank(target_name: &str, candidate_name: &str) -> Option<u8> {
-    let candidate_upper = canonical_uppercase_name(candidate_name);
-
-    if target_name.len() >= 4 && candidate_upper == target_name {
+    if target_name.len() >= 4
+        && target_name.len() == candidate_name.len()
+        && candidate_name
+            .as_bytes()
+            .eq_ignore_ascii_case(target_name.as_bytes())
+    {
         return Some(0);
     }
 
@@ -496,11 +500,11 @@ fn candidate_match_rank(target_name: &str, candidate_name: &str) -> Option<u8> {
     }
 
     let distance =
-        bounded_ascii_edit_distance(target_name.as_bytes(), candidate_upper.as_bytes(), 2)?;
+        bounded_ascii_edit_distance(target_name.as_bytes(), candidate_name.as_bytes(), 2)?;
     if distance == 0 {
         return None;
     }
-    if distance == 2 && !has_strong_two_edit_shape(target_name, candidate_upper.as_str()) {
+    if distance == 2 && !has_strong_two_edit_shape(target_name, candidate_name) {
         return None;
     }
     Some(distance + 1)
@@ -710,8 +714,9 @@ fn bounded_ascii_edit_distance(left: &[u8], right: &[u8], max_distance: u8) -> O
         return None;
     }
 
-    let mut previous = (0..=right.len()).collect::<Vec<_>>();
-    let mut current = vec![0; right.len() + 1];
+    let mut previous = (0..=right.len()).collect::<SmallVec<[usize; 32]>>();
+    let mut current = SmallVec::<[usize; 32]>::new();
+    current.resize(right.len() + 1, 0);
 
     for (left_index, left_byte) in left.iter().enumerate() {
         current[0] = left_index + 1;


### PR DESCRIPTION
## Summary
- use stack-backed scratch state sets in static case-pattern matching
- avoid hot-path uppercase/string allocations in possible-variable misspelling ranking
- remove collect-then-extend/report loops in literal brace and C-style comment scans

## Profiling
Command: `shuck check --no-cache --output-format concise crates/shuck-benchmark/resources/files`

- CPU mean: 78.5 ms ± 12.8 -> 75.6 ms ± 4.0 (-3.7%)
- dhat total blocks: 759,106 -> 612,761 (-19.3%)
- scratch bucket bytes: 5,402,743 -> 2,106,362 (-61.0%)
- scratch bucket blocks: 171,042 -> 35,275 (-79.4%)

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-cli`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`