### PR TITLE
fix(linter): improve C063 ShellCheck compatibility

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/c063.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/c063.yaml
@@ -1,211 +1,29 @@
 reviewed_divergences:
-  - side: shuck-only
-    path_suffix: "bats-core__bats-core__libexec__bats-core__bats-exec-test"
-    line: 82
-    reason: "This Bats exec-test harness sources shared helper libraries and then intentionally replaces selected tracing and trap helpers before the runner uses them."
-  - side: shuck-only
-    path_suffix: "dylanaraps__neofetch__neofetch"
-    line: 1520
-    reason: "This helper is intentionally replaced later in the same function for a Bedrock-specific path, so the earlier definition is a deliberate override pattern."
-  - side: shuck-only
-    path_suffix: "dylanaraps__neofetch__neofetch"
-    line: 1522
-    reason: "This helper is intentionally replaced later in the same function for a Bedrock-specific path, so the earlier definition is a deliberate override pattern."
-  - side: shuck-only
-    path_suffix: "dylanaraps__neofetch__neofetch"
-    line: 5406
-    reason: "This is a temporary command-line mode override for info rendering, not an accidental dead definition."
-  - side: shuck-only
-    path_suffix: "nvm-sh__nvm__update_test_mocks.sh"
-    line: 12
-    reason: "This fixture sources nvm.sh and then replaces the version-check helper with a mock implementation to generate test data."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__requirements__openindiana"
-    line: 68
-    reason: "This platform-specific helper is part of RVM's override chain, so the overwrite is intentional rather than a real dead-definition bug."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__build-package.sh"
-    line: 242
-    reason: "This build framework file loads default hook implementations that package build scripts are expected to override later."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__build-package.sh"
-    line: 254
-    reason: "This build framework file loads the default source-fetch hook that package-specific builders intentionally replace."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__angle-android__build.sh"
-    line: 126
-    reason: "Termux package scripts routinely override build-step hooks, and this configure hook is meant to replace the inherited implementation."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__dnglab__build.sh"
-    line: 16
-    reason: "Termux package scripts routinely override build-step hooks, and this install hook is meant to replace the inherited implementation."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__scripts__setup-offline-bundle.sh"
-    line: 86
-    reason: "This offline bundle helper sources the normal archive extractor and then overrides it with a no-op to avoid unpacking sources during cache population."
-  - side: shuck-only
-    path_suffix: "GameServerManagers__LinuxGSM__lgsm__modules__core_modules.sh"
-    line: 439
-    reason: "LinuxGSM core modules intentionally replace selected per-game helpers after sourcing the shared module stack, so this overwrite is part of the framework hook chain."
-  - side: shuck-only
-    path_suffix: "HariSekhon__DevOps-Bash-tools__.bash.d__travis_ci.sh"
-    line: 27
-    reason: "This shell profile re-sources the OS-detection helper stack and keeps compatibility wrappers for multiple naming conventions, so the repeated imports are an intentional bootstrap pattern."
-  - side: shuck-only
-    path_suffix: "HariSekhon__DevOps-Bash-tools__.bashrc"
-    line: 67
-    reason: "This interactive shell bootstrap intentionally reloads shared OS-detection helpers while preserving compatibility aliases, so the repeated import chain is deliberate."
-  - side: shuck-only
-    path_suffix: "HariSekhon__DevOps-Bash-tools__git__git_foreach_branch.sh"
-    line: 21
-    reason: "This Git helper sources a shared navigation library and then replaces a few wrapper helpers for the branch-iteration workflow, so the overwrite is intentional."
-  - side: shuck-only
-    path_suffix: "RetroPie__RetroPie-Setup__retropie_packages.sh"
-    line: 71
-    reason: "RetroPie swaps in its own fatal-error helper for the package-management workflow after sourcing the shared setup library, so the overwrite is intentional."
-  - side: shuck-only
-    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
-    line: 883
-    reason: "RetroPie's optional user menu helper is reached through runtime menu-file discovery, so this termination-only C063 hit is framework dispatch rather than a dead definition."
+  - side: shellcheck-only
+    path_suffix: "bittorf__kalua__openwrt-build__build.sh"
+    line: 3438
+    end_line: 3441
+    column: 6
+    end_column: 24
+    reason: "Backlog: this branch-local `_switch` override is installed to observe calls made by a sourced switch helper during `_switch_show`. Shuck follows that in-branch helper use today, while ShellCheck keeps SC2329 on the override; keep the divergence scoped to this exact span."
+  - side: shellcheck-only
+    path_suffix: "dehydrated-io__dehydrated__dehydrated"
+    line: 631
+    end_line: 631
+    column: 5
+    end_column: 43
+    reason: "Backlog: this cleanup helper is installed as an EXIT trap. Shuck treats the trap registration as a reachable use, while ShellCheck still reports the helper; keep the divergence scoped to this exact trap helper definition."
   - side: shuck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__network__openconnect__vpnc-script"
     line: 210
-    reason: "The OpenConnect route helper is used by branch-selected route functions and command-substitution pipelines, so this termination-only C063 hit reflects dispatch shape rather than a dead definition."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__owncloud-vm.sh"
-    line: 452
-    reason: "This ProxmoxVE provisioning script replaces the sourced start helper in a later execution branch as part of its workflow setup."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__lib__getoptions_base.sh"
-    reason: "ShellSpec's getoptions helper reuses tiny parser-function names inside its DSL-driven option builder, and the remaining C063 hits are framework-scoped helper reuse rather than dead definitions."
-  - side: shuck-only
-    path_suffix: "tj__git-extras__bin__git-sed"
-    line: 15
-    reason: "git-extras intentionally swaps in its own commit helper for this command wrapper after sourcing the shared Git helper library."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__helper__spec_helper.sh"
-    line: 113
-    reason: "ShellSpec's helper configuration creates nested mock output hooks for its DSL, and these are reached by framework indirection rather than plain direct calls."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__helper__spec_helper.sh"
-    line: 117
-    reason: "ShellSpec's helper configuration creates nested mock output hooks for its DSL, and these are reached by framework indirection rather than plain direct calls."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__helper__spec_helper.sh"
-    line: 121
-    reason: "ShellSpec's helper configuration creates nested mock output hooks for its DSL, and these are reached by framework indirection rather than plain direct calls."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__lib__core__evaluation.sh"
-    line: 238
-    reason: "ShellSpec installs a nested test wrapper as part of its interceptor machinery, so the remaining C063 hit is framework setup rather than a dead nested helper."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__lib__libexec__optparser__parser_definition.sh"
-    line: 301
-    reason: "ShellSpec's option-parser DSL creates extension-local helper names that are consumed through parser indirection rather than ordinary direct calls."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__lib__libexec__optparser__parser_definition.sh"
-    line: 306
-    reason: "ShellSpec's option-parser DSL creates extension-local helper names that are consumed through parser indirection rather than ordinary direct calls."
+    end_line: 213
+    column: 2
+    end_column: 3
+    reason: "Backlog: this route helper is defined under the IPROUTE branch and consumed by route functions from that same branch. Shuck still treats the command-substitution calls through those branch-local helpers as insufficient, so keep the remaining C063 divergence scoped to this exact span."
   - side: shuck-only
     path_suffix: "xwmx__nb__nb"
     line: 15574
