### PR TITLE
fix(linter): align C057 with SC2328

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C057.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C057.sh
@@ -1,10 +1,19 @@
 #!/bin/sh
 
-# Compatibility note: the pinned oracle currently stays quiet on this form.
+# Invalid: redirecting the captured command's stdout leaves the substitution empty.
 out=$(printf hi > out.txt)
 
-# Compatibility note: the pinned oracle also stays quiet on this reroute.
+# Invalid: redirecting stdout to stderr has the same capture issue.
 out=$(printf hi >&2)
+
+# Invalid: a compound wrapper redirect also controls the substitution output.
+out=$({ printf hi; } >/dev/tty)
 
 # Baseline direct capture.
 out=$(printf hi)
+
+# Valid: stderr is captured before stdout is redirected elsewhere.
+choice=$(printf hi 2>&1 >/dev/tty)
+
+# Valid: mixed output still leaves captured output available.
+out=$(printf quiet >/dev/null; printf loud)

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -601,25 +601,6 @@ fn summarize_stmt_redirects<'a>(
                 merge_redirect_summaries(left, right, true)
             }
         },
-        Command::Compound(CompoundCommand::Subshell(body))
-        | Command::Compound(CompoundCommand::BraceGroup(body)) => {
-            summarize_compound_stmt_redirects(
-                summarize_stmt_seq_redirects(body, commands, command_ids_by_span, source),
-                &stmt.redirects,
-                source,
-            )
-        }
-        Command::Compound(CompoundCommand::Time(command)) => command
-            .command
-            .as_deref()
-            .map(|inner_stmt| {
-                summarize_compound_stmt_redirects(
-                    summarize_stmt_redirects(inner_stmt, commands, command_ids_by_span, source),
-                    &stmt.redirects,
-                    source,
-                )
-            })
-            .unwrap_or_else(default_redirect_summary),
         Command::Simple(_)
         | Command::Builtin(_)
         | Command::Decl(_)
@@ -637,47 +618,13 @@ fn summarize_stmt_redirects<'a>(
             | CompoundCommand::Select(_)
             | CompoundCommand::Arithmetic(_)
             | CompoundCommand::Conditional(_)
+            | CompoundCommand::Subshell(_)
+            | CompoundCommand::BraceGroup(_)
+            | CompoundCommand::Time(_)
             | CompoundCommand::Coproc(_)
             | CompoundCommand::Always(_),
         ) => summarize_command_redirects(&stmt.command, &stmt.redirects, commands, command_ids_by_span, source),
     }
-}
-
-fn summarize_compound_stmt_redirects(
-    mut summary: RedirectSummary,
-    redirects: &[Redirect],
-    source: &str,
-) -> RedirectSummary {
-    let redirect_facts = build_redirect_facts(redirects, None, source, None);
-    if redirect_facts.is_empty() {
-        return summary;
-    }
-
-    let outer_summary = summarize_redirect_facts(&redirect_facts);
-    summary.has_stdout_redirect |= outer_summary.has_stdout_redirect;
-    summary
-        .stdout_redirect_spans
-        .extend(outer_summary.stdout_redirect_spans);
-    summary
-        .stdout_dev_null_redirect_spans
-        .extend(outer_summary.stdout_dev_null_redirect_spans);
-
-    if outer_summary.has_stdout_redirect {
-        summary.stdout_intent = outer_summary.stdout_intent;
-        summary.terminal_stdout_intent = outer_summary.terminal_stdout_intent;
-    }
-
-    if compound_redirects_capture_stderr_to_stdout(&redirect_facts) {
-        summary.stdout_intent = SubstitutionOutputIntent::Captured;
-        summary.terminal_stdout_intent = SubstitutionOutputIntent::Captured;
-        if !outer_summary.has_stdout_redirect {
-            summary.has_stdout_redirect = false;
-            summary.stdout_redirect_spans.clear();
-            summary.stdout_dev_null_redirect_spans.clear();
-        }
-    }
-
-    summary
 }
 
 fn summarize_command_redirects<'a>(
@@ -688,21 +635,21 @@ fn summarize_command_redirects<'a>(
     source: &str,
 ) -> RedirectSummary {
     if let Some(id) = command_id_for_command(command, command_ids_by_span) {
-        summarize_redirect_facts(command_fact(commands, id).redirect_facts())
+        summarize_redirect_facts(command_fact(commands, id).redirect_facts(), source)
     } else {
         let redirect_facts = build_redirect_facts(redirects, None, source, None);
-        summarize_redirect_facts(&redirect_facts)
+        summarize_redirect_facts(&redirect_facts, source)
     }
 }
 
