### PR TITLE
perf(parser): reduce checkpoint allocations

### DIFF
--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -616,7 +616,7 @@ impl<'a> Cursor<'a> {
 #[derive(Clone, Debug)]
 struct PositionMap<'a> {
     source: &'a str,
-    line_starts: Vec<usize>,
+    line_starts: Arc<[usize]>,
     cached: Position,
 }
 
@@ -640,7 +640,7 @@ impl<'a> PositionMap<'a> {
 
         Self {
             source,
-            line_starts,
+            line_starts: line_starts.into(),
             cached: Position::new(),
         }
     }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -1601,7 +1601,6 @@ struct ParserCheckpoint<'a> {
     synthetic_tokens: VecDeque<SyntheticToken>,
     alias_replays: Vec<AliasReplay>,
     current_token: Option<LexedToken<'a>>,
-    current_word_cache: Option<Word>,
     current_token_kind: Option<TokenKind>,
     current_keyword: Option<Keyword>,
     current_span: Span,
@@ -6699,7 +6698,6 @@ impl<'a> Parser<'a> {
             synthetic_tokens: self.synthetic_tokens.clone(),
             alias_replays: self.alias_replays.clone(),
             current_token: self.current_token.clone(),
-            current_word_cache: self.current_word_cache.clone(),
             current_token_kind: self.current_token_kind,
             current_keyword: self.current_keyword,
             current_span: self.current_span,
@@ -6721,7 +6719,8 @@ impl<'a> Parser<'a> {
         self.synthetic_tokens = checkpoint.synthetic_tokens;
         self.alias_replays = checkpoint.alias_replays;
         self.current_token = checkpoint.current_token;
-        self.current_word_cache = checkpoint.current_word_cache;
+        // This is a cache over current_token/current_span, so rebuilding it is equivalent.
+        self.current_word_cache = None;
         self.current_token_kind = checkpoint.current_token_kind;
         self.current_keyword = checkpoint.current_keyword;
         self.current_span = checkpoint.current_span;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -84,6 +84,27 @@ fn test_current_word_cache_tracks_token_changes() {
 }
 
 #[test]
+fn test_checkpoint_restore_rebuilds_current_word_cache() {
+    let input = "\"$foo\" bar\n";
+    let mut parser = Parser::new(input);
+
+    let first = parser.current_word().unwrap();
+    assert_eq!(first.render(input), "$foo");
+    assert!(parser.current_word_cache.is_some());
+
+    let checkpoint = parser.checkpoint();
+    parser.advance();
+    assert_eq!(parser.current_word().unwrap().render(input), "bar");
+
+    parser.restore(checkpoint);
+    assert!(parser.current_word_cache.is_none());
+    let restored = parser.current_word().unwrap();
+    assert_eq!(restored.render(input), "$foo");
+    assert_eq!(restored.span, first.span);
+    assert!(parser.current_word_cache.is_some());
+}
+
+#[test]
 fn test_parse_word_fragment_preserves_original_span_for_cooked_text() {
     let source = r#"foo\/bar"#;
     let span = Span::from_positions(Position::new(), Position::new().advanced_by(source));


### PR DESCRIPTION
## Summary
- share the lexer position map newline table across checkpoint clones
- avoid storing the memoized current word cache in ParserCheckpoint; restore rebuilds it from token state
- add a focused parser test for checkpoint restore/cache rebuilding

## Performance
- hyperfine fixture-dir check: 78.6 ms ± 6.0 ms -> 72.1 ms ± 2.5 ms (-8.3%)
- dhat total allocations: 252,672,775 -> 241,890,598 bytes (-4.3%)
- Parser::checkpoint allocation bucket: 11,472,146 -> 570,978 bytes (-95.0%)

## Validation
- cargo fmt --check
- cargo test -p shuck-parser
- cargo test -p shuck-semantic
- cargo test -p shuck-linter
- cargo test -p shuck-cli
- cargo clippy -p shuck-parser --all-targets -- -D warnings
- cargo test -p shuck-parser -- parser
- cargo test -p shuck-cli --test integration_test check_good_file_succeeds