-    reason: "nb's environment installer uses nested helper plumbing inside a dynamic command workflow, so this compat-only C063 hit is not a useful dead-function finding."
-  - side: shuck-only
-    path_contains: "bitnami__containers__"
-    reason: "Bitnami container libraries layer shared service wrappers and per-service overrides through sourced lib*.sh files, so the remaining Shuck-only C063 hits are framework hook replacements rather than dead definitions."
-  - side: shellcheck-only
-    path_contains: "ko1nksm__shellspec__"
-    reason: "ShellSpec's DSL generates transient helper functions and repeatedly reuses example-local names, so SC2329 overstates dead definitions in its spec and helper files."
-  - side: shellcheck-only
-    path_contains: "bitnami__containers__"
-    reason: "Bitnami container libraries expose many sourced service helpers and wrapper entrypoints that are reached indirectly by the container framework, so SC2329 is noisy here."
-  - side: shellcheck-only
-    path_contains: "quickemu-project__quickemu__quickget"
-    reason: "quickget dispatches through computed releases_* and editions_* helper names, which SC2329's direct-call heuristic does not follow."
-  - side: shellcheck-only
-    path_contains: "nvm-sh__nvm__test__"
-    reason: "NVM's test fixtures replace helpers and reach them through runner indirection, so SC2329 overstates dead definitions in these mocks."
-  - side: shellcheck-only
-    path_contains: "xwmx__nb__nb"
-    reason: "nb registers many subcommand handlers through dynamic dispatch, so direct-call analysis misses their real entrypoints."
-  - side: shellcheck-only
-    path_contains: "bittorf__kalua__"
-    reason: "These OpenWrt helper scripts choose handlers from sourced profiles and runtime state, which SC2329 does not model."
-  - side: shellcheck-only
-    path_contains: "moovweb__gvm__examples__native__ltmain.sh"
-    reason: "This libtool-generated example script contains generated helper definitions that are not actionable C063 findings."
-  - side: shellcheck-only
-    path_contains: "swoodford__aws__waf-web-acl-pingdom.sh"
-    reason: "This monitoring script selects action helpers from runtime state and user-driven paths, so SC2329's direct-call heuristic is noisy."
-  - side: shellcheck-only
-    path_contains: "SlackBuildsOrg__slackbuilds__"
-    reason: "These SlackBuild service and network helper scripts define hooks that are reached by external entrypoints rather than explicit in-file calls."
-  - side: shellcheck-only
-    path_contains: "rvm__rvm__"
-    reason: "RVM's sourced function libraries and alias machinery route through indirect helper dispatch, which SC2329 does not follow well."
-  - side: shellcheck-only
-    path_contains: "alpinelinux__aports__main__busybox__default.script"
-    reason: "This BusyBox default script defines externally-called init hooks, so SC2329's direct-call heuristic is noisy."
-  - side: shellcheck-only
-    path_contains: "gentoo__gentoo__"
-    reason: "These Gentoo helper scripts expose externally-called hooks rather than direct in-file calls, so SC2329 is not a useful oracle here."
-  - side: shellcheck-only
-    path_contains: "community-scripts__ProxmoxVE__"
-    reason: "These ProxmoxVE provisioning scripts wire steps and hooks dynamically across sourced helpers, which SC2329 does not track."
-  - side: shellcheck-only
-    path_contains: "233boy__v2ray__install.sh"
-    reason: "This installer drives menu and action helpers indirectly, so SC2329 overstates dead definitions."
-  - side: shellcheck-only
-    path_contains: "termux__termux-packages__"
-    reason: "Termux build scripts intentionally override and invoke package hooks through the build framework rather than direct calls, so SC2329 is noisy here."
-  - side: shellcheck-only
-    path_contains: "openvpn__easy-rsa__"
-    reason: "easy-rsa reaches its sourced command helpers through framework dispatch and generated command tables rather than explicit in-file calls."
-  - side: shellcheck-only
-    path_contains: "pyenv__pyenv__"
-    reason: "These pyenv test and install helpers are selected indirectly through the harness, so SC2329 overstates dead definitions."
-  - side: shellcheck-only
-    path_contains: "dylanaraps__neofetch__"
-    reason: "These temporary helper overrides are intentional rendering-path switches rather than dead definitions."
-  - side: shellcheck-only
-    path_contains: "docker-mailserver__docker-mailserver__"
-    reason: "These setup hooks are invoked by the surrounding entrypoint framework rather than direct in-file calls."
-  - side: shellcheck-only
-    path_contains: "dehydrated-io__dehydrated__"
-    reason: "Dehydrated hook entrypoints are selected externally, so SC2329's direct-call heuristic is noisy."
-  - side: shellcheck-only
-    path_contains: "HariSekhon__DevOps-Bash-tools__"
-    reason: "These dotfile and helper libraries rely on sourced dispatch and compatibility wrappers, which SC2329 does not model."
-  - side: shellcheck-only
-    path_contains: "tj__git-extras__bin__git-sed"
-    reason: "git-extras command helpers are selected by the surrounding Git wrapper, not explicit in-file calls."
-  - side: shellcheck-only
-    path_contains: "spiritLHLS__one-click-installation-script"
-    reason: "This installer chooses action helpers dynamically from user input and environment, which SC2329 does not track."
-  - side: shellcheck-only
-    path_contains: "romkatv__powerlevel10k__"
-    reason: "This generated installer script defines helpers for externally-driven invocation, which SC2329 treats as dead."
-  - side: shellcheck-only
-    path_contains: "google__oss-fuzz__"
-    reason: "This build wrapper defines helper entrypoints for the surrounding fuzzing harness rather than direct in-file calls."
-  - side: shellcheck-only
-    path_contains: "asdf-vm__asdf__"
-    reason: "asdf command handlers are reached through plugin dispatch, not explicit in-file calls."
-  - side: shellcheck-only
-    path_contains: "GameServerManagers__LinuxGSM__"
-    reason: "LinuxGSM selects module helpers through the surrounding game-server framework, so SC2329's direct-call heuristic is noisy."
-  - side: shellcheck-only
-    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
-    reason: "RetroPie's runcommand script dispatches mode-processing helpers indirectly from the active video-stack selection, so SC2329 overstates dead definitions."
-  - side: shellcheck-only
-    path_suffix: "alpinelinux__aports__main__libmaxminddb__libmaxminddb.cron"
-    line: 13
-    reason: "This cleanup helper is wired to a trap and invoked on shell exit, so it is not a dead definition."
-  - side: shellcheck-only
-    path_suffix: "nvm-sh__nvm__update_test_mocks.sh"
-    line: 18
-    reason: "This first nvm_make_alias mock is intentionally replaced later after the initial fixture batch is generated, so the overwrite is part of the mock-generation flow."
-  - side: shellcheck-only
-    path_suffix: "tj__git-extras__bin__git-rebase-patch"
-    line: 19
-    reason: "This cleanup helper is wired to an interrupt trap and invoked externally by the shell when the trap fires."
+    end_line: 15578
+    column: 3
+    end_column: 4
+    reason: "Backlog: this large dispatcher defines a nested `_env_max_version` helper inside `_env`; ShellCheck does not flag this exact helper even though shuck still treats it as an uncalled nested definition. Keep the remaining C063 divergence scoped to this single corpus span."

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -533,23 +533,27 @@ fn collect_condition_status_capture_from_sequence_segment(
     trailing_tail_has_test: bool,
     has_prior_barrier: bool,
 ) {
+    let tail_contains_test = sequence_tail_test_index(commands, source);
+    let mut recent = RecentSequenceStatus::default();
     for (index, window) in commands.windows(2).enumerate() {
         let [previous, current] = window else {
             continue;
         };
-        let recent = recent_sequence_region(&commands[..index], source);
-        let tail = &commands[index + 2..];
-        let effective_tail_has_test =
-            trailing_tail_has_test || sequence_tail_contains_test_command(tail, source);
-        let in_tbegin_region = commands[..index]
-            .iter()
-            .any(|stmt| stmt_is_named_simple_command(stmt, source, "tbegin"));
+        if index > 0 {
+            recent.push(&commands[index - 1], source);
+        }
+        let tail_has_test = tail_contains_test
+            .get(index + 2)
+            .copied()
+            .unwrap_or(false);
+        let effective_tail_has_test = trailing_tail_has_test || tail_has_test;
+        let in_tbegin_region = recent.seen_tbegin;
 
         if stmt_is_assignment_only_unquoted_status_capture(current) {
             if stmt_is_standalone_non_status_test_command(previous, source)
                 && in_tbegin_region
-                && recent_status_capture_stmt_count(recent, source) >= 2
-                && sequence_tail_contains_test_command(tail, source)
+                && recent.status_capture_count >= 2
+                && tail_has_test
             {
                 collect_status_parameter_spans_in_stmt(current, source, spans);
             }
@@ -561,8 +565,7 @@ fn collect_condition_status_capture_from_sequence_segment(
         }
 
         if stmt_is_status_based_test_command(previous, source) {
-            if (!has_prior_barrier && effective_tail_has_test)
-                || recent_contains_status_based_test(recent, source)
+            if (!has_prior_barrier && effective_tail_has_test) || recent.contains_status_based_test
             {
                 collect_status_parameter_spans_in_stmt(current, source, spans);
             }
@@ -574,7 +577,7 @@ fn collect_condition_status_capture_from_sequence_segment(
         }
 
         if in_tbegin_region
-            && recent_has_prior_non_status_capture_pair(recent, source)
+            && recent.has_prior_non_status_capture_pair
         {
             continue;
         }
@@ -585,10 +588,50 @@ fn collect_condition_status_capture_from_sequence_segment(
     }
 }
 
-fn sequence_tail_contains_test_command(commands: &[Stmt], source: &str) -> bool {
-    commands
-        .iter()
-        .any(|stmt| stmt_terminals_are_test_commands(stmt, source))
+#[derive(Default)]
+struct RecentSequenceStatus<'a> {
+    seen_tbegin: bool,
+    status_capture_count: usize,
+    contains_status_based_test: bool,
+    has_prior_non_status_capture_pair: bool,
+    last_stmt: Option<&'a Stmt>,
+}
+
+impl<'a> RecentSequenceStatus<'a> {
+    fn push(&mut self, stmt: &'a Stmt, source: &str) {
+        if stmt_is_named_simple_command(stmt, source, "tbegin") {
+            self.seen_tbegin = true;
+            self.status_capture_count = 0;
+            self.contains_status_based_test = false;
+            self.has_prior_non_status_capture_pair = false;
+            self.last_stmt = None;
+            return;
+        }
+
+        let contains_status_capture = stmt_contains_status_capture(stmt, source);
+        if self
+            .last_stmt
+            .is_some_and(|previous| stmt_is_standalone_non_status_test_command(previous, source))
+            && contains_status_capture
+        {
+            self.has_prior_non_status_capture_pair = true;
+        }
+        if contains_status_capture {
+            self.status_capture_count += 1;
+        }
+        if stmt_is_status_based_test_command(stmt, source) {
+            self.contains_status_based_test = true;
+        }
+        self.last_stmt = Some(stmt);
+    }
+}
+
+fn sequence_tail_test_index(commands: &[Stmt], source: &str) -> Vec<bool> {
+    let mut suffix = vec![false; commands.len() + 1];
+    for (index, stmt) in commands.iter().enumerate().rev() {
+        suffix[index] = suffix[index + 1] || stmt_terminals_are_test_commands(stmt, source);
+    }
+    suffix
 }
 
 fn sequence_tail_contains_nested_test_command(commands: &[Stmt], source: &str) -> bool {
@@ -1348,20 +1391,6 @@ fn stmt_contains_unquoted_standalone_status_capture(stmt: &Stmt, source: &str) -
     !spans.is_empty()
 }
 
-fn recent_sequence_region<'a>(commands: &'a [Stmt], source: &str) -> &'a [Stmt] {
-    let start = commands
-        .iter()
-        .rposition(|stmt| stmt_is_named_simple_command(stmt, source, "tbegin"))
-        .map_or(0, |index| index + 1);
-    &commands[start..]
-}
-
-fn recent_contains_status_based_test(commands: &[Stmt], source: &str) -> bool {
-    commands
-        .iter()
-        .any(|stmt| stmt_is_status_based_test_command(stmt, source))
-}
-
 fn stmt_starts_sequence_barrier(stmt: &Stmt) -> bool {
     matches!(
         &stmt.command,
@@ -1426,23 +1455,6 @@ fn assignment_value_is_unquoted_status_capture(value: &AssignmentValue) -> bool 
         AssignmentValue::Scalar(word) => word_is_unquoted_standalone_status_capture(word),
         AssignmentValue::Compound(_) => false,
     }
-}
-
-fn recent_has_prior_non_status_capture_pair(commands: &[Stmt], source: &str) -> bool {
-    commands.windows(2).any(|window| {
-        let [previous, current] = window else {
-            return false;
-        };
-        stmt_is_standalone_non_status_test_command(previous, source)
-            && stmt_contains_status_capture(current, source)
-    })
-}
-
-fn recent_status_capture_stmt_count(commands: &[Stmt], source: &str) -> usize {
-    commands
-        .iter()
-        .filter(|stmt| stmt_contains_status_capture(stmt, source))
-        .count()
 }
 
 fn stmt_is_exit_or_return_builtin(stmt: &Stmt) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,8 +1,10 @@
 use crate::context::FileContextTag;
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::static_word_text;
 use shuck_semantic::{
-    BindingKind, BindingOrigin, OverwrittenFunction as SemanticOverwrittenFunction,
-    UnreachedFunction as SemanticUnreachedFunction, UnreachedFunctionReason,
+    BindingKind, BindingOrigin, OverwrittenFunction as SemanticOverwrittenFunction, ScopeId,
+    ScopeKind, UnreachedFunction as SemanticUnreachedFunction, UnreachedFunctionReason,
 };
 
 #[derive(Clone, Copy)]
@@ -11,6 +13,7 @@ pub enum FunctionNotReachedReason {
     ScriptTerminates,
     UnreachableDefinition,
     EnclosingFunctionUnreached,
+    Removed,
 }
 
 pub struct OverwrittenFunction {
@@ -40,6 +43,10 @@ impl Violation for OverwrittenFunction {
                 "function `{}` cannot be reached by a direct call before the enclosing function exits",
                 self.name
             ),
+            FunctionNotReachedReason::Removed => format!(
+                "function `{}` is removed before any direct call can reach it",
+                self.name
+            ),
         }
     }
 
@@ -55,6 +62,9 @@ impl Violation for OverwrittenFunction {
             FunctionNotReachedReason::EnclosingFunctionUnreached => {
                 Some("delete the nested function definition that cannot be reached".to_owned())
             }
+            FunctionNotReachedReason::Removed => {
+                Some("delete the function definition that is removed before use".to_owned())
+            }
         }
     }
 }
