### PR TITLE
perf(parser): reduce word subscript allocations

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -417,20 +417,20 @@ impl Subscript {
 pub struct VarRef {
     pub name: Name,
     pub name_span: Span,
-    pub subscript: Option<Subscript>,
+    pub subscript: Option<Box<Subscript>>,
     pub span: Span,
 }
 
 impl VarRef {
     pub fn has_array_selector(&self) -> bool {
         self.subscript
-            .as_ref()
+            .as_deref()
             .is_some_and(Subscript::is_array_selector)
     }
 
     pub fn is_source_backed(&self) -> bool {
         self.subscript
-            .as_ref()
+            .as_deref()
             .is_none_or(Subscript::is_source_backed)
     }
 }
@@ -3895,14 +3895,14 @@ mod tests {
         VarRef {
             name: name.into(),
             name_span: span,
-            subscript: Some(Subscript {
+            subscript: Some(Box::new(Subscript {
                 text: index.into(),
                 raw: None,
                 kind: SubscriptKind::Ordinary,
                 interpretation: SubscriptInterpretation::Contextual,
                 word_ast: None,
                 arithmetic_ast: None,
-            }),
+            })),
             span,
         }
     }
@@ -3912,14 +3912,14 @@ mod tests {
         VarRef {
             name: name.into(),
             name_span: span,
-            subscript: Some(Subscript {
+            subscript: Some(Box::new(Subscript {
                 text: selector.as_char().to_string().into(),
                 raw: None,
                 kind: SubscriptKind::Selector(selector),
                 interpretation: SubscriptInterpretation::Contextual,
                 word_ast: None,
                 arithmetic_ast: None,
-            }),
+            })),
             span,
         }
     }
@@ -4520,14 +4520,14 @@ mod tests {
         let w = word(vec![WordPart::ArrayAccess(VarRef {
             name: "assoc".into(),
             name_span: Span::new(),
-            subscript: Some(Subscript {
+            subscript: Some(Box::new(Subscript {
                 text: "key".into(),
                 raw: Some("\"key\"".into()),
                 kind: SubscriptKind::Ordinary,
                 interpretation: SubscriptInterpretation::Associative,
                 word_ast: None,
                 arithmetic_ast: None,
-            }),
+            })),
             span: Span::new(),
         })]);
         assert_eq!(format!("{w}"), "${assoc[\"key\"]}");

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -554,7 +554,7 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_var_ref_subscript(&mut self, reference: &VarRef) {
-        self.visit_subscript(reference.subscript.as_ref());
+        self.visit_subscript(reference.subscript.as_deref());
     }
 
     fn visit_subscript(&mut self, subscript: Option<&Subscript>) {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -449,7 +449,7 @@ fn collect_base_prefix_spans_in_pattern(pattern: &Pattern, source: &str, spans: 
 }
 
 fn collect_base_prefix_spans_in_var_ref(reference: &VarRef, source: &str, spans: &mut Vec<Span>) {
-    collect_base_prefix_spans_in_subscript(reference.subscript.as_ref(), source, spans);
+    collect_base_prefix_spans_in_subscript(reference.subscript.as_deref(), source, spans);
 }
 
 fn collect_base_prefix_spans_in_subscript(
@@ -956,7 +956,7 @@ fn collect_arithmetic_update_operator_spans_in_assignment_target(
 ) {
     if !var_ref_subscript_has_assoc_semantics(reference, semantic) {
         collect_arithmetic_update_operator_spans_in_subscript(
-            reference.subscript.as_ref(),
+            reference.subscript.as_deref(),
             source,
             spans,
         );
@@ -967,7 +967,7 @@ fn collect_arithmetic_update_operator_spans_in_assignment_target(
 }
 
 fn var_ref_subscript_has_assoc_semantics(reference: &VarRef, semantic: &SemanticModel) -> bool {
-    let Some(subscript) = reference.subscript.as_ref() else {
+    let Some(subscript) = reference.subscript.as_deref() else {
         return false;
     };
     if matches!(

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -257,7 +257,7 @@ fn anchored_assignment_command_span(
 }
 
 fn assignment_target_span(assignment: &Assignment) -> Span {
-    assignment.target.subscript.as_ref().map_or_else(
+    assignment.target.subscript.as_deref().map_or_else(
         || assignment.target.name_span,
         |subscript| {
             Span::from_positions(
@@ -655,7 +655,7 @@ fn visit_assignment_reference_spans_outside_nested_commands(
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     visit_subscript_reference_spans_outside_nested_commands(
-        assignment.target.subscript.as_ref(),
+        assignment.target.subscript.as_deref(),
         name,
         visit,
     )?;
@@ -1059,7 +1059,7 @@ fn visit_var_ref_reference_spans_outside_nested_commands(
     }
 
     visit_subscript_reference_spans_outside_nested_commands(
-        reference.subscript.as_ref(),
+        reference.subscript.as_deref(),
         name,
         visit,
     )

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1262,7 +1262,7 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     pub(super) fn record_var_ref_subscript(&mut self, reference: &VarRef) {
-        let Some(subscript) = reference.subscript.as_ref() else {
+        let Some(subscript) = reference.subscript.as_deref() else {
             return;
         };
         if subscript.selector().is_some() {

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -99,7 +99,7 @@ fn visit_var_ref_subscript_words_with_source<'a>(
     _source: &'a str,
     visitor: &mut impl FnMut(&'a Word),
 ) {
-    visit_subscript_words(reference.subscript.as_ref(), _source, visitor);
+    visit_subscript_words(reference.subscript.as_deref(), _source, visitor);
 }
 
 fn visit_subscript_words<'a>(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -3784,11 +3784,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
                         Some(&reference.name),
                         Some(reference.name_span),
-                        reference.subscript.as_ref(),
+                        reference.subscript.as_deref(),
                     );
                     if !indexed_semantics {
                         self.surface.record_arithmetic_only_suppressed_subscript(
-                            reference.subscript.as_ref(),
+                            reference.subscript.as_deref(),
                         );
                     }
                     visit_var_ref_subscript_words_with_source(
@@ -3838,11 +3838,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
             Some(&assignment.target.name),
             Some(assignment.target.name_span),
-            assignment.target.subscript.as_ref(),
+            assignment.target.subscript.as_deref(),
         );
         if !indexed_semantics {
             self.surface
-                .record_arithmetic_only_suppressed_subscript(assignment.target.subscript.as_ref());
+                .record_arithmetic_only_suppressed_subscript(assignment.target.subscript.as_deref());
         }
         visit_var_ref_subscript_words_with_source(&assignment.target, self.source, &mut |word| {
             collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
@@ -4090,7 +4090,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             }
             ConditionalExpr::VarRef(reference) => {
                 self.surface
-                    .record_arithmetic_only_suppressed_subscript(reference.subscript.as_ref());
+                    .record_arithmetic_only_suppressed_subscript(reference.subscript.as_deref());
                 visit_var_ref_subscript_words_with_source(reference, self.source, &mut |word| {
                     self.push_word_with_surface(
                         word,
@@ -5970,7 +5970,7 @@ fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
 ) {
     if !var_ref_subscript_has_assoc_semantics(reference, semantic) {
         collect_arithmetic_update_operator_spans_in_subscript(
-            reference.subscript.as_ref(),
+            reference.subscript.as_deref(),
             source,
             spans,
         );

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -764,7 +764,7 @@ fn collect_var_ref_word_visits<'a>(
     reference: &'a VarRef,
     visits: &mut Vec<DirectiveCommandVisit<'a>>,
 ) {
-    let Some(subscript) = reference.subscript.as_ref() else {
+    let Some(subscript) = reference.subscript.as_deref() else {
         return;
     };
     if subscript.selector().is_some() {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -3519,7 +3519,7 @@ impl<'a> Parser<'a> {
                     ),
                 LexedWordSegmentKind::Composite => unreachable!(),
             };
-            parts.push(part);
+            Self::push_word_part_node(&mut parts, part);
         }
 
         Some(self.word_with_part_buffer(parts, span))
@@ -3730,10 +3730,12 @@ impl<'a> Parser<'a> {
             let preserve_escaped_expansion_literals = source_backed;
 
             match segment.kind() {
-                LexedWordSegmentKind::SingleQuoted => parts.push(
+                LexedWordSegmentKind::SingleQuoted => Self::push_word_part_node(
+                    &mut parts,
                     self.single_quoted_part_from_text(text, content_span, wrapper_span, false),
                 ),
-                LexedWordSegmentKind::DollarSingleQuoted => parts.push(
+                LexedWordSegmentKind::DollarSingleQuoted => Self::push_word_part_node(
+                    &mut parts,
                     self.single_quoted_part_from_text(text, content_span, wrapper_span, true),
                 ),
                 LexedWordSegmentKind::Plain => {
@@ -3749,7 +3751,10 @@ impl<'a> Parser<'a> {
                             .parts,
                         );
                     } else {
-                        parts.push(self.literal_part_from_text(text, content_span, source_backed));
+                        Self::push_word_part_node(
+                            &mut parts,
+                            self.literal_part_from_text(text, content_span, source_backed),
+                        );
                     }
                 }
                 LexedWordSegmentKind::DoubleQuoted | LexedWordSegmentKind::DollarDoubleQuoted => {
@@ -3760,24 +3765,30 @@ impl<'a> Parser<'a> {
                             content_span.start,
                             source_backed,
                         );
-                        parts.push(WordPartNode::new(
-                            WordPart::DoubleQuoted {
-                                parts: inner.parts,
-                                dollar: matches!(
-                                    segment.kind(),
-                                    LexedWordSegmentKind::DollarDoubleQuoted
-                                ),
-                            },
-                            wrapper_span,
-                        ));
+                        Self::push_word_part_node(
+                            &mut parts,
+                            WordPartNode::new(
+                                WordPart::DoubleQuoted {
+                                    parts: inner.parts,
+                                    dollar: matches!(
+                                        segment.kind(),
+                                        LexedWordSegmentKind::DollarDoubleQuoted
+                                    ),
+                                },
+                                wrapper_span,
+                            ),
+                        );
                     } else {
-                        parts.push(self.double_quoted_literal_part_from_text(
-                            text,
-                            content_span,
-                            wrapper_span,
-                            source_backed,
-                            matches!(segment.kind(), LexedWordSegmentKind::DollarDoubleQuoted),
-                        ));
+                        Self::push_word_part_node(
+                            &mut parts,
+                            self.double_quoted_literal_part_from_text(
+                                text,
+                                content_span,
+                                wrapper_span,
+                                source_backed,
+                                matches!(segment.kind(), LexedWordSegmentKind::DollarDoubleQuoted),
+                            ),
+                        );
                     }
                 }
                 LexedWordSegmentKind::Composite => return None,
@@ -5641,7 +5652,14 @@ impl<'a> Parser<'a> {
     }
 
     fn push_word_part(parts: &mut WordPartBuffer, part: WordPart, start: Position, end: Position) {
-        parts.push(WordPartNode::new(part, Span::from_positions(start, end)));
+        Self::push_word_part_node(
+            parts,
+            WordPartNode::new(part, Span::from_positions(start, end)),
+        );
+    }
+
+    fn push_word_part_node(parts: &mut WordPartBuffer, part: WordPartNode) {
+        parts.push(part);
     }
 
     fn flush_literal_part(
@@ -5873,7 +5891,7 @@ impl<'a> Parser<'a> {
         VarRef {
             name: name.into(),
             name_span,
-            subscript,
+            subscript: subscript.map(Box::new),
             span,
         }
     }
@@ -6361,7 +6379,7 @@ impl<'a> Parser<'a> {
             return VarRef {
                 name: Name::from(name),
                 name_span: Span::new(),
-                subscript: Some(subscript),
+                subscript: Some(Box::new(subscript)),
                 span: Span::new(),
             };
         }

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -944,31 +944,31 @@ fn test_parameter_forms_preserve_selector_kinds() {
 
     let reference = expect_array_access(&command.args[0]);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::At)
     );
 
     let reference = expect_array_access(&command.args[1]);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::Star)
     );
 
     let reference = expect_array_length_part(&command.args[2].parts[0].kind);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::At)
     );
 
     let reference = expect_array_indices_part(&command.args[3].parts[0].kind);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::Star)
     );
 
     let (reference, _, _) = expect_array_slice_part(&command.args[4].parts[0].kind);
     assert_eq!(
-        reference.subscript.as_ref().and_then(Subscript::selector),
+        reference.subscript.as_deref().and_then(Subscript::selector),
         Some(SubscriptSelector::At)
     );
 }
@@ -2412,7 +2412,7 @@ fn test_word_part_spans_track_nested_array_expansions() {
     );
 
     let reference = array_access_reference(&word.parts[0].kind).expect("expected array access");
-    let subscript = reference.subscript.as_ref().expect("expected subscript");
+    let subscript = reference.subscript.as_deref().expect("expected subscript");
     assert!(subscript.is_source_backed());
     assert_eq!(subscript.text.slice(input), "$RANDOM % ${#arr[@]}");
 }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1716,11 +1716,11 @@ impl<'a> Parser<'a> {
 
     pub(super) fn split_word_at(&self, word: Word, start: Position) -> Word {
         let value_span = Span::from_positions(start, word.span.end);
-        let mut parts = WordPartBuffer::new();
+        let mut parts = Self::word_part_buffer_with_capacity(word.parts.len());
 
         for part in word.parts {
             if let Some((kind, span)) = self.trim_word_part_prefix(part.kind, part.span, start) {
-                parts.push(WordPartNode::new(kind, span));
+                Self::push_word_part_node(&mut parts, WordPartNode::new(kind, span));
             }
         }
 
@@ -3876,7 +3876,7 @@ impl<'a> Parser<'a> {
                         );
                         let part = if reference
                             .subscript
-                            .as_ref()
+                            .as_deref()
                             .and_then(Subscript::selector)
                             .is_some()
                         {
@@ -3966,7 +3966,7 @@ impl<'a> Parser<'a> {
                         let part = self.parameter_word_part_from_legacy(
                             if reference
                                 .subscript
-                                .as_ref()
+                                .as_deref()
                                 .and_then(Subscript::selector)
                                 .is_some()
                             {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -520,7 +520,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 DeclOperand::Name(name) => {
                     self.visit_var_ref_subscript_words(
                         Some(&name.name),
-                        name.subscript.as_ref(),
+                        name.subscript.as_deref(),
                         WordVisitKind::Expansion,
                         flow,
                         &mut nested_regions,
@@ -1058,7 +1058,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let reference_start = self.references.len();
         self.visit_var_ref_subscript_words(
             Some(&assignment.target.name),
-            assignment.target.subscript.as_ref(),
+            assignment.target.subscript.as_deref(),
             WordVisitKind::Expansion,
             flow,
             nested_regions,
@@ -1346,7 +1346,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let id = self.add_reference(&reference.name, reference_kind, span);
         self.visit_var_ref_subscript_words(
             Some(&reference.name),
-            reference.subscript.as_ref(),
+            reference.subscript.as_deref(),
             if matches!(reference_kind, ReferenceKind::ConditionalOperand) {
                 WordVisitKind::Conditional
             } else {
@@ -4906,7 +4906,7 @@ fn binding_origin_for_assignment(assignment: &Assignment, source: &str) -> Bindi
 }
 
 fn assignment_target_span(assignment: &Assignment, source: &str) -> Span {
-    let Some(subscript) = assignment.target.subscript.as_ref() else {
+    let Some(subscript) = assignment.target.subscript.as_deref() else {
         return assignment.target.name_span;
     };
 


### PR DESCRIPTION
## Summary

- Box `VarRef` subscripts so the common unsubscripted reference path no longer carries the full `Subscript` payload inline.
- Add exact-capacity word-part allocation in parser hot paths to keep one-part words from over-allocating after the layout shrink.
- Update downstream subscript accessors to dereference through the boxed representation without changing parser behavior.

## Profiling

Command: `shuck check --no-cache --output-format concise crates/shuck-benchmark/resources/files`

- CPU: `67.8 ms ± 1.1` -> `60.7 ms ± 1.6` (`-10.5%`)
- Total dhat bytes: `252.6 MB` -> `238.6 MB` (`-5.5%`)
- Parser word bucket: `51.16 MB` -> `43.01 MB` (`-15.9%`)
- Peak heap: `61.18 MB` -> `52.88 MB` (`-8.3 MB`)

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-parser`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-cli`
- `cargo clippy -p shuck-parser --all-targets -- -D warnings`