-fn summarize_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectSummary {
+fn summarize_redirect_facts(redirects: &[RedirectFact<'_>], source: &str) -> RedirectSummary {
     let state = classify_redirect_facts(redirects);
     RedirectSummary {
         stdout_intent: state.stdout_intent,
         terminal_stdout_intent: state.stdout_intent,
         has_stdout_redirect: state.has_stdout_redirect,
-        stdout_redirect_spans: stdout_redirect_spans_for_fix(redirects),
-        stdout_dev_null_redirect_spans: stdout_dev_null_redirect_spans_for_fix(redirects),
+        stdout_redirect_spans: stdout_redirect_spans_for_fix(redirects, source),
+        stdout_dev_null_redirect_spans: stdout_dev_null_redirect_spans_for_fix(redirects, source),
     }
 }
 
@@ -727,16 +674,6 @@ fn merge_redirect_summaries(
         next.stdout_intent
     };
     current
-}
-
-fn default_redirect_summary() -> RedirectSummary {
-    RedirectSummary {
-        stdout_intent: SubstitutionOutputIntent::Captured,
-        terminal_stdout_intent: SubstitutionOutputIntent::Captured,
-        has_stdout_redirect: false,
-        stdout_redirect_spans: Vec::new(),
-        stdout_dev_null_redirect_spans: Vec::new(),
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -803,18 +740,23 @@ fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
     }
 }
 
-fn stdout_redirect_spans_for_fix(redirects: &[RedirectFact<'_>]) -> Vec<Span> {
+fn stdout_redirect_spans_for_fix(redirects: &[RedirectFact<'_>], source: &str) -> Vec<Span> {
     redirects
         .iter()
-        .filter(|redirect| redirect_matches_substitution_warning(redirect))
+        .filter(|redirect| redirect_matches_substitution_warning(redirect, source))
         .map(|redirect| redirect.redirect().span)
         .collect()
 }
 
-fn stdout_dev_null_redirect_spans_for_fix(redirects: &[RedirectFact<'_>]) -> Vec<Span> {
+fn stdout_dev_null_redirect_spans_for_fix(
+    redirects: &[RedirectFact<'_>],
+    source: &str,
+) -> Vec<Span> {
     redirects
         .iter()
-        .filter(|redirect| redirect_targets_stdout_dev_null_for_substitution_warning(redirect))
+        .filter(|redirect| {
+            redirect_targets_stdout_dev_null_for_substitution_warning(redirect, source)
+        })
         .map(|redirect| redirect.redirect().span)
         .collect()
 }
@@ -839,29 +781,40 @@ fn redirect_targets_stdout_dev_null(redirect: &RedirectFact<'_>) -> bool {
     redirect_affects_stdout(redirect) && redirect_file_sink(redirect) == OutputSink::DevNull
 }
 
-fn redirect_targets_stdout_dev_null_for_substitution_warning(redirect: &RedirectFact<'_>) -> bool {
-    redirect_matches_substitution_warning(redirect) && redirect_targets_stdout_dev_null(redirect)
+fn redirect_targets_stdout_dev_null_for_substitution_warning(
+    redirect: &RedirectFact<'_>,
+    source: &str,
+) -> bool {
+    redirect_matches_substitution_warning(redirect, source)
+        && redirect_targets_stdout_dev_null(redirect)
 }
 
-fn redirect_matches_substitution_warning(redirect: &RedirectFact<'_>) -> bool {
-    matches!(
-        redirect.redirect().kind,
-        RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append
-    ) && redirect.redirect().fd.unwrap_or(1) == 1
+fn redirect_matches_substitution_warning(redirect: &RedirectFact<'_>, source: &str) -> bool {
+    match redirect.redirect().kind {
+        RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append => {
+            redirect.redirect().fd.unwrap_or(1) == 1
+        }
+        RedirectKind::DupOutput => {
+            redirect.redirect().fd.unwrap_or(1) == 1
+                && redirect.redirect().span.slice(source).trim_start().starts_with(">&")
+                && dup_stdout_target_redirects_capture_away(redirect, source)
+        }
+        RedirectKind::Input
+        | RedirectKind::ReadWrite
+        | RedirectKind::HereDoc
+        | RedirectKind::HereDocStrip
+        | RedirectKind::HereString
+        | RedirectKind::OutputBoth
+        | RedirectKind::DupInput => false,
+    }
 }
 
-fn compound_redirects_capture_stderr_to_stdout(redirects: &[RedirectFact<'_>]) -> bool {
-    classify_redirect_facts(redirects).stdout_intent == SubstitutionOutputIntent::Captured
-        && redirects.iter().any(is_stderr_to_stdout_dup)
-}
+fn dup_stdout_target_redirects_capture_away(redirect: &RedirectFact<'_>, source: &str) -> bool {
+    let Some(target) = redirect.target_span().map(|span| span.slice(source).trim()) else {
+        return false;
+    };
 
-fn is_stderr_to_stdout_dup(redirect: &RedirectFact<'_>) -> bool {
-    redirect.redirect().kind == RedirectKind::DupOutput
-        && redirect.redirect().fd == Some(2)
-        && redirect
-            .analysis()
-            .and_then(|analysis| analysis.numeric_descriptor_target)
-            == Some(1)
+    target == "-" || (target.chars().all(|ch| ch.is_ascii_digit()) && target != "1")
 }
 
 fn substitution_body_contains_echo(body: &StmtSeq, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -3555,6 +3555,32 @@ shown=$({ printf hi; } >/dev/tty)
 }
 
 #[test]
+fn leaves_inner_compound_redirects_out_of_substitution_output_warnings() {
+    let source = "\
+#!/bin/sh
+file=$({ printf hi >out.txt; })
+fd=$({ printf hi >&5; })
+";
+
+    with_facts(source, None, |_, facts| {
+        let substitutions = facts
+            .commands()
+            .iter()
+            .flat_map(|fact| fact.substitution_facts().iter())
+            .collect::<Vec<_>>();
+
+        for substitution in substitutions {
+            assert_eq!(
+                substitution.stdout_intent(),
+                SubstitutionOutputIntent::Captured
+            );
+            assert!(substitution.stdout_redirect_spans().is_empty());
+            assert!(substitution.stdout_dev_null_redirect_spans().is_empty());
+        }
+    });
+}
+
+#[test]
 fn builds_docker_ps_substitution_facts_without_pgrep_exemptions() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__subst_with_redirect__tests__C057_C057.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__subst_with_redirect__tests__C057_C057.sh.snap
@@ -1,4 +1,20 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/subst_with_redirect.rs
-assertion_line: 64
 ---
+C057 command substitution redirects its output away
+ --> <source>:4:17
+  |
+4 | out=$(printf hi > out.txt)
+  |
+
+C057 command substitution redirects its output away
+ --> <source>:7:17
+  |
+7 | out=$(printf hi >&2)
+  |
+
+C057 command substitution redirects its output away
+  --> <source>:10:22
+   |
+10 | out=$({ printf hi; } >/dev/tty)
+   |

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C057_C057.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C057_C057.sh.snap
@@ -1,4 +1,20 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 285
 ---
+C057 command substitution redirects its output away
+ --> <source>:4:17
+  |
+4 | out=$(printf hi > out.txt)
+  |
+
+C057 command substitution redirects its output away
+ --> <source>:7:17
+  |
+7 | out=$(printf hi >&2)
+  |
+
+C057 command substitution redirects its output away
+  --> <source>:10:22
+   |
+10 | out=$({ printf hi; } >/dev/tty)
+   |

--- a/crates/shuck-linter/src/rules/correctness/subst_with_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subst_with_redirect.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, FixAvailability, Rule, Violation};
+use crate::{Checker, CommandSubstitutionKind, FixAvailability, Rule, Violation};
 
 pub struct SubstWithRedirect;
 
@@ -18,10 +18,26 @@ impl Violation for SubstWithRedirect {
     }
 }
 
-pub fn subst_with_redirect(_checker: &mut Checker) {
-    // The pinned ShellCheck oracle currently does not surface SC2255, even for
-    // direct reproductions, so keep C057 dormant until there is observable
-    // oracle behavior to match.
+pub fn subst_with_redirect(checker: &mut Checker) {
+    let redirect_spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .flat_map(|fact| {
+            fact.substitution_facts()
+                .iter()
+                .filter(|substitution| substitution.kind() == CommandSubstitutionKind::Command)
+                .filter(|substitution| {
+                    substitution.stdout_is_discarded() || substitution.stdout_is_rerouted()
+                })
+                .filter(|substitution| !substitution.body_is_negated())
+                .filter_map(|substitution| substitution.stdout_redirect_spans().first().copied())
+        })
+        .collect::<Vec<_>>();
+
+    for span in redirect_spans {
+        checker.report_diagnostic_dedup(crate::Diagnostic::new(SubstWithRedirect, span));
+    }
 }
 
 #[cfg(test)]
@@ -32,7 +48,40 @@ mod tests {
     use crate::{LinterSettings, Rule, assert_diagnostics};
 
     #[test]
-    fn stays_quiet_for_rerouted_substitutions_under_current_oracle() {
+    fn reports_first_redirect_for_rerouted_substitutions() {
+        let source = "\
+out=$(printf quiet >/dev/null; printf loud > out.txt)
+out=$(printf hi > out.txt)
+out=$(printf hi >&2)
+out=$(printf hi > \"$target\")
+out=$(printf hi > ${targets[@]})
+out=$(printf hi >a >b)
+out=$({ printf hi; } >/dev/tty)
+declare arr[$(printf hi > out.txt)]=1
+declare -A map=([$(printf bye > \"$target\")]=1)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubstWithRedirect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "> out.txt",
+                ">&2",
+                "> \"$target\"",
+                "> ${targets[@]}",
+                ">a",
+                ">/dev/tty",
+                "> out.txt",
+                "> \"$target\"",
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_oracle_quiet_redirect_shapes() {
         let source = "\
 opts=$(getopt -o a -- \"$@\" || { usage >&2 && false; })
 menu=$(whiptail --menu pick 0 0 0 foo bar 3>&1 1>&2 2>&3)
@@ -40,14 +89,16 @@ dialog_out=$(dialog --menu pick 0 0 0 foo bar 3>&1 1>&2 2>&3)
 json=$(jq -r . <<< \"$status\" || die >&2)
 awk_output=$(awk 'BEGIN { print \"ok\" }' || warn >&2)
 choice=$(\"${cmd[@]}\" \"${options[@]}\" 2>&1 >/dev/tty)
-out=$(printf quiet >/dev/null; printf loud > out.txt)
-out=$(printf hi > out.txt)
-out=$(printf hi >&2)
-out=$(printf hi > \"$target\")
-out=$(printf hi > ${targets[@]})
+probe=$(! printf hi >/dev/null 2>&1)
+out=$(printf hi &>/dev/null)
 out=$(printf hi 2>&\"$fd\")
-declare arr[$(printf hi > out.txt)]=1
-declare -A map=([$(printf bye > \"$target\")]=1)
+out=$(printf hi 3>/dev/null 1>&3)
+out=$(printf quiet >/dev/null; printf loud)
+out=$(printf quiet; printf loud >/dev/null)
+out=$({ printf hi >out.txt; })
+out=$({ printf hi >&5; })
+out=$(printf hi 1>&2)
+out=$(printf hi >&\"2\")
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubstWithRedirect));
 
@@ -66,10 +117,11 @@ declare -A map=([$(printf bye > \"$target\")]=1)
     }
 
     #[test]
-    fn keeps_direct_redirect_examples_quiet() {
+    fn reports_direct_redirect_examples() {
         let source = "#!/bin/sh\nout=$(printf hi > out.txt)\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubstWithRedirect));
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "> out.txt");
     }
 }

--- a/docs/rules/C057.yaml
+++ b/docs/rules/C057.yaml
@@ -3,8 +3,8 @@ legacy_name: subst-with-redirect
 new_category: Correctness
 new_code: C057
 runtime_kind: ast
-shellcheck_code: SC2255
-shellcheck_level: warning
+shellcheck_code: SC2328
+shellcheck_level: error
 shells:
   - sh
   - bash


### PR DESCRIPTION
## Summary

- Remap C057 from dormant SC2255 compatibility to the live SC2328 oracle behavior.
- Re-enable C057 so it reports the redirect span for command substitutions whose stdout is redirected away.
- Shape substitution redirect facts to match the pinned oracle boundary, including compound-body quiet cases, and refresh C057 fixtures/snapshots.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-linter subst_with_redirect`
- `cargo test -p shuck-linter rules::correctness::tests::rules::rule_substwithredirect_path_new_c057_sh_expects`
- `cargo test -p shuck-linter shellcheck_map`
- `cargo test -p shuck-linter leaves_inner_compound_redirects_out_of_substitution_output_warnings`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C057 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=180`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C058 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS=180`