@@ -65,9 +75,22 @@ pub fn overwritten_function(checker: &mut Checker) {
         .semantic_analysis()
         .unreached_functions_with_options(checker.rule_options().c063.semantic_options())
         .to_vec();
+    let compat_mode = checker
+        .rule_options()
+        .c063
+        .report_unreached_nested_definitions;
 
     for overwritten in overwritten {
-        if overwritten.first_called {
+        let second = checker.semantic().binding(overwritten.second);
+        if compat_mode {
+            if has_direct_call_to_binding_before_offset(
+                checker,
+                overwritten.first,
+                second.span.start.offset,
+            ) {
+                continue;
+            }
+        } else if overwritten.first_called {
             continue;
         }
         if should_suppress_overwrite(checker, &overwritten) {
@@ -103,6 +126,992 @@ pub fn overwritten_function(checker: &mut Checker) {
             reason,
         );
     }
+
+    if checker
+        .rule_options()
+        .c063
+        .report_unreached_nested_definitions
+    {
+        report_compat_cutoff_function_definitions(checker);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FunctionCutoff {
+    offset: usize,
+    reason: FunctionNotReachedReason,
+}
+
+#[derive(Clone, Copy)]
+struct CompatCallFact {
+    scope: ScopeId,
+    span: shuck_ast::Span,
+}
+
+#[derive(Clone, Copy)]
+struct CompatUnsetCommandFact {
+    scope: ScopeId,
+    offset: usize,
+}
+
+type CompatCallFactsByName = FxHashMap<String, Vec<CompatCallFact>>;
+type CompatFunctionBindingsByScope = FxHashMap<ScopeId, Vec<shuck_semantic::BindingId>>;
+type CompatUnsetCommandsByTarget = FxHashMap<String, Vec<CompatUnsetCommandFact>>;
+type CompatUnsetterFunctionsByTarget = FxHashMap<String, Vec<shuck_ast::Name>>;
+
+struct CompatUnsetFacts {
+    commands_by_target: CompatUnsetCommandsByTarget,
+    functions_by_target: CompatUnsetterFunctionsByTarget,
+}
+
+struct CompatReachState<'a> {
+    scope_run_cache: &'a mut FxHashMap<(ScopeId, usize), bool>,
+    scope_between_cache: &'a mut FxHashMap<(ScopeId, usize, usize), bool>,
+    call_facts_by_name: &'a CompatCallFactsByName,
+    function_bindings_by_scope: &'a CompatFunctionBindingsByScope,
+}
+
+fn build_compat_call_facts_by_name(checker: &Checker<'_>) -> CompatCallFactsByName {
+    let mut calls = CompatCallFactsByName::default();
+    for fact in checker.facts().structural_commands() {
+        if matches!(fact.command(), shuck_ast::Command::Function(_)) {
+            continue;
+        }
+        let Some(name) = fact.effective_name() else {
+            continue;
+        };
+        calls
+            .entry(name.to_owned())
+            .or_default()
+            .push(CompatCallFact {
+                scope: checker.semantic().scope_at(fact.body_span().start.offset),
+                span: fact.body_span(),
+            });
+    }
+    calls
+}
+
+fn build_compat_function_bindings_by_scope(checker: &Checker<'_>) -> CompatFunctionBindingsByScope {
+    let mut bindings = CompatFunctionBindingsByScope::default();
+    for header in checker.facts().function_headers() {
+        let (Some(scope), Some(binding_id)) = (header.function_scope(), header.binding_id()) else {
+            continue;
+        };
+        bindings.entry(scope).or_default().push(binding_id);
+    }
+    bindings
+}
+
+fn build_compat_unset_facts(
+    checker: &Checker<'_>,
+    function_bindings_by_scope: &CompatFunctionBindingsByScope,
+) -> CompatUnsetFacts {
+    let mut function_names_by_scope = FxHashMap::<ScopeId, Vec<shuck_ast::Name>>::default();
+    for (scope, binding_ids) in function_bindings_by_scope {
+        for binding_id in binding_ids {
+            let binding = checker.semantic().binding(*binding_id);
+            function_names_by_scope
+                .entry(*scope)
+                .or_default()
+                .push(binding.name.clone());
+        }
+    }
+
+    let mut commands_by_target = CompatUnsetCommandsByTarget::default();
+    let mut function_targets = FxHashMap::<String, FxHashSet<shuck_ast::Name>>::default();
+    for fact in checker.facts().structural_commands() {
+        if !fact.effective_name_is("unset") {
+            continue;
+        }
+        let Some(unset) = fact.options().unset() else {
+            continue;
+        };
+        if !unset.function_mode || !unset.options_parseable() {
+            continue;
+        }
+
+        let mut targets = Vec::new();
+        for word in unset.operand_words() {
+            let Some(text) = static_word_text(word, checker.source()) else {
+                break;
+            };
+            let target = text.into_owned();
+            if !targets.contains(&target) {
+                targets.push(target);
+            }
+        }
+
+        if targets.is_empty() {
+            continue;
+        }
+
+        let offset = fact.body_span().start.offset;
+        if command_offset_is_under_dominance_barrier(checker, offset)
+            || command_offset_is_unreachable(checker, offset)
+        {
+            continue;
+        }
+        let scope = checker.semantic().scope_at(offset);
+        let command_fact = CompatUnsetCommandFact { scope, offset };
+        for target in targets {
+            commands_by_target
+                .entry(target.clone())
+                .or_default()
+                .push(command_fact);
+            if let Some(function_scope) = enclosing_function_scope(checker, scope)
+                && let Some(function_names) = function_names_by_scope.get(&function_scope)
+            {
+                function_targets
+                    .entry(target.clone())
+                    .or_default()
+                    .extend(function_names.iter().cloned());
+            }
+        }
+    }
+
+    let functions_by_target = function_targets
+        .into_iter()
+        .map(|(target, names)| (target, names.into_iter().collect()))
+        .collect();
+
+    CompatUnsetFacts {
+        commands_by_target,
+        functions_by_target,
+    }
+}
+
+fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
+    let mut scope_run_cache = FxHashMap::default();
+    let mut scope_between_cache = FxHashMap::default();
+    let call_facts_by_name = build_compat_call_facts_by_name(checker);
+    let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
+    let unset_facts = build_compat_unset_facts(checker, &function_bindings_by_scope);
+    let mut reach = CompatReachState {
+        scope_run_cache: &mut scope_run_cache,
+        scope_between_cache: &mut scope_between_cache,
+        call_facts_by_name: &call_facts_by_name,
+        function_bindings_by_scope: &function_bindings_by_scope,
+    };
+    let candidates = checker
+        .semantic()
+        .bindings()
+        .iter()
+        .filter(|binding| matches!(binding.kind, BindingKind::FunctionDefinition))
+        .filter(|binding| !matches!(binding.kind, BindingKind::Imported))
+        .filter_map(|binding| {
+            let cutoff =
+                first_compat_cutoff_after_binding(checker, binding.id, &mut reach, &unset_facts)?;
+            (!has_direct_call_to_binding_before_offset_cached(
+                checker,
+                binding.id,
+                cutoff.offset,
+                &mut reach,
+            ))
+            .then(|| (binding.id, binding.name.to_string(), cutoff.reason))
+        })
+        .collect::<Vec<_>>();
+
+    for (binding_id, name, reason) in candidates {
+        report_function_definition(checker, binding_id, name, reason);
+    }
+}
+
+fn first_compat_cutoff_after_binding(
+    checker: &Checker<'_>,
+    binding_id: shuck_semantic::BindingId,
+    reach: &mut CompatReachState<'_>,
+    unset_facts: &CompatUnsetFacts,
+) -> Option<FunctionCutoff> {
+    let binding = checker.semantic().binding(binding_id);
+    let binding_offset = binding.span.start.offset;
+
+    let mut cutoffs = Vec::new();
+    cutoffs.extend(
+        unset_function_cutoff_offsets(
+            checker,
+            binding.name.as_str(),
+            binding_offset,
+            reach,
+            unset_facts,
+        )
+        .into_iter()
+        .map(|offset| FunctionCutoff {
+            offset,
+            reason: FunctionNotReachedReason::Removed,
+        }),
+    );
+    if !binding_definition_is_under_dominance_barrier(checker, binding_id) {
+        cutoffs.extend(
+            compat_script_terminator_offsets(checker, binding_id, binding_offset, reach)
+                .into_iter()
+                .map(|offset| FunctionCutoff {
+                    offset,
+                    reason: FunctionNotReachedReason::ScriptTerminates,
+                }),
+        );
+    }
+    let cutoff = cutoffs.into_iter().min_by_key(|cutoff| cutoff.offset)?;
+    if matches!(cutoff.reason, FunctionNotReachedReason::ScriptTerminates)
+        && has_apparent_infinite_loop_between(checker, binding_offset, cutoff.offset)
+    {
+        return None;
+    }
+    if matches!(cutoff.reason, FunctionNotReachedReason::ScriptTerminates)
+        && has_top_level_return_between(checker, binding_offset, cutoff.offset)
+    {
+        return None;
+    }
+
+    Some(cutoff)
+}
+
+fn binding_definition_is_under_dominance_barrier(
+    checker: &Checker<'_>,
+    binding_id: shuck_semantic::BindingId,
+) -> bool {
+    let binding = checker.semantic().binding(binding_id);
+    let definition_span = match &binding.origin {
+        BindingOrigin::FunctionDefinition { definition_span } => *definition_span,
+        _ => binding.span,
+    };
+    command_offset_is_under_dominance_barrier(checker, definition_span.start.offset)
+}
+
+fn unset_function_cutoff_offsets(
+    checker: &Checker<'_>,
+    name: &str,
+    after_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    unset_facts: &CompatUnsetFacts,
+) -> Vec<usize> {
+    let mut offsets = unset_facts
+        .commands_by_target
+        .get(name)
+        .into_iter()
+        .flat_map(|facts| facts.iter())
+        .filter(|fact| {
+            fact.offset > after_offset
+                && !command_offset_is_under_dominance_barrier(checker, fact.offset)
+                && command_scope_can_run_persistently_before_offset(
+                    checker,
+                    fact.scope,
+                    fact.offset,
+                    reach,
+                    &mut FxHashSet::default(),
+                )
+        })
+        .map(|fact| fact.offset)
+        .collect::<Vec<_>>();
+
+    for unsetter in unset_facts
+        .functions_by_target
+        .get(name)
+        .into_iter()
+        .flat_map(|names| names.iter())
+    {
+        offsets.extend(
+            checker
+                .semantic()
+                .call_sites_for(unsetter)
+                .iter()
+                .filter(|site| site.name_span.start.offset > after_offset)
+                .filter(|site| {
+                    !command_offset_is_under_dominance_barrier(checker, site.name_span.start.offset)
+                })
+                .filter(|site| {
+                    command_scope_can_run_persistently_before_offset(
+                        checker,
+                        site.scope,
+                        site.name_span.start.offset,
+                        reach,
+                        &mut FxHashSet::default(),
+                    )
+                })
+                .map(|site| site.name_span.start.offset),
+        );
+    }
+
+    offsets
+}
+
+fn command_offset_is_under_dominance_barrier(checker: &Checker<'_>, offset: usize) -> bool {
+    let Some(mut command_id) = checker.facts().innermost_command_id_at(offset) else {
+        return false;
+    };
+
+    loop {
+        if checker.facts().command_is_dominance_barrier(command_id) {
+            return true;
+        }
+        let Some(parent_id) = checker.facts().command_parent_id(command_id) else {
+            return false;
+        };
+        command_id = parent_id;
+    }
+}
+
+fn command_offset_is_unreachable(checker: &Checker<'_>, offset: usize) -> bool {
+    let cfg = checker.semantic_analysis().cfg();
+    cfg.unreachable().iter().any(|block_id| {
+        cfg.block(*block_id)
+            .commands
+            .iter()
+            .any(|span| span.start.offset == offset)
+    })
+}
+
+fn compat_script_terminator_offsets(
+    checker: &Checker<'_>,
+    binding_id: shuck_semantic::BindingId,
+    after_offset: usize,
+    reach: &mut CompatReachState<'_>,
+) -> Vec<usize> {
+    let cfg = checker.semantic_analysis().cfg();
+    let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+    let binding = checker.semantic().binding(binding_id);
+    let binding_is_file_scope = scope_is_file_scope(checker, binding.scope);
+
+    cfg.script_terminators()
+        .iter()
+        .filter(|block_id| !unreachable.contains(block_id))
+        .flat_map(|block_id| cfg.block(*block_id).commands.iter())
+        .filter_map(|span| {
+            let offset = span.start.offset;
+            let terminator_scope = checker.semantic().scope_at(offset);
+            (offset > after_offset
+                && !scope_has_transient_ancestor(checker, terminator_scope)
+                && terminator_scope_can_cut_off_binding(
+                    checker,
+                    binding.scope,
+                    binding_is_file_scope,
+                    terminator_scope,
+                    offset,
+                    reach,
+                )
+                && !span_starts_function_definition_command(checker, offset)
+                && !span_starts_command_named(checker, offset, "return"))
+            .then_some(offset)
+        })
+        .max()
+        .into_iter()
+        .collect()
+}
+
+fn terminator_scope_can_cut_off_binding(
+    checker: &Checker<'_>,
+    binding_scope: ScopeId,
+    binding_is_file_scope: bool,
+    terminator_scope: ScopeId,
+    terminator_offset: usize,
+    reach: &mut CompatReachState<'_>,
+) -> bool {
+    if binding_is_file_scope && !checker.semantic_analysis().cfg().script_always_terminates() {
+        return false;
+    }
+
+    command_scope_can_run_before_offset(
+        checker,
+        binding_scope,
+        terminator_offset,
+        reach,
+        &mut FxHashSet::default(),
+    ) && command_scope_can_run_before_offset(
+        checker,
+        terminator_scope,
+        terminator_offset,
+        reach,
+        &mut FxHashSet::default(),
+    )
+}
+
+fn scope_is_file_scope(checker: &Checker<'_>, scope: ScopeId) -> bool {
+    checker.semantic().scope(scope).parent.is_none()
+}
+
+fn scope_has_transient_ancestor(checker: &Checker<'_>, scope: ScopeId) -> bool {
+    checker.semantic().ancestor_scopes(scope).any(|scope_id| {
+        matches!(
+            checker.semantic().scope_kind(scope_id),
+            ScopeKind::Subshell | ScopeKind::CommandSubstitution | ScopeKind::Pipeline
+        )
+    })
+}
+
+fn span_starts_function_definition_command(checker: &Checker<'_>, offset: usize) -> bool {
+    checker.facts().structural_commands().any(|fact| {
+        fact.body_span().start.offset == offset
+            && matches!(fact.command(), shuck_ast::Command::Function(_))
+    })
+}
+
+fn span_starts_command_named(checker: &Checker<'_>, offset: usize, name: &str) -> bool {
+    checker
+        .facts()
+        .structural_commands()
+        .any(|fact| fact.body_span().start.offset == offset && fact.effective_name_is(name))
+}
+
+fn has_direct_call_to_binding_before_offset(
+    checker: &Checker<'_>,
+    binding_id: shuck_semantic::BindingId,
+    before_offset: usize,
+) -> bool {
+    let mut scope_run_cache = FxHashMap::default();
+    let mut scope_between_cache = FxHashMap::default();
+    let call_facts_by_name = build_compat_call_facts_by_name(checker);
+    let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
+    let mut reach = CompatReachState {
+        scope_run_cache: &mut scope_run_cache,
+        scope_between_cache: &mut scope_between_cache,
+        call_facts_by_name: &call_facts_by_name,
+        function_bindings_by_scope: &function_bindings_by_scope,
+    };
+    has_direct_call_to_binding_before_offset_cached(checker, binding_id, before_offset, &mut reach)
+}
+
+fn has_direct_call_to_binding_before_offset_cached(
+    checker: &Checker<'_>,
+    binding_id: shuck_semantic::BindingId,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+) -> bool {
+    let binding = checker.semantic().binding(binding_id);
+    let mut visiting = FxHashSet::default();
+    reach
+        .call_facts_by_name
+        .get(binding.name.as_str())
+        .into_iter()
+        .flat_map(|facts| facts.iter())
+        .any(|fact| {
+            !call_has_visible_shadowing_function_definition(
+                checker, binding_id, fact.scope, fact.span,
+            ) && call_can_reach_binding_before_offset(
+                checker,
+                fact.scope,
+                fact.span.start.offset,
+                binding.span.start.offset,
+                before_offset,
+                reach,
+                &mut visiting,
+            )
+        })
+        || checker
+            .semantic()
+            .call_sites_for(&binding.name)
+            .iter()
+            .any(|site| {
+                !call_has_visible_shadowing_function_definition(
+                    checker,
+                    binding_id,
+                    site.scope,
+                    site.name_span,
+                ) && call_can_reach_binding_before_offset(
+                    checker,
+                    site.scope,
+                    site.name_span.start.offset,
+                    binding.span.start.offset,
+                    before_offset,
+                    reach,
+                    &mut visiting,
+                )
+            })
+}
+
+fn call_can_reach_binding_before_offset(
+    checker: &Checker<'_>,
+    call_scope: ScopeId,
+    call_offset: usize,
+    binding_offset: usize,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    if call_offset > before_offset {
+        return false;
+    }
+
+    call_scope_can_execute_after_offset_before_offset(
+        checker,
+        call_scope,
+        call_offset,
+        binding_offset,
+        before_offset,
+        reach,
+        visiting,
+    )
+}
+
+fn command_scope_can_run_between_offsets(
+    checker: &Checker<'_>,
+    scope: ScopeId,
+    after_offset: usize,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    let Some(function_scope) = enclosing_function_scope(checker, scope) else {
+        return true;
+    };
+    if !visiting.contains(&function_scope)
+        && let Some(cached) =
+            reach
+                .scope_between_cache
+                .get(&(function_scope, after_offset, before_offset))
+    {
+        return *cached;
+    }
+    if !visiting.insert(function_scope) {
+        return false;
+    }
+
+    let can_run = reach
+        .function_bindings_by_scope
+        .get(&function_scope)
+        .into_iter()
+        .flat_map(|bindings| bindings.iter())
+        .any(|function_binding| {
+            has_call_to_function_binding_between_offsets(
+                checker,
+                *function_binding,
+                after_offset,
+                before_offset,
+                reach,
+                visiting,
+            )
+        });
+
+    visiting.remove(&function_scope);
+    reach
+        .scope_between_cache
+        .insert((function_scope, after_offset, before_offset), can_run);
+    can_run
+}
+
+fn has_call_to_function_binding_between_offsets(
+    checker: &Checker<'_>,
+    function_binding: shuck_semantic::BindingId,
+    after_offset: usize,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    let binding = checker.semantic().binding(function_binding);
+    let required_after = after_offset.max(binding.span.start.offset);
+    reach
+        .call_facts_by_name
+        .get(binding.name.as_str())
+        .into_iter()
+        .flat_map(|facts| facts.iter())
+        .any(|fact| {
+            let call_offset = fact.span.start.offset;
+            call_offset <= before_offset
+                && !call_has_visible_shadowing_function_definition(
+                    checker,
+                    function_binding,
+                    fact.scope,
+                    fact.span,
+                )
+                && call_scope_can_execute_after_offset_before_offset(
+                    checker,
+                    fact.scope,
+                    call_offset,
+                    required_after,
+                    before_offset,
+                    reach,
+                    visiting,
+                )
+        })
+        || checker
+            .semantic()
+            .call_sites_for(&binding.name)
+            .iter()
+            .any(|site| {
+                let call_offset = site.name_span.start.offset;
+                call_offset <= before_offset
+                    && !call_has_visible_shadowing_function_definition(
+                        checker,
+                        function_binding,
+                        site.scope,
+                        site.name_span,
+                    )
+                    && call_scope_can_execute_after_offset_before_offset(
+                        checker,
+                        site.scope,
+                        call_offset,
+                        required_after,
+                        before_offset,
+                        reach,
+                        visiting,
+                    )
+            })
+}
+
+fn command_scope_can_run_before_offset(
+    checker: &Checker<'_>,
+    scope: ScopeId,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    let Some(function_scope) = enclosing_function_scope(checker, scope) else {
+        return true;
+    };
+    if !visiting.contains(&function_scope)
+        && let Some(cached) = reach.scope_run_cache.get(&(function_scope, before_offset))
+    {
+        return *cached;
+    }
+    if !visiting.insert(function_scope) {
+        return false;
+    }
+
+    let can_run = reach
+        .function_bindings_by_scope
+        .get(&function_scope)
+        .into_iter()
+        .flat_map(|bindings| bindings.iter())
+        .any(|function_binding| {
+            has_call_to_function_binding_before_offset(
+                checker,
+                *function_binding,
+                before_offset,
+                reach,
+                visiting,
+            )
+        });
+
+    visiting.remove(&function_scope);
+    reach
+        .scope_run_cache
+        .insert((function_scope, before_offset), can_run);
+    can_run
+}
+
+fn command_scope_can_run_persistently_before_offset(
+    checker: &Checker<'_>,
+    scope: ScopeId,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    if scope_has_transient_ancestor(checker, scope) {
+        return false;
+    }
+    let Some(function_scope) = enclosing_function_scope(checker, scope) else {
+        return true;
+    };
+    if !visiting.insert(function_scope) {
+        return false;
+    }
+
+    let can_run = reach
+        .function_bindings_by_scope
+        .get(&function_scope)
+        .into_iter()
+        .flat_map(|bindings| bindings.iter())
+        .any(|function_binding| {
+            has_persistent_call_to_function_binding_before_offset(
+                checker,
+                *function_binding,
+                before_offset,
+                reach,
+                visiting,
+            )
+        });
+
+    visiting.remove(&function_scope);
+    can_run
+}
+
+fn has_persistent_call_to_function_binding_before_offset(
+    checker: &Checker<'_>,
+    function_binding: shuck_semantic::BindingId,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    let binding = checker.semantic().binding(function_binding);
+    reach
+        .call_facts_by_name
+        .get(binding.name.as_str())
+        .into_iter()
+        .flat_map(|facts| facts.iter())
+        .any(|fact| {
+            fact.span.start.offset <= before_offset
+                && !call_has_visible_shadowing_function_definition(
+                    checker,
+                    function_binding,
+                    fact.scope,
+                    fact.span,
+                )
+                && call_scope_can_execute_persistently_after_offset_before_offset(
+                    checker,
+                    fact.scope,
+                    fact.span.start.offset,
+                    binding.span.start.offset,
+                    before_offset,
+                    reach,
+                    visiting,
+                )
+        })
+        || checker
+            .semantic()
+            .call_sites_for(&binding.name)
+            .iter()
+            .any(|site| {
+                site.name_span.start.offset <= before_offset
+                    && !call_has_visible_shadowing_function_definition(
+                        checker,
+                        function_binding,
+                        site.scope,
+                        site.name_span,
+                    )
+                    && call_scope_can_execute_persistently_after_offset_before_offset(
+                        checker,
+                        site.scope,
+                        site.name_span.start.offset,
+                        binding.span.start.offset,
+                        before_offset,
+                        reach,
+                        visiting,
+                    )
+            })
+}
+
+fn command_scope_can_run_persistently_between_offsets(
+    checker: &Checker<'_>,
+    scope: ScopeId,
+    after_offset: usize,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    if scope_has_transient_ancestor(checker, scope) {
+        return false;
+    }
+    let Some(function_scope) = enclosing_function_scope(checker, scope) else {
+        return true;
+    };
+    if !visiting.insert(function_scope) {
+        return false;
+    }
+
+    let can_run = reach
+        .function_bindings_by_scope
+        .get(&function_scope)
+        .into_iter()
+        .flat_map(|bindings| bindings.iter())
+        .any(|function_binding| {
+            has_persistent_call_to_function_binding_between_offsets(
+                checker,
+                *function_binding,
+                after_offset,
+                before_offset,
+                reach,
+                visiting,
+            )
+        });
+
+    visiting.remove(&function_scope);
+    can_run
+}
+
+fn has_persistent_call_to_function_binding_between_offsets(
+    checker: &Checker<'_>,
+    function_binding: shuck_semantic::BindingId,
+    after_offset: usize,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    let binding = checker.semantic().binding(function_binding);
+    let required_after = after_offset.max(binding.span.start.offset);
+    reach
+        .call_facts_by_name
+        .get(binding.name.as_str())
+        .into_iter()
+        .flat_map(|facts| facts.iter())
+        .any(|fact| {
+            let call_offset = fact.span.start.offset;
+            call_offset <= before_offset
+                && !call_has_visible_shadowing_function_definition(
+                    checker,
+                    function_binding,
+                    fact.scope,
+                    fact.span,
+                )
+                && call_scope_can_execute_persistently_after_offset_before_offset(
+                    checker,
+                    fact.scope,
+                    call_offset,
+                    required_after,
+                    before_offset,
+                    reach,
+                    visiting,
+                )
+        })
+        || checker
+            .semantic()
+            .call_sites_for(&binding.name)
+            .iter()
+            .any(|site| {
+                let call_offset = site.name_span.start.offset;
+                call_offset <= before_offset
+                    && !call_has_visible_shadowing_function_definition(
+                        checker,
+                        function_binding,
+                        site.scope,
+                        site.name_span,
+                    )
+                    && call_scope_can_execute_persistently_after_offset_before_offset(
+                        checker,
+                        site.scope,
+                        call_offset,
+                        required_after,
+                        before_offset,
+                        reach,
+                        visiting,
+                    )
+            })
+}
+
+fn call_scope_can_execute_persistently_after_offset_before_offset(
+    checker: &Checker<'_>,
+    call_scope: ScopeId,
+    call_offset: usize,
+    after_offset: usize,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    if call_offset > before_offset || scope_has_transient_ancestor(checker, call_scope) {
+        return false;
+    }
+
+    if enclosing_function_scope(checker, call_scope).is_none() {
+        return call_offset > after_offset;
+    }
+
+    command_scope_can_run_persistently_between_offsets(
+        checker,
+        call_scope,
+        after_offset,
+        before_offset,
+        reach,
+        visiting,
+    )
+}
+
+fn has_call_to_function_binding_before_offset(
+    checker: &Checker<'_>,
+    function_binding: shuck_semantic::BindingId,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    let binding = checker.semantic().binding(function_binding);
+    reach
+        .call_facts_by_name
+        .get(binding.name.as_str())
+        .into_iter()
+        .flat_map(|facts| facts.iter())
+        .any(|fact| {
+            fact.span.start.offset <= before_offset
+                && !call_has_visible_shadowing_function_definition(
+                    checker,
+                    function_binding,
+                    fact.scope,
+                    fact.span,
+                )
+                && call_scope_can_execute_after_offset_before_offset(
+                    checker,
+                    fact.scope,
+                    fact.span.start.offset,
+                    binding.span.start.offset,
+                    before_offset,
+                    reach,
+                    visiting,
+                )
+        })
+        || checker
+            .semantic()
+            .call_sites_for(&binding.name)
+            .iter()
+            .any(|site| {
+                site.name_span.start.offset <= before_offset
+                    && !call_has_visible_shadowing_function_definition(
+                        checker,
+                        function_binding,
+                        site.scope,
+                        site.name_span,
+                    )
+                    && call_scope_can_execute_after_offset_before_offset(
+                        checker,
+                        site.scope,
+                        site.name_span.start.offset,
+                        binding.span.start.offset,
+                        before_offset,
+                        reach,
+                        visiting,
+                    )
+            })
+}
+
+fn call_has_visible_shadowing_function_definition(
+    checker: &Checker<'_>,
+    binding_id: shuck_semantic::BindingId,
+    call_scope: ScopeId,
+    call_span: shuck_ast::Span,
+) -> bool {
+    let binding = checker.semantic().binding(binding_id);
+    checker
+        .semantic()
+        .visible_binding(&binding.name, call_span)
+        .is_some_and(|visible| {
+            visible.id != binding_id
+                && matches!(visible.kind, BindingKind::FunctionDefinition)
+                && visible.span.start.offset < call_span.start.offset
+                && checker
+                    .semantic()
+                    .ancestor_scopes(call_scope)
+                    .any(|scope| scope == visible.scope)
+        })
+}
+
+fn call_scope_can_execute_after_offset_before_offset(
+    checker: &Checker<'_>,
+    call_scope: ScopeId,
+    call_offset: usize,
+    after_offset: usize,
+    before_offset: usize,
+    reach: &mut CompatReachState<'_>,
+    visiting: &mut FxHashSet<ScopeId>,
+) -> bool {
+    if call_offset > before_offset {
+        return false;
+    }
+
+    if enclosing_function_scope(checker, call_scope).is_none() {
+        return call_offset > after_offset;
+    }
+
+    command_scope_can_run_between_offsets(
+        checker,
+        call_scope,
+        after_offset,
+        before_offset,
+        reach,
+        visiting,
+    )
+}
+
+fn enclosing_function_scope(checker: &Checker<'_>, scope: ScopeId) -> Option<ScopeId> {
+    checker.semantic().ancestor_scopes(scope).find(|scope_id| {
+        matches!(
+            checker.semantic().scope_kind(*scope_id),
+            ScopeKind::Function(_)
+        )
+    })
 }
 
 fn report_function_definition(
@@ -116,7 +1125,7 @@ fn report_function_definition(
         BindingOrigin::FunctionDefinition { definition_span } => *definition_span,
         _ => binding.span,
     };
-    let diagnostic_span = trim_trailing_whitespace(definition_span, checker.source());
+    let diagnostic_span = trim_trailing_function_separator(definition_span, checker.source());
 
     checker.report_diagnostic_dedup(
         Diagnostic::new(OverwrittenFunction { name, reason }, diagnostic_span)
@@ -124,8 +1133,17 @@ fn report_function_definition(
     );
 }
 
-fn trim_trailing_whitespace(span: shuck_ast::Span, source: &str) -> shuck_ast::Span {
-    let trimmed = span.slice(source).trim_end_matches(char::is_whitespace);
+fn trim_trailing_function_separator(span: shuck_ast::Span, source: &str) -> shuck_ast::Span {
+    let mut trimmed = span.slice(source);
+    loop {
+        let without_whitespace = trimmed.trim_end_matches(char::is_whitespace);
+        if let Some(without_semicolon) = without_whitespace.strip_suffix(';') {
+            trimmed = without_semicolon;
+            continue;
+        }
+        trimmed = without_whitespace;
+        break;
+    }
     shuck_ast::Span::from_positions(span.start, span.start.advanced_by(trimmed))
 }
 
@@ -134,10 +1152,35 @@ fn should_suppress_overwrite(
     overwritten: &SemanticOverwrittenFunction,
 ) -> bool {
     let file_context = checker.file_context();
+    let compat_mode = checker
+        .rule_options()
+        .c063
+        .report_unreached_nested_definitions;
     let first = checker.semantic().binding(overwritten.first);
     let second = checker.semantic().binding(overwritten.second);
 
     if matches!(first.kind, BindingKind::Imported) || matches!(second.kind, BindingKind::Imported) {
+        return true;
+    }
+
+    if enclosing_function_has_reportable_c063_diagnostic(checker, first.scope) {
+        return true;
+    }
+
+    if compat_mode {
+        return false;
+    }
+
+    if file_context.has_tag(FileContextTag::ShellSpec)
+        && checker
+            .semantic()
+            .call_sites_for(&overwritten.name)
+            .iter()
+            .any(|site| {
+                site.name_span.start.offset > first.span.end.offset
+                    && site.name_span.start.offset < second.span.start.offset
+            })
+    {
         return true;
     }
 
@@ -178,9 +1221,174 @@ fn should_suppress_overwrite(
 
 fn should_suppress_unreached(checker: &Checker<'_>, unreached: &SemanticUnreachedFunction) -> bool {
     let binding = checker.semantic().binding(unreached.binding);
+    let compat_mode = checker
+        .rule_options()
+        .c063
+        .report_unreached_nested_definitions;
 
     matches!(binding.kind, BindingKind::Imported)
-        || checker.file_context().has_tag(FileContextTag::ShellSpec)
+        || (matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
+            && has_apparent_infinite_loop_after(checker, binding.span.start.offset))
+        || (compat_mode
+            && matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
+            && has_top_level_return_after(checker, binding.span.start.offset))
+        || (compat_mode
+            && matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
+            && last_script_terminator_offset_after(checker, binding.span.start.offset).is_some_and(
+                |terminator_offset| {
+                    has_direct_call_to_binding_before_offset(
+                        checker,
+                        unreached.binding,
+                        terminator_offset,
+                    )
+                },
+            ))
+        || (!checker
+            .rule_options()
+            .c063
+            .report_unreached_nested_definitions
+            && checker.file_context().has_tag(FileContextTag::ShellSpec))
+        || (matches!(
+            unreached.reason,
+            UnreachedFunctionReason::EnclosingFunctionUnreached
+        ) && enclosing_function_has_reportable_c063_diagnostic(checker, binding.scope))
+}
+
+fn last_script_terminator_offset_after(
+    checker: &Checker<'_>,
+    after_offset: usize,
+) -> Option<usize> {
+    let cfg = checker.semantic_analysis().cfg();
+    let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+    cfg.script_terminators()
+        .iter()
+        .filter(|block_id| !unreachable.contains(block_id))
+        .flat_map(|block_id| cfg.block(*block_id).commands.iter())
+        .filter_map(|span| {
+            let offset = span.start.offset;
+            let scope = checker.semantic().scope_at(offset);
+            (offset > after_offset && !scope_has_transient_ancestor(checker, scope))
+                .then_some(offset)
+        })
+        .max()
+}
+
+fn has_top_level_return_after(checker: &Checker<'_>, after_offset: usize) -> bool {
+    checker.facts().structural_commands().any(|fact| {
+        fact.body_span().start.offset > after_offset
+            && scope_is_file_scope(
+                checker,
+                checker.semantic().scope_at(fact.body_span().start.offset),
+            )
+            && fact.effective_name_is("return")
+    })
+}
+
+fn has_top_level_return_between(
+    checker: &Checker<'_>,
+    after_offset: usize,
+    before_offset: usize,
+) -> bool {
+    checker.facts().structural_commands().any(|fact| {
+        fact.body_span().start.offset > after_offset
+            && fact.body_span().start.offset < before_offset
+            && scope_is_file_scope(
+                checker,
+                checker.semantic().scope_at(fact.body_span().start.offset),
+            )
+            && fact.effective_name_is("return")
+    })
+}
+
+fn has_apparent_infinite_loop_after(checker: &Checker<'_>, offset: usize) -> bool {
+    checker.facts().structural_commands().any(|fact| {
+        fact.body_span().start.offset > offset
+            && scope_is_file_scope(
+                checker,
+                checker.semantic().scope_at(fact.body_span().start.offset),
+            )
+            && command_is_apparent_infinite_loop(checker, fact.command())
+    })
+}
+
+fn has_apparent_infinite_loop_between(
+    checker: &Checker<'_>,
+    start_offset: usize,
+    end_offset: usize,
+) -> bool {
+    checker.facts().structural_commands().any(|fact| {
+        fact.body_span().start.offset > start_offset
+            && fact.body_span().start.offset < end_offset
+            && scope_is_file_scope(
+                checker,
+                checker.semantic().scope_at(fact.body_span().start.offset),
+            )
+            && command_is_apparent_infinite_loop(checker, fact.command())
+    })
+}
+
+fn command_is_apparent_infinite_loop(checker: &Checker<'_>, command: &shuck_ast::Command) -> bool {
+    let source = checker.source();
+    match command {
+        shuck_ast::Command::Compound(shuck_ast::CompoundCommand::While(command)) => {
+            condition_text_is(source, command.condition.span, &["true", ":"])
+                && !loop_body_contains_break(checker, command.body.span)
+        }
+        shuck_ast::Command::Compound(shuck_ast::CompoundCommand::Until(command)) => {
+            condition_text_is(source, command.condition.span, &["false"])
+                && !loop_body_contains_break(checker, command.body.span)
+        }
+        _ => false,
+    }
+}
+
+fn condition_text_is(source: &str, span: shuck_ast::Span, values: &[&str]) -> bool {
+    let text = span.slice(source).trim().trim_end_matches(';').trim();
+    values.contains(&text)
+}
+
+fn loop_body_contains_break(checker: &Checker<'_>, body_span: shuck_ast::Span) -> bool {
+    checker.facts().structural_commands().any(|fact| {
+        fact.body_span().start.offset >= body_span.start.offset
+            && fact.body_span().end.offset <= body_span.end.offset
+            && matches!(
+                fact.command(),
+                shuck_ast::Command::Builtin(shuck_ast::BuiltinCommand::Break(_))
+            )
+    })
+}
+
+fn enclosing_function_has_reportable_c063_diagnostic(
+    checker: &Checker<'_>,
+    scope: ScopeId,
+) -> bool {
+    let Some(enclosing_scope) = enclosing_function_scope(checker, scope) else {
+        return false;
+    };
+    let enclosing_bindings = checker
+        .facts()
+        .function_headers()
+        .iter()
+        .filter(|header| header.function_scope() == Some(enclosing_scope))
+        .filter_map(|header| header.binding_id())
+        .collect::<FxHashSet<_>>();
+
+    let has_unreached_diagnostic = checker
+        .semantic_analysis()
+        .unreached_functions_with_options(checker.rule_options().c063.semantic_options())
+        .iter()
+        .any(|candidate| enclosing_bindings.contains(&candidate.binding));
+    let has_overwrite_diagnostic = checker
+        .semantic_analysis()
+        .overwritten_functions()
+        .iter()
+        .any(|candidate| {
+            !candidate.first_called
+                && enclosing_bindings.contains(&candidate.first)
+                && !should_suppress_overwrite(checker, candidate)
+        });
+
+    has_unreached_diagnostic || has_overwrite_diagnostic
 }
 
 fn unset_function_between(
@@ -323,6 +1531,27 @@ myfunc
     }
 
     #[test]
+    fn c063_option_reports_shellspec_overwrite_despite_later_body_call() {
+        let source = "\
+parse() { :; }
+restargs() {
+  parse \"$@\"
+}
+parse() { :; }
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/ko1nksm__shellspec__spec__getoptions_base_spec.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+    }
+
+    #[test]
     fn attaches_unsafe_fix_metadata_for_reported_overwrites() {
         let source = "\
 myfunc() { return 1; }
@@ -429,6 +1658,23 @@ exit 0
     }
 
     #[test]
+    fn c063_option_trims_nested_function_list_separator_from_report_span() {
+        let source = "mock() { trans() { echo trans; }; }\n";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        let nested = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.span.start.column == 10)
+            .expect("expected nested function diagnostic");
+        assert_eq!(nested.span.slice(source), "trans() { echo trans; }");
+    }
+
+    #[test]
     fn nested_functions_at_plain_eof_do_not_report_by_default() {
         let source = "\
 outer() {
@@ -469,6 +1715,630 @@ outer() {
             diagnostics[0].fix_title.as_deref(),
             Some("delete the nested function definition that cannot be reached")
         );
+    }
+
+    #[test]
+    fn c063_option_reports_shellspec_mock_installed_nested_helpers() {
+        let source = "\
+Describe 'run evaluation'
+  It 'restores mocked function'
+    echo_foo() { echo 'foo'; }
+    mock_foo() {
+      echo_foo() { echo 'FOO'; }
+    }
+    When run mock_foo
+  End
+End
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/ko1nksm__shellspec__spec__core__evaluation_spec.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 5);
+    }
+
+    #[test]
+    fn c063_option_suppresses_shellspec_nested_helpers_when_enclosing_function_reports() {
+        let source = "\
+Describe 'run evaluation'
+  mock() {
+    helper() { echo helper; }
+  }
+  mock() { :; }
+End
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/ko1nksm__shellspec__spec__core__evaluation_spec.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn c063_option_suppresses_nested_child_when_enclosing_function_reports() {
+        let source = "\
+outer() {
+  inner() {
+    child() { echo child; }
+  }
+}
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn c063_option_suppresses_nested_overwrite_when_enclosing_function_reports() {
+        let source = "\
+outer() {
+  inner() { echo first; }
+  inner() { echo second; }
+}
+outer() { :; }
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].span.start.line, 1);
+    }
+
+    #[test]
+    fn c063_option_reports_dynamic_only_function_before_terminating_call() {
+        let source = "\
+v_echo() { env \"$@\"; }
+V_ECHO=v_echo
+cleanup() { exit \"$1\"; }
+${V_ECHO} printf '%s\\n' hi || cleanup 1
+cleanup 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+    }
+
+    #[test]
+    fn c063_option_reports_nested_function_only_reached_in_command_substitution() {
+        let source = "\
+outer() {
+  inner() { echo hi; }
+}
+value=$(outer)
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn c063_option_accepts_nested_function_called_inside_command_substitution() {
+        let source = "\
+outer() {
+  inner() { echo hi; }
+  inner
+}
+value=$(outer)
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn c063_option_reports_nested_function_before_eventual_script_termination() {
+        let source = "\
+outer() {
+  inner() { echo hi; }
+}
+main() {
+  outer
+  exit 0
+}
+if should_run; then
+  main
+fi
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn c063_option_accepts_nested_function_called_before_eventual_script_termination() {
+        let source = "\
+outer() {
+  inner() { echo hi; }
+}
+main() {
+  outer
+  inner
+  exit 0
+}
+if should_run; then
+  main
+fi
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn c063_option_counts_calls_inside_final_terminating_driver_function() {
+        let source = "\
+helper() { echo hi; }
+finish() { exit 0; }
+main() {
+  helper
+  finish
+}
+main
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/install.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_counts_earlier_body_calls_when_function_runs_after_definition() {
+        let source = "\
+caller() {
+  late_helper
+}
+late_helper() { echo hi; }
+caller
+exit 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_counts_earlier_body_calls_before_terminating_function_exit() {
+        let source = "\
+caller() {
+  late_helper
+  exit 0
+}
+late_helper() { echo hi; }
+caller
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_counts_transitive_earlier_body_calls_when_driver_runs_after_definition() {
+        let source = "\
+worker() {
+  late_helper
+}
+driver() {
+  worker
+  exit 0
+}
+late_helper() { echo hi; }
+driver
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_body_calls_when_enclosing_function_runs_before_definition() {
+        let source = "\
+helper() { echo hi; }
+main() {
+  late
+}
+main
+late() {
+  helper
+}
+exit 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+        let lines = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.span.start.line)
+            .collect::<Vec<_>>();
+
+        assert_eq!(lines, [1, 6], "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_calls_after_unreachable_script_exit() {
+        let source = "\
+helper() { echo hi; }
+exit 0
+helper
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+    }
+
+    #[test]
+    fn c063_option_ignores_conditional_unset_cutoff() {
+        let source = "\
+helper() { echo hi; }
+false || unset -f helper
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_conditional_unsetter_call_cutoff() {
+        let source = "\
+cleanup() { unset -f helper; }
+helper() { echo hi; }
+false || cleanup
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_unsetter_call_inside_conditional_branch() {
+        let source = "\
+cleanup() { unset -f helper; }
+helper() { echo hi; }
+if failed; then
+  cleanup
+fi
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_unsetter_with_conditional_body_unset() {
+        let source = "\
+cleanup() {
+  if failed; then
+    unset -f helper
+  fi
+}
+helper() { echo hi; }
+cleanup
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_unsetter_with_unreachable_body_unset() {
+        let source = "\
+cleanup() {
+  return
+  unset -f helper
+}
+helper() { echo hi; }
+cleanup
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_uncalled_nested_unsetter_helper() {
+        let source = "\
+cleanup() {
+  nested() { unset -f helper; }
+}
+helper() { echo hi; }
+cleanup
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_unsetter_call_inside_command_substitution() {
+        let source = "\
+cleanup() { unset -f helper; }
+helper() { echo hi; }
+: \"$(cleanup)\"
+helper
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_unreachable_terminator_after_infinite_loop() {
+        let source = "\
+helper() { echo hi; }
+while true; do
+  :
+done
+exit 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_reports_when_static_loop_breaks_before_terminator() {
+        let source = "\
+helper() { echo hi; }
+while true; do
+  break
+done
+exit 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+    }
+
+    #[test]
+    fn c063_option_reports_when_infinite_loop_is_inside_called_function() {
+        let source = "\
+helper() { echo hi; }
+main() {
+  while true; do
+    :
+  done
+  exit 0
+}
+main
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
+        assert_eq!(diagnostics[0].span.start.line, 1);
+    }
+
+    #[test]
+    fn c063_option_ignores_top_level_return_as_script_cutoff() {
+        let source = "\
+helper() { echo hi; }
+return 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/lib.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_top_level_return_before_later_exit() {
+        let source = "\
+helper() { echo hi; }
+return 0
+exit 1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_conditional_top_level_return_before_later_exit() {
+        let source = "\
+helper() { echo hi; }
+${__SOURCED__:+false} : || return 0
+exit 1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_subshell_exit_as_script_cutoff() {
+        let source = "\
+helper() { (exit 123) && :; }
+helper
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_non_guaranteed_file_scope_exit() {
+        let source = "\
+helper() { echo hi; }
+if cond; then
+  exit 0
+fi
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn c063_option_ignores_conditionally_defined_functions_before_later_exit() {
+        let source = "\
+if cond; then
+  helper() { echo hi; }
+else
+  helper() { echo bye; }
+fi
+helper
+exit 0
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction)
+                .with_c063_report_unreached_nested_definitions(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -6854,6 +6854,9 @@ impl<'a> Parser<'a> {
             let Some(name) = self.current_token.as_ref().and_then(LexedToken::word_text) else {
                 break;
             };
+            if self.current_source_word_starts_posix_function_header(name) {
+                break;
+            }
             let Some(alias) = self.aliases.get(name).cloned() else {
                 break;
             };
@@ -6869,6 +6872,30 @@ impl<'a> Parser<'a> {
         }
 
         self.expand_next_word = expands_next_word;
+    }
+
+    fn current_source_word_starts_posix_function_header(&self, name: &str) -> bool {
+        if name.contains('=') || name.contains('[') {
+            return false;
+        }
+
+        if self
+            .current_token
+            .as_ref()
+            .is_some_and(|token| token.flags.is_synthetic())
+        {
+            return false;
+        }
+
+        let Some(tail) = self.input.get(self.current_span.end.offset..) else {
+            return false;
+        };
+        let tail = tail.trim_start_matches([' ', '\t']);
+        let Some(after_left) = tail.strip_prefix('(') else {
+            return false;
+        };
+        let after_left = after_left.trim_start_matches([' ', '\t']);
+        after_left.starts_with(')')
     }
 
     fn next_word_char(

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -322,6 +322,23 @@ fn test_posix_function_with_brace_group_preserves_surface_form() {
 }
 
 #[test]
+fn test_alias_expansion_does_not_replace_posix_function_name() {
+    let input = "\
+shopt -s expand_aliases
+alias wget='wget -V'
+wget() { echo hi; }
+";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let function = expect_function(&script.body[2]);
+
+    assert_eq!(
+        function.static_names().next().map(|name| name.as_str()),
+        Some("wget")
+    );
+}
+
+#[test]
 fn test_posix_function_allows_subshell_body() {
     let input = "inc_subshell() ( j=$((j+5)); )\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -34,6 +34,7 @@ pub enum EdgeKind {
     CaseArm,
     CaseFallthrough,
     CaseContinue,
+    NestedRegion,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -54,6 +55,7 @@ pub struct ControlFlowGraph {
     exits: Vec<BlockId>,
     natural_exits: Vec<BlockId>,
     script_terminators: Vec<BlockId>,
+    script_always_terminates: bool,
     unreachable: Vec<BlockId>,
     pub(crate) scope_entries: FxHashMap<ScopeId, BlockId>,
     pub(crate) scope_exits: FxHashMap<ScopeId, SmallVec<[BlockId; 2]>>,
@@ -98,6 +100,10 @@ impl ControlFlowGraph {
 
     pub fn script_terminators(&self) -> &[BlockId] {
         &self.script_terminators
+    }
+
+    pub fn script_always_terminates(&self) -> bool {
+        self.script_always_terminates
     }
 
     pub fn scope_entry(&self, scope: ScopeId) -> Option<BlockId> {
@@ -1389,6 +1395,7 @@ pub(crate) fn build_control_flow_graph(
     let file = builder.build_sequence(program.file_commands(), &[]);
     let entry = file.entry.unwrap_or_else(|| builder.empty_block());
     builder.scope_entries.insert(ScopeId(0), entry);
+    let script_always_terminates = file.exits.is_empty() && file.entry.is_some();
     let mut natural_exits: Vec<BlockId> = if file.entry.is_none() {
         vec![entry]
     } else {
@@ -1434,6 +1441,7 @@ pub(crate) fn build_control_flow_graph(
         exits,
         natural_exits,
         script_terminators: builder.script_terminators,
+        script_always_terminates,
         unreachable,
         scope_entries: builder.scope_entries,
         scope_exits,
@@ -1617,7 +1625,7 @@ impl<'a> GraphBuilder<'a> {
                 self.attach_nested_regions(block, command.nested_regions, loops);
                 let body_sequence = self.build_sequence(*body, loops);
                 if let Some(body_entry) = body_sequence.entry {
-                    self.add_edge(block, body_entry, EdgeKind::Sequential);
+                    self.add_edge(block, body_entry, EdgeKind::NestedRegion);
                 }
                 SequenceResult {
                     entry: Some(block),
@@ -1634,7 +1642,7 @@ impl<'a> GraphBuilder<'a> {
                         self.scope_entries
                             .entry(segment.scope)
                             .or_insert(segment_entry);
-                        self.add_edge(block, segment_entry, EdgeKind::Sequential);
+                        self.add_edge(block, segment_entry, EdgeKind::NestedRegion);
                     }
                 }
                 SequenceResult {
@@ -2157,7 +2165,7 @@ impl<'a> GraphBuilder<'a> {
             let sequence = self.build_sequence(region.commands, loops);
             if let Some(entry) = sequence.entry {
                 self.scope_entries.entry(region.scope).or_insert(entry);
-                self.add_edge(block, entry, EdgeKind::Sequential);
+                self.add_edge(block, entry, EdgeKind::NestedRegion);
             }
         }
     }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1943,12 +1943,16 @@ impl<'model> SemanticAnalysis<'model> {
         scope_execution_cache: &mut FxHashMap<ScopeId, bool>,
     ) -> bool {
         let binding = self.model.binding(binding_id);
-        if self.enclosing_function_scope(binding.scope).is_none() {
+        let Some(enclosing_scope) = self.enclosing_function_or_transient_scope(binding.scope)
+        else {
             return false;
-        }
+        };
 
         let empty_terminators = FxHashSet::default();
-        if self.binding_execution_scope_can_run_before_termination(
+        if matches!(
+            self.model.scope_kind(enclosing_scope),
+            ScopeKind::Function(function) if !function.is_anonymous()
+        ) && self.binding_execution_scope_can_run_persistently_before_termination(
             binding_id,
             cfg,
             unreachable,
@@ -2006,6 +2010,30 @@ impl<'model> SemanticAnalysis<'model> {
         )
     }
 
+    fn binding_execution_scope_can_run_persistently_before_termination(
+        &self,
+        binding_id: BindingId,
+        cfg: &ControlFlowGraph,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+        scope_execution_cache: &mut FxHashMap<ScopeId, bool>,
+    ) -> bool {
+        let binding = self.model.binding(binding_id);
+        let Some(function_scope) = self.enclosing_function_scope(binding.scope) else {
+            return true;
+        };
+
+        let mut visiting_scopes = FxHashSet::default();
+        self.function_scope_can_run_persistently_before_termination(
+            function_scope,
+            cfg,
+            unreachable,
+            script_terminators,
+            &mut visiting_scopes,
+            scope_execution_cache,
+        )
+    }
+
     fn function_scope_can_run_before_termination(
         &self,
         function_scope: ScopeId,
@@ -2040,6 +2068,9 @@ impl<'model> SemanticAnalysis<'model> {
                             &function.name,
                             site,
                             function_binding,
+                        ) && self.call_site_can_execute_after_function_definition(
+                            site,
+                            function.span.start.offset,
                         ) && self.call_site_context_can_run_before_termination(
                             site,
                             cfg,
@@ -2053,6 +2084,115 @@ impl<'model> SemanticAnalysis<'model> {
 
         visiting_scopes.remove(&function_scope);
         scope_execution_cache.insert(function_scope, can_run);
+        can_run
+    }
+
+    fn function_scope_can_run_persistently_before_termination(
+        &self,
+        function_scope: ScopeId,
+        cfg: &ControlFlowGraph,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+        scope_execution_cache: &mut FxHashMap<ScopeId, bool>,
+    ) -> bool {
+        if !visiting_scopes.contains(&function_scope)
+            && let Some(cached) = scope_execution_cache.get(&function_scope)
+        {
+            return *cached;
+        }
+        if !visiting_scopes.insert(function_scope) {
+            return false;
+        }
+
+        let can_run = self
+            .model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(binding, body_scope)| (*body_scope == function_scope).then_some(*binding))
+            .any(|function_binding| {
+                let function = self.model.binding(function_binding);
+                self.model
+                    .call_sites_for(&function.name)
+                    .iter()
+                    .any(|site| {
+                        self.overwrite_call_site_resolves_to_binding(
+                            &function.name,
+                            site,
+                            function_binding,
+                        ) && self.call_site_can_execute_after_function_definition(
+                            site,
+                            function.span.start.offset,
+                        ) && !self.call_site_runs_in_transient_context(site.scope)
+                            && self.call_site_context_can_run_persistently_before_termination(
+                                site,
+                                cfg,
+                                unreachable,
+                                script_terminators,
+                                visiting_scopes,
+                                scope_execution_cache,
+                            )
+                    })
+            });
+
+        visiting_scopes.remove(&function_scope);
+        scope_execution_cache.insert(function_scope, can_run);
+        can_run
+    }
+
+    fn call_site_can_execute_after_function_definition(
+        &self,
+        site: &CallSite,
+        function_offset: usize,
+    ) -> bool {
+        site.span.start.offset > function_offset || {
+            let mut visiting_scopes = FxHashSet::default();
+            self.call_site_context_can_run_after_offset(site, function_offset, &mut visiting_scopes)
+        }
+    }
+
+    fn call_site_context_can_run_after_offset(
+        &self,
+        site: &CallSite,
+        after_offset: usize,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let Some(function_scope) = self.enclosing_function_scope(site.scope) else {
+            return site.span.start.offset > after_offset;
+        };
+        if !visiting_scopes.insert(function_scope) {
+            return false;
+        }
+
+        let can_run = self
+            .model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(binding_id, body_scope)| {
+                (*body_scope == function_scope).then_some(*binding_id)
+            })
+            .any(|function_binding| {
+                let function = self.model.binding(function_binding);
+                self.model
+                    .call_sites_for(&function.name)
+                    .iter()
+                    .any(|caller| {
+                        self.overwrite_call_site_resolves_to_binding(
+                            &function.name,
+                            caller,
+                            function_binding,
+                        ) && (caller.span.start.offset > after_offset
+                            || self.call_site_context_can_run_after_offset(
+                                caller,
+                                after_offset,
+                                visiting_scopes,
+                            ))
+                    })
+            });
+
+        visiting_scopes.remove(&function_scope);
         can_run
     }
 
@@ -2095,6 +2235,54 @@ impl<'model> SemanticAnalysis<'model> {
         )
     }
 
+    fn call_site_context_can_run_persistently_before_termination(
+        &self,
+        site: &CallSite,
+        cfg: &ControlFlowGraph,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+        scope_execution_cache: &mut FxHashMap<ScopeId, bool>,
+    ) -> bool {
+        let site_blocks = self.reachable_call_site_blocks_in_cfg(cfg, site, unreachable);
+        if site_blocks.is_empty() {
+            return false;
+        }
+
+        let Some(function_scope) = self.enclosing_function_scope(site.scope) else {
+            return blocks_have_path_avoiding(
+                cfg,
+                &[cfg.entry()],
+                &site_blocks,
+                script_terminators,
+            );
+        };
+        let Some(scope_entry) = cfg.scope_entry(function_scope) else {
+            return false;
+        };
+        if !blocks_have_path_avoiding(cfg, &[scope_entry], &site_blocks, script_terminators) {
+            return false;
+        }
+
+        self.function_scope_can_run_persistently_before_termination(
+            function_scope,
+            cfg,
+            unreachable,
+            script_terminators,
+            visiting_scopes,
+            scope_execution_cache,
+        )
+    }
+
+    fn call_site_runs_in_transient_context(&self, scope: ScopeId) -> bool {
+        self.model.ancestor_scopes(scope).any(|scope_id| {
+            matches!(
+                self.model.scope_kind(scope_id),
+                ScopeKind::Subshell | ScopeKind::CommandSubstitution | ScopeKind::Pipeline
+            )
+        })
+    }
+
     fn function_binding_has_direct_call_before_termination(
         &self,
         name: &Name,
@@ -2113,6 +2301,10 @@ impl<'model> SemanticAnalysis<'model> {
         site: &CallSite,
         window: &FunctionReachWindow<'_>,
     ) -> bool {
+        if self.call_site_has_prior_shadowing_function_definition(name, site, window.binding) {
+            return false;
+        }
+
         let binding = self.model.binding(window.binding);
         if site.scope == binding.scope {
             let site_blocks =
@@ -2128,6 +2320,10 @@ impl<'model> SemanticAnalysis<'model> {
         }
 
         if self.overwrite_call_site_resolves_to_binding(name, site, window.binding) {
+            return true;
+        }
+
+        if self.call_site_can_use_function_binding_provided_earlier(site, window) {
             return true;
         }
 
@@ -2155,6 +2351,142 @@ impl<'model> SemanticAnalysis<'model> {
             })
     }
 
+    fn call_site_has_prior_shadowing_function_definition(
+        &self,
+        name: &Name,
+        site: &CallSite,
+        binding_id: BindingId,
+    ) -> bool {
+        let binding = self.model.binding(binding_id);
+        for scope in self.model.ancestor_scopes(site.scope) {
+            if scope == binding.scope {
+                return false;
+            }
+
+            if self.model.scopes[scope.index()]
+                .bindings
+                .get(name)
+                .into_iter()
+                .flat_map(|bindings| bindings.iter())
+                .any(|other| {
+                    *other != binding_id
+                        && matches!(
+                            self.model.binding(*other).kind,
+                            BindingKind::FunctionDefinition
+                        )
+                        && self.model.binding(*other).span.start.offset < site.span.start.offset
+                })
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn call_site_can_use_function_binding_provided_earlier(
+        &self,
+        site: &CallSite,
+        window: &FunctionReachWindow<'_>,
+    ) -> bool {
+        let binding = self.model.binding(window.binding);
+        let Some(provider_scope) = self.enclosing_function_scope(binding.scope) else {
+            return false;
+        };
+        let consumer_execution_scope = self.call_site_execution_scope(site.scope);
+        if self.function_scope_is_called_before_offset(
+            consumer_execution_scope,
+            binding.span.start.offset,
+            window,
+        ) {
+            return false;
+        }
+        let site_blocks =
+            self.reachable_call_site_blocks_in_cfg(window.cfg, site, window.unreachable);
+        if site_blocks.is_empty() {
+            return false;
+        }
+
+        self.model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(function_binding, body_scope)| {
+                (*body_scope == provider_scope).then_some(*function_binding)
+            })
+            .any(|provider_binding| {
+                let provider = self.model.binding(provider_binding);
+                self.model
+                    .call_sites_for(&provider.name)
+                    .iter()
+                    .any(|provider_site| {
+                        provider_site.span.start.offset < site.span.start.offset
+                            && self.call_site_execution_scope(provider_site.scope)
+                                == consumer_execution_scope
+                            && self.overwrite_call_site_resolves_to_binding(
+                                &provider.name,
+                                provider_site,
+                                provider_binding,
+                            )
+                            && {
+                                let provider_blocks = self.reachable_call_site_blocks_in_cfg(
+                                    window.cfg,
+                                    provider_site,
+                                    window.unreachable,
+                                );
+                                !provider_blocks.is_empty()
+                                    && blocks_have_path_avoiding_many(
+                                        window.cfg,
+                                        &provider_blocks,
+                                        &site_blocks,
+                                        window.shadow_blocks,
+                                        window.script_terminators,
+                                    )
+                            }
+                    })
+            })
+    }
+
+    fn function_scope_is_called_before_offset(
+        &self,
+        scope: ScopeId,
+        offset: usize,
+        window: &FunctionReachWindow<'_>,
+    ) -> bool {
+        self.model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(function_binding, body_scope)| {
+                (*body_scope == scope).then_some(*function_binding)
+            })
+            .any(|function_binding| {
+                let function = self.model.binding(function_binding);
+                self.model
+                    .call_sites_for(&function.name)
+                    .iter()
+                    .any(|site| {
+                        site.span.start.offset < offset
+                            && self.overwrite_call_site_resolves_to_binding(
+                                &function.name,
+                                site,
+                                function_binding,
+                            )
+                            && !self
+                                .reachable_call_site_blocks_in_cfg(
+                                    window.cfg,
+                                    site,
+                                    window.unreachable,
+                                )
+                                .is_empty()
+                    })
+            })
+    }
+
+    fn call_site_execution_scope(&self, scope: ScopeId) -> ScopeId {
+        self.enclosing_function_scope(scope).unwrap_or(scope)
+    }
+
     fn call_site_executes_before_termination(
         &self,
         site: &CallSite,
@@ -2165,6 +2497,10 @@ impl<'model> SemanticAnalysis<'model> {
             self.reachable_call_site_blocks_in_cfg(window.cfg, site, window.unreachable);
         if site_blocks.is_empty() {
             return false;
+        }
+
+        if self.call_site_can_use_function_binding_provided_earlier(site, window) {
+            return true;
         }
 
         let binding = self.model.binding(window.binding);
@@ -2222,7 +2558,9 @@ impl<'model> SemanticAnalysis<'model> {
                 (*body_scope == function_scope).then_some(*binding_id)
             })
             .any(|function_binding| {
-                let function_name = self.model.binding(function_binding).name.clone();
+                let function = self.model.binding(function_binding);
+                let function_name = function.name.clone();
+                let function_offset = function.span.start.offset;
                 self.model
                     .call_sites_for(&function_name)
                     .iter()
@@ -2231,6 +2569,9 @@ impl<'model> SemanticAnalysis<'model> {
                             &function_name,
                             caller,
                             function_binding,
+                        ) && self.call_site_can_execute_after_function_definition(
+                            caller,
+                            function_offset,
                         ) && self.call_site_executes_before_termination(
                             caller,
                             window,
@@ -2281,6 +2622,18 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    fn enclosing_function_or_transient_scope(&self, scope: ScopeId) -> Option<ScopeId> {
+        self.model.ancestor_scopes(scope).find(|scope_id| {
+            matches!(
+                self.model.scope_kind(*scope_id),
+                ScopeKind::Function(function) if !function.is_anonymous()
+            ) || matches!(
+                self.model.scope_kind(*scope_id),
+                ScopeKind::Subshell | ScopeKind::CommandSubstitution | ScopeKind::Pipeline
+            )
+        })
+    }
+
     fn compute_overwritten_functions(&self) -> Vec<OverwrittenFunction> {
         if self.model.functions.is_empty() {
             return Vec::new();
@@ -2288,6 +2641,11 @@ impl<'model> SemanticAnalysis<'model> {
 
         let cfg = self.cfg();
         let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let script_terminators = cfg
+            .script_terminators()
+            .iter()
+            .copied()
+            .collect::<FxHashSet<_>>();
         let binding_blocks = build_binding_block_index(cfg.blocks(), self.model.bindings.len());
         let mut reachability = ReachabilityCache::new(cfg);
         let mut overwritten = Vec::new();
@@ -2319,7 +2677,15 @@ impl<'model> SemanticAnalysis<'model> {
                         continue;
                     };
 
-                    if !blocks_have_path(&first_blocks, &second_blocks, &mut reachability) {
+                    if !blocks_have_path(&first_blocks, &second_blocks, &mut reachability)
+                        || !all_paths_reach_any_block_or_terminate(
+                            &first_blocks,
+                            &second_blocks,
+                            cfg,
+                            &unreachable,
+                            &script_terminators,
+                        )
+                    {
                         continue;
                     }
 
@@ -2704,6 +3070,66 @@ fn blocks_have_path(
     })
 }
 
+fn all_paths_reach_any_block_or_terminate(
+    starts: &[BlockId],
+    targets: &[BlockId],
+    cfg: &ControlFlowGraph,
+    unreachable: &FxHashSet<BlockId>,
+    script_terminators: &FxHashSet<BlockId>,
+) -> bool {
+    let targets = targets.iter().copied().collect::<FxHashSet<_>>();
+    starts.iter().copied().all(|start| {
+        path_reaches_any_target_or_terminates(
+            start,
+            &targets,
+            cfg,
+            unreachable,
+            script_terminators,
+            &mut FxHashSet::default(),
+        )
+    })
+}
+
+fn path_reaches_any_target_or_terminates(
+    block: BlockId,
+    targets: &FxHashSet<BlockId>,
+    cfg: &ControlFlowGraph,
+    unreachable: &FxHashSet<BlockId>,
+    script_terminators: &FxHashSet<BlockId>,
+    visiting: &mut FxHashSet<BlockId>,
+) -> bool {
+    if unreachable.contains(&block) {
+        return false;
+    }
+    if targets.contains(&block) || script_terminators.contains(&block) {
+        return true;
+    }
+    if !visiting.insert(block) {
+        return false;
+    }
+
+    let successors = cfg
+        .successors(block)
+        .iter()
+        .filter(|(_, edge)| !matches!(edge, EdgeKind::NestedRegion))
+        .copied()
+        .collect::<Vec<_>>();
+    let reaches = !successors.is_empty()
+        && successors.iter().all(|(successor, _)| {
+            path_reaches_any_target_or_terminates(
+                *successor,
+                targets,
+                cfg,
+                unreachable,
+                script_terminators,
+                visiting,
+            )
+        });
+
+    visiting.remove(&block);
+    reaches
+}
+
 fn reachable_blocks_for_binding(
     cfg: &ControlFlowGraph,
     binding: BindingId,
@@ -2850,7 +3276,13 @@ fn path_terminates_before_natural_exit(
         return false;
     }
 
-    let successors = context.cfg.successors(block);
+    let successors = context
+        .cfg
+        .successors(block)
+        .iter()
+        .filter(|(_, edge)| !matches!(edge, EdgeKind::NestedRegion))
+        .copied()
+        .collect::<Vec<_>>();
     let terminates = !successors.is_empty()
         && successors.iter().all(|(successor, _)| {
             path_terminates_before_natural_exit(*successor, visiting, context)
@@ -4222,6 +4654,36 @@ helper
     }
 
     #[test]
+    fn precise_overwritten_functions_ignore_conditional_redefinition_after_default() {
+        let source = "\
+helper() { return 0; }
+if cond; then
+  helper() { return 1; }
+fi
+helper
+";
+        let model = model(source);
+
+        assert!(model.analysis().overwritten_functions().is_empty());
+    }
+
+    #[test]
+    fn precise_overwritten_functions_allow_terminating_paths_before_redefinition() {
+        let source = "\
+helper() { return 0; }
+maybe || exit 1
+helper() { return 1; }
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let overwritten = analysis.overwritten_functions();
+
+        assert_eq!(overwritten.len(), 1);
+        assert_eq!(overwritten[0].name, "helper");
+        assert!(!overwritten[0].first_called);
+    }
+
+    #[test]
     fn precise_overwritten_functions_do_not_merge_distinct_helper_scopes() {
         let source = "\
 factory_one() {
@@ -4256,6 +4718,25 @@ factory_two
     }
 
     #[test]
+    fn unreached_functions_report_definitions_before_terminating_function_call() {
+        let source = "\
+f() { echo hi; }
+die() { exit 0; }
+die
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached = analysis.unreached_functions();
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "f");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::ScriptTerminates
+        );
+    }
+
+    #[test]
     fn unreached_functions_ignore_definitions_at_plain_eof() {
         let source = "f() { echo hi; }\n";
         let model = model(source);
@@ -4270,6 +4751,27 @@ outer() {
   inner() { :; }
 }
 ";
+        let model = model(source);
+        let analysis = model.analysis();
+
+        assert!(analysis.unreached_functions().is_empty());
+
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "inner");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::EnclosingFunctionUnreached
+        );
+    }
+
+    #[test]
+    fn unreached_functions_report_subshell_definitions_with_compat_option() {
+        let source = "( inner() { :; }; )\n";
         let model = model(source);
         let analysis = model.analysis();
 
@@ -4363,6 +4865,23 @@ outer() {
     }
 
     #[test]
+    fn transient_call_sites_include_function_scopes_under_command_substitution() {
+        let source = "\
+printf '%s\\n' \"$(
+  caller() {
+    target
+  }
+  caller
+)\"
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let site = &model.call_sites_for(&Name::from("target"))[0];
+
+        assert!(analysis.call_site_runs_in_transient_context(site.scope));
+    }
+
+    #[test]
     fn unreached_functions_count_transitive_nested_calls_before_enclosing_scope_exits() {
         let source = "\
 outer() {
@@ -4393,6 +4912,99 @@ outer() {
   wrapper
 }
 outer
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert!(unreached.is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_count_nested_definitions_installed_before_later_body_call() {
+        let source = "\
+provider() {
+  helper() { :; }
+}
+consumer() {
+  provider
+  helper
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert!(unreached.is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_report_nested_definitions_when_provider_call_follows_use() {
+        let source = "\
+provider() {
+  helper() { :; }
+}
+consumer() {
+  helper
+  provider
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "helper");
+    }
+
+    #[test]
+    fn unreached_functions_do_not_count_provider_call_when_consumer_runs_before_definition() {
+        let source = "\
+consumer() {
+  provider
+  helper
+}
+consumer
+provider() {
+  helper() { :; }
+}
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached =
+            analysis.unreached_functions_with_options(UnreachedFunctionAnalysisOptions {
+                report_unreached_nested_definitions: true,
+            });
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "helper");
+    }
+
+    #[test]
+    fn unreached_functions_ignore_unreachable_consumer_calls_before_provider_definition() {
+        let source = "\
+consumer() {
+  provider
+  helper
+}
+guard() {
+  return
+  consumer
+}
+guard
+provider() {
+  helper() { :; }
+}
+consumer
 ";
         let model = model(source);
         let analysis = model.analysis();
@@ -4499,6 +5111,30 @@ exit 0
     }
 
     #[test]
+    fn unreached_functions_ignore_body_calls_when_enclosing_function_runs_before_definition() {
+        let source = "\
+helper() { :; }
+main() {
+  late
+}
+main
+late() {
+  helper
+}
+exit 0
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached = analysis.unreached_functions();
+        let names = unreached
+            .iter()
+            .map(|function| function.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, ["helper", "late"]);
+    }
+
+    #[test]
     fn unreached_functions_count_nested_substitution_calls_before_termination() {
         let source = "\
 run_case() {
@@ -4511,6 +5147,84 @@ exit 0
         let model = model(source);
 
         assert!(model.analysis().unreached_functions().is_empty());
+    }
+
+    #[test]
+    fn unreached_functions_ignore_shadowed_command_substitution_calls_before_termination() {
+        let source = "\
+helper() { echo hi; }
+output=$(helper() { :; }; helper)
+exit 0
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached = analysis.unreached_functions();
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "helper");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::ScriptTerminates
+        );
+    }
+
+    #[test]
+    fn unreached_functions_ignore_shadowed_test_argument_command_substitution_calls() {
+        let source = "\
+helper() { echo hi; }
+if [ \"$(helper() { :; }; helper)\" = hi ]; then
+  echo yes
+fi
+exit 0
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached = analysis.unreached_functions();
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "helper");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::ScriptTerminates
+        );
+    }
+
+    #[test]
+    fn unreached_functions_ignore_command_substitution_paths_before_later_termination() {
+        let source = "\
+f() { echo hi; }
+output=$(echo value)
+exit 0
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached = analysis.unreached_functions();
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "f");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::ScriptTerminates
+        );
+    }
+
+    #[test]
+    fn unreached_functions_ignore_pipeline_paths_before_later_termination() {
+        let source = "\
+f() { echo hi; }
+echo value | cat
+exit 0
+";
+        let model = model(source);
+        let analysis = model.analysis();
+        let unreached = analysis.unreached_functions();
+
+        assert_eq!(unreached.len(), 1);
+        assert_eq!(unreached[0].name, "f");
+        assert_eq!(
+            unreached[0].reason,
+            UnreachedFunctionReason::ScriptTerminates
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Improves C063 reachability to better match ShellCheck for overwritten, removed, and termination-cut-off functions.
- Adds parser protection so alias expansion does not rewrite POSIX function headers.
- Replaces broad C063 corpus metadata with exact-span backlog entries only.

## Validation

- cargo test -p shuck-parser test_alias_expansion_does_not_replace_posix_function_name -- --nocapture
- cargo test -p shuck-semantic unreached_functions_ -- --nocapture
- cargo test -p shuck-semantic precise_overwritten_functions -- --nocapture
- cargo test -p shuck-linter c063_option_ -- --nocapture
- cargo test -p shuck-cli inline_config_overrides_validate_supported_c063_rule_option_keys -- --nocapture
- cargo test -p shuck-cli invalidates_cache_when_c063_rule_options_change -- --nocapture
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C063 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=5
- cargo fmt --check
- git diff --check

Note: full local C063 corpus runs were affected by thermal/performance timeouts on very large fixtures; CI should validate the full performance envelope.
